### PR TITLE
Redesign job scheduler to support multiple job types

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -27,8 +27,6 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
 import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.dev.runDevScript
-import fi.espoo.evaka.shared.job.ScheduledJob
-import fi.espoo.evaka.shared.job.ScheduledJobSettingsMap
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
 import fi.espoo.evaka.shared.security.actionrule.ActionRuleMapping
@@ -187,10 +185,6 @@ class SharedIntegrationTestConfig {
     @Bean fun invoiceProductProvider(): InvoiceProductProvider = TestInvoiceProductProvider()
 
     @Bean fun actionRuleMapping(): ActionRuleMapping = DefaultActionRuleMapping()
-
-    @Bean
-    fun scheduledJobsConfig(): ScheduledJobSettingsMap<ScheduledJob> =
-        ScheduledJobSettingsMap(emptyMap())
 }
 
 val testFeatureConfig =

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -27,6 +27,8 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.configureJdbi
 import fi.espoo.evaka.shared.dev.resetDatabase
 import fi.espoo.evaka.shared.dev.runDevScript
+import fi.espoo.evaka.shared.job.ScheduledJob
+import fi.espoo.evaka.shared.job.ScheduledJobSettingsMap
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
 import fi.espoo.evaka.shared.security.actionrule.ActionRuleMapping
