### PR TITLE
Messaging improvements, part 1

### DIFF
--- a/frontend/src/citizen-frontend/messages/queries.ts
+++ b/frontend/src/citizen-frontend/messages/queries.ts
@@ -18,8 +18,7 @@ import {
 } from './api'
 
 const queryKeys = createQueryKeys('messages', {
-  allReceivedMessages: () => ['receivedMessages'],
-  receivedMessages: (pageSize: number) => ['receivedMessages', pageSize],
+  receivedMessages: () => ['receivedMessages'],
   receivers: () => ['receivers'],
   unreadMessagesCount: () => ['unreadMessagesCount'],
   messageAccount: () => ['messageAccount']
@@ -58,15 +57,15 @@ export const markThreadReadMutation = mutation({
 
 export const sendMessageMutation = mutation({
   api: sendMessage,
-  invalidateQueryKeys: () => [queryKeys.allReceivedMessages()]
+  invalidateQueryKeys: () => [queryKeys.receivedMessages()]
 })
 
 export const replyToThreadMutation = mutation({
   api: replyToThread,
-  invalidateQueryKeys: () => []
+  invalidateQueryKeys: () => [queryKeys.receivedMessages()]
 })
 
 export const archiveThreadMutation = mutation({
   api: archiveThread,
-  invalidateQueryKeys: () => [queryKeys.allReceivedMessages()]
+  invalidateQueryKeys: () => [queryKeys.receivedMessages()]
 })

--- a/frontend/src/employee-mobile-frontend/common/BottomNavbar.tsx
+++ b/frontend/src/employee-mobile-frontend/common/BottomNavbar.tsx
@@ -104,86 +104,83 @@ export default function BottomNavbar({ selected }: BottomNavbarProps) {
     groupId: UUID | 'all'
   }>()
 
-  const { unitInfoResponse, unreadCountsResponse } = useContext(UnitContext)
+  const { unitInfoResponse, unreadCounts } = useContext(UnitContext)
   const { user } = useContext(UserContext)
   const { groupAccounts } = useContext(MessageContext)
 
   const groupAccountIds = groupAccounts.map(({ account }) => account.id)
 
-  return renderResult(
-    combine(unitInfoResponse, unreadCountsResponse, user),
-    ([unit, unreadCounts, user]) => (
-      <>
-        {/* Reserve navbar's height from the page, so that the fixed navbar doesn't hide anything */}
-        <ReserveSpace />
-        <Root>
-          <Button data-qa="bottomnav-children">
-            <BottomText
-              text={i18n.common.children}
+  return renderResult(combine(unitInfoResponse, user), ([unit, user]) => (
+    <>
+      {/* Reserve navbar's height from the page, so that the fixed navbar doesn't hide anything */}
+      <ReserveSpace />
+      <Root>
+        <Button data-qa="bottomnav-children">
+          <BottomText
+            text={i18n.common.children}
+            selected={selected === 'child'}
+            onClick={() =>
+              selected !== 'child' &&
+              navigate(`/units/${unitId}/groups/${groupId}/child-attendance`)
+            }
+          >
+            <CustomIcon
+              icon={selected === 'child' ? fasChild : faChild}
               selected={selected === 'child'}
-              onClick={() =>
-                selected !== 'child' &&
-                navigate(`/units/${unitId}/groups/${groupId}/child-attendance`)
-              }
-            >
-              <CustomIcon
-                icon={selected === 'child' ? fasChild : faChild}
-                selected={selected === 'child'}
-              />
-            </BottomText>
-          </Button>
-          <Button data-qa="bottomnav-staff">
-            <BottomText
-              text={i18n.common.staff}
+            />
+          </BottomText>
+        </Button>
+        <Button data-qa="bottomnav-staff">
+          <BottomText
+            text={i18n.common.staff}
+            selected={selected === 'staff'}
+            onClick={() =>
+              selected !== 'staff' &&
+              navigate(
+                unit.features.includes('REALTIME_STAFF_ATTENDANCE')
+                  ? `/units/${unitId}/groups/${groupId}/staff-attendance`
+                  : `/units/${unitId}/groups/${groupId}/staff`
+              )
+            }
+          >
+            <CustomIcon
+              icon={selected === 'staff' ? fasUser : faUser}
               selected={selected === 'staff'}
+            />
+          </BottomText>
+        </Button>
+        {unit.features.includes('MOBILE_MESSAGING') ? (
+          <Button data-qa="bottomnav-messages">
+            <BottomText
+              text={i18n.common.messages}
+              selected={selected === 'messages'}
               onClick={() =>
-                selected !== 'staff' &&
+                selected !== 'messages' &&
                 navigate(
-                  unit.features.includes('REALTIME_STAFF_ATTENDANCE')
-                    ? `/units/${unitId}/groups/${groupId}/staff-attendance`
-                    : `/units/${unitId}/groups/${groupId}/staff`
+                  user?.pinLoginActive
+                    ? `/units/${unitId}/groups/${unit.groups[0].id}/messages`
+                    : `/units/${unitId}/groups/${unit.groups[0].id}/messages/unread-messages`
                 )
               }
             >
               <CustomIcon
-                icon={selected === 'staff' ? fasUser : faUser}
-                selected={selected === 'staff'}
+                icon={selected === 'messages' ? fasEnvelope : faEnvelope}
+                selected={selected === 'messages'}
               />
+              {(user?.pinLoginActive && groupAccountIds.length > 0
+                ? unreadCounts.filter(({ accountId }) =>
+                    groupAccountIds.includes(accountId)
+                  )
+                : unreadCounts
+              ).some(({ unreadCount }) => unreadCount > 0) && (
+                <UnreadMessagesIndicator data-qa="unread-messages-indicator" />
+              )}
             </BottomText>
           </Button>
-          {unit.features.includes('MOBILE_MESSAGING') ? (
-            <Button data-qa="bottomnav-messages">
-              <BottomText
-                text={i18n.common.messages}
-                selected={selected === 'messages'}
-                onClick={() =>
-                  selected !== 'messages' &&
-                  navigate(
-                    user?.pinLoginActive
-                      ? `/units/${unitId}/groups/${unit.groups[0].id}/messages`
-                      : `/units/${unitId}/groups/${unit.groups[0].id}/messages/unread-messages`
-                  )
-                }
-              >
-                <CustomIcon
-                  icon={selected === 'messages' ? fasEnvelope : faEnvelope}
-                  selected={selected === 'messages'}
-                />
-                {(user?.pinLoginActive && groupAccountIds.length > 0
-                  ? unreadCounts.filter(({ accountId }) =>
-                      groupAccountIds.includes(accountId)
-                    )
-                  : unreadCounts
-                ).some(({ unreadCount }) => unreadCount > 0) && (
-                  <UnreadMessagesIndicator data-qa="unread-messages-indicator" />
-                )}
-              </BottomText>
-            </Button>
-          ) : null}
-        </Root>
-      </>
-    )
-  )
+        ) : null}
+      </Root>
+    </>
+  ))
 }
 
 const UnreadMessagesIndicator = styled.div`

--- a/frontend/src/employee-mobile-frontend/common/unit.tsx
+++ b/frontend/src/employee-mobile-frontend/common/unit.tsx
@@ -7,25 +7,24 @@ import React, { createContext, useEffect, useMemo } from 'react'
 import { Loading, Result } from 'lib-common/api'
 import { UnitInfo } from 'lib-common/generated/api-types/attendance'
 import { UnreadCountByAccountAndGroup } from 'lib-common/generated/api-types/messaging'
+import { useQueryResult } from 'lib-common/query'
 import { idleTracker } from 'lib-common/utils/idleTracker'
 import { useApiState } from 'lib-common/utils/useRestApi'
 
 import { client } from '../client'
-import { getUnreadCountsByUnit } from '../messages/api'
+import { unreadCountsQuery } from '../messages/queries'
 import { getMobileUnitInfo } from '../pairing/api'
 
 interface UnitState {
   unitInfoResponse: Result<UnitInfo>
   reloadUnitInfo: () => void
   unreadCounts: UnreadCountByAccountAndGroup[]
-  reloadUnreadCounts: () => void
 }
 
 const defaultState: UnitState = {
   unitInfoResponse: Loading.of(),
   reloadUnitInfo: () => undefined,
-  unreadCounts: [],
-  reloadUnreadCounts: () => undefined
+  unreadCounts: []
 }
 
 export const UnitContext = createContext<UnitState>(defaultState)
@@ -42,10 +41,7 @@ export const UnitContextProvider = React.memo(function UnitContextProvider({
     [unitId]
   )
 
-  const [unreadCountsResponse, reloadUnreadCounts] = useApiState(
-    () => getUnreadCountsByUnit(unitId),
-    [unitId]
-  )
+  const unreadCountsResponse = useQueryResult(unreadCountsQuery(unitId))
 
   const unreadCounts = useMemo(
     () => unreadCountsResponse.getOrElse([]),
@@ -61,10 +57,9 @@ export const UnitContextProvider = React.memo(function UnitContextProvider({
     () => ({
       unitInfoResponse,
       reloadUnitInfo,
-      unreadCounts,
-      reloadUnreadCounts
+      unreadCounts
     }),
-    [unitInfoResponse, reloadUnitInfo, unreadCounts, reloadUnreadCounts]
+    [unitInfoResponse, reloadUnitInfo, unreadCounts]
   )
 
   return <UnitContext.Provider value={value}>{children}</UnitContext.Provider>

--- a/frontend/src/employee-mobile-frontend/common/unit.tsx
+++ b/frontend/src/employee-mobile-frontend/common/unit.tsx
@@ -17,14 +17,14 @@ import { getMobileUnitInfo } from '../pairing/api'
 interface UnitState {
   unitInfoResponse: Result<UnitInfo>
   reloadUnitInfo: () => void
-  unreadCountsResponse: Result<UnreadCountByAccountAndGroup[]>
+  unreadCounts: UnreadCountByAccountAndGroup[]
   reloadUnreadCounts: () => void
 }
 
 const defaultState: UnitState = {
   unitInfoResponse: Loading.of(),
   reloadUnitInfo: () => undefined,
-  unreadCountsResponse: Loading.of(),
+  unreadCounts: [],
   reloadUnreadCounts: () => undefined
 }
 
@@ -47,6 +47,11 @@ export const UnitContextProvider = React.memo(function UnitContextProvider({
     [unitId]
   )
 
+  const unreadCounts = useMemo(
+    () => unreadCountsResponse.getOrElse([]),
+    [unreadCountsResponse]
+  )
+
   useEffect(
     () => idleTracker(client, reloadUnitInfo, { thresholdInMinutes: 5 }),
     [reloadUnitInfo]
@@ -56,10 +61,10 @@ export const UnitContextProvider = React.memo(function UnitContextProvider({
     () => ({
       unitInfoResponse,
       reloadUnitInfo,
-      unreadCountsResponse,
+      unreadCounts,
       reloadUnreadCounts
     }),
-    [unitInfoResponse, reloadUnitInfo, unreadCountsResponse, reloadUnreadCounts]
+    [unitInfoResponse, reloadUnitInfo, unreadCounts, reloadUnreadCounts]
   )
 
   return <UnitContext.Provider value={value}>{children}</UnitContext.Provider>

--- a/frontend/src/employee-mobile-frontend/messages/UnreadMessagesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/UnreadMessagesPage.tsx
@@ -35,62 +35,59 @@ export const UnreadMessagesPage = React.memo(function UnreadMessagesPage() {
     groupId: UUID
   }>()
   const { i18n } = useTranslation()
-  const { unitInfoResponse, unreadCountsResponse } = useContext(UnitContext)
+  const { unitInfoResponse, unreadCounts } = useContext(UnitContext)
   const { user } = useContext(UserContext)
   const { pushNotifications } = useContext(ServiceWorkerContext)
 
-  return renderResult(
-    combine(unitInfoResponse, unreadCountsResponse, user),
-    ([unit, counts, user]) => (
-      <ContentArea
-        opaque
-        fullHeight
-        paddingHorizontal="zero"
-        paddingVertical="zero"
-      >
-        <TopBar title={unit.name} />
-        <HeaderContainer>
-          <H1 noMargin={true}>{i18n.messages.unreadMessages}</H1>
-        </HeaderContainer>
-        <UnreadCounts>
-          {unit.groups.map((group) => (
-            <UnreadCountByGroupRow key={group.id}>
-              <LinkToGroupMessages
-                data-qa={`link-to-group-messages-${group.id}`}
-                to={`/units/${unitId}/groups/${group.id}/messages`}
-              >
-                {group.name}
-              </LinkToGroupMessages>
-              <UnreadCountNumber
-                dataQa={`unread-count-by-group-${group.id}`}
-                maybeNumber={
-                  counts.find((c) => c.groupId === group.id)?.unreadCount
-                }
-              />
-            </UnreadCountByGroupRow>
-          ))}
-        </UnreadCounts>
-        {!user?.pinLoginActive && (
-          <ButtonContainer>
-            <P noMargin={true} centered={true}>
-              {i18n.messages.pinLockInfo}
-            </P>
-            <WideLinkButton
-              $primary
-              data-qa="pin-login-button"
-              to={`/units/${unitId}/groups/${groupId}/messages`}
+  return renderResult(combine(unitInfoResponse, user), ([unit, user]) => (
+    <ContentArea
+      opaque
+      fullHeight
+      paddingHorizontal="zero"
+      paddingVertical="zero"
+    >
+      <TopBar title={unit.name} />
+      <HeaderContainer>
+        <H1 noMargin={true}>{i18n.messages.unreadMessages}</H1>
+      </HeaderContainer>
+      <UnreadCounts>
+        {unit.groups.map((group) => (
+          <UnreadCountByGroupRow key={group.id}>
+            <LinkToGroupMessages
+              data-qa={`link-to-group-messages-${group.id}`}
+              to={`/units/${unitId}/groups/${group.id}/messages`}
             >
-              {i18n.messages.openPinLock}
-            </WideLinkButton>
-          </ButtonContainer>
-        )}
-        {pushNotifications && (
-          <NotificationSettings pushNotifications={pushNotifications} />
-        )}
-        <BottomNavBar selected="messages" />
-      </ContentArea>
-    )
-  )
+              {group.name}
+            </LinkToGroupMessages>
+            <UnreadCountNumber
+              dataQa={`unread-count-by-group-${group.id}`}
+              maybeNumber={
+                unreadCounts.find((c) => c.groupId === group.id)?.unreadCount
+              }
+            />
+          </UnreadCountByGroupRow>
+        ))}
+      </UnreadCounts>
+      {!user?.pinLoginActive && (
+        <ButtonContainer>
+          <P noMargin={true} centered={true}>
+            {i18n.messages.pinLockInfo}
+          </P>
+          <WideLinkButton
+            $primary
+            data-qa="pin-login-button"
+            to={`/units/${unitId}/groups/${groupId}/messages`}
+          >
+            {i18n.messages.openPinLock}
+          </WideLinkButton>
+        </ButtonContainer>
+      )}
+      {pushNotifications && (
+        <NotificationSettings pushNotifications={pushNotifications} />
+      )}
+      <BottomNavBar selected="messages" />
+    </ContentArea>
+  ))
 })
 
 const NotificationSettings = React.memo(function NotificationSettings({

--- a/frontend/src/employee-mobile-frontend/messages/api.ts
+++ b/frontend/src/employee-mobile-frontend/messages/api.ts
@@ -45,18 +45,15 @@ export async function getReceivedMessages(
   accountId: UUID,
   page: number,
   pageSize: number
-): Promise<Result<Paged<MessageThread>>> {
+): Promise<Paged<MessageThread>> {
   return client
     .get<JsonOf<Paged<MessageThread>>>(`/messages/${accountId}/received`, {
       params: { page, pageSize }
     })
-    .then(({ data }) =>
-      Success.of({
-        ...data,
-        data: data.data.map((d) => deserializeMessageThread(d))
-      })
-    )
-    .catch((e) => Failure.fromError(e))
+    .then(({ data }) => ({
+      ...data,
+      data: data.data.map((d) => deserializeMessageThread(d))
+    }))
 }
 
 export type ReplyToThreadParams = ReplyToMessageBody & {
@@ -69,14 +66,13 @@ export async function replyToThread({
   content,
   accountId,
   recipientAccountIds
-}: ReplyToThreadParams): Promise<Result<ThreadReply>> {
+}: ReplyToThreadParams): Promise<ThreadReply> {
   return client
     .post<JsonOf<ThreadReply>>(`/messages/${accountId}/${messageId}/reply`, {
       content,
       recipientAccountIds
     })
-    .then(({ data }) => Success.of(deserializeReplyResponse(data)))
-    .catch((e) => Failure.fromError(e))
+    .then(({ data }) => deserializeReplyResponse(data))
 }
 
 export async function markThreadRead(

--- a/frontend/src/employee-mobile-frontend/messages/api.ts
+++ b/frontend/src/employee-mobile-frontend/messages/api.ts
@@ -34,11 +34,10 @@ export async function getMessagingAccounts(
 
 export async function getUnreadCountsByUnit(
   unitId: UUID
-): Promise<Result<UnreadCountByAccountAndGroup[]>> {
+): Promise<UnreadCountByAccountAndGroup[]> {
   return client
     .get<JsonOf<UnreadCountByAccountAndGroup[]>>(`/messages/unread/${unitId}`)
-    .then(({ data }) => Success.of(data))
-    .catch((e) => Failure.fromError(e))
+    .then((res) => res.data)
 }
 
 export async function getReceivedMessages(
@@ -75,14 +74,16 @@ export async function replyToThread({
     .then(({ data }) => deserializeReplyResponse(data))
 }
 
-export async function markThreadRead(
-  accountId: UUID,
+export async function markThreadRead({
+  accountId,
+  id
+}: {
+  accountId: UUID
   id: UUID
-): Promise<Result<void>> {
+}): Promise<void> {
   return client
     .put(`/messages/${accountId}/threads/${id}/read`)
-    .then(() => Success.of(undefined))
-    .catch((e) => Failure.fromError(e))
+    .then(() => undefined)
 }
 
 export async function deleteDraft(

--- a/frontend/src/employee-mobile-frontend/messages/api.ts
+++ b/frontend/src/employee-mobile-frontend/messages/api.ts
@@ -24,13 +24,12 @@ import { API_URL, client } from '../client'
 
 export async function getMessagingAccounts(
   unitId: UUID
-): Promise<Result<AuthorizedMessageAccount[]>> {
+): Promise<AuthorizedMessageAccount[]> {
   return client
     .get<JsonOf<AuthorizedMessageAccount[]>>(
       `/messages/mobile/my-accounts/${unitId}`
     )
-    .then(({ data }) => Success.of(data))
-    .catch((e) => Failure.fromError(e))
+    .then((res) => res.data)
 }
 
 export async function getUnreadCountsByUnit(

--- a/frontend/src/employee-mobile-frontend/messages/queries.ts
+++ b/frontend/src/employee-mobile-frontend/messages/queries.ts
@@ -2,17 +2,36 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { query } from 'lib-common/query'
+import { infiniteQuery, mutation, query } from 'lib-common/query'
 
 import { createQueryKeys } from '../query'
 
-import { getMessagingAccounts } from './api'
+import { getMessagingAccounts, getReceivedMessages, replyToThread } from './api'
 
 const queryKeys = createQueryKeys('messages', {
-  accounts: (unitId: string) => ['accounts', unitId]
+  accounts: (unitId: string) => ['accounts', unitId],
+  receivedMessages: (accountId: string) => ['receivedMessages', accountId]
 })
 
 export const messagingAccountsQuery = query({
   api: getMessagingAccounts,
   queryKey: queryKeys.accounts
+})
+
+export const receivedMessagesQuery = infiniteQuery({
+  api: (accountId: string, pageSize: number) => (page: number) =>
+    getReceivedMessages(accountId, page, pageSize),
+  queryKey: queryKeys.receivedMessages,
+  firstPageParam: 1,
+  getNextPageParam: (lastPage, pages) => {
+    const nextPage = pages.length + 1
+    return nextPage <= lastPage.pages ? nextPage : undefined
+  }
+})
+
+export const replyToThreadMutation = mutation({
+  api: replyToThread,
+  invalidateQueryKeys: ({ accountId }) => [
+    queryKeys.receivedMessages(accountId)
+  ]
 })

--- a/frontend/src/employee-mobile-frontend/messages/queries.ts
+++ b/frontend/src/employee-mobile-frontend/messages/queries.ts
@@ -6,11 +6,18 @@ import { infiniteQuery, mutation, query } from 'lib-common/query'
 
 import { createQueryKeys } from '../query'
 
-import { getMessagingAccounts, getReceivedMessages, replyToThread } from './api'
+import {
+  getMessagingAccounts,
+  getReceivedMessages,
+  getUnreadCountsByUnit,
+  markThreadRead,
+  replyToThread
+} from './api'
 
 const queryKeys = createQueryKeys('messages', {
   accounts: (unitId: string) => ['accounts', unitId],
-  receivedMessages: (accountId: string) => ['receivedMessages', accountId]
+  receivedMessages: (accountId: string) => ['receivedMessages', accountId],
+  unreadCounts: () => ['unreadCounts']
 })
 
 export const messagingAccountsQuery = query({
@@ -29,9 +36,19 @@ export const receivedMessagesQuery = infiniteQuery({
   }
 })
 
+export const unreadCountsQuery = query({
+  api: getUnreadCountsByUnit,
+  queryKey: queryKeys.unreadCounts
+})
+
 export const replyToThreadMutation = mutation({
   api: replyToThread,
   invalidateQueryKeys: ({ accountId }) => [
     queryKeys.receivedMessages(accountId)
   ]
+})
+
+export const markThreadReadMutation = mutation({
+  api: markThreadRead,
+  invalidateQueryKeys: () => [queryKeys.unreadCounts()]
 })

--- a/frontend/src/employee-mobile-frontend/messages/queries.ts
+++ b/frontend/src/employee-mobile-frontend/messages/queries.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { query } from 'lib-common/query'
+
+import { createQueryKeys } from '../query'
+
+import { getMessagingAccounts } from './api'
+
+const queryKeys = createQueryKeys('messages', {
+  accounts: (unitId: string) => ['accounts', unitId]
+})
+
+export const messagingAccountsQuery = query({
+  api: getMessagingAccounts,
+  queryKey: queryKeys.accounts
+})

--- a/frontend/src/employee-mobile-frontend/messages/state.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/state.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import uniqBy from 'lodash/uniqBy'
 import React, {
   createContext,
   useCallback,
@@ -11,51 +12,35 @@ import React, {
   useState
 } from 'react'
 
-import { Loading, Paged, Result } from 'lib-common/api'
+import { Loading, Result } from 'lib-common/api'
 import {
-  Message,
   MessageThread,
-  AuthorizedMessageAccount,
-  ThreadReply
+  AuthorizedMessageAccount
 } from 'lib-common/generated/api-types/messaging'
-import { useQueryResult } from 'lib-common/query'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import {
+  queryResult,
+  useInfiniteQuery,
+  useMutationResult,
+  useQueryResult
+} from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import useNonNullableParams from 'lib-common/useNonNullableParams'
-import { useRestApi } from 'lib-common/utils/useRestApi'
 
 import { UserContext } from '../auth/state'
 import { UnitContext } from '../common/unit'
 
+import { markThreadRead, ReplyToThreadParams } from './api'
 import {
-  getReceivedMessages,
-  markThreadRead,
-  replyToThread,
-  ReplyToThreadParams
-} from './api'
-import { messagingAccountsQuery } from './queries'
+  messagingAccountsQuery,
+  receivedMessagesQuery,
+  replyToThreadMutation
+} from './queries'
 
 const PAGE_SIZE = 20
 
-const addMessageToThread = (message: Message, thread: MessageThread) => ({
-  ...thread,
-  messages: [...thread.messages, message]
-})
-
-const appendMessageAndMoveThreadToTopOfList =
-  (threadId: UUID, message: Message) => (state: Result<MessageThread[]>) =>
-    state.map((threads) => {
-      const thread = threads.find((t) => t.id === threadId)
-      if (!thread) return threads
-      const otherThreads = threads.filter((t) => t.id !== threadId)
-      return [addMessageToThread(message, thread), ...otherThreads]
-    })
-
 export interface MessagesState {
   accounts: Result<AuthorizedMessageAccount[]>
-  page: number
-  setPage: (page: number) => void
-  pages: number | undefined
-  setPages: (pages: number) => void
   groupAccounts: AuthorizedMessageAccount[]
   selectedAccount: AuthorizedMessageAccount | undefined
   receivedMessages: Result<MessageThread[]>
@@ -68,10 +53,6 @@ export interface MessagesState {
 
 const defaultState: MessagesState = {
   accounts: Loading.of(),
-  page: 1,
-  setPage: () => undefined,
-  pages: undefined,
-  setPages: () => undefined,
   selectedAccount: undefined,
   groupAccounts: [],
   receivedMessages: Loading.of(),
@@ -84,10 +65,24 @@ const defaultState: MessagesState = {
 
 export const MessageContext = createContext<MessagesState>(defaultState)
 
+const markMatchingThreadRead = (
+  threads: MessageThread[],
+  id: UUID
+): MessageThread[] =>
+  threads.map((t) =>
+    t.id === id
+      ? {
+          ...t,
+          messages: t.messages.map((m) => ({
+            ...m,
+            readAt: m.readAt ?? HelsinkiDateTime.now()
+          }))
+        }
+      : t
+  )
+
 export const MessageContextProvider = React.memo(
   function MessageContextProvider({ children }: { children: JSX.Element }) {
-    const [page, setPage] = useState<number>(1)
-    const [pages, setPages] = useState<number>()
     const { unitInfoResponse, reloadUnreadCounts } = useContext(UnitContext)
     const { user } = useContext(UserContext)
     const unitId = unitInfoResponse.map((res) => res.id).getOrElse(undefined)
@@ -116,7 +111,7 @@ export const MessageContextProvider = React.memo(
       [accounts, unitId]
     )
 
-    const selectedAccount: AuthorizedMessageAccount = useMemo(
+    const selectedAccount: AuthorizedMessageAccount | undefined = useMemo(
       () =>
         groupAccounts.find(
           ({ daycareGroup }) => daycareGroup?.id === groupId
@@ -124,49 +119,62 @@ export const MessageContextProvider = React.memo(
       [groupAccounts, groupId]
     )
 
-    const [receivedMessages, setReceivedMessages] = useState<
-      Result<MessageThread[]>
-    >(Loading.of())
-
-    const setReceivedMessagesResult = useCallback(
-      (result: Result<Paged<MessageThread>>) => {
-        setReceivedMessages(result.map((r) => r.data))
-        if (result.isSuccess) {
-          setPages(result.value.pages)
+    const { data, transformPages, error, isFetching, isFetchingNextPage } =
+      useInfiniteQuery(
+        receivedMessagesQuery(selectedAccount?.account.id ?? '', PAGE_SIZE),
+        {
+          enabled: selectedAccount !== undefined
         }
-      },
-      []
+      )
+
+    const isFetchingFirstPage = isFetching && !isFetchingNextPage
+    const threads = useMemo(
+      () =>
+        // Use .map() to only call uniqBy/flatMap when it's a Success
+        queryResult(null, error, isFetchingFirstPage).map(() =>
+          data
+            ? uniqBy(
+                data.pages.flatMap((p) => p.data),
+                'id'
+              )
+            : []
+        ),
+      [data, error, isFetchingFirstPage]
     )
 
-    const loadReceivedMessages = useRestApi(
-      getReceivedMessages,
-      setReceivedMessagesResult
-    )
+    const [selectedThreadId, setSelectedThreadId] = useState<UUID>()
 
-    const [selectedThread, setSelectedThread] = useState<MessageThread>()
+    const selectedThread = threads
+      .map((threads) => threads.find((t) => t.id === selectedThreadId))
+      .getOrElse(undefined)
 
     useEffect(() => {
       if (selectedAccount && !selectedThread) {
-        void loadReceivedMessages(selectedAccount.account.id, page, PAGE_SIZE)
         reloadUnreadCounts()
       }
-    }, [
-      loadReceivedMessages,
-      reloadUnreadCounts,
-      page,
-      selectedAccount,
-      selectedThread
-    ])
+    }, [reloadUnreadCounts, selectedAccount, selectedThread])
 
     const selectThread = useCallback(
       (thread: MessageThread | undefined) => {
-        setSelectedThread(thread)
+        setSelectedThreadId(thread?.id)
+
         if (!thread) return
         if (!selectedAccount) throw new Error('Should never happen')
         const { id: accountId } = selectedAccount.account
-        void markThreadRead(accountId, thread.id)
+
+        const hasUnreadMessages = thread.messages.some(
+          (m) => !m.readAt && m.sender.id !== accountId
+        )
+
+        if (hasUnreadMessages) {
+          void markThreadRead(accountId, thread.id)
+          transformPages((page) => ({
+            ...page,
+            data: markMatchingThreadRead(page.data, thread.id)
+          }))
+        }
       },
-      [selectedAccount]
+      [selectedAccount, transformPages]
     )
 
     const [replyContents, setReplyContents] = useState<Record<UUID, string>>({})
@@ -179,50 +187,38 @@ export const MessageContextProvider = React.memo(
       setReplyContents((state) => ({ ...state, [threadId]: content }))
     }, [])
 
-    const setReplyResponse = useCallback((res: Result<ThreadReply>) => {
-      if (res.isSuccess) {
-        const {
-          value: { message, threadId }
-        } = res
-        setReceivedMessages(
-          appendMessageAndMoveThreadToTopOfList(threadId, message)
-        )
-        setSelectedThread((thread) =>
-          thread?.id === threadId ? addMessageToThread(message, thread) : thread
-        )
-        setReplyContents((state) => ({ ...state, [threadId]: '' }))
-      }
-    }, [])
-    const reply = useRestApi(replyToThread, setReplyResponse)
-    const sendReply = useCallback(reply, [reply])
+    const { mutateAsync: sendReply } = useMutationResult(replyToThreadMutation)
+    const sendReplyAndClear = useCallback(
+      async (arg: ReplyToThreadParams) => {
+        const result = await sendReply(arg)
+        if (result.isSuccess) {
+          setReplyContent(result.value.threadId, '')
+        }
+      },
+      [sendReply, setReplyContent]
+    )
 
     const value = useMemo(
       () => ({
         accounts,
         selectedAccount,
         groupAccounts,
-        page,
-        setPage,
-        pages,
-        setPages,
-        receivedMessages,
+        receivedMessages: threads,
         selectThread,
         selectedThread,
         getReplyContent,
-        sendReply,
+        sendReply: sendReplyAndClear,
         setReplyContent
       }),
       [
         accounts,
         groupAccounts,
         selectedAccount,
-        page,
-        pages,
-        receivedMessages,
+        threads,
         selectedThread,
         selectThread,
         getReplyContent,
-        sendReply,
+        sendReplyAndClear,
         setReplyContent
       ]
     )

--- a/frontend/src/employee-mobile-frontend/query.ts
+++ b/frontend/src/employee-mobile-frontend/query.ts
@@ -6,7 +6,11 @@ import { QueryClient } from '@tanstack/react-query'
 
 import { queryKeysNamespace } from 'lib-common/query'
 
-export type QueryKeyPrefix = 'childAttendance' | 'notes' | 'staffAttendance'
+export type QueryKeyPrefix =
+  | 'childAttendance'
+  | 'messages'
+  | 'notes'
+  | 'staffAttendance'
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -518,7 +518,7 @@ WHERE
         }
     } AND
     EXISTS (SELECT 1 FROM message m WHERE m.thread_id = t.id AND m.sent_at IS NOT NULL)
-ORDER BY tp.last_received_timestamp DESC
+ORDER BY tp.last_message_timestamp DESC
 LIMIT :pageSize OFFSET :offset
         """
             )


### PR DESCRIPTION
#### Summary

Use react-query in employee-mobile-frontend messaging. Notably, unread counts are now updated when evaka is opened on the phone, which gives better visibility to new messages.

Additionally, small UX improvements:
- Raise a thread to the top after replying in employee views (was already like this for citizens)
- Don't overlay a spinner on bottom navbar when reloading unread counts