### PR TITLE
Fix a bug in the voucher value decision report

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ServiceVoucherValueReport.kt
@@ -289,7 +289,7 @@ WITH min_voucher_decision_date AS (
     JOIN voucher_value_report_decision sn_decision ON sn_decision.realized_period && p.period
     JOIN voucher_value_decision decision on decision.id = sn_decision.decision_id
     WHERE lower(p.period) < :reportDate
-        AND decision.status = ANY(:effective::voucher_value_decision_status[])
+        AND (decision.status = ANY(:effective::voucher_value_decision_status[]) OR decision.status = 'ANNULLED')
         AND decision.validity_updated_at > (SELECT coalesce(max(taken_at), '-infinity'::timestamptz) FROM voucher_value_report_snapshot)
         AND (daterange(decision.valid_from, decision.valid_to, '[]') * p.period) <> sn_decision.realized_period
 


### PR DESCRIPTION
When a voucher value decision's validity has been first reduced, and then it's completely annulled later in the same month, the period for which the decision's validity was reduced would not be refunded properly. Fix the "validity updated after last freeze" check to also include annulled decisions. It should be safe to do so, since we know that that the validity can't be changed after the decision has been annulled, so the annulment must have happened after the validity update, which has happened after the last freeze, and thus the annulled decision is in scope for corrections

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

