### PR TITLE
Move staff annotation from datamodel into components

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -213,7 +213,11 @@ export default React.memo(function MessageEditor({
                 }
                 noOptionsMessage={i18n.messages.messageEditor.noResults}
                 getOptionId={({ id }) => id}
-                getOptionLabel={({ name }) => name}
+                getOptionLabel={({ name, type }) =>
+                  type === 'GROUP'
+                    ? `${name} (${i18n.messages.staffAnnotation})`
+                    : name
+                }
                 autoFocus={true}
                 data-qa="select-receiver"
               />

--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -18,8 +18,6 @@ import Container from 'lib-components/layout/Container'
 import { TabletAndDesktop } from 'lib-components/layout/responsive-layout'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 
-import { useTranslation } from '../localization'
-
 import EmptyThreadView from './EmptyThreadView'
 import MessageEditor from './MessageEditor'
 import ThreadList from './ThreadList'
@@ -47,8 +45,7 @@ export default React.memo(function MessagesPage() {
     useContext(MessageContext)
   const [editorVisible, setEditorVisible] = useState<boolean>(false)
   const [displaySendError, setDisplaySendError] = useState<boolean>(false)
-  const t = useTranslation()
-  const receivers = useQueryResult(receiversQuery(t.messages.staffAnnotation))
+  const receivers = useQueryResult(receiversQuery)
 
   const user = useUser()
 

--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -43,7 +43,13 @@ export default React.memo(function ThreadListItem({
 }: Props) {
   const i18n = useTranslation()
   const lastMessage = thread.messages[thread.messages.length - 1]
-  const participants = [...new Set(thread.messages.map((t) => t.sender.name))]
+  const participants = [
+    ...new Set(
+      thread.messages.map(({ sender: { name, type } }) =>
+        type === 'GROUP' ? `${name} (${i18n.messages.staffAnnotation})` : name
+      )
+    )
+  ]
 
   const handleDelete = useCallback(
     (e: SyntheticEvent<HTMLButtonElement>) => {

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -15,6 +15,7 @@ import styled from 'styled-components'
 
 import {
   Message,
+  MessageAccount,
   MessageThread
 } from 'lib-common/generated/api-types/messaging'
 import { formatFirstName } from 'lib-common/names'
@@ -42,7 +43,7 @@ import colors, { theme } from 'lib-customizations/common'
 import { faTrash } from 'lib-icons'
 
 import { getAttachmentUrl } from '../attachments'
-import { useTranslation } from '../localization'
+import { Translations, useTranslation } from '../localization'
 
 import { MessageCharacteristics } from './MessageCharacteristics'
 import {
@@ -111,6 +112,14 @@ const ReplyToThreadButton = styled(InlineButton)`
   align-self: flex-start;
 `
 
+const formatMessageAccountName = (
+  account: MessageAccount,
+  i18n: Translations
+) =>
+  account.type === 'GROUP'
+    ? `${account.name} (${i18n.messages.staffAnnotation})`
+    : account.name
+
 // eslint-disable-next-line react/display-name
 const SingleMessage = React.memo(
   React.forwardRef(function SingleMessage(
@@ -127,7 +136,7 @@ const SingleMessage = React.memo(
         <TitleRow>
           <SenderName>
             <ScreenReaderOnly>{i18n.messages.thread.sender}:</ScreenReaderOnly>
-            {message.sender.name}
+            {formatMessageAccountName(message.sender, i18n)}
           </SenderName>
           <InformationText>
             <ScreenReaderOnly>{i18n.messages.thread.sentAt}:</ScreenReaderOnly>
@@ -142,7 +151,7 @@ const SingleMessage = React.memo(
           </ScreenReaderOnly>
           {(message.recipientNames
             ? message.recipientNames
-            : message.recipients.map((r) => r.name)
+            : message.recipients.map((r) => formatMessageAccountName(r, i18n))
           ).join(', ')}
         </InformationText>
         <MessageContent data-qa="thread-reader-content">
@@ -222,10 +231,9 @@ export default React.memo(function ThreadView({
         messageId: messages.slice(-1)[0].id,
         recipientAccountIds: recipients
           .filter((r) => r.selected)
-          .map((r) => r.id),
-        staffAnnotation: i18n.messages.staffAnnotation
+          .map((r) => r.id)
       }),
-    [i18n, messages, recipients, replyContent, sendReply]
+    [messages, recipients, replyContent, sendReply]
   )
 
   const editorLabels = useMemo(

--- a/frontend/src/citizen-frontend/messages/api.ts
+++ b/frontend/src/citizen-frontend/messages/api.ts
@@ -6,7 +6,6 @@ import sortBy from 'lodash/sortBy'
 
 import { Paged } from 'lib-common/api'
 import {
-  deserializeMessageAccount,
   deserializeMessageThread,
   deserializeReplyResponse
 } from 'lib-common/api-types/messaging'
@@ -23,7 +22,6 @@ import { UUID } from 'lib-common/types'
 import { client } from '../api-client'
 
 export async function getReceivedMessages(
-  staffAnnotation: string,
   page: number,
   pageSize: number
 ): Promise<Paged<MessageThread>> {
@@ -33,25 +31,16 @@ export async function getReceivedMessages(
     })
     .then((res) => ({
       ...res.data,
-      data: res.data.data.map((d) =>
-        deserializeMessageThread(d, staffAnnotation)
-      )
+      data: res.data.data.map((d) => deserializeMessageThread(d))
     }))
 }
 
-export async function getReceivers(
-  staffAnnotation: string
-): Promise<GetReceiversResponse> {
+export async function getReceivers(): Promise<GetReceiversResponse> {
   return client
     .get<GetReceiversResponse>(`/citizen/messages/receivers`)
     .then((res) => ({
       ...res.data,
-      messageAccounts: sortBy(
-        res.data.messageAccounts.map((d) =>
-          deserializeMessageAccount(d, staffAnnotation)
-        ),
-        'name'
-      )
+      messageAccounts: sortBy(res.data.messageAccounts, 'name')
     }))
 }
 
@@ -81,21 +70,19 @@ export async function sendMessage(message: CitizenMessageBody): Promise<UUID> {
 
 export type ReplyToThreadParams = ReplyToMessageBody & {
   messageId: UUID
-  staffAnnotation: string
 }
 
 export async function replyToThread({
   messageId,
   content,
-  recipientAccountIds,
-  staffAnnotation
+  recipientAccountIds
 }: ReplyToThreadParams): Promise<ThreadReply> {
   return client
     .post<JsonOf<ThreadReply>>(`/citizen/messages/${messageId}/reply`, {
       content,
       recipientAccountIds
     })
-    .then(({ data }) => deserializeReplyResponse(data, staffAnnotation))
+    .then(({ data }) => deserializeReplyResponse(data))
 }
 
 export async function archiveThread(id: UUID): Promise<void> {

--- a/frontend/src/citizen-frontend/messages/queries.ts
+++ b/frontend/src/citizen-frontend/messages/queries.ts
@@ -19,19 +19,15 @@ import {
 
 const queryKeys = createQueryKeys('messages', {
   allReceivedMessages: () => ['receivedMessages'],
-  receivedMessages: (staffAnnotation: string, pageSize: number) => [
-    'receivedMessages',
-    staffAnnotation,
-    pageSize
-  ],
-  receivers: (staffAnnotation: string) => ['receivers', staffAnnotation],
+  receivedMessages: (pageSize: number) => ['receivedMessages', pageSize],
+  receivers: () => ['receivers'],
   unreadMessagesCount: () => ['unreadMessagesCount'],
   messageAccount: () => ['messageAccount']
 })
 
 export const receivedMessagesQuery = infiniteQuery({
-  api: (staffAnnotation: string, pageSize: number) => (page: number) =>
-    getReceivedMessages(staffAnnotation, page, pageSize),
+  api: (pageSize: number) => (page: number) =>
+    getReceivedMessages(page, pageSize),
   queryKey: queryKeys.receivedMessages,
   firstPageParam: 1,
   getNextPageParam: (lastPage, pages) => {

--- a/frontend/src/citizen-frontend/messages/state.tsx
+++ b/frontend/src/citizen-frontend/messages/state.tsx
@@ -27,7 +27,6 @@ import {
 import { UUID } from 'lib-common/types'
 
 import { useUser } from '../auth/state'
-import { useTranslation } from '../localization'
 
 import { ReplyToThreadParams } from './api'
 import {
@@ -81,8 +80,6 @@ const markMatchingThreadRead = (
 
 export const MessageContextProvider = React.memo(
   function MessageContextProvider({ children }: { children: React.ReactNode }) {
-    const t = useTranslation()
-
     const isLoggedIn = useUser() !== undefined
     const accountId = useQueryResult(messageAccountQuery, {
       enabled: isLoggedIn,
@@ -97,12 +94,9 @@ export const MessageContextProvider = React.memo(
       isFetching,
       isFetchingNextPage,
       hasNextPage
-    } = useInfiniteQuery(
-      receivedMessagesQuery(t.messages.staffAnnotation, 10),
-      {
-        enabled: accountId.isSuccess
-      }
-    )
+    } = useInfiniteQuery(receivedMessagesQuery(10), {
+      enabled: accountId.isSuccess
+    })
 
     const isFetchingFirstPage = isFetching && !isFetchingNextPage
     const threads = useMemo(

--- a/frontend/src/lib-common/api-types/messaging.ts
+++ b/frontend/src/lib-common/api-types/messaging.ts
@@ -6,7 +6,6 @@ import { UUID } from 'lib-common/types'
 
 import {
   Message,
-  MessageAccount,
   MessageCopy,
   MessageRecipientType,
   MessageThread,
@@ -41,44 +40,24 @@ interface MessageReceiverGroup extends MessageReceiverBase {
   receivers: MessageReceiverBase[]
 }
 
-export const deserializeMessageAccount = (
-  account: JsonOf<MessageAccount>,
-  staffAnnotation?: string
-): MessageAccount => ({
-  ...account,
-  name:
-    account.type === 'GROUP' && staffAnnotation
-      ? `${account.name} (${staffAnnotation})`
-      : account.name
-})
-
-export const deserializeMessage = (
-  message: JsonOf<Message>,
-  staffAnnotation?: string
-): Message => ({
+export const deserializeMessage = (message: JsonOf<Message>): Message => ({
   ...message,
-  sender: deserializeMessageAccount(message.sender, staffAnnotation),
-  recipients: message.recipients.map((a) =>
-    deserializeMessageAccount(a, staffAnnotation)
-  ),
   sentAt: HelsinkiDateTime.parseIso(message.sentAt),
   readAt: message.readAt ? HelsinkiDateTime.parseIso(message.readAt) : null
 })
 
 export const deserializeMessageThread = (
-  json: JsonOf<MessageThread>,
-  staffAnnotation?: string
+  json: JsonOf<MessageThread>
 ): MessageThread => ({
   ...json,
-  messages: json.messages.map((m) => deserializeMessage(m, staffAnnotation))
+  messages: json.messages.map(deserializeMessage)
 })
 
 export const deserializeReplyResponse = (
-  responseData: JsonOf<ThreadReply>,
-  staffAnnotation?: string
+  responseData: JsonOf<ThreadReply>
 ): ThreadReply => ({
   threadId: responseData.threadId,
-  message: deserializeMessage(responseData.message, staffAnnotation)
+  message: deserializeMessage(responseData.message)
 })
 
 export const deserializeMessageCopy = (

--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -46,6 +46,7 @@ export interface Translations {
     message: string
     returnMessage: string
   }
+  messages: { staffAnnotation: string }
   notifications: {
     close: string
   }

--- a/frontend/src/lib-components/molecules/ToggleableRecipient.tsx
+++ b/frontend/src/lib-components/molecules/ToggleableRecipient.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components'
 
 import { UUID } from 'lib-common/types'
 
+import { useTranslations } from '../i18n'
 import { fontWeights } from '../typography'
 import { defaultMargins } from '../white-space'
 
@@ -41,14 +42,14 @@ const Recipient = styled.button<{ selected: boolean; toggleable: boolean }>`
 
 export function ToggleableRecipient({
   'data-qa': dataQa,
-  recipient: { id, name, selected, toggleable },
+  recipient: { id, name, selected, toggleable, type },
   labelAdd,
   onToggleRecipient
 }: ToggleableRecipientProps) {
   const onClick = toggleable
     ? () => onToggleRecipient(id, !selected)
     : undefined
-
+  const i18n = useTranslations()
   return (
     <Recipient
       onClick={onClick}
@@ -59,7 +60,9 @@ export function ToggleableRecipient({
     >
       {selected ? (
         <>
-          {name}
+          {type === 'GROUP'
+            ? `${name} (${i18n.messages.staffAnnotation})`
+            : name}
           {toggleable && <FontAwesomeIcon icon={faTimes} />}
         </>
       ) : (

--- a/frontend/src/lib-components/utils/TestContextProvider.tsx
+++ b/frontend/src/lib-components/utils/TestContextProvider.tsx
@@ -53,6 +53,7 @@ export const testTranslations: Translations = {
     message: '',
     returnMessage: ''
   },
+  messages: { staffAnnotation: '' },
   notifications: {
     close: ''
   },

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -51,6 +51,9 @@ const components: Translations = {
       'The identification process failed or was stopped. To log in, go back and try again.',
     returnMessage: 'Go back'
   },
+  messages: {
+    staffAnnotation: 'Staff'
+  },
   notifications: {
     close: 'Close'
   },

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -50,6 +50,9 @@ const components: Translations = {
       'Palveluun tunnistautuminen epäonnistui tai se keskeytettiin. Kirjautuaksesi sisään palaa takaisin ja yritä uudelleen.',
     returnMessage: 'Palaa takaisin'
   },
+  messages: {
+    staffAnnotation: 'Henkilökunta'
+  },
   notifications: {
     close: 'Sulje'
   },

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -51,6 +51,9 @@ const components: Translations = {
       'Autentiseringen för tjänsten misslyckades eller avbröts. För att logga in gå tillbaka och försök på nytt.',
     returnMessage: 'Gå tillbaka till inloggningen'
   },
+  messages: {
+    staffAnnotation: 'Personal'
+  },
   notifications: {
     close: 'Stäng'
   },


### PR DESCRIPTION
## Before this change
`staffAnnotation` string had to be passed into data-deserialization and it was appended to the `name` field of message recipients.
## After this change
`staffAnnotation` is appended to the recipient `name` in the components that display recipients. This removes the need to pass the translation property into the data layer.
In citizen views the staff annotation is still visible in message thread views as it was before:
<img width="1373" alt="image" src="https://github.com/espoon-voltti/evaka/assets/886091/73be6794-1e68-4ac5-9930-7573bd178216">
<img width="701" alt="image" src="https://github.com/espoon-voltti/evaka/assets/886091/3187a11e-6d17-4050-92dd-9a18fe694dde">
