### PR TITLE
Return 404 instead of 500 if a requested thread is not accessible

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -1039,7 +1039,8 @@ WHERE t.id = :threadId AND tp.participant_id = :accountId
             )
             .bind("accountId", accountId)
             .bind("threadId", threadId)
-            .exactlyOne<ReceivedThread>()
+            .exactlyOneOrNull<ReceivedThread>()
+            ?: throw NotFound()
 
     val messagesByThread =
         getThreadMessages(


### PR DESCRIPTION
#### Summary

This can happen if a mobile pin session in the frontend has timed out.
