### PR TITLE
Fix remaining citizen preschool texts to pre-primary

### DIFF
--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2215,7 +2215,8 @@ const en: Translations = {
       empty: 'Not defined'
     },
     vasu: {
-      title: 'Early childhood education and care plan and learning plan for pre-primary education',
+      title:
+        'Early childhood education and care plan and learning plan for pre-primary education',
       lastModified: 'Last modified',
       lastPublished: 'Last published',
       noVasus: 'No early childhood education or pre-primary learning plans',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -205,8 +205,8 @@ const en: Translations = {
       infoBoxText:
         'When using strong authentication the personal data and address information of the registrant, the second guardian and the dependants are retrieved from the population data service.',
       infoBullets: [
-        'apply for an early childhood, pre-school or club place for your child or view a previous application',
-        'view pictures and other documents related to your child’s early childhood or pre-school education',
+        'apply for an early childhood, pre-primary or club place for your child or view a previous application',
+        'view pictures and other documents related to your child’s early childhood or pre-primary education',
         "report your or your child's income information",
         'accept or reject a decision, if you made the application'
       ],
@@ -318,7 +318,7 @@ const en: Translations = {
     reservationsAndRealized: 'Period of attendance',
     events: 'Events of the day',
     noActivePlacements:
-      'Your children are not in early childhood education or pre-school on this day',
+      'Your children are not in early childhood or pre-primary education on this day',
     attendanceWarning:
       'The realized attendance time exceeds the reported attendance time',
     eventsCount: 'events',
@@ -519,7 +519,7 @@ const en: Translations = {
         title: {
           DAYCARE:
             'Application for early childhood education and service voucher',
-          PRESCHOOL: 'Registration for pre-school education',
+          PRESCHOOL: 'Registration for pre-primary education',
           CLUB: 'Application for club'
         },
         info: {
@@ -1499,7 +1499,7 @@ const en: Translations = {
       ...fi.decisions.assistancePreschoolDecisions,
 
       // TODO
-      title: 'Decision of special support in preschool',
+      title: 'Decision of special support in pre-primary education',
       statuses: {
         DRAFT: 'Draft',
         NEEDS_WORK: 'Needs work',
@@ -2215,10 +2215,10 @@ const en: Translations = {
       empty: 'Not defined'
     },
     vasu: {
-      title: 'Early childhood education and preschool learning plan',
+      title: 'Early childhood education and care plan and learning plan for pre-primary education',
       lastModified: 'Last modified',
       lastPublished: 'Last published',
-      noVasus: 'No early childhood education or preschool learning plans',
+      noVasus: 'No early childhood education or pre-primary learning plans',
       leavePage: 'Leave page',
       edited: 'Edited',
       eventTypes: {
@@ -2238,21 +2238,21 @@ const en: Translations = {
       state: 'State',
       events: {
         DAYCARE: 'Early childhood plan events',
-        PRESCHOOL: 'Preschool plan events'
+        PRESCHOOL: 'Pre-primary plan events'
       },
       noRecord: 'No record',
       givePermissionToShareInfoVasu:
         'If necessary, some information from the plan will be transferred to other recipients (Section 41 of the Act on Early Childhood Education and Care, section 41 of the Basic Education Act)',
       givePermissionToShareInfoVasuInfoText:
-        "Contact the unit for early childhood education if you want to change the recipients mentioned in the plan. The plan may be handed over to a new provider of early childhood education, pre-school education or basic education even without the guardian's permission, if it is necessary for arranging early childhood education, pre-primary or primary education (Section 41 of the Act on Early Childhood Education and Care, Section 41 of the Basic Education Act).",
+        "Contact the unit for early childhood education if you want to change the recipients mentioned in the plan. The plan may be handed over to a new provider of early childhood education, pre-primary education or basic education even without the guardian's permission, if it is necessary for arranging early childhood education, pre-primary or primary education (Section 41 of the Act on Early Childhood Education and Care, Section 41 of the Basic Education Act).",
       givePermissionToShareTitleVasu:
         'Confirmation of the transfer of the early childhood education plan to other recipients',
       givePermissionToShareTitleLeops:
-        'Confirmation of the transfer of the pre-school learning plan to other recipients',
+        'Confirmation of the transfer of the pre-primary education learning plan to other recipients',
       givePermissionToShareVasu:
         "I confirm that the child's early childhood education plan may be handed over to the parties mentioned in the “Recipients” section.",
       givePermissionToShareLeops:
-        "I confirm that the child's pre-school learning plan may be handed over to the parties mentioned in the “Information Recipients” section.",
+        "I confirm that the child's pre-primary education learning plan may be handed over to the parties mentioned in the “Information Recipients” section.",
       givePermissionToShareInfoBase:
         "If you want to change the recipients mentioned in the plan, contact the staff of your child's early childhood education unit.",
       givePermissionToShareReminder:
@@ -2260,7 +2260,7 @@ const en: Translations = {
       sharingLeopsDisclaimer:
         "When a child changes to another early childhood education unit in the City of Espoo, the early childhood education plan and other early childhood education documents are transferred to the new unit (also applies to early childhood education organized by Espoo as a purchasing service). The guardian will be informed about the transfer in advance. We ask the guardian for permission to hand over the early childhood education plan to an outsider. However, if a child enters private or other municipality's early childhood education, the early childhood education plan must be submitted to the new early childhood education provider even without permission, if the information is necessary for arranging the child's early childhood education (section 41 (3) of the Early Childhood Education Act). In addition, the early childhood education plan must be submitted to the organizer of pre-primary or primary education if it is necessary for the organization of the child's education (section 41 (4) of the Basic Education Act). The guardian will be informed of the transfer in advance.",
       sharingVasuDisclaimer:
-        "The pre-school learning plan may be handed over to a new provider of early childhood education, pre-school education or basic education even without the guardian's permission, if it is necessary for arranging early childhood education, pre-primary or primary education (Section 4 of the Act on Early Childhood Education and Care, Section 41 of the Basic Education Act).",
+        "The pre-primary learning plan may be handed over to a new provider of early childhood education, pre-primary education or basic education even without the guardian's permission, if it is necessary for arranging early childhood education, pre-primary or primary education (Section 4 of the Act on Early Childhood Education and Care, Section 41 of the Basic Education Act).",
       givePermissionToShareVasuBrief:
         'Necessary information will be shared if required to do so. (Section 41 of the Act on Early Childhood Education and Care, section 41 of the Basic Education Act)',
       givePermissionToShareLeopsBrief:


### PR DESCRIPTION
Feedback in ticket was to the header on children page but I noticed some other pre-school terms in use and fixed those as well,
