### PR TITLE
Fix WebPushPayload serialization

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/utils/Jackson.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/utils/Jackson.kt
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.utils
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectWriter
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+
+@JvmInline
+value class JsonWriter<T> private constructor(private val writer: ObjectWriter) {
+    constructor(
+        jsonMapper: JsonMapper,
+        rootType: TypeReference<T>
+    ) : this(jsonMapper.writerFor(rootType))
+
+    fun writeValueAsString(value: T): String = writer.writeValueAsString(value)
+
+    fun writeValueAsBytes(value: T): ByteArray = writer.writeValueAsBytes(value)
+}
+
+/**
+ * Returns a specialized JSON writer, which retains exact type information and any
+ * JSON-serialization configuration for the type.
+ *
+ * Just using `JsonMapper.writeValueAsString(someValue)` may lose type information and serialize
+ * values incorrectly, but `JsonMapper.writerFor<SomeType>().writeValueAsString(someValue)` fixes
+ * this problem.
+ */
+inline fun <reified T> JsonMapper.writerFor(): JsonWriter<T> = JsonWriter(this, jacksonTypeRef<T>())

--- a/service/src/main/kotlin/fi/espoo/evaka/webpush/WebPush.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/webpush/WebPush.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.shared.config.SealedSubclassSimpleName
 import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.utils.writerFor
 import fi.espoo.voltti.logging.loggers.error
 import java.lang.RuntimeException
 import java.net.URI
@@ -129,7 +130,7 @@ private val VAPID_JWT_MIN_VALID_DURATION = Duration.ofHours(1)
 class WebPush(env: WebPushEnv) {
     private val fuel = FuelManager()
     private val secureRandom = SecureRandom()
-    private val jsonMapper = defaultJsonMapperBuilder().build()
+    private val jsonWriter = defaultJsonMapperBuilder().build().writerFor<List<WebPushPayload>>()
     private val vapidKeyPair: WebPushKeyPair =
         WebPushKeyPair.fromPrivateKey(WebPushCrypto.decodePrivateKey(env.vapidPrivateKey.value))
     val applicationServerKey: String
@@ -160,7 +161,7 @@ class WebPush(env: WebPushEnv) {
                     endpoint = notification.endpoint,
                     messageKeyPair = WebPushCrypto.generateKeyPair(secureRandom),
                     salt = secureRandom.generateSeed(16),
-                    data = jsonMapper.writeValueAsBytes(notification.payloads),
+                    data = jsonWriter.writeValueAsBytes(notification.payloads),
                     urgency = Urgency.Normal
                 )
                 .withVapid(vapidJwt)


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The serialization was broken in recent JsonTypeInfo changes, and the root cause is loss of type information due to internal implementation details of JVM generics.

Fix this by adding a *type-safe* serialization API, which retains type information.