### PR TITLE
Fix application deletes

### DIFF
--- a/service/src/main/resources/db/migration/V360__remove_application_form_fk.sql
+++ b/service/src/main/resources/db/migration/V360__remove_application_form_fk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE application_form DROP CONSTRAINT fk$application_id;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -356,3 +356,4 @@ V356__application_document_refactoring.sql
 V357__create_application_document_index.sql
 V358__rename_old_application_document_index.sql
 V359__really_create_application_document_index.sql
+V360__remove_application_form_fk.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Deleting old applications that had rows in `application_form` didn't work, because we still had a foreign key without cascade.