@@ -185,6 +187,10 @@ class SharedIntegrationTestConfig {
     @Bean fun invoiceProductProvider(): InvoiceProductProvider = TestInvoiceProductProvider()
 
     @Bean fun actionRuleMapping(): ActionRuleMapping = DefaultActionRuleMapping()
+
+    @Bean
+    fun scheduledJobsConfig(): ScheduledJobSettingsMap<ScheduledJob> =
+        ScheduledJobSettingsMap(emptyMap())
 }
 
 val testFeatureConfig =

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
@@ -27,7 +27,7 @@ class ScheduledJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
     private val testTime = LocalTime.of(1, 0)
     private val testSchedule =
         object : JobSchedule {
-            override val jobs: List<ScheduledJobDefinition<TestScheduledJob>> =
+            override val jobs: List<ScheduledJobDefinition> =
                 listOf(
                     ScheduledJobDefinition(
                         TestScheduledJob.TestJob,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunnerTest.kt
@@ -12,57 +12,60 @@ import fi.espoo.evaka.shared.domain.europeHelsinki
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalTime
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class ScheduledJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
+    enum class TestScheduledJob {
+        TestJob,
+    }
     private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
     private val testTime = LocalTime.of(1, 0)
     private val testSchedule =
         object : JobSchedule {
-            override fun getSettingsForJob(job: ScheduledJob): ScheduledJobSettings? =
-                if (job == ScheduledJob.EndOfDayAttendanceUpkeep) {
-                    ScheduledJobSettings(enabled = true, schedule = JobSchedule.daily(testTime))
-                } else {
-                    null
-                }
+            override val jobs: List<ScheduledJobDefinition<TestScheduledJob>> =
+                listOf(
+                    ScheduledJobDefinition(
+                        TestScheduledJob.TestJob,
+                        ScheduledJobSettings(enabled = true, schedule = JobSchedule.daily(testTime))
+                    ) { _, _ ->
+                        val previous = jobExecuted.getAndSet(true)
+                        assertFalse(previous)
+                    }
+                )
         }
+    private val jobExecuted = AtomicBoolean(false)
 
     @BeforeEach
     fun beforeEach() {
         asyncJobRunner = AsyncJobRunner(AsyncJob::class, listOf(AsyncJob.main), jdbi, noopTracer)
+        jobExecuted.set(false)
     }
 
     @Test
     fun `a job specified by DailySchedule is scheduled and executed correctly`() {
-        val executedJob = AtomicReference<ScheduledJob?>(null)
-        asyncJobRunner.registerHandler { _, _, msg: AsyncJob.RunScheduledJob ->
-            val previous = executedJob.getAndSet(msg.job)
-            assertNull(previous)
-        }
-        ScheduledJobRunner(jdbi, noopTracer, asyncJobRunner, dataSource, testSchedule).use { runner
-            ->
-            runner.scheduler.start()
-            val exec =
-                runner
-                    .getScheduledExecutionsForTask(ScheduledJob.EndOfDayAttendanceUpkeep)
-                    .singleOrNull()!!
-            assertEquals(exec.executionTime.atZone(europeHelsinki).toLocalTime(), testTime)
+        ScheduledJobRunner(jdbi, noopTracer, asyncJobRunner, listOf(testSchedule), dataSource)
+            .use { runner ->
+                runner.scheduler.start()
+                val exec =
+                    runner.getScheduledExecutionsForTask(TestScheduledJob.TestJob).singleOrNull()!!
+                assertEquals(exec.executionTime.atZone(europeHelsinki).toLocalTime(), testTime)
 
-            runner.scheduler.reschedule(exec.taskInstance, Instant.EPOCH)
-            runner.scheduler.triggerCheckForDueExecutions()
+                runner.scheduler.reschedule(exec.taskInstance, Instant.EPOCH)
+                runner.scheduler.triggerCheckForDueExecutions()
 
-            val start = Instant.now()
-            while (asyncJobRunner.runPendingJobsSync(RealEvakaClock()) == 0) {
-                Thread.sleep(100)
+                val start = Instant.now()
+                while (asyncJobRunner.runPendingJobsSync(RealEvakaClock()) == 0) {
+                    Thread.sleep(100)
 
-                assert(Duration.between(start, Instant.now()) < Duration.ofSeconds(10))
+                    assert(Duration.between(start, Instant.now()) < Duration.ofSeconds(10))
+                }
             }
-        }
 
-        assertEquals(executedJob.get(), ScheduledJob.EndOfDayAttendanceUpkeep)
+        assertTrue(jobExecuted.get())
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/VasuIntegrationTest.kt
@@ -449,7 +449,7 @@ class VasuIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         db.transaction { tx ->
             asyncJobRunner.plan(
                 tx,
-                listOf(AsyncJob.RunScheduledJob(ScheduledJob.CloseVasusWithExpiredTemplate)),
+                listOf(AsyncJob.RunScheduledJob(ScheduledJob.CloseVasusWithExpiredTemplate.name)),
                 runAt = futureClock.now(),
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -35,8 +35,8 @@ import fi.espoo.evaka.shared.db.DevDataInitializer
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.domain.Unauthorized
-import fi.espoo.evaka.shared.job.DefaultJobSchedule
-import fi.espoo.evaka.shared.job.JobSchedule
+import fi.espoo.evaka.shared.job.ScheduledJob
+import fi.espoo.evaka.shared.job.ScheduledJobSettingsMap
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
 import fi.espoo.evaka.shared.security.actionrule.ActionRuleMapping
@@ -134,7 +134,10 @@ class EspooConfig {
 
     @Bean fun templateProvider(): ITemplateProvider = EvakaTemplateProvider()
 
-    @Bean fun jobSchedule(env: ScheduledJobsEnv): JobSchedule = DefaultJobSchedule(env)
+    @Bean
+    fun scheduledJobSettingsMap(
+        env: ScheduledJobsEnv<ScheduledJob>
+    ): ScheduledJobSettingsMap<ScheduledJob> = ScheduledJobSettingsMap(env.jobs)
 
     @Bean
     @Profile("local")

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -37,8 +37,6 @@ import fi.espoo.evaka.shared.db.DevDataInitializer
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.domain.Unauthorized
-import fi.espoo.evaka.shared.job.ScheduledJob
-import fi.espoo.evaka.shared.job.ScheduledJobSettingsMap
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
 import fi.espoo.evaka.shared.security.actionrule.ActionRuleMapping
@@ -135,11 +133,6 @@ class EspooConfig {
     ): DocumentService = DocumentService(s3Client, s3Presigner, env.proxyThroughNginx)
 
     @Bean fun templateProvider(): ITemplateProvider = EvakaTemplateProvider()
-
-    @Bean
-    fun scheduledJobSettingsMap(
-        env: ScheduledJobsEnv<ScheduledJob>
-    ): ScheduledJobSettingsMap<ScheduledJob> = ScheduledJobSettingsMap(env.jobs)
 
     @Bean
     fun espooScheduledJobEnv(env: Environment): ScheduledJobsEnv<EspooScheduledJob> =

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import fi.espoo.evaka.children.consent.ChildConsentType
 import fi.espoo.evaka.emailclient.EvakaEmailMessageProvider
 import fi.espoo.evaka.emailclient.IEmailMessageProvider
+import fi.espoo.evaka.espoo.EspooScheduledJob
+import fi.espoo.evaka.espoo.EspooScheduledJobs
 import fi.espoo.evaka.espoobi.EspooBiPoc
 import fi.espoo.evaka.invoicing.domain.PaymentIntegrationClient
 import fi.espoo.evaka.invoicing.integration.EspooInvoiceIntegrationClient
@@ -140,6 +142,14 @@ class EspooConfig {
     ): ScheduledJobSettingsMap<ScheduledJob> = ScheduledJobSettingsMap(env.jobs)
 
     @Bean
+    fun espooScheduledJobEnv(env: Environment): ScheduledJobsEnv<EspooScheduledJob> =
+        ScheduledJobsEnv.fromEnvironment(
+            EspooScheduledJob.values().associateWith { it.defaultSettings },
+            "espoo.job",
+            env
+        )
+
+    @Bean
     @Profile("local")
     fun devDataInitializer(jdbi: Jdbi, tracer: Tracer) = DevDataInitializer(jdbi, tracer)
 
@@ -242,6 +252,12 @@ class EspooConfig {
         }
 
     @Bean fun actionRuleMapping(): ActionRuleMapping = DefaultActionRuleMapping()
+
+    @Bean
+    fun espooScheduledJobs(
+        patuReportingService: PatuReportingService,
+        env: ScheduledJobsEnv<EspooScheduledJob>
+    ): EspooScheduledJobs = EspooScheduledJobs(patuReportingService, env)
 }
 
 data class EspooEnv(

--- a/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooScheduledJobs.kt
@@ -29,7 +29,7 @@ class EspooScheduledJobs(
     private val patuReportingService: PatuReportingService,
     env: ScheduledJobsEnv<EspooScheduledJob>
 ) : JobSchedule {
-    override val jobs: List<ScheduledJobDefinition<*>> =
+    override val jobs: List<ScheduledJobDefinition> =
         env.jobs.map {
             ScheduledJobDefinition(it.key, it.value) { db, clock -> it.key.fn(this, db, clock) }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooScheduledJobs.kt
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.espoo
+
+import fi.espoo.evaka.ScheduledJobsEnv
+import fi.espoo.evaka.reports.patu.PatuReportingService
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.job.JobSchedule
+import fi.espoo.evaka.shared.job.ScheduledJobDefinition
+import fi.espoo.evaka.shared.job.ScheduledJobSettings
+import java.time.LocalTime
+import mu.KotlinLogging
+
+enum class EspooScheduledJob(
+    val fn: (EspooScheduledJobs, Database.Connection, EvakaClock) -> Unit,
+    val defaultSettings: ScheduledJobSettings
+) {
+    SendPatuReport(
+        EspooScheduledJobs::sendPatuReport,
+        ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(6, 0)))
+    )
+}
+
+class EspooScheduledJobs(
+    private val patuReportingService: PatuReportingService,
+    env: ScheduledJobsEnv<EspooScheduledJob>
+) : JobSchedule {
+    override val jobs: List<ScheduledJobDefinition<*>> =
+        env.jobs.map {
+            ScheduledJobDefinition(it.key, it.value) { db, clock -> it.key.fn(this, db, clock) }
+        }
+    private val logger = KotlinLogging.logger {}
+
+    fun sendPatuReport(db: Database.Connection, clock: EvakaClock) {
+        val yesterday = clock.today().minusDays(1)
+        logger.info("Sending patu report for $yesterday")
+        patuReportingService.sendPatuReport(db, DateRange(yesterday, yesterday))
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -33,7 +33,6 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
-import fi.espoo.evaka.shared.job.ScheduledJob
 import fi.espoo.evaka.varda.VardaChildCalculatedServiceNeedChanges
 import java.time.Duration
 import java.util.UUID
@@ -145,7 +144,7 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
-    data class RunScheduledJob(val job: ScheduledJob) : AsyncJob {
+    data class RunScheduledJob(val job: String) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/EnvConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/EnvConfig.kt
@@ -19,6 +19,7 @@ import fi.espoo.evaka.VardaEnv
 import fi.espoo.evaka.VtjEnv
 import fi.espoo.evaka.VtjXroadEnv
 import fi.espoo.evaka.WebPushEnv
+import fi.espoo.evaka.shared.job.ScheduledJob
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
@@ -51,7 +52,12 @@ class EnvConfig {
     @Bean fun jwtEnv(env: Environment): JwtEnv = JwtEnv.fromEnvironment(env)
 
     @Bean
-    fun scheduledJobsEnv(env: Environment): ScheduledJobsEnv = ScheduledJobsEnv.fromEnvironment(env)
+    fun scheduledJobsEnv(env: Environment): ScheduledJobsEnv<ScheduledJob> =
+        ScheduledJobsEnv.fromEnvironment(
+            ScheduledJob.values().associateWith { it.defaultSettings },
+            "evaka.job",
+            env
+        )
 
     @Bean fun vtjEnv(evakaEnv: EvakaEnv, env: Environment): VtjEnv = VtjEnv.fromEnvironment(env)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/ScheduledJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/ScheduledJobConfig.kt
@@ -26,8 +26,8 @@ class ScheduledJobConfig {
         tracer: Tracer,
         asyncJobRunner: AsyncJobRunner<AsyncJob>,
         dataSource: DataSource,
-        schedule: JobSchedule
-    ) = ScheduledJobRunner(jdbi, tracer, asyncJobRunner, dataSource, schedule)
+        schedules: List<JobSchedule>
+    ) = ScheduledJobRunner(jdbi, tracer, asyncJobRunner, schedules, dataSource)
 
     @Bean
     fun scheduledJobRunnerStart(runner: ScheduledJobRunner) =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/ScheduledJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/ScheduledJobConfig.kt
@@ -18,7 +18,6 @@ import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 
 @Configuration
-@Profile("production")
 class ScheduledJobConfig {
     @Bean
     fun scheduledJobRunner(
@@ -30,6 +29,7 @@ class ScheduledJobConfig {
     ) = ScheduledJobRunner(jdbi, tracer, asyncJobRunner, schedules, dataSource)
 
     @Bean
+    @Profile("production")
     fun scheduledJobRunnerStart(runner: ScheduledJobRunner) =
         object {
             @EventListener

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -20,8 +20,6 @@ interface JobSchedule {
     }
 }
 
-data class ScheduledJobSettingsMap<T : Enum<T>>(val jobs: Map<T, ScheduledJobSettings>)
-
 data class ScheduledJobDefinition(
     val job: Enum<*>,
     val settings: ScheduledJobSettings,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.shared.domain.europeHelsinki
 import java.time.LocalTime
 
 interface JobSchedule {
-    val jobs: List<ScheduledJobDefinition<*>>
+    val jobs: List<ScheduledJobDefinition>
     companion object {
         fun daily(at: LocalTime): Schedule = Daily(europeHelsinki, at)
         fun cron(expression: String): Schedule = CronSchedule(expression, europeHelsinki)
@@ -22,8 +22,8 @@ interface JobSchedule {
 
 data class ScheduledJobSettingsMap<T : Enum<T>>(val jobs: Map<T, ScheduledJobSettings>)
 
-data class ScheduledJobDefinition<T : Enum<T>>(
-    val job: T,
+data class ScheduledJobDefinition(
+    val job: Enum<*>,
     val settings: ScheduledJobSettings,
     val jobFn: (db: Database.Connection, clock: EvakaClock) -> Unit
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/JobSchedule.kt
@@ -7,129 +7,29 @@ package fi.espoo.evaka.shared.job
 import com.github.kagkarlsson.scheduler.task.schedule.CronSchedule
 import com.github.kagkarlsson.scheduler.task.schedule.Daily
 import com.github.kagkarlsson.scheduler.task.schedule.Schedule
-import fi.espoo.evaka.ScheduledJobsEnv
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.europeHelsinki
 import java.time.LocalTime
 
 interface JobSchedule {
-    fun getSettingsForJob(job: ScheduledJob): ScheduledJobSettings?
-
+    val jobs: List<ScheduledJobDefinition<*>>
     companion object {
         fun daily(at: LocalTime): Schedule = Daily(europeHelsinki, at)
         fun cron(expression: String): Schedule = CronSchedule(expression, europeHelsinki)
     }
 }
 
+data class ScheduledJobSettingsMap<T : Enum<T>>(val jobs: Map<T, ScheduledJobSettings>)
+
+data class ScheduledJobDefinition<T : Enum<T>>(
+    val job: T,
+    val settings: ScheduledJobSettings,
+    val jobFn: (db: Database.Connection, clock: EvakaClock) -> Unit
+)
+
 data class ScheduledJobSettings(
     val enabled: Boolean,
     val schedule: Schedule,
     val retryCount: Int? = null
-) {
-    companion object {
-        fun default(job: ScheduledJob) =
-            when (job) {
-                ScheduledJob.VardaUpdate ->
-                    ScheduledJobSettings(
-                        enabled = false,
-                        schedule = JobSchedule.cron("0 0 20 * * 1,2,3,4,5"), // mon - fri @ 20 pm
-                        retryCount = 1
-                    )
-                ScheduledJob.EndOfDayAttendanceUpkeep ->
-                    ScheduledJobSettings(
-                        enabled = true,
-                        schedule = JobSchedule.daily(LocalTime.of(0, 0))
-                    )
-                ScheduledJob.EndOfDayStaffAttendanceUpkeep ->
-                    ScheduledJobSettings(
-                        enabled = true,
-                        schedule = JobSchedule.daily(LocalTime.of(0, 0))
-                    )
-                ScheduledJob.EndOfDayReservationUpkeep ->
-                    ScheduledJobSettings(
-                        enabled = true,
-                        schedule = JobSchedule.daily(LocalTime.of(0, 0))
-                    )
-                ScheduledJob.KoskiUpdate ->
-                    ScheduledJobSettings(
-                        enabled = false,
-                        schedule = JobSchedule.daily(LocalTime.of(0, 0)),
-                        retryCount = 1
-                    )
-                ScheduledJob.RemoveOldDraftApplications ->
-                    ScheduledJobSettings(
-                        enabled = false,
-                        schedule = JobSchedule.daily(LocalTime.of(0, 30))
-                    )
-                ScheduledJob.CancelOutdatedTransferApplications ->
-                    ScheduledJobSettings(
-                        enabled = false,
-                        schedule = JobSchedule.daily(LocalTime.of(0, 35))
-                    )
-                ScheduledJob.CloseVasusWithExpiredTemplate ->
-                    ScheduledJobSettings(
-                        enabled = true,
-                        schedule = JobSchedule.daily(LocalTime.of(0, 40))
-                    )
-                ScheduledJob.RemoveOldAsyncJobs ->
-                    ScheduledJobSettings(
-                        enabled = true,
-                        schedule = JobSchedule.daily(LocalTime.of(3, 0))
-                    )
-                ScheduledJob.DvvUpdate ->
-                    ScheduledJobSettings(
-                        enabled = false,
-                        schedule = JobSchedule.daily(LocalTime.of(4, 0))
-                    )
-                ScheduledJob.RemoveOldDaycareDailyNotes ->
-                    ScheduledJobSettings(
-                        enabled = true,
-                        schedule = JobSchedule.daily(LocalTime.of(6, 30))
-                    )
-                ScheduledJob.SendPendingDecisionReminderEmails ->
-                    ScheduledJobSettings(
-                        enabled = false,
-                        schedule = JobSchedule.daily(LocalTime.of(7, 0))
-                    )
-                ScheduledJob.FreezeVoucherValueReports ->
-                    ScheduledJobSettings(
-                        enabled = true,
-                        schedule = JobSchedule.cron("0 0 0 25 * ?") // Monthly on 25th
-                    )
-                ScheduledJob.InactivePeopleCleanup ->
-                    ScheduledJobSettings(
-                        enabled = false,
-                        schedule = JobSchedule.daily(LocalTime.of(3, 30)),
-                        retryCount = 1
-                    )
-                ScheduledJob.InactiveEmployeesRoleReset ->
-                    ScheduledJobSettings(
-                        enabled = true,
-                        schedule = JobSchedule.daily(LocalTime.of(3, 15))
-                    )
-                ScheduledJob.SendMissingReservationReminders ->
-                    ScheduledJobSettings(
-                        enabled = false,
-                        schedule = JobSchedule.cron("0 0 18 * * 0") // Sunday 18:00
-                    )
-                ScheduledJob.SendOutdatedIncomeNotifications ->
-                    ScheduledJobSettings(
-                        enabled = false,
-                        schedule = JobSchedule.daily(LocalTime.of(6, 45))
-                    )
-                ScheduledJob.SendCalendarEventDigests ->
-                    ScheduledJobSettings(
-                        enabled = true,
-                        schedule = JobSchedule.daily(LocalTime.of(18, 0))
-                    )
-                ScheduledJob.SendPatuReport ->
-                    ScheduledJobSettings(
-                        enabled = false,
-                        schedule = JobSchedule.daily(LocalTime.of(6, 0))
-                    )
-            }
-    }
-}
-
-class DefaultJobSchedule(val env: ScheduledJobsEnv) : JobSchedule {
-    override fun getSettingsForJob(job: ScheduledJob): ScheduledJobSettings? = env.jobs[job]
-}
+)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunner.kt
@@ -61,7 +61,7 @@ class ScheduledJobRunner(
             .deleteUnresolvedAfter(Duration.ofHours(1))
             .build()
 
-    private fun planAsyncJob(db: Database.Connection, definition: ScheduledJobDefinition<*>) {
+    private fun planAsyncJob(db: Database.Connection, definition: ScheduledJobDefinition) {
         val (job, settings) = definition
         val logMeta = mapOf("jobName" to job.name)
         logger.info(logMeta) { "Planning scheduled job ${job.name}" }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobRunner.kt
@@ -10,7 +10,9 @@ import com.github.kagkarlsson.scheduler.task.helper.Tasks
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.withSpan
 import fi.espoo.voltti.logging.loggers.info
 import io.opentracing.Tracer
 import java.time.Duration
@@ -28,34 +30,30 @@ class ScheduledJobRunner(
     private val jdbi: Jdbi,
     private val tracer: Tracer,
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
+    private val schedules: List<JobSchedule>,
     dataSource: DataSource,
-    schedule: JobSchedule
 ) : AutoCloseable {
+    init {
+        asyncJobRunner.registerHandler(::runJob)
+    }
+
     val scheduler: Scheduler =
         Scheduler.create(dataSource)
             .startTasks(
-                ScheduledJob.values()
-                    .mapNotNull { job ->
-                        val settings = schedule.getSettingsForJob(job)
-                        if (settings?.enabled == true) {
-                            job to settings
-                        } else {
-                            null
+                schedules
+                    .flatMap { it.jobs }
+                    .filter { definition -> definition.settings.enabled }
+                    .map { definition ->
+                        val logMeta = mapOf("jobName" to definition.job.name)
+                        logger.info(logMeta) {
+                            "Scheduling job ${definition.job.name}: ${definition.settings.schedule}"
                         }
-                    }
-                    .map { (job, settings) ->
-                        val logMeta = mapOf("jobName" to job.name)
-                        logger.info(logMeta) { "Scheduling job ${job.name}: $schedule" }
-                        Tasks.recurring(job.name, settings.schedule).execute { _, _ ->
-                            Database(jdbi, tracer).connect {
-                                this.planAsyncJob(
-                                    it,
-                                    job,
-                                    settings.retryCount ?: ASYNC_JOB_RETRY_COUNT
-                                )
+                        Tasks.recurring(definition.job.name, definition.settings.schedule)
+                            .execute { _, _ ->
+                                Database(jdbi, tracer).connect { this.planAsyncJob(it, definition) }
                             }
-                        }
                     }
+                    .toList()
             )
             .threads(SCHEDULER_THREADS)
             .pollingInterval(POLLING_INTERVAL)
@@ -63,20 +61,32 @@ class ScheduledJobRunner(
             .deleteUnresolvedAfter(Duration.ofHours(1))
             .build()
 
-    private fun planAsyncJob(db: Database.Connection, job: ScheduledJob, retryCount: Int) {
+    private fun planAsyncJob(db: Database.Connection, definition: ScheduledJobDefinition<*>) {
+        val (job, settings) = definition
         val logMeta = mapOf("jobName" to job.name)
         logger.info(logMeta) { "Planning scheduled job ${job.name}" }
         db.transaction { tx ->
             asyncJobRunner.plan(
                 tx,
-                listOf(AsyncJob.RunScheduledJob(job)),
-                retryCount = retryCount,
+                listOf(AsyncJob.RunScheduledJob(job.name)),
+                retryCount = settings.retryCount ?: ASYNC_JOB_RETRY_COUNT,
                 runAt = HelsinkiDateTime.now()
             )
         }
     }
 
-    fun getScheduledExecutionsForTask(job: ScheduledJob): List<ScheduledExecution<Unit>> =
+    private fun runJob(db: Database.Connection, clock: EvakaClock, msg: AsyncJob.RunScheduledJob) {
+        val definition =
+            schedules.firstNotNullOfOrNull { schedule ->
+                schedule.jobs.find { it.job.name == msg.job }
+            }
+                ?: error("Can't run unknown job ${msg.job}")
+        val logMeta = mapOf("jobName" to msg.job)
+        logger.info(logMeta) { "Running scheduled job ${msg.job}" }
+        tracer.withSpan("scheduledjob ${msg.job}") { definition.jobFn(db, clock) }
+    }
+
+    fun getScheduledExecutionsForTask(job: Enum<*>): List<ScheduledExecution<Unit>> =
         scheduler.getScheduledExecutionsForTask(job.name, Unit::class.java)
 
     override fun close() = scheduler.stop()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.job
 
+import fi.espoo.evaka.ScheduledJobsEnv
 import fi.espoo.evaka.application.PendingDecisionEmailService
 import fi.espoo.evaka.application.cancelOutdatedSentTransferApplications
 import fi.espoo.evaka.application.removeOldDrafts
@@ -136,10 +137,10 @@ class ScheduledJobs(
     private val missingReservationsReminders: MissingReservationsReminders,
     private val outdatedIncomeNotifications: OutdatedIncomeNotifications,
     private val calendarEventNotificationService: CalendarEventNotificationService,
-    settings: ScheduledJobSettingsMap<ScheduledJob>
+    env: ScheduledJobsEnv<ScheduledJob>
 ) : JobSchedule {
     override val jobs: List<ScheduledJobDefinition> =
-        settings.jobs.map {
+        env.jobs.map {
             ScheduledJobDefinition(it.key, it.value) { db, clock -> it.key.fn(this, db, clock) }
         }
     fun endOfDayAttendanceUpkeep(db: Database.Connection, clock: EvakaClock) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -138,7 +138,7 @@ class ScheduledJobs(
     private val calendarEventNotificationService: CalendarEventNotificationService,
     settings: ScheduledJobSettingsMap<ScheduledJob>
 ) : JobSchedule {
-    override val jobs: List<ScheduledJobDefinition<*>> =
+    override val jobs: List<ScheduledJobDefinition> =
         settings.jobs.map {
             ScheduledJobDefinition(it.key, it.value) { db, clock -> it.key.fn(this, db, clock) }
         }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

We can't easily have duplicate `ScheduledJobRunner` instances for city-specific jobs, but instead need to supply *all possible jobs* to a single instance. Redesign how jobs are declared and configured, and pass a list of JobSchedule objects to `ScheduledJobRunner` which may come from different sources.
