### PR TITLE
Show planned absence for citizen

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -60,6 +60,7 @@ import {
 } from 'lib-components/molecules/modals/BaseModal'
 import { H1, H2, H3, LabelLike, P } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
+import { featureFlags } from 'lib-customizations/citizen'
 import { faChevronLeft, faChevronRight } from 'lib-icons'
 
 import ModalAccessibilityWrapper from '../ModalAccessibilityWrapper'
@@ -669,6 +670,9 @@ const Absence = React.memo(function Absence({
       <span data-qa="absence">
         {absence.type === 'SICKLEAVE'
           ? i18n.calendar.absences.SICKLEAVE
+          : featureFlags.experimental?.citizenAttendanceSummary &&
+            absence.type === 'PLANNED_ABSENCE'
+          ? i18n.calendar.absences.PLANNED_ABSENCE
           : i18n.calendar.absent}
       </span>
     )

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -300,8 +300,10 @@ const en: Translations = {
     holiday: 'Holiday',
     absent: 'Absent',
     absentFree: 'Free absence',
+    absentPlanned: 'Shift work absence',
     absences: {
-      SICKLEAVE: 'Absence due to illness'
+      SICKLEAVE: 'Absence due to illness',
+      PLANNED_ABSENCE: 'Shift work absence'
     },
     absenceMarkedByEmployee: 'Absence marked by staff',
     contactStaffToEditAbsence:

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -297,8 +297,10 @@ export default {
     holiday: 'Pyhäpäivä',
     absent: 'Poissa',
     absentFree: 'Maksuton poissaolo',
+    absentPlanned: 'Vuorotyöpoissaolo',
     absences: {
-      SICKLEAVE: 'Sairauspoissaolo'
+      SICKLEAVE: 'Sairauspoissaolo',
+      PLANNED_ABSENCE: 'Vuorotyöpoissaolo'
     },
     absenceMarkedByEmployee: 'Henkilökunnan merkitsemä poissaolo',
     contactStaffToEditAbsence:

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -298,8 +298,10 @@ const sv: Translations = {
     holiday: 'Helgdag',
     absent: 'Frånvarande',
     absentFree: 'Gratis frånvaro',
+    absentPlanned: 'Skiftarbete frånvaro',
     absences: {
-      SICKLEAVE: 'Sjukfrånvaro'
+      SICKLEAVE: 'Sjukfrånvaro',
+      PLANNED_ABSENCE: 'Skiftarbete frånvaro'
     },
     absenceMarkedByEmployee: 'Frånvaro markerad av personal',
     contactStaffToEditAbsence: 'Kontakta personalen om du vill ändra frånvaron',


### PR DESCRIPTION
#### Summary

Citizen calendar is currently showing generic absent message for all absence types (except sickleave in day modal and free absence in calendar view). This adds planned absence to calendar view and day modal.

Uses feature flag added in https://github.com/espoon-voltti/evaka/pull/3951 (yes name of the feature flag is pretty weird).

There are some hackish styles because our planned absence says "Sopimuksen mukainen poissaolo" which is pretty lengthy for the calendar.