### PR TITLE
Staff occupancy effect selection for external staff

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -10,6 +10,7 @@ import { UUID } from 'lib-common/types'
 import { waitUntilEqual, waitUntilTrue } from '../../../utils'
 import {
   AsyncButton,
+  Checkbox,
   DatePicker,
   DatePickerDeprecated,
   Element,
@@ -260,12 +261,14 @@ export class UnitStaffAttendancesTable extends Element {
 
   async assertTableRow({
     rowIx = 0,
+    hasStaffOccupancyEffect,
     name,
     nth = 0,
     plannedAttendances,
     attendances
   }: {
     rowIx?: number
+    hasStaffOccupancyEffect?: boolean
     name?: string
     nth?: number
     timeNth?: number
@@ -304,6 +307,16 @@ export class UnitStaffAttendancesTable extends Element {
           .findAllByDataQa('departure-time')
           .nth(i)
           .assertTextEquals(departure)
+      }
+    }
+
+    if (hasStaffOccupancyEffect !== undefined) {
+      if (hasStaffOccupancyEffect) {
+        await row
+          .findByDataQa('icon-occupancy-coefficient-pos')
+          .waitUntilVisible()
+      } else {
+        await row.findByDataQa('icon-occupancy-coefficient').waitUntilVisible()
       }
     }
   }
@@ -625,6 +638,14 @@ export class StaffAttendanceAddPersonModal extends Element {
     await new Select(this.findByDataQa('add-person-group-select')).selectOption(
       groupId
     )
+  }
+
+  async setStaffOccupancyEffect(value: boolean) {
+    const isResponsible = new Checkbox(
+      this.findByDataQa('has-staff-occupancy-effect')
+    )
+    if (value) await isResponsible.check()
+    else await isResponsible.uncheck()
   }
 
   async setArrivalDate(date: string) {

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -582,7 +582,9 @@ describe('Realtime staff attendances', () => {
       await addPersonModal.setArrivalTime('11:00')
       await addPersonModal.setDepartureTime('13:00')
       await addPersonModal.typeName('Sijainen Saija')
+      await addPersonModal.setStaffOccupancyEffect(false)
       await addPersonModal.selectGroup(groupId)
+
       await addPersonModal.save()
 
       let modal = await staffAttendances.openDetails(1, mockedToday.subDays(1))
@@ -602,7 +604,8 @@ describe('Realtime staff attendances', () => {
         rowIx: 1,
         nth: 0,
         name: 'Sijainen Saija',
-        attendances: [['11:00', '13:00']]
+        attendances: [['11:00', '13:00']],
+        hasStaffOccupancyEffect: false
       })
       await staffAttendances.assertTableRow({
         rowIx: 1,
@@ -623,13 +626,15 @@ describe('Realtime staff attendances', () => {
       await addPersonModal.setDepartureTime('16:00')
       await addPersonModal.typeName('Sijainen Saija')
       await addPersonModal.selectGroup(groupId)
+      await addPersonModal.setStaffOccupancyEffect(true)
       await addPersonModal.save()
 
       await staffAttendances.assertTableRow({
         rowIx: 1,
         nth: 2,
         name: 'Sijainen Saija',
-        attendances: [['11:00', '16:00']]
+        attendances: [['11:00', '16:00']],
+        hasStaffOccupancyEffect: true
       })
     })
 

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -544,13 +544,16 @@ describe('Realtime staff attendances', () => {
       await addPersonModal.setArrivalTime('11:00')
       await addPersonModal.typeName('Sijainen Saija')
       await addPersonModal.selectGroup(groupId)
+      await addPersonModal.setStaffOccupancyEffect(false)
+
       await addPersonModal.save()
 
       await staffAttendances.assertTableRow({
         rowIx: 1,
         nth: 2,
         name: 'Sijainen Saija',
-        attendances: [['11:00', '–']]
+        attendances: [['11:00', '–']],
+        hasStaffOccupancyEffect: false
       })
 
       let modal = await staffAttendances.openDetails(1, mockedToday)
@@ -562,7 +565,8 @@ describe('Realtime staff attendances', () => {
         rowIx: 1,
         nth: 2,
         name: 'Sijainen Saija',
-        attendances: [['11:00', '13:00']]
+        attendances: [['11:00', '13:00']],
+        hasStaffOccupancyEffect: false
       })
 
       modal = await staffAttendances.openDetails(1, mockedToday)

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
@@ -59,7 +59,7 @@ const externalPersonForm = object({
     value.length < 3 ? 'required' : undefined
   ),
   group: required(oneOf<UUID>()),
-  isDaycareResponsible: required(boolean())
+  hasStaffOccupancyEffect: required(boolean())
 })
 
 function initialFormState(
@@ -81,7 +81,7 @@ function initialFormState(
       options: groupOptions,
       domValue: defaultGroupId
     },
-    isDaycareResponsible: true
+    hasStaffOccupancyEffect: true
   }
 }
 
@@ -118,7 +118,7 @@ export default React.memo(function StaffAttendanceExternalPersonModal({
             : null,
           name: formValue.name,
           groupId: formValue.group,
-          isDaycareResponsible: formValue.isDaycareResponsible
+          hasStaffOccupancyEffect: formValue.hasStaffOccupancyEffect
         }
       ],
       staffAttendances: []
@@ -132,7 +132,7 @@ export default React.memo(function StaffAttendanceExternalPersonModal({
   const name = useFormField(form, 'name')
   const group = useFormField(form, 'group')
   const groupError = group.validationError()
-  const isDaycareResponsible = useFormField(form, 'isDaycareResponsible')
+  const hasStaffOccupancyEffect = useFormField(form, 'hasStaffOccupancyEffect')
 
   return (
     <PlainModal margin="auto" data-qa="staff-attendance-add-person-modal">
@@ -199,7 +199,7 @@ export default React.memo(function StaffAttendanceExternalPersonModal({
         <div>
           <CheckboxF
             label={i18n.unit.staffOccupancies.title}
-            bind={isDaycareResponsible}
+            bind={hasStaffOccupancyEffect}
             data-qa="has-staff-occupancy-effect"
           />
         </div>

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
@@ -200,6 +200,7 @@ export default React.memo(function StaffAttendanceExternalPersonModal({
           <CheckboxF
             label={i18n.unit.staffOccupancies.title}
             bind={isDaycareResponsible}
+            data-qa="has-staff-occupancy-effect"
           />
         </div>
 

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
@@ -8,7 +8,7 @@ import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
 import DateRange from 'lib-common/date-range'
-import { localDate, localTime, string } from 'lib-common/form/fields'
+import { localDate, localTime, string, boolean } from 'lib-common/form/fields'
 import { object, oneOf, required, validated } from 'lib-common/form/form'
 import { useForm, useFormField } from 'lib-common/form/hooks'
 import { StateOf } from 'lib-common/form/types'
@@ -21,6 +21,7 @@ import { UUID } from 'lib-common/types'
 import StatusIcon from 'lib-components/atoms/StatusIcon'
 import InlineButton from 'lib-components/atoms/buttons/InlineButton'
 import { SelectF } from 'lib-components/atoms/dropdowns/Select'
+import { CheckboxF } from 'lib-components/atoms/form/Checkbox'
 import {
   InputFieldF,
   InputFieldUnderRow
@@ -57,7 +58,8 @@ const externalPersonForm = object({
   name: validated(string(), (value) =>
     value.length < 3 ? 'required' : undefined
   ),
-  group: required(oneOf<UUID>())
+  group: required(oneOf<UUID>()),
+  isDaycareResponsible: required(boolean())
 })
 
 function initialFormState(
@@ -78,7 +80,8 @@ function initialFormState(
     group: {
       options: groupOptions,
       domValue: defaultGroupId
-    }
+    },
+    isDaycareResponsible: true
   }
 }
 
@@ -114,7 +117,8 @@ export default React.memo(function StaffAttendanceExternalPersonModal({
               )
             : null,
           name: formValue.name,
-          groupId: formValue.group
+          groupId: formValue.group,
+          isDaycareResponsible: formValue.isDaycareResponsible
         }
       ],
       staffAttendances: []
@@ -128,6 +132,7 @@ export default React.memo(function StaffAttendanceExternalPersonModal({
   const name = useFormField(form, 'name')
   const group = useFormField(form, 'group')
   const groupError = group.validationError()
+  const isDaycareResponsible = useFormField(form, 'isDaycareResponsible')
 
   return (
     <PlainModal margin="auto" data-qa="staff-attendance-add-person-modal">
@@ -189,6 +194,13 @@ export default React.memo(function StaffAttendanceExternalPersonModal({
               <StatusIcon status="warning" />
             </InputFieldUnderRow>
           )}
+        </div>
+
+        <div>
+          <CheckboxF
+            label={i18n.unit.staffOccupancies.title}
+            bind={isDaycareResponsible}
+          />
         </div>
 
         <Gap size="xs" />

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -313,6 +313,9 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
     <StaffAttendanceDetailsModal
       isExternal={true}
       onSave={onSaveExternal}
+      previousStaffOccupancyEffect={
+        detailsModalConfig.attendances[0]?.occupancyCoefficient > 0 ?? true
+      }
       validate={externalAttendanceValidator(detailsModalConfig)}
       name={detailsModalConfig.name}
       date={detailsModalConfig.date}

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -727,7 +727,8 @@ export const staffAttendanceValidator =
         groupId !== undefined
       ) {
         body[i] = {
-          ...item,
+          id: item.id,
+          type: item.type,
           arrived,
           departed,
           groupId

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -314,7 +314,8 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
       isExternal={true}
       onSave={onSaveExternal}
       previousStaffOccupancyEffect={
-        detailsModalConfig.attendances[0]?.occupancyCoefficient > 0 ?? true
+        detailsModalConfig.attendances[0] === undefined ||
+        detailsModalConfig.attendances[0].occupancyCoefficient > 0
       }
       validate={externalAttendanceValidator(detailsModalConfig)}
       name={detailsModalConfig.name}

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/attendanceEditState.spec.ts
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/attendanceEditState.spec.ts
@@ -32,7 +32,8 @@ describe('validateEditState', () => {
           type: 'PRESENT',
           groupId: 'group1',
           arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
-          departed: null
+          departed: null,
+          occupancyCoefficient: 7
         }
       ])
     )
@@ -42,14 +43,16 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '',
-        departed: '07:00'
+        departed: '07:00',
+        hasStaffOccupancyEffect: true
       },
       {
         id: null,
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '08:00',
-        departed: '12:00'
+        departed: '12:00',
+        hasStaffOccupancyEffect: true
       }
     ])
     expect(body).toEqual([
@@ -79,7 +82,8 @@ describe('validateEditState', () => {
           type: 'PRESENT',
           groupId: 'group1',
           arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
-          departed: null
+          departed: null,
+          occupancyCoefficient: 0
         }
       ])
     )
@@ -89,14 +93,16 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '',
-        departed: '07:00'
+        departed: '07:00',
+        hasStaffOccupancyEffect: false
       },
       {
         id: null,
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '08:00',
-        departed: '12:00'
+        departed: '12:00',
+        hasStaffOccupancyEffect: false
       }
     ])
     expect(body).toEqual([
@@ -105,14 +111,16 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
-        departed: HelsinkiDateTime.fromLocal(today, LocalTime.of(7, 0))
+        departed: HelsinkiDateTime.fromLocal(today, LocalTime.of(7, 0)),
+        hasStaffOccupancyEffect: false
       },
       {
         id: null,
         type: 'PRESENT',
         groupId: 'group1',
         arrived: HelsinkiDateTime.fromLocal(today, LocalTime.of(8, 0)),
-        departed: HelsinkiDateTime.fromLocal(today, LocalTime.of(12, 0))
+        departed: HelsinkiDateTime.fromLocal(today, LocalTime.of(12, 0)),
+        hasStaffOccupancyEffect: false
       }
     ])
     expect(errors).toEqual([{}, {}])
@@ -126,14 +134,16 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '12:00',
-        departed: '16:00'
+        departed: '16:00',
+        hasStaffOccupancyEffect: true
       },
       {
         id: null,
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '16:00',
-        departed: '10:00'
+        departed: '10:00',
+        hasStaffOccupancyEffect: true
       }
     ])
     expect(body).toEqual([
@@ -163,7 +173,8 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '',
-        departed: ''
+        departed: '',
+        hasStaffOccupancyEffect: true
       }
     ])
     expect(body).toBeUndefined()
@@ -178,7 +189,8 @@ describe('validateEditState', () => {
           type: 'PRESENT',
           groupId: 'group1',
           arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
-          departed: null
+          departed: null,
+          occupancyCoefficient: 7
         }
       ])
     )
@@ -188,7 +200,8 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '',
-        departed: ''
+        departed: '',
+        hasStaffOccupancyEffect: true
       }
     ])
     expect(body).toEqual(undefined)
@@ -202,14 +215,16 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '07:00',
-        departed: ''
+        departed: '',
+        hasStaffOccupancyEffect: true
       },
       {
         id: null,
         type: 'PRESENT',
         groupId: 'group2',
         arrived: '08:00',
-        departed: ''
+        departed: '',
+        hasStaffOccupancyEffect: true
       }
     ])
     expect(body).toBeUndefined()
@@ -224,7 +239,8 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: 'invalid',
-        departed: 'also invalid'
+        departed: 'also invalid',
+        hasStaffOccupancyEffect: true
       }
     ])
     expect(body).toBeUndefined()
