### PR TITLE
Use ReactNode functions to define decision info entries

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
@@ -551,7 +551,7 @@ const DecisionEditor = React.memo(function DecisionEditor({
 
               <LabeledValue>
                 <ExpandingInfo
-                  info={t.validFromInfo}
+                  info={t.validFromInfo()}
                   ariaLabel={i18n.common.openExpandingInfo}
                   closeLabel={i18n.common.openExpandingInfo}
                 >
@@ -574,7 +574,7 @@ const DecisionEditor = React.memo(function DecisionEditor({
                 {extendedCompulsoryEducation.value() && (
                   <LabeledValue>
                     <ExpandingInfo
-                      info={t.extendedCompulsoryEducationInfoInfo}
+                      info={t.extendedCompulsoryEducationInfoInfo()}
                       ariaLabel={i18n.common.openExpandingInfo}
                       closeLabel={i18n.common.openExpandingInfo}
                     >
@@ -592,7 +592,7 @@ const DecisionEditor = React.memo(function DecisionEditor({
 
               <FixedSpaceColumn>
                 <ExpandingInfo
-                  info={t.grantedAssistanceSectionInfo}
+                  info={t.grantedAssistanceSectionInfo()}
                   ariaLabel={i18n.common.openExpandingInfo}
                   closeLabel={i18n.common.openExpandingInfo}
                 >
@@ -637,7 +637,7 @@ const DecisionEditor = React.memo(function DecisionEditor({
 
               <LabeledValue>
                 <ExpandingInfo
-                  info={t.primaryGroupInfo}
+                  info={t.primaryGroupInfo()}
                   ariaLabel={i18n.common.openExpandingInfo}
                   closeLabel={i18n.common.openExpandingInfo}
                 >
@@ -653,7 +653,7 @@ const DecisionEditor = React.memo(function DecisionEditor({
 
               <LabeledValue>
                 <ExpandingInfo
-                  info={t.decisionBasisInfo}
+                  info={t.decisionBasisInfo()}
                   ariaLabel={i18n.common.openExpandingInfo}
                   closeLabel={i18n.common.openExpandingInfo}
                 >
@@ -671,7 +671,7 @@ const DecisionEditor = React.memo(function DecisionEditor({
               <FixedSpaceColumn>
                 <FixedSpaceRow alignItems="center">
                   <ExpandingInfo
-                    info={t.documentBasisInfo}
+                    info={t.documentBasisInfo()}
                     ariaLabel={i18n.common.openExpandingInfo}
                     closeLabel={i18n.common.openExpandingInfo}
                   >
@@ -771,7 +771,7 @@ const DecisionEditor = React.memo(function DecisionEditor({
 
               <FixedSpaceColumn>
                 <ExpandingInfo
-                  info={t.heardGuardiansInfo}
+                  info={t.heardGuardiansInfo()}
                   ariaLabel={i18n.common.openExpandingInfo}
                   closeLabel={i18n.common.openExpandingInfo}
                 >
@@ -812,7 +812,7 @@ const DecisionEditor = React.memo(function DecisionEditor({
 
               <LabeledValue>
                 <ExpandingInfo
-                  info={t.viewOfGuardiansInfo}
+                  info={t.viewOfGuardiansInfo()}
                   ariaLabel={i18n.common.openExpandingInfo}
                   closeLabel={i18n.common.openExpandingInfo}
                 >

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -864,11 +864,19 @@ export const fi = {
       no: 'Ei',
       extendedCompulsoryEducationInfo:
         'Lisätiedot pidennetystä oppivelvollisuudesta',
-      extendedCompulsoryEducationInfoInfo: 'infoa',
+      extendedCompulsoryEducationInfoInfo: <>infoa</>,
       grantedAssistanceSection:
         'Myönnettävät tulkitsemis- ja avustajapalvelut tai erityiset apuvälineet',
-      grantedAssistanceSectionInfo:
-        'Merkitään jos lapselle myönnetään avustamis-/tulkitsemispalveluita tai apuvälineitä. Kirjataan perusteluihin ”Lapselle myönnetään perusopetuslain 31§ mukaisena tukipalveluna avustamispalvelua/tarvittavat erityiset apuvälineet/tulkitsemispalvelua/opetuksen poikkeava järjestäminen” sekä lyhyt perustelu.',
+      grantedAssistanceSectionInfo: (
+        <>
+          Merkitään jos lapselle myönnetään avustamis-/tulkitsemispalveluita tai
+          apuvälineitä. Kirjataan perusteluihin ”Lapselle myönnetään
+          perusopetuslain 31§ mukaisena tukipalveluna
+          avustamispalvelua/tarvittavat erityiset
+          apuvälineet/tulkitsemispalvelua/opetuksen poikkeava järjestäminen”
+          sekä lyhyt perustelu.
+        </>
+      ),
       grantedAssistanceService: 'Lapselle myönnetään avustajapalveluita',
       grantedInterpretationService: 'Lapselle myönnetään tulkitsemispalveluita',
       grantedAssistiveDevices: 'Lapselle myönnetään erityisiä apuvälineitä',
@@ -877,25 +885,45 @@ export const fi = {
         'Perustelut myönnettäville tulkitsemis- ja avustajapalveluille ja apuvälineille',
       selectedUnit: 'Esiopetuksen järjestämispaikka',
       primaryGroup: 'Pääsääntöinen opetusryhmä',
-      primaryGroupInfo:
-        'Kirjaa tähän ryhmän muoto erityisryhmä/pedagogisesti vahvistettu ryhmä/esiopetusryhmä/3-5-vuotiaiden ryhmä.',
+      primaryGroupInfo: (
+        <>
+          Kirjaa tähän ryhmän muoto erityisryhmä/pedagogisesti vahvistettu
+          ryhmä/esiopetusryhmä/3-5-vuotiaiden ryhmä.
+        </>
+      ),
       decisionBasis: 'Perustelut päätökselle',
-      decisionBasisInfo:
-        'Kirjaa mihin selvityksiin päätös perustuu (pedagoginen selvitys ja/tai psykologinen tai lääketieteellinen lausunto sekä päivämäärät). Jos lapselle on myönnetty pidennetty oppivelvollisuus, kirjataan ”lapselle on tehty pidennetyn oppivelvollisuuden päätös pvm."',
+      decisionBasisInfo: (
+        <>
+          Kirjaa mihin selvityksiin päätös perustuu (pedagoginen selvitys ja/tai
+          psykologinen tai lääketieteellinen lausunto sekä päivämäärät). Jos
+          lapselle on myönnetty pidennetty oppivelvollisuus, kirjataan ”lapselle
+          on tehty pidennetyn oppivelvollisuuden päätös pvm”.
+        </>
+      ),
       documentBasis: 'Asiakirjat, joihin päätös perustuu',
-      documentBasisInfo:
-        'Liitteenä voi olla myös huoltajan yksilöity valtakirja, huoltajan nimi ja päivämäärä.',
+      documentBasisInfo: (
+        <>
+          Liitteenä voi olla myös huoltajan yksilöity valtakirja, huoltajan nimi
+          ja päivämäärä.
+        </>
+      ),
       basisDocumentPedagogicalReport: 'Pedagoginen selvitys',
       basisDocumentPsychologistStatement: 'Psykologin lausunto',
       basisDocumentDoctorStatement: 'Lääkärin lausunto',
       basisDocumentSocialReport: 'Sosiaalinen selvitys',
       basisDocumentOtherOrMissing: 'Liite puuttuu, tai muu liite, mikä?',
-      basisDocumentsInfo: 'Lisätiedot liitteistä',
+      basisDocumentsInfo: <>Lisätiedot liitteistä</>,
       guardianCollaborationSection: 'Huoltajien kanssa tehty yhteistyö',
       guardiansHeardOn: 'Huoltajien kuulemisen päivämäärä',
       heardGuardians: 'Huoltajat, joita on kuultu, ja kuulemistapa',
-      heardGuardiansInfo:
-        'Kirjaa tähän millä keinoin huoltajaa on kuultu (esim. palaveri, etäyhteys, huoltajien kirjallinen vastine, valtakirja). Jos huoltajaa ei ole kuultu, kirjaa tähän selvitys siitä, miten ja milloin hänet on kutsuttu kuultavaksi.',
+      heardGuardiansInfo: (
+        <>
+          Kirjaa tähän millä keinoin huoltajaa on kuultu (esim. palaveri,
+          etäyhteys, huoltajien kirjallinen vastine, valtakirja). Jos huoltajaa
+          ei ole kuultu, kirjaa tähän selvitys siitä, miten ja milloin hänet on
+          kutsuttu kuultavaksi.
+        </>
+      ),
       otherRepresentative:
         'Muu laillinen edustaja (nimi, puhelinnumero ja kuulemistapa)',
       viewOfGuardians: 'Huoltajien näkemys esitetystä tuesta',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -840,7 +840,7 @@ export const fi = {
       decidedAssistance: 'Päätettävä tuki',
       type: 'Erityisen tuen tila',
       validFrom: 'Voimassa alkaen',
-      validFromInfo: (
+      validFromInfo: (): React.ReactNode => (
         <ul>
           <li>
             Erityinen tuki alkaa merkitään huoltajien kuulemispäivämäärästä tai
@@ -864,19 +864,11 @@ export const fi = {
       no: 'Ei',
       extendedCompulsoryEducationInfo:
         'Lisätiedot pidennetystä oppivelvollisuudesta',
-      extendedCompulsoryEducationInfoInfo: <>infoa</>,
+      extendedCompulsoryEducationInfoInfo: (): React.ReactNode => 'infoa',
       grantedAssistanceSection:
         'Myönnettävät tulkitsemis- ja avustajapalvelut tai erityiset apuvälineet',
-      grantedAssistanceSectionInfo: (
-        <>
-          Merkitään jos lapselle myönnetään avustamis-/tulkitsemispalveluita tai
-          apuvälineitä. Kirjataan perusteluihin ”Lapselle myönnetään
-          perusopetuslain 31§ mukaisena tukipalveluna
-          avustamispalvelua/tarvittavat erityiset
-          apuvälineet/tulkitsemispalvelua/opetuksen poikkeava järjestäminen”
-          sekä lyhyt perustelu.
-        </>
-      ),
+      grantedAssistanceSectionInfo: (): React.ReactNode =>
+        'Merkitään jos lapselle myönnetään avustamis-/tulkitsemispalveluita tai apuvälineitä. Kirjataan perusteluihin ”Lapselle myönnetään perusopetuslain 31§ mukaisena tukipalveluna avustamispalvelua/tarvittavat erityiset apuvälineet/tulkitsemispalvelua/opetuksen poikkeava järjestäminen” sekä lyhyt perustelu.',
       grantedAssistanceService: 'Lapselle myönnetään avustajapalveluita',
       grantedInterpretationService: 'Lapselle myönnetään tulkitsemispalveluita',
       grantedAssistiveDevices: 'Lapselle myönnetään erityisiä apuvälineitä',
@@ -885,49 +877,29 @@ export const fi = {
         'Perustelut myönnettäville tulkitsemis- ja avustajapalveluille ja apuvälineille',
       selectedUnit: 'Esiopetuksen järjestämispaikka',
       primaryGroup: 'Pääsääntöinen opetusryhmä',
-      primaryGroupInfo: (
-        <>
-          Kirjaa tähän ryhmän muoto erityisryhmä/pedagogisesti vahvistettu
-          ryhmä/esiopetusryhmä/3-5-vuotiaiden ryhmä.
-        </>
-      ),
+      primaryGroupInfo: (): React.ReactNode =>
+        'Kirjaa tähän ryhmän muoto erityisryhmä/pedagogisesti vahvistettu ryhmä/esiopetusryhmä/3-5-vuotiaiden ryhmä.',
       decisionBasis: 'Perustelut päätökselle',
-      decisionBasisInfo: (
-        <>
-          Kirjaa mihin selvityksiin päätös perustuu (pedagoginen selvitys ja/tai
-          psykologinen tai lääketieteellinen lausunto sekä päivämäärät). Jos
-          lapselle on myönnetty pidennetty oppivelvollisuus, kirjataan ”lapselle
-          on tehty pidennetyn oppivelvollisuuden päätös pvm”.
-        </>
-      ),
+      decisionBasisInfo: (): React.ReactNode =>
+        'Kirjaa mihin selvityksiin päätös perustuu (pedagoginen selvitys ja/tai psykologinen tai lääketieteellinen lausunto sekä päivämäärät). Jos lapselle on myönnetty pidennetty oppivelvollisuus, kirjataan ”lapselle on tehty pidennetyn oppivelvollisuuden päätös pvm."',
       documentBasis: 'Asiakirjat, joihin päätös perustuu',
-      documentBasisInfo: (
-        <>
-          Liitteenä voi olla myös huoltajan yksilöity valtakirja, huoltajan nimi
-          ja päivämäärä.
-        </>
-      ),
+      documentBasisInfo: (): React.ReactNode =>
+        'Liitteenä voi olla myös huoltajan yksilöity valtakirja, huoltajan nimi ja päivämäärä.',
       basisDocumentPedagogicalReport: 'Pedagoginen selvitys',
       basisDocumentPsychologistStatement: 'Psykologin lausunto',
       basisDocumentDoctorStatement: 'Lääkärin lausunto',
       basisDocumentSocialReport: 'Sosiaalinen selvitys',
       basisDocumentOtherOrMissing: 'Liite puuttuu, tai muu liite, mikä?',
-      basisDocumentsInfo: <>Lisätiedot liitteistä</>,
+      basisDocumentsInfo: 'Lisätiedot liitteistä',
       guardianCollaborationSection: 'Huoltajien kanssa tehty yhteistyö',
       guardiansHeardOn: 'Huoltajien kuulemisen päivämäärä',
       heardGuardians: 'Huoltajat, joita on kuultu, ja kuulemistapa',
-      heardGuardiansInfo: (
-        <>
-          Kirjaa tähän millä keinoin huoltajaa on kuultu (esim. palaveri,
-          etäyhteys, huoltajien kirjallinen vastine, valtakirja). Jos huoltajaa
-          ei ole kuultu, kirjaa tähän selvitys siitä, miten ja milloin hänet on
-          kutsuttu kuultavaksi.
-        </>
-      ),
+      heardGuardiansInfo: (): React.ReactNode =>
+        'Kirjaa tähän millä keinoin huoltajaa on kuultu (esim. palaveri, etäyhteys, huoltajien kirjallinen vastine, valtakirja). Jos huoltajaa ei ole kuultu, kirjaa tähän selvitys siitä, miten ja milloin hänet on kutsuttu kuultavaksi.',
       otherRepresentative:
         'Muu laillinen edustaja (nimi, puhelinnumero ja kuulemistapa)',
       viewOfGuardians: 'Huoltajien näkemys esitetystä tuesta',
-      viewOfGuardiansInfo: (
+      viewOfGuardiansInfo: (): React.ReactNode => (
         <div>
           <p>
             Kirjaa selkeästi huoltajien mielipide. Mikäli huoltajat ovat

--- a/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
@@ -46,7 +46,7 @@ export const sv = {
       basisDocumentDoctorStatement: 'Läkarutlåtande',
       basisDocumentSocialReport: 'Social utredning',
       basisDocumentOtherOrMissing: 'Bilaga saknas, eller annan bilaga, vilken?',
-      basisDocumentsInfo: 'Mer information om bilagorna',
+      basisDocumentsInfo: <>'Mer information om bilagorna'</>,
       guardianCollaborationSection: 'Samarbete med vårdnadshavarna',
       guardiansHeardOn: 'Datum för hörande av vårdnadshavarna',
       heardGuardians: 'Vårdnadshavare som har hörts och hörandesätt',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
@@ -46,7 +46,7 @@ export const sv = {
       basisDocumentDoctorStatement: 'Läkarutlåtande',
       basisDocumentSocialReport: 'Social utredning',
       basisDocumentOtherOrMissing: 'Bilaga saknas, eller annan bilaga, vilken?',
-      basisDocumentsInfo: <>'Mer information om bilagorna'</>,
+      basisDocumentsInfo: 'Mer information om bilagorna',
       guardianCollaborationSection: 'Samarbete med vårdnadshavarna',
       guardiansHeardOn: 'Datum för hörande av vårdnadshavarna',
       heardGuardians: 'Vårdnadshavare som har hörts och hörandesätt',


### PR DESCRIPTION
Enables JSX or string format for city customizations on all extensible info sections for this decision.

**NOTE: this requires changes in customizations that have already implemented info content in string or JSX format. Customized content has to be wrapped in a function and the issue doesn't seem to show as a type error**
