### PR TITLE
Make notification count component dynamic width, fixes #4207

### DIFF
--- a/frontend/src/citizen-frontend/navigation/shared-components.tsx
+++ b/frontend/src/citizen-frontend/navigation/shared-components.tsx
@@ -23,16 +23,14 @@ import { fasChevronDown, fasChevronUp } from 'lib-icons'
 export const CircledChar = styled.div.attrs({
   className: 'circled-char'
 })`
-  width: ${defaultMargins.s};
-  height: ${defaultMargins.s};
+  height: ${defaultMargins.m};
   border: 1px solid ${colors.grayscale.g100};
-  padding: 11px;
+  padding: 0 5px;
   display: flex;
   justify-content: center;
   align-items: center;
-  text-align: center;
-  border-radius: 100%;
-  letter-spacing: 0;
+  border-radius: 12px;
+  min-width: ${defaultMargins.m};
 `
 
 const dropDownButtonStyles = css`


### PR DESCRIPTION
## Before this change
Notification count display was broken when count number was 3 or more digits long.
<img width="561" alt="image" src="https://github.com/espoon-voltti/evaka/assets/886091/af4eead4-0659-4fc0-abd4-a71195fef662">

## After this change
Notification count display works OK with 3+ digit numbers
![image](https://github.com/espoon-voltti/evaka/assets/886091/0741d6d6-1ee7-4cdf-a6a9-57f591056fe1)

