### PR TITLE
Pass a database connection as a parameter to the payment integration

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Payments.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Payments.kt
@@ -32,10 +32,10 @@ interface PaymentIntegrationClient {
         val failed: List<Payment> = listOf()
     )
 
-    fun send(payments: List<Payment>): SendResult
+    fun send(payments: List<Payment>, tx: Database.Read): SendResult
 
     class MockClient(private val jsonMapper: JsonMapper) : PaymentIntegrationClient {
-        override fun send(payments: List<Payment>): SendResult {
+        override fun send(payments: List<Payment>, tx: Database.Read): SendResult {
             logger.info(
                 "Mock payment integration client got payments ${jsonMapper.writeValueAsString(payments)}"
             )
@@ -44,7 +44,7 @@ interface PaymentIntegrationClient {
     }
 
     class FailingClient() : PaymentIntegrationClient {
-        override fun send(payments: List<Payment>): SendResult {
+        override fun send(payments: List<Payment>, tx: Database.Read): SendResult {
             throw RuntimeException("Payments are not in use")
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/PaymentService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/PaymentService.kt
@@ -75,7 +75,7 @@ class PaymentService(
                 listOf(updatedPayment)
             }
 
-        val sendResult = integrationClient.send(updatedPayments)
+        val sendResult = integrationClient.send(updatedPayments, tx)
         logger.info {
             "Successfully sent ${sendResult.succeeded.size} payments: ${
             sendResult.succeeded.map { it.id }.joinToString(", ")


### PR DESCRIPTION
This is needed by the Turku payment integration to rummage the DB for stuff which is not suitable for being included in the Payment objects
