### PR TITLE
Improve access control performance - part 2

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/ChildDailyNoteAccessControlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/ChildDailyNoteAccessControlTest.kt
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.security
+
+import fi.espoo.evaka.note.child.daily.ChildDailyNoteBody
+import fi.espoo.evaka.note.child.daily.createChildDailyNote
+import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPersonType
+import fi.espoo.evaka.shared.dev.DevPlacement
+import fi.espoo.evaka.shared.dev.insert
+import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.shared.security.actionrule.HasUnitRole
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class ChildDailyNoteAccessControlTest : AccessControlTest() {
+    private val clock = MockEvakaClock(2023, 1, 1, 12, 0)
+    private val dummyNote =
+        ChildDailyNoteBody(
+            "test",
+            feedingNote = null,
+            sleepingNote = null,
+            sleepingMinutes = null,
+            reminders = emptyList(),
+            reminderNote = "",
+        )
+
+    @Test
+    fun `HasUnitRole inPlacementUnitOfChildOfChildDailyNote`() {
+        val area = db.transaction { it.insert(DevCareArea()) }
+        val placementUnit = db.transaction { it.insert(DevDaycare(areaId = area)) }
+        val otherUnit = db.transaction { it.insert(DevDaycare(areaId = area)) }
+
+        val placedChild = db.transaction { it.insert(DevPerson(), DevPersonType.CHILD) }
+        db.transaction {
+            it.insert(
+                DevPlacement(
+                    unitId = placementUnit,
+                    childId = placedChild,
+                    startDate = clock.today(),
+                    endDate = clock.today().plusDays(30)
+                )
+            )
+        }
+        val placedChildNote = db.transaction { it.createChildDailyNote(placedChild, dummyNote) }
+        val otherChild = db.transaction { it.insert(DevPerson(), DevPersonType.CHILD) }
+        val otherChildNote = db.transaction { it.createChildDailyNote(otherChild, dummyNote) }
+
+        val unitSupervisor =
+            createTestEmployee(
+                globalRoles = emptySet(),
+                unitRoles = mapOf(placementUnit to UserRole.UNIT_SUPERVISOR)
+            )
+        val otherSupervisor =
+            createTestEmployee(
+                globalRoles = emptySet(),
+                unitRoles = mapOf(otherUnit to UserRole.UNIT_SUPERVISOR)
+            )
+
+        val action = Action.ChildDailyNote.UPDATE
+        rules.add(
+            action,
+            HasUnitRole(UserRole.UNIT_SUPERVISOR).inPlacementUnitOfChildOfChildDailyNote()
+        )
+
+        db.read { tx ->
+            assertTrue(
+                accessControl.hasPermissionFor(tx, unitSupervisor, clock, action, placedChildNote)
+            )
+            assertFalse(
+                accessControl.hasPermissionFor(tx, unitSupervisor, clock, action, otherChildNote)
+            )
+            assertFalse(
+                accessControl.hasPermissionFor(tx, otherSupervisor, clock, action, placedChildNote)
+            )
+            assertFalse(
+                accessControl.hasPermissionFor(tx, otherSupervisor, clock, action, otherChildNote)
+            )
+        }
+    }
+}

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/RuleCacheTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/RuleCacheTest.kt
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.security
+
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.shared.security.actionrule.DatabaseActionRule
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RuleCacheTest : AccessControlTest() {
+    private val clock = MockEvakaClock(2023, 1, 1, 12, 0)
+
+    private fun <P : Any> createUnscopedRule(
+        params: P,
+        cacheKey: Any,
+        deferred: () -> DatabaseActionRule.Deferred<P>
+    ) =
+        DatabaseActionRule.Unscoped(
+            params,
+            object : DatabaseActionRule.Unscoped.Query<P> {
+                override fun cacheKey(user: AuthenticatedUser, now: HelsinkiDateTime): Any =
+                    Triple(user, now, cacheKey)
+
+                override fun execute(
+                    ctx: DatabaseActionRule.QueryContext
+                ): DatabaseActionRule.Deferred<P> = deferred()
+            }
+        )
+
+    @Test
+    fun `unscoped rules with same type and same cache keys use cache in a single permission check`() {
+        var executionCount = 0
+        val actions =
+            listOf(
+                Action.Global.CREATE_UNIT,
+                Action.Global.CREATE_PERSON,
+                Action.Global.CREATE_PAPER_APPLICATION
+            )
+
+        // Multiple different instances of the same rule that take different params (= the index
+        // number).
+        // When *executed*, they return the same deferred, but when the deferred is *evaluated*, it
+        // only gives permission if we're evaluating the first rule
+        val deferred =
+            object : DatabaseActionRule.Deferred<Int> {
+                override fun evaluate(params: Int): AccessControlDecision =
+                    if (params == 0) AccessControlDecision.Permitted(params)
+                    else AccessControlDecision.None
+            }
+        actions.withIndex().forEach { (idx, action) ->
+            rules.add(
+                action,
+                createUnscopedRule(idx, cacheKey = Unit) { deferred.also { executionCount += 1 } }
+            )
+        }
+        val permittedActions =
+            db.read { tx ->
+                accessControl.getPermittedActions<Action.Global>(
+                    tx,
+                    AuthenticatedUser.SystemInternalUser,
+                    clock
+                )
+            }
+        // Without a cache all rules would be executed, but with the cache it should keep the
+        // deferred data of the first execution, which is evaluated multiple times (with different
+        // results)
+        assertEquals(1, executionCount)
+        assertEquals(setOf(actions.first()), permittedActions)
+    }
+
+    @Test
+    fun `unscoped rules with same type and different cache keys don't use cache in a single permission check`() {
+        val executed = mutableSetOf<Action.Global>()
+        val actions =
+            setOf(
+                Action.Global.CREATE_UNIT,
+                Action.Global.CREATE_PERSON,
+                Action.Global.CREATE_PAPER_APPLICATION
+            )
+
+        // Multiple different instances of the same rule that take same params (= Unit) but use
+        // different cache keys.
+        actions.withIndex().forEach { (idx, action) ->
+            rules.add(
+                action,
+                createUnscopedRule(Unit, cacheKey = idx) {
+                    DatabaseActionRule.Deferred.Permitted.also { executed += action }
+                }
+            )
+        }
+        val permittedActions =
+            db.read { tx ->
+                accessControl.getPermittedActions<Action.Global>(
+                    tx,
+                    AuthenticatedUser.SystemInternalUser,
+                    clock
+                )
+            }
+        assertEquals(actions, executed)
+        assertEquals(actions, permittedActions)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/Database.kt
@@ -753,6 +753,21 @@ data class QuerySql<@Suppress("unused") in Tag>(
     class Builder<Tag> : SqlBuilder() {
         private var used: Boolean = false
 
+        private fun combine(separator: String, queries: Iterable<QuerySql<Tag>>): QuerySql<Tag> {
+            check(!used) { "builder has already been used" }
+            this.used = true
+            for (query in queries) {
+                bindings += query.bindings
+            }
+            return QuerySql(
+                QuerySqlString(queries.joinToString(separator) { it.sql.toString() }),
+                bindings
+            )
+        }
+
+        fun union(all: Boolean, queries: Iterable<QuerySql<Tag>>): QuerySql<Tag> =
+            combine(if (all) "\nUNION ALL\n" else "\nUNION\n", queries)
+
         fun sql(@Language("sql") sql: String): QuerySql<Tag> {
             check(!used) { "builder has already been used" }
             this.used = true

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControl.kt
@@ -363,14 +363,14 @@ class AccessControl(private val actionRuleMapping: ActionRuleMapping, private va
     }
 
     private class UnscopedEvaluator(private val queryCtx: DatabaseActionRule.QueryContext) {
-        private val cache = mutableMapOf<Pair<Class<*>, *>, DatabaseActionRule.Deferred<in Any>?>()
+        private val cache = mutableMapOf<Pair<Class<*>, *>, DatabaseActionRule.Deferred<Any>>()
 
         fun <P : Any> evaluate(rule: DatabaseActionRule.Unscoped<P>): AccessControlDecision {
             @Suppress("UNCHECKED_CAST")
             val query = rule.query as DatabaseActionRule.Unscoped.Query<Any>
             val cacheKey = Pair(query.javaClass, query.cacheKey(queryCtx.user, queryCtx.now))
             val deferred = cache.getOrPut(cacheKey) { rule.query.execute(queryCtx) }
-            return deferred?.evaluate(rule.params) ?: AccessControlDecision.None
+            return deferred.evaluate(rule.params)
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlDecision.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlDecision.kt
@@ -6,35 +6,34 @@ package fi.espoo.evaka.shared.security
 
 import fi.espoo.evaka.shared.domain.Forbidden
 
-sealed interface AccessControlDecision {
-    /** No decision was made, so action is denied by default */
-    data object None : AccessControlDecision
+interface AccessControlDecision {
+    /** Returns true if this decision permits the requested action. */
+    fun isPermitted(): Boolean
 
-    /** Action was explicitly permitted based on some rule */
-    data class Permitted(val rule: Any) : AccessControlDecision
+    /** Throws an exception if this decision does not permit the requested action. */
+    fun assert()
 
     /**
-     * Action was explicitly denied based on some rule.
-     *
-     * This is only used to customize the Forbidden exception message/errorCode
+     * Throws an exception if this decision does not permit the requested action and the whole
+     * decision checking procedure should be terminated.
      */
-    data class Denied(val rule: Any, val message: String? = null, val errorCode: String? = null) :
-        AccessControlDecision {
-        fun toException(): Forbidden =
-            Forbidden(this.message ?: "Permission denied", this.errorCode)
+    fun assertIfTerminal()
+
+    /** No decision was made, so action is denied by default */
+    data object None : AccessControlDecision {
+        override fun isPermitted(): Boolean = false
+
+        override fun assert() = throw Forbidden()
+
+        override fun assertIfTerminal() {}
     }
 
-    fun isPermitted(): Boolean =
-        when (this) {
-            is Permitted -> true
-            is Denied -> false
-            is None -> false
-        }
+    /** Action was explicitly permitted based on some rule */
+    data class Permitted(val rule: Any) : AccessControlDecision {
+        override fun isPermitted(): Boolean = true
 
-    fun assert() =
-        when (this) {
-            is Permitted -> {}
-            is None -> throw Forbidden()
-            is Denied -> throw this.toException()
-        }
+        override fun assert() {}
+
+        override fun assertIfTerminal() {}
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlDecision.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlDecision.kt
@@ -8,7 +8,7 @@ import fi.espoo.evaka.shared.domain.Forbidden
 
 sealed interface AccessControlDecision {
     /** No decision was made, so action is denied by default */
-    object None : AccessControlDecision
+    data object None : AccessControlDecision
 
     /** Action was explicitly permitted based on some rule */
     data class Permitted(val rule: Any) : AccessControlDecision

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlQueries.kt
@@ -15,7 +15,13 @@ data class EmployeeChildAclConfig(
     val backupCare: Boolean = true,
     /** Enables access via placement plans originating from applications */
     val application: Boolean = true,
-)
+) {
+    init {
+        require(placement || backupCare || application) {
+            "At least one access mechanism must be enabled"
+        }
+    }
+}
 
 fun employeeChildAclViaPlacement(employee: EmployeeId, now: HelsinkiDateTime) =
     QuerySql.of<Any> {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlQueries.kt
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.security
+
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.db.QuerySql
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+
+data class EmployeeChildAclConfig(
+    /** Enables access via direct placements */
+    val placement: Boolean = true,
+    /** Enables access via backup care placements */
+    val backupCare: Boolean = true,
+    /** Enables access via placement plans originating from applications */
+    val application: Boolean = true,
+)
+
+fun employeeChildAclViaPlacement(employee: EmployeeId, now: HelsinkiDateTime) =
+    QuerySql.of<Any> {
+        sql(
+            """
+SELECT pl.child_id, pl.unit_id, role
+FROM placement pl
+JOIN daycare_acl ON pl.unit_id = daycare_acl.daycare_id
+WHERE ${bind(now.toLocalDate())} < pl.end_date + INTERVAL '1 month'
+AND daycare_acl.employee_id = ${bind(employee)}
+"""
+        )
+    }
+
+fun employeeChildAclViaBackupCare(employee: EmployeeId, now: HelsinkiDateTime) =
+    QuerySql.of<Any> {
+        sql(
+            """
+SELECT bc.child_id, bc.unit_id, role
+FROM backup_care bc
+JOIN daycare_acl ON unit_id = daycare_acl.daycare_id
+WHERE ${bind(now.toLocalDate())} < bc.end_date + INTERVAL '1 month'
+AND daycare_acl.employee_id = ${bind(employee)}
+"""
+        )
+    }
+
+fun employeeChildAclViaApplication(employee: EmployeeId) =
+    QuerySql.of<Any> {
+        sql(
+            """
+SELECT a.child_id, pp.unit_id, role
+FROM placement_plan pp
+JOIN application a ON pp.application_id = a.id
+JOIN daycare_acl ON pp.unit_id = daycare_acl.daycare_id
+WHERE a.status = ANY ('{SENT,WAITING_PLACEMENT,WAITING_CONFIRMATION,WAITING_DECISION,WAITING_MAILING,WAITING_UNIT_CONFIRMATION}'::application_status_type[])
+AND NOT (role = 'SPECIAL_EDUCATION_TEACHER' AND coalesce((a.document -> 'careDetails' ->> 'assistanceNeeded')::boolean, FALSE) IS FALSE)
+AND daycare_acl.employee_id = ${bind(employee)}
+"""
+        )
+    }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/ActionRule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/ActionRule.kt
@@ -144,7 +144,7 @@ internal data class RoleAndFeatures(
 )
 
 sealed interface AccessControlFilter<out T> {
-    object PermitAll : AccessControlFilter<Nothing>
+    data object PermitAll : AccessControlFilter<Nothing>
 
     data class Some<T>(val filter: QuerySql<T>) : AccessControlFilter<T>
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/ActionRule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/ActionRule.kt
@@ -83,8 +83,17 @@ object DatabaseActionRule {
         val now: HelsinkiDateTime
     )
 
-    interface Deferred<P> {
+    interface Deferred<in P> {
         fun evaluate(params: P): AccessControlDecision
+
+        data object None : Deferred<Any> {
+            override fun evaluate(params: Any): AccessControlDecision = AccessControlDecision.None
+        }
+
+        data object Permitted : Deferred<Any> {
+            override fun evaluate(params: Any): AccessControlDecision =
+                AccessControlDecision.Permitted(params)
+        }
     }
 
     interface Params {
@@ -130,7 +139,7 @@ object DatabaseActionRule {
              */
             fun cacheKey(user: AuthenticatedUser, now: HelsinkiDateTime): Any
 
-            fun execute(ctx: QueryContext): Deferred<P>?
+            fun execute(ctx: QueryContext): Deferred<P>
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
@@ -591,16 +591,14 @@ WHERE employee_id = ${bind(user.id)}
             )
         }
 
-    fun inPlacementUnitOfChildOfChildDailyNote() =
-        rule<ChildDailyNoteId> { user, now ->
-            sql(
-                """
-SELECT cdn.id, role, acl.daycare_id AS unit_id
-FROM child_daily_note cdn
-JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
-WHERE employee_id = ${bind(user.id)}
-            """
-            )
+    fun inPlacementUnitOfChildOfChildDailyNote(
+        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+    ) =
+        ruleViaChildAcl<ChildDailyNoteId>(cfg) {
+            sql("""
+SELECT child_daily_note.id, child_id
+FROM child_daily_note
+""")
         }
 
     fun inPlacementUnitOfChildOfChildStickyNote() =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
@@ -94,7 +94,6 @@ SELECT EXISTS (
     ${if (unitProviderTypes != null) "AND daycare.provider_type = ANY(${bind(unitProviderTypes.toSet())})" else ""}
 )
                 """
-                                .trimIndent()
                         )
                     }
                     .exactlyOne<Boolean>()
@@ -245,7 +244,6 @@ FROM daycare_acl acl
 JOIN daycare ON acl.daycare_id = daycare.id
 WHERE employee_id = ${bind(ctx.user.id)}
                                 """
-                                                .trimIndent()
                                         )
                                     }
                                     .toSet<RoleAndFeatures>()
@@ -266,7 +264,6 @@ JOIN daycare_acl acl ON acl.daycare_id = pp.unit_id
 WHERE employee_id = ${bind(user.id)} AND av.status = ANY ('{WAITING_CONFIRMATION,WAITING_MAILING,WAITING_UNIT_CONFIRMATION,ACTIVE}'::application_status_type[])
 ${if (onlyAllowDeletedForTypes != null) "AND (av.type = ANY(${bind(onlyAllowDeletedForTypes)}) OR NOT pp.deleted)" else ""}
             """
-                    .trimIndent()
             )
         }
 
@@ -295,7 +292,6 @@ AND CASE
      END
 ${if (hidePastAssistance) "AND aa.end_date >= ${bind(now.toLocalDate())}" else ""}    
             """
-                    .trimIndent()
             )
         }
 
@@ -324,7 +320,6 @@ AND CASE
      END
 ${if (hidePastAssistance) "AND NOT af.valid_during << ${bind(now.toLocalDate().toFiniteDateRange())}" else ""}    
             """
-                    .trimIndent()
             )
         }
 
@@ -353,7 +348,6 @@ AND CASE
      END
 ${if (hidePastAssistance) "AND NOT ad.validity_period << ${bind(now.toLocalDate().toFiniteDateRange())}" else ""} 
             """
-                    .trimIndent()
             )
         }
 
@@ -382,7 +376,6 @@ AND CASE
      END
 AND NOT ad.validity_period << ${bind(now.toLocalDate().toFiniteDateRange())} 
             """
-                    .trimIndent()
             )
         }
 
@@ -395,7 +388,6 @@ FROM assistance_need_preschool_decision apd
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)} AND apd.status = 'ACCEPTED'
             """
-                    .trimIndent()
             )
         }
 
@@ -424,7 +416,6 @@ AND CASE
      END
 ${if (hidePastAssistance) "AND NOT da.valid_during << ${bind(now.toLocalDate().toFiniteDateRange())}" else ""}    
             """
-                    .trimIndent()
             )
         }
 
@@ -453,7 +444,6 @@ AND CASE
      END
 ${if (hidePastAssistance) "AND NOT oam.valid_during << ${bind(now.toLocalDate().toFiniteDateRange())}" else ""}  
             """
-                    .trimIndent()
             )
         }
 
@@ -482,7 +472,6 @@ AND CASE
      END
 ${if (hidePastAssistance) "AND NOT pa.valid_during << ${bind(now.toLocalDate().toFiniteDateRange())}" else ""}  
             """
-                    .trimIndent()
             )
         }
 
@@ -495,7 +484,6 @@ FROM assistance_need_decision ad
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -510,7 +498,6 @@ JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE ad.decision_maker_employee_id = ${bind(user.id)}
   AND ad.sent_for_decision IS NOT NULL
             """
-                    .trimIndent()
             )
         }
 
@@ -523,7 +510,6 @@ FROM assistance_need_preschool_decision ad
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -536,7 +522,6 @@ FROM assistance_need_preschool_decision ad
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -551,7 +536,6 @@ JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE ad.decision_maker_employee_id = ${bind(user.id)}
   AND ad.sent_for_decision IS NOT NULL
             """
-                    .trimIndent()
             )
         }
 
@@ -569,7 +553,6 @@ WHERE employee_id = ${bind(user.id)} AND EXISTS(
       AND pd.provider_type = 'PRIVATE_SERVICE_VOUCHER'
 )
             """
-                    .trimIndent()
             )
         }
 
@@ -582,7 +565,6 @@ FROM backup_care bc
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -595,7 +577,6 @@ FROM backup_pickup bp
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -607,7 +588,6 @@ SELECT child_id AS id, role, acl.daycare_id AS unit_id
 FROM employee_child_daycare_acl(${bind(now.toLocalDate())}) acl
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -620,7 +600,6 @@ FROM child_daily_note cdn
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -633,7 +612,6 @@ FROM child_sticky_note csn
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -646,7 +624,6 @@ FROM child_images img
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -659,7 +636,6 @@ FROM decision
 JOIN daycare_acl acl ON decision.unit_id = acl.daycare_id
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -672,7 +648,6 @@ FROM fridge_child
 JOIN person_acl_view acl ON fridge_child.head_of_child = acl.person_id OR fridge_child.child_id = acl.person_id
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -685,7 +660,6 @@ FROM fridge_partner
 JOIN person_acl_view acl ON fridge_partner.person_id = acl.person_id
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -698,7 +672,6 @@ FROM pedagogical_document pd
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -712,7 +685,6 @@ JOIN pedagogical_document pd ON attachment.pedagogical_document_id = pd.id
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -724,7 +696,6 @@ SELECT person_id AS id, role, acl.daycare_id AS unit_id
 FROM person_acl_view acl
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -737,7 +708,6 @@ FROM placement
 JOIN daycare_acl acl ON placement.unit_id = acl.daycare_id
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -750,7 +720,6 @@ FROM placement
 JOIN daycare_acl acl ON placement.unit_id = acl.daycare_id
 WHERE employee_id = ${bind(user.id)} AND placement.start_date > ${bind(now)}
             """
-                    .trimIndent()
             )
         }
 
@@ -764,7 +733,6 @@ JOIN placement ON placement.id = service_need.placement_id
 JOIN daycare_acl acl ON placement.unit_id = acl.daycare_id
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -777,7 +745,6 @@ FROM child_discussion
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -797,7 +764,6 @@ ${if (editable) "AND status = ANY(${bind(DocumentStatus.values().filter { it.edi
 ${if (deletable) "AND status = 'DRAFT' AND published_at IS NULL" else ""}
 ${if (publishable) "AND status <> 'COMPLETED'" else ""}
             """
-                    .trimIndent()
             )
         }
 
