### PR TITLE
Validate that reservation start and end time are different + refactoring

### DIFF
--- a/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
+++ b/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
@@ -21,14 +21,14 @@ export interface Props {
   >
   hideErrorsBeforeTouched?: boolean
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
-  'data-qa'?: string
+  dataQaPrefix?: string
 }
 
 export default React.memo(function TimeRangeInputF({
   bind,
   hideErrorsBeforeTouched,
   onFocus,
-  'data-qa': dataQa
+  dataQaPrefix
 }: Props) {
   const i18n = useTranslation()
   const [touched, setTouched] = useState([false, false])
@@ -48,7 +48,7 @@ export default React.memo(function TimeRangeInputF({
           hideErrorsBeforeTouched={hideErrorsBeforeTouched}
           onFocus={onFocus}
           onBlur={() => setTouched(([_, t]) => [true, t])}
-          data-qa={dataQa ? `${dataQa}-start` : undefined}
+          data-qa={dataQaPrefix ? `${dataQaPrefix}-start` : undefined}
         />
         <span>–</span>
         <TimeInputF
@@ -58,12 +58,12 @@ export default React.memo(function TimeRangeInputF({
           hideErrorsBeforeTouched={hideErrorsBeforeTouched}
           onFocus={onFocus}
           onBlur={() => setTouched(([t, _]) => [t, true])}
-          data-qa={dataQa ? `${dataQa}-end` : undefined}
+          data-qa={dataQaPrefix ? `${dataQaPrefix}-end` : undefined}
         />
       </TimeRangeWrapper>
       {inputInfo !== undefined && (!hideErrorsBeforeTouched || bothTouched) ? (
         <ErrorRow $status={inputInfo.status}>
-          <span data-qa={dataQa ? `${dataQa}-info` : undefined}>
+          <span data-qa={dataQaPrefix ? `${dataQaPrefix}-info` : undefined}>
             {inputInfo.text}
           </span>
           <UnderRowStatusIcon status={inputInfo?.status} />

--- a/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
+++ b/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
@@ -5,19 +5,19 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
-import { limitedLocalTimeRange } from 'lib-common/form/fields'
+import { localTimeRange } from 'lib-common/form/fields'
 import { BoundFormShape, useFormField } from 'lib-common/form/hooks'
 import { ShapeOf, StateOf } from 'lib-common/form/types'
 import UnderRowStatusIcon, { InfoStatus } from 'lib-components/atoms/StatusIcon'
-import { TimeInputFWithUnitTimes } from 'lib-components/atoms/form/TimeInput'
+import { TimeInputF } from 'lib-components/atoms/form/TimeInput'
 import { defaultMargins } from 'lib-components/white-space'
 
 import { useTranslation } from '../localization'
 
 export interface Props {
   bind: BoundFormShape<
-    StateOf<typeof limitedLocalTimeRange>,
-    ShapeOf<typeof limitedLocalTimeRange>
+    StateOf<typeof localTimeRange>,
+    ShapeOf<typeof localTimeRange>
   >
   hideErrorsBeforeTouched?: boolean
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
@@ -41,7 +41,8 @@ export default React.memo(function TimeRangeInputF({
   return (
     <div>
       <TimeRangeWrapper>
-        <TimeInputFWithUnitTimes
+        <TimeInputF
+          wide
           bind={startTime}
           placeholder={i18n.calendar.reservationModal.start}
           hideErrorsBeforeTouched={hideErrorsBeforeTouched}
@@ -50,7 +51,8 @@ export default React.memo(function TimeRangeInputF({
           data-qa={dataQa ? `${dataQa}-start` : undefined}
         />
         <span>–</span>
-        <TimeInputFWithUnitTimes
+        <TimeInputF
+          wide
           bind={endTime}
           placeholder={i18n.calendar.reservationModal.end}
           hideErrorsBeforeTouched={hideErrorsBeforeTouched}

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -7,7 +7,6 @@ import partition from 'lodash/partition'
 import React, { useMemo } from 'react'
 import styled, { css } from 'styled-components'
 
-import { timeRangeContains } from 'lib-common/form/fields'
 import {
   ReservableTimeRange,
   ReservationResponseDay,
@@ -31,6 +30,7 @@ import { featureFlags } from 'lib-customizations/citizen'
 import { Translations, useTranslation } from '../localization'
 
 import RoundChildImages, { ChildImageData } from './RoundChildImages'
+import { timeRangeContains } from './reservation-modal/form'
 
 export const Reservations = React.memo(function Reservations({
   data,

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
 import { useTranslation } from 'citizen-frontend/localization'
+import { limitedLocalTimeRange } from 'lib-common/form/fields'
 import {
   BoundForm,
   useFormElem,
@@ -233,6 +234,30 @@ const ReadOnlyDay = React.memo(function ReadOnlyDay({
   }
 })
 
+interface LimitedLocalTimeRangeProps {
+  bind: BoundForm<typeof limitedLocalTimeRange>
+  hideErrorsBeforeTouched?: boolean
+  dataQa?: string
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
+}
+
+const LimitedLocalTimeRange = React.memo(function LimitedLocalTimeRange({
+  bind,
+  hideErrorsBeforeTouched,
+  dataQa,
+  onFocus
+}: LimitedLocalTimeRangeProps) {
+  const value = useFormField(bind, 'value')
+  return (
+    <TimeRangeInput
+      bind={value}
+      hideErrorsBeforeTouched={hideErrorsBeforeTouched}
+      data-qa={dataQa}
+      onFocus={onFocus}
+    />
+  )
+})
+
 interface TimeRangesProps {
   bind: BoundForm<typeof timeRanges>
   label: React.ReactNode
@@ -243,7 +268,7 @@ interface TimeRangesProps {
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
 }
 
-const TimeRanges = React.memo(function Times({
+const TimeRanges = React.memo(function TimeRanges({
   bind,
   label,
   showAllErrors,
@@ -265,7 +290,7 @@ const TimeRanges = React.memo(function Times({
       <FixedSpaceRow fullWidth alignItems="center">
         {label !== undefined ? <LeftCell>{label}</LeftCell> : null}
         <MiddleCell>
-          <TimeRangeInput
+          <LimitedLocalTimeRange
             bind={firstTimeRange}
             hideErrorsBeforeTouched={!showAllErrors}
             data-qa={dataQaPrefix ? `${dataQaPrefix}-time-0` : undefined}
@@ -292,20 +317,8 @@ const TimeRanges = React.memo(function Times({
                 }
                 onClick={() =>
                   bind.update((prev) =>
-                    // use same unit times as first reservation
-                    [
-                      prev[0],
-                      {
-                        startTime: {
-                          value: '',
-                          validRange: prev[0].startTime.validRange
-                        },
-                        endTime: {
-                          value: '',
-                          validRange: prev[0].endTime.validRange
-                        }
-                      }
-                    ]
+                    // use same valid range times as first reservation
+                    [prev[0], emptyTimeRange(prev[0].validRange)]
                   )
                 }
                 aria-label={i18n.common.add}
@@ -318,7 +331,7 @@ const TimeRanges = React.memo(function Times({
         <FixedSpaceRow fullWidth alignItems="center">
           {label !== undefined ? <LeftCell /> : null}
           <MiddleCell>
-            <TimeRangeInput
+            <LimitedLocalTimeRange
               bind={secondTimeRange}
               hideErrorsBeforeTouched={!showAllErrors}
               data-qa={dataQaPrefix ? `${dataQaPrefix}-time-1` : undefined}

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -243,14 +243,14 @@ const ReadOnlyDay = React.memo(function ReadOnlyDay({
 interface LimitedLocalTimeRangeProps {
   bind: BoundForm<typeof limitedLocalTimeRange>
   hideErrorsBeforeTouched?: boolean
-  dataQa?: string
+  dataQaPrefix?: string
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
 }
 
 const LimitedLocalTimeRange = React.memo(function LimitedLocalTimeRange({
   bind,
   hideErrorsBeforeTouched,
-  dataQa,
+  dataQaPrefix,
   onFocus
 }: LimitedLocalTimeRangeProps) {
   const value = useFormField(bind, 'value')
@@ -258,7 +258,7 @@ const LimitedLocalTimeRange = React.memo(function LimitedLocalTimeRange({
     <TimeRangeInput
       bind={value}
       hideErrorsBeforeTouched={hideErrorsBeforeTouched}
-      data-qa={dataQa}
+      dataQaPrefix={dataQaPrefix}
       onFocus={onFocus}
     />
   )
@@ -299,7 +299,7 @@ const TimeRanges = React.memo(function TimeRanges({
           <LimitedLocalTimeRange
             bind={firstTimeRange}
             hideErrorsBeforeTouched={!showAllErrors}
-            data-qa={dataQaPrefix ? `${dataQaPrefix}-time-0` : undefined}
+            dataQaPrefix={dataQaPrefix ? `${dataQaPrefix}-time-0` : undefined}
             onFocus={onFocus}
           />
         </MiddleCell>
@@ -340,7 +340,7 @@ const TimeRanges = React.memo(function TimeRanges({
             <LimitedLocalTimeRange
               bind={secondTimeRange}
               hideErrorsBeforeTouched={!showAllErrors}
-              data-qa={dataQaPrefix ? `${dataQaPrefix}-time-1` : undefined}
+              dataQaPrefix={dataQaPrefix ? `${dataQaPrefix}-time-1` : undefined}
               onFocus={onFocus}
             />
           </MiddleCell>

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -6,7 +6,6 @@ import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
 import { useTranslation } from 'citizen-frontend/localization'
-import { limitedLocalTimeRange } from 'lib-common/form/fields'
 import {
   BoundForm,
   useFormElem,
@@ -24,7 +23,14 @@ import { faPlus, fasUserMinus, faTrash, faUserMinus } from 'lib-icons'
 
 import TimeRangeInput from '../TimeRangeInput'
 
-import { day, emptyTimeRange, noTimes, timeRanges, reservation } from './form'
+import {
+  day,
+  emptyTimeRange,
+  noTimes,
+  timeRanges,
+  reservation,
+  limitedLocalTimeRange
+} from './form'
 
 interface DayProps {
   bind: BoundForm<typeof day>

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -62,9 +62,10 @@ const emptyChild: ReservationResponseDayChild = {
 }
 
 const timeInputState = (
-  value: string,
+  startTime: string,
+  endTime: string,
   validRange: TimeRange = defaultReservableTimeRange
-) => ({ value, validRange })
+) => ({ value: { startTime, endTime }, validRange })
 
 describe('resetTimes', () => {
   describe('DAILY', () => {
@@ -116,12 +117,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState(''),
-                    endTime: timeInputState('')
-                  }
-                ]
+                state: [timeInputState('', '')]
               }
             }
           }
@@ -157,12 +153,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState(''),
-                    endTime: timeInputState('')
-                  }
-                ]
+                state: [timeInputState('', '')]
               }
             }
           }
@@ -197,12 +188,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState(''),
-                    endTime: timeInputState('')
-                  }
-                ]
+                state: [timeInputState('', '')]
               }
             }
           }
@@ -265,12 +251,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState('08:00'),
-                    endTime: timeInputState('16:00')
-                  }
-                ]
+                state: [timeInputState('08:00', '16:00')]
               }
             }
           }
@@ -294,12 +275,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState(''),
-                    endTime: timeInputState('')
-                  }
-                ]
+                state: [timeInputState('', '')]
               }
             }
           }
@@ -455,12 +431,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState(''),
-                    endTime: timeInputState('')
-                  }
-                ]
+                state: [timeInputState('', '')]
               }
             }
           }
@@ -708,12 +679,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -750,12 +716,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState(''),
-                    endTime: timeInputState('')
-                  }
-                ]
+                state: [timeInputState('', '')]
               }
             }
           }
@@ -790,12 +751,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState(''),
-                    endTime: timeInputState('')
-                  }
-                ]
+                state: [timeInputState('', '')]
               }
             }
           }
@@ -878,12 +834,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -896,12 +847,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -928,12 +874,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -946,12 +887,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1029,12 +965,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1047,12 +978,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1073,12 +999,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1091,12 +1012,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1171,12 +1087,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState('08:05'),
-                      endTime: timeInputState('16:00')
-                    }
-                  ]
+                  state: [timeInputState('08:05', '16:00')]
                 }
               }
             }
@@ -1189,12 +1100,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState('08:10'),
-                      endTime: timeInputState('16:00')
-                    }
-                  ]
+                  state: [timeInputState('08:10', '16:00')]
                 }
               }
             }
@@ -1207,12 +1113,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState('08:15'),
-                      endTime: timeInputState('16:00')
-                    }
-                  ]
+                  state: [timeInputState('08:15', '16:00')]
                 }
               }
             }
@@ -1225,12 +1126,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState('08:20'),
-                      endTime: timeInputState('16:00')
-                    }
-                  ]
+                  state: [timeInputState('08:20', '16:00')]
                 }
               }
             }
