### PR TITLE
Fix child attendance summary

### DIFF
--- a/frontend/src/citizen-frontend/children/sections/service-need-and-daily-service-time/AttendanceSummaryTable.tsx
+++ b/frontend/src/citizen-frontend/children/sections/service-need-and-daily-service-time/AttendanceSummaryTable.tsx
@@ -101,32 +101,26 @@ interface AttendanceSummaryProps {
 
 const AttendanceSummary = ({
   serviceNeeds,
-  attendanceSummary: { plannedDays, realizedDays }
+  attendanceSummary: { attendanceDays }
 }: AttendanceSummaryProps) => {
   const t = useTranslation()
   return (
     <>
       {serviceNeeds.length > 0 ? (
         serviceNeeds.map(({ startDate, contractDaysPerMonth }) => {
-          const plannedWarning =
-            contractDaysPerMonth !== null && plannedDays > contractDaysPerMonth
-          const realizedWarning =
-            contractDaysPerMonth !== null && realizedDays > contractDaysPerMonth
+          const warning =
+            contractDaysPerMonth !== null &&
+            attendanceDays > contractDaysPerMonth
           return (
             <React.Fragment key={startDate.formatIso()}>
               <ListGrid>
-                <Label>{t.children.attendanceSummary.planned}</Label>
+                <Label>{t.children.attendanceSummary.attendanceDays}</Label>
                 <span>
-                  <Days warning={plannedWarning}>{plannedDays}</Days> /{' '}
-                  {contractDaysPerMonth} {t.common.datetime.dayShort}
-                </span>
-                <Label>{t.children.attendanceSummary.realized}</Label>
-                <span>
-                  <Days warning={realizedWarning}>{realizedDays}</Days> /{' '}
+                  <Days warning={warning}>{attendanceDays}</Days> /{' '}
                   {contractDaysPerMonth} {t.common.datetime.dayShort}
                 </span>
               </ListGrid>
-              {(plannedWarning || realizedWarning) && (
+              {warning && (
                 <AlertBox message={t.children.attendanceSummary.warning} />
               )}
             </React.Fragment>

--- a/frontend/src/lib-common/generated/api-types/children.ts
+++ b/frontend/src/lib-common/generated/api-types/children.ts
@@ -13,8 +13,7 @@ import { UUID } from '../../types'
 * Generated from fi.espoo.evaka.children.AttendanceSummary
 */
 export interface AttendanceSummary {
-  plannedDays: number
-  realizedDays: number
+  attendanceDays: number
 }
 
 /**

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2226,8 +2226,7 @@ const en: Translations = {
     },
     attendanceSummary: {
       title: 'Attendances',
-      planned: 'Planned',
-      realized: 'Realized',
+      attendanceDays: 'Contract days',
       warning: 'The number of contract days per month has been exceeded.',
       empty: 'No contract days in the selected period'
     },

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2405,8 +2405,7 @@ export default {
     },
     attendanceSummary: {
       title: 'Läsnäolot',
-      planned: 'Suunnitelma',
-      realized: 'Toteuma',
+      attendanceDays: 'Sopimuspäivät',
       warning: 'Kuukauden sopimuspäivien määrä on ylittynyt.',
       empty: 'Ei sopimuspäiviä valitulla ajanjaksolla'
     },

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2466,8 +2466,7 @@ const sv: Translations = {
     },
     attendanceSummary: {
       title: 'Läsnäolot',
-      planned: 'Suunnitelma',
-      realized: 'Toteuma',
+      attendanceDays: 'Sopimuspäivät',
       warning: 'Kuukauden sopimuspäivien määrä on ylittynyt.',
       empty: 'Ei sopimuspäiviä valitulla ajanjaksolla'
     },

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/children/ChildControllerCitizenTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/children/ChildControllerCitizenTest.kt
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.children
+
+import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.daycare.service.AbsenceCategory
+import fi.espoo.evaka.daycare.service.AbsenceType
+import fi.espoo.evaka.pis.service.insertGuardian
+import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.CitizenAuthLevel
+import fi.espoo.evaka.shared.dev.DevAbsence
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevChild
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.insertTestAbsence
+import fi.espoo.evaka.shared.dev.insertTestCareArea
+import fi.espoo.evaka.shared.dev.insertTestChild
+import fi.espoo.evaka.shared.dev.insertTestDaycare
+import fi.espoo.evaka.shared.dev.insertTestHoliday
+import fi.espoo.evaka.shared.dev.insertTestPerson
+import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.domain.Forbidden
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.YearMonth
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+
+class ChildControllerCitizenTest : FullApplicationTest(resetDbBeforeEach = true) {
+
+    @Autowired private lateinit var childControllerCitizen: ChildControllerCitizen
+
+    @Test
+    fun `getChildAttendanceSummary placement`() {
+        val (guardianId, childId) =
+            db.transaction { tx ->
+                val areaId = tx.insertTestCareArea(DevCareArea())
+                val unitId = tx.insertTestDaycare(DevDaycare(areaId = areaId))
+                val guardianId = tx.insertTestPerson(DevPerson())
+                val childId = tx.insertTestPerson(DevPerson())
+                tx.insertTestChild(DevChild(id = childId))
+                tx.insertGuardian(guardianId = guardianId, childId = childId)
+                tx.insertTestPlacement(
+                    childId = childId,
+                    unitId = unitId,
+                    startDate = LocalDate.of(2023, 8, 1),
+                    endDate = LocalDate.of(2023, 9, 17)
+                )
+                Pair(guardianId, childId)
+            }
+
+        assertThat(
+                childControllerCitizen.getChildAttendanceSummary(
+                    dbInstance(),
+                    AuthenticatedUser.Citizen(guardianId, CitizenAuthLevel.WEAK),
+                    MockEvakaClock(
+                        HelsinkiDateTime.of(LocalDate.of(2023, 9, 11), LocalTime.of(8, 23))
+                    ),
+                    childId,
+                    YearMonth.of(2023, 8)
+                )
+            )
+            .isEqualTo(AttendanceSummary(attendanceDays = 23))
+        assertThat(
+                childControllerCitizen.getChildAttendanceSummary(
+                    dbInstance(),
+                    AuthenticatedUser.Citizen(guardianId, CitizenAuthLevel.WEAK),
+                    MockEvakaClock(
+                        HelsinkiDateTime.of(LocalDate.of(2023, 9, 11), LocalTime.of(8, 23))
+                    ),
+                    childId,
+                    YearMonth.of(2023, 9)
+                )
+            )
+            .isEqualTo(AttendanceSummary(attendanceDays = 11))
+        assertThat(
+                childControllerCitizen.getChildAttendanceSummary(
+                    dbInstance(),
+                    AuthenticatedUser.Citizen(guardianId, CitizenAuthLevel.WEAK),
+                    MockEvakaClock(
+                        HelsinkiDateTime.of(LocalDate.of(2023, 9, 11), LocalTime.of(8, 23))
+                    ),
+                    childId,
+                    YearMonth.of(2023, 10)
+                )
+            )
+            .isEqualTo(AttendanceSummary(attendanceDays = 0))
+    }
+
+    @Test
+    fun `getChildAttendanceSummary planned absence`() {
+        val (guardianId, childId) =
+            db.transaction { tx ->
+                val areaId = tx.insertTestCareArea(DevCareArea())
+                val unitId = tx.insertTestDaycare(DevDaycare(areaId = areaId))
+                val guardianId = tx.insertTestPerson(DevPerson())
+                val childId = tx.insertTestPerson(DevPerson())
+                tx.insertTestChild(DevChild(id = childId))
+                tx.insertGuardian(guardianId = guardianId, childId = childId)
+                tx.insertTestPlacement(
+                    childId = childId,
+                    unitId = unitId,
+                    startDate = LocalDate.of(2023, 9, 1),
+                    endDate = LocalDate.of(2023, 9, 30)
+                )
+                tx.insertTestAbsence(
+                    DevAbsence(
+                        childId = childId,
+                        date = LocalDate.of(2023, 9, 11),
+                        absenceType = AbsenceType.PLANNED_ABSENCE,
+                        absenceCategory = AbsenceCategory.BILLABLE
+                    )
+                )
+                Pair(guardianId, childId)
+            }
+
+        assertThat(
+                childControllerCitizen.getChildAttendanceSummary(
+                    dbInstance(),
+                    AuthenticatedUser.Citizen(guardianId, CitizenAuthLevel.WEAK),
+                    MockEvakaClock(
+                        HelsinkiDateTime.of(LocalDate.of(2023, 9, 11), LocalTime.of(8, 23))
+                    ),
+                    childId,
+                    YearMonth.of(2023, 9)
+                )
+            )
+            .isEqualTo(AttendanceSummary(attendanceDays = 20))
+    }
+
+    @Test
+    fun `getChildAttendanceSummary planned absence outside placement`() {
+        val (guardianId, childId) =
+            db.transaction { tx ->
+                val areaId = tx.insertTestCareArea(DevCareArea())
+                val unitId = tx.insertTestDaycare(DevDaycare(areaId = areaId))
+                val guardianId = tx.insertTestPerson(DevPerson())
+                val childId = tx.insertTestPerson(DevPerson())
+                tx.insertTestChild(DevChild(id = childId))
+                tx.insertGuardian(guardianId = guardianId, childId = childId)
+                tx.insertTestPlacement(
+                    childId = childId,
+                    unitId = unitId,
+                    startDate = LocalDate.of(2023, 9, 4),
+                    endDate = LocalDate.of(2023, 9, 17)
+                )
+                tx.insertTestAbsence(
+                    DevAbsence(
+                        childId = childId,
+                        date = LocalDate.of(2023, 9, 18),
+                        absenceType = AbsenceType.PLANNED_ABSENCE,
+                        absenceCategory = AbsenceCategory.BILLABLE
+                    )
+                )
+                Pair(guardianId, childId)
+            }
+
+        assertThat(
+                childControllerCitizen.getChildAttendanceSummary(
+                    dbInstance(),
+                    AuthenticatedUser.Citizen(guardianId, CitizenAuthLevel.WEAK),
+                    MockEvakaClock(
+                        HelsinkiDateTime.of(LocalDate.of(2023, 9, 11), LocalTime.of(8, 23))
+                    ),
+                    childId,
+                    YearMonth.of(2023, 9)
+                )
+            )
+            .isEqualTo(AttendanceSummary(attendanceDays = 10))
+    }
+
+    @Test
+    fun `getChildAttendanceSummary unknown absence`() {
+        val (guardianId, childId) =
+            db.transaction { tx ->
+                val areaId = tx.insertTestCareArea(DevCareArea())
+                val unitId = tx.insertTestDaycare(DevDaycare(areaId = areaId))
+                val guardianId = tx.insertTestPerson(DevPerson())
+                val childId = tx.insertTestPerson(DevPerson())
+                tx.insertTestChild(DevChild(id = childId))
+                tx.insertGuardian(guardianId = guardianId, childId = childId)
+                tx.insertTestPlacement(
+                    childId = childId,
+                    unitId = unitId,
+                    startDate = LocalDate.of(2023, 9, 1),
+                    endDate = LocalDate.of(2023, 9, 30)
+                )
+                tx.insertTestAbsence(
+                    DevAbsence(
+                        childId = childId,
+                        date = LocalDate.of(2023, 9, 11),
+                        absenceType = AbsenceType.UNKNOWN_ABSENCE,
+                        absenceCategory = AbsenceCategory.BILLABLE
+                    )
+                )
+                Pair(guardianId, childId)
+            }
+
+        assertThat(
+                childControllerCitizen.getChildAttendanceSummary(
+                    dbInstance(),
+                    AuthenticatedUser.Citizen(guardianId, CitizenAuthLevel.WEAK),
+                    MockEvakaClock(
+                        HelsinkiDateTime.of(LocalDate.of(2023, 9, 11), LocalTime.of(8, 23))
+                    ),
+                    childId,
+                    YearMonth.of(2023, 9)
+                )
+            )
+            .isEqualTo(AttendanceSummary(attendanceDays = 21))
+    }
+
+    @Test
+    fun `getChildAttendanceSummary holiday`() {
+        val (guardianId, childId) =
+            db.transaction { tx ->
+                val areaId = tx.insertTestCareArea(DevCareArea())
+                val unitId = tx.insertTestDaycare(DevDaycare(areaId = areaId))
+                val guardianId = tx.insertTestPerson(DevPerson())
+                val childId = tx.insertTestPerson(DevPerson())
+                tx.insertTestChild(DevChild(id = childId))
+                tx.insertGuardian(guardianId = guardianId, childId = childId)
+                tx.insertTestPlacement(
+                    childId = childId,
+                    unitId = unitId,
+                    startDate = LocalDate.of(2023, 9, 1),
+                    endDate = LocalDate.of(2023, 9, 30)
+                )
+                tx.insertTestHoliday(date = LocalDate.of(2023, 9, 11))
+                Pair(guardianId, childId)
+            }
+
+        assertThat(
+                childControllerCitizen.getChildAttendanceSummary(
+                    dbInstance(),
+                    AuthenticatedUser.Citizen(guardianId, CitizenAuthLevel.WEAK),
+                    MockEvakaClock(
+                        HelsinkiDateTime.of(LocalDate.of(2023, 9, 11), LocalTime.of(8, 23))
+                    ),
+                    childId,
+                    YearMonth.of(2023, 9)
+                )
+            )
+            .isEqualTo(AttendanceSummary(attendanceDays = 20))
+    }
+
+    @Test
+    fun `getChildAttendanceSummary forbidden`() {
+        val (_, childId) =
+            db.transaction { tx ->
+                val areaId = tx.insertTestCareArea(DevCareArea())
+                val unitId = tx.insertTestDaycare(DevDaycare(areaId = areaId))
+                val guardianId = tx.insertTestPerson(DevPerson())
+                val childId = tx.insertTestPerson(DevPerson())
+                tx.insertTestChild(DevChild(id = childId))
+                tx.insertGuardian(guardianId = guardianId, childId = childId)
+                tx.insertTestPlacement(
+                    childId = childId,
+                    unitId = unitId,
+                    startDate = LocalDate.of(2023, 9, 1),
+                    endDate = LocalDate.of(2023, 9, 30)
+                )
+                Pair(guardianId, childId)
+            }
+
+        assertThrows<Forbidden> {
+            childControllerCitizen.getChildAttendanceSummary(
+                dbInstance(),
+                AuthenticatedUser.Citizen(PersonId(UUID.randomUUID()), CitizenAuthLevel.WEAK),
+                MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2023, 9, 11), LocalTime.of(8, 23))),
+                childId,
+                YearMonth.of(2023, 9)
+            )
+        }
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -442,21 +442,3 @@ fun Database.Transaction.deleteAbsencesByFiniteDateRange(
         .mapTo<AbsenceId>()
         .toList()
 }
-
-fun Database.Read.countChildAttendanceDays(childId: ChildId, range: FiniteDateRange): Int {
-    val sql =
-        """
-SELECT count(DISTINCT ca.date)
-FROM child_attendance ca
-WHERE ca.child_id = :childId
-AND ca.date BETWEEN :start AND :end
-    """
-            .trimIndent()
-
-    return createQuery(sql)
-        .bind("childId", childId)
-        .bind("start", range.start)
-        .bind("end", range.end)
-        .mapTo<Int>()
-        .one()
-}

--- a/service/src/main/kotlin/fi/espoo/evaka/children/ChildControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/children/ChildControllerCitizen.kt
@@ -5,13 +5,12 @@
 package fi.espoo.evaka.children
 
 import fi.espoo.evaka.Audit
-import fi.espoo.evaka.attendance.countChildAttendanceDays
 import fi.espoo.evaka.dailyservicetimes.DailyServiceTimes
 import fi.espoo.evaka.dailyservicetimes.getChildDailyServiceTimes
 import fi.espoo.evaka.daycare.service.AbsenceType
-import fi.espoo.evaka.daycare.service.countAbsenceDays
+import fi.espoo.evaka.daycare.service.getAbsencesOfChildByRange
+import fi.espoo.evaka.placement.getChildPlacementTypesByRange
 import fi.espoo.evaka.placement.getPlacementSummary
-import fi.espoo.evaka.reservations.countReservationDays
 import fi.espoo.evaka.serviceneed.ServiceNeedOptionPublicInfo
 import fi.espoo.evaka.serviceneed.ServiceNeedSummary
 import fi.espoo.evaka.serviceneed.getServiceNeedOptions
@@ -19,10 +18,13 @@ import fi.espoo.evaka.serviceneed.getServiceNeedSummary
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.operationalDays
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
+import java.time.LocalDate
 import java.time.YearMonth
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -117,22 +119,37 @@ class ChildControllerCitizen(private val accessControl: AccessControl) {
                         Action.Citizen.Child.READ_ATTENDANCE_SUMMARY,
                         childId
                     )
-                    val range = FiniteDateRange(yearMonth.atDay(1), yearMonth.atEndOfMonth())
-                    val reservationDays = tx.countReservationDays(childId, range)
-                    val attendanceDays = tx.countChildAttendanceDays(childId, range)
-                    val unplannedAbsenceDays =
-                        tx.countAbsenceDays(
-                            childId,
-                            range,
-                            setOf(
-                                AbsenceType.OTHER_ABSENCE,
-                                AbsenceType.UNKNOWN_ABSENCE,
-                                AbsenceType.SICKLEAVE,
-                                AbsenceType.FORCE_MAJEURE,
-                                AbsenceType.UNAUTHORIZED_ABSENCE
-                            )
-                        )
-                    AttendanceSummary(reservationDays, attendanceDays + unplannedAbsenceDays)
+
+                    val operationalDays = tx.operationalDays(yearMonth.year, yearMonth.month)
+                    val range = DateRange(yearMonth.atDay(1), yearMonth.atEndOfMonth())
+                    val placements = tx.getChildPlacementTypesByRange(childId, range)
+                    val plannedAbsences =
+                        tx.getAbsencesOfChildByRange(childId, range).filter { absence ->
+                            val placement =
+                                placements.find { placement ->
+                                    placement.period.includes(absence.date)
+                                }
+                            placement != null &&
+                                operationalDays.forUnit(placement.unitId).contains(absence.date) &&
+                                setOf(
+                                        AbsenceType.PLANNED_ABSENCE,
+                                        AbsenceType.FREE_ABSENCE,
+                                        AbsenceType.PARENTLEAVE
+                                    )
+                                    .contains(absence.absenceType)
+                        }
+
+                    val operationalDates =
+                        placements.fold(setOf<LocalDate>()) { dates, placement ->
+                            placement.period.intersection(range)?.let { range ->
+                                val unitDates = operationalDays.forUnit(placement.unitId)
+                                dates.plus(unitDates.filter { date -> range.includes(date) })
+                            }
+                                ?: dates
+                        }
+                    AttendanceSummary(
+                        attendanceDays = operationalDates.count() - plannedAbsences.count()
+                    )
                 }
             }
             .also { Audit.CitizenChildAttendanceSummaryRead.log(targetId = childId) }
@@ -161,4 +178,4 @@ class ChildControllerCitizen(private val accessControl: AccessControl) {
     }
 }
 
-data class AttendanceSummary(val plannedDays: Int, val realizedDays: Int)
+data class AttendanceSummary(val attendanceDays: Int)

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -525,25 +525,3 @@ fun Database.Read.getReservationContractDayRanges(
         .mapTo<ChildContractDays>()
         .associate { it.childId to it.contractDays }
 }
-
-fun Database.Read.countReservationDays(childId: ChildId, range: FiniteDateRange): Int {
-    val sql =
-        """
-SELECT count(DISTINCT ar.date)
-FROM attendance_reservation ar
-JOIN realized_placement_one(ar.date) p ON p.child_id = ar.child_id
-JOIN daycare u ON u.id = p.unit_id
-WHERE ar.child_id = :childId
-AND ar.date BETWEEN :start AND :end
-AND date_part('isodow', ar.date) = ANY (u.operation_days)
-AND (NOT EXISTS (SELECT FROM holiday WHERE date = ar.date) OR array_length(u.operation_days, 1) = 7)
-    """
-            .trimIndent()
-
-    return createQuery(sql)
-        .bind("childId", childId)
-        .bind("start", range.start)
-        .bind("end", range.end)
-        .mapTo<Int>()
-        .one()
-}


### PR DESCRIPTION
#### Summary

Summary should be based on only unit operational days and absences because they are used for invoicing.