@@ -812,7 +778,6 @@ JOIN person ON person.id = child_document.child_id
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl ON acl.child_id = person.duplicate_of
 WHERE employee_id = ${bind(user.id)} AND document_template.type = 'HOJKS'
             """
-                    .trimIndent()
             )
         }
 
@@ -842,7 +807,6 @@ WHERE employee_id = ${bind(user.id)} AND ct.type = 'DAYCARE' AND cd.created = (
     WHERE child_id = cd.child_id AND curriculum_template.type = ct.type
 )
             """
-                    .trimIndent()
             )
         }
 
@@ -857,7 +821,6 @@ JOIN person ON person.id = curriculum_document.child_id
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl ON acl.child_id = person.duplicate_of
 WHERE employee_id = ${bind(user.id)} AND curriculum_template.type = 'PRESCHOOL'
             """
-                    .trimIndent()
             )
         }
 
@@ -870,7 +833,6 @@ FROM daily_service_time dst
 JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -884,7 +846,6 @@ JOIN employee_child_daycare_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 WHERE employee_id = ${bind(user.id)}
   AND lower(dst.validity_period) > ${bind(now.toLocalDate())}
             """
-                    .trimIndent()
             )
         }
 
@@ -897,7 +858,6 @@ FROM application_view av
 JOIN daycare_acl acl ON acl.daycare_id = ANY (av.preferredunits)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -910,7 +870,6 @@ FROM daycare_group g
 JOIN daycare_acl acl USING (daycare_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -924,7 +883,6 @@ JOIN daycare_group g ON gn.group_id = g.id
 JOIN daycare_acl acl USING (daycare_id)
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -938,7 +896,6 @@ JOIN daycare_acl acl ON placement.unit_id = acl.daycare_id
 JOIN daycare_group_placement on placement.id = daycare_group_placement.daycare_placement_id
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -951,7 +908,6 @@ FROM daycare_acl acl
 JOIN mobile_device d ON acl.daycare_id = d.unit_id
 WHERE acl.employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -964,7 +920,6 @@ FROM daycare_acl acl
 JOIN pairing p ON acl.daycare_id = p.unit_id
 WHERE acl.employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -976,7 +931,6 @@ SELECT daycare_id AS id, role, acl.daycare_id AS unit_id
 FROM daycare_acl acl
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -992,7 +946,6 @@ JOIN daycare_acl ON daycare.id = daycare_acl.daycare_id
 WHERE employee_id = ${bind(user.id)}
 AND attachment.type = 'EXTENDED_CARE'
             """
-                    .trimIndent()
             )
         }
 
@@ -1009,7 +962,6 @@ WHERE employee_id = ${bind(user.id)} AND EXISTS(
       AND pd.provider_type = 'PRIVATE_SERVICE_VOUCHER'
 )
             """
-                    .trimIndent()
             )
         }
 
