### PR TITLE
Hide the actual names of the recipients of sent messages

### DIFF
--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -25,7 +25,8 @@ export default class ApplicationReadView {
   #giveOtherGuardianEmail = this.page.find('[data-qa="second-guardian-email"]')
   #applicationStatus = this.page.find('[data-qa="application-status"]')
   #sendMessageButton = this.page.findByDataQa('send-message-button')
-  #notes = this.page.findAllByDataQa('note-container')
+  notesList = this.page.findByDataQa('application-notes-list')
+  notes = this.notesList.findAllByDataQa('note-container')
 
   async waitUntilLoaded() {
     await this.page.find('[data-qa="application-read-view"]').waitUntilVisible()
@@ -176,7 +177,7 @@ export default class ApplicationReadView {
 
   async clickMessageThreadLinkInNote(index: number): Promise<MessagesPage> {
     const popup = await this.page.capturePopup(async () => {
-      await this.#notes
+      await this.notes
         .nth(index)
         .findByDataQa('note-message-thread-link')
         .click()
@@ -185,22 +186,23 @@ export default class ApplicationReadView {
   }
 
   async assertNote(index: number, note: string) {
-    await this.#notes
+    await this.notes
       .nth(index)
       .findByDataQa('application-note-content')
       .assertTextEquals(note)
   }
 
   async assertNoteNotEditable(index: number) {
-    await this.#notes.nth(index).findByDataQa('edit-note').waitUntilHidden()
+    await this.notes.nth(index).findByDataQa('edit-note').waitUntilHidden()
   }
 
   async assertNoteNotDeletable(index: number) {
-    await this.#notes.nth(index).findByDataQa('delete-note').waitUntilHidden()
+    await this.notes.nth(index).findByDataQa('delete-note').waitUntilHidden()
   }
 
   async assertNoNotes() {
-    await this.#notes.nth(0).waitUntilHidden()
+    await this.notesList.waitUntilAttached()
+    await this.notes.nth(0).waitUntilHidden()
   }
 
   async reload() {

--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -16,6 +16,11 @@ import {
 export default class MessagesPage {
   constructor(private readonly page: Page) {}
 
+  async openSentMessages(nth = 0) {
+    await this.page.findAllByDataQa('message-box-row-sent').nth(nth).click()
+    return new SentMessagesPage(this.page)
+  }
+
   newMessageButton = this.page.find('[data-qa="new-message-btn"]')
   #personalAccount = this.page.find('[data-qa="personal-account"]')
   #draftMessagesBoxRow = new TextInput(
@@ -39,15 +44,6 @@ export default class MessagesPage {
 
   async getReceivedMessageCount() {
     return await this.page.findAll('[data-qa="received-message-row"]').count()
-  }
-
-  async assertMessageIsSentForParticipants(nth: number, participants: string) {
-    await this.page.findAll('[data-qa="message-box-row-sent"]').first().click()
-    await this.page
-      .findAllByDataQa('sent-message-row')
-      .nth(nth)
-      .findByDataQa('participants')
-      .assertTextEquals(participants)
   }
 
   async assertReceivedMessageParticipantsContains(nth: number, str: string) {
@@ -140,6 +136,32 @@ export default class MessagesPage {
 
   async close() {
     return this.page.close()
+  }
+}
+
+export class SentMessagesPage {
+  constructor(private readonly page: Page) {}
+
+  sentMessages = this.page.findAllByDataQa('sent-message-row')
+
+  async assertMessageParticipants(nth: number, participants: string) {
+    await this.sentMessages
+      .nth(nth)
+      .findByDataQa('participants')
+      .assertTextEquals(participants)
+  }
+
+  async openMessage(nth: number) {
+    await this.sentMessages.nth(nth).click()
+    return new SentMessagePage(this.page)
+  }
+}
+
+export class SentMessagePage {
+  constructor(private readonly page: Page) {}
+
+  async assertMessageRecipients(recipients: string) {
+    await this.page.findByDataQa('recipient-names').assertTextEquals(recipients)
   }
 }
 

--- a/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
@@ -244,7 +244,8 @@ test('Foster parent can receive and reply to messages', async () => {
     title: 'Message title',
     content: 'Message content'
   }
-  await messagesPage.sendNewMessage(message)
+  const messageEditor = await messagesPage.openMessageEditor()
+  await messageEditor.sendNewMessage(message)
   await runPendingAsyncJobs(mockedNow)
 
   await activeRelationshipPage.goto(config.enduserMessagesUrl)

--- a/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
@@ -166,7 +166,8 @@ describe('Sending and receiving messages', () => {
         await initStaffPage(mockedDateAt10)
         await staffPage.goto(`${config.employeeUrl}/messages`)
         let messagesPage = new MessagesPage(staffPage)
-        await messagesPage.sendNewMessage(defaultMessage)
+        const messageEditor = await messagesPage.openMessageEditor()
+        await messageEditor.sendNewMessage(defaultMessage)
         await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
         await initCitizen(mockedDateAt11)
@@ -189,7 +190,8 @@ describe('Sending and receiving messages', () => {
         await initStaffPage(mockedDateAt10)
         await staffPage.goto(`${config.employeeUrl}/messages`)
         let messagesPage = new MessagesPage(staffPage)
-        await messagesPage.sendNewMessage(defaultMessage)
+        const messageEditor = await messagesPage.openMessageEditor()
+        await messageEditor.sendNewMessage(defaultMessage)
         await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
         await initCitizen(mockedDateAt11)
@@ -231,7 +233,8 @@ describe('Sending and receiving sensitive messages', () => {
     await initStaffPage(mockedDateAt10)
     await staffPage.goto(`${config.employeeUrl}/messages`)
     const messagesPage = new MessagesPage(staffPage)
-    await messagesPage.sendNewMessage(sensitiveMessage)
+    const messageEditor = await messagesPage.openMessageEditor()
+    await messageEditor.sendNewMessage(sensitiveMessage)
 
     await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
@@ -258,7 +261,10 @@ describe('Staff copies', () => {
       content: 'Ilmoituksen sisältö',
       receiver: fixtures.daycareFixture.id
     }
-    await new MessagesPage(unitSupervisorPage).sendNewMessage(message)
+    const messageEditor = await new MessagesPage(
+      unitSupervisorPage
+    ).openMessageEditor()
+    await messageEditor.sendNewMessage(message)
     await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
     await initStaffPage(mockedDateAt11)
@@ -277,7 +283,10 @@ describe('Staff copies', () => {
       content: 'Ilmoituksen sisältö',
       receiver: fixtures.enduserChildFixtureKaarina.id
     }
-    await new MessagesPage(unitSupervisorPage).sendNewMessage(message)
+    const messageEditor = await new MessagesPage(
+      unitSupervisorPage
+    ).openMessageEditor()
+    await messageEditor.sendNewMessage(message)
     await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
     await initStaffPage(mockedDateAt11)
@@ -294,7 +303,10 @@ describe('Staff copies', () => {
       sender: `${fixtures.daycareFixture.name} - ${daycareGroupFixture.name}`,
       receiver: daycareGroupFixture.id
     }
-    await new MessagesPage(unitSupervisorPage).sendNewMessage(message)
+    const messageEditor = await new MessagesPage(
+      unitSupervisorPage
+    ).openMessageEditor()
+    await messageEditor.sendNewMessage(message)
     await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
     await initStaffPage(mockedDateAt11)

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -158,7 +158,8 @@ describe('Sending and receiving messages', () => {
         await openSupervisorPage(mockedDateAt10)
         await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
         let messagesPage = new MessagesPage(unitSupervisorPage)
-        await messagesPage.sendNewMessage(defaultMessage)
+        const messageEditor = await messagesPage.openMessageEditor()
+        await messageEditor.sendNewMessage(defaultMessage)
         await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
         await openCitizen(mockedDateAt11)
@@ -210,7 +211,8 @@ describe('Sending and receiving messages', () => {
         await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
         let messagesPage = new MessagesPage(unitSupervisorPage)
 
-        await messagesPage.sendNewMessage({
+        const messageEditor = await messagesPage.openMessageEditor()
+        await messageEditor.sendNewMessage({
           ...defaultMessage,
           receiver: enduserChildFixtureKaarina.id
         })
@@ -274,7 +276,8 @@ describe('Sending and receiving messages', () => {
         await openSupervisorPage(mockedDateAt10)
         await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
         let messagesPage = new MessagesPage(unitSupervisorPage)
-        await messagesPage.sendNewMessage(message)
+        const messageEditor = await messagesPage.openMessageEditor()
+        await messageEditor.sendNewMessage(message)
         await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
         await openCitizen(mockedDateAt11)
@@ -297,7 +300,8 @@ describe('Sending and receiving messages', () => {
         await openSupervisorPage(mockedDateAt10)
         await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
         const messagesPage = new MessagesPage(unitSupervisorPage)
-        await messagesPage.sendNewMessage({
+        const messageEditor = await messagesPage.openMessageEditor()
+        await messageEditor.sendNewMessage({
           ...defaultMessage,
           attachmentCount: 2
         })
@@ -317,7 +321,8 @@ describe('Sending and receiving messages', () => {
         await openSupervisorPage(mockedDateAt10)
         await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
         let messagesPage = new MessagesPage(unitSupervisorPage)
-        await messagesPage.sendNewMessage(defaultMessage)
+        const messageEditor = await messagesPage.openMessageEditor()
+        await messageEditor.sendNewMessage(defaultMessage)
         await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
         await openCitizen(mockedDateAt11)
@@ -363,7 +368,8 @@ describe('Sending and receiving messages', () => {
         await openSupervisorPage(mockedDateAt10)
         await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
         const messagesPage = new MessagesPage(unitSupervisorPage)
-        await messagesPage.sendNewMessage({ title, content })
+        const messageEditor = await messagesPage.openMessageEditor()
+        await messageEditor.sendNewMessage({ title, content })
         await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
         await openCitizen(mockedDateAt11)
@@ -571,7 +577,8 @@ describe('Sending and receiving messages', () => {
         await openSupervisorPage(mockedDateAt10)
         await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
         const messagesPage = new MessagesPage(unitSupervisorPage)
-        await messagesPage.sendNewMessage(defaultMessage)
+        const messageEditor = await messagesPage.openMessageEditor()
+        await messageEditor.sendNewMessage(defaultMessage)
         await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
         await openCitizen(mockedDateAt11)
@@ -591,7 +598,8 @@ describe('Sending and receiving messages', () => {
           await openSupervisorPage(mockedDateAt10)
           await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
           const messagesPage = new MessagesPage(unitSupervisorPage)
-          await messagesPage.sendNewMessage(defaultMessage)
+          const messageEditor = await messagesPage.openMessageEditor()
+          await messageEditor.sendNewMessage(defaultMessage)
           await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
           await openCitizen(mockedDateAt11)
@@ -611,8 +619,9 @@ describe('Sending and receiving messages', () => {
       await openSupervisorPage(mockedDateAt10)
       await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
       const messagesPage = new MessagesPage(unitSupervisorPage)
-      await messagesPage.draftNewMessage(defaultTitle, defaultContent)
-      await messagesPage.closeMessageEditor()
+      const messageEditor = await messagesPage.openMessageEditor()
+      await messageEditor.draftNewMessage(defaultTitle, defaultContent)
+      await messageEditor.closeButton.click()
       await messagesPage.assertDraftContent(defaultTitle, defaultContent)
     })
 
@@ -620,8 +629,9 @@ describe('Sending and receiving messages', () => {
       await openSupervisorPage(mockedDateAt10)
       await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
       const messagesPage = new MessagesPage(unitSupervisorPage)
-      await messagesPage.draftNewMessage(defaultTitle, defaultContent)
-      await messagesPage.sendEditedMessage()
+      const messageEditor = await messagesPage.openMessageEditor()
+      await messageEditor.draftNewMessage(defaultTitle, defaultContent)
+      await messageEditor.sendButton.click()
       await messagesPage.assertNoDrafts()
     })
 
@@ -629,8 +639,9 @@ describe('Sending and receiving messages', () => {
       await openSupervisorPage(mockedDateAt10)
       await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
       const messagesPage = new MessagesPage(unitSupervisorPage)
-      await messagesPage.draftNewMessage(defaultTitle, defaultContent)
-      await messagesPage.discardMessage()
+      const messageEditor = await messagesPage.openMessageEditor()
+      await messageEditor.draftNewMessage(defaultTitle, defaultContent)
+      await messageEditor.discardButton.click()
       await messagesPage.assertNoDrafts()
     })
   })
@@ -640,7 +651,8 @@ describe('Sending and receiving messages', () => {
       await openSupervisorPage(mockedDateAt10)
       await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
       const messagesPage = new MessagesPage(unitSupervisorPage)
-      await messagesPage.sendNewMessage(defaultMessage)
+      const messageEditor = await messagesPage.openMessageEditor()
+      await messageEditor.sendNewMessage(defaultMessage)
       await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
       await openCitizenPage(mockedDateAt11)
@@ -659,7 +671,8 @@ describe('Sending and receiving messages', () => {
       await openSupervisorPage(mockedDateAt10)
       await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
       const messagesPage = new MessagesPage(unitSupervisorPage)
-      await messagesPage.sendNewMessage({
+      const messageEditor = await messagesPage.openMessageEditor()
+      await messageEditor.sendNewMessage({
         ...defaultMessage,
         attachmentCount: 1
       })
@@ -681,7 +694,8 @@ describe('Sending and receiving messages', () => {
       await openSupervisorPage(mockedDateAt10)
       await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
       let messagesPage = new MessagesPage(unitSupervisorPage)
-      await messagesPage.sendNewMessage(defaultMessage)
+      const messageEditor = await messagesPage.openMessageEditor()
+      await messageEditor.sendNewMessage(defaultMessage)
       await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
       await openCitizenPage(mockedDateAt11)

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -218,7 +218,8 @@ describe('Sending and receiving messages', () => {
         })
         await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 
-        await messagesPage.assertMessageIsSentForParticipants(
+        const sentMessagesPage = await messagesPage.openSentMessages()
+        await sentMessagesPage.assertMessageParticipants(
           0,
           `${enduserChildFixtureKaarina.lastName} ${enduserChildFixtureKaarina.firstName}`
         )

--- a/frontend/src/e2e-test/specs/7_messaging/municipal-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/municipal-messaging.spec.ts
@@ -145,7 +145,8 @@ describe('Municipal messaging -', () => {
     await openMessagingPage(messageSendTime)
     await messagingPage.goto(`${config.employeeUrl}/messages`)
     const messagesPage = new MessagesPage(messagingPage)
-    await messagesPage.sendNewMessage(defaultMessage)
+    const messageEditor = await messagesPage.openMessageEditor()
+    await messageEditor.sendNewMessage(defaultMessage)
     await runPendingAsyncJobs(messageSendTime.addMinutes(1))
 
     await openCitizenPage(messageReadTime)
@@ -158,7 +159,8 @@ describe('Municipal messaging -', () => {
     await openMessagingPage(messageSendTime)
     await messagingPage.goto(`${config.employeeUrl}/messages`)
     const messagesPage = new MessagesPage(messagingPage)
-    await messagesPage.sendNewMessage({
+    const messageEditor = await messagesPage.openMessageEditor()
+    await messageEditor.sendNewMessage({
       ...defaultMessage,
       receiver: fixtures.careAreaFixture.id
     })

--- a/frontend/src/e2e-test/specs/7_messaging/municipal-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/municipal-messaging.spec.ts
@@ -155,6 +155,26 @@ describe('Municipal messaging -', () => {
     await citizenMessagesPage.assertThreadContent(defaultMessage)
   })
 
+  test('Sent municipal message has area name as recipients', async () => {
+    await openMessagingPage(messageSendTime)
+    await messagingPage.goto(`${config.employeeUrl}/messages`)
+    const messagesPage = new MessagesPage(messagingPage)
+    const messageEditor = await messagesPage.openMessageEditor()
+    await messageEditor.sendNewMessage({
+      ...defaultMessage,
+      receiver: fixtures.careAreaFixture.id
+    })
+
+    const sentMessagesPage = await messagesPage.openSentMessages()
+    await sentMessagesPage.assertMessageParticipants(
+      0,
+      fixtures.careAreaFixture.name
+    )
+
+    const messagePage = await sentMessagesPage.openMessage(0)
+    await messagePage.assertMessageRecipients(fixtures.careAreaFixture.name)
+  })
+
   test('Messages sent by messaging role creates a copy for the staff', async () => {
     await openMessagingPage(messageSendTime)
     await messagingPage.goto(`${config.employeeUrl}/messages`)

--- a/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
@@ -28,7 +28,6 @@ import CitizenMessagesPage from '../../pages/citizen/citizen-messages'
 import ApplicationsPage from '../../pages/employee/applications'
 import EmployeeNav from '../../pages/employee/employee-nav'
 import MessagesPage from '../../pages/employee/messages/messages-page'
-import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
 import { employeeLogin, enduserLogin } from '../../utils/user'
 
@@ -100,13 +99,15 @@ describe('Service Worker Messaging', () => {
       const applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      const messagesPage = await applReadView.openMessagesPage()
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
       const title = 'Message to citizen'
       const content = 'Hello citizen!'
-      await messagesPage.inputTitle.fill(title)
-      await messagesPage.inputContent.fill(content)
-      await messagesPage.sendMessageButton.click()
-      await waitUntilEqual(() => messagesPage.isEditorVisible(), false)
+      await messageEditor.inputTitle.fill(title)
+      await messageEditor.inputContent.fill(content)
+      await messageEditor.sendButton.click()
+      await messageEditor.waitUntilHidden()
       await runPendingAsyncJobs(mockedTime.addMinutes(1))
 
       await openCitizenPage(mockedTime.addHours(1))
@@ -124,10 +125,12 @@ describe('Service Worker Messaging', () => {
       const applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      const messagesPage = await applReadView.openMessagesPage()
-      await messagesPage.inputContent.fill('message')
-      await messagesPage.sendMessageButton.click()
-      await waitUntilEqual(() => messagesPage.isEditorVisible(), false)
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
+      await messageEditor.inputContent.fill('message')
+      await messageEditor.sendButton.click()
+      await messageEditor.waitUntilHidden()
       await runPendingAsyncJobs(mockedTime.addMinutes(1))
 
       await openCitizenPage(mockedTime.addHours(1))
@@ -144,12 +147,14 @@ describe('Service Worker Messaging', () => {
       const applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      const messagesPage = await applReadView.openMessagesPage()
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
 
-      await messagesPage.assertReceiver(
+      await messageEditor.assertReceiver(
         `${fixtures.enduserGuardianFixture.lastName} ${fixtures.enduserGuardianFixture.firstName}`
       )
-      await messagesPage.assertTitle(
+      await messageEditor.assertTitle(
         `Hakemus 08.11.2022: ${fixtures.enduserChildFixtureJari.firstName} ${fixtures.enduserChildFixtureJari.lastName}`
       )
     })
@@ -161,11 +166,13 @@ describe('Service Worker Messaging', () => {
       const applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      const messagesPage = await applReadView.openMessagesPage()
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
       const content = 'This should be visible in the application note'
-      await messagesPage.inputContent.fill(content)
-      await messagesPage.sendMessageButton.click()
-      await waitUntilEqual(() => messagesPage.isEditorVisible(), false)
+      await messageEditor.inputContent.fill(content)
+      await messageEditor.sendButton.click()
+      await messageEditor.waitUntilHidden()
       await runPendingAsyncJobs(mockedTime.addMinutes(1))
 
       await applReadView.reload()
@@ -179,11 +186,13 @@ describe('Service Worker Messaging', () => {
       const applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      const messagesPage = await applReadView.openMessagesPage()
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
       const content = 'This should be visible in the application note'
-      await messagesPage.inputContent.fill(content)
-      await messagesPage.sendMessageButton.click()
-      await waitUntilEqual(() => messagesPage.isEditorVisible(), false)
+      await messageEditor.inputContent.fill(content)
+      await messageEditor.sendButton.click()
+      await messageEditor.waitUntilHidden()
       await runPendingAsyncJobs(mockedTime.addMinutes(1))
 
       await applReadView.reload()
@@ -194,7 +203,7 @@ describe('Service Worker Messaging', () => {
       await messagesPageWithThread.assertMessageContent(0, content)
     })
 
-    it('should delete the application note if the message is cancelled', async () => {
+    it('should delete the application note if the message is undone', async () => {
       await openStaffPage(mockedTime, serviceWorker)
       const applicationsPage = new ApplicationsPage(staffPage)
       await new EmployeeNav(staffPage).applicationsTab.click()
@@ -202,10 +211,11 @@ describe('Service Worker Messaging', () => {
         .applicationRow(applicationFixtureId)
         .openApplication()
       const messagesPage = await applReadView.openMessagesPage()
+      const messageEditor = messagesPage.getMessageEditor()
       const content = 'This should be visible in the application note'
-      await messagesPage.inputContent.fill(content)
-      await messagesPage.sendMessageButton.click()
-      await waitUntilEqual(() => messagesPage.isEditorVisible(), false)
+      await messageEditor.inputContent.fill(content)
+      await messageEditor.sendButton.click()
+      await messageEditor.waitUntilHidden()
       await runPendingAsyncJobs(mockedTime.addMinutes(1))
       await messagesPage.undoMessage()
 
@@ -220,13 +230,15 @@ describe('Service Worker Messaging', () => {
       let applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      const messagesPage = await applReadView.openMessagesPage()
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
       const title = 'Message about application that needs a reply'
       const content = 'Hello citizen, please reply to this'
-      await messagesPage.inputTitle.fill(title)
-      await messagesPage.inputContent.fill(content)
-      await messagesPage.sendMessageButton.click()
-      await waitUntilEqual(() => messagesPage.isEditorVisible(), false)
+      await messageEditor.inputTitle.fill(title)
+      await messageEditor.inputContent.fill(content)
+      await messageEditor.sendButton.click()
+      await messageEditor.waitUntilHidden()
       await runPendingAsyncJobs(mockedTime.addMinutes(1))
 
       await openCitizenPage(mockedTime.addHours(1))
@@ -254,13 +266,15 @@ describe('Service Worker Messaging', () => {
       let applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      let messagesPage = await applReadView.openMessagesPage()
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
       const title = 'This is the first message'
       const content = 'First!!1'
-      await messagesPage.inputTitle.fill(title)
-      await messagesPage.inputContent.fill(content)
-      await messagesPage.sendMessageButton.click()
-      await waitUntilEqual(() => messagesPage.isEditorVisible(), false)
+      await messageEditor.inputTitle.fill(title)
+      await messageEditor.inputContent.fill(content)
+      await messageEditor.sendButton.click()
+      await messageEditor.waitUntilHidden()
       await runPendingAsyncJobs(mockedTime.addMinutes(1))
 
       await openCitizenPage(mockedTime.addHours(1))
@@ -277,7 +291,7 @@ describe('Service Worker Messaging', () => {
       applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      messagesPage = await applReadView.openMessagesPage()
+      const messagesPage = await applReadView.openMessagesPage()
       await messagesPage.assertReplyContentIsEmpty()
       const replyContent = 'Service worker reply'
       await messagesPage.fillReplyContent(replyContent)
@@ -306,8 +320,10 @@ describe('Service Worker Messaging', () => {
       const applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      const messagesPage = await applReadView.openMessagesPage()
-      await messagesPage.assertSimpleViewVisible()
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
+      await messageEditor.assertSimpleViewVisible()
     })
 
     it('should not be possible for service workers to delete or edit notes created from messages', async () => {
@@ -317,10 +333,12 @@ describe('Service Worker Messaging', () => {
       const applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      const messagesPage = await applReadView.openMessagesPage()
-      await messagesPage.inputContent.fill('message content')
-      await messagesPage.sendMessageButton.click()
-      await waitUntilEqual(() => messagesPage.isEditorVisible(), false)
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
+      await messageEditor.inputContent.fill('message content')
+      await messageEditor.sendButton.click()
+      await messageEditor.waitUntilHidden()
       await runPendingAsyncJobs(mockedTime.addMinutes(1))
 
       await applReadView.reload()
@@ -335,11 +353,13 @@ describe('Service Worker Messaging', () => {
       let applReadView = await applicationsPage
         .applicationRow(applicationFixtureId)
         .openApplication()
-      const messagesPage = await applReadView.openMessagesPage()
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
       const content = 'This is the message'
-      await messagesPage.inputContent.fill(content)
-      await messagesPage.sendMessageButton.click()
-      await waitUntilEqual(() => messagesPage.isEditorVisible(), false)
+      await messageEditor.inputContent.fill(content)
+      await messageEditor.sendButton.click()
+      await messageEditor.waitUntilHidden()
       await runPendingAsyncJobs(mockedTime.addMinutes(1))
 
       await openStaffPage(mockedTime, messagingAndServiceWorker)

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -238,6 +238,11 @@ export class Element {
     await this.locator.click()
   }
 
+  /// Like waitUntilVisible, but also works for elements with zero size
+  async waitUntilAttached(): Promise<void> {
+    await this.locator.waitFor({ state: 'attached' })
+  }
+
   async waitUntilVisible(): Promise<void> {
     await this.locator.waitFor({ state: 'visible' })
   }

--- a/frontend/src/employee-frontend/components/application-page/ApplicationNotes.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationNotes.tsx
@@ -38,7 +38,7 @@ export default React.memo(function ApplicationNotes({
 
   return renderResult(notesResponse, (notes) => (
     <>
-      <FixedSpaceColumn>
+      <FixedSpaceColumn data-qa="application-notes-list">
         {notes.map(({ note, permittedActions }) =>
           editing === note.id ? (
             <ApplicationNoteBox

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -472,7 +472,7 @@ export const MessageContextProvider = React.memo(
                     threadId: message.contentId,
                     sender: { ...selectedAccount.account },
                     sentAt: message.sentAt,
-                    recipients: message.recipients,
+                    recipients: [], // recipientNames should be used when viewing sent messages
                     readAt: HelsinkiDateTime.now(),
                     content: message.content,
                     attachments: message.attachments,

--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -92,28 +92,48 @@ const MessageContent = styled.div`
 `
 
 function SingleMessage({
+  view,
   message,
   messageChildren,
   index
 }: {
+  view: View
   message: Message
   messageChildren: MessageChild[]
   type?: MessageType
   title?: string
   index: number
 }) {
-  const { senderName, recipientNames } = useMemo(
-    () =>
-      formatAccountNames(message.sender, message.recipients, messageChildren),
-    [message.sender, message.recipients, messageChildren]
-  )
+  const { senderName, recipientNames } = useMemo(() => {
+    if (view === 'sent') {
+      return {
+        senderName: message.sender.name,
+        // message.recipientNames should always exist for sent messages, ?? is there to satisfy the type checker
+        recipientNames: message.recipientNames ?? []
+      }
+    } else {
+      return formatAccountNames(
+        message.sender,
+        message.recipients,
+        messageChildren
+      )
+    }
+  }, [
+    view,
+    message.sender,
+    message.recipients,
+    message.recipientNames,
+    messageChildren
+  ])
   return (
     <MessageContainer>
       <TitleRow>
         <Bold>{senderName}</Bold>
         <InformationText>{message.sentAt.format()}</InformationText>
       </TitleRow>
-      <InformationText>{recipientNames.join(', ')}</InformationText>
+      <InformationText data-qa="recipient-names">
+        {recipientNames.join(', ')}
+      </InformationText>
       <MessageContent data-qa="message-content" data-index={index}>
         <Linkify text={message.content} />
       </MessageContent>
@@ -251,6 +271,7 @@ export function SingleThreadView({
             )}
             <SingleMessage
               key={message.id}
+              view={view}
               message={message}
               messageChildren={children}
               index={idx}

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -296,7 +296,6 @@ export interface SentMessage {
   content: string
   contentId: UUID
   recipientNames: string[]
-  recipients: MessageAccount[]
   sensitive: boolean
   sentAt: HelsinkiDateTime
   threadTitle: string

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -311,7 +311,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         val newestMessage = firstPage.data[0]
         assertEquals("content 2", newestMessage.content)
         assertEquals("thread 2", newestMessage.threadTitle)
-        assertEquals(setOf(accounts.person1), newestMessage.recipients)
+        assertEquals(listOf(accounts.person1.name), newestMessage.recipientNames)
 
         val secondPage = db.read { it.getMessagesSentByAccount(accounts.employee1.id, 1, 2) }
         assertEquals(2, secondPage.total)
@@ -321,7 +321,10 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         val oldestMessage = secondPage.data[0]
         assertEquals("content 1", oldestMessage.content)
         assertEquals("thread 1", oldestMessage.threadTitle)
-        assertEquals(setOf(accounts.person1, accounts.person2), oldestMessage.recipients)
+        assertEquals(
+            listOf(accounts.person1.name, accounts.person2.name),
+            oldestMessage.recipientNames
+        )
 
         // then fetching sent messages by recipient ids does not return the messages
         assertEquals(0, db.read { it.getMessagesSentByAccount(accounts.person1.id, 1, 1) }.total)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/Message.kt
@@ -116,7 +116,6 @@ data class SentMessage(
     val type: MessageType,
     val urgent: Boolean,
     val sensitive: Boolean,
-    @Json val recipients: Set<MessageAccount>,
     val recipientNames: List<String>,
     @Json val attachments: List<MessageAttachment>
 )


### PR DESCRIPTION
#### Summary

Avoid disclosing the names of all recipients to senders of municipal messages.

The fix is to hide the actual names of recipients from _all_ sent messages. `recipientNames` is the set of names the sender chose when sending the message, so always show that list. It may contain names of children, groups, units, areas or the name of the municipality. The point is that whoever sent the message, they were permitted to see that name when sending, so it's safe to show.