### PR TITLE
Enhance file upload type handling

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
@@ -143,16 +143,7 @@ const PedagogicalDocumentRow = React.memo(function PedagogicalDocument({
             getDownloadUrl={getAttachmentUrl}
             onUpload={handleAttachmentUpload}
             onDelete={handleAttachmentDelete}
-            accept={[
-              'image/jpeg',
-              'image/png',
-              'application/pdf',
-              'application/msword',
-              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-              'application/vnd.oasis.opendocument.text',
-              'video/*',
-              'audio/*'
-            ]}
+            allowedFileTypes={['image', 'document', 'audio', 'video']}
           />
         </AttachmentsContainer>
       </NameTd>

--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -6,6 +6,8 @@ import React, { useContext, useMemo } from 'react'
 
 import { DocumentStatus } from 'lib-common/generated/api-types/document'
 
+import { FileType } from './molecules/FileUpload'
+
 export interface Translations {
   asyncButton: {
     inProgress: string
@@ -51,7 +53,7 @@ export interface Translations {
     deleteFile: string
     input: {
       title: string
-      text: string[]
+      text: (fileTypes: FileType[]) => string
     }
     loading: string
     loaded: string

--- a/frontend/src/lib-components/molecules/FileUpload.tsx
+++ b/frontend/src/lib-components/molecules/FileUpload.tsx
@@ -248,7 +248,7 @@ const attachmentToFile = (attachment: Attachment): FileObject => ({
   deleteInProgress: false
 })
 
-export type FileType = 'document' | 'image' | 'audio' | 'video'
+export type FileType = 'document' | 'image' | 'audio' | 'video' | 'csv'
 
 const contentTypes: Record<FileType, string[]> = {
   document: [
@@ -259,7 +259,8 @@ const contentTypes: Record<FileType, string[]> = {
   ],
   image: ['image/jpeg', 'image/png'],
   audio: ['audio/*'],
-  video: ['video/*']
+  video: ['video/*'],
+  csv: ['text/csv']
 }
 
 const defaultAllowedFileTypes: FileType[] = ['image', 'document']

--- a/frontend/src/lib-components/molecules/FileUpload.tsx
+++ b/frontend/src/lib-components/molecules/FileUpload.tsx
@@ -13,7 +13,7 @@ import { UUID } from 'lib-common/types'
 import { useUniqueId } from 'lib-common/utils/useUniqueId'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import FileDownloadButton from 'lib-components/molecules/FileDownloadButton'
-import { H4, InformationText } from 'lib-components/typography'
+import { H4, InformationText, P } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import {
   faExclamationTriangle,
@@ -75,10 +75,12 @@ interface FileUploadProps {
   slim?: boolean
   'data-qa'?: string
   slimSingleFile?: boolean
-  accept?: string[]
+  allowedFileTypes?: FileType[]
 }
 
-const FileUploadContainer = styled.div<{ slim: boolean }>`
+const FileUploadContainer = styled.div<{
+  slim: boolean
+}>`
   display: flex;
   flex-direction: ${(p) => (p.slim ? 'column' : 'row')};
   flex-wrap: wrap;
@@ -246,14 +248,21 @@ const attachmentToFile = (attachment: Attachment): FileObject => ({
   deleteInProgress: false
 })
 
-const defaultAllowedContentTypes = [
-  'image/jpeg',
-  'image/png',
-  'application/pdf',
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'application/vnd.oasis.opendocument.text'
-]
+export type FileType = 'document' | 'image' | 'audio' | 'video'
+
+const contentTypes: Record<FileType, string[]> = {
+  document: [
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.oasis.opendocument.text',
+    'application/pdf'
+  ],
+  image: ['image/jpeg', 'image/png'],
+  audio: ['audio/*'],
+  video: ['video/*']
+}
+
+const defaultAllowedFileTypes: FileType[] = ['image', 'document']
 
 export const fileIcon = (file: Attachment): IconDefinition => {
   switch (file.contentType) {
@@ -282,7 +291,7 @@ export default React.memo(function FileUpload({
   slim = false,
   disabled = false,
   'data-qa': dataQa,
-  accept = defaultAllowedContentTypes
+  allowedFileTypes = defaultAllowedFileTypes
 }: FileUploadProps) {
   const i18n = useTranslations().fileUpload
 
@@ -411,7 +420,7 @@ export default React.memo(function FileUpload({
     <input
       disabled={disabled}
       type="file"
-      accept={accept?.join(',')}
+      accept={allowedFileTypes.flatMap((t) => contentTypes[t]).join(',')}
       onChange={onChange}
       data-qa="btn-upload-file"
       ref={inputRef}
@@ -465,9 +474,11 @@ export default React.memo(function FileUpload({
           <span role="button" tabIndex={0}>
             {fileInput}
             <H4>{i18n.input.title}</H4>
-            <p>
-              <InformationText>{i18n.input.text.join('\n')}</InformationText>
-            </p>
+            <P>
+              <InformationText>
+                {i18n.input.text(allowedFileTypes)}
+              </InformationText>
+            </P>
           </span>
         </FileInputLabel>
       )}

--- a/frontend/src/lib-components/utils/TestContextProvider.tsx
+++ b/frontend/src/lib-components/utils/TestContextProvider.tsx
@@ -58,7 +58,7 @@ export const testTranslations: Translations = {
     deleteFile: '',
     input: {
       title: '',
-      text: []
+      text: () => ''
     },
     loading: '',
     loaded: '',

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -63,12 +63,22 @@ const components: Translations = {
     },
     input: {
       title: 'Add an attachment',
-      text: [
-        'Press here or drag and drop a new file',
-        'Max file size: 10MB.',
-        'Allowed formats:',
-        'PDF, JPEG/JPG, PNG and DOC/DOCX'
-      ]
+      text: (fileTypes) =>
+        'Press here or drag and drop a new file. Max file size: 10MB. Allowed formats: ' +
+        fileTypes
+          .map((type) => {
+            switch (type) {
+              case 'image':
+                return 'images (JPEG, JPG, PNG)'
+              case 'document':
+                return 'documents (PDF, DOC, DOCX, ODT)'
+              case 'audio':
+                return 'audio'
+              case 'video':
+                return 'video'
+            }
+          })
+          .join(', ')
     },
     deleteFile: 'Delete file'
   },

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -76,6 +76,8 @@ const components: Translations = {
                 return 'audio'
               case 'video':
                 return 'video'
+              case 'csv':
+                return 'CSV files'
             }
           })
           .join(', ')

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -62,12 +62,22 @@ const components: Translations = {
     },
     input: {
       title: 'Lisää liite',
-      text: [
-        'Paina tästä tai raahaa liite laatikkoon yksi kerrallaan.',
-        'Tiedoston maksimikoko: 10MB.',
-        'Sallitut tiedostomuodot:',
-        'PDF, JPEG/JPG, PNG ja DOC/DOCX'
-      ]
+      text: (fileTypes) =>
+        'Paina tästä tai raahaa liite laatikkoon yksi kerrallaan. Tiedoston maksimikoko: 10MB. Sallitut tiedostomuodot: ' +
+        fileTypes
+          .map((type) => {
+            switch (type) {
+              case 'image':
+                return 'kuvat (JPEG, JPG, PNG)'
+              case 'document':
+                return 'dokumentit (PDF, DOC, DOCX, ODT)'
+              case 'audio':
+                return 'äänitiedostot'
+              case 'video':
+                return 'videotiedostot'
+            }
+          })
+          .join(', ')
     },
     deleteFile: 'Poista tiedosto'
   },

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -75,6 +75,8 @@ const components: Translations = {
                 return 'äänitiedostot'
               case 'video':
                 return 'videotiedostot'
+              case 'csv':
+                return 'CSV-tiedostot'
             }
           })
           .join(', ')

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -63,12 +63,22 @@ const components: Translations = {
     },
     input: {
       title: 'Lägg till bilaga',
-      text: [
-        'Tryck här eller dra en bilaga åt gången till lådan.',
-        'Maximal storlek för filen: 10 MB.',
-        'Tillåtna format:',
-        'PDF, JPEG/JPG, PNG och DOC/DOCX'
-      ]
+      text: (fileTypes) =>
+        'Tryck här eller dra en bilaga åt gången till lådan. Maximal storlek för filen: 10 MB. Tillåtna format: ' +
+        fileTypes
+          .map((type) => {
+            switch (type) {
+              case 'image':
+                return 'bilder (JPEG, JPG, PNG)'
+              case 'document':
+                return 'dokument (PDF, DOC, DOCX, ODT)'
+              case 'audio':
+                return 'ljud'
+              case 'video':
+                return 'video'
+            }
+          })
+          .join(', ')
     },
     deleteFile: 'Radera fil'
   },

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -76,6 +76,8 @@ const components: Translations = {
                 return 'ljud'
               case 'video':
                 return 'video'
+              case 'csv':
+                return 'CSV filer'
             }
           })
           .join(', ')


### PR DESCRIPTION
#### Summary

Instead of giving a list of MIME content types, `FileUpload` components can now be configured to allow more general file types: images, documents, video, audio and csv. Localization takes into account the allowed file types.