### PR TITLE
Revert "Bump node from 18.18.2-bookworm-slim to 20.9.0-bookworm-slim in /apigw"

### DIFF
--- a/apigw/Dockerfile
+++ b/apigw/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-FROM node:20.9.0-bookworm-slim AS base
+FROM node:18.18.2-bookworm-slim AS base
 
 WORKDIR /project
 


### PR DESCRIPTION
Reverts espoon-voltti/evaka#4337