### PR TITLE
Citizen email notification settings, part 2

### DIFF
--- a/frontend/src/citizen-frontend/personal-details/NotificationSettingsSection.tsx
+++ b/frontend/src/citizen-frontend/personal-details/NotificationSettingsSection.tsx
@@ -15,6 +15,7 @@ import MutateButton from 'lib-components/atoms/buttons/MutateButton'
 import { CheckboxF } from 'lib-components/atoms/form/Checkbox'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
+import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 import { H2, P, Strong } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
@@ -103,6 +104,17 @@ export default React.memo(
             data-qa="outdated-income"
           />
         </ExpandingInfo>
+        {outdatedIncome.state === false ? (
+          <>
+            <Gap size="s" />
+            <AlertBox
+              noMargin
+              message={
+                t.personalDetails.notificationsSection.outdatedIncomeWarning
+              }
+            />
+          </>
+        ) : null}
         <Gap size="s" />
         <CheckboxF
           bind={calendarEvent}

--- a/frontend/src/citizen-frontend/personal-details/NotificationSettingsSection.tsx
+++ b/frontend/src/citizen-frontend/personal-details/NotificationSettingsSection.tsx
@@ -27,7 +27,9 @@ const notificationSettingsForm = object({
   bulletin: boolean(),
   outdatedIncome: boolean(),
   calendarEvent: boolean(),
+  decision: boolean(),
   document: boolean(),
+  informalDocument: boolean(),
   missingAttendanceReservation: boolean()
 })
 
@@ -52,7 +54,9 @@ export default React.memo(
       bulletin,
       outdatedIncome,
       calendarEvent,
+      decision,
       document,
+      informalDocument,
       missingAttendanceReservation
     } = useFormFields(form)
 
@@ -101,10 +105,24 @@ export default React.memo(
         />
         <Gap size="s" />
         <CheckboxF
+          bind={decision}
+          label={t.personalDetails.notificationsSection.decision}
+          disabled={!editing}
+          data-qa="decision"
+        />
+        <Gap size="s" />
+        <CheckboxF
           bind={document}
           label={t.personalDetails.notificationsSection.document}
           disabled={!editing}
           data-qa="document"
+        />
+        <Gap size="s" />
+        <CheckboxF
+          bind={informalDocument}
+          label={t.personalDetails.notificationsSection.informalDocument}
+          disabled={!editing}
+          data-qa="informal-document"
         />
         <Gap size="s" />
         <CheckboxF

--- a/frontend/src/citizen-frontend/personal-details/NotificationSettingsSection.tsx
+++ b/frontend/src/citizen-frontend/personal-details/NotificationSettingsSection.tsx
@@ -14,6 +14,7 @@ import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import MutateButton from 'lib-components/atoms/buttons/MutateButton'
 import { CheckboxF } from 'lib-components/atoms/form/Checkbox'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
+import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 import { H2, P, Strong } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
@@ -90,12 +91,18 @@ export default React.memo(
           data-qa="bulletin"
         />
         <Gap size="s" />
-        <CheckboxF
-          bind={outdatedIncome}
-          label={t.personalDetails.notificationsSection.outdatedIncome}
-          disabled={!editing}
-          data-qa="outdated-income"
-        />
+        <ExpandingInfo
+          info={t.personalDetails.notificationsSection.outdatedIncomeInfo}
+          ariaLabel={t.common.openExpandingInfo}
+          closeLabel={t.common.close}
+        >
+          <CheckboxF
+            bind={outdatedIncome}
+            label={t.personalDetails.notificationsSection.outdatedIncome}
+            disabled={!editing}
+            data-qa="outdated-income"
+          />
+        </ExpandingInfo>
         <Gap size="s" />
         <CheckboxF
           bind={calendarEvent}
@@ -111,28 +118,50 @@ export default React.memo(
           data-qa="decision"
         />
         <Gap size="s" />
-        <CheckboxF
-          bind={document}
-          label={t.personalDetails.notificationsSection.document}
-          disabled={!editing}
-          data-qa="document"
-        />
+        <ExpandingInfo
+          info={t.personalDetails.notificationsSection.documentInfo}
+          ariaLabel={t.common.openExpandingInfo}
+          closeLabel={t.common.close}
+        >
+          <CheckboxF
+            bind={document}
+            label={t.personalDetails.notificationsSection.document}
+            disabled={!editing}
+            data-qa="document"
+          />
+        </ExpandingInfo>
         <Gap size="s" />
-        <CheckboxF
-          bind={informalDocument}
-          label={t.personalDetails.notificationsSection.informalDocument}
-          disabled={!editing}
-          data-qa="informal-document"
-        />
+        <ExpandingInfo
+          info={t.personalDetails.notificationsSection.informalDocumentInfo}
+          ariaLabel={t.common.openExpandingInfo}
+          closeLabel={t.common.close}
+        >
+          <CheckboxF
+            bind={informalDocument}
+            label={t.personalDetails.notificationsSection.informalDocument}
+            disabled={!editing}
+            data-qa="informal-document"
+          />
+        </ExpandingInfo>
         <Gap size="s" />
-        <CheckboxF
-          bind={missingAttendanceReservation}
-          label={
-            t.personalDetails.notificationsSection.missingAttendanceReservation
+        <ExpandingInfo
+          info={
+            t.personalDetails.notificationsSection
+              .missingAttendanceReservationInfo
           }
-          disabled={!editing}
-          data-qa="missing-attendance-reservation"
-        />
+          ariaLabel={t.common.openExpandingInfo}
+          closeLabel={t.common.close}
+        >
+          <CheckboxF
+            bind={missingAttendanceReservation}
+            label={
+              t.personalDetails.notificationsSection
+                .missingAttendanceReservation
+            }
+            disabled={!editing}
+            data-qa="missing-attendance-reservation"
+          />
+        </ExpandingInfo>
         <Gap size="s" />
         {editing ? (
           <FixedSpaceRow justifyContent="flex-end">

--- a/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
@@ -107,7 +107,9 @@ export class CitizenNotificationSettingsSection extends Element {
     bulletin: new Checkbox(this.findByDataQa('bulletin')),
     outdatedIncome: new Checkbox(this.findByDataQa('outdated-income')),
     calendarEvent: new Checkbox(this.findByDataQa('calendar-event')),
+    decision: new Checkbox(this.findByDataQa('decision')),
     document: new Checkbox(this.findByDataQa('document')),
+    informalDocument: new Checkbox(this.findByDataQa('informal-document')),
     missingAttendanceReservation: new Checkbox(
       this.findByDataQa('missing-attendance-reservation')
     )

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-personal-details.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-personal-details.spec.ts
@@ -111,21 +111,19 @@ describe('Citizen notification settings', () => {
     await section.assertAllChecked(true)
     await section.startEditing.click()
     await section.checkboxes.message.uncheck()
-    await section.checkboxes.document.uncheck()
-    await section.checkboxes.missingAttendanceReservation.uncheck()
+    await section.checkboxes.outdatedIncome.uncheck()
+    await section.checkboxes.decision.uncheck()
+    await section.checkboxes.informalDocument.uncheck()
     await section.save.click()
     await section.assertEditable(false)
 
-    // Guard against new settings in the future
-    expect(Object.keys(section.checkboxes).length).toEqual(6)
-
     await section.checkboxes.message.waitUntilChecked(false)
     await section.checkboxes.bulletin.waitUntilChecked(true)
-    await section.checkboxes.outdatedIncome.waitUntilChecked(true)
+    await section.checkboxes.outdatedIncome.waitUntilChecked(false)
     await section.checkboxes.calendarEvent.waitUntilChecked(true)
-    await section.checkboxes.document.waitUntilChecked(false)
-    await section.checkboxes.missingAttendanceReservation.waitUntilChecked(
-      false
-    )
+    await section.checkboxes.decision.waitUntilChecked(false)
+    await section.checkboxes.document.waitUntilChecked(true)
+    await section.checkboxes.informalDocument.waitUntilChecked(false)
+    await section.checkboxes.missingAttendanceReservation.waitUntilChecked(true)
   })
 })

--- a/frontend/src/lib-common/generated/api-types/pis.ts
+++ b/frontend/src/lib-common/generated/api-types/pis.ts
@@ -76,7 +76,9 @@ export interface DisableSsnRequest {
 export interface EmailNotificationSettings {
   bulletin: boolean
   calendarEvent: boolean
+  decision: boolean
   document: boolean
+  informalDocument: boolean
   message: boolean
   missingAttendanceReservation: boolean
   outdatedIncome: boolean

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1652,18 +1652,26 @@ const en: Translations = {
     },
     notificationsSection: {
       title: 'Sähköposti-ilmoitukset',
-      info: 'Voit saada ilmoituksia sähköpostiin seuraavista aiheista. Asetuksia pystyy muokkaamaan muokkaus-nappia painamalla.',
+      info: 'Voit saada ilmoituksia sähköpostiin seuraavista aiheista. Asetuksia pystyy muokkaamaan muokkaa-nappia painamalla.',
       subtitle: 'Sähköpostiin lähetettävät ilmoitukset',
       message: 'eVakaan saapuneista henkilökunnan lähettämistä viesteistä',
       bulletin: 'eVakaan saapuneista yleisistä tiedotteista',
-      outdatedIncome: 'Muistutukset puuttuvista tulotiedoista',
+      outdatedIncome: 'Muistutukset tulotietojen päivittämisestä',
+      outdatedIncomeInfo:
+        'Mikäli ette maksa korkeinta varhaiskasvatusmaksua, on tulotiedot päivitettävä säännöllisesti. Jos tulotiedot puuttuvat tai vanhenevat, merkitään varhaiskasvatuksesta maksettavaksi korkein maksu.',
       calendarEvent:
         'Muistutukset kalenteriin merkityistä uusista tapahtumista',
       decision: 'Saapuneista päätöksistä',
       document: 'Uusista asiakirjoista',
+      documentInfo:
+        'Asiakirjoilla tarkoitetaan virallisia asiakirjoja, jotka eivät ole päätöksiä. Tällaisia ovat esimerkiksi varhaiskasvatussuunnitelmat ja pedagogiset arviot.',
       informalDocument: 'Muista lapsen arkeen liittyvistä dokumenteista',
+      informalDocumentInfo:
+        'Muut lapsen arkeen liittyvät dokumentit voivat olla esimerkiksi kuvia lapsen tekemistä piirustuksista.',
       missingAttendanceReservation:
-        'Muistutukset puuttuvista läsnäoloilmoituksista'
+        'Muistutukset puuttuvista läsnäoloilmoituksista',
+      missingAttendanceReservationInfo:
+        'Muistutus lähetetään ennen läsnäoloilmoitusten määräaikaa, mikäli jollakin lapsistasi puuttuu läsnäoloilmoitus tai poissaolomerkintä seuraavalta kahdelta viikolta.'
     }
   },
   income: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1659,7 +1659,9 @@ const en: Translations = {
       outdatedIncome: 'Muistutukset puuttuvista tulotiedoista',
       calendarEvent:
         'Muistutukset kalenteriin merkityistä uusista tapahtumista',
-      document: 'Saapuneista dokumenteista',
+      decision: 'Saapuneista päätöksistä',
+      document: 'Uusista asiakirjoista',
+      informalDocument: 'Muista lapsen arkeen liittyvistä dokumenteista',
       missingAttendanceReservation:
         'Muistutukset puuttuvista läsnäoloilmoituksista'
     }

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1651,27 +1651,26 @@ const en: Translations = {
         'Email is required to receive notifications about new messages, attendance reservations and other matters concerning your child’s early childhood education.'
     },
     notificationsSection: {
-      title: 'Sähköposti-ilmoitukset',
-      info: 'Voit saada ilmoituksia sähköpostiin seuraavista aiheista. Asetuksia pystyy muokkaamaan muokkaa-nappia painamalla.',
-      subtitle: 'Sähköpostiin lähetettävät ilmoitukset',
-      message: 'eVakaan saapuneista henkilökunnan lähettämistä viesteistä',
-      bulletin: 'eVakaan saapuneista yleisistä tiedotteista',
-      outdatedIncome: 'Muistutukset tulotietojen päivittämisestä',
+      title: 'Email notifications',
+      info: 'You can receive email notifications regarding the following topics. You can edit the settings by clicking the edit button.',
+      subtitle: 'Notifications sent to email',
+      message: 'eVaka messages sent by the staff',
+      bulletin: 'eVaka bulletins',
+      outdatedIncome: 'Reminders to update income information',
       outdatedIncomeInfo:
-        'Mikäli ette maksa korkeinta varhaiskasvatusmaksua, on tulotiedot päivitettävä säännöllisesti. Jos tulotiedot puuttuvat tai vanhenevat, merkitään varhaiskasvatuksesta maksettavaksi korkein maksu.',
-      calendarEvent:
-        'Muistutukset kalenteriin merkityistä uusista tapahtumista',
-      decision: 'Saapuneista päätöksistä',
-      document: 'Uusista asiakirjoista',
+        'If you do not pay the highest early childhood education fee, your income information must be updated regularly. If the income information is missing or out of date, the highest payment for early childhood education is charged.',
+      calendarEvent: 'Reminders about new events marked in the calendar',
+      decision: 'New decisions',
+      document: 'New documents',
       documentInfo:
-        'Asiakirjoilla tarkoitetaan virallisia asiakirjoja, jotka eivät ole päätöksiä. Tällaisia ovat esimerkiksi varhaiskasvatussuunnitelmat ja pedagogiset arviot.',
-      informalDocument: 'Muista lapsen arkeen liittyvistä dokumenteista',
+        'Documents mean official documents that are not decisions. Such are, for example, early childhood education plans and pedagogical assessments.',
+      informalDocument: "Other documents related to the child's daily life",
       informalDocumentInfo:
-        'Muut lapsen arkeen liittyvät dokumentit voivat olla esimerkiksi kuvia lapsen tekemistä piirustuksista.',
+        "Other documents related to the child's daily life can be, for example, pictures of the child's drawings.",
       missingAttendanceReservation:
-        'Muistutukset puuttuvista läsnäoloilmoituksista',
+        'Reminders about missing attendance reservations',
       missingAttendanceReservationInfo:
-        'Muistutus lähetetään ennen läsnäoloilmoitusten määräaikaa, mikäli jollakin lapsistasi puuttuu läsnäoloilmoitus tai poissaolomerkintä seuraavalta kahdelta viikolta.'
+        'A reminder will be sent before the deadline for attendance reservations if one of your children is missing an attendance report or an absence entry for the next two weeks.'
     }
   },
   income: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1659,6 +1659,8 @@ const en: Translations = {
       outdatedIncome: 'Reminders to update income information',
       outdatedIncomeInfo:
         'If you do not pay the highest early childhood education fee, your income information must be updated regularly. If the income information is missing or out of date, the highest payment for early childhood education is charged.',
+      outdatedIncomeWarning:
+        'If income information is missing or out of date, the highest payment for early childhood education is charged.',
       calendarEvent: 'Reminders about new events marked in the calendar',
       decision: 'New decisions',
       document: 'New documents',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -1880,7 +1880,9 @@ export default {
       outdatedIncome: 'Muistutukset puuttuvista tulotiedoista',
       calendarEvent:
         'Muistutukset kalenteriin merkityistä uusista tapahtumista',
-      document: 'Saapuneista dokumenteista',
+      decision: 'Saapuneista päätöksistä',
+      document: 'Uusista asiakirjoista',
+      informalDocument: 'Muista lapsen arkeen liittyvistä dokumenteista',
       missingAttendanceReservation:
         'Muistutukset puuttuvista läsnäoloilmoituksista'
     }

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -1880,6 +1880,8 @@ export default {
       outdatedIncome: 'Muistutukset tulotietojen päivittämisestä',
       outdatedIncomeInfo:
         'Mikäli ette maksa korkeinta varhaiskasvatusmaksua, on tulotiedot päivitettävä säännöllisesti. Jos tulotiedot puuttuvat tai vanhenevat, merkitään varhaiskasvatuksesta maksettavaksi korkein maksu.',
+      outdatedIncomeWarning:
+        'Jos tulotiedot puuttuvat tai vanhenevat, merkitään varhaiskasvatuksesta maksettavaksi korkein maksu.',
       calendarEvent:
         'Muistutukset kalenteriin merkityistä uusista tapahtumista',
       decision: 'Saapuneista päätöksistä',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -1873,18 +1873,26 @@ export default {
     },
     notificationsSection: {
       title: 'Sähköposti-ilmoitukset',
-      info: 'Voit saada ilmoituksia sähköpostiin seuraavista aiheista. Asetuksia pystyy muokkaamaan muokkaus-nappia painamalla.',
+      info: 'Voit saada ilmoituksia sähköpostiin seuraavista aiheista. Asetuksia pystyy muokkaamaan muokkaa-nappia painamalla.',
       subtitle: 'Sähköpostiin lähetettävät ilmoitukset',
       message: 'eVakaan saapuneista henkilökunnan lähettämistä viesteistä',
       bulletin: 'eVakaan saapuneista yleisistä tiedotteista',
-      outdatedIncome: 'Muistutukset puuttuvista tulotiedoista',
+      outdatedIncome: 'Muistutukset tulotietojen päivittämisestä',
+      outdatedIncomeInfo:
+        'Mikäli ette maksa korkeinta varhaiskasvatusmaksua, on tulotiedot päivitettävä säännöllisesti. Jos tulotiedot puuttuvat tai vanhenevat, merkitään varhaiskasvatuksesta maksettavaksi korkein maksu.',
       calendarEvent:
         'Muistutukset kalenteriin merkityistä uusista tapahtumista',
       decision: 'Saapuneista päätöksistä',
       document: 'Uusista asiakirjoista',
+      documentInfo:
+        'Asiakirjoilla tarkoitetaan virallisia asiakirjoja, jotka eivät ole päätöksiä. Tällaisia ovat esimerkiksi varhaiskasvatussuunnitelmat ja pedagogiset arviot.',
       informalDocument: 'Muista lapsen arkeen liittyvistä dokumenteista',
+      informalDocumentInfo:
+        'Muut lapsen arkeen liittyvät dokumentit voivat olla esimerkiksi kuvia lapsen tekemistä piirustuksista.',
       missingAttendanceReservation:
-        'Muistutukset puuttuvista läsnäoloilmoituksista'
+        'Muistutukset puuttuvista läsnäoloilmoituksista',
+      missingAttendanceReservationInfo:
+        'Muistutus lähetetään ennen läsnäoloilmoitusten määräaikaa, mikäli jollakin lapsistasi puuttuu läsnäoloilmoitus tai poissaolomerkintä seuraavalta kahdelta viikolta.'
     }
   },
   income: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1889,7 +1889,9 @@ const sv: Translations = {
       outdatedIncome: 'Muistutukset puuttuvista tulotiedoista',
       calendarEvent:
         'Muistutukset kalenteriin merkityistä uusista tapahtumista',
-      document: 'Saapuneista dokumenteista',
+      decision: 'Saapuneista päätöksistä',
+      document: 'Uusista asiakirjoista',
+      informalDocument: 'Muista lapsen arkeen liittyvistä dokumenteista',
       missingAttendanceReservation:
         'Muistutukset puuttuvista läsnäoloilmoituksista'
     }

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1882,18 +1882,26 @@ const sv: Translations = {
     },
     notificationsSection: {
       title: 'Sähköposti-ilmoitukset',
-      info: 'Voit saada ilmoituksia sähköpostiin seuraavista aiheista. Asetuksia pystyy muokkaamaan muokkaus-nappia painamalla.',
+      info: 'Voit saada ilmoituksia sähköpostiin seuraavista aiheista. Asetuksia pystyy muokkaamaan muokkaa-nappia painamalla.',
       subtitle: 'Sähköpostiin lähetettävät ilmoitukset',
       message: 'eVakaan saapuneista henkilökunnan lähettämistä viesteistä',
       bulletin: 'eVakaan saapuneista yleisistä tiedotteista',
-      outdatedIncome: 'Muistutukset puuttuvista tulotiedoista',
+      outdatedIncome: 'Muistutukset tulotietojen päivittämisestä',
+      outdatedIncomeInfo:
+        'Mikäli ette maksa korkeinta varhaiskasvatusmaksua, on tulotiedot päivitettävä säännöllisesti. Jos tulotiedot puuttuvat tai vanhenevat, merkitään varhaiskasvatuksesta maksettavaksi korkein maksu.',
       calendarEvent:
         'Muistutukset kalenteriin merkityistä uusista tapahtumista',
       decision: 'Saapuneista päätöksistä',
       document: 'Uusista asiakirjoista',
+      documentInfo:
+        'Asiakirjoilla tarkoitetaan virallisia asiakirjoja, jotka eivät ole päätöksiä. Tällaisia ovat esimerkiksi varhaiskasvatussuunnitelmat ja pedagogiset arviot.',
       informalDocument: 'Muista lapsen arkeen liittyvistä dokumenteista',
+      informalDocumentInfo:
+        'Muut lapsen arkeen liittyvät dokumentit voivat olla esimerkiksi kuvia lapsen tekemistä piirustuksista.',
       missingAttendanceReservation:
-        'Muistutukset puuttuvista läsnäoloilmoituksista'
+        'Muistutukset puuttuvista läsnäoloilmoituksista',
+      missingAttendanceReservationInfo:
+        'Muistutus lähetetään ennen läsnäoloilmoitusten määräaikaa, mikäli jollakin lapsistasi puuttuu läsnäoloilmoitus tai poissaolomerkintä seuraavalta kahdelta viikolta.'
     }
   },
   income: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1889,6 +1889,8 @@ const sv: Translations = {
       outdatedIncome: 'Påminnelser om att uppdatera inkomstuppgifter',
       outdatedIncomeInfo:
         'Om du inte betalar den högsta avgiften för småbarnspedagogik, måste dina inkomstuppgifter uppdateras regelbundet. Om inkomstuppgifter saknas eller är föråldrade tas högsta avgiften ut för småbarnspedagogik.',
+      outdatedIncomeWarning:
+        'Om inkomstuppgifter saknas eller är föråldrade tas högsta avgiften ut för småbarnspedagogik.',
       calendarEvent: 'Påminnelser om nya händelser markerade i kalendern',
       decision: 'Nya beslut',
       document: 'Nya dokument',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1881,27 +1881,25 @@ const sv: Translations = {
         'En epostadress behövs så att vi kan skicka notiser om nya meddelanden, bokningar av närvarotider samt andra angelägenheter angående ditt barns småbarnspedagogik.'
     },
     notificationsSection: {
-      title: 'Sähköposti-ilmoitukset',
-      info: 'Voit saada ilmoituksia sähköpostiin seuraavista aiheista. Asetuksia pystyy muokkaamaan muokkaa-nappia painamalla.',
-      subtitle: 'Sähköpostiin lähetettävät ilmoitukset',
-      message: 'eVakaan saapuneista henkilökunnan lähettämistä viesteistä',
-      bulletin: 'eVakaan saapuneista yleisistä tiedotteista',
-      outdatedIncome: 'Muistutukset tulotietojen päivittämisestä',
+      title: 'E-postmeddelanden',
+      info: 'Du kan få e-postmeddelanden om följande ämnen. Du kan redigera inställningarna genom att klicka på redigera-knappen.',
+      subtitle: 'Meddelande skickade till e-post',
+      message: 'eVaka-meddelanden skickat av personalen',
+      bulletin: 'eVaka-bulletiner',
+      outdatedIncome: 'Påminnelser om att uppdatera inkomstuppgifter',
       outdatedIncomeInfo:
-        'Mikäli ette maksa korkeinta varhaiskasvatusmaksua, on tulotiedot päivitettävä säännöllisesti. Jos tulotiedot puuttuvat tai vanhenevat, merkitään varhaiskasvatuksesta maksettavaksi korkein maksu.',
-      calendarEvent:
-        'Muistutukset kalenteriin merkityistä uusista tapahtumista',
-      decision: 'Saapuneista päätöksistä',
-      document: 'Uusista asiakirjoista',
+        'Om du inte betalar den högsta avgiften för småbarnspedagogik, måste dina inkomstuppgifter uppdateras regelbundet. Om inkomstuppgifter saknas eller är föråldrade tas högsta avgiften ut för småbarnspedagogik.',
+      calendarEvent: 'Påminnelser om nya händelser markerade i kalendern',
+      decision: 'Nya beslut',
+      document: 'Nya dokument',
       documentInfo:
-        'Asiakirjoilla tarkoitetaan virallisia asiakirjoja, jotka eivät ole päätöksiä. Tällaisia ovat esimerkiksi varhaiskasvatussuunnitelmat ja pedagogiset arviot.',
-      informalDocument: 'Muista lapsen arkeen liittyvistä dokumenteista',
+        'Dokument avser officiella dokument som inte är beslut. Exempel på sådana är plan för småbarnspedagogik och pedagogiska bedömningar.',
+      informalDocument: 'Andra dokument relaterade till barnets vardag',
       informalDocumentInfo:
-        'Muut lapsen arkeen liittyvät dokumentit voivat olla esimerkiksi kuvia lapsen tekemistä piirustuksista.',
-      missingAttendanceReservation:
-        'Muistutukset puuttuvista läsnäoloilmoituksista',
+        'Andra dokument relaterade till barnets vardag kan vara till exempel bilder på barnets tecknignar.',
+      missingAttendanceReservation: 'Påminnelser om saknade närvaro',
       missingAttendanceReservationInfo:
-        'Muistutus lähetetään ennen läsnäoloilmoitusten määräaikaa, mikäli jollakin lapsistasi puuttuu läsnäoloilmoitus tai poissaolomerkintä seuraavalta kahdelta viikolta.'
+        'En påminnelse skickas innan tidsfristen för närvaroanmälan, om ett av dina barn saknar närvaroanmälan eller frånvaroanmälan för de kommande två veckorna.'
     }
   },
   income: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonalDataControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonalDataControllerCitizenIntegrationTest.kt
@@ -35,7 +35,9 @@ class PersonalDataControllerCitizenIntegrationTest : FullApplicationTest(resetDb
                 bulletin = true,
                 outdatedIncome = true,
                 calendarEvent = true,
+                decision = true,
                 document = true,
+                informalDocument = true,
                 missingAttendanceReservation = true,
             ),
             settings
@@ -55,7 +57,9 @@ class PersonalDataControllerCitizenIntegrationTest : FullApplicationTest(resetDb
                 bulletin = false,
                 outdatedIncome = true,
                 calendarEvent = false,
-                document = true,
+                decision = true,
+                document = false,
+                informalDocument = true,
                 missingAttendanceReservation = false,
             )
         )
@@ -72,7 +76,9 @@ class PersonalDataControllerCitizenIntegrationTest : FullApplicationTest(resetDb
                 bulletin = false,
                 outdatedIncome = true,
                 calendarEvent = false,
-                document = true,
+                decision = true,
+                document = false,
+                informalDocument = true,
                 missingAttendanceReservation = false,
             ),
             settings

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PendingDecisionEmailService.kt
@@ -131,7 +131,7 @@ GROUP BY application.guardian_id
         Email.create(
                 db,
                 pendingDecision.guardianId,
-                EmailMessageType.DOCUMENT_NOTIFICATION,
+                EmailMessageType.DECISION_NOTIFICATION,
                 emailEnv.sender(lang),
                 emailMessageProvider.pendingDecisionNotification(lang),
                 "${pendingDecision.guardianId} - ${pendingDecision.decisionIds.joinToString("-")}",

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
@@ -108,7 +108,7 @@ class AssistanceNeedDecisionService(
             Email.create(
                     dbc,
                     guardianId,
-                    EmailMessageType.DOCUMENT_NOTIFICATION,
+                    EmailMessageType.DECISION_NOTIFICATION,
                     fromAddress,
                     content,
                     "$decisionId - $guardianId",

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionService.kt
@@ -100,7 +100,7 @@ class AssistanceNeedPreschoolDecisionService(
             Email.create(
                     dbc,
                     guardianId,
-                    EmailMessageType.DOCUMENT_NOTIFICATION,
+                    EmailMessageType.DECISION_NOTIFICATION,
                     fromAddress,
                     content,
                     "$decisionId - $guardianId",

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationService.kt
@@ -134,7 +134,7 @@ SELECT EXISTS(
         Email.create(
                 dbc = db,
                 personId = msg.recipientId,
-                emailType = EmailMessageType.DOCUMENT_NOTIFICATION,
+                emailType = EmailMessageType.INFORMAL_DOCUMENT_NOTIFICATION,
                 fromAddress = emailEnv.sender(msg.language),
                 content = emailMessageProvider.pedagogicalDocumentNotification(msg.language),
                 traceId = msg.pedagogicalDocumentId.toString(),

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalData.kt
@@ -30,8 +30,17 @@ enum class EmailMessageType {
     /** Notifications about new calendar events of daycare groups */
     CALENDAR_EVENT_NOTIFICATION,
 
-    /** Notifications about new decisions, pedagogical documents, etc. */
+    /** Notifications about new decisions (e.g. daycare decision, assistance decision) */
+    DECISION_NOTIFICATION,
+
+    /**
+     * Notifications about *official documents* that are not decisions (e.g. vasu, pedagogical
+     * assesments, etc.)
+     */
     DOCUMENT_NOTIFICATION,
+
+    /** Notifications about informal documents (photos of children's drawings, etc.) */
+    INFORMAL_DOCUMENT_NOTIFICATION,
 
     /** Reminders about making attendance reservations */
     MISSING_ATTENDANCE_RESERVATION_NOTIFICATION
@@ -42,7 +51,9 @@ data class EmailNotificationSettings(
     val bulletin: Boolean,
     val outdatedIncome: Boolean,
     val calendarEvent: Boolean,
+    val decision: Boolean,
     val document: Boolean,
+    val informalDocument: Boolean,
     val missingAttendanceReservation: Boolean
 ) {
     fun toNotificationTypes() =
@@ -52,7 +63,9 @@ data class EmailNotificationSettings(
             EmailMessageType.BULLETIN_NOTIFICATION.takeIf { bulletin },
             EmailMessageType.OUTDATED_INCOME_NOTIFICATION.takeIf { outdatedIncome },
             EmailMessageType.CALENDAR_EVENT_NOTIFICATION.takeIf { calendarEvent },
+            EmailMessageType.DECISION_NOTIFICATION.takeIf { decision },
             EmailMessageType.DOCUMENT_NOTIFICATION.takeIf { document },
+            EmailMessageType.INFORMAL_DOCUMENT_NOTIFICATION.takeIf { informalDocument },
             EmailMessageType.MISSING_ATTENDANCE_RESERVATION_NOTIFICATION.takeIf {
                 missingAttendanceReservation
             }
@@ -67,7 +80,9 @@ data class EmailNotificationSettings(
                     bulletin = true,
                     outdatedIncome = true,
                     calendarEvent = true,
+                    decision = true,
                     document = true,
+                    informalDocument = true,
                     missingAttendanceReservation = true
                 )
             } else {
@@ -78,7 +93,10 @@ data class EmailNotificationSettings(
                         EmailMessageType.OUTDATED_INCOME_NOTIFICATION in enabledNotificationTypes,
                     calendarEvent =
                         EmailMessageType.CALENDAR_EVENT_NOTIFICATION in enabledNotificationTypes,
+                    decision = EmailMessageType.DECISION_NOTIFICATION in enabledNotificationTypes,
                     document = EmailMessageType.DOCUMENT_NOTIFICATION in enabledNotificationTypes,
+                    informalDocument =
+                        EmailMessageType.INFORMAL_DOCUMENT_NOTIFICATION in enabledNotificationTypes,
                     missingAttendanceReservation =
                         EmailMessageType.MISSING_ATTENDANCE_RESERVATION_NOTIFICATION in
                             enabledNotificationTypes


### PR DESCRIPTION
#### Summary

- Add 2 new email message types: decision and informal document.
- Add info bubbles
- Show a warning if outdated income notification is unchecked
- Add `sv` and `en` translations