### PR TITLE
Fix non-symmetrical ser/deser for daterange types

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/JdbiExtensionsTest.kt
@@ -96,6 +96,20 @@ class JdbiExtensionsTest : PureJdbiTest(resetDbBeforeEach = false) {
     }
 
     @Test
+    fun testDateRangeWithIsoMax() {
+        val input = DateRange(LocalDate.of(1, 1, 1), LocalDate.of(9999, 12, 31))
+
+        val match =
+            db.read {
+                it.checkMatch("SELECT :input = daterange('0001-01-01', '9999-12-31', '[]')", input)
+            }
+        assertTrue(match)
+
+        val output = db.read { it.passThrough(input) }
+        assertEquals(input, output)
+    }
+
+    @Test
     fun testDateRangeWithoutEnd() {
         val input = DateRange(LocalDate.of(2020, 6, 7), null)
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Serialization/deserialization should generally be symmetric (= serialising and then deserialising the output should work).

This fix makes daterange ser/deser symmetric, but unfortunately dates and dateranges don't work exactly the same way, because the former uses PostgreSQL JDBC driver internal formatting/parsing and the latter uses LocalDate default ISO formatting/parsing and they don't agree 100%.