### PR TITLE
Validate overlaps in frontend assistance forms

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/assistance/AssistanceFactorSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance/AssistanceFactorSection.tsx
@@ -70,6 +70,7 @@ export const AssistanceFactorSection = React.memo(
         ),
       [props.rows]
     )
+
     const info = t.assistanceFactor.info()
     return renderResult(rowsResult, (rows) => (
       <div ref={refSectionTop}>
@@ -116,6 +117,7 @@ export const AssistanceFactorSection = React.memo(
             <Tbody>
               {mode?.type === 'new' ? (
                 <AssistanceFactorForm
+                  allRows={rows}
                   onSubmit={(data) => createAssistanceFactor({ childId, data })}
                   onClose={clearMode}
                 />
@@ -125,6 +127,7 @@ export const AssistanceFactorSection = React.memo(
                   <AssistanceFactorForm
                     key={row.data.id}
                     assistanceFactor={row.data}
+                    allRows={rows}
                     onSubmit={(data) =>
                       updateAssistanceFactor({
                         childId,

--- a/frontend/src/employee-frontend/components/child-information/assistance/DaycareAssistanceSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance/DaycareAssistanceSection.tsx
@@ -94,6 +94,7 @@ export const DaycareAssistanceSection = React.memo(
             <Tbody>
               {mode?.type === 'new' ? (
                 <DaycareAssistanceForm
+                  allRows={rows}
                   onSubmit={(data) =>
                     createDaycareAssistance({ childId, data })
                   }
@@ -105,6 +106,7 @@ export const DaycareAssistanceSection = React.memo(
                   <DaycareAssistanceForm
                     key={row.data.id}
                     daycareAssistance={row.data}
+                    allRows={rows}
                     onSubmit={(data) =>
                       updateDaycareAssistance({
                         childId,

--- a/frontend/src/employee-frontend/components/child-information/assistance/OtherAssistanceMeasureForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance/OtherAssistanceMeasureForm.tsx
@@ -7,18 +7,22 @@ import React, { useCallback } from 'react'
 import { Result } from 'lib-common/api'
 import { localDateRange } from 'lib-common/form/fields'
 import {
-  mapped,
   object,
   oneOf,
   OneOfOption,
-  required
+  required,
+  transformed,
+  value
 } from 'lib-common/form/form'
 import { useForm, useFormFields } from 'lib-common/form/hooks'
+import { ValidationError, ValidationSuccess } from 'lib-common/form/types'
 import {
   OtherAssistanceMeasure,
+  OtherAssistanceMeasureResponse,
   OtherAssistanceMeasureType,
   OtherAssistanceMeasureUpdate
 } from 'lib-common/generated/api-types/assistance'
+import { UUID } from 'lib-common/types'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import { SelectF } from 'lib-components/atoms/dropdowns/Select'
 import { Td, Tr } from 'lib-components/layout/Table'
@@ -30,19 +34,32 @@ import { Translations, useTranslation } from '../../../state/i18n'
 import { getStatusLabelByDateRange } from '../../../utils/date'
 import StatusLabel from '../../common/StatusLabel'
 
-export const otherAssistanceMeasureForm = mapped(
+export const otherAssistanceMeasureForm = transformed(
   object({
     type: required(oneOf<OtherAssistanceMeasureType>()),
-    validDuring: required(localDateRange)
+    validDuring: required(localDateRange),
+    allRows: value<OtherAssistanceMeasureResponse[]>(),
+    ignoredId: value<UUID | undefined>()
   }),
-  (fields): OtherAssistanceMeasureUpdate => ({
-    type: fields.type,
-    validDuring: fields.validDuring
-  })
+  ({ type, validDuring, allRows, ignoredId }) => {
+    if (
+      allRows.some(
+        ({ data }) =>
+          data.id !== ignoredId &&
+          data.type === type &&
+          data.validDuring.overlaps(validDuring)
+      )
+    ) {
+      return ValidationError.of('overlap')
+    }
+    const success: OtherAssistanceMeasureUpdate = { type, validDuring }
+    return ValidationSuccess.of(success)
+  }
 )
 
 interface Props {
   otherAssistanceMeasure?: OtherAssistanceMeasure
+  allRows: OtherAssistanceMeasureResponse[]
   onClose: () => void
   onSubmit: (factor: OtherAssistanceMeasureUpdate) => Promise<Result<void>>
 }
@@ -61,6 +78,7 @@ export const OtherAssistanceMeasureForm = React.memo(
   function OtherAssistanceMeasureForm(props: Props) {
     const initialData = props.otherAssistanceMeasure
     const { i18n, lang } = useTranslation()
+
     const form = useForm(
       otherAssistanceMeasureForm,
       () => ({
@@ -71,9 +89,14 @@ export const OtherAssistanceMeasureForm = React.memo(
         validDuring: {
           startDate: initialData?.validDuring.start ?? null,
           endDate: initialData?.validDuring.end ?? null
-        }
+        },
+        allRows: props.allRows,
+        ignoredId: initialData?.id
       }),
-      i18n.validationErrors
+      {
+        ...i18n.validationErrors,
+        ...i18n.childInformation.assistance.validationErrors
+      }
     )
     const { type, validDuring } = useFormFields(form)
 
@@ -95,6 +118,7 @@ export const OtherAssistanceMeasureForm = React.memo(
             bind={validDuring}
             locale={lang}
             data-qa="valid-during"
+            info={form.inputInfo()}
           />
         </Td>
         <Td>

--- a/frontend/src/employee-frontend/components/child-information/assistance/OtherAssistanceMeasureSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance/OtherAssistanceMeasureSection.tsx
@@ -146,6 +146,7 @@ export const OtherAssistanceMeasureSection = React.memo(
             <Tbody>
               {mode?.type === 'new' ? (
                 <OtherAssistanceMeasureForm
+                  allRows={rows}
                   onSubmit={(data) =>
                     createOtherAssistanceMeasure({ childId, data })
                   }
@@ -157,6 +158,7 @@ export const OtherAssistanceMeasureSection = React.memo(
                   <OtherAssistanceMeasureForm
                     key={row.data.id}
                     otherAssistanceMeasure={row.data}
+                    allRows={rows}
                     onSubmit={(data) =>
                       updateOtherAssistanceMeasure({
                         childId,

--- a/frontend/src/employee-frontend/components/child-information/assistance/PreschoolAssistanceSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance/PreschoolAssistanceSection.tsx
@@ -94,6 +94,7 @@ export const PreschoolAssistanceSection = React.memo(
             <Tbody>
               {mode?.type === 'new' ? (
                 <PreschoolAssistanceForm
+                  allRows={rows}
                   onSubmit={(data) =>
                     createPreschoolAssistance({ childId, data })
                   }
@@ -105,6 +106,7 @@ export const PreschoolAssistanceSection = React.memo(
                   <PreschoolAssistanceForm
                     key={row.data.id}
                     preschoolAssistance={row.data}
+                    allRows={rows}
                     onSubmit={(data) =>
                       updatePreschoolAssistance({
                         childId,

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
@@ -158,14 +158,16 @@ export interface DateRangePickerFProps
     }
   >
   externalRangeValidation?: boolean
+  info?: InputInfo
 }
 
 export const DateRangePickerF = React.memo(function DateRangePickerF({
   bind,
   externalRangeValidation,
+  info: infoOverride,
   ...props
 }: DateRangePickerFProps) {
-  const info = bind.inputInfo()
+  const info = infoOverride ?? bind.inputInfo()
   const startDate = useFormField(bind, 'startDate')
   const endDate = useFormField(bind, 'endDate')
   return (

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -679,6 +679,10 @@ export const fi = {
         level: 'Taso',
         otherAssistanceMeasureType: 'Toimi'
       },
+      validationErrors: {
+        overlap:
+          'Tälle ajanjaksolle on jo päällekkäinen merkintä. Muokkaa tarvittaessa edellistä ajanjaksoa'
+      },
       types: {
         daycareAssistanceLevel: {
           GENERAL_SUPPORT: 'Yleinen tuki, ei päätöstä',


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

![Screenshot from 2023-08-18 16-24-08](https://github.com/espoon-voltti/evaka/assets/94033/b25ebd3e-00ee-4bb1-826e-07f5aaf99f5b)

Limitations:

- the validation doesn't see rows filtered out by permission rules (= rows existing in db but not returned by backend), e.g. pre-preschool rows when applicable -> validation says yes, save button won't work
- the validation error for assistance factor doesn't appear if the factor number is invalid. This is a limitation that could be fixed by changing the form structure, but then other assistance measures would have to work differently
- if the underlying rows are refreshed *while a form is open*, the form won't see the new refreshed rows and may validate incorrectly. This is a limitation of the validation approach where the rows go to the *initial form state*