### PR TITLE
Hide delete button in thread list on touch devices

### DIFF
--- a/frontend/src/lib-components/molecules/ThreadListItem.tsx
+++ b/frontend/src/lib-components/molecules/ThreadListItem.tsx
@@ -57,17 +57,23 @@ export const Container = styled.div<{ isRead: boolean; active: boolean }>`
     padding: calc(${defaultMargins.s} - 1px) calc(${defaultMargins.m} - 2px);
   }
 
-  ${DeleteThreadButton} {
-    opacity: 0;
-  }
-
-  ${DeleteThreadButton}:focus {
-    opacity: 1;
-  }
-
-  &:hover {
+  @media (pointer: coarse) {
     ${DeleteThreadButton} {
+      display: none;
+    }
+  }
+  @media (pointer: fine) {
+    ${DeleteThreadButton} {
+      opacity: 0;
+    }
+
+    ${DeleteThreadButton}:focus {
       opacity: 1;
+    }
+    &:hover {
+      ${DeleteThreadButton} {
+        opacity: 1;
+      }
     }
   }
 


### PR DESCRIPTION
## Before this change
Opening a thread required two taps on iPhone because `:hover` styles made delete button to appear. More info about this browser quirk: https://stackoverflow.com/a/50500578
## After this change
Delete button in thread list is always hidden on touch devices. Touch device detection is done with media query `@media (pointer: coarse)`

Deleting thread is still possible in thread view.