### PR TITLE
Show an error and prevent submitting arrival time if departure is mis…

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -553,6 +553,9 @@ export class UnitOccupanciesSection extends Element {
 }
 
 export class StaffAttendanceDetailsModal extends Element {
+  openAttendanceWarning = this.findByDataQa(`open-attendance-warning`)
+  arrivalTimeInputInfo = this.findByDataQa('arrival-time-input-info')
+
   async setGroup(row: number, groupId: UUID) {
     await new Select(
       this.findAllByDataQa('group-indicator')

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
@@ -248,6 +248,18 @@ function StaffAttendanceDetailsModal<
     [gaplessAttendances]
   )
 
+  const arrivalWithoutDeparture = useMemo(() => {
+    const arrivalWithoutDeparture = gaplessAttendances.find(
+      ({ arrived, departed }) =>
+        !arrived.toLocalDate().isEqual(LocalDate.todayInHelsinkiTz()) &&
+        !departed
+    )
+
+    return arrivalWithoutDeparture
+      ? arrivalWithoutDeparture.arrived.format()
+      : undefined
+  }, [gaplessAttendances])
+
   const diffPlannedTotalMinutes = useMemo(
     () =>
       totalMinutes === 'incalculable'
@@ -355,6 +367,26 @@ function StaffAttendanceDetailsModal<
         ) : null}
 
         <H3>{i18n.unit.staffAttendance.dailyAttendances}</H3>
+        {!!arrivalWithoutDeparture && (
+          <FullGridWidth>
+            <FixedSpaceRow
+              justifyContent="left"
+              alignItems="center"
+              spacing="s"
+            >
+              <FontAwesomeIcon
+                icon={faExclamationTriangle}
+                color={colors.status.warning}
+              />
+              <div data-qa="open-attendance-warning">
+                {i18n.unit.staffAttendance.openAttendanceWarning(
+                  arrivalWithoutDeparture
+                )}
+              </div>
+            </FixedSpaceRow>
+            <Gap size="s" />
+          </FullGridWidth>
+        )}
         <ListGrid rowGap="s" labelWidth="auto">
           {editState.map(({ arrived, departed, type, groupId }, index) => {
             const gap = getGapBefore(index)

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -697,7 +697,6 @@ export const staffAttendanceValidator =
   ): [undefined | StaffAttendanceUpsert[], ValidationError[]] => {
     const body: (StaffAttendanceUpsert | undefined)[] = []
     const errors: ValidationError[] = []
-
     for (let i = 0; i < state.length; i++) {
       const item = state[i]
       const existing = config.attendances.find((a) => a.id === item.id)
@@ -805,7 +804,6 @@ export const externalAttendanceValidator =
 
     return [undefined, errors]
   }
-
 const validateArrived = (
   config: ValidatorConfig,
   item: EditedAttendance,
@@ -819,6 +817,15 @@ const validateArrived = (
 
   const isOvernightAttendance =
     existing && existing.arrived.toLocalDate().isBefore(config.date)
+
+  // If there is an open attendance (arrival without departure), check that only departure can be set
+  if (
+    isFirstAttendance &&
+    isOvernightAttendance &&
+    existing.departed === null
+  ) {
+    if (!item.departed || item.arrived) return [undefined, 'openAttendance']
+  }
 
   if (!item.arrived && isFirstAttendance && isOvernightAttendance) {
     return [existing.arrived, undefined]
@@ -839,7 +846,6 @@ const validateArrived = (
 
   return [arrived, undefined]
 }
-
 const validateDeparted = (
   config: ValidatorConfig,
   item: EditedAttendance,

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/attendanceEditState.spec.ts
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/attendanceEditState.spec.ts
@@ -170,7 +170,7 @@ describe('validateEditState', () => {
     expect(errors).toEqual([{ arrived: 'required' }])
   })
 
-  it('does not require the arrived timestamp for the first entry for an ongoing overnight attendance', () => {
+  it('does not allow the arrived timestamp for the first entry for an ongoing overnight attendance', () => {
     const validate = staffAttendanceValidator(
       getConfig([
         {
@@ -191,16 +191,8 @@ describe('validateEditState', () => {
         departed: ''
       }
     ])
-    expect(body).toEqual([
-      {
-        id: 'id1',
-        groupId: 'group1',
-        arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
-        departed: null,
-        type: 'PRESENT'
-      }
-    ])
-    expect(errors).toEqual([{}])
+    expect(body).toEqual(undefined)
+    expect(errors).toEqual([{ arrived: 'openAttendance' }])
   })
   it('requires departed timestamp for all except the last entry', () => {
     const validate = staffAttendanceValidator(getConfig([]))
@@ -256,7 +248,7 @@ describe('validateEditState', () => {
         id: 'id1',
         type: 'PRESENT',
         groupId: 'group1',
-        arrived: '08:00',
+        arrived: '',
         departed: '07:00'
       },
       {
@@ -267,8 +259,23 @@ describe('validateEditState', () => {
         departed: '09:00'
       }
     ])
-    expect(body).toBeUndefined()
-    expect(errors).toEqual([{ departed: 'timeFormat' }, {}])
+    expect(body).toEqual([
+      {
+        id: 'id1',
+        type: 'PRESENT',
+        groupId: 'group1',
+        arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
+        departed: HelsinkiDateTime.fromLocal(today, LocalTime.of(7, 0))
+      },
+      {
+        id: null,
+        type: 'PRESENT',
+        groupId: 'group1',
+        arrived: HelsinkiDateTime.fromLocal(today, LocalTime.of(10, 0)),
+        departed: HelsinkiDateTime.fromLocal(tomorrow, LocalTime.of(9, 0))
+      }
+    ])
+    expect(errors).toEqual([{}, {}])
   })
 
   it('requires a value only for arrival if editing a day that IS today', () => {

--- a/frontend/src/lib-common/form-validation.ts
+++ b/frontend/src/lib-common/form-validation.ts
@@ -31,6 +31,7 @@ export type ErrorKey =
   | 'preferredStartDate'
   | 'emailsDoNotMatch'
   | 'httpUrl'
+  | 'openAttendance'
 
 export const required = (
   val: unknown,

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2116,6 +2116,8 @@ const en: Translations = {
     emailsDoNotMatch: 'The emails do not match',
     httpUrl: 'Valid url format is https://example.com',
     unselectableDate: 'Invalid date',
+    outsideUnitOperationTime: 'Outside opening hours',
+    openAttendance: 'Open attendance',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2331,6 +2331,8 @@ export default {
     emailsDoNotMatch: 'Sähköpostiosoitteet eivät täsmää',
     httpUrl: 'Anna muodossa https://example.com',
     unselectableDate: 'Päivä ei ole sallittu',
+    outsideUnitOperationTime: 'Yksikön aukiolo ylittyy',
+    openAttendance: 'Avoin kirjaus',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2350,6 +2350,8 @@ const sv: Translations = {
     emailsDoNotMatch: 'E-postadresserna är olika',
     httpUrl: 'Ange i formen https://example.com',
     unselectableDate: 'Ogiltigt datum',
+    outsideUnitOperationTime: 'Utanför enhetens öppettid',
+    openAttendance: 'Öppen närvaro',
     ...components.datePicker.validationErrors
   },
   placement: {

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2359,6 +2359,7 @@ export const fi = {
       incalculableSum:
         'Tunteja ei voi laskea, koska päivän kirjauksista puuttuu viimeinen lähtöaika.',
       gapWarning: (gapRange: string) => `Kirjaus puuttuu välillä ${gapRange}`,
+      openAttendanceWarning: (arrival: string) => `Avoin kirjaus ${arrival}`,
       personCount: 'Läsnäolleiden yhteismäärä',
       personCountAbbr: 'hlö',
       unlinkOvernight: 'Erota yön yli menevä läsnäolo',
@@ -4210,6 +4211,7 @@ export const fi = {
     httpUrl: 'Anna muodossa https://example.com',
     unselectableDate: 'Päivä ei ole sallittu',
     guardianMustBeHeard: 'Huoltajaa on kuultava',
+    openAttendance: 'Avoin kirjaus',
     ...components.datePicker.validationErrors
   },
   holidayPeriods: {


### PR DESCRIPTION
Prevent submitting an arrival time if there is an open arrival in the past

<img width="714" alt="Screenshot 2023-08-09 at 12 59 35" src="https://github.com/espoon-voltti/evaka/assets/158767/631989d1-63e8-4cc9-9896-170d879a9967">

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

