### PR TITLE
Use React.JSX instead of deprecated global JSX namespace

### DIFF
--- a/frontend/src/citizen-frontend/children/sections/vasu-and-leops/vasu/components/ValueOrNoRecord.tsx
+++ b/frontend/src/citizen-frontend/children/sections/vasu-and-leops/vasu/components/ValueOrNoRecord.tsx
@@ -22,7 +22,7 @@ export function ValueOrNoRecord({
   text,
   translations,
   dataQa = 'value-or-no-record'
-}: Props): JSX.Element {
+}: Props): React.JSX.Element {
   return (
     <PreFormattedText data-qa={dataQa}>
       {text || <Dimmed>{translations.noRecord}</Dimmed>}

--- a/frontend/src/employee-frontend/components/application-page/ApplicationStatusSection.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationStatusSection.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from '../../state/i18n'
 interface Props {
   application: ApplicationDetails
   decisions?: Decision[]
-  dueDateEditor?: JSX.Element
+  dueDateEditor?: React.JSX.Element
 }
 
 export default React.memo(function ApplicationStatusSection({

--- a/frontend/src/employee-frontend/components/common/Filters.tsx
+++ b/frontend/src/employee-frontend/components/common/Filters.tsx
@@ -68,9 +68,9 @@ interface Props {
   freeText?: string
   setFreeText?: (s: string) => void
   clearFilters: () => void
-  column1?: JSX.Element
-  column2?: JSX.Element
-  column3?: JSX.Element
+  column1?: React.JSX.Element
+  column2?: React.JSX.Element
+  column3?: React.JSX.Element
   searchPlaceholder?: string
   clearMargin?: number
 }

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -172,7 +172,11 @@ const appendMessageAndMoveThreadToTopOfList =
     })
 
 export const MessageContextProvider = React.memo(
-  function MessageContextProvider({ children }: { children: JSX.Element }) {
+  function MessageContextProvider({
+    children
+  }: {
+    children: React.JSX.Element
+  }) {
     const theme = useTheme()
     const { user } = useContext(UserContext)
     const { addNotification, removeNotification } =

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemHeader.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemHeader.tsx
@@ -47,7 +47,7 @@ interface Props {
   startEditing: () => void
   startDeleting: () => void
   permittedActions: Action.Income[]
-  children?: JSX.Element[] | JSX.Element
+  children?: React.JSX.Element[] | React.JSX.Element
 }
 
 const IncomeItemHeader = React.memo(function IncomeItemHeader({

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ReservationModalSingleChild.tsx
@@ -465,7 +465,7 @@ const TimeInputs = React.memo(function TimeInputs({
   bind,
   showAllErrors
 }: {
-  label: JSX.Element
+  label: React.JSX.Element
   bind: BoundForm<typeof times>
   showAllErrors: boolean
 }) {

--- a/frontend/src/employee-frontend/components/vasu/components/ValueOrNoRecord.tsx
+++ b/frontend/src/employee-frontend/components/vasu/components/ValueOrNoRecord.tsx
@@ -22,7 +22,7 @@ export function ValueOrNoRecord({
   text,
   translations,
   dataQa = 'value-or-no-record'
-}: Props): JSX.Element {
+}: Props): React.JSX.Element {
   return (
     <PreFormattedText data-qa={dataQa}>
       {text || <Dimmed>{translations.noRecord}</Dimmed>}

--- a/frontend/src/employee-frontend/state/application-ui.tsx
+++ b/frontend/src/employee-frontend/state/application-ui.tsx
@@ -115,7 +115,7 @@ export const ApplicationUIContextProvider = React.memo(
   function ApplicationUIContextProvider({
     children
   }: {
-    children: JSX.Element
+    children: React.JSX.Element
   }) {
     const { loggedIn } = useContext(UserContext)
 

--- a/frontend/src/employee-frontend/state/customers.tsx
+++ b/frontend/src/employee-frontend/state/customers.tsx
@@ -46,7 +46,11 @@ const defaultState: CustomersState = {
 export const CustomersContext = createContext<CustomersState>(defaultState)
 
 export const CustomersContextProvider = React.memo(
-  function CustomersContextProvider({ children }: { children: JSX.Element }) {
+  function CustomersContextProvider({
+    children
+  }: {
+    children: React.JSX.Element
+  }) {
     const [customers, setCustomers] = useState<Result<PersonSummary[]>>(
       defaultState.customers
     )

--- a/frontend/src/employee-frontend/state/i18n.tsx
+++ b/frontend/src/employee-frontend/state/i18n.tsx
@@ -24,7 +24,7 @@ export const I18nContext = createContext<I18nState>(defaultState)
 export const I18nContextProvider = React.memo(function I18nContextProvider({
   children
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [lang, setLang] = useState<Lang>('fi')
 

--- a/frontend/src/employee-frontend/state/invoicing-ui.tsx
+++ b/frontend/src/employee-frontend/state/invoicing-ui.tsx
@@ -245,7 +245,11 @@ const defaultState: UiState = {
 export const InvoicingUiContext = createContext<UiState>(defaultState)
 
 export const InvoicingUIContextProvider = React.memo(
-  function InvoicingUIContextProvider({ children }: { children: JSX.Element }) {
+  function InvoicingUIContextProvider({
+    children
+  }: {
+    children: React.JSX.Element
+  }) {
     const { loggedIn } = useContext(UserContext)
 
     const [feeDecisionSearchFilters, setFeeDecisionSearchFilters] =

--- a/frontend/src/employee-frontend/state/person.tsx
+++ b/frontend/src/employee-frontend/state/person.tsx
@@ -54,7 +54,7 @@ export const PersonContextProvider = React.memo(function PersonContextProvider({
   children
 }: {
   id: UUID
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [personResponse, setPersonResponse] = useState<Result<PersonResponse>>(
     Loading.of()

--- a/frontend/src/employee-frontend/state/title.tsx
+++ b/frontend/src/employee-frontend/state/title.tsx
@@ -21,7 +21,7 @@ export const TitleContext = createContext<TitleState>(defaultState)
 export const TitleContextProvider = React.memo(function TitleContextProvider({
   children
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const { i18n } = useTranslation()
 

--- a/frontend/src/employee-frontend/state/ui.tsx
+++ b/frontend/src/employee-frontend/state/ui.tsx
@@ -46,7 +46,7 @@ export const UIContext = createContext<UiState>(defaultState)
 export const UIContextProvider = React.memo(function UIContextProvider({
   children
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [uiMode, setUiMode] = useState<string>('')
   const [errorMessage, setErrorMessage] = useState<ErrorMessage | null>(null)

--- a/frontend/src/employee-frontend/state/unit.tsx
+++ b/frontend/src/employee-frontend/state/unit.tsx
@@ -46,7 +46,7 @@ export const UnitContextProvider = React.memo(function UnitContextProvider({
   children
 }: {
   id: UUID
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [filters, setFilters] = useState(defaultState.filters)
   const unitInformation = useQueryResult(unitQuery(id))

--- a/frontend/src/employee-frontend/state/units.tsx
+++ b/frontend/src/employee-frontend/state/units.tsx
@@ -41,7 +41,7 @@ export type SearchColumn = 'name' | 'area.name' | 'address' | 'type'
 export const UnitsContextProvider = React.memo(function UnitsContextProvider({
   children
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [filter, setFilter] = useState<string>(defaultState.filter)
   const [sortColumn, setSortColumn] = useState<string>(defaultState.sortColumn)

--- a/frontend/src/employee-frontend/state/user.tsx
+++ b/frontend/src/employee-frontend/state/user.tsx
@@ -26,7 +26,7 @@ export const UserContextProvider = React.memo(function UserContextProvider({
   roles,
   refreshAuthStatus
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
   user: User | undefined
   roles: AdRole[] | undefined
   refreshAuthStatus: () => void

--- a/frontend/src/employee-mobile-frontend/common/i18n.tsx
+++ b/frontend/src/employee-mobile-frontend/common/i18n.tsx
@@ -29,7 +29,7 @@ export const I18nContext = createContext<I18nState>(defaultState)
 export const I18nContextProvider = React.memo(function I18nContextProvider({
   children
 }: {
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [lang, setLang] = useState<Lang>('fi')
 

--- a/frontend/src/employee-mobile-frontend/common/service-worker.tsx
+++ b/frontend/src/employee-mobile-frontend/common/service-worker.tsx
@@ -32,7 +32,7 @@ export const ServiceWorkerContextProvider = React.memo(
   function ServiceWorkerContextProvider({
     children
   }: {
-    children: JSX.Element
+    children: React.JSX.Element
   }) {
     const user = useContext(UserContext).user.getOrElse(undefined)
 

--- a/frontend/src/employee-mobile-frontend/common/unit.tsx
+++ b/frontend/src/employee-mobile-frontend/common/unit.tsx
@@ -34,7 +34,7 @@ export const UnitContextProvider = React.memo(function UnitContextProvider({
   children
 }: {
   unitId: string
-  children: JSX.Element
+  children: React.JSX.Element
 }) {
   const [unitInfoResponse, reloadUnitInfo] = useApiState(
     () => getMobileUnitInfo(unitId),

--- a/frontend/src/employee-mobile-frontend/messages/state.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/state.tsx
@@ -84,7 +84,11 @@ const markMatchingThreadRead = (
   )
 
 export const MessageContextProvider = React.memo(
-  function MessageContextProvider({ children }: { children: JSX.Element }) {
+  function MessageContextProvider({
+    children
+  }: {
+    children: React.JSX.Element
+  }) {
     const { unitInfoResponse } = useContext(UnitContext)
 
     const { user } = useContext(UserContext)

--- a/frontend/src/lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly.tsx
+++ b/frontend/src/lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly.tsx
@@ -77,7 +77,7 @@ export interface AssistanceNeedDecisionTexts {
   confidential: string
   lawReference: string
   appealInstructionsTitle: string
-  appealInstructions: JSX.Element
+  appealInstructions: React.JSX.Element
   legalInstructions: string
   legalInstructionsText: string
   jurisdiction: string

--- a/frontend/src/lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly.tsx
+++ b/frontend/src/lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly.tsx
@@ -104,7 +104,7 @@ interface ViewTranslations {
   jurisdiction: string
   jurisdictionText: string
   appealInstructionsTitle: string
-  appealInstructions: JSX.Element
+  appealInstructions: React.JSX.Element
 }
 
 export default React.memo(function DecisionFormReadView({

--- a/frontend/src/lib-components/atoms/ExternalLink.tsx
+++ b/frontend/src/lib-components/atoms/ExternalLink.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import { faExternalLink } from 'lib-icons'
 
 type ExternalLinkProps = {
-  text: string | JSX.Element
+  text: string | React.JSX.Element
   href: string
   newTab?: boolean
   'data-qa'?: string

--- a/frontend/src/lib-components/atoms/InternalLink.tsx
+++ b/frontend/src/lib-components/atoms/InternalLink.tsx
@@ -13,7 +13,7 @@ import { Bold } from '../typography'
 interface Props {
   newTab: boolean
   to: string
-  text: string | JSX.Element
+  text: string | React.JSX.Element
 }
 
 export const InternalLink = React.memo(function InternalLink({

--- a/frontend/src/lib-components/molecules/Tabs.tsx
+++ b/frontend/src/lib-components/molecules/Tabs.tsx
@@ -15,7 +15,7 @@ import { defaultMargins } from '../white-space'
 interface Tab {
   id: string
   link: string
-  label: string | JSX.Element
+  label: string | React.JSX.Element
   counter?: number
 }
 

--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.spec.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.spec.tsx
@@ -5,7 +5,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
-import React, { cloneElement, JSX } from 'react'
+import React, { cloneElement } from 'react'
 
 import LocalDate from 'lib-common/local-date'
 
@@ -32,7 +32,7 @@ const translations: Translations = {
 
 describe('DatePicker', () => {
   describe('desktop', () => {
-    const jsx = (child: JSX.Element) => (
+    const jsx = (child: React.JSX.Element) => (
       <TestContextProvider translations={translations}>
         {child}
       </TestContextProvider>
@@ -114,7 +114,7 @@ describe('DatePicker', () => {
     })
   })
   describe('native datepicker (android)', () => {
-    const jsx = (child: JSX.Element) => (
+    const jsx = (child: React.JSX.Element) => (
       <TestContextProvider translations={translations}>
         <label htmlFor="datepicker">Date picker</label>
         {cloneElement(child, { id: 'datepicker', useBrowserPicker: true })}

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -855,9 +855,9 @@ export default {
             ),
             CLUB: null
           } as {
-            DAYCARE: JSX.Element | null
-            PRESCHOOL: JSX.Element | null
-            CLUB: JSX.Element | null
+            DAYCARE: React.JSX.Element | null
+            PRESCHOOL: React.JSX.Element | null
+            CLUB: React.JSX.Element | null
           },
           placeholder: 'Valitse aloituspäivä',
           validationText: 'Toivottu aloituspäivä: '
@@ -1061,9 +1061,9 @@ export default {
               </>
             )
           } as {
-            DAYCARE: JSX.Element | null
-            PRESCHOOL: JSX.Element | null
-            CLUB: JSX.Element | null
+            DAYCARE: React.JSX.Element | null
+            PRESCHOOL: React.JSX.Element | null
+            CLUB: React.JSX.Element | null
           },
           checkbox: {
             DAYCARE:

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -76,7 +76,7 @@ export interface CitizenCustomizations {
   langs: LangCitizen[]
   translations: Record<LangCitizen, DeepPartial<TranslationsCitizen>>
   cityLogo: ImgProps
-  footerLogo?: JSX.Element
+  footerLogo?: React.JSX.Element
   routeLinkRootUrl: string
   mapConfig: MapConfig
   featureFlags: FeatureFlags
@@ -243,7 +243,7 @@ interface BaseFeatureFlags {
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>
 
-type CityLogo = JSX.Element | ImgProps
+type CityLogo = React.JSX.Element | ImgProps
 
 export interface EmployeeCustomizations {
   appConfig: BaseAppConfig


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