@@ -1243,12 +1139,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState('08:25'),
-                      endTime: timeInputState('16:00')
-                    }
-                  ]
+                  state: [timeInputState('08:25', '16:00')]
                 }
               }
             }
@@ -1274,12 +1165,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1292,12 +1178,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1311,12 +1192,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState('08:15'),
-                      endTime: timeInputState('16:00')
-                    }
-                  ]
+                  state: [timeInputState('08:15', '16:00')]
                 }
               }
             }
@@ -1329,12 +1205,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1347,12 +1218,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1501,12 +1367,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1519,12 +1380,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -1601,12 +1457,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState(''),
-                    endTime: timeInputState('')
-                  }
-                ]
+                state: [timeInputState('', '')]
               }
             }
           }
@@ -2105,12 +1956,7 @@ describe('resetTimes', () => {
               validTimeRange: expectedValidRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState('', expectedValidRange),
-                    endTime: timeInputState('', expectedValidRange)
-                  }
-                ]
+                state: [timeInputState('', '', expectedValidRange)]
               }
             }
           }
@@ -2173,12 +2019,7 @@ describe('resetTimes', () => {
                   validTimeRange: defaultReservableTimeRange,
                   reservation: {
                     branch: 'timeRanges',
-                    state: [
-                      {
-                        startTime: timeInputState(''),
-                        endTime: timeInputState('')
-                      }
-                    ]
+                    state: [timeInputState('', '')]
                   }
                 }
               }
