### PR TITLE
Force type-checking of already built files

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently -n tsc,esbuild -c blue,green 'yarn type-check:watch' 'yarn build:serve'",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --max-warnings 0 .",
     "lint:fix": "yarn lint --fix",
-    "type-check": "tsc -b .",
+    "type-check": "tsc --build --force .",
     "type-check:watch": "yarn type-check --watch --preserveWatchOutput",
     "build": "webpack --mode production",
     "build:dev": "node build.js --dev",


### PR DESCRIPTION
#### Summary

In CI, `yarn type-check` didn't catch all type errors. This is probably happens because `webpack` is run first, and its TypeScript configuration is different becaese it uses `ts-loader`.

Use `tsc --build --force .` to force building (i.e. type-checking) every file, even if they have already been build.