### PR TITLE
Greatly increase response read timeout in BI requests

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/espoo/bi/EspooBiHttpClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/espoo/bi/EspooBiHttpClient.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.core.requests.DefaultBody
 import fi.espoo.evaka.EspooBiEnv
 import fi.espoo.voltti.logging.loggers.error
+import java.time.Duration
 import mu.KotlinLogging
 
 class EspooBiHttpClient(
@@ -16,6 +17,7 @@ class EspooBiHttpClient(
     private val env: EspooBiEnv,
 ) : EspooBiClient {
     private val logger = KotlinLogging.logger {}
+    private val readTimeout = Duration.ofMinutes(5)
 
     override fun sendBiCsvFile(fileName: String, stream: EspooBiJob.CsvInputStream) {
         logger.info("Sending BI CSV file $fileName")
@@ -23,6 +25,7 @@ class EspooBiHttpClient(
             fuel
                 .put("${env.url}/report", listOf("filename" to fileName))
                 .header("Content-type", "text/csv")
+                .timeoutRead(readTimeout.toMillis().toInt())
                 .authentication()
                 .basic(env.username, env.password.value)
                 .body(DefaultBody({ stream }))


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

We're streaming a very large request, and immediately after we have sent the last byte, we start reading a response. By default the read timeout is only 15 seconds, but if the other end is still processing the last chunk we sent, it may take longer than that for it to respond.

There's no reason to use a small timeout here, so increase it to 5 minutes.