### PR TITLE
extend nightly generation to start from finance min date

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FinanceDecisionGenerator.kt
@@ -93,7 +93,7 @@ SELECT 'GenerateFinanceDecisions',
 FROM ids;
         """
                 )
-                .bind("from", clock.today().minusMonths(15))
+                .bind("from", feeDecisionMinDate)
                 .execute()
 
         logger.info { "Scheduled GenerateFinanceDecisions for $inserted people" }


### PR DESCRIPTION
#### Summary

this was forgotten when removing 15 months limit and is needed to regenerate voucher value decisions after revert to v1

