### PR TITLE
Add flyway additional locations support

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -124,6 +124,7 @@ data class DatabaseEnv(
     val password: Sensitive<String>,
     val flywayUsername: String,
     val flywayPassword: Sensitive<String>,
+    val flywayAdditionalLocations: List<String>?,
     val flywayIgnoreFutureMigrations: Boolean,
     val leakDetectionThreshold: Long,
     val defaultStatementTimeout: Duration,
@@ -140,6 +141,8 @@ data class DatabaseEnv(
                 flywayUsername = env.lookup("evaka.database.flyway.username", "flyway.username"),
                 flywayPassword =
                     Sensitive(env.lookup("evaka.database.flyway.password", "flyway.password")),
+                flywayAdditionalLocations =
+                    env.lookup("evaka.database.flyway.additional_locations"),
                 flywayIgnoreFutureMigrations =
                     env.lookup("evaka.database.flyway.ignore-future-migrations") ?: true,
                 leakDetectionThreshold =

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -124,7 +124,7 @@ data class DatabaseEnv(
     val password: Sensitive<String>,
     val flywayUsername: String,
     val flywayPassword: Sensitive<String>,
-    val flywayAdditionalLocations: List<String>?,
+    val flywayLocations: List<String>,
     val flywayIgnoreFutureMigrations: Boolean,
     val leakDetectionThreshold: Long,
     val defaultStatementTimeout: Duration,
@@ -141,8 +141,8 @@ data class DatabaseEnv(
                 flywayUsername = env.lookup("evaka.database.flyway.username", "flyway.username"),
                 flywayPassword =
                     Sensitive(env.lookup("evaka.database.flyway.password", "flyway.password")),
-                flywayAdditionalLocations =
-                    env.lookup("evaka.database.flyway.additional_locations"),
+                flywayLocations = env.lookup("evaka.database.flyway.locations")
+                        ?: listOf("db/migration"),
                 flywayIgnoreFutureMigrations =
                     env.lookup("evaka.database.flyway.ignore-future-migrations") ?: true,
                 leakDetectionThreshold =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
@@ -44,6 +44,11 @@ class DatabaseConfig {
                 }
             )
             .dataSource(env.url, env.flywayUsername, env.flywayPassword.value)
+            .apply {
+                if (env.flywayAdditionalLocations != null) {
+                    locations("db/migration", *env.flywayAdditionalLocations.toTypedArray())
+                }
+            }
             .placeholders(
                 mapOf("application_user" to env.username, "migration_user" to env.flywayUsername)
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/DatabaseConfig.kt
@@ -44,11 +44,7 @@ class DatabaseConfig {
                 }
             )
             .dataSource(env.url, env.flywayUsername, env.flywayPassword.value)
-            .apply {
-                if (env.flywayAdditionalLocations != null) {
-                    locations("db/migration", *env.flywayAdditionalLocations.toTypedArray())
-                }
-            }
+            .locations(*env.flywayLocations.toTypedArray())
             .placeholders(
                 mapOf("application_user" to env.username, "migration_user" to env.flywayUsername)
             )


### PR DESCRIPTION
#### Summary

eVaka doesn't have UI to modify every database so we have been using flyway after migrate scripts to populate the data. This has been working great: every environment we have has the exactly same data and it is well documented and versioned through git.

We are going to use service for multiple municipalities, so we would like to have different after migrate scripts for every municipality. This little change adds support for it.

Example configuration with application.yml:

```
evaka:
  database:
    flyway:
      additional_locations: db/data/tampere
```