### PR TITLE
Fix unit week calendar's style

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDay.tsx
@@ -326,7 +326,7 @@ const TimesRow = styled.div`
   padding: ${defaultMargins.xs};
   gap: ${defaultMargins.xs};
 
-  :nth-child(even) {
+  &:nth-child(even) {
     background: ${colors.grayscale.g4};
   }
 `


### PR DESCRIPTION
#### Summary

Same pseudo-class targeting problem as in #4357.

Before:

<img width="502" alt="Screenshot 2023-11-03 at 7 15 48" src="https://github.com/espoon-voltti/evaka/assets/70927/82ab6a1a-ecf4-43f2-9ec6-41eb55cfd48f">

After:

<img width="503" alt="Screenshot 2023-11-03 at 7 15 09" src="https://github.com/espoon-voltti/evaka/assets/70927/f4637895-95a7-4ca6-9fdb-b0aa66ed0f2a">