@@ -2213,12 +2054,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState(''),
-                    endTime: timeInputState('')
-                  }
-                ]
+                state: [timeInputState('', '')]
               }
             }
           }
@@ -2252,12 +2088,7 @@ describe('resetTimes', () => {
               validTimeRange: defaultReservableTimeRange,
               reservation: {
                 branch: 'timeRanges',
-                state: [
-                  {
-                    startTime: timeInputState(''),
-                    endTime: timeInputState('')
-                  }
-                ]
+                state: [timeInputState('', '')]
               }
             }
           }
@@ -2466,12 +2297,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState('08:00'),
-                      endTime: timeInputState('16:00')
-                    }
-                  ]
+                  state: [timeInputState('08:00', '16:00')]
                 }
               }
             }
@@ -2484,12 +2310,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -2502,12 +2323,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -2533,12 +2349,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -2555,12 +2366,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -2643,12 +2449,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -2661,12 +2462,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -3039,12 +2835,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -3064,12 +2855,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -3219,8 +3005,8 @@ describe('resetTimes', () => {
                         branch: 'timeRanges',
                         state: [
                           {
-                            startTime: timeInputState('08:15'),
-                            endTime: timeInputState('13:45')
+                            value: { startTime: '08:15', endTime: '13:45' },
+                            validRange: defaultReservableTimeRange
                           }
                         ]
                       }
@@ -3250,12 +3036,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -3268,12 +3049,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState('08:15'),
-                      endTime: timeInputState('13:45')
-                    }
-                  ]
+                  state: [timeInputState('08:15', '13:45')]
                 }
               }
             }
