### PR TITLE
Application duedate rework

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -211,5 +211,6 @@ val testFeatureConfig =
         municipalMessageAccountName = "Espoon kaupunki - Esbo stad - City of Espoo",
         serviceWorkerMessageAccountName =
             "Varhaiskasvatuksen palveluohjaus - Småbarnspedagogikens servicehandledning - Early childhood education service guidance",
-        applyPlacementUnitFromDecision = false
+        applyPlacementUnitFromDecision = false,
+        preferredStartRelativeApplicationDueDate = false,
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -189,6 +189,7 @@ class EspooConfig {
             serviceWorkerMessageAccountName =
                 "Varhaiskasvatuksen palveluohjaus - Småbarnspedagogikens servicehandledning - Early childhood education service guidance",
             applyPlacementUnitFromDecision = false,
+            preferredStartRelativeApplicationDueDate = false
         )
 
     @Bean

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -236,6 +236,7 @@ class ApplicationStateService(
                 ?: calculateDueDate(
                     application.type,
                     sentDate,
+                    application.form.preferences.preferredStartDate,
                     application.form.preferences.urgent,
                     applicationFlags.isTransferApplication,
                     application.attachments
@@ -973,6 +974,7 @@ class ApplicationStateService(
             calculateDueDate(
                 original.type,
                 sentDate,
+                original.form.preferences.preferredStartDate,
                 urgent,
                 original.transferApplication,
                 original.attachments
@@ -1094,6 +1096,7 @@ class ApplicationStateService(
     private fun calculateDueDate(
         applicationType: ApplicationType,
         sentDate: LocalDate,
+        preferredStartDate: LocalDate?,
         isUrgent: Boolean,
         isTransferApplication: Boolean,
         attachments: List<ApplicationAttachment>
@@ -1112,7 +1115,8 @@ class ApplicationStateService(
                     attachments.minByOrNull { it.receivedAt }?.receivedAt?.toLocalDate()
                 listOfNotNull(minAttachmentDate, sentDate).maxOrNull()?.plusWeeks(2)
             } else {
-                sentDate.plusMonths(4)
+                val defaultDueDate = sentDate.plusMonths(4)
+                preferredStartDate?.let { maxOf(defaultDueDate, it) } ?: defaultDueDate
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -138,5 +138,12 @@ data class FeatureConfig(
      * true = placement unit is resolved from decision when it's accepted, false = placement unit is
      * resolved from placement plan
      */
-    val applyPlacementUnitFromDecision: Boolean
+    val applyPlacementUnitFromDecision: Boolean,
+
+    /**
+     * Whether automatic application due date is calculated in relation to the preferred start date
+     * true = non-urgent early education application due date is max(sentDate + 4 months, preferred
+     * start date) false = non-urgent early education application due date is sentDate + 4 months
+     */
+    val preferredStartRelativeApplicationDueDate: Boolean,
 )


### PR DESCRIPTION
Adds a feature flagged option to use the preferred start date as the due date for applications that are sent more than 4 months before the preferred start date. Espoo config sets the flag as FALSE.

Only the non-urgent, non-transfer, early education application branch is changed.

There is no migration for existing 4+ month applications to update their due dates.

Note: as adding an attachment forces a recalculation of the application's due date, depending on configuration-specific attachment sending rules there may be scenarios where existing 4+ month applications are recalculated with the new logic. This was tested and confirmed with Tampere config as a shift care application accepts attachments (without being marked urgent) and ends up changing the due date.
