### PR TITLE
Use correctly translated email links

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.invoicing.service.IncomeNotificationType
 import fi.espoo.evaka.messaging.MessageThreadStub
 import fi.espoo.evaka.messaging.MessageType
 import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.MessageThreadId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -17,11 +18,24 @@ import java.util.Locale
 
 /** Use http://localhost:9099/api/internal/dev-api/email-content to preview email messages */
 class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvider {
-    private fun baseUrl(language: Language) =
-        when (language) {
-            Language.sv -> env.frontendBaseUrlSv
-            else -> env.frontendBaseUrlFi
-        }
+    private fun link(language: Language, path: String): String {
+        val baseUrl =
+            when (language) {
+                Language.sv -> env.frontendBaseUrlSv
+                else -> env.frontendBaseUrlFi
+            }
+        val url = "$baseUrl$path"
+        return """<a href="$url">$url</a>"""
+    }
+    private fun frontPageLink(language: Language) = link(language, "")
+    private fun calendarLink(language: Language) = link(language, "/calendar")
+    private fun messageLink(language: Language, threadId: MessageThreadId) =
+        link(language, "/messages/${threadId}")
+    private fun childLink(language: Language, childId: ChildId) =
+        link(language, "/children/$childId")
+    private fun pedagogicalDocumentsLink(langage: Language) =
+        link(langage, "/pedagogical-documents")
+    private fun incomeLink(language: Language) = link(language, "/income")
 
     override fun pendingDecisionNotification(language: Language): EmailContent {
         return EmailContent.fromHtml(
@@ -30,15 +44,15 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
             html =
                 """
 <p>Sinulla on vastaamaton päätös Espoon varhaiskasvatukselta. Päätös tulee hyväksyä tai hylätä kahden viikon sisällä sen saapumisesta.</p>
-<p>Hakemuksen tekijä voi hyväksyä tai hylätä vastaamattomat päätökset kirjautumalla osoitteeseen <a href="${baseUrl(Language.fi)}">${baseUrl(Language.fi)}</a>, tai palauttamalla täytetyn lomakkeen päätöksen viimeiseltä sivulta siinä mainittuun osoitteeseen.</p>
+<p>Hakemuksen tekijä voi hyväksyä tai hylätä vastaamattomat päätökset kirjautumalla osoitteeseen ${frontPageLink(Language.fi)}, tai palauttamalla täytetyn lomakkeen päätöksen viimeiseltä sivulta siinä mainittuun osoitteeseen.</p>
 <p>Tähän viestiin ei voi vastata. Tarvittaessa ole yhteydessä varhaiskasvatuksen palveluohjaukseen p. 09 816 31000</p>
 <hr>
 <p>Du har ett obesvarat beslut av småbarnspedagogiken i Esbo. Beslutet ska godkännas eller förkastas inom två veckor från att det inkommit.</p>
-<p>Den som lämnat in ansökan kan godkänna eller förkasta obesvarade beslut genom att logga in på adressen <a href="${baseUrl(Language.sv)}">${baseUrl(Language.sv)}</a> eller genom att returnera den ifyllda blanketten som finns på sista sidan av beslutet till den adress som nämns på sidan.</p>
+<p>Den som lämnat in ansökan kan godkänna eller förkasta obesvarade beslut genom att logga in på adressen ${frontPageLink(Language.sv)} eller genom att returnera den ifyllda blanketten som finns på sista sidan av beslutet till den adress som nämns på sidan.</p>
 <p>Detta meddelande kan inte besvaras. Kontakta vid behov servicehandledningen inom småbarnspedagogiken, tfn 09 816 27600</p>
 <hr>
 <p>You have an unanswered decision from Espoo’s early childhood education. The decision must be accepted or rejected within two weeks of receiving it.</p>
-<p>The person who submitted the application can accept or reject an unanswered decision by logging in to <a href="${baseUrl(Language.en)}">${baseUrl(Language.en)}</a> or by sending the completed form on the last page of the decision to the address specified on the page.</p>
+<p>The person who submitted the application can accept or reject an unanswered decision by logging in to ${frontPageLink(Language.en)} or by sending the completed form on the last page of the decision to the address specified on the page.</p>
 <p>You cannot reply to this message. If you have questions, please contact early childhood education service counselling, tel. 09 816 31000.</p>
 """
         )
@@ -53,10 +67,10 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
             html =
                 """
 <p>Hyvä(t) huoltaja(t),</p>
-<p>Lapsenne kerhohakemus on vastaanotettu. Hakemuksen tehnyt huoltaja voi muokata hakemusta osoitteessa <a href="${baseUrl(language)}">${baseUrl(language)}</a> siihen saakka, kunnes se on otettu käsittelyyn.</p>
+<p>Lapsenne kerhohakemus on vastaanotettu. Hakemuksen tehnyt huoltaja voi muokata hakemusta osoitteessa ${frontPageLink(Language.fi)} siihen saakka, kunnes se on otettu käsittelyyn.</p>
 <p>Syksyllä alkaviin kerhoihin tehdään päätöksiä kevään aikana hakuajan (1-31.3.) päättymisen jälkeen paikkatilanteen mukaan.</p>
 <p>Kerhoihin voi hakea myös hakuajan jälkeen koko toimintavuoden ajan mahdollisesti vapautuville paikoille.</p>
-<p>Päätös on nähtävissä ja hyväksyttävissä/hylättävissä <a href="${baseUrl(language)}">${baseUrl(language)}</a>.</p>
+<p>Päätös on nähtävissä ja hyväksyttävissä/hylättävissä ${frontPageLink(Language.fi)}.</p>
 <p>Hakiessanne lapsellenne siirtoa uudella hakemuksella toiseen kerhoon. Uusi kerhopäätös tehdään paikkatilanteen sen salliessa. Hakemus on voimassa kuluvan kerhokauden. </p>
 """
         )
@@ -67,9 +81,9 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
             html =
                 """
 <p>Hyvä(t) huoltaja(t),<br>Lapsenne varhaiskasvatushakemus on vastaanotettu.</p>
-<p>Varhaiskasvatushakemuksella on <strong>neljän (4) kuukauden hakuaika.</strong> Hakemuksen tehnyt huoltaja voi muokata hakemusta osoitteessa <a href="${baseUrl(Language.fi)}">${baseUrl(Language.fi)}</a> siihen saakka, kunnes se on otettu käsittelyyn.</p>
+<p>Varhaiskasvatushakemuksella on <strong>neljän (4) kuukauden hakuaika.</strong> Hakemuksen tehnyt huoltaja voi muokata hakemusta osoitteessa ${frontPageLink(Language.fi)} siihen saakka, kunnes se on otettu käsittelyyn.</p>
 <p>Saatte tiedon lapsenne varhaiskasvatuspaikasta noin kuukautta ennen varhaiskasvatuksen toivottua aloittamista huomioiden varhaiskasvatuslain mukaiset neljän (4) kuukauden tai kahden viikon hakuajat.</p>
-<p>Päätös on nähtävissä ja hyväksyttävissä/hylättävissä <a href="${baseUrl(Language.fi)}">${baseUrl(Language.fi)}</a>.</p>
+<p>Päätös on nähtävissä ja hyväksyttävissä/hylättävissä ${frontPageLink(Language.fi)}.</p>
 <p>Hakiessanne palvelusetelipäiväkotiin, olkaa viimeistään hakemuksen jättämisen jälkeen yhteydessä suoraan kyseiseen yksikköön.</p>
 <p>Mikäli valitsitte hakemuksen kiireelliseksi, teidän tulee toimittaa hakemuksen liitteeksi <strong>todistus äkillisestä työllistymisestä uuteen työpaikkaan tai todistus äkillisesti saadusta uudesta opiskelupaikasta.</strong> Hakuaika on tällöin <strong>minimissään 2 viikkoa</strong> ja alkaa todistuksen saapumispäivämäärästä.</p>
 <p><strong>Ympärivuorokautista- tai iltahoitoa</strong> hakiessanne, teidän tulee toimittaa molempien samassa taloudessa asuvien huoltajien todistukset työnantajalta vuorotyöstä tai oppilaitoksesta iltaisin tapahtuvasta opiskelusta. <strong>Hakemusta käsitellään vuorohoidon hakemuksena vasta kun edellä mainitut todistukset on toimitettu.</strong></p>
@@ -79,9 +93,9 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>Hakeminen yksityisiin varhaiskasvatusyksiköihin: <a href="https://espoo.fi/fi/kasvatus-ja-opetus/varhaiskasvatus/yksityinen-varhaiskasvatus-ja-paivakodit">espoo.fi/fi/kasvatus-ja-opetus/varhaiskasvatus/yksityinen-varhaiskasvatus-ja-paivakodit</a></p>
 <hr>
 <p>Bästa vårdnadshavare,<br>Vi har tagit emot en ansökan om småbarnspedagogik för ditt barn.</p>
-<p>Ansökan om småbarnspedagogik har en <strong>ansökningstid på fyra (4) månader.</strong> Den vårdnadshavare som har lämnat in ansökan kan redigera ansökan på adressen <a href="${baseUrl(Language.sv)}">${baseUrl(Language.sv)}</a> tills den har tagits upp till behandling.</p>
+<p>Ansökan om småbarnspedagogik har en <strong>ansökningstid på fyra (4) månader.</strong> Den vårdnadshavare som har lämnat in ansökan kan redigera ansökan på adressen ${frontPageLink(Language.sv)} tills den har tagits upp till behandling.</p>
 <p>Du får besked om ditt barns plats i småbarnspedagogiken cirka en månad före ansökt datum med beaktande av ansökningstiderna på fyra (4) månader eller två veckor enligt lagen om småbarnspedagogik.</p>
-<p>Du kan se och godkänna/förkasta beslutet på <a href="${baseUrl(Language.sv)}">${baseUrl(Language.sv)}</a>.</p>
+<p>Du kan se och godkänna/förkasta beslutet på ${frontPageLink(Language.sv)}.</p>
 <p>När du ansöker plats till ett servicesedel daghem behöver du senast  vara i kontakt med daghemmet när du lämnat in ansökan till enheten i fråga.</p>
 <p>Om du valde att ansökan är brådskande, ska du bifoga ansökan <strong>ett intyg över att du plötsligt fått ett nytt jobb eller en ny studieplats.</strong> Ansökningstiden är då <strong>minst 2 veckor</strong> och börjar den dag då intyget inkom.</p>
 <p>När du ansöker om <strong>vård dygnet runt eller kvällstid</strong>, ska du lämna in arbetsgivarens intyg över skiftarbete eller läroanstaltens intyg över kvällsstudier för båda vårdnadshavarna som bor i samma hushåll. <strong>Ansökan behandlas som ansökan om skiftvård först när de ovannämnda intygen har lämnats in.</strong></p>
@@ -92,9 +106,9 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>Du kan göra ändringar i ansökan så länge den inte har tagits upp till behandling. Därefter kan du göra ändringar i ansökan genom att kontakta småbarnspedagogikens servicehandledning (tfn 09 816 27600). Du kan återta en ansökan som du redan lämnat in genom att meddela detta per e-post till småbarnspedagogikens servicehandledning <a href="mailto:dagis@esbo.fi">dagis@esbo.fi</a></p>
 <hr>
 <p>Dear guardian(s),<br>We have received your child’s application for early childhood education.</p>
-<p>The <strong>application period</strong> for early childhood education applications is <strong>four (4) months</strong>. The guardian who submitted the application can make changes to it at <a href="${baseUrl(Language.en)}">${baseUrl(Language.en)}</a> until its processing starts.</p>
+<p>The <strong>application period</strong> for early childhood education applications is <strong>four (4) months</strong>. The guardian who submitted the application can make changes to it at ${frontPageLink(Language.en)} until its processing starts.</p>
 <p>You will be informed of your child’s early childhood education unit approximately one month before the desired start date of early childhood education, taking into account the application periods of four (4) months or two (2) weeks specified in the Act on Early Childhood Education and Care.</p>
-<p>You can see the decision and accept/reject it at <a href="${baseUrl(Language.en)}">${baseUrl(Language.en)}</a>.</p>
+<p>You can see the decision and accept/reject it at ${frontPageLink(Language.en)}.</p>
 <p>When applying for a service voucher day care centre, please contact the unit directly at the latest after submitting your application.</p>
 <p>If you chose to have your application processed urgently, you will also need to provide <strong>a document as proof of sudden employment at a new workplace or a sudden offer of a new study place.</strong> In this case, the <strong>minimum application period is two (2) weeks</strong> and it begins from the date on which the required document was received.</p>
 <p>When applying for <strong>round-the-clock or evening care</strong>, both guardians living in the same household need to provide a document issued by their employer concerning shift work or a document issued by their educational institution concerning evening studies. <strong>Your application will only be processed as an application for round-the-clock care after you have provided the required documents</strong>.</p>
@@ -115,9 +129,9 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
                 html =
                     """
 <p>Hyvä(t) huoltaja(t),</p>
-<p>Lapsenne esiopetushakemus on vastaanotettu. Hakemuksen tehnyt huoltaja voi muokata hakemusta osoitteessa <a href="${baseUrl(Language.fi)}">${baseUrl(Language.fi)}</a> siihen saakka, kunnes hakemus on otettu käsittelyyn.</p>
+<p>Lapsenne esiopetushakemus on vastaanotettu. Hakemuksen tehnyt huoltaja voi muokata hakemusta osoitteessa ${frontPageLink(Language.fi)} siihen saakka, kunnes hakemus on otettu käsittelyyn.</p>
 <p>Päätökset tehdään hakuaikana (tammikuu) saapuneisiin hakemuksiin maaliskuun aikana.</p>
-<p>Päätös on nähtävissä ja hyväksyttävissä/hylättävissä <a href="${baseUrl(Language.fi)}">${baseUrl(Language.fi)}</a>.</p>
+<p>Päätös on nähtävissä ja hyväksyttävissä/hylättävissä ${frontPageLink(Language.fi)}.</p>
 <p>Hakiessanne palvelusetelipäiväkotiin, olkaa viimeistään hakemuksen jättämisen jälkeen yhteydessä suoraan kyseiseen yksikköön.</p>
 <p>Ympärivuorokautista- tai iltahoitoa hakiessanne, teidän tulee toimittaa molempien samassa taloudessa asuvien huoltajien todistukset työnantajalta vuorotyöstä tai oppilaitoksesta iltaisin tapahtuvasta opiskelusta. Hakemusta käsitellään vuorohoidon hakemuksena vasta kun edellä mainitut todistukset on toimitettu.</p>
 <p>Hakemuksen liitteet voi lisätä suoraan sähköiselle hakemukselle tai toimittaa postitse osoitteeseen Espoon kaupunki, Varhaiskasvatuksen palveluohjaus, PL 3125, 02070 Espoon kaupunki.</p>
@@ -125,9 +139,9 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>Hakeminen yksityisiin varhaiskasvatusyksiköihin: <a href="https://espoo.fi/fi/kasvatus-ja-opetus/varhaiskasvatus/yksityinen-varhaiskasvatus-ja-paivakodit">Yksityinen varhaiskasvatus</a></p>
 <hr>
 <p>Bästa vårdnadshavare,</p>
-<p>Vi har tagit emot ansökan om förskoleundervisning för ditt barn. Den vårdnadshavare som har lämnat in ansökan kan redigera ansökan på adressen <a href="${baseUrl(Language.sv)}">${baseUrl(Language.sv)}</a> tills den har tagits upp till behandling.</p>
+<p>Vi har tagit emot ansökan om förskoleundervisning för ditt barn. Den vårdnadshavare som har lämnat in ansökan kan redigera ansökan på adressen ${frontPageLink(Language.sv)} tills den har tagits upp till behandling.</p>
 <p>Om de ansökningar som kommit in under ansökningstiden (januari) fattas beslut i mars.</p>
-<p>Du kan se och godkänna/förkasta beslutet på adressen <a href="${baseUrl(Language.sv)}">${baseUrl(Language.sv)}</a>.</p>
+<p>Du kan se och godkänna/förkasta beslutet på adressen ${frontPageLink(Language.sv)}.</p>
 <p>När du ansöker till ett servicesedeldaghem, kontakta daghemmet direkt senast efter att du lämnat ansökan.</p>
 <p>När du ansöker om vård dygnet runt eller kvällstid, ska du lämna in arbetsgivarens intyg över skiftarbete eller läroanstaltens intyg över kvällsstudier för båda vårdnadshavarna som bor i samma hushåll. Ansökan behandlas som en ansökan om skiftomsorg först när de ovannämnda intygen har lämnats in.</p>
 <p>Bilagor till ansökan kan bifogas direkt till ansökan på webben eller skickas per post till adressen Esbo stad, Servicehandledningen inom småbarnspedagogiken, PB 32, 02070 Esbo stad.</p>
@@ -135,9 +149,9 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>Ansökan till privata enheter för småbarnspedagogik: <a href="https://esbo.fi/tjanster/privat-smabarnspedagogik">Privat småbarnspedagogik</a></p>
 <hr>
 <p>Dear guardian(s),</p>
-<p>We have received your child’s application for pre-primary education. The guardian who submitted the application can make changes to it at <a href="${baseUrl(Language.en)}">${baseUrl(Language.en)}</a> until its processing starts.</p>
+<p>We have received your child’s application for pre-primary education. The guardian who submitted the application can make changes to it at ${frontPageLink(Language.en)} until its processing starts.</p>
 <p>The city will make decisions on applications received during the application period (January) in March.</p>
-<p>You can see the decision and accept/reject it at <a href="${baseUrl(Language.en)}">${baseUrl(Language.en)}</a></p>
+<p>You can see the decision and accept/reject it at ${frontPageLink(Language.en)}</p>
 <p>When applying to a service voucher day care centre, please contact the unit no later than after you have submitted the application.</p>
 <p>When applying for round-the-clock or evening care, both guardians living in the same household need to provide a document issued by their employer concerning shift work or a document issued by their educational institution concerning evening studies. Your application will only be processed as an application for round-the-clock care after you have provided the required documents.</p>
 <p>You can add your supporting documents to your online application or send them by post to City of Espoo, Early childhood education service guidance, P.O. Box 3125, 02070 City of Espoo.</p>
@@ -151,9 +165,9 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
                 html =
                     """
 <p>Hyvä(t) huoltaja(t),</p>
-<p>Lapsenne esiopetushakemus on vastaanotettu. Hakemuksen tehnyt huoltaja voi muokata hakemusta osoitteessa <a href="${baseUrl(Language.fi)}">${baseUrl(Language.fi)}</a> siihen saakka, kunnes se on otettu käsittelyyn.</p>
+<p>Lapsenne esiopetushakemus on vastaanotettu. Hakemuksen tehnyt huoltaja voi muokata hakemusta osoitteessa ${frontPageLink(Language.fi)} siihen saakka, kunnes se on otettu käsittelyyn.</p>
 <p>Saatte tiedon lapsenne esiopetuspaikasta mahdollisimman pian, huomioiden hakemuksessa oleva aloitustoive ja alueen esiopetuspaikkatilanne.</p>
-<p>Päätös on nähtävissä ja hyväksyttävissä/hylättävissä <a href="${baseUrl(Language.fi)}">${baseUrl(Language.fi)}</a>.</p>
+<p>Päätös on nähtävissä ja hyväksyttävissä/hylättävissä ${frontPageLink(Language.fi)}.</p>
 <p>Hakiessanne esiopetusta palvelusetelipäiväkotiin, olkaa viimeistään hakemuksen jättämisen jälkeen yhteydessä suoraan kyseiseen yksikköön.</p>
 <p>Mikäli valitsitte hakemuksen kiireelliseksi, teidän tulee toimittaa hakemuksen liitteeksi todistus äkillisestä työllistymisestä uuteen työpaikkaan tai todistus äkillisesti saadusta uudesta opiskelupaikasta. Hakuaika on tällöin minimissään 2 viikkoa ja alkaa todistuksen saapumispäivämäärästä.</p>
 <p>Ympärivuorokautista- tai iltahoitoa hakiessanne, teidän tulee toimittaa molempien samassa taloudessa asuvien huoltajien todistukset työnantajalta vuorotyöstä tai oppilaitoksesta iltaisin tapahtuvasta opiskelusta. Hakemusta käsitellään vuorohoidon hakemuksena vasta kun edellä mainitut todistukset on toimitettu.</p>
@@ -163,9 +177,9 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>Hakeminen yksityisiin varhaiskasvatusyksiköihin: <a href="https://espoo.fi/fi/kasvatus-ja-opetus/varhaiskasvatus/yksityinen-varhaiskasvatus-ja-paivakodit">Yksityinen varhaiskasvatus</a></p>
 <hr>
 <p>Bästa vårdnadshavare,</p>
-<p>Vi har tagit emot ansökan om förskoleundervisning för ditt barn. Den vårdnadshavare som har lämnat in ansökan kan redigera ansökan på adressen <a href="${baseUrl(Language.sv)}">${baseUrl(Language.sv)}</a> tills den har tagits upp till behandling.</p>
+<p>Vi har tagit emot ansökan om förskoleundervisning för ditt barn. Den vårdnadshavare som har lämnat in ansökan kan redigera ansökan på adressen ${frontPageLink(Language.sv)} tills den har tagits upp till behandling.</p>
 <p>Du får information om ditt barns förskoleplats så snart som möjligt, med beaktande av önskemålet om startdatum och läget med förskoleplatser i området.</p>
-<p>Du kan se och godkänna/förkasta beslutet på adressen <a href="${baseUrl(Language.sv)}">${baseUrl(Language.sv)}</a>.</p>
+<p>Du kan se och godkänna/förkasta beslutet på adressen ${frontPageLink(Language.sv)}.</p>
 <p>När du ansöker om förskoleundervisning i ett servicesedeldaghem, kontakta enheten direkt senast efter att du lämnat ansökan.</p>
 <p>Om du valde att ansökan är brådskande, ska du till ansökan bifoga ett intyg över att du plötsligt fått ett nytt jobb eller en ny studieplats. Ansökningstiden är då minst två veckor och börjar den dag då intyget inkommer.</p>
 <p>När du ansöker om vård dygnet runt eller kvällstid, ska du lämna in arbetsgivarens intyg över skiftarbete eller läroanstaltens intyg över kvällsstudier för båda vårdnadshavarna som bor i samma hushåll. Ansökan behandlas som en ansökan om skiftomsorg först när de ovannämnda intygen har lämnats in.</p>
@@ -175,9 +189,9 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>Ansökan till privata enheter för småbarnspedagogik: <a href="https://esbo.fi/tjanster/privat-smabarnspedagogik">Privat småbarnspedagogik</a></p>
 <hr>
 <p>Dear guardian(s),</p>
-<p>We have received your child’s application for pre-primary education. The guardian who submitted the application can make changes to it at <a href="${baseUrl(Language.en)}">${baseUrl(Language.en)}</a> until its processing starts.</p>
+<p>We have received your child’s application for pre-primary education. The guardian who submitted the application can make changes to it at ${frontPageLink(Language.en)} until its processing starts.</p>
 <p>You will be informed of your child’s pre-primary education unit as soon as possible, taking into account the preferred starting date indicated in your application and the availability of pre-primary education places in your area.</p>
-<p>You can see the decision and accept/reject it at <a href="${baseUrl(Language.en)}">${baseUrl(Language.en)}</a>.</p>
+<p>You can see the decision and accept/reject it at ${frontPageLink(Language.en)}.</p>
 <p>When applying for pre-primary education at a service voucher day care centre, please contact the unit no later than after you have submitted the application.</p>
 <p>If you chose to have your application processed urgently, you will also need to provide a document as proof of sudden employment at a new workplace or a sudden offer of a new study place. In this case, the minimum application period is two (2) weeks and begins from the date on which the required document was received.</p>
 <p>When applying for round-the-clock or evening care, both guardians living in the same household need to provide a document issued by their employer concerning shift work or a document issued by their educational institution concerning evening studies. Your application will only be processed as an application for round-the-clock care after you have provided the required documents.</p>
@@ -193,7 +207,6 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
         language: Language,
         checkedRange: FiniteDateRange
     ): EmailContent {
-        val messageUrl = "${baseUrl(language)}/calendar"
         val start =
             checkedRange.start.format(
                 DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(Locale("fi", "FI"))
@@ -203,11 +216,11 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
                 "Läsnäolovarauksia puuttuu / Det finns några närvarobokningar som saknas / There are missing attendance reservations",
             html =
                 """
-<p>Läsnäolovarauksia puuttuu $start alkavalta viikolta. Käythän merkitsemässä ne mahdollisimman pian: <a href="$messageUrl">$messageUrl</a></p>
+<p>Läsnäolovarauksia puuttuu $start alkavalta viikolta. Käythän merkitsemässä ne mahdollisimman pian: ${calendarLink(Language.fi)}</p>
 <hr>
-<p>Det finns några närvarobokningar som saknas för veckan som börjar $start. Vänligen markera dem så snart som möjligt: <a href="$messageUrl">$messageUrl</a></p>
+<p>Det finns några närvarobokningar som saknas för veckan som börjar $start. Vänligen markera dem så snart som möjligt: ${calendarLink(Language.sv)}</p>
 <hr>
-<p>There are missing attendance reservations for week starting $start. Please mark them as soon as possible: <a href="$messageUrl">$messageUrl</a></p>
+<p>There are missing attendance reservations for week starting $start. Please mark them as soon as possible: ${calendarLink(Language.en)}</p>
 """
         )
     }
@@ -219,15 +232,15 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
                 """
 <p>Hyvä(t) huoltaja(t),</p>
 <p>Lapsellenne on tehty päätös.</p>
-<p>Päätös on nähtävissä eVakassa osoitteessa <a href="${baseUrl(Language.fi)}">${baseUrl(Language.fi)}</a>.</p>
+<p>Päätös on nähtävissä eVakassa osoitteessa ${frontPageLink(Language.fi)}.</p>
 <hr>
 <p>Bästa vårdnadshavare,</p>
 <p>Beslut har fattats angående ditt barn.</p>
-<p>Beslutet finns att se i eVaka på <a href="${baseUrl(Language.sv)}">${baseUrl(Language.sv)}</a>.</p>
+<p>Beslutet finns att se i eVaka på ${frontPageLink(Language.sv)}.</p>
 <hr>
 <p>Dear guardian(s),</p>
 <p>A decision has been made regarding your child.</p>
-<p>The decision can be viewed on eVaka at <a href="${baseUrl(Language.en)}">${baseUrl(Language.en)}</a>.</p>
+<p>The decision can be viewed on eVaka at ${frontPageLink(Language.en)}.</p>
 """
         )
 
@@ -235,7 +248,6 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
         assistanceNeedDecisionNotification(language) // currently same content
 
     override fun messageNotification(language: Language, thread: MessageThreadStub): EmailContent {
-        val messageUrl = "${baseUrl(language)}/messages/${thread.id}"
         val (typeFi, typeSv, typeEn) =
             when (thread.type) {
                 MessageType.MESSAGE ->
@@ -259,50 +271,48 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
             subject = "Uusi $typeFi eVakassa / Nytt $typeSv i eVaka / New $typeEn in eVaka",
             html =
                 """
-<p>Sinulle on saapunut uusi $typeFi eVakaan. Lue viesti ${if (thread.urgent) "mahdollisimman pian " else ""}täältä: <a href="$messageUrl">$messageUrl</a></p>
+<p>Sinulle on saapunut uusi $typeFi eVakaan. Lue viesti ${if (thread.urgent) "mahdollisimman pian " else ""}täältä: ${messageLink(Language.fi, thread.id)}</p>
 <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
 <hr>
-<p>Du har fått ett nytt $typeSv i eVaka. Läs meddelandet ${if (thread.urgent) "så snart som möjligt " else ""}här: <a href="$messageUrl">$messageUrl</a></p>
+<p>Du har fått ett nytt $typeSv i eVaka. Läs meddelandet ${if (thread.urgent) "så snart som möjligt " else ""}här: ${messageLink(Language.sv, thread.id)}</p>
 <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>
 <hr>
-<p>You have received a new $typeEn in eVaka. Read the message ${if (thread.urgent) "as soon as possible " else ""}here: <a href="$messageUrl">$messageUrl</a></p>
+<p>You have received a new $typeEn in eVaka. Read the message ${if (thread.urgent) "as soon as possible " else ""}here: ${messageLink(Language.en, thread.id)}</p>
 <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>
 """
         )
     }
 
     override fun vasuNotification(language: Language, childId: ChildId): EmailContent {
-        val documentsUrl = "${baseUrl(language)}/children/$childId"
         return EmailContent.fromHtml(
             subject = "Uusi dokumentti eVakassa / Nytt dokument i eVaka / New document in eVaka",
             html =
                 """
-<p>Sinulle on saapunut uusi dokumentti eVakaan. Lue dokumentti täältä: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>Sinulle on saapunut uusi dokumentti eVakaan. Lue dokumentti täältä: ${childLink(Language.fi, childId)}</p>
 <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
 <hr>
-<p>Du har fått ett nytt dokument i eVaka. Läs dokumentet här: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>Du har fått ett nytt dokument i eVaka. Läs dokumentet här: ${childLink(Language.sv, childId)}</p>
 <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>
 <hr>
-<p>You have received a new eVaka document. Read the document here: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>You have received a new eVaka document. Read the document here: ${childLink(Language.en, childId)}</p>
 <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>
 """
         )
     }
 
     override fun pedagogicalDocumentNotification(language: Language): EmailContent {
-        val documentsUrl = "${baseUrl(language)}/pedagogical-documents"
         return EmailContent.fromHtml(
             subject =
                 "Uusi pedagoginen dokumentti eVakassa / Nytt pedagogiskt dokument i eVaka / New pedagogical document in eVaka",
             html =
                 """
-<p>Sinulle on saapunut uusi pedagoginen dokumentti eVakaan. Lue dokumentti täältä: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>Sinulle on saapunut uusi pedagoginen dokumentti eVakaan. Lue dokumentti täältä: ${pedagogicalDocumentsLink(Language.fi)}</p>
 <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
 <hr>
-<p>Du har fått ett nytt pedagogiskt dokument i eVaka. Läs dokumentet här: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>Du har fått ett nytt pedagogiskt dokument i eVaka. Läs dokumentet här: ${pedagogicalDocumentsLink(Language.sv)}</p>
 <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>
 <hr>
-<p>You have received a new eVaka pedagogical document. Read the document here: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>You have received a new eVaka pedagogical document. Read the document here: ${pedagogicalDocumentsLink(Language.en)}</p>
 <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>
 """
         )
@@ -313,14 +323,13 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
         language: Language
     ): EmailContent {
         return when (notificationType) {
-            IncomeNotificationType.INITIAL_EMAIL -> outdatedIncomeNotificationInitial(language)
-            IncomeNotificationType.REMINDER_EMAIL -> outdatedIncomeNotificationReminder(language)
+            IncomeNotificationType.INITIAL_EMAIL -> outdatedIncomeNotificationInitial()
+            IncomeNotificationType.REMINDER_EMAIL -> outdatedIncomeNotificationReminder()
             IncomeNotificationType.EXPIRED_EMAIL -> outdatedIncomeNotificationExpired()
         }
     }
 
-    private fun outdatedIncomeNotificationInitial(language: Language): EmailContent {
-        val documentsUrl = "${baseUrl(language)}/income"
+    private fun outdatedIncomeNotificationInitial(): EmailContent {
         return EmailContent.fromHtml(
             subject =
                 "Tulotietojen tarkastuskehotus / Uppmaning att göra en inkomstutredning / Request to review income information",
@@ -332,7 +341,7 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan. Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.</p>
 <p>Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut PL 30 02070 Espoon kaupunki</p>
 <p>Lisätietoja saatte tarvittaessa: vaka.maksut@espoo.fi</p>
-<p>Tulotiedot: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>Tulotiedot: ${incomeLink(Language.fi)}</p>
 <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
 <hr>
 <p>Bästa klient</p>
@@ -341,7 +350,7 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grund av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.</p>
 <p>Du kan vid behov också skicka inkomstutredningen per post till adressen Esbo stad/sektorn för fostran och lärande, ekonomienheten/klientavgifter för småbarnspedagogik PB 30 02070 Esbo stad</p>
 <p>Mer information: vaka.maksut@espoo.fi</p>
-<p>Inkomstuppgifterna: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>Inkomstuppgifterna: ${incomeLink(Language.sv)}</p>
 <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>
 <hr>
 <p>Dear client</p>
@@ -350,14 +359,13 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>If you do not provide your latest income information, your client fee will be determined based on the highest fee category. We will not retroactively reimburse you for fees charged in a situation where you have not provided your income information.</p>
 <p>If necessary, you can also send your income information by post to the following address: City of Espoo / Growth and Learning Sector, Financial Management / Early childhood education client fees, P.O. Box 30, 02070 City of Espoo.</p>
 <p>Inquiries: vaka.maksut@espoo.fi</p>
-<p>Income information: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>Income information: ${incomeLink(Language.en)}</p>
 <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>
 """
         )
     }
 
