### PR TITLE
Fix keycloak email property name in zod validation

### DIFF
--- a/apigw/src/enduser/keycloak-citizen-saml.ts
+++ b/apigw/src/enduser/keycloak-citizen-saml.ts
@@ -12,7 +12,7 @@ const Profile = z.object({
   socialSecurityNumber: z.string(),
   firstName: z.string(),
   lastName: z.string(),
-  keycloakEmail: z.string()
+  email: z.string()
 })
 
 export function createKeycloakCitizenSamlStrategy(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This affects validation only, because the profile is currently still parsed separately and this parsing code used the right property name