### PR TITLE
Mobile messaging fixes and e2e tests

### DIFF
--- a/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
@@ -22,9 +22,7 @@ export class CitizenChildIncomeStatementViewPage {
   async assertAttachmentExists(name: string) {
     await waitUntilTrue(async () =>
       (
-        await this.page
-          .findAllByDataQa('attachment-download-button')
-          .allInnerTexts()
+        await this.page.findAllByDataQa('attachment-download-button').allTexts()
       ).includes(name)
     )
   }

--- a/frontend/src/e2e-test/pages/citizen/citizen-children.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-children.ts
@@ -124,7 +124,7 @@ export class CitizenChildPage {
   }
 
   getTerminatedPlacements(): Promise<string[]> {
-    return this.#terminatedPlacements.allInnerTexts()
+    return this.#terminatedPlacements.allTexts()
   }
 
   async togglePlacement(label: string) {
@@ -145,13 +145,11 @@ export class CitizenChildPage {
   }
 
   getTerminatablePlacements(): Promise<string[]> {
-    return this.#placements.allInnerTexts()
+    return this.#placements.allTexts()
   }
 
   getNonTerminatablePlacements(): Promise<string[]> {
-    return this.page
-      .findAllByDataQa('non-terminatable-placement')
-      .allInnerTexts()
+    return this.page.findAllByDataQa('non-terminatable-placement').allTexts()
   }
 
   getToggledPlacements(): Promise<string[]> {

--- a/frontend/src/e2e-test/pages/employee/child-information.ts
+++ b/frontend/src/e2e-test/pages/employee/child-information.ts
@@ -374,7 +374,7 @@ export class PedagogicalDocumentsSection extends Section {
     )
     await waitUntilTrue(async () =>
       (
-        await page.findAll('[data-qa="file-download-button"]').allInnerTexts()
+        await page.findAll('[data-qa="file-download-button"]').allTexts()
       ).includes(testfileName)
     )
   }
@@ -1210,9 +1210,7 @@ export class FeeAlterationsSection extends Section {
 
   async assertAttachmentExists(name: string) {
     await waitUntilTrue(async () =>
-      (await this.page.findAllByDataQa('attachment').allInnerTexts()).includes(
-        name
-      )
+      (await this.page.findAllByDataQa('attachment').allTexts()).includes(name)
     )
   }
 }

--- a/frontend/src/e2e-test/pages/employee/employees.ts
+++ b/frontend/src/e2e-test/pages/employee/employees.ts
@@ -12,6 +12,6 @@ export class EmployeesPage {
   )
 
   get visibleUsers(): Promise<string[]> {
-    return this.page.findAllByDataQa('employee-name').allInnerTexts()
+    return this.page.findAllByDataQa('employee-name').allTexts()
   }
 }

--- a/frontend/src/e2e-test/pages/employee/holiday-periods.ts
+++ b/frontend/src/e2e-test/pages/employee/holiday-periods.ts
@@ -8,14 +8,14 @@ export class HolidayPeriodsPage {
   constructor(private readonly page: Page) {}
 
   get visiblePeriods(): Promise<string[]> {
-    return this.page.findAllByDataQa('holiday-period').allInnerTexts()
+    return this.page.findAllByDataQa('holiday-period').allTexts()
   }
 
   #periodRows = this.page.findAllByDataQa('holiday-period-row')
   #questionnaireRows = this.page.findAllByDataQa('questionnaire-row')
 
   get visibleQuestionnaires(): Promise<string[]> {
-    return this.#questionnaireRows.allInnerTexts()
+    return this.#questionnaireRows.allTexts()
   }
 
   async assertQuestionnaireContainsText(nth: number, texts: string[]) {

--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -231,7 +231,7 @@ export class UnitStaffAttendancesTable extends Element {
   }
 
   get allNames(): Promise<string[]> {
-    return this.findAllByDataQa('staff-attendance-name').allInnerTexts()
+    return this.findAllByDataQa('staff-attendance-name').allTexts()
   }
 
   get rowCount(): Promise<number> {

--- a/frontend/src/e2e-test/pages/employee/units/unit.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit.ts
@@ -597,7 +597,7 @@ class AclSection extends Element {
       )
       .waitUntilVisible()
     await waitUntilEqual(
-      () => row.find('[data-qa="groups"] > div').findAll('div').allInnerTexts(),
+      () => row.find('[data-qa="groups"] > div').findAll('div').allTexts(),
       fields.groups
     )
   }

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
@@ -190,7 +190,7 @@ export class VasuPage extends VasuPageCommon {
   // The (first) label for the state chip has no corresponding span, so the index is off by one.
   #valueForLabel = (label: string): Promise<string> =>
     this.#vasuEventListLabels
-      .allInnerTexts()
+      .allTexts()
       .then((labels) =>
         labels.reduce(
           async (acc, l, ix) =>

--- a/frontend/src/e2e-test/pages/mobile/child-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/child-page.ts
@@ -119,7 +119,7 @@ export default class MobileChildPage {
     await waitUntilEqual(
       () =>
         this.attendance.arrivalTimes
-          .allInnerTexts()
+          .allTexts()
           .then((texts) =>
             texts.map((text) => text.replace(/\s/g, '')).join(',')
           ),
@@ -131,7 +131,7 @@ export default class MobileChildPage {
     await waitUntilEqual(
       () =>
         this.attendance.departureTimes
-          .allInnerTexts()
+          .allTexts()
           .then((texts) =>
             texts.map((text) => text.replace(/\s/g, '')).join(',')
           ),

--- a/frontend/src/e2e-test/pages/mobile/message-editor.ts
+++ b/frontend/src/e2e-test/pages/mobile/message-editor.ts
@@ -20,7 +20,10 @@ export default class MobileMessageEditor extends Element {
   title = new TextInput(this.findByDataQa('input-title'))
   content = new TextInput(this.findByDataQa('input-content'))
   urgent = new Checkbox(this.findByDataQa('checkbox-urgent'))
+
   send = this.findByDataQa('send-message-btn')
+  discard = this.findByDataQa('discard-message-btn')
+  close = this.find('[aria-label="Sulje"]')
 
   async fillMessage(message: {
     title: string

--- a/frontend/src/e2e-test/pages/mobile/messages.ts
+++ b/frontend/src/e2e-test/pages/mobile/messages.ts
@@ -3,19 +3,26 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { waitUntilTrue } from '../../utils'
-import { Page } from '../../utils/page'
+import { Element, Page } from '../../utils/page'
+
+import MobileMessageEditor from './message-editor'
 
 export default class MobileMessagesPage {
   constructor(private readonly page: Page) {}
 
   messagesContainer = this.page.findByDataQa('messages-page-content-area')
   noAccountInfo = this.page.findByDataQa('info-no-account-access')
+
+  receivedTab = this.page.findByDataQa('received-tab')
+  sentTab = this.page.findByDataQa('sent-tab')
+  draftsTab = this.page.findByDataQa('drafts-tab')
+
   threads = this.page.findAllByDataQa('message-preview')
+  titles = this.page.findAllByDataQa('message-preview-title')
   newMessage = this.page.findByDataQa('new-message-btn')
 
   async getThreadTitle(index: number) {
-    const titles = this.page.findAllByDataQa('message-preview-title')
-    return titles.nth(index).text
+    return this.titles.nth(index).text
   }
 
   async assertThreadsExist() {
@@ -24,5 +31,75 @@ export default class MobileMessagesPage {
 
   async openFirstThread() {
     await this.threads.first().click()
+  }
+
+  async openSentTab() {
+    await this.sentTab.click()
+    return new SentTab(this.page)
+  }
+
+  async openDraftsTab() {
+    await this.draftsTab.click()
+    return new DraftsTab(this.page)
+  }
+}
+
+export class SentTab {
+  constructor(private readonly page: Page) {}
+
+  messages = this.page.findAllByDataQa('sent-message-preview')
+
+  message(nth: number) {
+    return new SentMessagePreview(this.page, this.messages.nth(nth))
+  }
+}
+
+export class SentMessagePreview extends Element {
+  constructor(
+    private readonly page: Page,
+    el: Element
+  ) {
+    super(el)
+  }
+
+  title = this.findByDataQa('message-preview-title')
+
+  async openMessage() {
+    await this.click()
+    return new SentMessage(this.page)
+  }
+}
+
+export class SentMessage {
+  constructor(private readonly page: Page) {}
+
+  topBarTitle = this.page.findByDataQa('top-bar-title')
+  content = this.page.findByDataQa('single-message-content')
+}
+
+export class DraftsTab {
+  constructor(private readonly page: Page) {}
+
+  list = this.page.findByDataQa('draft-list')
+  messages = this.list.findAllByDataQa('draft-message-preview')
+
+  message(nth: number) {
+    return new DraftMessagePreview(this.page, this.messages.nth(nth))
+  }
+}
+
+class DraftMessagePreview extends Element {
+  constructor(
+    private readonly page: Page,
+    el: Element
+  ) {
+    super(el)
+  }
+
+  title = this.findByDataQa('message-preview-title')
+
+  async editDraft() {
+    await this.click()
+    return new MobileMessageEditor(this.page)
   }
 }

--- a/frontend/src/e2e-test/pages/mobile/messages.ts
+++ b/frontend/src/e2e-test/pages/mobile/messages.ts
@@ -29,8 +29,8 @@ export default class MobileMessagesPage {
     await waitUntilTrue(async () => (await this.threads.count()) > 0)
   }
 
-  async openFirstThread() {
-    await this.threads.first().click()
+  thread(nth: number) {
+    return new ReceivedThreadPreview(this.threads.nth(nth))
   }
 
   async openSentTab() {
@@ -42,6 +42,10 @@ export default class MobileMessagesPage {
     await this.draftsTab.click()
     return new DraftsTab(this.page)
   }
+}
+
+export class ReceivedThreadPreview extends Element {
+  draftIndicator = this.findByDataQa('draft-indicator')
 }
 
 export class SentTab {

--- a/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
@@ -22,6 +22,11 @@ export default class PinLoginPage {
     await this.submitPin(pin)
   }
 
+  async personalDeviceLogin(pin: string) {
+    // The staff member is not asked on personal mobile device
+    await this.submitPin(pin)
+  }
+
   async assertWrongPinError() {
     await this.#pinInfo.assertTextEquals('Väärä PIN-koodi')
   }

--- a/frontend/src/e2e-test/pages/mobile/staff-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/staff-page.ts
@@ -177,7 +177,7 @@ export class StaffAttendancePage {
     await waitUntilEqual(
       () =>
         this.staffMemberPage.attendanceTimeTexts
-          .allInnerTexts()
+          .allTexts()
           .then((texts) => texts.join(',')),
       expectedText
     )

--- a/frontend/src/e2e-test/pages/mobile/thread-view.ts
+++ b/frontend/src/e2e-test/pages/mobile/thread-view.ts
@@ -7,6 +7,7 @@ import { Page, TextInput } from '../../utils/page'
 export default class ThreadViewPage {
   constructor(private readonly page: Page) {}
 
+  goBack = this.page.findByDataQa('go-back')
   replyButton = this.page.findByDataQa('message-reply-editor-btn')
   replyContent = new TextInput(this.page.findByDataQa('message-reply-content'))
   sendReplyButton = this.page.findByDataQa('message-send-btn')

--- a/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
@@ -383,11 +383,6 @@ describe('Messages page', () => {
 
     messageEditor = await firstDraft.editDraft()
 
-    // TODO: recipients have to be reselected because the TreeView doesn't restore them correctly
-    await messageEditor.recipients.open()
-    await messageEditor.recipients.option(daycareGroup.id).click()
-    await messageEditor.recipients.option(daycareGroup.id).click()
-
     await messageEditor.recipients.values.assertTextsEqual([daycareGroup.name])
     await messageEditor.title.assertValueEquals(message.title)
     await messageEditor.content.assertValueEquals(message.content)

--- a/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
@@ -283,6 +283,26 @@ describe('Messages page', () => {
     await messagesPage.assertThreadsExist()
   })
 
+  test('Draft replies are indicated in the thread list', async () => {
+    await initCitizenPage(mockedDateAt10)
+    await citizenSendsMessageToGroup()
+    await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
+    await userSeesNewMessagesIndicator()
+    await employeeLoginsToMessagesPage()
+
+    await nav.selectGroup(daycareGroupId)
+
+    await messagesPage.thread(0).click()
+    await waitUntilEqual(() => threadView.singleMessageContents.count(), 1)
+    const replyContent = 'Testivastauksen sisältö'
+    await threadView.replyButton.click()
+    await threadView.replyContent.fill(replyContent)
+
+    await threadView.goBack.click()
+
+    await messagesPage.thread(0).draftIndicator.waitUntilVisible()
+  })
+
   test('Employee replies as a group to message sent to group', async () => {
     await initCitizenPage(mockedDateAt10)
     await citizenSendsMessageToGroup()
@@ -292,7 +312,7 @@ describe('Messages page', () => {
 
     await nav.selectGroup(daycareGroupId)
 
-    await messagesPage.openFirstThread()
+    await messagesPage.thread(0).click()
     await waitUntilEqual(() => threadView.singleMessageContents.count(), 1)
     const replyContent = 'Testivastauksen sisältö'
     await threadView.replyButton.click()
@@ -315,7 +335,7 @@ describe('Messages page', () => {
 
     await nav.selectGroup(daycareGroupId)
 
-    await messagesPage.openFirstThread()
+    await messagesPage.thread(0).click()
     await waitUntilEqual(() => threadView.singleMessageContents.count(), 1)
     await threadView.replyButton.click()
     await threadView.replyContent.fill('foo bar baz')
@@ -433,7 +453,7 @@ describe('Messages page', () => {
 
     await nav.selectGroup(daycareGroup.id)
     await messagesPage.assertThreadsExist()
-    await messagesPage.openFirstThread()
+    await messagesPage.thread(0).click()
 
     await waitUntilEqual(() => threadView.singleMessageContents.count(), 1)
     await waitUntilEqual(

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -158,6 +158,10 @@ export class ElementCollection {
       await this.nth(count).waitUntilHidden()
     }
   }
+
+  async assertTextsEqual(values: string[]) {
+    await waitUntilEqual(() => this.allTexts(), values)
+  }
 }
 
 export class Element {
@@ -505,6 +509,8 @@ export class Modal extends Element {
 }
 
 export class TreeDropdown extends Element {
+  values = this.findByDataQa('selected-values').findAllByDataQa('value')
+
   private async expanded(): Promise<boolean> {
     return (
       (await this.findByDataQa('tree-dropdown').getAttribute(

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -116,7 +116,7 @@ export class ElementCollection {
     return this.locator.count()
   }
 
-  async allInnerTexts(): Promise<string[]> {
+  async allTexts(): Promise<string[]> {
     return this.locator.allInnerTexts()
   }
 
@@ -418,7 +418,7 @@ export class Select extends Element {
   }
 
   get allOptions(): Promise<string[]> {
-    return this.#input.findAll('option').allInnerTexts()
+    return this.#input.findAll('option').allTexts()
   }
 }
 

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
@@ -12,7 +12,7 @@ import {
 } from 'lib-common/form/fields'
 import { object, oneOf, required, validated } from 'lib-common/form/form'
 import { useForm, useFormFields } from 'lib-common/form/hooks'
-import { nonEmpty } from 'lib-common/form/validators'
+import { nonBlank } from 'lib-common/form/validators'
 import {
   DocumentLanguage,
   DocumentType,
@@ -34,7 +34,7 @@ import {
 } from '../queries'
 
 const documentTemplateForm = object({
-  name: validated(string(), nonEmpty),
+  name: validated(string(), nonBlank),
   type: required(oneOf<DocumentType>()),
   language: required(oneOf<DocumentLanguage>()),
   confidential: boolean(),

--- a/frontend/src/employee-frontend/components/document-templates/templates.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/templates.tsx
@@ -8,7 +8,7 @@ import { string } from 'lib-common/form/fields'
 import { array, mapped, object, union, validated } from 'lib-common/form/form'
 import { BoundForm, useFormUnion } from 'lib-common/form/hooks'
 import { StateOf } from 'lib-common/form/types'
-import { nonEmpty } from 'lib-common/form/validators'
+import { nonBlank } from 'lib-common/form/validators'
 import {
   DocumentTemplateContent,
   Question,
@@ -60,8 +60,8 @@ export const templateQuestionForm = mapped(
 )
 
 export const templateSectionForm = object({
-  id: validated(string(), nonEmpty),
-  label: validated(string(), nonEmpty),
+  id: validated(string(), nonBlank),
+  label: validated(string(), nonBlank),
   questions: array(templateQuestionForm),
   infoText: string()
 })

--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReportPreschoolDecision.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReportPreschoolDecision.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components'
 import { string } from 'lib-common/form/fields'
 import { object, validated } from 'lib-common/form/form'
 import { useForm, useFormFields } from 'lib-common/form/hooks'
-import { nonEmpty } from 'lib-common/form/validators'
+import { nonBlank } from 'lib-common/form/validators'
 import {
   AssistanceNeedPreschoolDecision,
   AssistanceNeedPreschoolDecisionResponse
@@ -62,7 +62,7 @@ const DangerButton = styled(Button)`
 `
 
 const annulForm = object({
-  reason: validated(string(), nonEmpty)
+  reason: validated(string(), nonBlank)
 })
 
 const AnnulModal = React.memo(function AnnulModal({

--- a/frontend/src/employee-mobile-frontend/common/TopBar.tsx
+++ b/frontend/src/employee-mobile-frontend/common/TopBar.tsx
@@ -52,6 +52,7 @@ interface Props {
   title: string
   onBack?: () => void
   onClose?: () => void
+  closeDisabled?: boolean
   invertedColors?: boolean
 }
 
@@ -59,6 +60,7 @@ export default React.memo(function TopBar({
   title,
   onBack,
   onClose,
+  closeDisabled = false,
   invertedColors
 }: Props) {
   const { i18n } = useTranslation()
@@ -89,6 +91,7 @@ export default React.memo(function TopBar({
           <IconButton
             icon={faTimes}
             white
+            disabled={closeDisabled}
             onClick={onClose}
             aria-label={i18n.common.close}
           />

--- a/frontend/src/employee-mobile-frontend/messages/DraftMessagesList.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/DraftMessagesList.tsx
@@ -39,7 +39,7 @@ export default React.memo(function DraftMessagesList({ onSelectDraft }: Props) {
   )
 
   return renderResult(draftMessages, (messages) => (
-    <div>
+    <div data-qa="draft-list">
       {messages.length > 0 ? (
         messages.map((message) => (
           <DraftMessagePreview
@@ -72,7 +72,7 @@ const DraftMessagePreview = React.memo(function DraftMessagePreview({
     <Container
       isRead={true}
       active={false}
-      data-qa="sent-message-preview"
+      data-qa="draft-message-preview"
       onClick={onClick}
     >
       <FixedSpaceColumn>

--- a/frontend/src/employee-mobile-frontend/messages/DraftMessagesList.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/DraftMessagesList.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useContext } from 'react'
+import styled from 'styled-components'
 
 import { DraftContent } from 'lib-common/generated/api-types/messaging'
 import { queryOrDefault, useQueryResult } from 'lib-common/query'
@@ -14,6 +15,7 @@ import {
   TitleAndDate,
   Truncated
 } from 'lib-components/messages/ThreadListItem'
+import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 
 import { renderResult } from '../async-rendering'
@@ -27,6 +29,7 @@ interface Props {
 }
 
 export default React.memo(function DraftMessagesList({ onSelectDraft }: Props) {
+  const { i18n } = useTranslation()
   const { selectedAccount } = useContext(MessageContext)
   const draftMessages = useQueryResult(
     queryOrDefault(
@@ -37,16 +40,25 @@ export default React.memo(function DraftMessagesList({ onSelectDraft }: Props) {
 
   return renderResult(draftMessages, (messages) => (
     <div>
-      {messages.map((message) => (
-        <DraftMessagePreview
-          key={message.id}
-          message={message}
-          onClick={() => onSelectDraft(message)}
-        />
-      ))}
+      {messages.length > 0 ? (
+        messages.map((message) => (
+          <DraftMessagePreview
+            key={message.id}
+            message={message}
+            onClick={() => onSelectDraft(message)}
+          />
+        ))
+      ) : (
+        <NoDrafts>{i18n.messages.noDrafts}</NoDrafts>
+      )}
     </div>
   ))
 })
+
+const NoDrafts = styled.div`
+  padding: ${defaultMargins.s};
+  text-align: center;
+`
 
 const DraftMessagePreview = React.memo(function DraftMessagePreview({
   message,

--- a/frontend/src/employee-mobile-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/MessageEditor.tsx
@@ -253,6 +253,7 @@ export default React.memo(function MessageEditor({
               return cancelMutation
             }}
             onSuccess={onClose}
+            data-qa="discard-message-btn"
           />
           <span />
           <MutateButton

--- a/frontend/src/employee-mobile-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/MessageEditor.tsx
@@ -171,6 +171,7 @@ export default React.memo(function MessageEditor({
       <TopBar
         invertedColors
         title={i18n.messages.messageEditor.newMessage}
+        closeDisabled={isSavingDraft}
         onClose={() => {
           saveDraftImmediately()
           onClose()

--- a/frontend/src/employee-mobile-frontend/messages/ReceivedThreadsList.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/ReceivedThreadsList.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useCallback, useContext } from 'react'
+import styled from 'styled-components'
 
 import { formatDateOrTime } from 'lib-common/date'
 import { MessageThread } from 'lib-common/generated/api-types/messaging'
@@ -125,6 +126,10 @@ const MessagePreview = React.memo(function MessagePreview({
   hasUnreadMessages: boolean
   onClick: () => void
 }) {
+  const { i18n } = useTranslation()
+  const { getReplyContent } = useContext(MessageContext)
+  const hasDraftReply = getReplyContent(thread.id) !== ''
+
   const lastMessage = thread.messages[thread.messages.length - 1]
   const participants = [...new Set(thread.messages.map((t) => t.sender.name))]
   return (
@@ -150,7 +155,16 @@ const MessagePreview = React.memo(function MessagePreview({
             .substring(0, 200)
             .replace(new RegExp('\\n', 'g'), ' ')}
         </Truncated>
+        {hasDraftReply ? (
+          <DraftIndicator data-qa="draft-indicator">
+            {i18n.messages.draftReply}
+          </DraftIndicator>
+        ) : null}
       </FixedSpaceColumn>
     </Container>
   )
 })
+
+const DraftIndicator = styled.div`
+  color: ${(p) => p.theme.colors.accents.a2orangeDark};
+`

--- a/frontend/src/employee-mobile-frontend/messages/SentMessagesList.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/SentMessagesList.tsx
@@ -40,7 +40,7 @@ export default React.memo(function SentMessagesList({
   )
 
   return renderResult(sentMessages, (messages) => (
-    <div>
+    <div data-qa="sent-list">
       {messages.length > 0 ? (
         messages.map((message) => (
           <SentMessagePreview

--- a/frontend/src/employee-mobile-frontend/messages/SentMessagesList.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/SentMessagesList.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useContext } from 'react'
+import styled from 'styled-components'
 
 import { formatDateOrTime } from 'lib-common/date'
 import { SentMessage } from 'lib-common/generated/api-types/messaging'
@@ -15,8 +16,10 @@ import {
   TitleAndDate,
   Truncated
 } from 'lib-components/messages/ThreadListItem'
+import { defaultMargins } from 'lib-components/white-space'
 
 import { renderResult } from '../async-rendering'
+import { useTranslation } from '../common/i18n'
 
 import { sentMessagesQuery } from './queries'
 import { MessageContext } from './state'
@@ -28,6 +31,7 @@ interface Props {
 export default React.memo(function SentMessagesList({
   onSelectMessage
 }: Props) {
+  const { i18n } = useTranslation()
   const { selectedAccount } = useContext(MessageContext)
 
   const { data: sentMessages } = usePagedInfiniteQueryResult(
@@ -37,16 +41,25 @@ export default React.memo(function SentMessagesList({
 
   return renderResult(sentMessages, (messages) => (
     <div>
-      {messages.map((message) => (
-        <SentMessagePreview
-          key={message.contentId}
-          message={message}
-          onClick={() => onSelectMessage(message)}
-        />
-      ))}
+      {messages.length > 0 ? (
+        messages.map((message) => (
+          <SentMessagePreview
+            key={message.contentId}
+            message={message}
+            onClick={() => onSelectMessage(message)}
+          />
+        ))
+      ) : (
+        <NoSentMessages>{i18n.messages.noSentMessages}</NoSentMessages>
+      )}
     </div>
   ))
 })
+
+const NoSentMessages = styled.div`
+  padding: ${defaultMargins.s};
+  text-align: center;
+`
 
 const SentMessagePreview = React.memo(function SentMessagePreview({
   message,

--- a/frontend/src/employee-mobile-frontend/staff-attendance/StaffAttendanceEditPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/StaffAttendanceEditPage.tsx
@@ -25,7 +25,7 @@ import {
   useFormFields
 } from 'lib-common/form/hooks'
 import { StateOf } from 'lib-common/form/types'
-import { nonEmpty } from 'lib-common/form/validators'
+import { nonBlank } from 'lib-common/form/validators'
 import {
   GroupInfo,
   StaffAttendanceType,
@@ -112,7 +112,7 @@ const staffAttendanceRow = mapped(
 const staffAttendanceRows = array(staffAttendanceRow)
 
 const staffAttendancesForm = object({
-  pinCode: validated(string(), nonEmpty),
+  pinCode: validated(string(), nonBlank),
   rows: staffAttendanceRows
 })
 

--- a/frontend/src/lib-common/form/validators.ts
+++ b/frontend/src/lib-common/form/validators.ts
@@ -20,5 +20,5 @@ export const requiredPhoneNumber = regexp(PHONE_REGEXP, 'phone')
 export const optionalEmail = regexpOrBlank(EMAIL_REGEXP, 'email')
 export const requiredEmail = regexp(EMAIL_REGEXP, 'email')
 
-export const nonEmpty = (s: string) =>
+export const nonBlank = (s: string) =>
   s.trim() === '' ? 'required' : undefined

--- a/frontend/src/lib-components/atoms/dropdowns/TreeDropdown.tsx
+++ b/frontend/src/lib-components/atoms/dropdowns/TreeDropdown.tsx
@@ -333,7 +333,7 @@ function TreeDropdown<N extends TreeNode>({
       .map((node) =>
         hasUncheckedChildren(node) ? (
           formEntries(node.children).map(({ child, key }) => (
-            <ValueChip key={JSON.stringify([...node.key, key])}>
+            <ValueChip key={JSON.stringify([...node.key, key])} data-qa="value">
               {tree.length !== 1 ? (
                 // do not show unnecessary top-level node text if it's the only top-level node
                 <>{node.text}/</>
@@ -342,7 +342,9 @@ function TreeDropdown<N extends TreeNode>({
             </ValueChip>
           ))
         ) : (
-          <ValueChip key={node.key}>{node.text}</ValueChip>
+          <ValueChip key={node.key} data-qa="value">
+            {node.text}
+          </ValueChip>
         )
       )
   }, [tree])
@@ -362,7 +364,7 @@ function TreeDropdown<N extends TreeNode>({
         data-qa="tree-dropdown"
         data-qa-expanded={active}
       >
-        <DropdownContainerContent>
+        <DropdownContainerContent data-qa="selected-values">
           {treeValue.length === 0 ? placeholder : treeValue}
         </DropdownContainerContent>
         <IconButton icon={faChevronDown} aria-label={i18n.expandDropdown} />

--- a/frontend/src/lib-components/document-templates/question-descriptors/CheckboxGroupQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/CheckboxGroupQuestionDescriptor.tsx
@@ -16,7 +16,7 @@ import {
   useFormFields
 } from 'lib-common/form/hooks'
 import { StateOf } from 'lib-common/form/types'
-import { nonEmpty } from 'lib-common/form/validators'
+import { nonBlank } from 'lib-common/form/validators'
 import {
   AnsweredQuestion,
   CheckboxGroupAnswerContent,
@@ -43,14 +43,14 @@ const questionType: QuestionType = 'CHECKBOX_GROUP'
 type ApiQuestion = Question.CheckboxGroupQuestion
 
 const optionForm = object({
-  id: validated(string(), nonEmpty),
-  label: validated(string(), nonEmpty),
+  id: validated(string(), nonBlank),
+  label: validated(string(), nonBlank),
   withText: boolean()
 })
 
 const templateForm = object({
-  id: validated(string(), nonEmpty),
-  label: validated(string(), nonEmpty),
+  id: validated(string(), nonBlank),
+  label: validated(string(), nonBlank),
   options: validated(array(optionForm), (arr) =>
     arr.length > 0 ? undefined : 'required'
   ),

--- a/frontend/src/lib-components/document-templates/question-descriptors/CheckboxQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/CheckboxQuestionDescriptor.tsx
@@ -9,7 +9,7 @@ import { string } from 'lib-common/form/fields'
 import { mapped, object, validated, value } from 'lib-common/form/form'
 import { BoundForm, useForm, useFormFields } from 'lib-common/form/hooks'
 import { StateOf } from 'lib-common/form/types'
-import { nonEmpty } from 'lib-common/form/validators'
+import { nonBlank } from 'lib-common/form/validators'
 import {
   AnsweredQuestion,
   Question,
@@ -30,8 +30,8 @@ const questionType: QuestionType = 'CHECKBOX'
 type ApiQuestion = Question.CheckboxQuestion
 
 const templateForm = object({
-  id: validated(string(), nonEmpty),
-  label: validated(string(), nonEmpty),
+  id: validated(string(), nonBlank),
+  label: validated(string(), nonBlank),
   infoText: string()
 })
 

--- a/frontend/src/lib-components/document-templates/question-descriptors/RadioButtonGroupQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/RadioButtonGroupQuestionDescriptor.tsx
@@ -16,7 +16,7 @@ import {
   useFormFields
 } from 'lib-common/form/hooks'
 import { StateOf } from 'lib-common/form/types'
-import { nonEmpty } from 'lib-common/form/validators'
+import { nonBlank } from 'lib-common/form/validators'
 import {
   AnsweredQuestion,
   Question,
@@ -42,13 +42,13 @@ const questionType: QuestionType = 'RADIO_BUTTON_GROUP'
 type ApiQuestion = Question.RadioButtonGroupQuestion
 
 const optionForm = object({
-  id: validated(string(), nonEmpty),
-  label: validated(string(), nonEmpty)
+  id: validated(string(), nonBlank),
+  label: validated(string(), nonBlank)
 })
 
 const templateForm = object({
-  id: validated(string(), nonEmpty),
-  label: validated(string(), nonEmpty),
+  id: validated(string(), nonBlank),
+  label: validated(string(), nonBlank),
   options: validated(array(optionForm), (arr) =>
     arr.length > 0 ? undefined : 'required'
   ),

--- a/frontend/src/lib-components/document-templates/question-descriptors/StaticTextDisplayQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/StaticTextDisplayQuestionDescriptor.tsx
@@ -10,7 +10,7 @@ import { string } from 'lib-common/form/fields'
 import { mapped, object, validated, value } from 'lib-common/form/form'
 import { BoundForm, useForm, useFormFields } from 'lib-common/form/hooks'
 import { StateOf } from 'lib-common/form/types'
-import { nonEmpty } from 'lib-common/form/validators'
+import { nonBlank } from 'lib-common/form/validators'
 import {
   AnsweredQuestion,
   Question,
@@ -32,7 +32,7 @@ const questionType: QuestionType = 'STATIC_TEXT_DISPLAY'
 type ApiQuestion = Question.StaticTextDisplayQuestion
 
 const templateForm = object({
-  id: validated(string(), nonEmpty),
+  id: validated(string(), nonBlank),
   label: string(),
   text: string(),
   infoText: string()

--- a/frontend/src/lib-components/document-templates/question-descriptors/TextQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/TextQuestionDescriptor.tsx
@@ -9,7 +9,7 @@ import { boolean, string } from 'lib-common/form/fields'
 import { mapped, object, validated, value } from 'lib-common/form/form'
 import { BoundForm, useForm, useFormFields } from 'lib-common/form/hooks'
 import { StateOf } from 'lib-common/form/types'
-import { nonEmpty } from 'lib-common/form/validators'
+import { nonBlank } from 'lib-common/form/validators'
 import {
   AnsweredQuestion,
   Question,
@@ -31,8 +31,8 @@ const questionType: QuestionType = 'TEXT'
 type ApiQuestion = Question.TextQuestion
 
 const templateForm = object({
-  id: validated(string(), nonEmpty),
-  label: validated(string(), nonEmpty),
+  id: validated(string(), nonBlank),
+  label: validated(string(), nonBlank),
   infoText: string(),
   multiline: boolean()
 })

--- a/frontend/src/lib-components/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageEditor.tsx
@@ -113,6 +113,7 @@ const shouldSensitiveCheckboxBeEnabled = (
   }
   return senderAccountType === 'PERSONAL'
 }
+
 interface FlagProps {
   urgent: boolean
   sensitive: boolean
@@ -138,6 +139,7 @@ const FlagsInfoContent = React.memo(function FlagsInfoContent({
     </UlNoMargin>
   )
 })
+
 interface Props {
   availableReceivers: MessageReceiversResponse[]
   defaultSender: SelectOption
@@ -178,7 +180,11 @@ export default React.memo(function MessageEditor({
   const i18n = useTranslations()
 
   const [receiverTree, setReceiverTree] = useState<SelectorNode[]>(
-    receiversAsSelectorNode(defaultSender.value, availableReceivers)
+    receiversAsSelectorNode(
+      defaultSender.value,
+      availableReceivers,
+      draftContent?.recipientIds
+    )
   )
   const [message, setMessage] = useState<Message>(() =>
     getInitialMessage(draftContent, defaultSender, defaultTitle)
@@ -270,14 +276,16 @@ export default React.memo(function MessageEditor({
         senderAccountType
       )
 
-      setMessage((old) => ({
-        ...old,
+      const updatedMessage = {
+        ...message,
         recipientIds: selected.map((s) => s.key),
         recipientNames: selected.map((s) => s.text),
-        sensitive: shouldResetSensitivity ? false : old.sensitive
-      }))
+        sensitive: shouldResetSensitivity ? false : message.sensitive
+      }
+      setMessage(updatedMessage)
+      setDraft(messageToUpdatableDraftWithAccount(updatedMessage, selected))
     },
-    [message.type, senderAccountType]
+    [message, senderAccountType, setDraft]
   )
 
   const [expandedView, setExpandedView] = useState(false)

--- a/frontend/src/lib-components/messages/SelectorNode.ts
+++ b/frontend/src/lib-components/messages/SelectorNode.ts
@@ -49,15 +49,22 @@ export const receiversAsSelectorNode = (
 }
 
 function checkSelected(selectedIds: UUID[], node: SelectorNode): SelectorNode {
-  const children = node.children.map((child) =>
-    checkSelected(selectedIds, child)
-  )
-  return {
-    ...node,
-    checked:
-      selectedIds.includes(node.key) || children.some((child) => child.checked),
-    children
+  if (selectedIds.includes(node.key)) {
+    return checkAll(node)
+  } else {
+    const children = node.children.map((child) =>
+      checkSelected(selectedIds, child)
+    )
+    return {
+      ...node,
+      checked: children.some((child) => child.checked),
+      children
+    }
   }
+}
+
+function checkAll(node: SelectorNode): SelectorNode {
+  return { ...node, checked: true, children: node.children.map(checkAll) }
 }
 
 const receiverAsSelectorNode = (receiver: MessageReceiver): SelectorNode => ({

--- a/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
+++ b/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
@@ -358,6 +358,7 @@ export const fi = {
       reply: 'Vastaa viestiin'
     },
     draft: 'Luonnos',
+    draftReply: '- Luonnos -',
     messageEditor: {
       newMessage: 'Uusi viesti',
       to: {

--- a/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
+++ b/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
@@ -391,6 +391,8 @@ export const fi = {
       sending: 'Lähetetään'
     },
     emptyInbox: 'Viestilaatikkosi on tyhjä',
+    noSentMessages: 'Ei lähetettyjä viestejä',
+    noDrafts: 'Ei luonnoksia',
     unreadMessages: 'Uudet viestit',
     openPinLock: 'Avaa lukitus',
     pinLockInfo:

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -334,6 +334,15 @@ class MessageController(
         @PathVariable accountId: MessageAccountId,
         @RequestBody body: PostMessageBody
     ): MessageContentId? {
+        if (body.recipients.isEmpty()) {
+            throw BadRequest("Message must have at least one recipient")
+        }
+        if (body.content.isBlank()) {
+            throw BadRequest("Message content cannot be empty")
+        }
+        if (body.title.isBlank()) {
+            throw BadRequest("Message title cannot be empty")
+        }
         return db.connect { dbc ->
                 requireMessageAccountAccess(dbc, user, clock, accountId)
                 dbc.transaction { tx ->


### PR DESCRIPTION
#### Summary

Employee mobile:
- Prevent sending a message without recipients, title or content
- When there are no messages, show "no sent messages" / "no drafts" in their respective tabs
- Make draft saving more robust
- Indicate threads with a draft reply in the inbox
- Add e2e tests for sent messages and drafts
- Add a simple e2e test that checks that messages can be accessed from personal mobile devices

Employee desktop + employee mobile:
- Restore selected recipients when opening a draft message