@@ -239,7 +255,8 @@ describe('validateEditState', () => {
           type: 'PRESENT',
           groupId: 'group1',
           arrived: HelsinkiDateTime.fromLocal(yesterday, LocalTime.of(8, 0)),
-          departed: null
+          departed: null,
+          occupancyCoefficient: 7
         }
       ])
     )
@@ -249,14 +266,16 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '',
-        departed: '07:00'
+        departed: '07:00',
+        hasStaffOccupancyEffect: true
       },
       {
         id: null,
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '10:00',
-        departed: '09:00'
+        departed: '09:00',
+        hasStaffOccupancyEffect: true
       }
     ])
     expect(body).toEqual([
@@ -286,7 +305,8 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '',
-        departed: ''
+        departed: '',
+        hasStaffOccupancyEffect: true
       }
     ])
     expect(body).toBeUndefined()
@@ -301,7 +321,8 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: 'group1',
         arrived: '',
-        departed: ''
+        departed: '',
+        hasStaffOccupancyEffect: true
       }
     ])
     expect(body).toBeUndefined()
@@ -316,35 +337,40 @@ describe('validateEditState', () => {
         type: 'PRESENT',
         groupId: null,
         arrived: '08:00',
-        departed: '09:00'
+        departed: '09:00',
+        hasStaffOccupancyEffect: true
       },
       {
         id: 'id2',
         type: 'OVERTIME',
         groupId: null,
         arrived: '09:00',
-        departed: '10:00'
+        departed: '10:00',
+        hasStaffOccupancyEffect: true
       },
       {
         id: 'id3',
         type: 'JUSTIFIED_CHANGE',
         groupId: null,
         arrived: '10:00',
-        departed: '11:00'
+        departed: '11:00',
+        hasStaffOccupancyEffect: true
       },
       {
         id: 'id4',
         type: 'TRAINING',
         groupId: null,
         arrived: '11:00',
-        departed: '12:00'
+        departed: '12:00',
+        hasStaffOccupancyEffect: true
       },
       {
         id: 'id5',
         type: 'OTHER_WORK',
         groupId: null,
         arrived: '12:00',
-        departed: '13:00'
+        departed: '13:00',
+        hasStaffOccupancyEffect: true
       }
     ])
     expect(body).toBeUndefined()

