### PR TITLE
Format account and child names consistently

### DIFF
--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -7,6 +7,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState
 } from 'react'
@@ -19,7 +20,7 @@ import {
   MessageThread,
   MessageType
 } from 'lib-common/generated/api-types/messaging'
-import { formatPreferredName } from 'lib-common/names'
+import { formatAccountNames } from 'lib-common/messaging'
 import { UUID } from 'lib-common/types'
 import { scrollRefIntoView } from 'lib-common/utils/scrolling'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
@@ -99,24 +100,18 @@ function SingleMessage({
   title?: string
   index: number
 }) {
+  const { senderName, recipientNames } = useMemo(
+    () =>
+      formatAccountNames(message.sender, message.recipients, messageChildren),
+    [message.sender, message.recipients, messageChildren]
+  )
   return (
     <MessageContainer>
       <TitleRow>
-        <Bold>
-          {message.sender.name}
-          {messageChildren.length > 0
-            ? ` (${messageChildren
-                .map((ch) => `${ch.lastName} ${formatPreferredName(ch)}`)
-                .join(', ')})`
-            : ''}
-        </Bold>
+        <Bold>{senderName}</Bold>
         <InformationText>{message.sentAt.format()}</InformationText>
       </TitleRow>
-      <InformationText>
-        {(message.recipientNames || message.recipients.map((r) => r.name)).join(
-          ', '
-        )}
-      </InformationText>
+      <InformationText>{recipientNames.join(', ')}</InformationText>
       <MessageContent data-qa="message-content" data-index={index}>
         <Linkify text={message.content} />
       </MessageContent>

--- a/frontend/src/employee-mobile-frontend/messages/ThreadView.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/ThreadView.tsx
@@ -19,7 +19,7 @@ import {
   MessageThread,
   SentMessage
 } from 'lib-common/generated/api-types/messaging'
-import { formatFirstName } from 'lib-common/names'
+import { formatAccountNames } from 'lib-common/messaging'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { scrollRefIntoView } from 'lib-common/utils/scrolling'
@@ -221,26 +221,6 @@ const SingleMessage = React.memo(
     )
   })
 )
-
-function formatAccountNames(
-  sender: MessageAccount,
-  recipients: MessageAccount[],
-  children: MessageChild[]
-): { senderName: string; recipientNames: string[] } {
-  const childNames =
-    children.length > 0
-      ? children.map((child) => formatFirstName(child)).join(', ')
-      : undefined
-  const childSuffix = childNames ? ` (${childNames})` : ''
-
-  const senderName =
-    sender.name + (sender.type === 'CITIZEN' ? childSuffix : '')
-  const recipientNames = recipients.map(
-    (r) => r.name + (r.type === 'CITIZEN' ? childSuffix : '')
-  )
-
-  return { senderName, recipientNames }
-}
 
 interface SentMessageViewProps {
   account: MessageAccount

--- a/frontend/src/lib-common/messaging.ts
+++ b/frontend/src/lib-common/messaging.ts
@@ -4,10 +4,14 @@
 
 import {
   DraftContent,
+  MessageAccount,
+  MessageChild,
   SentMessage
 } from 'lib-common/generated/api-types/messaging'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { JsonOf } from 'lib-common/json'
+
+import { formatFirstName } from './names'
 
 export const deserializeDraftContent = ({
   created,
@@ -24,3 +28,23 @@ export const deserializeSentMessage = ({
   ...rest,
   sentAt: HelsinkiDateTime.parseIso(sentAt)
 })
+
+export function formatAccountNames(
+  sender: MessageAccount,
+  recipients: MessageAccount[],
+  children: MessageChild[]
+): { senderName: string; recipientNames: string[] } {
+  const childNames =
+    children.length > 0
+      ? children.map((child) => formatFirstName(child)).join(', ')
+      : undefined
+  const childSuffix = childNames ? ` (${childNames})` : ''
+
+  const senderName =
+    sender.name + (sender.type === 'CITIZEN' ? childSuffix : '')
+  const recipientNames = recipients.map(
+    (r) => r.name + (r.type === 'CITIZEN' ? childSuffix : '')
+  )
+
+  return { senderName, recipientNames }
+}


### PR DESCRIPTION
#### Summary

Show the child name(s) after the parent's name instead of always showing them after the sender's name.