### PR TITLE
Fix citizen reservation time range validation

### DIFF
--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -95,7 +95,7 @@ export default React.memo(function ReservationModal({
         initialEnd,
         i18n
       ),
-    i18n.validationErrors,
+    { ...i18n.validationErrors, ...i18n.calendar.validationErrors },
     {
       onUpdate: (prevState, nextState, form) => {
         const prev = combine(

--- a/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
+++ b/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
-import { localTimeRangeWithUnitTimes } from 'lib-common/form/fields'
+import { limitedLocalTimeRange } from 'lib-common/form/fields'
 import { BoundFormShape, useFormField } from 'lib-common/form/hooks'
 import { ShapeOf, StateOf } from 'lib-common/form/types'
 import UnderRowStatusIcon, { InfoStatus } from 'lib-components/atoms/StatusIcon'
@@ -16,8 +16,8 @@ import { useTranslation } from '../localization'
 
 export interface Props {
   bind: BoundFormShape<
-    StateOf<typeof localTimeRangeWithUnitTimes>,
-    ShapeOf<typeof localTimeRangeWithUnitTimes>
+    StateOf<typeof limitedLocalTimeRange>,
+    ShapeOf<typeof limitedLocalTimeRange>
   >
   hideErrorsBeforeTouched?: boolean
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void

--- a/frontend/src/citizen-frontend/calendar/api.ts
+++ b/frontend/src/citizen-frontend/calendar/api.ts
@@ -4,6 +4,7 @@
 
 import mapValues from 'lodash/mapValues'
 
+import { parseIsoTimeRange } from 'lib-common/api-types/daily-service-times'
 import {
   deserializeActiveQuestionnaire,
   deserializeHolidayPeriod
@@ -46,12 +47,22 @@ export async function getReservations(
           date: LocalDate.parseIso(day.date),
           children: day.children.map((child) => ({
             ...child,
-            unitOperationTime: child.unitOperationTime
-              ? {
-                  start: LocalTime.parseIso(child.unitOperationTime.start),
-                  end: LocalTime.parseIso(child.unitOperationTime.end)
-                }
-              : null,
+            reservableTimeRange:
+              child.reservableTimeRange.type === 'NORMAL'
+                ? {
+                    type: 'NORMAL',
+                    range: parseIsoTimeRange(child.reservableTimeRange.range)
+                  }
+                : {
+                    type: 'INTERMITTENT_SHIFT_CARE',
+                    placementUnitOperationTime:
+                      child.reservableTimeRange.placementUnitOperationTime !==
+                      null
+                        ? parseIsoTimeRange(
+                            child.reservableTimeRange.placementUnitOperationTime
+                          )
+                        : null
+                  },
             attendances: child.attendances.map((r) => ({
               startTime: LocalTime.parseIso(r.startTime),
               endTime: r.endTime ? LocalTime.parseIso(r.endTime) : null

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/DailyRepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/DailyRepetitionTimeInputGrid.tsx
@@ -24,12 +24,8 @@ export default React.memo(function DailyRepetitionTimeInputGrid({
   const i18n = useTranslation()
 
   const { weekDayRange, day } = useFormFields(bind)
-
-  if (weekDayRange.state === undefined) {
-    return <div>{i18n.calendar.reservationModal.noReservableDays}</div>
-  }
-
   const [firstWeekDay, lastWeekDay] = weekDayRange.state
+
   const label = (
     <Label>{`${i18n.common.datetime.weekdaysShort[firstWeekDay - 1]}-${
       i18n.common.datetime.weekdaysShort[lastWeekDay - 1]

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/RepetitionTimeInputGrid.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/RepetitionTimeInputGrid.tsx
@@ -7,6 +7,8 @@ import React from 'react'
 import { BoundForm, useFormUnion } from 'lib-common/form/hooks'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 
+import { useTranslation } from '../../localization'
+
 import DailyRepetitionTimeInputGrid from './DailyRepetitionTimeInputGrid'
 import IrregularRepetitionTimeInputGrid from './IrregularRepetitionTimeInputGrid'
 import WeeklyRepetitionTimeInputGrid from './WeeklyRepetitionTimeInputGrid'
@@ -21,6 +23,7 @@ export default React.memo(function RepetitionTimeInputGrid({
   bind,
   ...props
 }: RepetitionTimeInputGridProps) {
+  const i18n = useTranslation()
   const { branch, form } = useFormUnion(bind)
   switch (branch) {
     case 'dailyTimes':
@@ -39,6 +42,12 @@ export default React.memo(function RepetitionTimeInputGrid({
       return (
         <FixedSpaceColumn>
           <IrregularRepetitionTimeInputGrid bind={form} {...props} />
+        </FixedSpaceColumn>
+      )
+    case 'notInitialized':
+      return (
+        <FixedSpaceColumn>
+          <div>{i18n.calendar.reservationModal.noReservableDays}</div>
         </FixedSpaceColumn>
       )
   }

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -42,6 +42,11 @@ const emptyCalendarDays = emptyCalendarDaysIncludingWeekend.filter(
   (day) => !day.date.isWeekend()
 )
 
+const defaultReservableTimeRange = {
+  start: LocalTime.of(7, 0),
+  end: LocalTime.of(17, 30)
+}
+
 const emptyChild: ReservationResponseDayChild = {
   childId: 'child-1',
   requiresReservation: true,
@@ -50,28 +55,16 @@ const emptyChild: ReservationResponseDayChild = {
   absence: null,
   reservations: [],
   attendances: [],
-  unitOperationTime: {
-    start: LocalTime.MIN,
-    end: LocalTime.of(23, 59)
-  },
-  shiftCareType: 'NONE'
+  reservableTimeRange: {
+    type: 'NORMAL',
+    range: defaultReservableTimeRange
+  }
 }
 
-const buildTimeInputState = (
+const timeInputState = (
   value: string,
-  unitOperationTimeRange?: TimeRange | null
-) =>
-  unitOperationTimeRange !== undefined
-    ? {
-        value,
-        unitStartTime: unitOperationTimeRange?.start ?? null,
-        unitEndTime: unitOperationTimeRange?.end ?? null
-      }
-    : {
-        value,
-        unitStartTime: emptyChild.unitOperationTime?.start ?? null,
-        unitEndTime: emptyChild.unitOperationTime?.end ?? null
-      }
+  validRange: TimeRange = defaultReservableTimeRange
+) => ({ value, validRange })
 
 describe('resetTimes', () => {
   describe('DAILY', () => {
@@ -120,13 +113,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState(''),
-                  endTime: buildTimeInputState('')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState(''),
+                    endTime: timeInputState('')
+                  }
+                ]
+              }
             }
           }
         }
@@ -158,13 +154,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState(''),
-                  endTime: buildTimeInputState('')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState(''),
+                    endTime: timeInputState('')
+                  }
+                ]
+              }
             }
           }
         }
@@ -195,13 +194,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState(''),
-                  endTime: buildTimeInputState('')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState(''),
+                    endTime: timeInputState('')
+                  }
+                ]
+              }
             }
           }
         }
@@ -260,13 +262,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState('08:00'),
-                  endTime: buildTimeInputState('16:00')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState('08:00'),
+                    endTime: timeInputState('16:00')
+                  }
+                ]
+              }
             }
           }
         }
@@ -286,13 +291,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState(''),
-                  endTime: buildTimeInputState('')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState(''),
+                    endTime: timeInputState('')
+                  }
+                ]
+              }
             }
           }
         }
@@ -444,13 +452,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState(''),
-                  endTime: buildTimeInputState('')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState(''),
+                    endTime: timeInputState('')
+                  }
+                ]
+              }
             }
           }
         }
@@ -694,13 +705,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState('', null),
-                    endTime: buildTimeInputState('', null)
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           }
@@ -733,13 +747,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState(''),
-                  endTime: buildTimeInputState('')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState(''),
+                    endTime: timeInputState('')
+                  }
+                ]
+              }
             }
           }
         }))
@@ -770,13 +787,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState(''),
-                  endTime: buildTimeInputState('')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState(''),
+                    endTime: timeInputState('')
+                  }
+                ]
+              }
             }
           }
         }))
@@ -829,7 +849,13 @@ describe('resetTimes', () => {
           weekDay,
           day: {
             branch: 'reservation',
-            state: { branch: 'absent', state: true }
+            state: {
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'absent',
+                state: true
+              }
+            }
           }
         }))
       })
@@ -849,13 +875,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -864,13 +893,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -878,7 +910,14 @@ describe('resetTimes', () => {
             weekDay: 3,
             day: {
               branch: 'reservation',
-              state: { branch: 'absent', state: true } // this day has an absence for all children
+              state: {
+                validTimeRange: defaultReservableTimeRange,
+                // this day has an absence for all children
+                reservation: {
+                  branch: 'absent',
+                  state: true
+                }
+              }
             }
           },
           {
@@ -886,13 +925,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -901,13 +943,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           }
@@ -981,13 +1026,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -996,13 +1044,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1019,13 +1070,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1034,13 +1088,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           }
@@ -1111,13 +1168,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState('08:05'),
-                    endTime: buildTimeInputState('16:00')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState('08:05'),
+                      endTime: timeInputState('16:00')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1126,13 +1186,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState('08:10'),
-                    endTime: buildTimeInputState('16:00')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState('08:10'),
+                      endTime: timeInputState('16:00')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1141,13 +1204,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState('08:15'),
-                    endTime: buildTimeInputState('16:00')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState('08:15'),
+                      endTime: timeInputState('16:00')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1156,13 +1222,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState('08:20'),
-                    endTime: buildTimeInputState('16:00')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState('08:20'),
+                      endTime: timeInputState('16:00')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1171,13 +1240,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState('08:25'),
-                    endTime: buildTimeInputState('16:00')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState('08:25'),
+                      endTime: timeInputState('16:00')
+                    }
+                  ]
+                }
               }
             }
           }
@@ -1199,13 +1271,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1214,13 +1289,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1230,13 +1308,16 @@ describe('resetTimes', () => {
               // This day has a common reservation for all children
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState('08:15'),
-                    endTime: buildTimeInputState('16:00')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState('08:15'),
+                      endTime: timeInputState('16:00')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1245,13 +1326,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1260,13 +1344,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           }
@@ -1411,13 +1498,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1426,13 +1516,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           }
@@ -1505,13 +1598,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState(''),
-                  endTime: buildTimeInputState('')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState(''),
+                    endTime: timeInputState('')
+                  }
+                ]
+              }
             }
           }
         }))
@@ -1934,6 +2030,93 @@ describe('resetTimes', () => {
         ]
       })
     })
+
+    it('Intersection of normal reservable time ranges is used for validating reservation times', () => {
+      const calendarDays = emptyCalendarDays.map((day) => ({
+        ...day,
+        children: [
+          {
+            ...emptyChild,
+            childId: 'child-1',
+            reservableTimeRange: {
+              type: 'NORMAL' as const,
+              range: {
+                start: LocalTime.of(8, 0),
+                end: LocalTime.of(18, 0)
+              }
+            }
+          },
+          {
+            ...emptyChild,
+            childId: 'child-2',
+            reservableTimeRange: {
+              type: 'NORMAL' as const,
+              range: {
+                start: LocalTime.of(7, 0),
+                end: LocalTime.of(16, 0)
+              }
+            }
+          },
+          {
+            ...emptyChild,
+            childId: 'child-3',
+            reservableTimeRange: {
+              type: 'INTERMITTENT_SHIFT_CARE' as const,
+              // Very short operation time -> can still reserve any times
+              placementUnitOperationTime: {
+                start: LocalTime.of(10, 0),
+                end: LocalTime.of(13, 0)
+              }
+            }
+          },
+          {
+            ...emptyChild,
+            childId: 'child-4',
+            reservableTimeRange: {
+              type: 'INTERMITTENT_SHIFT_CARE' as const,
+              // Placement unit not open at all -> can still reserve any times
+              placementUnitOperationTime: null
+            }
+          }
+        ]
+      }))
+
+      // Intersection of the two normal reservable time ranges
+      const expectedValidRange = {
+        start: LocalTime.of(8, 0),
+        end: LocalTime.of(16, 0)
+      }
+
+      const dayProperties = new DayProperties(calendarDays, [])
+
+      expect(
+        resetTimes(dayProperties, undefined, {
+          repetition: 'WEEKLY',
+          selectedRange,
+          selectedChildren: ['child-1', 'child-2', 'child-3', 'child-4']
+        })
+      ).toEqual({
+        branch: 'weeklyTimes',
+        state: [1, 2, 3, 4, 5].map((weekDay) => ({
+          weekDay,
+          day: {
+            branch: 'reservation',
+            state: {
+              validTimeRange: expectedValidRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState('', expectedValidRange),
+                    endTime: timeInputState('', expectedValidRange)
+                  }
+                ]
+              }
+            }
+          }
+        }))
+      })
+    })
   })
 
   describe('IRREGULAR', () => {
@@ -1987,13 +2170,16 @@ describe('resetTimes', () => {
             ? {
                 branch: 'reservation',
                 state: {
-                  branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: buildTimeInputState(''),
-                      endTime: buildTimeInputState('')
-                    }
-                  ]
+                  validTimeRange: defaultReservableTimeRange,
+                  reservation: {
+                    branch: 'timeRanges',
+                    state: [
+                      {
+                        startTime: timeInputState(''),
+                        endTime: timeInputState('')
+                      }
+                    ]
+                  }
                 }
               }
             : { branch: 'readOnly', state: 'noChildren' }
@@ -2024,13 +2210,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState(''),
-                  endTime: buildTimeInputState('')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState(''),
+                    endTime: timeInputState('')
+                  }
+                ]
+              }
             }
           }
         }))
@@ -2060,13 +2249,16 @@ describe('resetTimes', () => {
           day: {
             branch: 'reservation',
             state: {
-              branch: 'timeRanges',
-              state: [
-                {
-                  startTime: buildTimeInputState(''),
-                  endTime: buildTimeInputState('')
-                }
-              ]
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [
+                  {
+                    startTime: timeInputState(''),
+                    endTime: timeInputState('')
+                  }
+                ]
+              }
             }
           }
         }))
@@ -2271,13 +2463,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState('08:00'),
-                    endTime: buildTimeInputState('16:00')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState('08:00'),
+                      endTime: timeInputState('16:00')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -2286,13 +2481,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -2301,13 +2499,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -2315,7 +2516,13 @@ describe('resetTimes', () => {
             date: rangeWeekDays[3],
             day: {
               branch: 'reservation',
-              state: { branch: 'absent', state: true }
+              state: {
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'absent',
+                  state: true
+                }
+              }
             }
           },
           {
@@ -2323,13 +2530,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -2342,13 +2552,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -2427,13 +2640,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -2442,13 +2658,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           }
@@ -2817,13 +3036,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -2839,13 +3061,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -2989,13 +3214,16 @@ describe('resetTimes', () => {
                   day: {
                     branch: 'reservation',
                     state: {
-                      branch: 'timeRanges',
-                      state: [
-                        {
-                          startTime: buildTimeInputState('08:15'),
-                          endTime: buildTimeInputState('13:45')
-                        }
-                      ]
+                      validTimeRange: defaultReservableTimeRange,
+                      reservation: {
+                        branch: 'timeRanges',
+                        state: [
+                          {
+                            startTime: timeInputState('08:15'),
+                            endTime: timeInputState('13:45')
+                          }
+                        ]
+                      }
                     }
                   }
                 }
@@ -3019,13 +3247,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -3034,13 +3265,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState('08:15'),
-                    endTime: buildTimeInputState('13:45')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState('08:15'),
+                      endTime: timeInputState('13:45')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -3049,13 +3283,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           }
@@ -3086,13 +3323,16 @@ describe('resetTimes', () => {
                   day: {
                     branch: 'reservation',
                     state: {
-                      branch: 'timeRanges',
-                      state: [
-                        {
-                          startTime: buildTimeInputState('08:15'),
-                          endTime: buildTimeInputState('13:45')
-                        }
-                      ]
+                      validTimeRange: defaultReservableTimeRange,
+                      reservation: {
+                        branch: 'timeRanges',
+                        state: [
+                          {
+                            startTime: timeInputState('08:15'),
+                            endTime: timeInputState('13:45')
+                          }
+                        ]
+                      }
                     }
                   }
                 }
@@ -3116,13 +3356,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -3131,13 +3374,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           },
@@ -3146,13 +3392,16 @@ describe('resetTimes', () => {
             day: {
               branch: 'reservation',
               state: {
-                branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: buildTimeInputState(''),
-                    endTime: buildTimeInputState('')
-                  }
-                ]
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [
+                    {
+                      startTime: timeInputState(''),
+                      endTime: timeInputState('')
+                    }
+                  ]
+                }
               }
             }
           }

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -76,6 +76,9 @@ const buildTimeInputState = (
 describe('resetTimes', () => {
   describe('DAILY', () => {
     it('No reservable days', () => {
+      // This doesn't happen in practice because selectedRange is limited
+      // so that at least one child has a placement. It shouldn't break nevertheless.
+
       // mo tu we th fr sa su | MO TU WE TH FR SA SU | MO TU we th fr sa su
       //          [] []       | [] [] [] [] []       | [] [] [] [] []
       const dayProperties = new DayProperties(emptyCalendarDays, [])
@@ -87,14 +90,8 @@ describe('resetTimes', () => {
           selectedChildren: ['child-1', 'child-2']
         })
       ).toEqual({
-        branch: 'dailyTimes',
-        state: {
-          weekDayRange: undefined,
-          day: {
-            branch: 'readOnly',
-            state: 'noChildren'
-          }
-        }
+        branch: 'notInitialized',
+        state: undefined
       })
     })
 

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -8,7 +8,7 @@ import uniqBy from 'lodash/uniqBy'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import {
   localDateRange,
-  localTimeRangeWithUnitTimes,
+  limitedLocalTimeRange,
   string
 } from 'lib-common/form/fields'
 import {
@@ -30,47 +30,32 @@ import {
 import {
   DailyReservationRequest,
   ReservationChild,
-  ReservationResponseDay,
-  ReservationResponseDayChild
+  ReservationResponseDay
 } from 'lib-common/generated/api-types/reservations'
 import { TimeRange } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { Repetition } from 'lib-common/reservations'
 import { UUID } from 'lib-common/types'
-import { Translations, featureFlags } from 'lib-customizations/citizen'
+import { Translations } from 'lib-customizations/citizen'
 
 export const MAX_TIME_RANGE = {
   start: LocalTime.MIN,
   end: LocalTime.MAX
 }
 
-type Dictionary<T> = Record<string, T>
-
-export const emptyTimeRange: StateOf<typeof localTimeRangeWithUnitTimes> = {
-  startTime: {
-    value: '',
-    unitStartTime: null,
-    unitEndTime: null
-  },
-  endTime: {
-    value: '',
-    unitStartTime: null,
-    unitEndTime: null
-  }
-}
-
-export const getEmptyTimeRangeWithUnitTimes = (unitTimes: TimeRange | null) => {
-  const emptyTimeInputState = createTimeInputState('', unitTimes)
+export function emptyTimeRange(
+  validRange: TimeRange
+): StateOf<typeof limitedLocalTimeRange> {
   return {
-    startTime: emptyTimeInputState,
-    endTime: emptyTimeInputState
+    startTime: { value: '', validRange },
+    endTime: { value: '', validRange }
   }
 }
 
 export const timeRanges = mapped(
   array(
-    validated(localTimeRangeWithUnitTimes, (output) =>
+    validated(limitedLocalTimeRange, (output) =>
       // 00:00 is not a valid end time
       output !== undefined && output.end.hour === 0 && output.end.minute === 0
         ? 'timeFormat'
@@ -85,9 +70,14 @@ export const timeRanges = mapped(
   }
 )
 
-export const reservation = union({
-  timeRanges,
-  absent: value<true>()
+export const reservation = object({
+  reservation: union({
+    timeRanges,
+    absent: value<true>()
+  }),
+  // `timeRanges` needs the valid time range, so it needs to be saved here
+  // because `absent` can be changed to `timeRanges`
+  validTimeRange: value<TimeRange>()
 })
 
 export const noTimes = value<'present' | 'absent' | 'notSet'>()
@@ -113,14 +103,14 @@ export const day = mapped(
       case 'readOnly':
         return { type: 'readOnly' }
       case 'reservation': {
-        switch (value.branch) {
+        switch (value.reservation.branch) {
           case 'timeRanges':
-            return value.value === undefined
+            return value.reservation.value === undefined
               ? { type: 'nothing' }
               : {
                   type: 'reservations',
-                  first: value.value[0],
-                  second: value.value[1]
+                  first: value.reservation.value[0],
+                  second: value.reservation.value[1]
                 }
           case 'absent':
             return { type: 'absent' }
@@ -348,14 +338,6 @@ export function resetTimes(
     const holidayPeriodState =
       dayProperties.holidayPeriodStateForRange(selectedRange)
 
-    const unitTimesInRange = calendarDaysInRange.flatMap((d) =>
-      d.children
-        .filter((c) => selectedChildren.includes(c.childId))
-        .map(getUnitTimeForDay)
-    )
-
-    const unitOperationTimeRange = getMinimalOverlappingRange(unitTimesInRange)
-
     return {
       branch: 'dailyTimes',
       state: {
@@ -363,12 +345,7 @@ export function resetTimes(
           includedWeekDays[0],
           includedWeekDays[includedWeekDays.length - 1]
         ],
-        day: resetDay(
-          holidayPeriodState,
-          calendarDaysInRange,
-          selectedChildren,
-          unitOperationTimeRange
-        )
+        day: resetDay(holidayPeriodState, calendarDaysInRange, selectedChildren)
       }
     }
   } else if (repetition === 'WEEKLY') {
@@ -379,10 +356,6 @@ export function resetTimes(
     const holidayPeriodState =
       dayProperties.holidayPeriodStateForRange(selectedRange)
 
-    const unitTimeOverlapByDayOfWeek = getCommonUnitTimeRangesByDayOfWeek(
-      calendarDaysInRange,
-      selectedChildren
-    )
     const weeklyTimes = includedWeekDays.map(
       (dayOfWeek): StateOf<typeof weekDay> => {
         const dayOfWeekDays = groupedDays[dayOfWeek]
@@ -397,15 +370,12 @@ export function resetTimes(
           dayOfWeekDays.some((d) => d.isEqual(date))
         )
 
-        const weekDayUnitTimeRange = unitTimeOverlapByDayOfWeek[dayOfWeek]
-
         return {
           weekDay: dayOfWeek,
           day: resetDay(
             holidayPeriodState,
             relevantCalendarDays,
-            selectedChildren,
-            weekDayUnitTimeRange
+            selectedChildren
           )
         }
       }
@@ -430,20 +400,12 @@ export function resetTimes(
           if (existing) return existing
         }
 
-        const dailyUnitTimes = calendarDay.children
-          .filter((c) => selectedChildren.includes(c.childId))
-          .map(getUnitTimeForDay)
-
-        const unitOperationTimeRange =
-          getMinimalOverlappingRange(dailyUnitTimes)
-
         return {
           date: rangeDate,
           day: resetDay(
             dayProperties.holidayPeriodStateForDate(rangeDate),
             [calendarDay],
-            selectedChildren,
-            unitOperationTimeRange
+            selectedChildren
           )
         }
       }
@@ -460,8 +422,7 @@ export function resetTimes(
 export function resetDay(
   holidayPeriodState: 'open' | 'closed' | undefined,
   calendarDays: ReservationResponseDay[],
-  selectedChildren: UUID[],
-  unitOperationTimeRange: TimeRange | null
+  selectedChildren: UUID[]
 ): StateOf<typeof day> {
   const reservationNotRequired = reservationNotRequiredForAnyChild(
     calendarDays,
@@ -492,13 +453,31 @@ export function resetDay(
     }
   }
 
+  const validTimeRanges = calendarDays.flatMap((d) =>
+    d.children
+      .filter((c) => selectedChildren.includes(c.childId))
+      .map((c) =>
+        // Any times can be reserved for intermittent shift care children
+        c.reservableTimeRange.type === 'INTERMITTENT_SHIFT_CARE'
+          ? MAX_TIME_RANGE
+          : c.reservableTimeRange.range
+      )
+  )
+  const validTimeRange = timeRangeIntersection(validTimeRanges)
+
   if (allChildrenAreAbsent(calendarDays, selectedChildren)) {
     return holidayPeriodState === 'open' ||
       (holidayPeriodState === undefined && reservationNotRequired)
       ? { branch: 'reservationNoTimes', state: 'absent' }
       : holidayPeriodState === 'closed'
       ? { branch: 'readOnly', state: 'reservationClosed' }
-      : { branch: 'reservation', state: { branch: 'absent', state: true } }
+      : {
+          branch: 'reservation',
+          state: {
+            validTimeRange,
+            reservation: { branch: 'absent', state: true }
+          }
+        }
   }
 
   if (hasReservationsForEveryChild(calendarDays, selectedChildren)) {
@@ -511,11 +490,11 @@ export function resetDay(
       return {
         branch: 'reservation',
         state: {
-          branch: 'timeRanges',
-          state: bindUnboundedTimeRanges(
-            commonTimeRanges,
-            unitOperationTimeRange
-          )
+          validTimeRange,
+          reservation: {
+            branch: 'timeRanges',
+            state: bindUnboundedTimeRanges(commonTimeRanges, validTimeRange)
+          }
         }
       }
     }
@@ -530,7 +509,21 @@ export function resetDay(
 
   return holidayPeriodState === 'open' || reservationNotRequired
     ? { branch: 'reservationNoTimes', state: 'notSet' }
-    : getEmptyDayWithUnitTimes(unitOperationTimeRange)
+    : {
+        branch: 'reservation',
+        state: {
+          validTimeRange,
+          reservation: {
+            branch: 'timeRanges',
+            state: [
+              {
+                startTime: { value: '', validRange: validTimeRange },
+                endTime: { value: '', validRange: validTimeRange }
+              }
+            ]
+          }
+        }
+      }
 }
 
 const holidayWithNoChildrenInShiftCare = (
@@ -617,11 +610,11 @@ const reservationNotRequiredForAnyChild = (
 
 const bindUnboundedTimeRanges = (
   ranges: TimeRange[],
-  unitOperationTimeRange: TimeRange | null
-): StateOf<typeof localTimeRangeWithUnitTimes>[] => {
+  validRange: TimeRange
+): StateOf<typeof limitedLocalTimeRange>[] => {
   const formatted = ranges.map(({ start, end }) => ({
-    startTime: createTimeInputState(start.format(), unitOperationTimeRange),
-    endTime: createTimeInputState(end.format(), unitOperationTimeRange)
+    startTime: { value: start.format(), validRange },
+    endTime: { value: end.format(), validRange }
   }))
 
   if (ranges.length === 1 || ranges.length === 2) {
@@ -658,81 +651,15 @@ const getCommonTimeRanges = (
 
 type HolidayPeriodState = 'open' | 'closed' | undefined
 
-const getMinimalOverlappingRange = (
-  ranges: (TimeRange | null)[]
-): TimeRange | null => {
-  let minValue: { start?: LocalTime; end?: LocalTime } | null = {}
-  ranges.forEach((r) => {
-    if (minValue === null) return
-    const { start, end } = minValue
-    if (r === null) {
-      minValue = null
-    } else {
-      if (!start || start.isBefore(r.start)) {
-        minValue.start = r.start
-      }
-      if (!end || end.isAfter(r.end)) {
-        minValue.end = r.end
-      }
-    }
-  })
-
-  return minValue && minValue.start && minValue.end
-    ? { start: minValue.start, end: minValue.end }
-    : null
+function timeRangeIntersection(ranges: TimeRange[]): TimeRange {
+  return ranges.reduce(
+    (acc, range) => ({
+      start: range.start.isAfter(acc.start) ? range.start : acc.start,
+      end: range.end.isBefore(acc.end) ? range.end : acc.end
+    }),
+    MAX_TIME_RANGE
+  )
 }
-
-const getCommonUnitTimeRangesByDayOfWeek = (
-  dayInRange: ReservationResponseDay[],
-  selectedChildIds: string[]
-) => {
-  const weeklyTimes: Dictionary<TimeRange | null> = {}
-
-  dayInRange.forEach((day) => {
-    const dayOfWeek = day.date.getIsoDayOfWeek()
-    const allChildUnitTimes = day.children
-      .filter((c) => selectedChildIds.includes(c.childId))
-      .map(getUnitTimeForDay)
-
-    const dailyTime = weeklyTimes[dayOfWeek]
-    const dailyMinimum = getMinimalOverlappingRange(allChildUnitTimes)
-
-    if (!dailyMinimum || dailyTime === undefined) {
-      weeklyTimes[dayOfWeek] = dailyMinimum
-    } else if (dailyTime && dailyMinimum) {
-      weeklyTimes[dayOfWeek] = getMinimalOverlappingRange([
-        dailyTime,
-        dailyMinimum
-      ])
-    }
-  })
-
-  return weeklyTimes
-}
-
-const getEmptyDayWithUnitTimes = (
-  unitOperationTimeRange: TimeRange | null
-): StateOf<typeof day> => ({
-  branch: 'reservation',
-  state: {
-    branch: 'timeRanges',
-    state: [
-      {
-        startTime: createTimeInputState('', unitOperationTimeRange),
-        endTime: createTimeInputState('', unitOperationTimeRange)
-      }
-    ]
-  }
-})
-
-const createTimeInputState = (
-  value: string,
-  unitOperationTimeRange: TimeRange | null
-) => ({
-  value,
-  unitStartTime: unitOperationTimeRange?.start ?? null,
-  unitEndTime: unitOperationTimeRange?.end ?? null
-})
 
 export class DayProperties {
   private readonly reservableDaysByChild: Record<UUID, Set<string> | undefined>
@@ -792,13 +719,4 @@ export class DayProperties {
       holidayPeriod.period.contains(dateRange)
     )?.state
   }
-}
-
-export function getUnitTimeForDay(
-  d: ReservationResponseDayChild
-): TimeRange | null {
-  return featureFlags.experimental?.intermittentShiftCare &&
-    d.shiftCareType === 'INTERMITTENT'
-    ? MAX_TIME_RANGE
-    : d.unitOperationTime
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -605,42 +605,30 @@ class DayView extends Element {
 }
 
 class DayViewEditor extends Element {
-  #saveButton = this.findByDataQa('save')
+  saveButton = this.findByDataQa('save')
 
-  #childSection(childId: UUID) {
-    return this.findByDataQa(`child-${childId}`)
+  childSection(childId: UUID) {
+    return new DayViewEditorChildSection(this.findByDataQa(`child-${childId}`))
   }
+}
 
-  async addSecondReservation(
-    childId: UUID,
-    startTime: string,
-    endTime: string
-  ) {
-    const child = this.#childSection(childId)
-    await child.findByDataQa('edit-reservation-add-res-button').click()
-    await this.fillReservationTimes(childId, startTime, endTime, 1)
-  }
-
-  async fillReservationTimes(
-    childId: UUID,
-    startTime: string,
-    endTime: string,
-    reservationIndex = 0
-  ) {
-    const child = this.#childSection(childId)
-    await new TextInput(
-      child.findByDataQa(`edit-reservation-time-${reservationIndex}-start`)
-    ).fill(startTime)
-    const endInput = new TextInput(
-      child.findByDataQa(`edit-reservation-time-${reservationIndex}-end`)
-    )
-    await endInput.fill(endTime)
-    await endInput.press('Tab')
-  }
-
-  async save() {
-    await this.#saveButton.click()
-  }
+class DayViewEditorChildSection extends Element {
+  absentButton = this.findByDataQa('edit-reservation-absent-button')
+  addSecondReservationButton = this.findByDataQa(
+    'edit-reservation-add-res-button'
+  )
+  reservationStart = new TextInput(
+    this.findByDataQa('edit-reservation-time-0-start')
+  )
+  reservationEnd = new TextInput(
+    this.findByDataQa('edit-reservation-time-0-end')
+  )
+  reservation2Start = new TextInput(
+    this.findByDataQa('edit-reservation-time-1-start')
+  )
+  reservation2End = new TextInput(
+    this.findByDataQa('edit-reservation-time-1-end')
+  )
 }
 
 class HolidayModal extends Element {

--- a/frontend/src/e2e-test/specs/0_citizen/feature-flag-citizen-reservations-intermittent-shif-care.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/feature-flag-citizen-reservations-intermittent-shif-care.spec.ts
@@ -199,17 +199,13 @@ describe.each(e)(
       await dayView.assertNoReservation(child.id)
 
       const editor = await dayView.edit()
-      await editor.fillReservationTimes(
-        child.id,
-        reservation1.startTime,
-        reservation1.endTime
-      )
-      await editor.addSecondReservation(
-        child.id,
-        reservation2.startTime,
-        reservation2.endTime
-      )
-      await editor.save()
+      const childSection = editor.childSection(child.id)
+      await childSection.reservationStart.fill(reservation1.startTime)
+      await childSection.reservationEnd.fill(reservation1.endTime)
+      await childSection.addSecondReservationButton.click()
+      await childSection.reservation2Start.fill(reservation2.startTime)
+      await childSection.reservation2End.fill(reservation2.endTime)
+      await editor.saveButton.click()
 
       await dayView.assertReservations(
         child.id,

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -271,6 +271,10 @@ export class TextInput extends Element {
     await this.locator.fill(text)
   }
 
+  async blur(): Promise<void> {
+    await this.locator.blur()
+  }
+
   async clear(): Promise<void> {
     await this.locator.fill('')
   }

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -10,7 +10,6 @@ import LocalDate from '../../local-date'
 import LocalTime from '../../local-time'
 import { AbsenceType } from './daycare'
 import { PlacementType } from './placement'
-import { ShiftCareType } from './serviceneed'
 import { TimeRange } from './shared'
 import { UUID } from '../../types'
 
@@ -85,6 +84,30 @@ export interface OpenTimeRange {
   startTime: LocalTime
 }
 
+export namespace ReservableTimeRange {
+  /**
+  * Generated from fi.espoo.evaka.reservations.ReservableTimeRange.IntermittentShiftCare
+  */
+  export interface IntermittentShiftCare {
+    type: 'INTERMITTENT_SHIFT_CARE'
+    placementUnitOperationTime: TimeRange | null
+  }
+  
+  /**
+  * Generated from fi.espoo.evaka.reservations.ReservableTimeRange.Normal
+  */
+  export interface Normal {
+    type: 'NORMAL'
+    range: TimeRange
+  }
+}
+
+/**
+* Generated from fi.espoo.evaka.reservations.ReservableTimeRange
+*/
+export type ReservableTimeRange = ReservableTimeRange.IntermittentShiftCare | ReservableTimeRange.Normal
+
+
 export namespace Reservation {
   /**
   * Generated from fi.espoo.evaka.reservations.Reservation.NoTimes
@@ -140,10 +163,9 @@ export interface ReservationResponseDayChild {
   childId: UUID
   contractDays: boolean
   requiresReservation: boolean
+  reservableTimeRange: ReservableTimeRange
   reservations: Reservation[]
   shiftCare: boolean
-  shiftCareType: ShiftCareType
-  unitOperationTime: TimeRange | null
 }
 
 /**

--- a/frontend/src/lib-components/atoms/form/TimeInput.tsx
+++ b/frontend/src/lib-components/atoms/form/TimeInput.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
-import { localTimeWithUnitTimes } from 'lib-common/form/fields'
+import { limitedLocalTime } from 'lib-common/form/fields'
 import { BoundFormState } from 'lib-common/form/hooks'
 import { StateOf } from 'lib-common/form/types'
 import { autocomplete } from 'lib-common/time'
@@ -126,7 +126,7 @@ export const TimeInputF = React.memo(function TimeInputF({
 
 export interface TimeInputFWithUnitTimesProps
   extends Omit<TimeInputProps, 'value' | 'onChange'> {
-  bind: BoundFormState<StateOf<typeof localTimeWithUnitTimes>>
+  bind: BoundFormState<StateOf<typeof limitedLocalTime>>
 }
 
 export const TimeInputFWithUnitTimes = React.memo(

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -401,6 +401,9 @@ const en: Translations = {
         </>
       ),
       ok: 'OK'
+    },
+    validationErrors: {
+      range: 'Outside opening hours'
     }
   },
   messages: {
@@ -2113,7 +2116,6 @@ const en: Translations = {
     emailsDoNotMatch: 'The emails do not match',
     httpUrl: 'Valid url format is https://example.com',
     unselectableDate: 'Invalid date',
-    outsideUnitOperationTime: 'Outside opening hours',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -398,6 +398,9 @@ export default {
         </>
       ),
       ok: 'Selvä!'
+    },
+    validationErrors: {
+      range: 'Yksikön aukiolo ylittyy'
     }
   },
   messages: {
@@ -2328,7 +2331,6 @@ export default {
     emailsDoNotMatch: 'Sähköpostiosoitteet eivät täsmää',
     httpUrl: 'Anna muodossa https://example.com',
     unselectableDate: 'Päivä ei ole sallittu',
-    outsideUnitOperationTime: 'Yksikön aukiolo ylittyy',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -397,6 +397,9 @@ const sv: Translations = {
         </>
       ),
       ok: 'Klart!'
+    },
+    validationErrors: {
+      range: 'Utanför enhetens öppettid'
     }
   },
   messages: {
@@ -2347,7 +2350,6 @@ const sv: Translations = {
     emailsDoNotMatch: 'E-postadresserna är olika',
     httpUrl: 'Ange i formen https://example.com',
     unselectableDate: 'Ogiltigt datum',
-    outsideUnitOperationTime: 'Utanför enhetens öppettid',
     ...components.datePicker.validationErrors
   },
   placement: {


### PR DESCRIPTION
#### Summary

Use the type system to differentiate between two cases:

1. The child is in "normal daycare", and can make reservations within the placement unit's opening hours
2. The child is in intermittent shift care and can make any reservations with no limits.

This, along with some other frontend typing changes, fixes various bugs in the time range validation of citizen reservations.

Other changes:
- Better naming (naming is hard)
- Use unit's operation times instead of both operation times and days in the reservation backend