### PR TITLE
Avoid React warnings for invalid DOM attributes

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import isPropValid from '@emotion/is-prop-valid'
 import { ErrorBoundary } from '@sentry/react'
 import React, { ReactNode, useCallback, useContext } from 'react'
 import { Navigate, Outlet, createBrowserRouter } from 'react-router-dom'
-import styled, { ThemeProvider } from 'styled-components'
+import styled, { StyleSheetManager, ThemeProvider } from 'styled-components'
 
 import {
   Notifications,
@@ -55,28 +56,43 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <Localization>
-          <ErrorBoundary
-            fallback={() => <ErrorPage basePath="/" labels={i18n.errorPage} />}
-          >
-            <AuthContextProvider>
-              <OverlayContextProvider>
-                <NotificationsContextProvider>
-                  <MessageContextProvider>
-                    <Content />
-                    <GlobalDialog />
-                    <LoginErrorModal />
-                    <div id="modal-container" />
-                  </MessageContextProvider>
-                </NotificationsContextProvider>
-              </OverlayContextProvider>
-            </AuthContextProvider>
-          </ErrorBoundary>
-        </Localization>
-      </ThemeProvider>
+      <StyleSheetManager shouldForwardProp={shouldForwardProp}>
+        <ThemeProvider theme={theme}>
+          <Localization>
+            <ErrorBoundary
+              fallback={() => (
+                <ErrorPage basePath="/" labels={i18n.errorPage} />
+              )}
+            >
+              <AuthContextProvider>
+                <OverlayContextProvider>
+                  <NotificationsContextProvider>
+                    <MessageContextProvider>
+                      <Content />
+                      <GlobalDialog />
+                      <LoginErrorModal />
+                      <div id="modal-container" />
+                    </MessageContextProvider>
+                  </NotificationsContextProvider>
+                </OverlayContextProvider>
+              </AuthContextProvider>
+            </ErrorBoundary>
+          </Localization>
+        </ThemeProvider>
+      </StyleSheetManager>
     </QueryClientProvider>
   )
