### PR TITLE
Add frontend build context support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,7 @@ jobs:
             ICONS=pro
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
           build-contexts:
-            customizations=src/lib-customizations/espoo
+            customizations=frontend/src/lib-customizations/espoo
 
       - name: Docker cleanup
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,8 @@ jobs:
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
             ICONS=free
+          build-contexts:
+            customizations=frontend/src/lib-customizations/espoo
 
       - name: Build frontend image builder
         if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
@@ -124,6 +126,8 @@ jobs:
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
             ICONS=free
+          build-contexts:
+            customizations=frontend/src/lib-customizations/espoo
 
       - name: Docker cleanup
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,8 @@ jobs:
             commit=${{ github.event.pull_request.head.sha || github.sha }}
             ICONS=pro
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          build-contexts:
+            customizations=src/lib-customizations/espoo
 
       - name: Docker cleanup
         if: always()

--- a/apigw/README.md
+++ b/apigw/README.md
@@ -20,7 +20,7 @@ Gateway between eVaka frontends and backend services
 The service requires redis running on port 6379. Easiest way is to run it with [compose](../compose/README.md) command
 
 ```bash
-docker-compose up -d redis
+docker compose up -d redis
 ```
 
 ## Development

--- a/compose/README.md
+++ b/compose/README.md
@@ -41,7 +41,7 @@ packages.
 - [JDK](https://openjdk.java.net/projects/jdk/17/) – Java Development
   Kit, version 17. We recommend using OpenJDK.
 - [Docker](https://docs.docker.com/get-docker/) – Docker is an open platform for developing, shipping, and running applications.
-- [docker-compose](https://docs.docker.com/compose/install/) - Tool for running multi-container Docker applications, version 1.26.0+
+- [docker compose](https://docs.docker.com/compose/install/) - Tool for running multi-container Docker applications, version 1.26.0+
 
 ### Required tooling
 
@@ -74,10 +74,10 @@ See sub-projects' README files for more information. At the time of writing,
 you can skip this, if you just want to see if you can get everything running
 locally.
 
-First, start the third-party dependencies using `docker-compose`:
+First, start the third-party dependencies using `docker compose`:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Then, start eVaka projects with PM2:
@@ -119,7 +119,7 @@ Start the whole stack locally:
 ./compose-e2e up -d
 ```
 
-`compose-e2e` is simple wrapper for `docker-compose`.
+`compose-e2e` is simple wrapper for `docker compose`.
 
 Access the frontends at
 
@@ -127,9 +127,9 @@ Access the frontends at
 - <http://localhost:9099/employee> – Frontend for the employee
 - <http://localhost:9099/employee/mobile> – Frontend for the employee mobile
 
-## Running tests inside docker-compose
+## Running tests inside docker compose
 
-To run tests inside `docker-compose` locally.
+To run tests inside `docker compose` locally.
 
 ```sh
 ./test-e2e build
@@ -193,9 +193,9 @@ docker inspect <container> | jq '.[] | .HostConfig.Binds[]'
 docker volume prune
 
 # or take down services and volumes altogether with
-docker-compose down -v
+docker compose down -v
 
-docker-compose build db
+docker compose build db
 ```
 
 ### Unable to start services correctly

--- a/compose/compose-e2e
+++ b/compose/compose-e2e
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 if [ "${BUILD:-true}" = "true" ] && ( [ "$1" = "up" ] || [ "$1" = "run" ] ); then
-    docker-compose -f docker-compose.yml -f docker-compose.e2e.yml build --parallel
+    docker compose -f docker-compose.yml -f docker-compose.e2e.yml build --parallel
 fi
 
-docker-compose -f docker-compose.yml -f docker-compose.e2e.yml $@
+docker compose -f docker-compose.yml -f docker-compose.e2e.yml $@
 

--- a/compose/compose-integration
+++ b/compose/compose-integration
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 if [ "${BUILD:-true}" = "true" ] && ( [ "$1" = "up" ] || [ "$1" = "run" ] ); then
-    docker-compose -f docker-compose.yml -f docker-compose.integration.yml build --parallel
+    docker compose -f docker-compose.yml -f docker-compose.integration.yml build --parallel
 fi
 
-docker-compose -f docker-compose.yml -f docker-compose.integration.yml $@
+docker compose -f docker-compose.yml -f docker-compose.integration.yml $@

--- a/compose/db.sh
+++ b/compose/db.sh
@@ -24,12 +24,12 @@ local_database=evaka_local
 mkdir -p ./backup
 
 if [ "$1" = "dump" ]; then
-  docker-compose -f docker-compose.yml -f docker-compose.dbdump.yml run dbdump pg_dump -Fc -h "$local_host" -p "$local_port" -U "$local_postgres_user" -f "$dump_remote_path" "$local_database"
+  docker compose -f docker-compose.yml -f docker-compose.dbdump.yml run dbdump pg_dump -Fc -h "$local_host" -p "$local_port" -U "$local_postgres_user" -f "$dump_remote_path" "$local_database"
   echo "Wrote dump to $dump_remote_path -> $dump_local_path"
 elif [ "$1" = "restore" ]; then
   date_string="$(date +%Y%m%d%H%M)"
 
-  docker-compose -f docker-compose.yml -f docker-compose.dbdump.yml run dbdump psql -h "$local_host" -U "$local_postgres_user" postgres <<EOSQL
+  docker compose -f docker-compose.yml -f docker-compose.dbdump.yml run dbdump psql -h "$local_host" -U "$local_postgres_user" postgres <<EOSQL
     SELECT
         pg_terminate_backend(pid)
     FROM
@@ -41,7 +41,7 @@ elif [ "$1" = "restore" ]; then
 EOSQL
 
   echo "Restoring"
-  docker-compose -f docker-compose.yml -f docker-compose.dbdump.yml run dbdump pg_restore \
+  docker compose -f docker-compose.yml -f docker-compose.dbdump.yml run dbdump pg_restore \
     -Fc \
     --verbose \
     --host="$local_host" \

--- a/compose/docker-compose.e2e.yml
+++ b/compose/docker-compose.e2e.yml
@@ -11,6 +11,8 @@ services:
     image: ${FRONTEND_IMAGE:-ghcr.io/espoon-voltti/evaka/frontend-common}:${TAG:-master}
     build:
       context: ../frontend/
+      additional_contexts: # requires docker-compose 2.17.0 or newer
+        customizations: ../frontend/src/lib-customizations/espoo
       cache_from:
         - ghcr.io/espoon-voltti/evaka/frontend-common:cache-${CACHE_TAG:-master}
         - ghcr.io/espoon-voltti/evaka/frontend-common:cache-master

--- a/compose/docker-compose.e2e.yml
+++ b/compose/docker-compose.e2e.yml
@@ -11,7 +11,7 @@ services:
     image: ${FRONTEND_IMAGE:-ghcr.io/espoon-voltti/evaka/frontend-common}:${TAG:-master}
     build:
       context: ../frontend/
-      additional_contexts: # requires docker-compose 2.17.0 or newer
+      additional_contexts: # requires docker compose 2.17.0 or newer
         customizations: ../frontend/src/lib-customizations/espoo
       cache_from:
         - ghcr.io/espoon-voltti/evaka/frontend-common:cache-${CACHE_TAG:-master}

--- a/compose/test-e2e
+++ b/compose/test-e2e
@@ -8,7 +8,7 @@ export UID="${UID:-$(id -u)}"
 export GID="${GID:-$(id -g)}"
 
 if [ "${BUILD:-true}" = "true" ] && ( [ "$1" = "up" ] || [ "$1" = "run" ] ); then
-    docker-compose -f docker-compose.yml -f docker-compose.e2e.yml build --parallel # not building playwright
+    docker compose -f docker-compose.yml -f docker-compose.e2e.yml build --parallel # not building playwright
 fi
 
-docker-compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.e2e-tests.yml $@
+docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.e2e-tests.yml $@

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -4,6 +4,7 @@
 
 *
 !src
+src/lib-customizations/espoo
 !packages
 !vendor
 !*.json

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,8 +21,8 @@ COPY ./package.json ./yarn.lock ./.yarnrc.yml ./
 RUN yarn install --immutable
 
 COPY . .
+COPY --from=customizations . src/lib-customizations/docker
 
-ARG EVAKA_CUSTOMIZATIONS=espoo
 ARG ICONS=free
 ARG SENTRY_PUBLISH_ENABLED="false"
 ARG SENTRY_AUTH_TOKEN=""
@@ -30,7 +30,6 @@ ARG SENTRY_ORG="espoon-voltti"
 ARG build=none
 ARG commit=none
 
-ENV EVAKA_CUSTOMIZATIONS="$EVAKA_CUSTOMIZATIONS"
 ENV ICONS="$ICONS"
 ENV SENTRY_PUBLISH_ENABLED="$SENTRY_PUBLISH_ENABLED"
 ENV SENTRY_ORG="$SENTRY_ORG"
@@ -40,6 +39,7 @@ ENV APP_BUILD="$build"
 ENV APP_COMMIT="$commit"
 
 RUN export NODE_OPTIONS="--max-old-space-size=4096" \
+ && export EVAKA_CUSTOMIZATIONS=docker \
  && yarn build
 
 FROM nginx:${NGINX_VERSION}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,7 +22,9 @@ COPY ./package.json ./yarn.lock ./.yarnrc.yml ./
 RUN yarn install --immutable
 
 COPY . .
-COPY --from=customizations . src/lib-customizations/docker
+
+ARG EVAKA_CUSTOMIZATIONS=espoo
+COPY --from=customizations . src/lib-customizations/${EVAKA_CUSTOMIZATIONS}
 
 ARG ICONS=free
 ARG SENTRY_PUBLISH_ENABLED="false"
@@ -31,6 +33,7 @@ ARG SENTRY_ORG="espoon-voltti"
 ARG build=none
 ARG commit=none
 
+ENV EVAKA_CUSTOMIZATIONS="$EVAKA_CUSTOMIZATIONS"
 ENV ICONS="$ICONS"
 ENV SENTRY_PUBLISH_ENABLED="$SENTRY_PUBLISH_ENABLED"
 ENV SENTRY_ORG="$SENTRY_ORG"
@@ -40,7 +43,6 @@ ENV APP_BUILD="$build"
 ENV APP_COMMIT="$commit"
 
 RUN export NODE_OPTIONS="--max-old-space-size=4096" \
- && export EVAKA_CUSTOMIZATIONS=docker \
  && yarn build
 
 FROM nginx:${NGINX_VERSION}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.6.0
 # SPDX-FileCopyrightText: 2017-2023 City of Espoo
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later

--- a/frontend/build-docker.sh
+++ b/frontend/build-docker.sh
@@ -13,11 +13,13 @@ if [ "${1:-}" = "test" ] || [ "${1:-}" = "builder" ]; then
         --target=builder \
         --build-arg build=0 \
         --build-arg commit="$(git rev-parse HEAD)" \
+        --build-context customizations=src/lib-customizations/espoo \
         -f Dockerfile .
 else
     docker build -t evaka/frontend \
         --build-arg build=0 \
         --build-arg commit="$(git rev-parse HEAD)" \
+        --build-context customizations=src/lib-customizations/espoo \
         -f Dockerfile .
 fi
 

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -8,17 +8,17 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 This project has Evaka [KeyCloak](https://www.keycloak.org/). Theme is based to [Helsinki KeyCloak Theme](https://github.com/City-of-Helsinki/helsinki-keycloak-theme).
 
-## docker-compose
+## docker compose
 
-#### Usage with Evaka docker-compose
+#### Usage with Evaka docker compose
 
-Evaka docker-compose already has KeyCloak. To develop KeyCloak theme replace it with compose found here.
+Evaka docker compose already has KeyCloak. To develop KeyCloak theme replace it with compose found here.
 
 ```bash
 cd ../compose
-docker-compose up -d
+docker compose up -d
 
-docker-compose stop keycloak smtp
+docker compose stop keycloak smtp
 
 cd ../keycloak
 ./compose-keycloak up

--- a/keycloak/compose-keycloak
+++ b/keycloak/compose-keycloak
@@ -15,7 +15,7 @@ if [ "$1" = "up" ]; then
     npm install
     npm run build
     cd -
-    docker-compose build
+    docker compose build
 fi
 
-docker-compose $@
+docker compose $@

--- a/service/README.md
+++ b/service/README.md
@@ -22,7 +22,7 @@ To build `./gradlew build`
 Start / setup dependencies with [compose](../compose/README.md):
 
 ```sh
-docker-compose up db sqs
+docker compose up db sqs
 ```
 
 ### Start evaka-service


### PR DESCRIPTION
#### Summary

To use `frontend/Dockerfile` we first need to copy frontend customization files to correct location and then use `docker build`. This changes Dockerfile so that we can provide customization files with just docker (which is great because we can just use `docker compose up` and everything works).

Downside to this (for Espoo) is that `docker build -t evaka/frontend` doesn't anymore work and requires additional command line parameter: `--build-context customizations=src/lib-customizations/espoo`. This can be fixed with high-level docker bake file, but I left that out of this commit because bake files aren't currently used.

Note: I think this requires a little change to `voltti-actions` but I don't have write access to it so here it goes:
```
diff --git a/docker-build-registry/action.yml b/docker-build-registry/action.yml
index 6143fcc..bb28892 100644
--- a/docker-build-registry/action.yml
+++ b/docker-build-registry/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Docker build-args. See docker/build-push-action build-args"
     required: false
     default: ""
+  build-contexts:
+    description: "Docker build-contexts. See docker/build-push-action build-contexts"
+    required: false
+    default: ""
   target:
     description: "Docker target"
     default: null
@@ -106,6 +110,7 @@ runs:
         target: ${{ inputs.target }}
         file: ${{ inputs.dockerfile }}
         build-args: ${{ inputs.build-args }}
+        build-contexts: ${{ inputs.build-contexts }}
         cache-from: |
           ${{ inputs.cache_from != '' && format('type=registry,ref={0}', inputs.cache_from) || '' }}
           ${{ format('type=registry,ref={0}', steps.image.outputs.cache) }}
```