### PR TITLE
Set fetch size in BI queries

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
@@ -293,6 +293,8 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
         SqlStatement<Query>(), ResultBearing {
         override fun self(): Query = this
 
+        fun setFetchSize(fetchSize: Int): Query = this.also { raw.setFetchSize(fetchSize) }
+
         inline fun <reified T> mapTo(
             qualifiers: Array<KClass<out Annotation>> = defaultQualifiers<T>()
         ): ResultIterable<T> = mapTo(createQualifiedType(*qualifiers))


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

JDBI has a default fetch size of 0, which means *all results are buffered in memory*...even if we fetch results using `Sequence`/`Iterable`/`Iterator`, that won't enable streaming unless fetch size is set.