### PR TITLE
Remove explicit id parameter

### DIFF
--- a/frontend/src/employee-mobile-frontend/auth/api.ts
+++ b/frontend/src/employee-mobile-frontend/auth/api.ts
@@ -13,7 +13,6 @@ import {
 import { PinLoginResponse } from 'lib-common/generated/api-types/pairing'
 import { WebPushSubscription } from 'lib-common/generated/api-types/webpush'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
 
 import { client } from '../client'
 
@@ -71,11 +70,10 @@ export const mapPinLoginRequiredError = (
 }
 
 export async function upsertPushSubscription(
-  id: UUID,
   subscription: WebPushSubscription
 ): Promise<Result<void>> {
   return await client
-    .post<void>(`/mobile-devices/${encodeURIComponent(id)}/push-subscription`, {
+    .post<void>(`/mobile-devices/push-subscription`, {
       ...subscription,
       expires: subscription.expires?.toJSON()
     })

--- a/frontend/src/employee-mobile-frontend/common/service-worker.tsx
+++ b/frontend/src/employee-mobile-frontend/common/service-worker.tsx
@@ -13,7 +13,6 @@ import React, {
 } from 'react'
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { UUID } from 'lib-common/types'
 import { mockNow } from 'lib-common/utils/helpers'
 
 import { upsertPushSubscription } from '../auth/api'
@@ -51,11 +50,11 @@ export const ServiceWorkerContextProvider = React.memo(
     const pushNotifications = useMemo(() => {
       if (!user?.pushApplicationServerKey) return undefined
       if (!pushManager) return undefined
-      return new PushNotifications(user.id, pushManager, {
+      return new PushNotifications(pushManager, {
         userVisibleOnly: true,
         applicationServerKey: user.pushApplicationServerKey
       })
-    }, [user?.pushApplicationServerKey, user?.id, pushManager])
+    }, [user?.pushApplicationServerKey, pushManager])
 
     useEffect(() => {
       registerServiceWorker()
@@ -94,7 +93,6 @@ const registerServiceWorker = async () => {
 
 export class PushNotifications {
   constructor(
-    private device: UUID,
     private pushManager: PushManager,
     private options: PushSubscriptionOptionsInit
   ) {}
@@ -108,7 +106,7 @@ export class PushNotifications {
     const authSecret = sub?.getKey('auth')
     const ecdhKey = sub?.getKey('p256dh')
     if (sub && authSecret && ecdhKey) {
-      await upsertPushSubscription(this.device, {
+      await upsertPushSubscription({
         endpoint: sub.endpoint,
         expires: sub.expirationTime
           ? HelsinkiDateTime.fromSystemTzDate(new Date(sub.expirationTime))

--- a/service/src/main/kotlin/fi/espoo/evaka/webpush/WebPushController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/webpush/WebPushController.kt
@@ -5,12 +5,10 @@
 package fi.espoo.evaka.webpush
 
 import fi.espoo.evaka.Audit
-import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.net.URI
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -31,16 +29,15 @@ data class WebPushSubscription(
 
 @RestController
 class WebPushController {
-    @PostMapping("/mobile-devices/{id}/push-subscription")
+    @PostMapping("/mobile-devices/push-subscription")
     fun upsertPushSubscription(
         db: Database,
         user: AuthenticatedUser.MobileDevice,
-        @PathVariable id: MobileDeviceId,
         @RequestBody subscription: WebPushSubscription
     ) {
-        db.connect { dbc -> dbc.transaction { it.upsertPushSubscription(id, subscription) } }
+        db.connect { dbc -> dbc.transaction { it.upsertPushSubscription(user.id, subscription) } }
         Audit.PushSubscriptionUpsert.log(
-            targetId = id,
+            targetId = user.id,
             meta = mapOf("endpoint" to subscription.endpoint, "expires" to subscription.expires)
         )
     }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

We don't want to allow upsert subscriptions for *other* mobile devices, so get the id from AuthenticatedUser instead