### PR TITLE
Hide reply editor after sending a reply

### DIFF
--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { waitUntilTrue } from '../../utils'
 import { Element, MultiSelect, Page, TextInput } from '../../utils/page'
 
 export class MockStrongAuthPage {
@@ -111,8 +110,8 @@ export default class CitizenMessagesPage {
     await this.#openReplyEditorButton.click()
     await this.#messageReplyContent.fill(content)
     await this.#sendReplyButton.click()
-    // the content is cleared and the button is disabled once the reply has been sent
-    await waitUntilTrue(() => this.#sendReplyButton.disabled)
+    // the editor is hidden after sending the reply
+    await this.#sendReplyButton.waitUntilHidden()
   }
 
   async deleteFirstThread() {

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -31,7 +31,7 @@ import { CareArea, EmployeeDetail } from '../../dev-api/types'
 import CitizenMessagesPage from '../../pages/citizen/citizen-messages'
 import ChildInformationPage from '../../pages/employee/child-information'
 import MessagesPage from '../../pages/employee/messages/messages-page'
-import { waitUntilEqual, waitUntilTrue } from '../../utils'
+import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 import { employeeLogin, enduserLogin, enduserLoginWeak } from '../../utils/user'
 
@@ -701,7 +701,7 @@ describe('Sending and receiving messages', () => {
       await messagesPage.sendReplyButton.waitUntilVisible()
       await messagesPage.fillReplyContent(defaultContent)
       await messagesPage.sendReplyButton.click()
-      await waitUntilTrue(() => messagesPage.sendReplyButton.disabled)
+      await messagesPage.sendReplyButton.waitUntilHidden()
       await runPendingAsyncJobs(mockedDateAt12.addMinutes(1))
 
       await openCitizenPage(mockedDateAt12.addMinutes(1))

--- a/frontend/src/employee-frontend/components/messages/api.ts
+++ b/frontend/src/employee-frontend/components/messages/api.ts
@@ -168,19 +168,19 @@ export type ReplyToThreadParams = ReplyToMessageBody & {
   messageId: UUID
   accountId: UUID
 }
+
 export async function replyToThread({
   messageId,
   content,
   accountId,
   recipientAccountIds
-}: ReplyToThreadParams): Promise<Result<ThreadReply>> {
+}: ReplyToThreadParams): Promise<ThreadReply> {
   return client
     .post<JsonOf<ThreadReply>>(`/messages/${accountId}/${messageId}/reply`, {
       content,
       recipientAccountIds
     })
-    .then(({ data }) => Success.of(deserializeReplyResponse(data)))
-    .catch((e) => Failure.fromError(e))
+    .then((res) => deserializeReplyResponse(res.data))
 }
 
 export async function postMessage(

--- a/frontend/src/employee-frontend/components/messages/queries.ts
+++ b/frontend/src/employee-frontend/components/messages/queries.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { mutation } from 'lib-common/query'
+
+import { replyToThread } from './api'
+
+export const replyToThreadMutation = mutation({
+  api: replyToThread
+})

--- a/frontend/src/employee-mobile-frontend/messages/state.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/state.tsx
@@ -12,25 +12,19 @@ import React, {
 
 import { Loading, Result } from 'lib-common/api'
 import { AuthorizedMessageAccount } from 'lib-common/generated/api-types/messaging'
-import {
-  queryOrDefault,
-  useMutationResult,
-  useQueryResult
-} from 'lib-common/query'
+import { queryOrDefault, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 
 import { UserContext } from '../auth/state'
 import { useSelectedGroup } from '../common/selected-group'
 import { UnitContext } from '../common/unit'
 
-import { ReplyToThreadParams } from './api'
-import { messagingAccountsQuery, replyToThreadMutation } from './queries'
+import { messagingAccountsQuery } from './queries'
 
 export interface MessagesState {
   accounts: Result<AuthorizedMessageAccount[]>
   groupAccounts: AuthorizedMessageAccount[]
   selectedAccount: AuthorizedMessageAccount | undefined
-  sendReply: (params: ReplyToThreadParams) => Promise<Result<unknown>>
   setReplyContent: (threadId: UUID, content: string) => void
   getReplyContent: (threadId: UUID) => string
 }
@@ -39,7 +33,6 @@ const defaultState: MessagesState = {
   accounts: Loading.of(),
   selectedAccount: undefined,
   groupAccounts: [],
-  sendReply: () => Promise.resolve(Loading.of()),
   getReplyContent: () => '',
   setReplyContent: () => undefined
 }
@@ -107,25 +100,12 @@ export const MessageContextProvider = React.memo(
       setReplyContents((state) => ({ ...state, [threadId]: content }))
     }, [])
 
-    const { mutateAsync: sendReply } = useMutationResult(replyToThreadMutation)
-    const sendReplyAndClear = useCallback(
-      async (arg: ReplyToThreadParams) => {
-        const result = await sendReply(arg)
-        if (result.isSuccess) {
-          setReplyContent(result.value.threadId, '')
-        }
-        return result
-      },
-      [sendReply, setReplyContent]
-    )
-
     const value = useMemo(
       () => ({
         accounts,
         selectedAccount,
         groupAccounts,
         getReplyContent,
-        sendReply: sendReplyAndClear,
         setReplyContent
       }),
       [
@@ -133,7 +113,6 @@ export const MessageContextProvider = React.memo(
         groupAccounts,
         selectedAccount,
         getReplyContent,
-        sendReplyAndClear,
         setReplyContent
       ]
     )


### PR DESCRIPTION
#### Summary

Both employee-frontend and citizen-frontend now hide the reply editor after sending. employee-mobile-frontend already did this.

Refactor MessageReplyEditor to use MutateButton. This causes less flickering in the UI when sending the reply. Refactor it to also empty the reply contents after sending. This lets us remove that logic from message contexts.