@@ -1022,7 +974,6 @@ FROM calendar_event_attendee cea
 JOIN daycare_acl acl ON acl.daycare_id = cea.unit_id
 WHERE employee_id = ${bind(user.id)}
             """
-                    .trimIndent()
             )
         }
 
@@ -1036,7 +987,6 @@ JOIN daycare_group dg ON acc.daycare_group_id = dg.id
 JOIN daycare_acl acl ON acl.daycare_id = dg.daycare_id
 WHERE acl.employee_id = ${bind(user.id)} AND acc.active = TRUE
                 """
-                    .trimIndent()
             )
         }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
@@ -194,7 +194,7 @@ SELECT EXISTS (
 
                 override fun execute(
                     ctx: DatabaseActionRule.QueryContext
-                ): DatabaseActionRule.Deferred<HasUnitRole>? =
+                ): DatabaseActionRule.Deferred<HasUnitRole> =
                     when (ctx.user) {
                         is AuthenticatedUser.Employee ->
                             Deferred(
@@ -212,7 +212,7 @@ WHERE employee_id = ${bind(ctx.user.id)}
                                     }
                                     .toSet<RoleAndFeatures>()
                             )
-                        else -> null
+                        else -> DatabaseActionRule.Deferred.None
                     }
             }
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsEmployee.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsEmployee.kt
@@ -21,16 +21,12 @@ import fi.espoo.evaka.shared.security.AccessControlDecision
 private typealias FilterByEmployee<T> =
     QuerySql.Builder<T>.(user: AuthenticatedUser.Employee, now: HelsinkiDateTime) -> QuerySql<T>
 
