### PR TITLE
Send outdated income notifications to fridge parents

### DIFF
--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income.spec.ts
@@ -126,6 +126,15 @@ describe.each(e)('Citizen income (%s)', (env) => {
       })
       .save()
 
+    await Fixture.fridgeChild()
+      .with({
+        childId: child.id,
+        headOfChild: guardian.data.id,
+        startDate: placementStart,
+        endDate: placementEnd
+      })
+      .save()
+
     await enduserLogin(page)
     const header = new CitizenHeader(page, env)
     await header.selectTab('calendar')

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/controller/IncomeControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/controller/IncomeControllerCitizenIntegrationTest.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.DevFridgeChild
 import fi.espoo.evaka.shared.dev.DevGuardian
 import fi.espoo.evaka.shared.dev.DevIncome
 import fi.espoo.evaka.shared.dev.DevPerson
@@ -110,6 +111,14 @@ class IncomeControllerCitizenIntegrationTest : FullApplicationTest(resetDbBefore
                     updatedBy = employeeEvakaUserId,
                     validFrom = clock.today().minusMonths(6),
                     validTo = expirationDate
+                )
+            )
+            it.insert(
+                DevFridgeChild(
+                    headOfChild = guardianId,
+                    childId = childId,
+                    startDate = clock.today().minusMonths(6),
+                    endDate = expirationDate.plusMonths(6)
                 )
             )
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotificationsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotificationsIntegrationTest.kt
@@ -295,6 +295,34 @@ class OutdatedIncomeNotificationsIntegrationTest : FullApplicationTest(resetDbBe
     }
 
     @Test
+    fun `expiring income is notified if there is an unhandled income statement reaching after expiration`() {
+        val incomeExpirationDate = clock.today().plusWeeks(4)
+
+        db.transaction {
+            it.insert(
+                DevIncome(
+                    personId = fridgeHeadOfChildId,
+                    updatedBy = employeeEvakaUserId,
+                    validFrom = incomeExpirationDate.minusMonths(1),
+                    validTo = incomeExpirationDate
+                )
+            )
+
+            it.insert(
+                DevIncomeStatement(
+                    id = IncomeStatementId(UUID.randomUUID()),
+                    personId = fridgeHeadOfChildId,
+                    startDate = incomeExpirationDate.plusDays(1),
+                    type = IncomeStatementType.INCOME,
+                    grossEstimatedMonthlyIncome = 42
+                )
+            )
+        }
+
+        assertEquals(0, getEmails().size)
+    }
+
+    @Test
     fun `If there is no placement a day after expiration no notification is sent`() {
         val expirationDate = clock.today().plusWeeks(2)
         db.transaction {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
@@ -85,7 +85,7 @@ FROM expiring_income_with_billable_placement_day_after_expiration expiring_incom
 WHERE NOT EXISTS (
     SELECT 1 FROM income_statement
     WHERE person_id = expiring_income.person_id
-        AND created > :today - INTERVAL '1 month'
+        AND (created > :today - INTERVAL '1 month' OR (end_date IS NOT NULL AND :dayAfterExpiration <= end_date))
         AND handler_id IS NULL
 ) 
 ${if (checkForExistingRecentIncomeNotificationType != null) " AND NOT EXISTS ($existingRecentIncomeNotificationQuery)" else ""}                

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
@@ -53,7 +53,7 @@ class OutdatedIncomeNotifications(
                     FiniteDateRange(clock.today(), clock.today().plusWeeks(4)),
                     IncomeNotificationType.INITIAL_EMAIL
                 )
-                .map { it.guardianId }
+                .map { it.personId }
 
         val guardiansForReminderNotification =
             tx.expiringIncomes(
@@ -61,8 +61,8 @@ class OutdatedIncomeNotifications(
                     FiniteDateRange(clock.today(), clock.today().plusWeeks(2)),
                     IncomeNotificationType.REMINDER_EMAIL
                 )
-                .filter { !guardiansForInitialNotification.contains(it.guardianId) }
-                .map { it.guardianId }
+                .filter { !guardiansForInitialNotification.contains(it.personId) }
+                .map { it.personId }
 
         val guardiansForExpirationNotification =
             tx.expiringIncomes(
@@ -70,9 +70,9 @@ class OutdatedIncomeNotifications(
                     FiniteDateRange(clock.today(), clock.today()),
                     IncomeNotificationType.EXPIRED_EMAIL
                 )
-                .filter { !guardiansForInitialNotification.contains(it.guardianId) }
-                .filter { !guardiansForReminderNotification.contains(it.guardianId) }
-                .map { it.guardianId }
+                .filter { !guardiansForInitialNotification.contains(it.personId) }
+                .filter { !guardiansForReminderNotification.contains(it.personId) }
+                .map { it.personId }
 
         asyncJobRunner.plan(
             tx,


### PR DESCRIPTION
Send outdated income notifications to fridge parents instead of guardians.

#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

