### PR TITLE
Add unit care type to payment data

### DIFF
--- a/frontend/src/lib-common/generated/api-types/invoicing.ts
+++ b/frontend/src/lib-common/generated/api-types/invoicing.ts
@@ -713,6 +713,7 @@ export type PaymentStatus =
 */
 export interface PaymentUnit {
   businessId: string | null
+  careType: CareType[]
   iban: string | null
   id: UUID
   name: string

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/PaymentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/PaymentQueries.kt
@@ -40,7 +40,7 @@ fun Database.Read.readPaymentsByIdsWithFreshUnitData(ids: List<PaymentId>): List
             """
         SELECT 
             p.id, p.created, p.updated, p.unit_id, 
-            d.name AS unit_name, d.business_id AS unit_business_id, d.iban AS unit_iban, d.provider_id AS unit_provider_id,
+            d.name AS unit_name, d.business_id AS unit_business_id, d.iban AS unit_iban, d.provider_id AS unit_provider_id, d.type as unit_care_type,
             p.period, p.number, p.amount, p.status, p.payment_date, p.due_date, p.sent_at, p.sent_by
         FROM payment p
         JOIN daycare d ON d.id = p.unit_id
@@ -55,10 +55,12 @@ fun Database.Read.readPayments(): List<Payment> {
     return createQuery(
             """
             SELECT
-                id, created, updated,
-                unit_id, unit_name, unit_business_id, unit_iban, unit_provider_id,
-                period, number, amount, status, payment_date, due_date, sent_at, sent_by
-            FROM payment
+                p.id, p.created, p.updated,
+                p.unit_id, p.unit_name, p.unit_business_id, p.unit_iban, p.unit_provider_id,
+                p.period, p.number, p.amount, p.status, p.payment_date, p.due_date, p.sent_at, p.sent_by,
+                d.type as unit_care_type
+            FROM payment p
+            JOIN daycare d ON d.id = p.unit_id
             ORDER BY period DESC, unit_name
         """
         )
@@ -92,6 +94,7 @@ fun Database.Read.searchPayments(params: SearchPaymentsRequest): PagedPayments {
                 CASE WHEN p.status = 'SENT' THEN unit_business_id ELSE d.business_id END AS unit_business_id,
                 CASE WHEN p.status = 'SENT' THEN unit_iban ELSE d.iban END AS unit_iban,
                 CASE WHEN p.status = 'SENT' THEN unit_provider_id ELSE d.provider_id END AS unit_provider_id,
+                d.type AS unit_care_type,
                 p.period, p.number, p.amount, p.status, p.payment_date, p.due_date, p.sent_at, p.sent_by,
                 count(*) OVER () AS count
             FROM payment p

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Payments.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Payments.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.invoicing.domain
 
 import com.fasterxml.jackson.databind.json.JsonMapper
+import fi.espoo.evaka.daycare.CareType
 import fi.espoo.evaka.invoicing.data.deletePaymentDraftsByDateRange
 import fi.espoo.evaka.invoicing.data.insertPaymentDrafts
 import fi.espoo.evaka.reports.REPORT_STATEMENT_TIMEOUT
@@ -97,7 +98,8 @@ data class PaymentUnit(
     val name: String,
     val businessId: String?,
     val iban: String?,
-    val providerId: String?
+    val providerId: String?,
+    val careType: Set<CareType>
 )
 
 data class Payment(


### PR DESCRIPTION
Add unit care type to Payment objects and fetch it appropriately from the DB along the other payment data. This is backwards compatible for anyone who doesn't need the new field.
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

