### PR TITLE
Reduce unread messages count queries

### DIFF
--- a/frontend/src/employee-mobile-frontend/common/BottomNavbar.tsx
+++ b/frontend/src/employee-mobile-frontend/common/BottomNavbar.tsx
@@ -108,7 +108,9 @@ export default function BottomNavbar({ selected }: BottomNavbarProps) {
 
   const { unitInfoResponse } = useContext(UnitContext)
   const { user } = useContext(UserContext)
-  const { data: unreadCounts = [] } = useQuery(unreadCountsQuery(unitId))
+  const { data: unreadCounts = [] } = useQuery(unreadCountsQuery(unitId), {
+    refetchOnMount: false
+  })
   const { groupAccounts } = useContext(MessageContext)
 
   const groupAccountIds = groupAccounts.map(({ account }) => account.id)


### PR DESCRIPTION
#### Summary

Bottom navbar is often unmounted and mounted again when browsing through different mobile views. Don't refresh the unread messages count on every mount, just when the window gains focus (i.e. eVaka is "opened").