-object IsEmployee : DatabaseActionRule.Params {
+data object IsEmployee : DatabaseActionRule.Params {
     override fun isPermittedForSomeTarget(ctx: DatabaseActionRule.QueryContext): Boolean =
         when (ctx.user) {
             is AuthenticatedUser.Employee -> true
             else -> false
         }
-
-    override fun equals(other: Any?): Boolean = other?.javaClass == this.javaClass
-
-    override fun hashCode(): Int = this.javaClass.hashCode()
 
     private fun <T : Id<*>> rule(
         filter: FilterByEmployee<T>


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Old implementation had this query structure:

```
SELECT ...
FROM foo
JOIN (
  SELECT ...
  
  UNION ALL
  
  SELECT ...
  
  UNION ALL
  
  SELECT ...
) acl
```

This didn't generate good query plans when checking for permissions for a single target (= the common case). The union queries effectively fetched acl information for *all possible targets* for the current user, regardless of which targets we're interested in.

New implementation has this query structure:

```
SELECT ...
FROM foo
JOIN (
  SELECT ...
) acl

UNION ALL

SELECT ...
FROM foo
JOIN (
  SELECT ...
) acl

UNION ALL

SELECT ...
FROM foo
JOIN (
  SELECT ...
) acl
```

This can generate an optimal query plan, where the database effectively does three separate checks, but each of them is optimal for a single target. The repetition in the query is minimized by abstracting it away and requiring rules to provide a *minimal query* (= just target id + child id pairs).

The new implementation is currently only used by one vasu rule, so we can check its impact first in production.