### PR TITLE
Sensitive messages citizen views

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -20,6 +20,7 @@ import { defaultMargins, Gap } from 'lib-components/white-space'
 
 import EmptyThreadView from './EmptyThreadView'
 import MessageEditor from './MessageEditor'
+import RedactedThreadView from './RedactedThreadView'
 import ThreadList from './ThreadList'
 import ThreadView from './ThreadView'
 import { receiversQuery, sendMessageMutation } from './queries'
@@ -105,12 +106,17 @@ export default React.memo(function MessagesPage() {
                 newMessageButtonEnabled={canSendNewMessage}
               />
               {selectedThread ? (
-                isRegularThread(selectedThread) && (
+                isRegularThread(selectedThread) ? (
                   <ThreadView
                     accountId={id}
                     closeThread={() => selectThread(undefined)}
                     thread={selectedThread}
                     onThreadDeleted={() => onSelectedThreadDeleted()}
+                  />
+                ) : (
+                  <RedactedThreadView
+                    thread={selectedThread}
+                    closeThread={() => selectThread(undefined)}
                   />
                 )
               ) : (

--- a/frontend/src/citizen-frontend/messages/RedactedThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/RedactedThreadView.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { CitizenMessageThread } from 'lib-common/generated/api-types/messaging'
+import { FixedSpaceFlexWrap } from 'lib-components/layout/flex-helpers'
+import { MessageCharacteristics } from 'lib-components/messages/MessageCharacteristics'
+import { ThreadContainer } from 'lib-components/messages/ThreadListItem'
+import { ScreenReaderButton } from 'lib-components/molecules/ScreenReaderButton'
+import { H2 } from 'lib-components/typography'
+import { defaultMargins, Gap } from 'lib-components/white-space'
+import colors from 'lib-customizations/common'
+
+import { useTranslation } from '../localization'
+import { getStrongLoginUri } from '../navigation/const'
+
+import { ThreadTitleRow } from './ThreadView'
+
+const RedactedThreadInfo = styled.div`
+  background-color: ${colors.grayscale.g0};
+  margin: ${defaultMargins.xxs};
+  padding: ${defaultMargins.L};
+`
+interface Props {
+  thread: CitizenMessageThread.Redacted
+  closeThread: () => void
+}
+export default React.memo(function ThreadView({
+  thread: { urgent },
+  closeThread
+}: Props) {
+  const i18n = useTranslation()
+
+  const returnUrl = `${location.pathname}${location.search}${location.hash}`
+
+  return (
+    <ThreadContainer data-qa="thread-reader">
+      <ThreadTitleRow>
+        <FixedSpaceFlexWrap>
+          <MessageCharacteristics
+            type="MESSAGE"
+            urgent={urgent}
+            sensitive={true}
+          />
+        </FixedSpaceFlexWrap>
+        <H2 noMargin data-qa="thread-reader-title">
+          {i18n.messages.sensitive}
+        </H2>
+      </ThreadTitleRow>
+      <Gap size="s" />
+      <RedactedThreadInfo>
+        <p>
+          {i18n.messages.strongAuthRequiredThread}{' '}
+          <a href={getStrongLoginUri(returnUrl)}>
+            {i18n.messages.strongAuthLink}
+          </a>
+        </p>
+      </RedactedThreadInfo>
+      <ScreenReaderButton
+        onClick={closeThread}
+        text={i18n.messages.thread.close}
+      />
+    </ThreadContainer>
+  )
+})

--- a/frontend/src/citizen-frontend/messages/RedactedThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/RedactedThreadView.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 import React from 'react'
 import styled from 'styled-components'
 
@@ -42,7 +46,7 @@ export default React.memo(function ThreadView({
             sensitive={true}
           />
         </FixedSpaceFlexWrap>
-        <H2 noMargin data-qa="thread-reader-title">
+        <H2 noMargin data-qa="redacted-thread-reader-title">
           {i18n.messages.sensitive}
         </H2>
       </ThreadTitleRow>
@@ -50,7 +54,7 @@ export default React.memo(function ThreadView({
       <RedactedThreadInfo>
         <p>
           {i18n.messages.strongAuthRequiredThread}{' '}
-          <a href={getStrongLoginUri(returnUrl)}>
+          <a href={getStrongLoginUri(returnUrl)} data-qa="strong-auth-link">
             {i18n.messages.strongAuthLink}
           </a>
         </p>

--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -90,17 +90,18 @@ export default React.memo(function ThreadListItem({
             {participants}
           </Truncated>
           <FixedSpaceRow>
-            <DeleteThreadButton
-              aria-label={i18n.common.delete}
-              data-qa="delete-thread-btn"
-              onClick={handleDelete}
-            />
             {isRegularThread(thread) && (
-              <MessageCharacteristics
-                type={thread.messageType}
-                urgent={thread.urgent}
+              <DeleteThreadButton
+                aria-label={i18n.common.delete}
+                data-qa="delete-thread-btn"
+                onClick={handleDelete}
               />
             )}
+            <MessageCharacteristics
+              type={isRegularThread(thread) ? thread.messageType : 'MESSAGE'}
+              urgent={thread.urgent}
+              sensitive={!isRegularThread(thread) || thread.sensitive}
+            />
           </FixedSpaceRow>
         </Header>
         <ScreenReaderOnly>

--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -100,7 +100,7 @@ export default React.memo(function ThreadListItem({
             <MessageCharacteristics
               type={isRegularThread(thread) ? thread.messageType : 'MESSAGE'}
               urgent={thread.urgent}
-              sensitive={!isRegularThread(thread) || thread.sensitive}
+              sensitive={!isRegularThread(thread)}
             />
           </FixedSpaceRow>
         </Header>
@@ -114,7 +114,10 @@ export default React.memo(function ThreadListItem({
             <ScreenReaderOnly>
               {i18n.messages.threadList.title}:
             </ScreenReaderOnly>
-            {isRegularThread(thread) ? thread.title : i18n.messages.sensitive}
+            {isRegularThread(thread)
+              ? thread.title +
+                (thread.sensitive && ` (${i18n.messages.sensitive})`)
+              : i18n.messages.sensitive}
           </Truncated>
           <div>
             <ScreenReaderOnly>

--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -116,7 +116,7 @@ export default React.memo(function ThreadListItem({
             </ScreenReaderOnly>
             {isRegularThread(thread)
               ? thread.title +
-                (thread.sensitive && ` (${i18n.messages.sensitive})`)
+                (thread.sensitive ? ` (${i18n.messages.sensitive})` : '')
               : i18n.messages.sensitive}
           </Truncated>
           <div>

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -273,7 +273,7 @@ export default React.memo(function ThreadView({
           <MessageCharacteristics
             type={messageType}
             urgent={urgent}
-            sensitive={sensitive}
+            sensitive={false}
           />
           {children.length > 0 ? (
             <>
@@ -291,6 +291,7 @@ export default React.memo(function ThreadView({
         <H2 noMargin data-qa="thread-reader-title">
           <ScreenReaderOnly>{i18n.messages.thread.title}:</ScreenReaderOnly>
           {title}
+          {sensitive && ` (${i18n.messages.sensitive})`}
         </H2>
         <ScreenReaderButton
           data-qa="jump-to-end"

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -270,11 +270,7 @@ export default React.memo(function ThreadView({
     <ThreadContainer data-qa="thread-reader">
       <ThreadTitleRow tabIndex={-1} ref={titleRowRef}>
         <FixedSpaceFlexWrap>
-          <MessageCharacteristics
-            type={messageType}
-            urgent={urgent}
-            sensitive={false}
-          />
+          <MessageCharacteristics type={messageType} urgent={urgent} />
           {children.length > 0 ? (
             <>
               <ScreenReaderOnly>

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -59,7 +59,7 @@ const TitleRow = styled.div`
   }
 `
 
-const ThreadTitleRow = styled.div`
+export const ThreadTitleRow = styled.div`
   background-color: ${colors.grayscale.g0};
   max-height: 215px; // fits roughly 5 rows of heading text with the chip and paddings
   overflow: auto;
@@ -205,7 +205,15 @@ interface Props {
 
 export default React.memo(function ThreadView({
   accountId,
-  thread: { id: threadId, messages, title, messageType, urgent, children },
+  thread: {
+    id: threadId,
+    messages,
+    title,
+    messageType,
+    urgent,
+    sensitive,
+    children
+  },
   closeThread,
   onThreadDeleted
 }: Props) {
@@ -262,7 +270,11 @@ export default React.memo(function ThreadView({
     <ThreadContainer data-qa="thread-reader">
       <ThreadTitleRow tabIndex={-1} ref={titleRowRef}>
         <FixedSpaceFlexWrap>
-          <MessageCharacteristics type={messageType} urgent={urgent} />
+          <MessageCharacteristics
+            type={messageType}
+            urgent={urgent}
+            sensitive={sensitive}
+          />
           {children.length > 0 ? (
             <>
               <ScreenReaderOnly>

--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -47,6 +47,7 @@ export default class MessagesPage {
     this.page.find('[data-qa="message-reply-content"]')
   )
   #urgent = new Checkbox(this.page.findByDataQa('checkbox-urgent'))
+  #sensitive = new Checkbox(this.page.findByDataQa('checkbox-sensitive'))
   #messageTypeMessage = new Checkbox(
     this.page.findByDataQa('radio-message-type-message')
   )
@@ -121,6 +122,7 @@ export default class MessagesPage {
     title: string
     content: string
     urgent?: boolean
+    sensitive?: boolean
     attachmentCount?: number
     sender?: string
     receiver?: string
@@ -135,6 +137,7 @@ export default class MessagesPage {
     if (message.sender) {
       await this.#senderSelection.fillAndSelectFirst(message.sender)
     }
+
     if (message.receiver) {
       await this.#receiverSelection.open()
       await this.#receiverSelection.expandAll()
@@ -147,6 +150,9 @@ export default class MessagesPage {
     }
     if (message.urgent ?? false) {
       await this.#urgent.check()
+    }
+    if (message.sensitive ?? false) {
+      await this.#sensitive.check()
     }
 
     if (attachmentCount > 0) {

--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -230,11 +230,7 @@ export function SingleThreadView({
             {title}
             {sensitive && ` (${i18n.messages.sensitive})`}
           </H2>
-          <MessageCharacteristics
-            type={type}
-            urgent={urgent}
-            sensitive={sensitive}
-          />
+          <MessageCharacteristics type={type} urgent={urgent} />
         </StickyTitleRow>
         {messages.map((message, idx) => (
           <React.Fragment key={`${message.id}-fragment`}>

--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -165,7 +165,7 @@ interface Props {
 export function SingleThreadView({
   accountId,
   goBack,
-  thread: { id: threadId, messages, title, type, urgent, children },
+  thread: { id: threadId, messages, title, type, urgent, sensitive, children },
   view,
   onArchived
 }: Props) {
@@ -226,8 +226,15 @@ export function SingleThreadView({
       <Gap size="xs" />
       <ScrollContainer>
         <StickyTitleRow ref={stickyTitleRowRef}>
-          <H2 noMargin>{title}</H2>
-          <MessageCharacteristics type={type} urgent={urgent} />
+          <H2 noMargin>
+            {title}
+            {sensitive && ` (${i18n.messages.sensitive})`}
+          </H2>
+          <MessageCharacteristics
+            type={type}
+            urgent={urgent}
+            sensitive={sensitive}
+          />
         </StickyTitleRow>
         {messages.map((message, idx) => (
           <React.Fragment key={`${message.id}-fragment`}>

--- a/frontend/src/employee-frontend/components/messages/ThreadList.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadList.tsx
@@ -33,6 +33,7 @@ export type ThreadListItem = {
   title: string
   content: string
   urgent: boolean
+  sensitive: boolean
   participants: string[]
   unread: boolean
   onClick: () => void
@@ -70,6 +71,7 @@ export function ThreadList({ items: messages, accountId, onArchive }: Props) {
             <Truncated>
               <Title unread={item.unread} data-qa="thread-list-item-title">
                 {item.title}
+                {item.sensitive && ` (${i18n.messages.sensitive})`}
               </Title>
               <Hyphen>{' ― '}</Hyphen>
               <span data-qa="thread-list-item-content">{item.content}</span>
@@ -88,7 +90,11 @@ export function ThreadList({ items: messages, accountId, onArchive }: Props) {
               />
             )}
             <TypeAndDate>
-              <MessageCharacteristics type={item.type} urgent={item.urgent} />
+              <MessageCharacteristics
+                type={item.type}
+                urgent={item.urgent}
+                sensitive={item.sensitive}
+              />
               {item.timestamp && <Timestamp date={item.timestamp} />}
             </TypeAndDate>
           </FixedSpaceRow>

--- a/frontend/src/employee-frontend/components/messages/ThreadList.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadList.tsx
@@ -90,11 +90,7 @@ export function ThreadList({ items: messages, accountId, onArchive }: Props) {
               />
             )}
             <TypeAndDate>
-              <MessageCharacteristics
-                type={item.type}
-                urgent={item.urgent}
-                sensitive={item.sensitive}
-              />
+              <MessageCharacteristics type={item.type} urgent={item.urgent} />
               {item.timestamp && <Timestamp date={item.timestamp} />}
             </TypeAndDate>
           </FixedSpaceRow>

--- a/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
@@ -113,6 +113,7 @@ export default React.memo(function ThreadListContainer({
       title: thread.title,
       content: thread.messages[thread.messages.length - 1].content,
       urgent: thread.urgent,
+      sensitive: thread.sensitive,
       participants:
         view === 'sent'
           ? thread.messages[0].recipientNames || getUniqueParticipants(thread)
@@ -151,6 +152,7 @@ export default React.memo(function ThreadListContainer({
           title: draft.title,
           content: draft.content,
           urgent: draft.urgent,
+          sensitive: draft.sensitive,
           participants: draft.recipientNames,
           unread: false,
           onClick: () => setSelectedDraft(draft),

--- a/frontend/src/employee-mobile-frontend/messages/ReceivedThreadsList.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/ReceivedThreadsList.tsx
@@ -139,11 +139,7 @@ const MessagePreview = React.memo(function MessagePreview({
           <Truncated data-qa="message-participants">
             {participants.join(', ')}
           </Truncated>
-          <MessageCharacteristics
-            type={thread.type}
-            urgent={thread.urgent}
-            sensitive={false}
-          />
+          <MessageCharacteristics type={thread.type} urgent={thread.urgent} />
         </Header>
         <TitleAndDate isRead={!hasUnreadMessages}>
           <Truncated data-qa="message-preview-title">{thread.title}</Truncated>

--- a/frontend/src/employee-mobile-frontend/messages/ReceivedThreadsList.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/ReceivedThreadsList.tsx
@@ -139,7 +139,11 @@ const MessagePreview = React.memo(function MessagePreview({
           <Truncated data-qa="message-participants">
             {participants.join(', ')}
           </Truncated>
-          <MessageCharacteristics type={thread.type} urgent={thread.urgent} />
+          <MessageCharacteristics
+            type={thread.type}
+            urgent={thread.urgent}
+            sensitive={false}
+          />
         </Header>
         <TitleAndDate isRead={!hasUnreadMessages}>
           <Truncated data-qa="message-preview-title">{thread.title}</Truncated>

--- a/frontend/src/employee-mobile-frontend/messages/SentMessagesList.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/SentMessagesList.tsx
@@ -67,11 +67,7 @@ const SentMessagePreview = React.memo(function SentMessagePreview({
           <Truncated data-qa="message-recipients">
             {message.recipientNames.join(', ')}
           </Truncated>
-          <MessageCharacteristics
-            type={message.type}
-            urgent={message.urgent}
-            sensitive={false}
-          />
+          <MessageCharacteristics type={message.type} urgent={message.urgent} />
         </Header>
         <TitleAndDate isRead={true}>
           <Truncated data-qa="message-preview-title">

--- a/frontend/src/employee-mobile-frontend/messages/SentMessagesList.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/SentMessagesList.tsx
@@ -67,7 +67,11 @@ const SentMessagePreview = React.memo(function SentMessagePreview({
           <Truncated data-qa="message-recipients">
             {message.recipientNames.join(', ')}
           </Truncated>
-          <MessageCharacteristics type={message.type} urgent={message.urgent} />
+          <MessageCharacteristics
+            type={message.type}
+            urgent={message.urgent}
+            sensitive={false}
+          />
         </Header>
         <TitleAndDate isRead={true}>
           <Truncated data-qa="message-preview-title">

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -44,7 +44,6 @@ export namespace CitizenMessageThread {
   */
   export interface Redacted {
     type: 'Redacted'
-    children: MessageChild[]
     hasUnreadMessages: boolean
     id: UUID
     lastMessageSentAt: HelsinkiDateTime | null

--- a/frontend/src/lib-components/messages/MessageCharacteristics.tsx
+++ b/frontend/src/lib-components/messages/MessageCharacteristics.tsx
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faLockAlt } from 'Icons'
 import React from 'react'
 import styled, { useTheme } from 'styled-components'
 
@@ -31,14 +33,16 @@ function chipColor(theme: Theme, type: 'MESSAGE' | 'BULLETIN'): string {
 interface Props {
   type: MessageType
   urgent: boolean
+  sensitive: boolean
 }
 
-export function MessageCharacteristics({ type, urgent }: Props) {
+export function MessageCharacteristics({ type, urgent, sensitive }: Props) {
   const theme = useTheme()
   const i18n = useTranslations()
   return (
     <FixedSpaceRow spacing="xs" alignItems="center">
       <ScreenReaderOnly>{i18n.messages.thread.type}:</ScreenReaderOnly>
+      {sensitive && <FontAwesomeIcon icon={faLockAlt} />}
       {urgent && (
         <RoundIcon
           data-qa="urgent"

--- a/frontend/src/lib-components/messages/MessageCharacteristics.tsx
+++ b/frontend/src/lib-components/messages/MessageCharacteristics.tsx
@@ -33,10 +33,14 @@ function chipColor(theme: Theme, type: 'MESSAGE' | 'BULLETIN'): string {
 interface Props {
   type: MessageType
   urgent: boolean
-  sensitive: boolean
+  sensitive?: boolean
 }
 
-export function MessageCharacteristics({ type, urgent, sensitive }: Props) {
+export function MessageCharacteristics({
+  type,
+  urgent,
+  sensitive = false
+}: Props) {
   const theme = useTheme()
   const i18n = useTranslations()
   return (

--- a/frontend/src/lib-components/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageEditor.tsx
@@ -378,7 +378,7 @@ export default React.memo(function MessageEditor({
   const sensitiveCheckbox = (
     <FixedSpaceRow spacing="xs" alignItems="center">
       <Checkbox
-        data-qa="checkbox-senstitive"
+        data-qa="checkbox-sensitive"
         label={i18n.messageEditor.flags.sensitive.label}
         checked={message.sensitive}
         disabled={!sensitiveCheckboxEnabled}

--- a/frontend/src/lib-components/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageEditor.tsx
@@ -420,20 +420,27 @@ export default React.memo(function MessageEditor({
         />
       </>
     )
+  const FlagsInfoContent = () => {
+    // If only one of the flags is present
+    if (message.urgent !== message.sensitive) {
+      if (message.urgent) return <>{i18n.messageEditor.flags.urgent.info}</>
+      if (message.sensitive)
+        return <>{i18n.messageEditor.flags.sensitive.info}</>
+      return null
+    }
+
+    // If both flags are present
+    return (
+      <UlNoMargin>
+        <li>{i18n.messageEditor.flags.urgent.info}</li>
+        <li>{i18n.messageEditor.flags.sensitive.info}</li>)
+      </UlNoMargin>
+    )
+  }
   const flagsInfo = (message.urgent || message.sensitive) && (
     <>
       <Gap size="s" />
-      <InfoBox
-        message={
-          <UlNoMargin>
-            {message.urgent && <li>{i18n.messageEditor.flags.urgent.info}</li>}
-            {message.sensitive && (
-              <li>{i18n.messageEditor.flags.sensitive.info}</li>
-            )}
-          </UlNoMargin>
-        }
-        noMargin={true}
-      />
+      <InfoBox noMargin={true} message={<FlagsInfoContent />} />
     </>
   )
 

--- a/frontend/src/lib-components/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageEditor.tsx
@@ -113,7 +113,31 @@ const shouldSensitiveCheckboxBeEnabled = (
   }
   return senderAccountType === 'PERSONAL'
 }
+interface FlagProps {
+  urgent: boolean
+  sensitive: boolean
+}
 
+const FlagsInfoContent = React.memo(function FlagsInfoContent({
+  urgent,
+  sensitive
+}: FlagProps) {
+  const i18n = useTranslations()
+  // If only one of the flags is present
+  if (urgent !== sensitive) {
+    if (urgent) return <>{i18n.messageEditor.flags.urgent.info}</>
+    if (sensitive) return <>{i18n.messageEditor.flags.sensitive.info}</>
+    return null
+  }
+
+  // If both flags are present
+  return (
+    <UlNoMargin>
+      <li>{i18n.messageEditor.flags.urgent.info}</li>
+      <li>{i18n.messageEditor.flags.sensitive.info}</li>)
+    </UlNoMargin>
+  )
+})
 interface Props {
   availableReceivers: MessageReceiversResponse[]
   defaultSender: SelectOption
@@ -420,27 +444,18 @@ export default React.memo(function MessageEditor({
         />
       </>
     )
-  const FlagsInfoContent = () => {
-    // If only one of the flags is present
-    if (message.urgent !== message.sensitive) {
-      if (message.urgent) return <>{i18n.messageEditor.flags.urgent.info}</>
-      if (message.sensitive)
-        return <>{i18n.messageEditor.flags.sensitive.info}</>
-      return null
-    }
-
-    // If both flags are present
-    return (
-      <UlNoMargin>
-        <li>{i18n.messageEditor.flags.urgent.info}</li>
-        <li>{i18n.messageEditor.flags.sensitive.info}</li>)
-      </UlNoMargin>
-    )
-  }
   const flagsInfo = (message.urgent || message.sensitive) && (
     <>
       <Gap size="s" />
-      <InfoBox noMargin={true} message={<FlagsInfoContent />} />
+      <InfoBox
+        noMargin={true}
+        message={
+          <FlagsInfoContent
+            urgent={message.urgent}
+            sensitive={message.sensitive}
+          />
+        }
+      />
     </>
   )
 

--- a/frontend/src/lib-components/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageEditor.tsx
@@ -10,11 +10,11 @@ import { Failure, Result } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
 import { UpdateStateFn } from 'lib-common/form-state'
 import {
-  DraftContent,
   AuthorizedMessageAccount,
+  DraftContent,
+  MessageReceiversResponse,
   PostMessageBody,
-  UpdatableDraftContent,
-  MessageReceiversResponse
+  UpdatableDraftContent
 } from 'lib-common/generated/api-types/messaging'
 import { UUID } from 'lib-common/types'
 import { useDebounce } from 'lib-common/utils/useDebounce'
@@ -32,8 +32,8 @@ import { modalZIndex } from 'lib-components/layout/z-helpers'
 import {
   getSelected,
   receiversAsSelectorNode,
-  SelectorNode,
-  SelectedNode
+  SelectedNode,
+  SelectorNode
 } from 'lib-components/messages/SelectorNode'
 import { SaveDraftParams } from 'lib-components/messages/types'
 import { Draft, useDraft } from 'lib-components/messages/useDraft'
@@ -513,16 +513,16 @@ export default React.memo(function MessageEditor({
             </Dropdowns>
             {expandedView && !simpleMode && (
               <ExpandedRightPane>
-                <HorizontalField long={true}>
+                <ExpandedHorizontalField>
                   <Bold>{i18n.messageEditor.type.label}</Bold>
                   {messageType}
-                </HorizontalField>
+                </ExpandedHorizontalField>
                 <Gap size="s" />
-                <HorizontalField long={true}>
+                <ExpandedHorizontalField>
                   <Bold>{i18n.messageEditor.flags.heading}</Bold>
                   {urgent}
                   {sensitiveMessagingEnabled && sensitiveCheckbox}
-                </HorizontalField>
+                </ExpandedHorizontalField>
                 {sensitiveInfoOpen && (
                   <FixedSpaceRow fullWidth>
                     <ExpandingInfoBox
@@ -701,7 +701,7 @@ const BottomBar = styled.div`
   padding: ${defaultMargins.xs};
 `
 
-const HorizontalField = styled.div<{ long?: boolean }>`
+const HorizontalField = styled.div`
   display: flex;
   align-items: center;
 
@@ -711,7 +711,23 @@ const HorizontalField = styled.div<{ long?: boolean }>`
 
   & > :nth-child(1) {
     flex: 0 0 auto;
-    width: ${(props) => (props.long ? '200px' : '130px')};
+    width: 130px;
+  }
+`
+const ExpandedHorizontalField = styled.div`
+  display: flex;
+  align-items: center;
+
+  & > * {
+    width: 150px;
+  }
+
+  & > :first-child {
+    width: 190px;
+  }
+
+  & > :last-child {
+    width: unset;
   }
 `
 

--- a/frontend/src/lib-components/messages/ThreadListItem.tsx
+++ b/frontend/src/lib-components/messages/ThreadListItem.tsx
@@ -102,4 +102,8 @@ export const ThreadContainer = styled.div`
   max-width: 100%;
   min-height: 500px;
   overflow-y: auto;
+
+  a {
+    text-decoration: underline;
+  }
 `

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -463,7 +463,9 @@ const en: Translations = {
       confirm: 'Delete thread'
     },
     sensitive: 'Sensitive message thread',
-    strongAuthRequired: 'Reading requires strong authentication'
+    strongAuthRequired: 'Reading requires strong authentication',
+    strongAuthRequiredThread: 'Reading requires strong authentication.',
+    strongAuthLink: 'Authenticate'
   },
   applications: {
     title: 'Applications',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -460,7 +460,10 @@ export default {
       confirm: 'Poista viestiketju'
     },
     sensitive: 'Arkaluontoinen viestiketju',
-    strongAuthRequired: 'Lukeminen vaatii vahvan tunnistautuminen'
+    strongAuthRequired: 'Lukeminen vaatii vahvan tunnistautuminen',
+    strongAuthRequiredThread:
+      'Viestiketjun lukeminen vaatii vahvan tunnistautumisen.',
+    strongAuthLink: 'Tunnistaudu'
   },
   applications: {
     title: 'Hakemukset',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -458,9 +458,10 @@ const sv: Translations = {
       cancel: 'Radera inte',
       confirm: 'Radera tråden'
     },
-    sensitive: 'Känslig meddelandetråd',
-    strongAuthRequired: 'Läsning kräver stark autentisering',
-    strongAuthRequiredThread: 'Läsning kräver stark autentisering.',
+    sensitive: 'Känslig diskussiontråd',
+    strongAuthRequired: 'För att kunna läsa krävs stark identifikation',
+    strongAuthRequiredThread:
+      'För att kunna läsa diskussionstråden krävs stark identifikation.',
     strongAuthLink: 'Autentisera'
   },
   applications: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -459,7 +459,9 @@ const sv: Translations = {
       confirm: 'Radera tråden'
     },
     sensitive: 'Känslig meddelandetråd',
-    strongAuthRequired: 'Läsning kräver stark autentisering'
+    strongAuthRequired: 'Läsning kräver stark autentisering',
+    strongAuthRequiredThread: 'Läsning kräver stark autentisering.',
+    strongAuthLink: 'Autentisera'
   },
   applications: {
     title: 'Ansökningar',

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -127,7 +127,7 @@ const components: Translations = {
         info: 'Arkaluontoisen viestin avaaminen vaatii kuntalaiselta vahvan tunnistautumisen.',
         label: 'Arkaluontoinen',
         whyDisabled:
-          'Arkaluontoisen viestin voi lähettää vain normaalina viestinä yksittäisen lapsen huoltajille henkilökohtaisesta lähettäjätilistä.'
+          'Arkaluontoisen viestin voi lähettää vain henkilökohtaisesta käyttäjätilistä yksittäisen lapsen huoltajille.'
       }
     },
     sender: 'Lähettäjä',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4035,7 +4035,8 @@ export const fi = {
       info: 'Viesti lähetetty',
       secondsLeft: (s: number) =>
         s === 1 ? '1 sekunti aikaa' : `${s} sekuntia aikaa`
-    }
+    },
+    sensitive: 'arkaluontoinen'
   },
   pinCode: {
     title: 'eVaka-mobiilin PIN-koodi',

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -73,7 +73,8 @@ const features: Features = {
     assistanceNeedPreschoolDecisions: true,
     feeDecisionIgnoredStatus: true,
     hojks: true,
-    sensitiveMessaging: false
+    employeeMobileGroupMessages: true,
+    sensitiveMessaging: true
   },
   prod: {
     citizenShiftCareAbsence: true,

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -73,7 +73,6 @@ const features: Features = {
     assistanceNeedPreschoolDecisions: true,
     feeDecisionIgnoredStatus: true,
     hojks: true,
-    employeeMobileGroupMessages: true,
     sensitiveMessaging: true
   },
   prod: {

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
@@ -60,26 +60,23 @@ data class MessageThreadStub(
 sealed interface CitizenMessageThread {
     val id: MessageThreadId
     val urgent: Boolean
-    val children: List<MessageChild>
 
     data class Redacted(
         override val id: MessageThreadId,
         override val urgent: Boolean,
-        override val children: List<MessageChild>,
         val sender: MessageAccount?,
         val lastMessageSentAt: HelsinkiDateTime?,
         val hasUnreadMessages: Boolean
     ) : CitizenMessageThread {
         companion object {
-            fun fromMessageThread(userId: PersonId, messageThread: MessageThread) =
+            fun fromMessageThread(accountId: MessageAccountId, messageThread: MessageThread) =
                 Redacted(
                     messageThread.id,
                     messageThread.urgent,
-                    messageThread.children,
                     messageThread.messages.firstOrNull()?.sender,
                     messageThread.messages.lastOrNull()?.sentAt,
                     messageThread.messages
-                        .findLast { message -> message.sender.id != userId }
+                        .findLast { message -> message.sender.id != accountId }
                         ?.readAt == null
                 )
         }
@@ -88,7 +85,7 @@ sealed interface CitizenMessageThread {
     data class Regular(
         override val id: MessageThreadId,
         override val urgent: Boolean,
-        override val children: List<MessageChild>,
+        val children: List<MessageChild>,
         val messageType: MessageType,
         val title: String,
         val sensitive: Boolean,

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
@@ -80,7 +80,7 @@ sealed interface CitizenMessageThread {
                     messageThread.messages.lastOrNull()?.sentAt,
                     messageThread.messages
                         .findLast { message -> message.sender.id != userId }
-                        ?.readAt != null
+                        ?.readAt == null
                 )
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -109,7 +109,7 @@ class MessageControllerCitizen(
                     }
                     .mapTo(::PagedCitizenMessageThreads) {
                         if (user.authLevel != CitizenAuthLevel.STRONG && it.sensitive) {
-                            CitizenMessageThread.Redacted.fromMessageThread(user.id, it)
+                            CitizenMessageThread.Redacted.fromMessageThread(accountId, it)
                         } else {
                             CitizenMessageThread.Regular.fromMessageThread(it)
                         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -727,7 +727,7 @@ RETURNING id
                     "INSERT INTO message_account (person_id, type) SELECT id, 'CITIZEN'::message_account_type as type FROM person ON CONFLICT DO NOTHING"
                 )
                 tx.execute(
-                    "INSERT INTO message_account (employee_id, type) SELECT employee_id, 'PERSONAL'::message_account_type as type FROM daycare_acl WHERE role = 'UNIT_SUPERVISOR' ON CONFLICT DO NOTHING"
+                    "INSERT INTO message_account (employee_id, type) SELECT employee_id, 'PERSONAL'::message_account_type as type FROM daycare_acl WHERE role = 'UNIT_SUPERVISOR' OR role = 'SPECIAL_EDUCATION_TEACHER' ON CONFLICT DO NOTHING"
                 )
                 tx.execute(
                     "INSERT INTO message_account (daycare_group_id, person_id, employee_id, type) VALUES (NULL, NULL, NULL, 'MUNICIPAL') ON CONFLICT DO NOTHING"


### PR DESCRIPTION
## Before this change
Display of redacted versions on sensitive message threads was not implemented.
## After this change
When citizen is logged-in with weak authentication they see a prompt to login with strong authentication when trying to view message threads marked as sensitive.
<img width="1266" alt="image" src="https://github.com/espoon-voltti/evaka/assets/886091/fdaf83d1-d23c-4842-81d0-e55c56f207ae">

After strong authentication the lock icons are removed from sensitive threads and instead their title is appended with "(Sensitive message thread)"
![image](https://github.com/espoon-voltti/evaka/assets/886091/46fc2472-5c17-4b48-9feb-013a0d21e780)


This change also adds end-to-end tests for sending and viewing sensitive messages.