### PR TITLE
Preschool/club term breaks, part 2 (employee frontend)

### DIFF
--- a/frontend/src/e2e-test/dev-api/data-init.ts
+++ b/frontend/src/e2e-test/dev-api/data-init.ts
@@ -23,7 +23,9 @@ import {
   familyWithDeadGuardian,
   enduserDeceasedChildFixture,
   enduserNonSsnChildFixture,
-  daycareFixturePrivateVoucher
+  daycareFixturePrivateVoucher,
+  preschoolTermFixtures,
+  clubTermFixtures
 } from './fixtures'
 
 import * as devApi from '.'
@@ -54,6 +56,12 @@ export type AreaAndPersonFixtures = typeof areaAndPersonFixtures
 export const initializeAreaAndPersonData = async (): Promise<
   typeof areaAndPersonFixtures
 > => {
+  for (const preschoolTermFixture of preschoolTermFixtures) {
+    await Fixture.preschoolTerm().with(preschoolTermFixture).save()
+  }
+  for (const clubTermFixture of clubTermFixtures) {
+    await Fixture.clubTerm().with(clubTermFixture).save()
+  }
   const careArea = await Fixture.careArea()
     .with(areaAndPersonFixtures.careAreaFixture)
     .save()

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -22,6 +22,7 @@ import {
   AssistanceNeedPreschoolDecisionForm,
   AssistanceNeedPreschoolDecisionGuardian
 } from 'lib-common/generated/api-types/assistanceneed'
+import { ClubTerm, PreschoolTerm } from 'lib-common/generated/api-types/daycare'
 import {
   FixedPeriodQuestionnaire,
   HolidayPeriod
@@ -132,7 +133,9 @@ import {
   insertOtherAssistanceMeasureFixtures,
   insertAssistanceNeedPreschoolDecisionFixtures,
   insertDocumentTemplateFixture,
-  insertChildDocumentFixture
+  insertChildDocumentFixture,
+  insertPreschoolTerm,
+  insertClubTerm
 } from './index'
 
 export const fullDayTimeRange: TimeRange = {
@@ -144,6 +147,156 @@ export const nonFullDayTimeRange: TimeRange = {
   start: LocalTime.of(1, 0),
   end: LocalTime.of(23, 0)
 }
+
+export const preschoolTermFixture2020: PreschoolTerm = {
+  finnishPreschool: new FiniteDateRange(
+    LocalDate.of(2020, 8, 13),
+    LocalDate.of(2021, 6, 4)
+  ),
+  swedishPreschool: new FiniteDateRange(
+    LocalDate.of(2020, 8, 18),
+    LocalDate.of(2021, 6, 4)
+  ),
+  extendedTerm: new FiniteDateRange(
+    LocalDate.of(2020, 8, 1),
+    LocalDate.of(2021, 6, 4)
+  ),
+  applicationPeriod: new FiniteDateRange(
+    LocalDate.of(2020, 1, 8),
+    LocalDate.of(2020, 1, 20)
+  ),
+  termBreaks: []
+}
+
+export const preschoolTermFixture2021: PreschoolTerm = {
+  finnishPreschool: new FiniteDateRange(
+    LocalDate.of(2021, 8, 11),
+    LocalDate.of(2022, 6, 3)
+  ),
+  swedishPreschool: new FiniteDateRange(
+    LocalDate.of(2021, 8, 11),
+    LocalDate.of(2022, 6, 3)
+  ),
+  extendedTerm: new FiniteDateRange(
+    LocalDate.of(2021, 8, 1),
+    LocalDate.of(2022, 6, 3)
+  ),
+  applicationPeriod: new FiniteDateRange(
+    LocalDate.of(2021, 1, 8),
+    LocalDate.of(2021, 1, 20)
+  ),
+  termBreaks: []
+}
+
+export const preschoolTermFixture2022: PreschoolTerm = {
+  finnishPreschool: new FiniteDateRange(
+    LocalDate.of(2022, 8, 11),
+    LocalDate.of(2023, 6, 2)
+  ),
+  swedishPreschool: new FiniteDateRange(
+    LocalDate.of(2022, 8, 11),
+    LocalDate.of(2023, 6, 2)
+  ),
+  extendedTerm: new FiniteDateRange(
+    LocalDate.of(2022, 8, 1),
+    LocalDate.of(2023, 6, 2)
+  ),
+  applicationPeriod: new FiniteDateRange(
+    LocalDate.of(2022, 1, 10),
+    LocalDate.of(2022, 1, 21)
+  ),
+  termBreaks: []
+}
+
+export const preschoolTermFixture2023: PreschoolTerm = {
+  finnishPreschool: new FiniteDateRange(
+    LocalDate.of(2023, 8, 11),
+    LocalDate.of(2024, 6, 3)
+  ),
+  swedishPreschool: new FiniteDateRange(
+    LocalDate.of(2023, 8, 13),
+    LocalDate.of(2024, 6, 6)
+  ),
+  extendedTerm: new FiniteDateRange(
+    LocalDate.of(2023, 8, 1),
+    LocalDate.of(2024, 6, 6)
+  ),
+  applicationPeriod: new FiniteDateRange(
+    LocalDate.of(2023, 1, 8),
+    LocalDate.of(2023, 1, 20)
+  ),
+  termBreaks: [
+    new FiniteDateRange(LocalDate.of(2023, 10, 16), LocalDate.of(2023, 10, 20)),
+    new FiniteDateRange(LocalDate.of(2023, 12, 23), LocalDate.of(2024, 1, 7)),
+    new FiniteDateRange(LocalDate.of(2024, 2, 19), LocalDate.of(2024, 2, 23))
+  ]
+}
+
+export const preschoolTermFixtures = [
+  preschoolTermFixture2020,
+  preschoolTermFixture2021,
+  preschoolTermFixture2022,
+  preschoolTermFixture2023
+]
+
+export const clubTermFixture2020: ClubTerm = {
+  term: new FiniteDateRange(
+    LocalDate.of(2020, 8, 13),
+    LocalDate.of(2021, 6, 4)
+  ),
+  applicationPeriod: new FiniteDateRange(
+    LocalDate.of(2020, 1, 8),
+    LocalDate.of(2020, 1, 20)
+  ),
+  termBreaks: []
+}
+
+export const clubTermFixture2021: ClubTerm = {
+  term: new FiniteDateRange(
+    LocalDate.of(2021, 8, 11),
+    LocalDate.of(2022, 6, 3)
+  ),
+  applicationPeriod: new FiniteDateRange(
+    LocalDate.of(2021, 1, 8),
+    LocalDate.of(2021, 1, 20)
+  ),
+  termBreaks: []
+}
+
+export const clubTermFixture2022: ClubTerm = {
+  term: new FiniteDateRange(
+    LocalDate.of(2022, 8, 10),
+    LocalDate.of(2023, 6, 3)
+  ),
+  applicationPeriod: new FiniteDateRange(
+    LocalDate.of(2022, 1, 8),
+    LocalDate.of(2022, 1, 20)
+  ),
+  termBreaks: []
+}
+
+export const clubTermFixture2023: ClubTerm = {
+  term: new FiniteDateRange(
+    LocalDate.of(2023, 8, 10),
+    LocalDate.of(2024, 6, 3)
+  ),
+  applicationPeriod: new FiniteDateRange(
+    LocalDate.of(2023, 1, 8),
+    LocalDate.of(2023, 1, 20)
+  ),
+  termBreaks: [
+    new FiniteDateRange(LocalDate.of(2023, 10, 16), LocalDate.of(2023, 10, 20)),
+    new FiniteDateRange(LocalDate.of(2023, 12, 23), LocalDate.of(2024, 1, 7)),
+    new FiniteDateRange(LocalDate.of(2024, 2, 19), LocalDate.of(2024, 2, 23))
+  ]
+}
+
+export const clubTermFixtures = [
+  clubTermFixture2020,
+  clubTermFixture2021,
+  clubTermFixture2022,
+  clubTermFixture2023
+]
 
 export const careAreaFixture: CareArea = {
   id: '674dfb66-8849-489e-b094-e6a0ebfb3c71',
@@ -1204,6 +1357,14 @@ export class Fixture {
     })
   }
 
+  static preschoolTerm(): PreschoolTermBuilder {
+    return new PreschoolTermBuilder(preschoolTermFixture2023)
+  }
+
+  static clubTerm(): ClubTermBuilder {
+    return new ClubTermBuilder(clubTermFixture2023)
+  }
+
   static person(): PersonBuilder {
     const id = uniqueLabel()
     return new PersonBuilder({
@@ -2078,6 +2239,30 @@ export class CareAreaBuilder extends FixtureBuilder<CareArea> {
   // Note: shallow copy
   copy() {
     return new CareAreaBuilder({ ...this.data })
+  }
+}
+
+export class PreschoolTermBuilder extends FixtureBuilder<PreschoolTerm> {
+  async save() {
+    await insertPreschoolTerm(this.data)
+    return this
+  }
+
+  // Note: shallow copy
+  copy() {
+    return new PreschoolTermBuilder({ ...this.data })
+  }
+}
+
+export class ClubTermBuilder extends FixtureBuilder<ClubTerm> {
+  async save() {
+    await insertClubTerm(this.data)
+    return this
+  }
+
+  // Note: shallow copy
+  copy() {
+    return new ClubTermBuilder({ ...this.data })
   }
 }
 

--- a/frontend/src/e2e-test/dev-api/index.ts
+++ b/frontend/src/e2e-test/dev-api/index.ts
@@ -27,7 +27,9 @@ import {
 import { ChildDiscussionData } from 'lib-common/generated/api-types/childdiscussion'
 import {
   AbsenceCategory,
-  AbsenceType
+  AbsenceType,
+  ClubTerm,
+  PreschoolTerm
 } from 'lib-common/generated/api-types/daycare'
 import {
   FeeDecision,
@@ -1314,6 +1316,22 @@ export async function insertAbsence(
       absenceCategory,
       modifiedBy
     })
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}
+
+export async function insertClubTerm(body: ClubTerm): Promise<void> {
+  try {
+    await devClient.post<void>('/club-term', body)
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}
+
+export async function insertPreschoolTerm(body: PreschoolTerm): Promise<void> {
+  try {
+    await devClient.post<void>('/preschool-term', body)
   } catch (e) {
     throw new DevApiError(e)
   }

--- a/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
@@ -11,7 +11,7 @@ import {
   TextInput
 } from '../../../utils/page'
 
-import { UnitDiaryPage } from './unit-diary-page'
+import { UnitMonthCalendarPage } from './unit-month-calendar-page'
 
 export class UnitGroupsPage {
   constructor(private readonly page: Page) {}
@@ -216,7 +216,7 @@ export class GroupCollapsible extends Element {
   #groupStartDate = this.find('[data-qa="group-start-date"]')
   #groupEndDate = this.find('[data-qa="group-end-date"]')
 
-  #diaryButton = this.find('[data-qa="open-absence-diary-button"]')
+  #monthCalendarButton = this.find('[data-qa="open-month-calendar-button"]')
   #groupDailyNoteButton = this.find('[data-qa="btn-create-group-note"]')
 
   #childRows = this.find('[data-qa="table-of-group-placements"]').findAll(
@@ -252,9 +252,9 @@ export class GroupCollapsible extends Element {
     await this.#childRows.nth(n).find('[data-qa="remove-btn"]').click()
   }
 
-  async openDiary() {
-    await this.#diaryButton.click()
-    return new UnitDiaryPage(this.page)
+  async openMonthCalendar() {
+    await this.#monthCalendarButton.click()
+    return new UnitMonthCalendarPage(this.page)
   }
 
   async openGroupDailyNoteModal() {

--- a/frontend/src/e2e-test/pages/employee/units/unit-month-calendar-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-month-calendar-page.ts
@@ -20,7 +20,7 @@ import {
   TextInput
 } from '../../../utils/page'
 
-export class UnitDiaryPage {
+export class UnitMonthCalendarPage {
   constructor(private page: Page) {}
 
   #unitName = this.page.find('[data-qa="attendances-unit-name"]')

--- a/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
@@ -81,7 +81,7 @@ describe('Employee - Absences', () => {
     await groupSection.assertChildCount(1)
   })
 
-  test('User can open the diary page and add an absence for a child with only one absence category', async () => {
+  test('User can open the month calendar and add an absence for a child with only one absence category', async () => {
     await unitPage.navigateToUnit(fixtures.daycareFixture.id)
     const groupsPage = await unitPage.openGroupsPage()
 
@@ -91,15 +91,15 @@ describe('Employee - Absences', () => {
     const groupSection = await groupsPage.openGroupCollapsible(
       daycareGroupFixture.id
     )
-    const diaryPage = await groupSection.openDiary()
+    const monthCalendarPage = await groupSection.openMonthCalendar()
 
     // Can add an absence
-    await diaryPage.addAbsenceToChild(
+    await monthCalendarPage.addAbsenceToChild(
       fixtures.enduserChildFixtureJari.id,
       today,
       'SICKLEAVE'
     )
-    await diaryPage.childHasAbsence(
+    await monthCalendarPage.childHasAbsence(
       fixtures.enduserChildFixtureJari.id,
       today,
       'SICKLEAVE',
@@ -107,12 +107,12 @@ describe('Employee - Absences', () => {
     )
 
     // Can change the absence type
-    await diaryPage.addAbsenceToChild(
+    await monthCalendarPage.addAbsenceToChild(
       fixtures.enduserChildFixtureJari.id,
       today,
       'UNKNOWN_ABSENCE'
     )
-    await diaryPage.childHasAbsence(
+    await monthCalendarPage.childHasAbsence(
       fixtures.enduserChildFixtureJari.id,
       today,
       'UNKNOWN_ABSENCE',
@@ -120,7 +120,7 @@ describe('Employee - Absences', () => {
     )
 
     // Hover shows type and who is the absence maker
-    await diaryPage.assertTooltipContains(
+    await monthCalendarPage.assertTooltipContains(
       fixtures.enduserChildFixtureJari.id,
       today,
       [
@@ -130,34 +130,34 @@ describe('Employee - Absences', () => {
     )
 
     // Can clear an absence
-    await diaryPage.addAbsenceToChild(
+    await monthCalendarPage.addAbsenceToChild(
       fixtures.enduserChildFixtureJari.id,
       today,
       'NO_ABSENCE'
     )
-    await diaryPage.childHasNoAbsence(
+    await monthCalendarPage.childHasNoAbsence(
       fixtures.enduserChildFixtureJari.id,
       today,
       'BILLABLE'
     )
   })
 
-  test('User can open the diary page and add an absence for a child with two absence categories', async () => {
+  test('User can open the month calendar and add an absence for a child with two absence categories', async () => {
     await unitPage.navigateToUnit(fixtures.daycareFixture.id)
     const groupsPage = await unitPage.openGroupsPage()
     const groupSection = await groupsPage.openGroupCollapsible(
       daycareGroupFixture.id
     )
-    const diaryPage = await groupSection.openDiary()
+    const monthCalendarPage = await groupSection.openMonthCalendar()
 
     // Can add an absence
-    await diaryPage.addAbsenceToChild(
+    await monthCalendarPage.addAbsenceToChild(
       fixtures.enduserChildFixtureKaarina.id,
       today,
       'SICKLEAVE',
       ['BILLABLE']
     )
-    await diaryPage.childHasAbsence(
+    await monthCalendarPage.childHasAbsence(
       fixtures.enduserChildFixtureKaarina.id,
       today,
       'SICKLEAVE',
@@ -165,13 +165,13 @@ describe('Employee - Absences', () => {
     )
 
     // Can change the absence type
-    await diaryPage.addAbsenceToChild(
+    await monthCalendarPage.addAbsenceToChild(
       fixtures.enduserChildFixtureKaarina.id,
       today,
       'UNKNOWN_ABSENCE',
       ['NONBILLABLE']
     )
-    await diaryPage.childHasAbsence(
+    await monthCalendarPage.childHasAbsence(
       fixtures.enduserChildFixtureKaarina.id,
       today,
       'UNKNOWN_ABSENCE',
@@ -179,7 +179,7 @@ describe('Employee - Absences', () => {
     )
 
     // Hover shows type and who is the absence maker
-    await diaryPage.assertTooltipContains(
+    await monthCalendarPage.assertTooltipContains(
       fixtures.enduserChildFixtureKaarina.id,
       today,
       [
@@ -189,18 +189,18 @@ describe('Employee - Absences', () => {
     )
 
     // Can clear an absence
-    await diaryPage.addAbsenceToChild(
+    await monthCalendarPage.addAbsenceToChild(
       fixtures.enduserChildFixtureKaarina.id,
       today,
       'NO_ABSENCE',
       ['BILLABLE', 'NONBILLABLE']
     )
-    await diaryPage.childHasNoAbsence(
+    await monthCalendarPage.childHasNoAbsence(
       fixtures.enduserChildFixtureKaarina.id,
       today,
       'BILLABLE'
     )
-    await diaryPage.childHasNoAbsence(
+    await monthCalendarPage.childHasNoAbsence(
       fixtures.enduserChildFixtureKaarina.id,
       today,
       'NONBILLABLE'
@@ -217,15 +217,15 @@ describe('Employee - Absences', () => {
     const groupSection = await groupsPage.openGroupCollapsible(
       daycareGroupFixture.id
     )
-    const diaryPage = await groupSection.openDiary()
+    const monthCalendarPage = await groupSection.openMonthCalendar()
 
-    await diaryPage.fillStaffAttendance(0, 3)
+    await monthCalendarPage.fillStaffAttendance(0, 3)
 
     // Change to another page and back to reload data
     await unitPage.openGroupsPage()
-    await groupSection.openDiary()
+    await groupSection.openMonthCalendar()
 
-    await diaryPage.assertStaffAttendance(0, 3)
+    await monthCalendarPage.assertStaffAttendance(0, 3)
   })
 
   describe('Holiday period reservations', () => {
@@ -246,37 +246,37 @@ describe('Employee - Absences', () => {
       const groupSection = await groupsPage.openGroupCollapsible(
         daycareGroupFixture.id
       )
-      const diaryPage = await groupSection.openDiary()
+      const monthCalendarPage = await groupSection.openMonthCalendar()
 
       // Today is not in a holiday period
-      await diaryPage
+      await monthCalendarPage
         .absenceCell(fixtures.enduserChildFixtureKaarina.id, today)
         .waitUntilVisible()
-      await diaryPage
+      await monthCalendarPage
         .absenceCell(fixtures.enduserChildFixtureKaarina.id, today)
         .missingHolidayReservation.waitUntilHidden()
 
       // Missing holiday reservation is shown for holiday period dates
-      await diaryPage.nextWeekButton.click()
+      await monthCalendarPage.nextWeekButton.click()
       let date = holidayStart
       while (date <= holidayEnd) {
-        await diaryPage
+        await monthCalendarPage
           .absenceCell(fixtures.enduserChildFixtureKaarina.id, date)
           .missingHolidayReservation.waitUntilVisible()
         date = date.addDays(1)
       }
 
       // Adding an absence hides the missing holiday reservation marker
-      await diaryPage.addAbsenceToChild(
+      await monthCalendarPage.addAbsenceToChild(
         fixtures.enduserChildFixtureKaarina.id,
         holidayStart,
         'UNKNOWN_ABSENCE',
         ['NONBILLABLE']
       )
-      await diaryPage
+      await monthCalendarPage
         .absenceCell(fixtures.enduserChildFixtureKaarina.id, holidayStart)
         .waitUntilVisible()
-      await diaryPage
+      await monthCalendarPage
         .absenceCell(fixtures.enduserChildFixtureKaarina.id, holidayStart)
         .missingHolidayReservation.waitUntilHidden()
     })

--- a/frontend/src/employee-frontend/components/absences/MonthCalendarTable.tsx
+++ b/frontend/src/employee-frontend/components/absences/MonthCalendarTable.tsx
@@ -93,7 +93,7 @@ const MonthCalendarRow = React.memo(function MonthCalendarRow({
         </FixedSpaceRow>
       </ChildNameTd>
       {days.map(([date, day]) =>
-        day !== undefined ? (
+        day !== undefined && day.scheduleType !== 'TERM_BREAK' ? (
           <CalendarTd
             key={`${child.id}${date.formatIso()}`}
             $isToday={date.isToday()}

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
@@ -316,7 +316,7 @@ export default React.memo(function Group({
                 icon={faCalendarAlt}
                 text={i18n.unit.groups.diaryButton}
                 onClick={() => undefined}
-                data-qa="open-absence-diary-button"
+                data-qa="open-month-calendar-button"
               />
             </Link>
           )}

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -231,6 +231,10 @@ export default React.memo(function ChildDay({
               {i18n.unit.attendanceReservations.missingHolidayReservationShort}
             </ReservationTime>
           </Tooltip>
+        ) : scheduleType === 'TERM_BREAK' ? (
+          <ReservationTime data-qa="term-break">
+            {i18n.unit.attendanceReservations.termBreak}
+          </ReservationTime>
         ) : serviceTimeOfDay ? (
           // daily service times
           <>
@@ -243,6 +247,10 @@ export default React.memo(function ChildDay({
               {i18n.unit.attendanceReservations.serviceTimeIndicator}
             </ReservationTime>
           </>
+        ) : scheduleType === 'FIXED_SCHEDULE' ? (
+          <ReservationTime data-qa="fixed-schedule">
+            {i18n.unit.attendanceReservations.fixedSchedule}
+          </ReservationTime>
         ) : (
           // otherwise show missing service time indicator
           <ReservationTime warning data-qa="reservation-missing">

--- a/frontend/src/lib-common/generated/api-types/daycare.ts
+++ b/frontend/src/lib-common/generated/api-types/daycare.ts
@@ -19,6 +19,7 @@ import { OccupancyResponse } from './occupancy'
 import { PersonJSON } from './pis'
 import { PilotFeature } from './shared'
 import { Reservation } from './reservations'
+import { ScheduleType } from './placement'
 import { ShiftCareType } from './serviceneed'
 import { TerminatedPlacement } from './placement'
 import { TimeRange } from './shared'
@@ -426,6 +427,7 @@ export interface GroupMonthCalendarDayChild {
   dailyServiceTimes: TimeRange | null
   missingHolidayReservation: boolean
   reservations: ChildReservation[]
+  scheduleType: ScheduleType
 }
 
 /**

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2401,6 +2401,8 @@ export const fi = {
       },
       missingHolidayReservation: 'Lomavaraus puuttuu',
       missingHolidayReservationShort: 'Lomavar. puuttuu',
+      fixedSchedule: 'Läsnä',
+      termBreak: 'Ei toimintaa',
       missingServiceTime: 'Sop.aika puuttuu',
       serviceTimeIndicator: '(s)',
       legend: {

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -139,6 +139,8 @@ fun getGroupMonthCalendar(
                                     val childAbsences = absences[child.id to date] ?: emptyList()
                                     val childReservations =
                                         reservations[child.id to date] ?: emptyList()
+                                    val scheduleType =
+                                        placement.type.scheduleType(date, clubTerms, preschoolTerms)
 
                                     GroupMonthCalendarDayChild(
                                         childId = child.id,
@@ -146,12 +148,9 @@ fun getGroupMonthCalendar(
                                         backupCare =
                                             backupCares[child.id]?.any { it.includes(date) }
                                                 ?: false,
+                                        scheduleType = scheduleType,
                                         missingHolidayReservation =
-                                            placement.type.scheduleType(
-                                                date,
-                                                clubTerms,
-                                                preschoolTerms
-                                            ) == ScheduleType.RESERVATION_REQUIRED &&
+                                            scheduleType == ScheduleType.RESERVATION_REQUIRED &&
                                                 isHolidayPeriodDate &&
                                                 childReservations.isEmpty() &&
                                                 childAbsences.isEmpty(),
@@ -170,7 +169,7 @@ fun getGroupMonthCalendar(
                                                         is DailyServiceTimesValue.VariableTimes ->
                                                             null
                                                     }
-                                                }
+                                                },
                                     )
                                 }
                                 .sortedBy { it.childId }
@@ -430,7 +429,8 @@ data class GroupMonthCalendarDayChild(
     val missingHolidayReservation: Boolean,
     val absences: List<AbsenceWithModifierInfo>,
     val reservations: List<ChildReservation>,
-    val dailyServiceTimes: TimeRange?
+    val dailyServiceTimes: TimeRange?,
+    val scheduleType: ScheduleType
 )
 
 data class ChildServiceNeedInfo(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -35,12 +35,16 @@ import fi.espoo.evaka.childdiscussion.getChildDiscussions
 import fi.espoo.evaka.children.consent.ChildConsentType
 import fi.espoo.evaka.dailyservicetimes.DailyServiceTimesType
 import fi.espoo.evaka.daycare.CareType
+import fi.espoo.evaka.daycare.ClubTerm
 import fi.espoo.evaka.daycare.DaycareDecisionCustomization
 import fi.espoo.evaka.daycare.MailingAddress
+import fi.espoo.evaka.daycare.PreschoolTerm
 import fi.espoo.evaka.daycare.UnitManager
 import fi.espoo.evaka.daycare.VisitingAddress
 import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.daycare.insertClubTerm
+import fi.espoo.evaka.daycare.insertPreschoolTerm
 import fi.espoo.evaka.daycare.service.AbsenceCategory
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.decision.Decision
@@ -255,13 +259,7 @@ class DevApi(
 
         db.connect { dbc ->
             dbc.waitUntilNoQueriesRunning(timeout = Duration.ofSeconds(10))
-            dbc.withLockedDatabase(timeout = Duration.ofSeconds(10)) {
-                it.resetDatabase()
-
-                // Terms are not inserted by fixtures
-                it.runDevScript("preschool-terms.sql")
-                it.runDevScript("club-terms.sql")
-            }
+            dbc.withLockedDatabase(timeout = Duration.ofSeconds(10)) { it.resetDatabase() }
         }
         MockEmailClient.clear()
     }
@@ -1574,6 +1572,16 @@ RETURNING id
         @PathVariable childId: ChildId
     ): List<ChildDiscussionData> {
         return db.connect { dbc -> dbc.read { tx -> tx.getChildDiscussions(childId) } }
+    }
+
+    @PostMapping("/club-term")
+    fun createClubTerm(db: Database, @RequestBody body: ClubTerm) {
+        db.connect { dbc -> dbc.transaction { tx -> tx.insertClubTerm(body) } }
+    }
+
+    @PostMapping("/preschool-term")
+    fun createPreschoolTerm(db: Database, @RequestBody body: PreschoolTerm) {
+        db.connect { dbc -> dbc.transaction { tx -> tx.insertPreschoolTerm(body) } }
     }
 
     enum class EmailMessageType {


### PR DESCRIPTION
#### Summary

During term breaks:
- Show "Ei toimintaa" in week calendar
- Hide the absence triangles in month calendar

<img width="631" alt="Screenshot 2023-09-12 at 8 54 49" src="https://github.com/espoon-voltti/evaka/assets/70927/938e9bd9-b4d0-4c5f-8679-125751d3dc85">

<img width="369" alt="Screenshot 2023-09-12 at 8 55 10" src="https://github.com/espoon-voltti/evaka/assets/70927/9542c2f8-55a0-4297-b8c1-da043c749b5d">
