### PR TITLE
Update citizen's new message recipient logic

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components'
 import Footer, { footerHeightDesktop } from 'citizen-frontend/Footer'
 import { renderResult } from 'citizen-frontend/async-rendering'
 import { useUser } from 'citizen-frontend/auth/state'
+import { combine } from 'lib-common/api'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import Main from 'lib-components/atoms/Main'
@@ -17,6 +18,8 @@ import AdaptiveFlex from 'lib-components/layout/AdaptiveFlex'
 import Container from 'lib-components/layout/Container'
 import { TabletAndDesktop } from 'lib-components/layout/responsive-layout'
 import { defaultMargins, Gap } from 'lib-components/white-space'
+
+import { childrenQuery } from '../children/queries'
 
 import EmptyThreadView from './EmptyThreadView'
 import MessageEditor from './MessageEditor'
@@ -46,6 +49,8 @@ export default React.memo(function MessagesPage() {
     useContext(MessageContext)
   const [editorVisible, setEditorVisible] = useState<boolean>(false)
   const [displaySendError, setDisplaySendError] = useState<boolean>(false)
+
+  const children = useQueryResult(childrenQuery())
   const receivers = useQueryResult(receiversQuery())
 
   const user = useUser()
@@ -124,18 +129,22 @@ export default React.memo(function MessagesPage() {
               )}
             </StyledFlex>
             {editorVisible &&
-              renderResult(receivers, (receiverOptions) => (
-                <MessageEditor
-                  receiverOptions={receiverOptions}
-                  onSend={sendMessage}
-                  onSuccess={() => {
-                    changeEditorVisibility(false)
-                  }}
-                  onFailure={() => setDisplaySendError(true)}
-                  onClose={() => changeEditorVisibility(false)}
-                  displaySendError={displaySendError}
-                />
-              ))}
+              renderResult(
+                combine(children, receivers),
+                ([children, receiverOptions]) => (
+                  <MessageEditor
+                    children_={children}
+                    receiverOptions={receiverOptions}
+                    onSend={sendMessage}
+                    onSuccess={() => {
+                      changeEditorVisibility(false)
+                    }}
+                    onFailure={() => setDisplaySendError(true)}
+                    onClose={() => changeEditorVisibility(false)}
+                    displaySendError={displaySendError}
+                  />
+                )
+              )}
           </Main>
           <Footer />
         </>

--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { waitUntilTrue } from '../../utils'
-import { Element, Page, TextInput, TreeDropdown } from '../../utils/page'
+import { Element, MultiSelect, Page, TextInput } from '../../utils/page'
 
 export class MockStrongAuthPage {
   constructor(private readonly page: Page) {}
@@ -140,8 +140,8 @@ export default class CitizenMessagesPage {
 }
 
 export class CitizenMessageEditor extends Element {
-  readonly #receiverSelection = new TreeDropdown(
-    this.find('[data-qa="select-receiver"]')
+  readonly #recipientSelection = new MultiSelect(
+    this.findByDataQa('select-recipient')
   )
   readonly title = new TextInput(this.findByDataQa('input-title'))
   readonly content = new TextInput(this.findByDataQa('input-content'))
@@ -165,11 +165,16 @@ export class CitizenMessageEditor extends Element {
   }
 
   async selectRecipients(recipients: string[]) {
-    await this.#receiverSelection.click()
+    await this.#recipientSelection.click()
     for (const recipient of recipients) {
-      await this.#receiverSelection.findTextExact(recipient).click()
+      await this.#recipientSelection.fillAndSelectFirst(recipient)
     }
-    await this.#receiverSelection.click()
+    await this.#recipientSelection.click()
+  }
+
+  async assertNoRecipients() {
+    await this.#recipientSelection.click()
+    await this.#recipientSelection.assertNoOptions()
   }
 
   async fillMessage(title: string, content: string) {

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -418,7 +418,7 @@ describe('Sending and receiving messages', () => {
           '(Karhula Jari)'
         )
       })
-      test('The citizen can select the child that the message is in regards to', async () => {
+      test('The citizen must select the child that the message is in regards to', async () => {
         const daycarePlacementFixture = await Fixture.placement()
           .with({
             childId: enduserChildFixtureKaarina.id,
@@ -451,6 +451,10 @@ describe('Sending and receiving messages', () => {
           fixtures.enduserChildFixtureJari.id,
           enduserChildFixtureKaarina.id
         ])
+
+        // No recipients available before selecting a child
+        await editor.assertNoRecipients()
+
         await editor.selectChildren([enduserChildFixtureKaarina.id])
         await editor.selectRecipients(recipients)
         await editor.fillMessage(defaultTitle, defaultContent)

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -459,13 +459,17 @@ export class MultiSelect extends Element {
 
   async selectFirst() {
     await this.click()
-    await this.findAll(`[data-qa="option"]`).first().click()
+    await this.findAllByDataQa('option').first().click()
   }
 
   async fillAndSelectFirst(text: string) {
     await this.#input.fill(text)
-    await this.findAll(`[data-qa="option"]`).first().click()
+    await this.findAllByDataQa('option').first().click()
     await this.close()
+  }
+
+  async assertNoOptions() {
+    await this.findByDataQa('no-options').waitUntilVisible()
   }
 }
 

--- a/frontend/src/lib-components/atoms/form/MultiSelect.tsx
+++ b/frontend/src/lib-components/atoms/form/MultiSelect.tsx
@@ -83,7 +83,9 @@ function MultiSelect<T>({
         hideSelectedOptions={false}
         backspaceRemovesValue={false}
         closeMenuOnSelect={closeMenuOnSelect ?? false}
-        noOptionsMessage={() => noOptionsMessage ?? 'Ei tuloksia'}
+        noOptionsMessage={() => (
+          <span data-qa="no-options">{noOptionsMessage ?? 'Ei tuloksia'}</span>
+        )}
         getOptionLabel={getOptionLabel}
         getOptionValue={getOptionId}
         value={value}

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -449,6 +449,8 @@ const en: Translations = {
       newMessage: 'New message',
       recipients: 'Recipients',
       secondaryRecipients: 'Other recipients',
+      singleUnitRequired:
+        'Messages can only be sent to a single unit at a time',
       children: 'The message is regarding',
       subject: 'Subject',
       message: 'Message',
@@ -456,7 +458,7 @@ const en: Translations = {
       send: 'Send',
       discard: 'Discard',
       search: 'Search',
-      noResults: 'No results',
+      noResults: 'No results, select a child or children first',
       messageSendError: 'Failed to send the message'
     },
     confirmDelete: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -446,6 +446,8 @@ export default {
       newMessage: 'Uusi viesti',
       recipients: 'Vastaanottajat',
       secondaryRecipients: 'Muut vastaanottajat',
+      singleUnitRequired:
+        'Viestejä voi lähettää vain yhteen yksikköön kerrallaan',
       children: 'Viesti koskee',
       subject: 'Otsikko',
       message: 'Viesti',
@@ -453,7 +455,7 @@ export default {
       send: 'Lähetä',
       discard: 'Hylkää',
       search: 'Haku',
-      noResults: 'Ei tuloksia',
+      noResults: 'Ei tuloksia, valitse ensin lapsi tai lapsia',
       messageSendError: 'Viestin lähetys epäonnistui'
     },
     confirmDelete: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -445,6 +445,8 @@ const sv: Translations = {
       newMessage: 'Nytt Meddelande',
       recipients: 'Mottagare',
       secondaryRecipients: 'Andra mottagare',
+      singleUnitRequired:
+        'Meddelanden kan endast skickas till en enhet åt gången',
       children: 'Meddelandet angår',
       subject: 'Ämne',
       message: 'Meddelande',
@@ -452,7 +454,7 @@ const sv: Translations = {
       send: 'Skicka',
       discard: 'Kassera',
       search: 'Sök',
-      noResults: 'Inga resultat',
+      noResults: 'Inga resultat, välj ett barn eller flera barn först',
       messageSendError: 'Misslyckades med att skicka meddelande'
     },
     confirmDelete: {


### PR DESCRIPTION
#### Summary

Selecting children for a new message now adds to available recipients instead of reducing. If multiple children are selected, a message can be sent to all of their groups, for example. Howevew, selecting children in different units is not allowed.