+}
+
+// This implements the default behavior from styled-components v5
+// TODO: Prefix all custom props with $, then remove this
+function shouldForwardProp(propName: string, target: unknown) {
+  if (typeof target === 'string') {
+    // For HTML elements, forward the prop if it is a valid HTML attribute
+    return isPropValid(propName)
+  }
+  // For other elements, forward all props
+  return true
 }
 
 const FullPageContainer = styled.div`

--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import isPropValid from '@emotion/is-prop-valid'
 import { ErrorBoundary } from '@sentry/react'
 import React, { useCallback, useContext, useEffect, useState } from 'react'
 import { Navigate, createBrowserRouter, Outlet } from 'react-router-dom'
-import { ThemeProvider } from 'styled-components'
+import { StyleSheetManager, ThemeProvider } from 'styled-components'
 
 import { AuthStatus, User } from 'lib-common/api-types/employee-auth'
 import { idleTracker } from 'lib-common/utils/idleTracker'
@@ -122,35 +123,48 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <I18nContextProvider>
-        <ThemeProvider theme={theme}>
-          <ErrorBoundary
-            fallback={() => (
-              <ErrorPage basePath="/employee" labels={i18n.errorPage} />
-            )}
-          >
-            <UserContextProvider
-              user={authStatus.user}
-              roles={authStatus.roles}
-              refreshAuthStatus={refreshAuthStatus}
+        <StyleSheetManager shouldForwardProp={shouldForwardProp}>
+          <ThemeProvider theme={theme}>
+            <ErrorBoundary
+              fallback={() => (
+                <ErrorPage basePath="/employee" labels={i18n.errorPage} />
+              )}
             >
-              <StateProvider>
-                <Header />
-                <Notifications apiVersion={authStatus.apiVersion} />
+              <UserContextProvider
+                user={authStatus.user}
+                roles={authStatus.roles}
+                refreshAuthStatus={refreshAuthStatus}
+              >
+                <StateProvider>
+                  <Header />
+                  <Notifications apiVersion={authStatus.apiVersion} />
 
-                {/* the matched route element will be inserted at <Outlet /> */}
-                <Outlet />
+                  {/* the matched route element will be inserted at <Outlet /> */}
+                  <Outlet />
 
-                <Footer />
-                <ErrorMessage />
-                <LoginErrorModal />
-                <PairingModal />
-              </StateProvider>
-            </UserContextProvider>
-          </ErrorBoundary>
-        </ThemeProvider>
+                  <Footer />
+                  <ErrorMessage />
+                  <LoginErrorModal />
+                  <PairingModal />
+                </StateProvider>
+              </UserContextProvider>
+            </ErrorBoundary>
+          </ThemeProvider>
+        </StyleSheetManager>
       </I18nContextProvider>
     </QueryClientProvider>
   )
+}
+
+// This implements the default behavior from styled-components v5
+// TODO: Prefix all custom props with $, then remove this
+function shouldForwardProp(propName: string, target: unknown) {
+  if (typeof target === 'string') {
+    // For HTML elements, forward the prop if it is a valid HTML attribute
+    return isPropValid(propName)
+  }
+  // For other elements, forward all props
+  return true
 }
 
 export default createBrowserRouter(

--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import isPropValid from '@emotion/is-prop-valid'
 import { ErrorBoundary } from '@sentry/react'
 import React, { useContext, useEffect } from 'react'
 import {
@@ -11,7 +12,7 @@ import {
   Routes,
   useNavigate
 } from 'react-router-dom'
-import { ThemeProvider } from 'styled-components'
+import { StyleSheetManager, ThemeProvider } from 'styled-components'
 
 import { useQuery } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -63,50 +64,66 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <I18nContextProvider>
-        <ThemeProvider theme={theme}>
-          <ErrorBoundary
-            fallback={() => (
-              <ErrorPage basePath="/employee/mobile" labels={i18n.errorPage} />
-            )}
-          >
-            <UserContextProvider>
-              <ServiceWorkerContextProvider>
-                <NotificationsContextProvider>
-                  <Notifications apiVersion={apiVersion} />
-                  <Router basename="/employee/mobile">
-                    <Routes>
-                      <Route path="/landing" element={<MobileLander />} />
-                      <Route path="/pairing" element={<PairingWizard />} />
-                      <Route
-                        path="/units"
-                        element={
-                          <RequireAuth>
-                            <UnitList />
-                          </RequireAuth>
-                        }
-                      />
-                      <Route
-                        path="/units/:unitId/*"
-                        element={
-                          <RequireAuth>
-                            <UnitRouter />
-                          </RequireAuth>
-                        }
-                      />
-                      <Route
-                        index
-                        element={<Navigate replace to="/landing" />}
-                      />
-                    </Routes>
-                  </Router>
-                </NotificationsContextProvider>
-              </ServiceWorkerContextProvider>
-            </UserContextProvider>
-          </ErrorBoundary>
-        </ThemeProvider>
+        <StyleSheetManager shouldForwardProp={shouldForwardProp}>
+          <ThemeProvider theme={theme}>
+            <ErrorBoundary
+              fallback={() => (
+                <ErrorPage
+                  basePath="/employee/mobile"
+                  labels={i18n.errorPage}
+                />
+              )}
+            >
+              <UserContextProvider>
+                <ServiceWorkerContextProvider>
+                  <NotificationsContextProvider>
+                    <Notifications apiVersion={apiVersion} />
+                    <Router basename="/employee/mobile">
+                      <Routes>
+                        <Route path="/landing" element={<MobileLander />} />
+                        <Route path="/pairing" element={<PairingWizard />} />
+                        <Route
+                          path="/units"
+                          element={
+                            <RequireAuth>
+                              <UnitList />
+                            </RequireAuth>
+                          }
+                        />
+                        <Route
+                          path="/units/:unitId/*"
+                          element={
+                            <RequireAuth>
+                              <UnitRouter />
+                            </RequireAuth>
+                          }
+                        />
+                        <Route
+                          index
+                          element={<Navigate replace to="/landing" />}
+                        />
+                      </Routes>
+                    </Router>
+                  </NotificationsContextProvider>
+                </ServiceWorkerContextProvider>
+              </UserContextProvider>
+            </ErrorBoundary>
+          </ThemeProvider>
+        </StyleSheetManager>
       </I18nContextProvider>
     </QueryClientProvider>
   )
+}
+
+// This implements the default behavior from styled-components v5
+// TODO: Prefix all custom props with $, then remove this
+function shouldForwardProp(propName: string, target: unknown) {
+  if (typeof target === 'string') {
+    // For HTML elements, forward the prop if it is a valid HTML attribute
+    return isPropValid(propName)
+  }
+  // For other elements, forward all props
+  return true
 }
 
 function UnitRouter() {


### PR DESCRIPTION
#### Summary

styled-components v6 caused a lot of React warnings about unknown DOM attributes, because styled-components now passes all props through.

Restore styled-components v5 behavior by using a library function to check whether a prop is allowed for a given HTML element.

The real fix would be to rename all custom props so that they are prefixed with `$`.