-    private fun outdatedIncomeNotificationReminder(language: Language): EmailContent {
-        val documentsUrl = "${baseUrl(language)}/income"
+    private fun outdatedIncomeNotificationReminder(): EmailContent {
         return EmailContent.fromHtml(
             subject =
                 "Tulotietojen tarkastuskehotus / Uppmaning att göra en inkomstutredning / Request to review income information",
@@ -369,7 +377,7 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>Mikäli ette toimita uusia tulotietoja, asiakasmaksu määräytyy korkeimman maksuluokan mukaan. Puuttuvilla tulotiedoilla määrättyä maksua ei korjata takautuvasti.</p>
 <p>Voitte tarvittaessa toimittaa tulotiedot myös postitse osoitteeseen Espoon kaupunki/ Kasvun ja oppimisen toimiala, talousyksikkö/ varhaiskasvatuksen asiakasmaksut PL 30 02070 Espoon kaupunki</p>
 <p>Lisätietoja saatte tarvittaessa: vaka.maksut@espoo.fi</p>
-<p>Tulotiedot: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>Tulotiedot: ${incomeLink(Language.fi)}</p>
 <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
 <hr>
 <p>Bästa klient</p>
@@ -378,7 +386,7 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>Om du inte lämnar in en ny inkomstutredning bestäms din klientavgift enligt den högsta avgiften. En avgift som fastställts på grund av bristfälliga inkomstuppgifter korrigeras inte retroaktivt.</p>
 <p>Du kan vid behov också skicka inkomstutredningen per post till adressen: Esbo stad/sektorn för fostran och lärande, ekonomienheten/klientavgifter för småbarnspedagogik PB 30 02070 Esbo stad</p>
 <p>Mer information: vaka.maksut@espoo.fi</p>
-<p>Inkomstuppgifterna: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>Inkomstuppgifterna: ${incomeLink(Language.sv)}</p>
 <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>
 <hr>
 <p>Dear client</p>
@@ -387,7 +395,7 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
 <p>If you do not provide your latest income information, your client fee will be determined based on the highest fee category. We will not retroactively reimburse you for fees charged in a situation where you have not provided your income information.</p>
 <p>If necessary, you can also send your income information by post to the following address: City of Espoo / Growth and Learning Sector, Financial Management / Early childhood education client fees, P.O. Box 30, 02070 City of Espoo</p>
 <p>Inquiries: vaka.maksut@espoo.fi</p>
-<p>Income information: <a href="$documentsUrl">$documentsUrl</a></p>
+<p>Income information: ${incomeLink(Language.en)}</p>
 <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>
 """
         )
@@ -440,15 +448,15 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
                 """
 <p>eVakaan on lisätty uusia kalenteritapahtumia:</p>
 $eventsHtml
-<p>Katso lisää kalenterissa: <a href="${baseUrl(language)}/calendar">${baseUrl(language)}/calendar</a></p>
+<p>Katso lisää kalenterissa: ${calendarLink(Language.fi)}</p>
 <hr>
 <p>Nya kalenderhändelser i eVaka:</p>
 $eventsHtml
-<p>Se mer i kalendern: <a href="${baseUrl(language)}/calendar">${baseUrl(language)}/calendar</a></p>
+<p>Se mer i kalendern: ${calendarLink(Language.sv)}</p>
 <hr>
 <p>New calendar events in eVaka:</p>
 $eventsHtml
-<p>See more in the calendar: <a href="${baseUrl(language)}/calendar">${baseUrl(language)}/calendar</a></p>
+<p>See more in the calendar: ${calendarLink(Language.en)}</p>
 """
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -33,8 +33,6 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
         link(language, "/messages/${threadId}")
     private fun childLink(language: Language, childId: ChildId) =
         link(language, "/children/$childId")
-    private fun pedagogicalDocumentsLink(langage: Language) =
-        link(langage, "/pedagogical-documents")
     private fun incomeLink(language: Language) = link(language, "/income")
 
     override fun pendingDecisionNotification(language: Language): EmailContent {
@@ -300,19 +298,22 @@ class EvakaEmailMessageProvider(private val env: EvakaEnv) : IEmailMessageProvid
         )
     }
 
-    override fun pedagogicalDocumentNotification(language: Language): EmailContent {
+    override fun pedagogicalDocumentNotification(
+        language: Language,
+        childId: ChildId
+    ): EmailContent {
         return EmailContent.fromHtml(
             subject =
                 "Uusi pedagoginen dokumentti eVakassa / Nytt pedagogiskt dokument i eVaka / New pedagogical document in eVaka",
             html =
                 """
-<p>Sinulle on saapunut uusi pedagoginen dokumentti eVakaan. Lue dokumentti täältä: ${pedagogicalDocumentsLink(Language.fi)}</p>
+<p>Sinulle on saapunut uusi pedagoginen dokumentti eVakaan. Lue dokumentti täältä: ${childLink(Language.fi, childId)}</p>
 <p>Tämä on eVaka-järjestelmän automaattisesti lähettämä ilmoitus. Älä vastaa tähän viestiin.</p>
 <hr>
-<p>Du har fått ett nytt pedagogiskt dokument i eVaka. Läs dokumentet här: ${pedagogicalDocumentsLink(Language.sv)}</p>
+<p>Du har fått ett nytt pedagogiskt dokument i eVaka. Läs dokumentet här: ${childLink(Language.sv, childId)}</p>
 <p>Detta besked skickas automatiskt av eVaka. Svara inte på detta besked.</p>
 <hr>
-<p>You have received a new eVaka pedagogical document. Read the document here: ${pedagogicalDocumentsLink(Language.en)}</p>
+<p>You have received a new eVaka pedagogical document. Read the document here: ${childLink(Language.en, childId)}</p>
 <p>This is an automatic message from the eVaka system. Do not reply to this message.</p>
 """
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
@@ -72,7 +72,7 @@ interface IEmailMessageProvider {
 
     fun vasuNotification(language: Language, childId: ChildId): EmailContent
 
-    fun pedagogicalDocumentNotification(language: Language): EmailContent
+    fun pedagogicalDocumentNotification(language: Language, childId: ChildId): EmailContent
 
     fun outdatedIncomeNotification(
         notificationType: IncomeNotificationType,

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentNotificationService.kt
@@ -131,12 +131,14 @@ SELECT EXISTS(
         clock: EvakaClock,
         msg: AsyncJob.SendPedagogicalDocumentNotificationEmail
     ) {
+        val childId = db.read { tx -> tx.getPedagogicalDocumentChild(msg.pedagogicalDocumentId) }
         Email.create(
                 dbc = db,
                 personId = msg.recipientId,
                 emailType = EmailMessageType.INFORMAL_DOCUMENT_NOTIFICATION,
                 fromAddress = emailEnv.sender(msg.language),
-                content = emailMessageProvider.pedagogicalDocumentNotification(msg.language),
+                content =
+                    emailMessageProvider.pedagogicalDocumentNotification(msg.language, childId),
                 traceId = msg.pedagogicalDocumentId.toString(),
             )
             ?.also {

--- a/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pedagogicaldocument/PedagogicalDocumentQueries.kt
@@ -75,3 +75,14 @@ fun Database.Read.getChildPedagogicalDocuments(
         .mapTo<PedagogicalDocumentCitizen>()
         .list()
 }
+
+fun Database.Read.getPedagogicalDocumentChild(
+    pedagogicalDocumentId: PedagogicalDocumentId
+): ChildId {
+    return createQuery(
+            "SELECT child_id FROM pedagogical_document WHERE id = :pedagogicalDocumentId"
+        )
+        .bind("pedagogicalDocumentId", pedagogicalDocumentId)
+        .mapTo<ChildId>()
+        .one()
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1610,7 +1610,10 @@ RETURNING id
                 EmailMessageType.vasuNotification ->
                     emailMessageProvider.vasuNotification(Language.fi, ChildId(UUID.randomUUID()))
                 EmailMessageType.pedagogicalDocumentNotification ->
-                    emailMessageProvider.pedagogicalDocumentNotification(Language.fi)
+                    emailMessageProvider.pedagogicalDocumentNotification(
+                        Language.fi,
+                        ChildId(UUID.randomUUID())
+                    )
                 EmailMessageType.outdatedIncomeNotification ->
                     emailMessageProvider.outdatedIncomeNotification(
                         IncomeNotificationType.INITIAL_EMAIL,


### PR DESCRIPTION
#### Summary

As all emails are in 3 languages, ignore the `language` parameter altogether and use correct links for the language used. Refactor link generation so that there's less repetition.

Contais a small breaking change: Adds `childId` parameter to `IEmailMessageProvider.pedagogicalDocumentNotification`