### PR TITLE
Don't use empty string to mean empty body

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/s3/DocumentService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/s3/DocumentService.kt
@@ -88,13 +88,13 @@ class DocumentService(
             ResponseEntity.ok()
                 .header("X-Accel-Redirect", url)
                 .header("Content-Disposition", contentDispositionHeader)
-                .body("")
+                .body(null)
         } else {
             // nginx is not available in development => redirect to the presigned S3 url
             ResponseEntity.status(HttpStatus.FOUND)
                 .header("Location", presignedUrl.toString())
                 .header("Content-Disposition", contentDispositionHeader)
-                .body("")
+                .body(null)
         }
     }
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

empty string = `Content-Length: 0` *and* `Content-Type: text/plain`, which seems to sometimes cause Spring Boot to fail the whole request if the client has set `Accept` or other headers so that content type negotation fails.

null body = `Content-Length: 0` without making any claims about the content type.

In both cases nginx will override these headers with actual values from S3.