@@ -3286,12 +3062,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -3328,8 +3099,8 @@ describe('resetTimes', () => {
                         branch: 'timeRanges',
                         state: [
                           {
-                            startTime: timeInputState('08:15'),
-                            endTime: timeInputState('13:45')
+                            value: { startTime: '08:15', endTime: '13:45' },
+                            validRange: defaultReservableTimeRange
                           }
                         ]
                       }
@@ -3359,12 +3130,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -3377,12 +3143,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }
@@ -3395,12 +3156,7 @@ describe('resetTimes', () => {
                 validTimeRange: defaultReservableTimeRange,
                 reservation: {
                   branch: 'timeRanges',
-                  state: [
-                    {
-                      startTime: timeInputState(''),
-                      endTime: timeInputState('')
-                    }
-                  ]
+                  state: [timeInputState('', '')]
                 }
               }
             }

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -83,22 +83,12 @@ export function emptyTimeRange(
   }
 }
 
-export const timeRanges = mapped(
-  array(
-    validated(limitedLocalTimeRange, (output) =>
-      // 00:00 is not a valid end time
-      output !== undefined && output.end.hour === 0 && output.end.minute === 0
-        ? 'timeFormat'
-        : undefined
-    )
-  ),
-  (output) => {
-    const nonEmpty = output.flatMap((x) => x ?? [])
-    return nonEmpty.length === 0
-      ? undefined // All inputs empty => no value
-      : nonEmpty
-  }
-)
+export const timeRanges = mapped(array(limitedLocalTimeRange), (output) => {
+  const nonEmpty = output.flatMap((x) => x ?? [])
+  return nonEmpty.length === 0
+    ? undefined // All inputs empty => no value
+    : nonEmpty
+})
 
 export const reservation = object({
   reservation: union({

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -48,8 +48,8 @@ export function emptyTimeRange(
   validRange: TimeRange
 ): StateOf<typeof limitedLocalTimeRange> {
   return {
-    startTime: { value: '', validRange },
-    endTime: { value: '', validRange }
+    value: { startTime: '', endTime: '' },
+    validRange
   }
 }
 
@@ -515,12 +515,7 @@ export function resetDay(
           validTimeRange,
           reservation: {
             branch: 'timeRanges',
-            state: [
-              {
-                startTime: { value: '', validRange: validTimeRange },
-                endTime: { value: '', validRange: validTimeRange }
-              }
-            ]
+            state: [emptyTimeRange(validTimeRange)]
           }
         }
       }
@@ -613,8 +608,8 @@ const bindUnboundedTimeRanges = (
   validRange: TimeRange
 ): StateOf<typeof limitedLocalTimeRange>[] => {
   const formatted = ranges.map(({ start, end }) => ({
-    startTime: { value: start.format(), validRange },
-    endTime: { value: end.format(), validRange }
+    value: { startTime: start.format(), endTime: end.format() },
+    validRange
   }))
 
   if (ranges.length === 1 || ranges.length === 2) {

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -47,8 +47,16 @@ export const limitedLocalTimeRange = transformed(
     value: localTimeRange,
     validRange: value<TimeRange>()
   }),
-  ({ value, validRange }): ValidationResult<TimeRange | undefined, 'range'> => {
+  ({
+    value,
+    validRange
+  }): ValidationResult<TimeRange | undefined, 'timeFormat' | 'range'> => {
     if (value === undefined) return ValidationSuccess.of(undefined)
+
+    // Don't allow reservations with same start and end times
+    if (value.start.isEqual(value.end)) {
+      return ValidationError.field('value', 'timeFormat')
+    }
 
     let errors: FieldErrors<'range'> | undefined = undefined
     if (!timeRangeContains(value.start, validRange)) {

--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
@@ -521,7 +521,7 @@ describe('Unit group calendar for shift care unit', () => {
     await reservationModal.addNewTimeRow(0)
 
     await reservationModal.setStartTime('20:00', 1)
-    await reservationModal.setEndTime('00:00', 1)
+    await reservationModal.setEndTime('23:59', 1)
     await reservationModal.save()
 
     await waitUntilEqual(
@@ -578,7 +578,7 @@ describe('Unit group calendar for shift care unit', () => {
     await reservationModal.addNewTimeRow(0)
 
     await reservationModal.setStartTime('20:00', 1)
-    await reservationModal.setEndTime('00:00', 1)
+    await reservationModal.setEndTime('23:59', 1)
 
     await reservationModal.save()
 

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
@@ -185,7 +185,7 @@ export default React.memo(function StaffAttendanceExternalPersonModal({
           />
           {groupError && (
             <InputFieldUnderRow className={classNames('warning')}>
-              <span>{group.translateError(groupError)}</span>
+              <span>{group.inputInfo()?.text}</span>
               <StatusIcon status="warning" />
             </InputFieldUnderRow>
           )}

--- a/frontend/src/lib-common/form/fields.ts
+++ b/frontend/src/lib-common/form/fields.ts
@@ -10,7 +10,6 @@ import LocalTime from '../local-time'
 
 import { mapped, object, transformed, value } from './form'
 import {
-  FieldErrors,
   ObjectFieldError,
   ValidationError,
   ValidationResult,
@@ -112,36 +111,4 @@ export const localTimeRange = transformed(
   }
 )
 
-export const limitedLocalTimeRange = transformed(
-  object({
-    value: localTimeRange,
-    validRange: value<TimeRange>()
-  }),
-  ({ value, validRange }): ValidationResult<TimeRange | undefined, 'range'> => {
-    if (value === undefined) return ValidationSuccess.of(undefined)
-
-    let errors: FieldErrors<'range'> | undefined = undefined
-    if (!timeRangeContains(value.start, validRange)) {
-      errors = errors ?? {}
-      errors.startTime = 'range'
-    }
-    if (!timeRangeContains(value.end, validRange)) {
-      errors = errors ?? {}
-      errors.endTime = 'range'
-    }
-    if (errors !== undefined) {
-      return ValidationError.fromFieldErrors({ value: errors })
-    } else {
-      return ValidationSuccess.of(value)
-    }
-  }
-)
-
 const midnight = LocalTime.of(0, 0)
-
-export function timeRangeContains(
-  inputTime: LocalTime,
-  { start, end }: TimeRange
-) {
-  return inputTime.isEqualOrAfter(start) && inputTime.isEqualOrBefore(end)
-}

--- a/frontend/src/lib-common/form/fields.ts
+++ b/frontend/src/lib-common/form/fields.ts
@@ -111,10 +111,7 @@ export const limitedLocalTimeRange = transformed(
   ({
     startTime,
     endTime
-  }): ValidationResult<
-    TimeRange | undefined,
-    ObjectFieldError | 'timeFormat' | 'range'
-  > => {
+  }): ValidationResult<TimeRange | undefined, 'timeFormat' | 'range'> => {
     if (startTime === undefined && endTime === undefined) {
       return ValidationSuccess.of(undefined)
     }
@@ -139,10 +136,7 @@ export const localTimeRange = transformed(
   ({
     startTime,
     endTime
-  }): ValidationResult<
-    TimeRange | undefined,
-    ObjectFieldError | 'timeFormat'
-  > => {
+  }): ValidationResult<TimeRange | undefined, 'timeFormat'> => {
     if (startTime === undefined && endTime === undefined) {
       return ValidationSuccess.of(undefined)
     }

--- a/frontend/src/lib-common/form/fields.ts
+++ b/frontend/src/lib-common/form/fields.ts
@@ -101,8 +101,7 @@ export const localTimeRange = transformed(
     if (
       startTime === undefined ||
       endTime === undefined ||
-      // Allow midnight as the end time, even though it's "before" all other times
-      (endTime.isBefore(startTime) && !endTime.isEqual(midnight))
+      endTime.isBefore(startTime)
     ) {
       return ValidationError.of('timeFormat')
     } else {
@@ -110,5 +109,3 @@ export const localTimeRange = transformed(
     }
   }
 )
-
-const midnight = LocalTime.of(0, 0)

--- a/frontend/src/lib-common/form/memoize.ts
+++ b/frontend/src/lib-common/form/memoize.ts
@@ -4,6 +4,8 @@
 
 const none: unique symbol = Symbol('none')
 
+export function memoizeLast<T>(fn: () => T): () => T
+export function memoizeLast<S, T>(fn: (input: S) => T): (input: S) => T
 export function memoizeLast<S, T>(fn: (input: S) => T): (input: S) => T {
   let lastInput: S | typeof none = none
   let lastOutput: T | typeof none = none

--- a/frontend/src/lib-common/form/types.ts
+++ b/frontend/src/lib-common/form/types.ts
@@ -76,15 +76,33 @@ export class ValidationSuccess<Output, Error> {
   }
 }
 
+export interface FieldErrors<Error> {
+  [key: string]: Error | FieldErrors<Error> | undefined
+}
+
 export class ValidationError<Output, Error> {
   readonly isValid = false
+
   static objectFieldError: ValidationResult<never, ObjectFieldError> =
     ValidationError.of(ObjectFieldError)
 
-  private constructor(public validationError: Error) {}
+  private constructor(public error: FieldErrors<Error> | Error) {}
 
   static of<Error>(validationError: Error): ValidationResult<never, Error> {
     return new ValidationError(validationError)
+  }
+
+  static fromFieldErrors<Error>(
+    fieldErrors: FieldErrors<Error>
+  ): ValidationResult<never, Error> {
+    return new ValidationError(fieldErrors)
+  }
+
+  static field<Error>(
+    fieldName: string,
+    validationError: Error
+  ): ValidationResult<never, Error> {
+    return ValidationError.fromFieldErrors({ [fieldName]: validationError })
   }
 
   map<T>(_fn: (value: Output) => T): ValidationError<T, Error> {

--- a/frontend/src/lib-components/atoms/form/TimeInput.tsx
+++ b/frontend/src/lib-components/atoms/form/TimeInput.tsx
@@ -5,9 +5,7 @@
 import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
-import { limitedLocalTime } from 'lib-common/form/fields'
 import { BoundFormState } from 'lib-common/form/hooks'
-import { StateOf } from 'lib-common/form/types'
 import { autocomplete } from 'lib-common/time'
 
 import InputField, { TextInputProps } from './InputField'
@@ -26,6 +24,7 @@ export interface TimeInputProps
     | 'aria-describedby'
     | 'data-qa'
   > {
+  wide?: boolean
   value: string
   onChange: (v: string) => void
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
@@ -35,6 +34,7 @@ const TimeInput = React.memo(function TimeInput({
   value,
   onChange,
   onFocus,
+  wide,
   ...props
 }: TimeInputProps) {
   const onChangeWithAutocomplete = useCallback(
@@ -42,34 +42,10 @@ const TimeInput = React.memo(function TimeInput({
     [value, onChange]
   )
 
-  return (
-    <ShorterInput
-      {...props}
-      value={value}
-      onChange={onChangeWithAutocomplete}
-      type="text"
-      inputMode="numeric"
-      onFocus={(event) => {
-        event.target.select()
-        onFocus?.(event)
-      }}
-    />
-  )
-})
-
-const TimeInputWide = React.memo(function TimeInput({
-  value,
-  onChange,
-  onFocus,
-  ...props
-}: TimeInputProps) {
-  const onChangeWithAutocomplete = useCallback(
-    (v: string) => onChange(autocomplete(value, v)),
-    [value, onChange]
-  )
+  const InputComponent = wide ? ScalingInput : ShorterInput
 
   return (
-    <ScalingInput
+    <InputComponent
       {...props}
       value={value}
       onChange={onChangeWithAutocomplete}
@@ -111,9 +87,10 @@ export interface TimeInputFProps
 }
 
 export const TimeInputF = React.memo(function TimeInputF({
-  bind: { state, set, inputInfo },
+  bind,
   ...props
 }: TimeInputFProps) {
+  const { state, set, inputInfo } = bind
   return (
     <TimeInput
       {...props}
@@ -123,24 +100,3 @@ export const TimeInputF = React.memo(function TimeInputF({
     />
   )
 })
-
-export interface TimeInputFWithUnitTimesProps
-  extends Omit<TimeInputProps, 'value' | 'onChange'> {
-  bind: BoundFormState<StateOf<typeof limitedLocalTime>>
-}
-
-export const TimeInputFWithUnitTimes = React.memo(
-  function TimeInputFWithUnitTimes({
-    bind: { state, set, inputInfo },
-    ...props
-  }: TimeInputFWithUnitTimesProps) {
-    return (
-      <TimeInputWide
-        {...props}
-        value={state.value}
-        onChange={(newValue) => set({ ...state, value: newValue })}
-        info={'info' in props ? props.info : inputInfo()}
-      />
-    )
-  }
-)


### PR DESCRIPTION
#### Summary

Allow form fields to assign errors to their subfields. Use this to simplify `limitedLocalTimeRange` field and related components.

The actual beef of this PR: Show a validation error if reservation start = end.