### PR TITLE
Disallow adding absence on days which already contain attendance records

### DIFF
--- a/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { getDuplicateChildInfo } from 'citizen-frontend/utils/duplicated-child-utils'
+import { Failure } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import { localDateRange } from 'lib-common/form/fields'
 import { array, mapped, object, required, value } from 'lib-common/form/form'
@@ -130,6 +131,9 @@ export default React.memo(function AbsenceModal({
       )
       .reduce((sum, r) => sum + r.durationInDays(), 0) > 1
 
+  const [attendanceAlreadyExistsError, setAttendanceAlreadyExistsError] =
+    useState(false)
+
   return (
     <ModalAccessibilityWrapper>
       <PlainModal mobileFullScreen margin="auto">
@@ -204,6 +208,18 @@ export default React.memo(function AbsenceModal({
                     }
                   />
                 )}
+                {attendanceAlreadyExistsError && (
+                  <AlertBox
+                    title={
+                      i18n.calendar.absenceModal
+                        .attendanceAlreadyExistsErrorTitle
+                    }
+                    message={
+                      i18n.calendar.absenceModal
+                        .attendanceAlreadyExistsErrorDescription
+                    }
+                  />
+                )}
               </CalendarModalSection>
               <Gap size="zero" sizeOnMobile="s" />
               <LineContainer>
@@ -273,6 +289,11 @@ export default React.memo(function AbsenceModal({
                 }}
                 onSuccess={close}
                 data-qa="modal-okBtn"
+                onFailure={(failure: Failure<unknown>) => {
+                  setAttendanceAlreadyExistsError(
+                    failure.errorCode === 'ATTENDANCE_ALREADY_EXISTS'
+                  )
+                }}
               />
             </CalendarModalButtons>
           </BottomFooterContainer>

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -384,7 +384,11 @@ const en: Translations = {
         PLANNED_ABSENCE: 'Shift work absence'
       },
       contractDayAbsenceTypeWarning:
-        'Only some of the children have contract days in use, so the absence of contract days cannot be recorded for all children at the same time'
+        'Only some of the children have contract days in use, so the absence of contract days cannot be recorded for all children at the same time',
+      attendanceAlreadyExistsErrorTitle:
+        'There is already attendance record for the selected days',
+      attendanceAlreadyExistsErrorDescription:
+        'It is not possible to add an absence for a child on a day that already has an attendance record.'
     },
     holidayModal: {
       additionalInformation: 'Read more',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -381,7 +381,11 @@ export default {
         PLANNED_ABSENCE: 'Vuorotyöpoissaolo'
       },
       contractDayAbsenceTypeWarning:
-        'Vain osalla lapsista on sopimuspäivät käytössä, joten sopimuspäivien poissaoloa ei voida tallentaa kaikille lapsille samaan aikaan.'
+        'Vain osalla lapsista on sopimuspäivät käytössä, joten sopimuspäivien poissaoloa ei voida tallentaa kaikille lapsille samaan aikaan.',
+      attendanceAlreadyExistsErrorTitle:
+        'Valituille päiville on jo läsnäolomerkintöjä',
+      attendanceAlreadyExistsErrorDescription:
+        'Et voi lisätä poissaolomerkintää päivälle jolle lapsella on jo läsnäolomerkintä.'
     },
     holidayModal: {
       additionalInformation: 'Lisätietoja',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -380,7 +380,11 @@ const sv: Translations = {
         PLANNED_ABSENCE: 'Skiftarbete frånvaro'
       },
       contractDayAbsenceTypeWarning:
-        'Endast några av barnen har avtalsdagar i bruk, så frånvaron av avtalsdagar kan inte registreras för alla barn samtidigt'
+        'Endast några av barnen har avtalsdagar i bruk, så frånvaron av avtalsdagar kan inte registreras för alla barn samtidigt',
+      attendanceAlreadyExistsErrorTitle:
+        'De valda dagarna har redan anteckningar för närvaro',
+      attendanceAlreadyExistsErrorDescription:
+        'Det är inte möjligt att tillägga en frånvaro för barnet på en dag som redan har en anteckning om närvaro.'
     },
     holidayModal: {
       additionalInformation: 'Läs mera',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -29,10 +29,10 @@ import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.insert
 import fi.espoo.evaka.shared.dev.insertTestAbsence
+import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.dev.insertTestHoliday
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
-import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -1012,26 +1012,27 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
         assertAbsenceCounts(testChild_2.id, listOf(monday to 1, tuesday to 1))
     }
 
-
     @Test
     fun `cannot add absences to day which already contains attendance`() {
         db.transaction { tx ->
             tx.insertTestChildAttendance(
-                    unitId = testDaycare.id,
-                    childId = testChild_1.id,
-                    arrived = HelsinkiDateTime.of(mockToday, LocalTime.of(9, 0, 0)),
-                    departed = HelsinkiDateTime.of(mockToday, LocalTime.of(11, 0, 0)),
-            )}
+                unitId = testDaycare.id,
+                childId = testChild_1.id,
+                arrived = HelsinkiDateTime.of(mockToday, LocalTime.of(9, 0, 0)),
+                departed = HelsinkiDateTime.of(mockToday, LocalTime.of(11, 0, 0)),
+            )
+        }
         assertThrows<BadRequest> {
             postAbsences(
-                    AbsenceRequest(
-                            childIds = setOf(testChild_1.id, testChild_2.id),
-                            dateRange = FiniteDateRange(mockToday, mockToday),
-                            absenceType = AbsenceType.SICKLEAVE
-                    )
+                AbsenceRequest(
+                    childIds = setOf(testChild_1.id, testChild_2.id),
+                    dateRange = FiniteDateRange(mockToday, mockToday),
+                    absenceType = AbsenceType.SICKLEAVE
+                )
             )
         }
     }
+
     private fun dayChild(
         childId: ChildId,
         reservableTimeRange: ReservableTimeRange,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -32,6 +32,7 @@ import fi.espoo.evaka.shared.dev.insertTestAbsence
 import fi.espoo.evaka.shared.dev.insertTestHoliday
 import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.dev.insertTestServiceNeed
+import fi.espoo.evaka.shared.dev.insertTestChildAttendance
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -1011,6 +1012,26 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
         assertAbsenceCounts(testChild_2.id, listOf(monday to 1, tuesday to 1))
     }
 
+
+    @Test
+    fun `cannot add absences to day which already contains attendance`() {
+        db.transaction { tx ->
+            tx.insertTestChildAttendance(
+                    unitId = testDaycare.id,
+                    childId = testChild_1.id,
+                    arrived = HelsinkiDateTime.of(mockToday, LocalTime.of(9, 0, 0)),
+                    departed = HelsinkiDateTime.of(mockToday, LocalTime.of(11, 0, 0)),
+            )}
+        assertThrows<BadRequest> {
+            postAbsences(
+                    AbsenceRequest(
+                            childIds = setOf(testChild_1.id, testChild_2.id),
+                            dateRange = FiniteDateRange(mockToday, mockToday),
+                            absenceType = AbsenceType.SICKLEAVE
+                    )
+            )
+        }
+    }
     private fun dayChild(
         childId: ChildId,
         reservableTimeRange: ReservableTimeRange,

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -423,12 +423,15 @@ fun Database.Transaction.deleteAbsencesByFiniteDateRange(
 }
 
 fun Database.Read.childrenHaveAttendanceInRange(
-        childIds: Set<PersonId>,
-        range: FiniteDateRange
+    childIds: Set<PersonId>,
+    range: FiniteDateRange
 ): Boolean {
     return createQuery<Any> {
-        sql("""
+            sql(
+                """
             SELECT EXISTS(SELECT FROM child_attendance WHERE child_id = any(${bind(childIds)}) AND ${bind(range)} @> date)
-            """)
-    }.exactlyOne()
+            """
+            )
+        }
+        .exactlyOne()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.shared.AttendanceId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
+import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -419,4 +420,15 @@ fun Database.Transaction.deleteAbsencesByFiniteDateRange(
         .bind("dateRange", dateRange)
         .executeAndReturnGeneratedKeys()
         .toList<AbsenceId>()
+}
+
+fun Database.Read.childrenHaveAttendanceInRange(
+        childIds: Set<PersonId>,
+        range: FiniteDateRange
+): Boolean {
+    return createQuery<Any> {
+        sql("""
+            SELECT EXISTS(SELECT FROM child_attendance WHERE child_id = any(${bind(childIds)}) AND ${bind(range)} @> date)
+            """)
+    }.exactlyOne()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.reservations
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.attendance.childrenHaveAttendanceInRange
 import fi.espoo.evaka.daycare.ClubTerm
 import fi.espoo.evaka.daycare.PreschoolTerm
 import fi.espoo.evaka.daycare.getClubTerms
@@ -245,6 +246,9 @@ class ReservationControllerCitizen(
                         Action.Citizen.Child.CREATE_ABSENCE,
                         body.childIds
                     )
+                    if (tx.childrenHaveAttendanceInRange(body.childIds, body.dateRange)) {
+                        throw BadRequest("Attendance already exists for given dates", "ATTENDANCE_ALREADY_EXISTS")
+                    }
 
                     val reservableRange =
                         getReservableRange(

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -247,7 +247,10 @@ class ReservationControllerCitizen(
                         body.childIds
                     )
                     if (tx.childrenHaveAttendanceInRange(body.childIds, body.dateRange)) {
-                        throw BadRequest("Attendance already exists for given dates", "ATTENDANCE_ALREADY_EXISTS")
+                        throw BadRequest(
+                            "Attendance already exists for given dates",
+                            "ATTENDANCE_ALREADY_EXISTS"
+                        )
                     }
 
                     val reservableRange =


### PR DESCRIPTION
## Before this change
It was possible to add an absence (e.g. sick leave) for a day which already contains attendance records. This may affect billing in a way that should not be allowed.
## After this change
Creating absence markings for a day with existing attendance record is no more possible via `POST /citizen/absences`. Instead the API will return a HTTP 400 - Invalid Request with error code `ATTENDANCE_ALREADY_EXISTS` and the UI will react to this error by displaying 
> There is already attendance record for the selected days
> It is not possible to add an absence for a child on a day that already has an attendance record.

![image](https://github.com/espoon-voltti/evaka/assets/886091/ebaea40a-55f4-4779-b5da-ff7bbe13fac8)
