### PR TITLE
Evaka improve decisions a11y

### DIFF
--- a/frontend/src/citizen-frontend/decisions/decisions-page/ApplicationDecision.tsx
+++ b/frontend/src/citizen-frontend/decisions/decisions-page/ApplicationDecision.tsx
@@ -57,7 +57,15 @@ export default React.memo(function ApplicationDecision({
       open={open}
       toggleOpen={toggleOpen}
       title={
-        <H3 noMargin data-qa="title-decision-type">
+        <H3
+          noMargin
+          data-qa="title-decision-type"
+          aria-label={`${t.decisions.applicationDecisions.decision} ${
+            t.decisions.applicationDecisions.type[type]
+          } ${sentDate.format()} - ${
+            t.decisions.applicationDecisions.status[status]
+          }`}
+        >
           {`${t.decisions.applicationDecisions.decision} ${
             t.decisions.applicationDecisions.type[type]
           } ${sentDate.format()}`}

--- a/frontend/src/citizen-frontend/decisions/decisions-page/AssistanceDecision.tsx
+++ b/frontend/src/citizen-frontend/decisions/decisions-page/AssistanceDecision.tsx
@@ -55,7 +55,16 @@ export default React.memo(function AssistanceDecision({
       open={open}
       toggleOpen={toggleOpen}
       title={
-        <H3 noMargin data-qa={`title-decision-type-${id}`}>
+        <H3
+          noMargin
+          data-qa={`title-decision-type-${id}`}
+          aria-label={
+            `${
+              t.decisions.assistanceDecisions.title
+            } ${decisionMade.format()}` +
+            (isUnread ? ' - ' + t.decisions.unreadDecision : '')
+          }
+        >
           {t.decisions.assistanceDecisions.title} {decisionMade.format()}
         </H3>
       }

--- a/frontend/src/citizen-frontend/decisions/decisions-page/AssistancePreschoolDecision.tsx
+++ b/frontend/src/citizen-frontend/decisions/decisions-page/AssistancePreschoolDecision.tsx
@@ -40,7 +40,16 @@ export default React.memo(function AssistancePreschoolDecision({
       open={open}
       toggleOpen={toggleOpen}
       title={
-        <H3 noMargin data-qa={`title-decision-type-${id}`}>
+        <H3
+          noMargin
+          data-qa={`title-decision-type-${id}`}
+          aria-label={
+            `${
+              t.decisions.assistancePreschoolDecisions.title
+            } ${decisionMade.format()}` +
+            (isUnread ? ' - ' + t.decisions.unreadDecision : '')
+          }
+        >
           {t.decisions.assistancePreschoolDecisions.title}{' '}
           {decisionMade.format()}
         </H3>

--- a/frontend/src/citizen-frontend/decisions/decisions-page/Decisions.tsx
+++ b/frontend/src/citizen-frontend/decisions/decisions-page/Decisions.tsx
@@ -115,7 +115,7 @@ export default React.memo(function Decisions() {
                 ],
                 (decision) =>
                   'decisionMade' in decision
-                    ? decision.decisionMade?.formatIso()
+                    ? [decision.decisionMade.formatIso(), '']
                     : [decision.sentDate.formatIso(), decision.type]
               ).reverse()
               return {

--- a/frontend/src/citizen-frontend/decisions/decisions-page/Decisions.tsx
+++ b/frontend/src/citizen-frontend/decisions/decisions-page/Decisions.tsx
@@ -7,7 +7,13 @@ import React, { Fragment, useMemo } from 'react'
 
 import { renderResult } from 'citizen-frontend/async-rendering'
 import { combine } from 'lib-common/api'
+import {
+  AssistanceNeedDecisionCitizenListItem,
+  AssistanceNeedPreschoolDecisionCitizenListItem
+} from 'lib-common/generated/api-types/assistanceneed'
+import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
+import { UUID } from 'lib-common/types'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
@@ -37,6 +43,29 @@ export default React.memo(function Decisions() {
   )
 
   useTitle(t, t.decisions.title)
+
+  const getAriaLabelForChild = (child: {
+    decisions: (
+      | AssistanceNeedDecisionCitizenListItem
+      | AssistanceNeedPreschoolDecisionCitizenListItem
+      | {
+          applicationId: UUID
+          resolved: LocalDate | null
+        }
+    )[]
+    firstName: string
+    lastName: string
+  }) => {
+    const unconfirmedDecisionsCount = child.decisions.filter(
+      (decision) => 'applicationId' in decision && decision.resolved === null
+    ).length
+    return (
+      `${child.firstName} ${child.lastName}` +
+      (unconfirmedDecisionsCount > 0
+        ? ' - ' + t.decisions.unconfirmedDecisions(unconfirmedDecisionsCount)
+        : ' - ' + t.decisions.noUnconfirmedDecisions)
+    )
+  }
 
   const unconfirmedDecisionsCount = useMemo(
     () =>
@@ -88,7 +117,7 @@ export default React.memo(function Decisions() {
                   'decisionMade' in decision
                     ? decision.decisionMade?.formatIso()
                     : [decision.sentDate.formatIso(), decision.type]
-              )
+              ).reverse()
               return {
                 ...child,
                 decisions: childDecisions,
@@ -112,7 +141,7 @@ export default React.memo(function Decisions() {
   return (
     <Container data-qa="decisions-page">
       <Gap size="s" />
-      <ContentArea opaque paddingVertical="L">
+      <ContentArea opaque paddingVertical="L" id="main">
         <H1 noMargin>{t.decisions.title}</H1>
         <Gap size="xs" />
         {t.decisions.summary}
@@ -140,7 +169,7 @@ export default React.memo(function Decisions() {
                 paddingVertical="L"
                 data-qa={`child-decisions-${child.id}`}
               >
-                <H2 noMargin>
+                <H2 noMargin aria-label={getAriaLabelForChild(child)}>
                   {child.firstName} {child.lastName}
                 </H2>
                 {child.decisions.map((decision) => (

--- a/frontend/src/citizen-frontend/navigation/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/DesktopNav.tsx
@@ -373,15 +373,15 @@ const SubNavigationMenu = React.memo(function SubNavigationMenu({
             onClick={() => setOpen(false)}
             aria-label={
               t.header.nav.decisions +
-              (weakAuth ? ` (${t.header.requiresStrongAuth})` : '')
+              (weakAuth ? ` (${t.header.requiresStrongAuth})` : '') +
+              (unreadDecisions
+                ? ` ${unreadDecisions} ${t.header.notifications}`
+                : '')
             }
           >
             {t.header.nav.decisions} {maybeLockElem}
             {unreadDecisions ? (
-              <CircledChar
-                aria-label={`${unreadDecisions} ${t.header.notifications}`}
-                data-qa="sub-nav-menu-decisions-notification-count"
-              >
+              <CircledChar data-qa="sub-nav-menu-decisions-notification-count">
                 {unreadDecisions}
               </CircledChar>
             ) : null}

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1434,6 +1434,8 @@ const en: Translations = {
       `${n} ${
         n === 1 ? 'decision is' : 'decisions are'
       } waiting for confirmation`,
+    noUnconfirmedDecisions: 'all decisions confirmed',
+    unreadDecision: 'unread decision',
     pageLoadError: 'Error in fetching the requested information',
     applicationDecisions: {
       decision: 'Decision of',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1423,8 +1423,8 @@ const en: Translations = {
       <P width="800px">
         This page displays the received decisions regarding child&lsquo;s early
         childhood education, pre-primary education and clubs.
-        <br />
-        <br />
+        <br aria-hidden="true" />
+        <br aria-hidden="true" />
         Upon receiving a new decision concerning a new placement applied for a
         child, you are required to respond in two weeks, whether you accept or
         reject it.

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -1367,8 +1367,8 @@ export default {
       <P width="800px">
         Tälle sivulle saapuvat lapsen varhaiskasvatukseen, esiopetukseen ja
         kerhoon liittyvät päätökset.
-        <br />
-        <br />
+        <br aria-hidden="true" />
+        <br aria-hidden="true" />
         Jos päätös koskee uutta lapselle haettua paikkaa,{' '}
         <strong>sinun tulee vastata kahden viikon sisällä</strong>, hyväksytkö
         vai hylkäätkö lapselle tarjotun paikan.

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -1376,6 +1376,8 @@ export default {
     ),
     unconfirmedDecisions: (n: number) =>
       `${n} ${n === 1 ? 'päätös' : 'päätöstä'} odottaa vahvistustasi`,
+    noUnconfirmedDecisions: 'kaikki päätökset vahvistettu',
+    unreadDecision: 'lukematon päätös',
     pageLoadError: 'Tietojen hakeminen ei onnistunut',
     applicationDecisions: {
       decision: 'Päätös',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1381,6 +1381,8 @@ const sv: Translations = {
       </P>
     ),
     unconfirmedDecisions: (n: number) => `${n} beslut inväntar bekräftelse`,
+    noUnconfirmedDecisions: 'alla beslut bekräftade',
+    unreadDecision: 'oläst beslut',
     pageLoadError: 'Hämtning av information misslyckades',
     applicationDecisions: {
       decision: 'Beslut',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1373,8 +1373,8 @@ const sv: Translations = {
       <P width="800px">
         Till denna sida kommer beslut gällande barnets ansökan till
         småbarnspedagogik, förskola och klubbverksamhet.
-        <br />
-        <br />
+        <br aria-hidden="true" />
+        <br aria-hidden="true" />
         Om beslutet rör en ansökan till en för barnet ny plats, bör du ta emot
         eller annullera platsen / platserna inom två veckor från mottagandet av
         beslutet.


### PR DESCRIPTION
## Before this change
It was hard to navigate the decisions page with a screen reader.
## After this change
- "Skip to main content" link works on decisions page
- amount of decisions waiting for confirmation is announced in main menu
- decisions page headings contains info about decisions waiting for confirmation
- decisions are listed from newest to oldest under each child
- `<br/>`elements are hidden from screen reader