### PR TITLE
Daily service times fixes

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
@@ -6,6 +6,7 @@ import orderBy from 'lodash/orderBy'
 import React, { useContext, useState } from 'react'
 
 import { ChildContext, ChildState } from 'employee-frontend/state/child'
+import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
@@ -113,6 +114,16 @@ export default React.memo(function DailyServiceTimesSection({
                 }
               }}
               childId={id}
+              hasActiveOrUpcomingServiceTimes={apiData
+                .map((rows) =>
+                  rows.some(
+                    (row) =>
+                      row.dailyServiceTimes.times.validityPeriod.end?.isAfter(
+                        LocalDate.todayInHelsinkiTz()
+                      ) ?? true
+                  )
+                )
+                .getOrElse(false)}
             />
           </>
         )}

--- a/frontend/src/employee-frontend/components/child-information/daily-service-times/DailyServiceTimesForms.tsx
+++ b/frontend/src/employee-frontend/components/child-information/daily-service-times/DailyServiceTimesForms.tsx
@@ -209,10 +209,15 @@ const emptyTimeRange: JsonOf<TimeRange> = {
 export interface CreateProps {
   onClose: (shouldRefresh: boolean) => void
   childId: UUID
+  hasActiveOrUpcomingServiceTimes: boolean
 }
 
 export const DailyServiceTimesCreationForm = React.memo(
-  function DailyServiceTimesCreationForm({ onClose, childId }: CreateProps) {
+  function DailyServiceTimesCreationForm({
+    onClose,
+    childId,
+    hasActiveOrUpcomingServiceTimes
+  }: CreateProps) {
     const { i18n, lang } = useTranslation()
 
     const [formData, setFormData] = useState<FormState>({
@@ -272,6 +277,13 @@ export const DailyServiceTimesCreationForm = React.memo(
             data-qa="daily-service-times-validity-period-start"
           />
         </div>
+        {hasActiveOrUpcomingServiceTimes && (
+          <AlertBox
+            message={
+              i18n.childInformation.dailyServiceTimes.preferExtensionWarning
+            }
+          />
+        )}
         <Gap size="m" />
         <div>
           <Label>

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -670,6 +670,8 @@ export const fi = {
       validFrom: 'Päivittäinen varhaiskasvatusaika voimassa alkaen',
       validUntil: 'Päivittäisen varhaiskasvatusajan voimassaolo päättyy',
       createNewTimes: 'Luo uusi päivittäinen varhaiskasvatusaika',
+      preferExtensionWarning:
+        'Kaikki voimassaolon alun jälkeiselle ajalle tehdyt läsnäoloilmoitukset poistetaan. Älä luo uutta varhaiskasvatusaikaa jos aika ei ole muuttunut aiemmasta varhaiskasvatusajasta.',
       deleteModal: {
         title: 'Poistetaanko varhaiskasvatusaika?',
         description:

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dailyservicetimes/DailyServiceTimesIntegrationTest.kt
@@ -151,7 +151,8 @@ class DailyServiceTimesIntegrationTest : FullApplicationTest(resetDbBeforeEach =
                 DevDailyServiceTimes(
                     id = past,
                     childId = testChild_2.id,
-                    validityPeriod = DateRange(now.toLocalDate().minusDays(1), now.toLocalDate())
+                    validityPeriod =
+                        DateRange(now.toLocalDate().minusDays(2), now.toLocalDate().minusDays(1))
                 )
             )
         }
@@ -420,10 +421,11 @@ class DailyServiceTimesIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
     @Test
     fun `updating a daily service times validity end creates a new notification`() {
+        val originalEnd = now.toLocalDate().plusDays(10)
         createDailyServiceTimes(
             testChild_1.id,
             DailyServiceTimesValue.RegularTimes(
-                validityPeriod = dailyServiceTimesValidity,
+                validityPeriod = DateRange(now.toLocalDate().plusDays(5), originalEnd),
                 regularTimes = tenToNoonRange
             )
         )
@@ -433,10 +435,11 @@ class DailyServiceTimesIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
         val times = this.getDailyServiceTimes(testChild_1.id)
         assertEquals(1, times.size)
-        setDailyServiceTimesEndDate(times[0].dailyServiceTimes.id, LocalDate.now().plusDays(102))
+        setDailyServiceTimesEndDate(times[0].dailyServiceTimes.id, originalEnd.plusDays(5))
 
         val newGuardian1Notifications = this.getDailyServiceTimeNotifications(guardian1)
         assertEquals(1, newGuardian1Notifications.size)
+        assertEquals(originalEnd.plusDays(1), newGuardian1Notifications[0].dateFrom)
         assertEquals(false, newGuardian1Notifications[0].hasDeletedReservations)
     }
 


### PR DESCRIPTION
#### Summary

-  show warning when creating new service times if already exists active or upcoming times
- when changing end date only remove reservations from the extension period