### PR TITLE
Change MDC key for HTTP method

### DIFF
--- a/service/service-lib/src/main/kotlin/fi/espoo/voltti/logging/MdcKey.kt
+++ b/service/service-lib/src/main/kotlin/fi/espoo/voltti/logging/MdcKey.kt
@@ -9,7 +9,7 @@ import org.slf4j.MDC
 enum class MdcKey(val key: String) {
     SPAN_ID("spanId"),
     REQ_IP("userIp"),
-    METHOD("method"),
+    HTTP_METHOD("httpMethod"),
     PATH("path"),
     QUERY_STRING("queryString"),
     TRACE_ID("traceId"),

--- a/service/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
+++ b/service/service-lib/src/main/resources/fi/espoo/voltti/logging/logback/default-appender-sanitized.xml
@@ -52,7 +52,7 @@ Sanitized default appender logback configuration provided for import
             "appName": "${appName}",
             "env": "${VOLTTI_ENV}",
             "hostIp": "${HOST_IP}",
-            "httpMethod": "%mdc{method}",
+            "httpMethod": "%mdc{httpMethod}",
             "path": "%mdc{path}",
             "queryString": "%mdc{queryString}",
             "userIdHash": "%mdc{userIdHash}",

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
@@ -101,7 +101,7 @@ class HttpFilterConfig {
             response: HttpServletResponse,
             chain: FilterChain
         ) {
-            MdcKey.METHOD.set(request.method)
+            MdcKey.HTTP_METHOD.set(request.method)
             MdcKey.PATH.set(request.requestURI)
             MdcKey.QUERY_STRING.set(request.queryString ?: "")
             val (traceId, spanId) =
@@ -119,7 +119,7 @@ class HttpFilterConfig {
                 MdcKey.TRACE_ID.unset()
                 MdcKey.QUERY_STRING.unset()
                 MdcKey.PATH.unset()
-                MdcKey.METHOD.unset()
+                MdcKey.HTTP_METHOD.unset()
             }
         }
     }


### PR DESCRIPTION
#### Summary

`LogStashEncoder` writes all entries from MDC, so the key must match the desired property name in the JSON output.