--- a/frontend/src/employee-mobile-frontend/staff-attendance/MarkExternalStaffMemberArrivalPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/MarkExternalStaffMemberArrivalPage.tsx
@@ -38,7 +38,7 @@ interface FormState {
   arrived: string
   name: string
   group: GroupInfo | null
-  isDaycareResponsible: boolean
+  hasStaffOccupancyEffect: boolean
 }
 
 export default function MarkExternalStaffMemberArrivalPage() {
@@ -56,7 +56,7 @@ export default function MarkExternalStaffMemberArrivalPage() {
       .map(({ groups }) => groups.find(({ id }) => id === groupId) ?? null)
       .getOrElse(null),
     name: '',
-    isDaycareResponsible: true
+    hasStaffOccupancyEffect: true
   }))
 
   const formIsValid = () =>
@@ -116,12 +116,12 @@ export default function MarkExternalStaffMemberArrivalPage() {
                   data-qa="input-group"
                 />
                 <Checkbox
-                  label={i18n.staff.isDaycareResponsible}
-                  checked={form.isDaycareResponsible}
+                  label={i18n.staff.staffOccupancyEffect}
+                  checked={form.hasStaffOccupancyEffect}
                   onChange={(state) =>
                     setForm((prev) => ({
                       ...prev,
-                      isDaycareResponsible: state
+                      hasStaffOccupancyEffect: state
                     }))
                   }
                 />
@@ -149,7 +149,8 @@ export default function MarkExternalStaffMemberArrivalPage() {
                             arrived: LocalTime.parse(form.arrived),
                             groupId: form.group.id,
                             name: form.name.trim(),
-                            isDaycareResponsible: form.isDaycareResponsible
+                            hasStaffOccupancyEffect:
+                              form.hasStaffOccupancyEffect
                           }
                         }
                       : cancelMutation

