### PR TITLE
Evaka enable sensitive messaging

### DIFF
--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -313,6 +313,7 @@ export default React.memo(function ThreadView({
             onToggleRecipient={onToggleRecipient}
             replyContent={replyContent}
             sendEnabled={sendEnabled}
+            messageThreadSensitive={sensitive}
           />
         </ReplyEditorContainer>
       ) : (

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -21,7 +21,6 @@ import { useApiState } from 'lib-common/utils/useRestApi'
 import Container from 'lib-components/layout/Container'
 import MessageEditor from 'lib-components/messages/MessageEditor'
 import { defaultMargins } from 'lib-components/white-space'
-import { featureFlags } from 'lib-customizations/employee'
 
 import {
   deleteAttachment,
@@ -237,7 +236,6 @@ export default React.memo(function MessagesPage({
               saveMessageAttachment={saveMessageAttachment}
               sending={sending}
               defaultTitle={prefilledTitle ?? undefined}
-              sensitiveMessagingEnabled={featureFlags.sensitiveMessaging}
             />
           )}
       </PanelContainer>

--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -118,6 +118,7 @@ export interface Translations {
   messageReplyEditor: {
     messagePlaceholder: string | undefined
     discard: string
+    messagePlaceholderSensitiveThread: string | undefined
   }
   notifications: {
     close: string

--- a/frontend/src/lib-components/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageEditor.tsx
@@ -157,7 +157,6 @@ interface Props {
   ) => Promise<Result<UUID>>
   sending: boolean
   defaultTitle?: string
-  sensitiveMessagingEnabled?: boolean
 }
 
 export default React.memo(function MessageEditor({
@@ -174,8 +173,7 @@ export default React.memo(function MessageEditor({
   saveDraftRaw,
   saveMessageAttachment,
   sending,
-  defaultTitle = '',
-  sensitiveMessagingEnabled
+  defaultTitle = ''
 }: Props) {
   const i18n = useTranslations()
 
@@ -536,7 +534,7 @@ export default React.memo(function MessageEditor({
                 <ExpandedHorizontalField>
                   <Bold>{i18n.messageEditor.flags.heading}</Bold>
                   {urgent}
-                  {sensitiveMessagingEnabled && sensitiveCheckbox}
+                  {sensitiveCheckbox}
                 </ExpandedHorizontalField>
                 {sensitiveInfoOpen && (
                   <FixedSpaceRow fullWidth>
@@ -571,7 +569,7 @@ export default React.memo(function MessageEditor({
                 <HalfWidthColumn>
                   <Bold>{i18n.messageEditor.flags.heading}</Bold>
                   {urgent}
-                  {sensitiveMessagingEnabled && sensitiveCheckbox}
+                  {sensitiveCheckbox}
                 </HalfWidthColumn>
               </FixedSpaceRow>
               {sensitiveInfoOpen && !sensitiveCheckboxEnabled && (

--- a/frontend/src/lib-components/messages/MessageReplyEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageReplyEditor.tsx
@@ -53,6 +53,7 @@ interface Props<T, R> {
   onUpdateContent: (content: string) => void
   replyContent: string
   sendEnabled: boolean
+  messageThreadSensitive?: boolean
 }
 
 function MessageReplyEditor<T, R>({
@@ -64,7 +65,8 @@ function MessageReplyEditor<T, R>({
   onToggleRecipient,
   recipients,
   replyContent,
-  sendEnabled
+  sendEnabled,
+  messageThreadSensitive = false
 }: Props<T, R>) {
   const i18n = useTranslations()
   const handleSuccess = useCallback(
@@ -91,7 +93,11 @@ function MessageReplyEditor<T, R>({
         <Label>{i18n.messages.message}</Label>
         <MultiRowTextArea
           rows={4}
-          placeholder={i18n.messageReplyEditor.messagePlaceholder}
+          placeholder={
+            messageThreadSensitive
+              ? i18n.messageReplyEditor.messagePlaceholderSensitiveThread
+              : i18n.messageReplyEditor.messagePlaceholder
+          }
           value={replyContent}
           onChange={(value) => onUpdateContent(value)}
           data-qa="message-reply-content"

--- a/frontend/src/lib-components/utils/TestContextProvider.tsx
+++ b/frontend/src/lib-components/utils/TestContextProvider.tsx
@@ -122,7 +122,8 @@ export const testTranslations: Translations = {
   },
   messageReplyEditor: {
     discard: '',
-    messagePlaceholder: undefined
+    messagePlaceholder: undefined,
+    messagePlaceholderSensitiveThread: undefined
   },
   notifications: {
     close: ''

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -27,7 +27,8 @@ const componentTranslations: ComponentTranslations = {
   messageReplyEditor: {
     ...components.messageReplyEditor,
     messagePlaceholder:
-      'Content... Note! Do not enter sensitive information here.'
+      'Content... Note! Do not enter sensitive information here.',
+    messagePlaceholderSensitiveThread: 'Content...'
   }
 }
 

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -21,7 +21,8 @@ const componentTranslations: ComponentTranslations = {
   messageReplyEditor: {
     ...components.messageReplyEditor,
     messagePlaceholder:
-      'Viestin sisältö... Huom! Älä kirjoita tähän arkaluontoisia asioita.'
+      'Viestin sisältö... Huom! Älä kirjoita tähän arkaluontoisia asioita.',
+    messagePlaceholderSensitiveThread: 'Viestin sisältö...'
   }
 }
 

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -22,7 +22,8 @@ const componentTranslations: ComponentTranslations = {
   messageReplyEditor: {
     ...components.messageReplyEditor,
     messagePlaceholder:
-      'Meddelandeinnehåll... Obs! Ange inte känslig information här.'
+      'Meddelandeinnehåll... Obs! Ange inte känslig information här.',
+    messagePlaceholderSensitiveThread: 'Meddelandeinnehåll...'
   }
 }
 

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -139,7 +139,8 @@ const components: Translations = {
   messageReplyEditor: {
     // Currently only used for Finnish frontends
     discard: '',
-    messagePlaceholder: undefined
+    messagePlaceholder: undefined,
+    messagePlaceholderSensitiveThread: undefined
   },
   notifications: {
     close: 'Close'

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -137,7 +137,8 @@ const components: Translations = {
   },
   messageReplyEditor: {
     messagePlaceholder: undefined,
-    discard: 'Hylkää'
+    discard: 'Hylkää',
+    messagePlaceholderSensitiveThread: undefined
   },
   notifications: {
     close: 'Sulje'

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -139,7 +139,8 @@ const components: Translations = {
   messageReplyEditor: {
     // Currently only used for Finnish frontends
     discard: '',
-    messagePlaceholder: undefined
+    messagePlaceholder: undefined,
+    messagePlaceholderSensitiveThread: undefined
   },
   notifications: {
     close: 'Stäng'

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -104,7 +104,7 @@ const features: Features = {
     assistanceNeedPreschoolDecisions: true,
     feeDecisionIgnoredStatus: true,
     hojks: false,
-    sensitiveMessaging: false
+    sensitiveMessaging: true
   }
 }
 

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -41,8 +41,7 @@ const features: Features = {
     childDocuments: true,
     assistanceNeedPreschoolDecisions: true,
     feeDecisionIgnoredStatus: true,
-    hojks: true,
-    sensitiveMessaging: true
+    hojks: true
   },
   staging: {
     citizenShiftCareAbsence: true,
@@ -72,8 +71,7 @@ const features: Features = {
     childDocuments: true,
     assistanceNeedPreschoolDecisions: true,
     feeDecisionIgnoredStatus: true,
-    hojks: true,
-    sensitiveMessaging: true
+    hojks: true
   },
   prod: {
     citizenShiftCareAbsence: true,
@@ -103,8 +101,7 @@ const features: Features = {
     childDocuments: true,
     assistanceNeedPreschoolDecisions: true,
     feeDecisionIgnoredStatus: true,
-    hojks: false,
-    sensitiveMessaging: true
+    hojks: false
   }
 }
 

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -239,12 +239,6 @@ interface BaseFeatureFlags {
    * EXPERIMENTAL: Allows creating and displaying HOJKS documents
    */
   hojks?: boolean
-
-  /**
-   * EXPERIMENTAL: Enable sending messages with sensitive flag. Sensitive messages
-   * require strong authentication from citizens in order to display the message content
-   */
-  sensitiveMessaging?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>


### PR DESCRIPTION
## Before this change

- Placeholder in citizen message editor was misleading in sensitive message threads.
- Sensitive messaging was behind a feature flag not enabled in Espoo production.

## After this change
 - "Note! Do not enter sensitive information here." is no-longer shown in the message placeholder in sensitive message threads.
 - Sensitive messaging feature flag was removed and it's now enabled everywhere