### PR TITLE
Add flags to employee message editor

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -21,6 +21,7 @@ import { useApiState } from 'lib-common/utils/useRestApi'
 import Container from 'lib-components/layout/Container'
 import MessageEditor from 'lib-components/messages/MessageEditor'
 import { defaultMargins } from 'lib-components/white-space'
+import { featureFlags } from 'lib-customizations/employee'
 
 import {
   deleteAttachment,
@@ -236,6 +237,7 @@ export default React.memo(function MessagesPage({
               saveMessageAttachment={saveMessageAttachment}
               sending={sending}
               defaultTitle={prefilledTitle ?? undefined}
+              sensitiveMessagingEnabled={featureFlags.sensitiveMessaging}
             />
           )}
       </PanelContainer>

--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -27,6 +27,7 @@ export interface Translations {
     saved: string
     search: string
     yes: string
+    openExpandingInfo: string
   }
   datePicker: {
     placeholder: string
@@ -97,10 +98,17 @@ export interface Translations {
       message: string
       bulletin: string
     }
-    urgent: {
+    flags: {
       heading: string
-      info: string
-      label: string
+      urgent: {
+        info: string
+        label: string
+      }
+      sensitive: {
+        info: string
+        label: string
+        whyDisabled: string
+      }
     }
     sender: string
     recipientsPlaceholder: string

--- a/frontend/src/lib-components/layout/flex-helpers.ts
+++ b/frontend/src/lib-components/layout/flex-helpers.ts
@@ -15,6 +15,7 @@ interface FixedSpaceRowProps {
   fullWidth?: boolean
   maxWidth?: string
   flexWrap?: Property.FlexWrap
+  zeroMarginLastChild?: boolean
 }
 export const FixedSpaceRow = styled.div<FixedSpaceRowProps>`
   display: flex;
@@ -31,9 +32,13 @@ export const FixedSpaceRow = styled.div<FixedSpaceRowProps>`
           ? defaultMargins[p.spacing]
           : p.spacing
         : defaultMargins.s};
-    &:last-child {
-      margin-right: 0;
-    }
+    ${(p) =>
+      p.zeroMarginLastChild &&
+      `
+      &:last-child {
+        margin-right: 0;
+      }
+    `}
     ${(p) => (p.maxWidth ? `max-width: ${p.maxWidth};` : '')};
   }
 
@@ -49,7 +54,9 @@ export const FixedSpaceRow = styled.div<FixedSpaceRowProps>`
     }
   }
 `
-
+FixedSpaceRow.defaultProps = {
+  zeroMarginLastChild: true
+}
 interface FixedSpaceColumnProps {
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   spacing?: SpacingSize | string

--- a/frontend/src/lib-components/layout/flex-helpers.ts
+++ b/frontend/src/lib-components/layout/flex-helpers.ts
@@ -15,7 +15,6 @@ interface FixedSpaceRowProps {
   fullWidth?: boolean
   maxWidth?: string
   flexWrap?: Property.FlexWrap
-  zeroMarginLastChild?: boolean
 }
 export const FixedSpaceRow = styled.div<FixedSpaceRowProps>`
   display: flex;
@@ -32,13 +31,9 @@ export const FixedSpaceRow = styled.div<FixedSpaceRowProps>`
           ? defaultMargins[p.spacing]
           : p.spacing
         : defaultMargins.s};
-    ${(p) =>
-      p.zeroMarginLastChild &&
-      `
-      &:last-child {
-        margin-right: 0;
-      }
-    `}
+    &:last-child {
+      margin-right: 0;
+    }
     ${(p) => (p.maxWidth ? `max-width: ${p.maxWidth};` : '')};
   }
 
@@ -54,9 +49,7 @@ export const FixedSpaceRow = styled.div<FixedSpaceRowProps>`
     }
   }
 `
-FixedSpaceRow.defaultProps = {
-  zeroMarginLastChild: true
-}
+
 interface FixedSpaceColumnProps {
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   spacing?: SpacingSize | string

--- a/frontend/src/lib-components/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageEditor.tsx
@@ -208,7 +208,7 @@ export default React.memo(function MessageEditor({
     senderAccountType
   )
 
-  const setSender = useCallback(
+  const handleSenderChange = useCallback(
     (sender: SelectOption | null) => {
       const shouldResetSensitivity = !shouldSensitiveCheckboxBeEnabled(
         selectedReceivers,
@@ -237,26 +237,25 @@ export default React.memo(function MessageEditor({
     },
     [availableReceivers, message.type, selectedReceivers, updateMessage]
   )
-  const updateReceivers = useCallback(
-    (receivers: SelectorNode[]) => {
-      setReceiverTree(receivers)
-      const selected = getSelected(receivers)
-      setMessage((old) => ({
-        ...old,
-        recipientIds: selected.map((s) => s.key),
-        recipientNames: selected.map((s) => s.text)
-      }))
+  const handleRecipientChange = useCallback(
+    (recipients: SelectorNode[]) => {
+      setReceiverTree(recipients)
+      const selected = getSelected(recipients)
 
       const shouldResetSensitivity = !shouldSensitiveCheckboxBeEnabled(
         selected,
         message.type,
         senderAccountType
       )
-      if (shouldResetSensitivity) {
-        updateMessage({ sensitive: false })
-      }
+
+      setMessage((old) => ({
+        ...old,
+        recipientIds: selected.map((s) => s.key),
+        recipientNames: selected.map((s) => s.text),
+        sensitive: shouldResetSensitivity ? false : old.sensitive
+      }))
     },
-    [message.type, senderAccountType, updateMessage]
+    [message.type, senderAccountType]
   )
 
   const [expandedView, setExpandedView] = useState(false)
@@ -487,7 +486,7 @@ export default React.memo(function MessageEditor({
                 <Bold>{i18n.messageEditor.sender}</Bold>
                 <Combobox
                   items={senderOptions}
-                  onChange={setSender}
+                  onChange={handleSenderChange}
                   selectedItem={message.sender}
                   getItemLabel={(sender) => sender.label}
                   data-qa="select-sender"
@@ -499,7 +498,7 @@ export default React.memo(function MessageEditor({
                 <Bold>{i18n.messages.recipients}</Bold>
                 <TreeDropdown
                   tree={receiverTree}
-                  onChange={updateReceivers}
+                  onChange={handleRecipientChange}
                   placeholder={i18n.messageEditor.recipientsPlaceholder}
                   data-qa="select-receiver"
                 />

--- a/frontend/src/lib-components/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageEditor.tsx
@@ -555,14 +555,12 @@ export default React.memo(function MessageEditor({
                 </HalfWidthColumn>
               </FixedSpaceRow>
               {sensitiveInfoOpen && !sensitiveCheckboxEnabled && (
-                <FixedSpaceRow fullWidth zeroMarginLastChild={false}>
-                  <ExpandingInfoBox
-                    width="auto"
-                    info={i18n.messageEditor.flags.sensitive.whyDisabled}
-                    close={onSensitiveInfoClick}
-                    closeLabel={i18n.common.close}
-                  />
-                </FixedSpaceRow>
+                <ExpandingInfoBox
+                  width="full"
+                  info={i18n.messageEditor.flags.sensitive.whyDisabled}
+                  close={onSensitiveInfoClick}
+                  closeLabel={i18n.common.close}
+                />
               )}
               {flagsInfo}
             </>

--- a/frontend/src/lib-components/messages/SelectorNode.ts
+++ b/frontend/src/lib-components/messages/SelectorNode.ts
@@ -56,7 +56,7 @@ const receiverAsSelectorNode = (receiver: MessageReceiver): SelectorNode => ({
       : []
 })
 
-type SelectedNode = {
+export type SelectedNode = {
   key: UUID
   text: string
   messageRecipient: MessageRecipient

--- a/frontend/src/lib-components/molecules/MessageBoxes.tsx
+++ b/frontend/src/lib-components/molecules/MessageBoxes.tsx
@@ -103,7 +103,7 @@ export const MessageBox = React.memo(function MessageBox({
 
 interface InfoBoxProps {
   title?: string
-  message?: string
+  message?: string | React.ReactNode
   icon?: IconProp
   wide?: boolean
   thin?: boolean

--- a/frontend/src/lib-components/utils/TestContextProvider.tsx
+++ b/frontend/src/lib-components/utils/TestContextProvider.tsx
@@ -27,7 +27,8 @@ export const testTranslations: Translations = {
     saved: '',
     saving: '',
     search: '',
-    yes: ''
+    yes: '',
+    openExpandingInfo: ''
   },
   datePicker: {
     placeholder: '',
@@ -102,10 +103,17 @@ export const testTranslations: Translations = {
       message: '',
       bulletin: ''
     },
-    urgent: {
+    flags: {
       heading: '',
-      info: '',
-      label: ''
+      urgent: {
+        info: '',
+        label: ''
+      },
+      sensitive: {
+        info: '',
+        label: '',
+        whyDisabled: ''
+      }
     },
     sender: '',
     recipientsPlaceholder: '',

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -22,7 +22,8 @@ const components: Translations = {
     saving: 'Saving',
     saved: 'Saved',
     search: 'Search',
-    yes: 'Yes'
+    yes: 'Yes',
+    openExpandingInfo: 'Open the details'
   },
   datePicker: {
     placeholder: 'dd.mm.yyyy',
@@ -118,10 +119,17 @@ const components: Translations = {
       message: '',
       bulletin: ''
     },
-    urgent: {
+    flags: {
       heading: '',
-      info: '',
-      label: ''
+      urgent: {
+        info: '',
+        label: ''
+      },
+      sensitive: {
+        info: '',
+        label: '',
+        whyDisabled: ''
+      }
     },
     sender: '',
     recipientsPlaceholder: '',

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -118,7 +118,7 @@ const components: Translations = {
       bulletin: 'Tiedote (ei voi vastata)'
     },
     flags: {
-      heading: 'Viestin lisämekinnät',
+      heading: 'Viestin lisämerkinnät',
       urgent: {
         info: 'Lähetä viesti kiireellisenä vain, jos haluat että huoltaja lukee sen työpäivän aikana.',
         label: 'Kiireellinen'

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -22,7 +22,8 @@ const components: Translations = {
     saving: 'Tallennetaan',
     saved: 'Tallennettu',
     search: 'Hae',
-    yes: 'Kyllä'
+    yes: 'Kyllä',
+    openExpandingInfo: 'Avaa lisätietokenttä'
   },
   datePicker: {
     placeholder: 'pp.kk.vvvv',
@@ -116,10 +117,18 @@ const components: Translations = {
       message: 'Viesti',
       bulletin: 'Tiedote (ei voi vastata)'
     },
-    urgent: {
-      heading: 'Merkitse kiireelliseksi',
-      info: 'Lähetä viesti kiireellisenä vain, jos haluat että huoltaja lukee sen työpäivän aikana.',
-      label: 'Kiireellinen'
+    flags: {
+      heading: 'Viestin lisämekinnät',
+      urgent: {
+        info: 'Lähetä viesti kiireellisenä vain, jos haluat että huoltaja lukee sen työpäivän aikana.',
+        label: 'Kiireellinen'
+      },
+      sensitive: {
+        info: 'Arkaluontoisen viestin avaaminen vaatii kuntalaiselta vahvan tunnistautumisen.',
+        label: 'Arkaluontoinen',
+        whyDisabled:
+          'Arkaluontoisen viestin voi lähettää vain normaalina viestinä yksittäisen lapsen huoltajille henkilökohtaisesta lähettäjätilistä.'
+      }
     },
     sender: 'Lähettäjä',
     recipientsPlaceholder: 'Valitse...',

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -22,7 +22,8 @@ const components: Translations = {
     saving: 'Sparar',
     saved: 'Sparad',
     search: 'Sök',
-    yes: 'Ja'
+    yes: 'Ja',
+    openExpandingInfo: 'Öppna detaljer'
   },
   datePicker: {
     placeholder: 'dd.mm.åååå',
@@ -118,10 +119,17 @@ const components: Translations = {
       message: '',
       bulletin: ''
     },
-    urgent: {
+    flags: {
       heading: '',
-      info: '',
-      label: ''
+      urgent: {
+        info: '',
+        label: ''
+      },
+      sensitive: {
+        info: '',
+        label: '',
+        whyDisabled: ''
+      }
     },
     sender: '',
     recipientsPlaceholder: '',

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -43,7 +43,7 @@ const features: Features = {
     feeDecisionIgnoredStatus: true,
     hojks: true,
     employeeMobileGroupMessages: true,
-    sensitiveMessaging: false
+    sensitiveMessaging: true
   },
   staging: {
     citizenShiftCareAbsence: true,
@@ -74,7 +74,8 @@ const features: Features = {
     assistanceNeedPreschoolDecisions: true,
     feeDecisionIgnoredStatus: true,
     hojks: true,
-    employeeMobileGroupMessages: true
+    employeeMobileGroupMessages: true,
+    sensitiveMessaging: false
   },
   prod: {
     citizenShiftCareAbsence: true,
@@ -104,7 +105,8 @@ const features: Features = {
     childDocuments: false,
     feeDecisionIgnoredStatus: true,
     hojks: false,
-    employeeMobileGroupMessages: false
+    employeeMobileGroupMessages: false,
+    sensitiveMessaging: false
   }
 }
 

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -42,7 +42,8 @@ const features: Features = {
     assistanceNeedPreschoolDecisions: true,
     feeDecisionIgnoredStatus: true,
     hojks: true,
-    employeeMobileGroupMessages: true
+    employeeMobileGroupMessages: true,
+    sensitiveMessaging: false
   },
   staging: {
     citizenShiftCareAbsence: true,

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -244,6 +244,12 @@ interface BaseFeatureFlags {
    * EXPERIMENTAL: Enable sending messages to groups or multiple children in employee mobile
    */
   employeeMobileGroupMessages?: boolean
+
+  /**
+   * EXPERIMENTAL: Enable sending messages with sensitive flag. Sensitive messages
+   * require strong authentication from citizens in order to display the message content
+   */
+  sensitiveMessaging?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>


### PR DESCRIPTION
## Before this change
It was not possible to send message threads marked as sensitive.
## After this change
Employee front-end gains support for sending message threads marked as sensitive. This feature (displaying the sensitivity checkbox) is behind a feature flag `sensitiveMessaging` which is set false in all Espoo production and staging environments, but defaults to true in order to have it enabled during localhost development.
![sensitive messaging](https://github.com/espoon-voltti/evaka/assets/886091/c4e1ddce-d940-4910-b4fa-b1e05908960e)
