### PR TITLE
Improve invoice correction editor layout

### DIFF
--- a/frontend/src/employee-frontend/components/invoice/InvoiceRowsSectionRow.tsx
+++ b/frontend/src/employee-frontend/components/invoice/InvoiceRowsSectionRow.tsx
@@ -29,6 +29,7 @@ import Combobox, {
 } from 'lib-components/atoms/dropdowns/Combobox'
 import Select from 'lib-components/atoms/dropdowns/Select'
 import InputField from 'lib-components/atoms/form/InputField'
+import TextArea from 'lib-components/atoms/form/TextArea'
 import { Td, Tr } from 'lib-components/layout/Table'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { faCommentAlt, fasCommentAltLines, faTrash } from 'lib-icons'
@@ -115,7 +116,8 @@ function InvoiceRowSectionRow({
       </Td>
       <Td>
         {editable ? (
-          <InputField
+          <TextArea
+            maxLength={53}
             placeholder={i18n.invoice.form.rows.description}
             type="text"
             value={description}


### PR DESCRIPTION
- Only accept as many characters as is really stored
- Give the first two invoice correction inputs as much room as available

<img width="1387" alt="Screenshot 2023-11-20 at 8 33 37" src="https://github.com/espoon-voltti/evaka/assets/158767/ae75af70-47d3-4ff9-97eb-998be66ffb9f">

Same in read only view:
![Uploading Screenshot 2023-11-20 at 8.36.23.png…]()