--- a/frontend/src/employee-mobile-frontend/staff-attendance/MarkExternalStaffMemberArrivalPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/MarkExternalStaffMemberArrivalPage.tsx
@@ -16,6 +16,7 @@ import MutateButton, {
   cancelMutation
 } from 'lib-components/atoms/buttons/MutateButton'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
+import Checkbox from 'lib-components/atoms/form/Checkbox'
 import InputField from 'lib-components/atoms/form/InputField'
 import TimeInput from 'lib-components/atoms/form/TimeInput'
 import { ContentArea } from 'lib-components/layout/Container'
@@ -37,6 +38,7 @@ interface FormState {
   arrived: string
   name: string
   group: GroupInfo | null
+  isDaycareResponsible: boolean
 }
 
 export default function MarkExternalStaffMemberArrivalPage() {
@@ -53,7 +55,8 @@ export default function MarkExternalStaffMemberArrivalPage() {
     group: unitInfoResponse
       .map(({ groups }) => groups.find(({ id }) => id === groupId) ?? null)
       .getOrElse(null),
-    name: ''
+    name: '',
+    isDaycareResponsible: true
   }))
 
   const formIsValid = () =>
@@ -112,6 +115,16 @@ export default function MarkExternalStaffMemberArrivalPage() {
                   onChange={(group) => setForm((old) => ({ ...old, group }))}
                   data-qa="input-group"
                 />
+                <Checkbox
+                  label={i18n.staff.isDaycareResponsible}
+                  checked={form.isDaycareResponsible}
+                  onChange={(state) =>
+                    setForm((prev) => ({
+                      ...prev,
+                      isDaycareResponsible: state
+                    }))
+                  }
+                />
               </ListGrid>
             ) : (
               <H4 centered={true}>{i18n.attendances.notOperationalDate}</H4>
@@ -135,7 +148,8 @@ export default function MarkExternalStaffMemberArrivalPage() {
                           request: {
                             arrived: LocalTime.parse(form.arrived),
                             groupId: form.group.id,
-                            name: form.name.trim()
+                            name: form.name.trim(),
+                            isDaycareResponsible: form.isDaycareResponsible
                           }
                         }
                       : cancelMutation

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -204,6 +204,7 @@ export interface ExternalAttendanceUpsert {
 export interface ExternalStaffArrivalRequest {
   arrived: LocalTime
   groupId: UUID
+  isDaycareResponsible: boolean
   name: string
 }
 
@@ -409,6 +410,7 @@ export interface UpsertExternalAttendance {
   attendanceId: UUID | null
   departed: HelsinkiDateTime | null
   groupId: UUID
+  isDaycareResponsible: boolean
   name: string | null
 }
 

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -205,7 +205,7 @@ export interface ExternalAttendanceUpsert {
 export interface ExternalStaffArrivalRequest {
   arrived: LocalTime
   groupId: UUID
-  isDaycareResponsible: boolean
+  hasStaffOccupancyEffect: boolean
   name: string
 }
 
@@ -411,7 +411,7 @@ export interface UpsertExternalAttendance {
   attendanceId: UUID | null
   departed: HelsinkiDateTime | null
   groupId: UUID
-  isDaycareResponsible: boolean
+  hasStaffOccupancyEffect: boolean
   name: string | null
 }
 

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -195,6 +195,7 @@ export interface ExternalAttendanceUpsert {
   arrived: HelsinkiDateTime
   departed: HelsinkiDateTime | null
   groupId: UUID
+  hasStaffOccupancyEffect: boolean
   id: UUID | null
 }
 

--- a/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
+++ b/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
@@ -245,7 +245,7 @@ export const fi = {
       },
       externalPerson: 'Muu henkilö',
       markExternalPerson: 'Kirjaa muu henkilö',
-      markExternalPersonTitle: 'Kirjaa muu vastuullinen henkilö sisään',
+      markExternalPersonTitle: 'Kirjaa muu työntekijä sisään',
       markArrived: 'Kirjaudu läsnäolevaksi',
       markDeparted: 'Kirjaudu poissaolevaksi',
       loginWithPin: 'Kirjaudu PIN-koodilla',
@@ -309,6 +309,7 @@ export const fi = {
   staff: {
     title: 'Henkilökunnan määrä tänään',
     daycareResponsible: 'Kasvatusvastuullisia',
+    isDaycareResponsible: 'Kasvatusvastuullisuus',
     other: 'Muita (esim. avustajat, opiskelijat, veot)',
     cancel: 'Peru muokkaus',
     realizedGroupOccupancy: 'Ryhmän käyttöaste tänään',

--- a/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
+++ b/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
@@ -309,7 +309,7 @@ export const fi = {
   staff: {
     title: 'Henkilökunnan määrä tänään',
     daycareResponsible: 'Kasvatusvastuullisia',
-    isDaycareResponsible: 'Kasvatusvastuullisuus',
+    staffOccupancyEffect: 'Kasvatusvastuullisuus',
     other: 'Muita (esim. avustajat, opiskelijat, veot)',
     cancel: 'Peru muokkaus',
     realizedGroupOccupancy: 'Ryhmän käyttöaste tänään',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2451,7 +2451,7 @@ export const fi = {
       nextDay: 'Seuraava päivä',
       addPersonModal: {
         description:
-          'Lisää väliaikaisesti läsnäoleva henkilö, joka lasketaan mukaan käyttöasteeseen.',
+          'Lisää väliaikaisesti läsnäoleva henkilö ja valitse lasketaanko hänet mukaan käyttöasteeseen.',
         arrival: 'Saapumisaika',
         name: 'Nimi',
         namePlaceholder: 'Sukunimi Etunimi',

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
@@ -196,7 +196,8 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
     data class ExternalStaffArrivalRequest(
         val name: String,
         val groupId: GroupId,
-        val arrived: LocalTime
+        val arrived: LocalTime,
+        val isDaycareResponsible: Boolean
     )
 
     @PostMapping("/arrival-external")
@@ -225,7 +226,9 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
                             name = body.name,
                             groupId = body.groupId,
                             arrived = arrivedTimeOrDefault,
-                            occupancyCoefficient = occupancyCoefficientSeven
+                            occupancyCoefficient =
+                                if (body.isDaycareResponsible) occupancyCoefficientSeven
+                                else occupancyCoefficientZero
                         )
                     )
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
@@ -197,7 +197,7 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
         val name: String,
         val groupId: GroupId,
         val arrived: LocalTime,
-        val isDaycareResponsible: Boolean
+        val hasStaffOccupancyEffect: Boolean
     )
 
     @PostMapping("/arrival-external")
@@ -227,7 +227,7 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
                             groupId = body.groupId,
                             arrived = arrivedTimeOrDefault,
                             occupancyCoefficient =
-                                if (body.isDaycareResponsible) occupancyCoefficientSeven
+                                if (body.hasStaffOccupancyEffect) occupancyCoefficientSeven
                                 else occupancyCoefficientZero
                         )
                     )

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -161,7 +161,7 @@ class RealtimeStaffAttendanceController(private val accessControl: AccessControl
         val attendanceId: StaffAttendanceExternalId?,
         val name: String?,
         val groupId: GroupId,
-        val isDaycareResponsible: Boolean,
+        val hasStaffOccupancyEffect: Boolean,
         val arrived: HelsinkiDateTime,
         val departed: HelsinkiDateTime?
     )
@@ -247,7 +247,7 @@ class RealtimeStaffAttendanceController(private val accessControl: AccessControl
                                     it.groupId,
                                     it.arrived,
                                     it.departed,
-                                    if (it.isDaycareResponsible) occupancyCoefficientSeven
+                                    if (it.hasStaffOccupancyEffect) occupancyCoefficientSeven
                                     else occupancyCoefficientZero
                                 )
                             }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -161,6 +161,7 @@ class RealtimeStaffAttendanceController(private val accessControl: AccessControl
         val attendanceId: StaffAttendanceExternalId?,
         val name: String?,
         val groupId: GroupId,
+        val isDaycareResponsible: Boolean,
         val arrived: HelsinkiDateTime,
         val departed: HelsinkiDateTime?
     )
@@ -246,7 +247,8 @@ class RealtimeStaffAttendanceController(private val accessControl: AccessControl
                                     it.groupId,
                                     it.arrived,
                                     it.departed,
-                                    occupancyCoefficientSeven
+                                    if (it.isDaycareResponsible) occupancyCoefficientSeven
+                                    else occupancyCoefficientZero
                                 )
                             }
                         staffAttendanceIds + externalStaffAttendanceIds

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -346,6 +346,7 @@ class RealtimeStaffAttendanceController(private val accessControl: AccessControl
     data class ExternalAttendanceUpsert(
         val id: StaffAttendanceExternalId?,
         val groupId: GroupId,
+        val hasStaffOccupancyEffect: Boolean,
         val arrived: HelsinkiDateTime,
         val departed: HelsinkiDateTime?
     )
@@ -401,7 +402,8 @@ class RealtimeStaffAttendanceController(private val accessControl: AccessControl
                             it.groupId,
                             it.arrived,
                             it.departed,
-                            occupancyCoefficientSeven
+                            if (it.hasStaffOccupancyEffect) occupancyCoefficientSeven
+                            else occupancyCoefficientZero
                         )
                     }
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffOccupancyCoefficient.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.StaffOccupancyCoefficientId
 import java.math.BigDecimal
 
 val occupancyCoefficientSeven = BigDecimal("7.0")
+val occupancyCoefficientZero = BigDecimal.ZERO
 
 data class StaffOccupancyCoefficient(
     val id: StaffOccupancyCoefficientId,


### PR DESCRIPTION
Adds checkboxes to external staff member addition forms for selecting whether added person has any effect on staff occupancy (mobile & desktop). Previously externals were assumed to always have staff occupancy effect.

Includes:
- UI modifications to add checkboxes
- translation modifications to remove references to assumed occupancy effect
- API changes to allow relaying the user's selection
- desktop UI logic to implicitly interpret attendance specific occupancy effect from earlier attendance markings
- test additions