### PR TITLE
Do not prevent full reset on MA003

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaService.kt
@@ -330,8 +330,7 @@ private fun addServiceNeedDataToVarda(
                 "VardaUpdate: error adding service need ${evakaServiceNeed.id} to Varda: ${e.message}"
             )
         db.transaction { it.upsertVardaServiceNeed(vardaServiceNeed, errors) }
-        if (e.message?.contains("MA003") != true)
-            error(errors) // Error code MA003 should result to successful reset
+        error(errors)
     }
 }
 


### PR DESCRIPTION
#### Summary
Mark a varda reset failed after a MA003 error.

Varda fails with MA003 if fee data refers to guardian it does not know. Varda fetches VTJ info every night for the unknown guardians, next reset retry will succeed. 

