### PR TITLE
Fix employee message list style

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessageComponents.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageComponents.tsx
@@ -16,7 +16,7 @@ export const MessageRow = styled.div<{ unread?: boolean }>`
   justify-content: space-between;
   padding: ${defaultMargins.s};
   cursor: pointer;
-  :first-child {
+  &:first-child {
     border-top: 1px solid ${colors.grayscale.g15};
   }
   border-bottom: 1px solid ${colors.grayscale.g15};


### PR DESCRIPTION
#### Summary

Before:

<img width="774" alt="Screenshot 2023-11-02 at 9 35 58" src="https://github.com/espoon-voltti/evaka/assets/70927/0f268dcb-8a23-4c9d-8464-bb4361d71d0c">

After:

<img width="786" alt="Screenshot 2023-11-02 at 9 36 20" src="https://github.com/espoon-voltti/evaka/assets/70927/45a5ace7-91f8-4f46-917b-89dfaf905f52">
