### PR TITLE
Pass Content-Disposition header in nginx response, fixes #2412

### DIFF
--- a/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -336,6 +336,9 @@ server {
   location ~* ^/internal_redirect/(.*) {
     internal;
 
+    # Pass trough Content-Disposition header from original X-Accel-Redirect response
+    add_header Content-Disposition $upstream_http_content_disposition;
+
     # Don't proxy sensitive headers
     proxy_set_header        Authorization '';
     proxy_set_header        Cookie '';


### PR DESCRIPTION
## Before this change
Service generated Content-disposition header was not present attachment responses.
## After this change
Content-disposition header generated in `DocumentService` `X-Accel-Redirect` response is passed on to the response response nginx creates.