### PR TITLE
Add Espoo-specific permission customizations

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.core.FuelManager
 import fi.espoo.evaka.children.consent.ChildConsentType
 import fi.espoo.evaka.emailclient.EvakaEmailMessageProvider
 import fi.espoo.evaka.emailclient.IEmailMessageProvider
+import fi.espoo.evaka.espoo.EspooActionRuleMapping
 import fi.espoo.evaka.espoo.EspooAsyncJob
 import fi.espoo.evaka.espoo.EspooAsyncJobRegistration
 import fi.espoo.evaka.espoo.EspooScheduledJob
@@ -35,7 +36,6 @@ import fi.espoo.evaka.shared.db.DevDataInitializer
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
 import fi.espoo.evaka.shared.security.actionrule.ActionRuleMapping
-import fi.espoo.evaka.shared.security.actionrule.DefaultActionRuleMapping
 import fi.espoo.evaka.shared.template.EvakaTemplateProvider
 import fi.espoo.evaka.shared.template.ITemplateProvider
 import io.opentracing.Tracer
@@ -193,7 +193,7 @@ class EspooConfig {
             it.setDisableMBeanRegistry(false)
         }
 
-    @Bean fun actionRuleMapping(): ActionRuleMapping = DefaultActionRuleMapping()
+    @Bean fun actionRuleMapping(): ActionRuleMapping = EspooActionRuleMapping()
 
     @Bean
     fun espooScheduledJobs(

--- a/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooActionRuleMapping.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooActionRuleMapping.kt
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.espoo
+
+import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.security.Action
+import fi.espoo.evaka.shared.security.actionrule.ActionRuleMapping
+import fi.espoo.evaka.shared.security.actionrule.HasGlobalRole
+import fi.espoo.evaka.shared.security.actionrule.HasUnitRole
+import fi.espoo.evaka.shared.security.actionrule.ScopedActionRule
+import fi.espoo.evaka.shared.security.actionrule.UnscopedActionRule
+
+class EspooActionRuleMapping : ActionRuleMapping {
+    override fun rulesOf(action: Action.UnscopedAction): Sequence<UnscopedActionRule> =
+        when (action) {
+            Action.Global.SEND_PATU_REPORT,
+            Action.Global.SUBMIT_PATU_REPORT -> sequenceOf(HasGlobalRole(UserRole.ADMIN))
+            else -> action.defaultRules.asSequence()
+        }
+
+    override fun <T> rulesOf(action: Action.ScopedAction<in T>): Sequence<ScopedActionRule<in T>> =
+        when (action) {
+            Action.Unit.READ_OCCUPANCY_REPORT -> {
+                @Suppress("UNCHECKED_CAST")
+                sequenceOf(
+                    HasGlobalRole(
+                        UserRole.ADMIN,
+                        UserRole.SERVICE_WORKER,
+                        UserRole.DIRECTOR,
+                        UserRole.REPORT_VIEWER
+                    )
+                        as ScopedActionRule<in T>,
+                ) +
+                    sequenceOf(
+                        HasUnitRole(UserRole.UNIT_SUPERVISOR).inAnyUnit() as ScopedActionRule<in T>,
+                    )
+            }
+            Action.Unit.READ_PLACEMENT_GUARANTEE_REPORT -> {
+                @Suppress("UNCHECKED_CAST")
+                sequenceOf(HasGlobalRole(UserRole.ADMIN) as ScopedActionRule<in T>) +
+                    sequenceOf(
+                        HasUnitRole(UserRole.UNIT_SUPERVISOR).inUnit() as ScopedActionRule<in T>
+                    )
+            }
+            else -> action.defaultRules.asSequence()
+        }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -287,7 +287,7 @@ sealed interface Action {
         CREATE_HOLIDAY_QUESTIONNAIRE(HasGlobalRole(ADMIN)),
         DELETE_HOLIDAY_QUESTIONNAIRE(HasGlobalRole(ADMIN)),
         UPDATE_HOLIDAY_QUESTIONNAIRE(HasGlobalRole(ADMIN)),
-        SEND_PATU_REPORT(HasGlobalRole(ADMIN)),
+        SEND_PATU_REPORT,
         CREATE_EMPLOYEE(HasGlobalRole(ADMIN)),
         READ_EMPLOYEES(
             HasGlobalRole(ADMIN, SERVICE_WORKER),
@@ -299,7 +299,7 @@ sealed interface Action {
                 .inAnyUnit()
         ),
         SEARCH_EMPLOYEES(HasGlobalRole(ADMIN)),
-        SUBMIT_PATU_REPORT(HasGlobalRole(ADMIN)),
+        SUBMIT_PATU_REPORT,
         READ_FUTURE_PRESCHOOLERS(HasGlobalRole(ADMIN));
 
         override fun toString(): String = "${javaClass.name}.$name"


### PR DESCRIPTION
#### Summary

- Disable Patu report in default permissions
- Allow unit supervisors to see occupancy report for any unit
- Disallow placement guarantee report for service workers and directors
