### PR TITLE
Fix sentry upload

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -99,7 +99,7 @@ function baseConfig({ isDevelopment }, { name, publicPath, entry }) {
         },
         project: `evaka-${name}`,
         sourcemaps: {
-          assets: path.resolve(__dirname, `dist/bundle/${name}`)
+          assets: path.resolve(__dirname, `dist/bundle/${name}/**`)
         }
       })
     )


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

`assets` is not a path to a directory but a *glob*, so we need to use some kind of a wildcard that finds all the files.