### PR TITLE
Message undo optimization

### DIFF
--- a/frontend/src/employee-frontend/components/messages/UndoMessageNotification.tsx
+++ b/frontend/src/employee-frontend/components/messages/UndoMessageNotification.tsx
@@ -27,6 +27,7 @@ export const UndoMessage = React.memo(function UndoMessageToast({
   const [secondsLeft, setSecondsLeft] = useState<number>(() =>
     getSecondsLeft(message.sentAt)
   )
+  const [cancelling, setCancelling] = useState(false)
 
   const cancelMessage = useCallback(() => {
     if (!message) {
@@ -38,15 +39,18 @@ export const UndoMessage = React.memo(function UndoMessageToast({
         ? undoMessage(message.accountId, message.contentId)
         : undoMessageReply(message.accountId, message.messageId)
 
-    void request.then((result) => {
-      if (result.isSuccess) {
-        close()
-        refreshMessages(message.accountId)
-        if ('contentId' in message) {
-          selectThread(undefined)
+    setCancelling(true)
+    void request
+      .then((result) => {
+        if (result.isSuccess) {
+          close()
+          refreshMessages(message.accountId)
+          if ('contentId' in message) {
+            selectThread(undefined)
+          }
         }
-      }
-    })
+      })
+      .finally(() => setCancelling(false))
   }, [close, message, refreshMessages, selectThread])
 
   useEffect(() => {
@@ -66,6 +70,7 @@ export const UndoMessage = React.memo(function UndoMessageToast({
           secondsLeft
         )})`}
         onClick={cancelMessage}
+        disabled={cancelling}
         data-qa="cancel-message"
       />
     </FixedSpaceColumn>

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -234,12 +234,7 @@ class MessageNotificationEmailServiceIntegrationTest :
 
         assertTrue(MockEmailClient.emails.isEmpty())
 
-        // orphan threads are deleted with a scheduled job
-        assertEquals(
-            1,
-            db.read { it.createQuery("SELECT count(*) FROM message_thread").exactlyOne<Int>() }
-        )
-        scheduledJobs.removeOrphanMessageThreads(db, clock)
+        // threads are also deleted
         assertEquals(
             0,
             db.read { it.createQuery("SELECT count(*) FROM message_thread").exactlyOne<Int>() }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailServiceIntegrationTest.kt
@@ -29,6 +29,7 @@ import fi.espoo.evaka.shared.dev.insertTestPerson
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.shared.job.ScheduledJobs
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import fi.espoo.evaka.testChild_1
@@ -47,6 +48,7 @@ class MessageNotificationEmailServiceIntegrationTest :
     @Autowired lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
     @Autowired lateinit var accessControl: AccessControl
     @Autowired lateinit var messageController: MessageController
+    @Autowired lateinit var scheduledJobs: ScheduledJobs
 
     private val testPersonFi = DevPerson(email = "fi@example.com", language = "fi")
     private val testPersonSv = DevPerson(email = "sv@example.com", language = "sv")
@@ -231,6 +233,17 @@ class MessageNotificationEmailServiceIntegrationTest :
         )
 
         assertTrue(MockEmailClient.emails.isEmpty())
+
+        // orphan threads are deleted with a scheduled job
+        assertEquals(
+            1,
+            db.read { it.createQuery("SELECT count(*) FROM message_thread").exactlyOne<Int>() }
+        )
+        scheduledJobs.removeOrphanMessageThreads(db, clock)
+        assertEquals(
+            0,
+            db.read { it.createQuery("SELECT count(*) FROM message_thread").exactlyOne<Int>() }
+        )
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/ApplicationNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/ApplicationNoteQueries.kt
@@ -125,12 +125,3 @@ fun Database.Transaction.deleteApplicationNote(id: ApplicationNoteId) {
 
     createUpdate(sql).bind("id", id).execute()
 }
-
-fun Database.Transaction.deleteApplicationNotesLinkedToMessages(
-    messageContentIds: Set<MessageContentId>
-) {
-    // language=SQL
-    val sql = "DELETE FROM application_note WHERE message_content_id = ANY(:messageContentIds)"
-
-    createUpdate(sql).bind("messageContentIds", messageContentIds).execute()
-}

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -566,7 +566,7 @@ class MessageController(
     ): MessageDraftId {
         return db.connect { dbc ->
                 requireMessageAccountAccess(dbc, user, clock, accountId)
-                dbc.transaction { it.undoMessageAndAllThreads(clock.now(), accountId, contentId) }
+                dbc.transaction { it.undoNewMessages(clock.now(), accountId, contentId) }
             }
             .also { Audit.MessagingUndoMessage.log(targetId = contentId) }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -1524,15 +1524,10 @@ fun Database.Transaction.deleteMessages(contentId: MessageContentId) {
     this.createUpdate<Any> {
             sql(
                 """
-            DELETE FROM message_thread
-            WHERE id IN (
-                SELECT mt.id
-                FROM message_thread mt
-                JOIN message m on mt.id = m.thread_id
-                WHERE m.content_id = ${bind(contentId)}
-                FOR UPDATE 
-            )
-        """
+                DELETE FROM message_thread mt
+                USING message m
+                WHERE mt.id = m.thread_id AND m.content_id = ${bind(contentId)}
+            """
             )
         }
         .execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -4,7 +4,6 @@
 
 package fi.espoo.evaka.messaging
 
-import fi.espoo.evaka.application.notes.deleteApplicationNotesLinkedToMessages
 import fi.espoo.evaka.attachment.MessageAttachment
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AreaId
@@ -1429,13 +1428,10 @@ fun Database.Read.getArchiveFolderId(accountId: MessageAccountId): MessageThread
         .bind("accountId", accountId)
         .exactlyOneOrNull<MessageThreadFolderId>()
 
-data class MessageToUndo(
-    val created: HelsinkiDateTime,
-    val messageId: MessageId,
+data class UndoReplyTarget(
     val contentId: MessageContentId,
     val threadId: MessageThreadId,
-    val senderId: MessageAccountId,
-    val onlyMessageInThread: Boolean
+    val messageCreated: HelsinkiDateTime
 )
 
 fun Database.Transaction.undoMessageReply(
@@ -1443,109 +1439,91 @@ fun Database.Transaction.undoMessageReply(
     accountId: MessageAccountId,
     messageId: MessageId
 ) {
-    val messageToUndo =
-        this.createQuery(
-                """
-SELECT created, id AS message_id, content_id, thread_id, sender_id, FALSE AS only_message_in_thread
-FROM message WHERE sender_id = :accountId AND id = :messageId
-"""
-            )
-            .bind("accountId", accountId)
-            .bind("messageId", messageId)
-            .exactlyOneOrNull<MessageToUndo>()
-            ?: throw BadRequest("No message found with messageId $messageId")
+    val undoTarget =
+        createQuery<Any> {
+                sql(
+                    """
+            SELECT content_id, thread_id, created AS message_created
+            FROM message 
+            WHERE id = ${bind(messageId)} AND sender_id = ${bind(accountId)}
+        """
+                )
+            }
+            .exactlyOneOrNull<UndoReplyTarget>()
+            ?: throw BadRequest("No message found with messageId $messageId for account $accountId")
 
-    if (messageToUndo.created.plusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS).isBefore(now)) {
+    if (undoTarget.messageCreated.plusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS).isBefore(now)) {
         throw BadRequest(
             "Messages older than $MESSAGE_UNDO_WINDOW_IN_SECONDS seconds cannot be undone"
         )
     }
 
-    this.deleteApplicationNotesLinkedToMessages(listOf(messageToUndo.contentId).toSet())
-    this.deleteMessages(listOf(messageToUndo))
-    this.resetSenderThreadParticipants(messageToUndo.threadId, messageToUndo.senderId)
+    this.deleteMessages(undoTarget.contentId)
+    this.resetSenderThreadParticipants(undoTarget.threadId, accountId)
 }
 
-fun Database.Transaction.undoMessageAndAllThreads(
+fun Database.Transaction.undoNewMessages(
     now: HelsinkiDateTime,
     accountId: MessageAccountId,
     contentId: MessageContentId
 ): MessageDraftId {
-    val messagesToUndo =
-        this.createQuery(
+    this.createQuery<Any> {
+            sql(
                 """
-SELECT m.created, m.id AS message_id, m.content_id, m.thread_id, m.sender_id,
-    NOT EXISTS (SELECT 1 FROM message m2 WHERE m.thread_id = m2.thread_id AND m2.content_id != :contentId) AS only_message_in_thread
-FROM message m
-WHERE sender_id = :accountId AND content_id = :contentId
-"""
+            SELECT created
+            FROM message m
+            WHERE sender_id = ${bind(accountId)} AND content_id = ${bind(contentId)}
+            LIMIT 1 -- created should be essentially same for each
+        """
             )
-            .bind("accountId", accountId)
-            .bind("contentId", contentId)
-            .toList<MessageToUndo>()
-
-    if (messagesToUndo.isEmpty()) {
-        throw BadRequest("No messages found with contentId $contentId")
-    }
-
-    if (
-        messagesToUndo.any { it.created.plusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS).isBefore(now) }
-    ) {
-        throw BadRequest(
-            "Messages older than $MESSAGE_UNDO_WINDOW_IN_SECONDS seconds cannot be undone"
-        )
-    }
-
-    if (messagesToUndo.any { !it.onlyMessageInThread }) {
-        throw BadRequest("Cannot undo message threads that have replies")
-    }
+        }
+        .exactlyOneOrNull<HelsinkiDateTime>()
+        ?.also { created ->
+            if (created.plusSeconds(MESSAGE_UNDO_WINDOW_IN_SECONDS).isBefore(now)) {
+                throw BadRequest(
+                    "Messages older than $MESSAGE_UNDO_WINDOW_IN_SECONDS seconds cannot be undone"
+                )
+            }
+        }
+        ?: throw BadRequest("No messages found with contentId $contentId")
 
     val draftContent =
         this.createQuery(
                 """
-SELECT DISTINCT t.title, t.message_type AS type, t.urgent, t.sensitive, c.content, '{}'::text[] AS recipient_ids, '{}'::text[] AS recipient_names
+SELECT t.title, t.message_type AS type, t.urgent, t.sensitive, c.content, '{}'::text[] AS recipient_ids, '{}'::text[] AS recipient_names
 FROM message_content c
 JOIN message m ON c.id = m.content_id
 JOIN message_thread t ON m.thread_id = t.id
 WHERE c.id = :contentId
+LIMIT 1 -- all threads with same content are identical in regards to this query
 """
             )
             .bind("contentId", contentId)
-            .exactlyOneOrNull<UpdatableDraftContent>()
-            ?: error("Multiple draft contents found")
+            .exactlyOne<UpdatableDraftContent>()
 
-    this.deleteApplicationNotesLinkedToMessages(messagesToUndo.map { it.contentId }.toSet())
-    this.deleteMessages(messagesToUndo)
+    this.deleteMessages(contentId)
 
     val draftId = this.initDraft(accountId)
     this.updateDraft(accountId, draftId, draftContent)
     return draftId
 }
 
-fun Database.Transaction.deleteMessages(messages: List<MessageToUndo>) {
-    this.createUpdate(
-            """
-WITH deleted_message AS (
-    DELETE FROM message WHERE id = ANY(:messageIds)
-), deleted_recipients AS (
-    DELETE FROM message_recipients WHERE message_id = ANY(:messageIds)
-), deleted_thread AS (
-    DELETE FROM message_thread WHERE id = ANY(:threadIds)
-), deleted_thread_children AS (
-    DELETE FROM message_thread_children WHERE thread_id = ANY(:threadIds)
-), deleted_attachment AS (
-    DELETE FROM attachment WHERE message_content_id = ANY(:contentIds)
-)
-DELETE FROM message_content WHERE id = ANY(:contentIds)
-"""
-        )
-        .bind("messageIds", messages.map { it.messageId }.distinct())
-        .bind(
-            "threadIds",
-            messages.filter { it.onlyMessageInThread }.map { it.threadId }.distinct()
-        )
-        .bind("contentIds", messages.map { it.contentId }.distinct())
+fun Database.Transaction.deleteMessages(contentId: MessageContentId) {
+    this.createUpdate<Any> {
+            sql("DELETE FROM application_note WHERE message_content_id = ${bind(contentId)}")
+        }
         .execute()
+
+    this.createUpdate<Any> {
+            sql("DELETE FROM attachment WHERE message_content_id = ${bind(contentId)}")
+        }
+        .execute()
+
+    // cascade deletes from message and message_recipients
+    this.createUpdate<Any> { sql("DELETE FROM message_content WHERE id = ${bind(contentId)}") }
+        .execute()
+
+    // this will leave orphan message_threads which will be cleaned separately
 }
 
 fun Database.Transaction.resetSenderThreadParticipants(

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
@@ -45,6 +45,7 @@ class MessageService(
         msg: AsyncJob.MarkMessagesAsSent
     ) {
         db.transaction { tx ->
+            tx.lockMessageContentForUpdate(msg.messageContentId)
             val sender = tx.getMessageAuthor(msg.messageContentId) ?: return@transaction
             tx.upsertReceiverThreadParticipants(msg.messageContentId, msg.sentAt)
             val messages = tx.markMessagesAsSent(msg.messageContentId, msg.sentAt)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -94,10 +94,6 @@ enum class ScheduledJob(
         ScheduledJobs::removeOldDraftApplications,
         ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(0, 30)))
     ),
-    RemoveOrphanMessageThreads(
-        ScheduledJobs::removeOrphanMessageThreads,
-        ScheduledJobSettings(enabled = true, schedule = JobSchedule.daily(LocalTime.of(4, 30)))
-    ),
     SendPendingDecisionReminderEmails(
         ScheduledJobs::sendPendingDecisionReminderEmails,
         ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(7, 0)))
@@ -278,20 +274,6 @@ WHERE id IN (SELECT id FROM attendances_to_end)
 
     fun removeOldAsyncJobs(db: Database.Connection, clock: EvakaClock) {
         db.removeOldAsyncJobs(clock.now())
-    }
-
-    fun removeOrphanMessageThreads(db: Database.Connection, clock: EvakaClock) {
-        db.transaction { tx ->
-            tx.createUpdate(
-                    """
-                    DELETE FROM message_thread
-                    WHERE NOT EXISTS(
-                        SELECT 1 FROM message WHERE thread_id = message_thread.id
-                    )
-                """
-                )
-                .execute()
-        }
     }
 
     fun inactivePeopleCleanup(db: Database.Connection, clock: EvakaClock) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -94,6 +94,10 @@ enum class ScheduledJob(
         ScheduledJobs::removeOldDraftApplications,
         ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(0, 30)))
     ),
+    RemoveOrphanMessageThreads(
+        ScheduledJobs::removeOrphanMessageThreads,
+        ScheduledJobSettings(enabled = true, schedule = JobSchedule.daily(LocalTime.of(4, 30)))
+    ),
     SendPendingDecisionReminderEmails(
         ScheduledJobs::sendPendingDecisionReminderEmails,
         ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(7, 0)))
@@ -274,6 +278,20 @@ WHERE id IN (SELECT id FROM attendances_to_end)
 
     fun removeOldAsyncJobs(db: Database.Connection, clock: EvakaClock) {
         db.removeOldAsyncJobs(clock.now())
+    }
+
+    fun removeOrphanMessageThreads(db: Database.Connection, clock: EvakaClock) {
+        db.transaction { tx ->
+            tx.createUpdate(
+                    """
+                    DELETE FROM message_thread
+                    WHERE NOT EXISTS(
+                        SELECT 1 FROM message WHERE thread_id = message_thread.id
+                    )
+                """
+                )
+                .execute()
+        }
     }
 
     fun inactivePeopleCleanup(db: Database.Connection, clock: EvakaClock) {

--- a/service/src/main/resources/db/migration/V366__message_delete_cascades.sql
+++ b/service/src/main/resources/db/migration/V366__message_delete_cascades.sql
@@ -1,0 +1,17 @@
+ALTER TABLE message
+    DROP CONSTRAINT message_thread_id_fkey,
+    ADD CONSTRAINT message_thread_id_fkey
+        FOREIGN KEY (thread_id) REFERENCES message_thread(id) ON DELETE CASCADE,
+    DROP CONSTRAINT message_content_id_fkey,
+    ADD CONSTRAINT message_content_id_fkey
+        FOREIGN KEY (content_id) REFERENCES message_content(id) ON DELETE CASCADE;
+
+ALTER TABLE message_recipients
+    DROP CONSTRAINT message_recipients_message_id_fkey,
+    ADD CONSTRAINT message_recipients_message_id_fkey
+        FOREIGN KEY (message_id) REFERENCES message(id) ON DELETE CASCADE;
+
+ALTER TABLE message_thread_children
+    DROP CONSTRAINT message_thread_children_thread_id_fkey,
+    ADD CONSTRAINT message_thread_children_thread_id_fkey
+        FOREIGN KEY (thread_id) REFERENCES message_thread(id) ON DELETE CASCADE;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -362,3 +362,4 @@ V362__drop_temporary_fee_decision_v2_tables.sql
 V363__message_thread_sensitivity_flag.sql
 V364__koski_model_updates.sql
 V365__employee_active.sql
+V366__message_delete_cascades.sql


### PR DESCRIPTION
#### Summary

- Add `on delete cascade`s to simplify deletion and possibly improve performance
- Avoid fetching a long list of IDs and then later deleting based on passing it back
- Introduce assumptions to improve performance (e.g. `limit 1` vs `distinct`)