### PR TITLE
Document template fixes

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/ChildDocuments.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildDocuments.tsx
@@ -211,7 +211,7 @@ const ChildDocumentsList = React.memo(function ChildDocumentsList({
           (template) =>
             !documents.some(
               ({ data: doc }) =>
-                doc.type === template.type && doc.status !== 'COMPLETED'
+                doc.templateId === template.id && doc.status !== 'COMPLETED'
             )
         )
         .filter((template) => featureFlags.hojks || template.type !== 'HOJKS')

--- a/frontend/src/employee-frontend/components/document-templates/queries.ts
+++ b/frontend/src/employee-frontend/components/document-templates/queries.ts
@@ -25,7 +25,11 @@ import { createQueryKeys } from '../../query'
 
 const queryKeys = createQueryKeys('documentTemplates', {
   documentTemplateSummaries: () => ['documentTemplateSummaries'],
-  documentTemplate: (templateId: UUID) => ['documentTemplates', templateId]
+  documentTemplate: (templateId: UUID) => ['documentTemplates', templateId],
+  activeDocumentTemplateSummaries: (childId: UUID) => [
+    'activeDocumentTemplateSummaries',
+    childId
+  ]
 })
 
 export const documentTemplateSummariesQuery = query({
@@ -35,7 +39,7 @@ export const documentTemplateSummariesQuery = query({
 
 export const activeDocumentTemplateSummariesQuery = query({
   api: getActiveDocumentTemplateSummaries,
-  queryKey: queryKeys.documentTemplateSummaries
+  queryKey: queryKeys.activeDocumentTemplateSummaries
 })
 
 export const documentTemplateQuery = query({

--- a/frontend/src/lib-common/generated/api-types/document.ts
+++ b/frontend/src/lib-common/generated/api-types/document.ts
@@ -144,6 +144,7 @@ export interface ChildDocumentSummary {
   modifiedAt: HelsinkiDateTime
   publishedAt: HelsinkiDateTime | null
   status: DocumentStatus
+  templateId: UUID
   templateName: string
   type: DocumentType
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerIntegrationTest.kt
@@ -225,6 +225,7 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
                     id = documentId,
                     status = DocumentStatus.DRAFT,
                     type = devTemplatePed.type,
+                    templateId = devTemplatePed.id,
                     templateName = devTemplatePed.name,
                     modifiedAt = clock.now(),
                     publishedAt = null

--- a/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplateController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplateController.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka.document
 
 import fi.espoo.evaka.Audit
-import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.placement.getChildPlacementUnitLanguage
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DocumentTemplateId
@@ -90,7 +89,8 @@ class DocumentTemplateController(private val accessControl: AccessControl) {
                     tx.getTemplateSummaries().filter {
                         it.published &&
                             it.validity.includes(clock.today()) &&
-                            (placementLanguage != Language.sv || it.language == DocumentLanguage.SV)
+                            (placementLanguage == null ||
+                                it.language.name.uppercase() == placementLanguage.name.uppercase())
                     }
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocument.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocument.kt
@@ -102,6 +102,7 @@ data class ChildDocumentSummary(
     val id: ChildDocumentId,
     val status: DocumentStatus,
     val type: DocumentType,
+    val templateId: DocumentTemplateId,
     val templateName: String,
     val modifiedAt: HelsinkiDateTime,
     val publishedAt: HelsinkiDateTime?

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentController.kt
@@ -58,12 +58,12 @@ class ChildDocumentController(
                             }
                         } ?: throw NotFound()
 
-                    val sameTypeAlreadyStarted =
+                    val sameTemplateAlreadyStarted =
                         tx.getChildDocuments(body.childId).any {
-                            it.type == template.type && it.status != DocumentStatus.COMPLETED
+                            it.templateId == template.id && it.status != DocumentStatus.COMPLETED
                         }
-                    if (sameTypeAlreadyStarted) {
-                        throw Conflict("Child already has incomplete document of same type")
+                    if (sameTemplateAlreadyStarted) {
+                        throw Conflict("Child already has incomplete document of the same template")
                     }
 
                     tx.insertChildDocument(body, clock.now())

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
@@ -32,7 +32,7 @@ fun Database.Transaction.insertChildDocument(
 fun Database.Read.getChildDocuments(childId: PersonId): List<ChildDocumentSummary> {
     return createQuery(
             """
-            SELECT cd.id, cd.status, dt.type, cd.modified_at, cd.published_at, dt.name as template_name
+            SELECT cd.id, cd.status, dt.type, cd.modified_at, cd.published_at, dt.id as template_id, dt.name as template_name
             FROM child_document cd
             JOIN document_template dt on cd.template_id = dt.id
             WHERE cd.child_id = :childId


### PR DESCRIPTION
#### Summary

- Return document templates of the language that matches the placement unit's language.
- Allow having incomplete documents of the same type as long as the template is different.

Documentation: https://github.com/espoon-voltti/evaka/wiki/Lapsen-sivu#lapsen-pedagogiset-lomakkeet
