### PR TITLE
Adjust DateRangePicker start/end logic

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/income.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/income.spec.ts
@@ -111,14 +111,6 @@ describe('Income', () => {
     // too many decimals
     await incomesSection.fillIncome('MAIN_INCOME', '123,123')
     await waitUntilTrue(() => incomesSection.saveIsDisabled())
-
-    await incomesSection.fillIncome('MAIN_INCOME', '100')
-    await waitUntilFalse(() => incomesSection.saveIsDisabled())
-
-    // inverted date range
-    await incomesSection.fillIncomeStartDate('31.1.2020')
-    await incomesSection.fillIncomeEndDate('1.1.2020')
-    await waitUntilTrue(() => incomesSection.saveIsDisabled())
   })
 
   it('Existing income item can have its values updated.', async () => {

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePicker.spec.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePicker.spec.tsx
@@ -221,4 +221,69 @@ describe('DateRangePicker', () => {
     expect(onChange.mock.calls).toEqual([])
     onChange.mockClear()
   })
+
+  it('if start passes end, sets end to start', async () => {
+    const dateBefore = LocalDate.of(2023, 9, 1)
+    const dateAfter = dateBefore.addDays(5)
+    const onChange = jest.fn()
+
+    render(
+      <TestContextProvider translations={translations}>
+        <DateRangePicker
+          start={null}
+          end={dateBefore}
+          onChange={onChange}
+          locale="fi"
+        />
+      </TestContextProvider>
+    )
+
+    const [start] = screen.getAllByRole('textbox')
+    await userEvent.type(start, dateAfter.format())
+    expect(onChange.mock.calls).toEqual([[dateAfter, dateAfter]])
+    onChange.mockClear()
+  })
+
+  it('if end precedes start, sets start to end', async () => {
+    const dateBefore = LocalDate.of(2023, 9, 1)
+    const dateAfter = dateBefore.addDays(5)
+    const onChange = jest.fn()
+
+    render(
+      <TestContextProvider translations={translations}>
+        <DateRangePicker
+          start={dateAfter}
+          end={null}
+          onChange={onChange}
+          locale="fi"
+        />
+      </TestContextProvider>
+    )
+
+    const [_, end] = screen.getAllByRole('textbox')
+    await userEvent.type(end, dateBefore.format())
+    expect(onChange.mock.calls).toEqual([[dateBefore, dateBefore]])
+    onChange.mockClear()
+  })
+
+  it('start and end can be set to invalid order using props', () => {
+    const dateBefore = LocalDate.of(2023, 9, 1)
+    const dateAfter = dateBefore.addDays(5)
+    const onChange = jest.fn()
+
+    render(
+      <TestContextProvider translations={translations}>
+        <DateRangePicker
+          start={dateAfter}
+          end={dateBefore}
+          onChange={onChange}
+          locale="fi"
+        />
+      </TestContextProvider>
+    )
+
+    const [start, end] = screen.getAllByRole('textbox')
+    expect(start).toHaveValue(dateAfter.format())
+    expect(end).toHaveValue(dateBefore.format())
+  })
 })

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
@@ -110,7 +110,9 @@ const DateRangePicker = React.memo(function DateRangePicker({
   }
 
   const handleChange = useCallback(
-    (startStr: string, endStr: string) => {
+    ([startStr, endStr]: [string, string]) => {
+      setInternalStart(startStr)
+      setInternalEnd(endStr)
       const newStart = LocalDate.parseFiOrNull(startStr)
       const newEnd = LocalDate.parseFiOrNull(endStr)
       const isValid = validate(newStart, newEnd)
@@ -125,28 +127,10 @@ const DateRangePicker = React.memo(function DateRangePicker({
     [end, onChange, start, validate]
   )
 
-  const handleChangeStart = useCallback(
-    (newStart: string) => {
-      setInternalStart(newStart)
-      handleChange(newStart, internalEnd)
-    },
-    [handleChange, internalEnd]
-  )
-
-  const handleChangeEnd = useCallback(
-    (newEnd: string) => {
-      setInternalEnd(newEnd)
-      handleChange(internalStart, newEnd)
-    },
-    [handleChange, internalStart]
-  )
-
   return (
     <DateRangePickerLowLevel
-      start={internalStart}
-      end={internalEnd}
-      onChangeStart={handleChangeStart}
-      onChangeEnd={handleChangeEnd}
+      value={[internalStart, internalEnd]}
+      onChange={handleChange}
       startInfo={internalStartError ?? datePickerProps.startInfo}
       endInfo={internalEndError ?? datePickerProps.endInfo}
       minDate={minDate}
@@ -169,14 +153,7 @@ const DateInputSpacer = styled.div`
 export interface DateRangePickerFProps
   extends Omit<
     DateRangePickerLowLevelProps,
-    | 'start'
-    | 'end'
-    | 'onChangeStart'
-    | 'onChangeEnd'
-    | 'startInfo'
-    | 'endInfo'
-    | 'minDate'
-    | 'maxDate'
+    'value' | 'onChange' | 'startInfo' | 'endInfo' | 'minDate' | 'maxDate'
   > {
   bind: BoundForm<LocalDateRangeField>
   info?: InputInfo | undefined
@@ -188,14 +165,25 @@ export const DateRangePickerF = React.memo(function DateRangePickerF({
   ...props
 }: DateRangePickerFProps) {
   const { start, end, config } = useFormFields(bind)
+  const { update } = bind
+
+  const handleChange = useCallback(
+    ([newStart, newEnd]: [string, string]) => {
+      update((prev) => ({
+        ...prev,
+        start: newStart,
+        end: newEnd
+      }))
+    },
+    [update]
+  )
   const info = infoOverride ?? bind.inputInfo()
+
   return (
     <div>
       <DateRangePickerLowLevel
-        start={start.state}
-        end={end.state}
-        onChangeStart={start.set}
-        onChangeEnd={end.set}
+        value={[start.state, end.state]}
+        onChange={handleChange}
         startInfo={start.inputInfo()}
         endInfo={end.inputInfo()}
         minDate={config.state?.minDate}

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePickerLowLevel.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePickerLowLevel.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import LocalDate from 'lib-common/local-date'
 
@@ -16,19 +16,15 @@ import { DatePickerSpacer } from './DateRangePicker'
 
 export interface DateRangePickerLowLevelProps
   extends Omit<DatePickerLowLevelProps, 'value' | 'onChange' | 'info'> {
-  start: string
-  end: string
-  onChangeStart: (start: string) => void
-  onChangeEnd: (end: string) => void
+  value: [string, string]
+  onChange: (value: [string, string]) => void
   startInfo?: InputInfo
   endInfo?: InputInfo
 }
 
 export default React.memo(function DateRangePickerLowLevel({
-  start,
-  end,
-  onChangeStart,
-  onChangeEnd,
+  value: [start, end],
+  onChange,
   startInfo,
   endInfo,
   'data-qa': dataQa,
@@ -39,39 +35,58 @@ export default React.memo(function DateRangePickerLowLevel({
   const startDate = useMemo(() => LocalDate.parseFiOrNull(start), [start])
   const endDate = useMemo(() => LocalDate.parseFiOrNull(end), [end])
 
-  const minDateForEnd = useMemo(
-    () =>
-      (!minDate || startDate?.isAfter(minDate) ? startDate : minDate) ??
-      undefined,
-    [minDate, startDate]
+  const handleChangeStart = useCallback(
+    (newStart: string) => {
+      const newStartDate = LocalDate.parseFiOrNull(newStart)
+      if (
+        newStartDate !== null &&
+        endDate !== null &&
+        newStartDate.isAfter(endDate)
+      ) {
+        onChange([newStart, newStart])
+      } else {
+        onChange([newStart, end])
+      }
+    },
+    [end, endDate, onChange]
   )
 
-  const maxDateForStart = useMemo(
-    () =>
-      (!maxDate || endDate?.isBefore(maxDate) ? endDate : maxDate) ?? undefined,
-    [maxDate, endDate]
+  const handleChangeEnd = useCallback(
+    (newEnd: string) => {
+      const newEndDate = LocalDate.parseFiOrNull(newEnd)
+      if (
+        startDate !== null &&
+        newEndDate !== null &&
+        newEndDate.isBefore(startDate)
+      ) {
+        onChange([newEnd, newEnd])
+      } else {
+        onChange([start, newEnd])
+      }
+    },
+    [onChange, start, startDate]
   )
 
   return (
     <FixedSpaceRow data-qa={dataQa}>
       <DatePickerLowLevel
         value={start}
-        onChange={onChangeStart}
+        onChange={handleChangeStart}
         info={startInfo}
         initialMonth={startDate ?? minDate}
         data-qa="start-date"
         minDate={minDate}
-        maxDate={maxDateForStart}
+        maxDate={maxDate}
         {...datePickerProps}
       />
       <DatePickerSpacer />
       <DatePickerLowLevel
         value={end}
-        onChange={onChangeEnd}
+        onChange={handleChangeEnd}
         info={endInfo}
-        initialMonth={endDate ?? startDate ?? minDateForEnd}
+        initialMonth={endDate ?? startDate ?? minDate}
         data-qa="end-date"
-        minDate={minDateForEnd}
+        minDate={minDate}
         maxDate={maxDate}
         {...datePickerProps}
       />


### PR DESCRIPTION
#### Summary

If start passes end, set end to start. If end precedes start, set start to end.


https://github.com/espoon-voltti/evaka/assets/70927/6384e804-6ff1-4301-a676-020e8147aa70

