### PR TITLE
Only link to application if current user can open the application

### DIFF
--- a/frontend/src/employee-frontend/components/timeline/renderers.tsx
+++ b/frontend/src/employee-frontend/components/timeline/renderers.tsx
@@ -164,6 +164,7 @@ const PartnershipMetadata = React.memo(function PartnershipMetadata({
     createdBy,
     createdByName,
     createSource,
+    originApplicationAccessible,
     createdFromApplication,
     createdFromApplicationType,
     createdFromApplicationCreated,
@@ -186,13 +187,18 @@ const PartnershipMetadata = React.memo(function PartnershipMetadata({
         createdFromApplicationType &&
         createdFromApplicationCreated
       ) {
-        return (
-          <Link to={`/applications/${createdFromApplication}`}>
-            {`${i18n.timeline.application}: ${
-              i18n.common.types[createdFromApplicationType]
-            }, ${createdFromApplicationCreated.format()}`}
-          </Link>
-        )
+        const applicationInfo = `${i18n.timeline.application}: ${
+          i18n.common.types[createdFromApplicationType]
+        }, ${createdFromApplicationCreated.format()}`
+        if (originApplicationAccessible) {
+          return (
+            <Link to={`/applications/${createdFromApplication}`}>
+              {applicationInfo}
+            </Link>
+          )
+        } else {
+          return applicationInfo
+        }
       } else {
         return i18n.timeline.notAvailable
       }

--- a/frontend/src/lib-common/generated/api-types/timeline.ts
+++ b/frontend/src/lib-common/generated/api-types/timeline.ts
@@ -100,6 +100,7 @@ export interface TimelinePartnerDetailed {
   modifiedBy: UUID | null
   modifiedByName: string | null
   modifySource: ModifySource | null
+  originApplicationAccessible: boolean
   partnerId: UUID
   range: DateRange
   valueDecisions: TimelineValueDecision[]

--- a/service/src/main/kotlin/fi/espoo/evaka/timeline/TimelineController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/timeline/TimelineController.kt
@@ -81,6 +81,17 @@ class TimelineController(private val accessControl: AccessControl) {
                         partners =
                             tx.getPartners(personId, range).map { partner ->
                                 val partnerRange = range.intersection(partner.range)!!
+                                val originApplicationAccessible =
+                                    if (partner.createdFromApplication != null)
+                                        accessControl
+                                            .getPermittedActions<ApplicationId, Action.Application>(
+                                                tx,
+                                                user,
+                                                clock,
+                                                partner.createdFromApplication
+                                            )
+                                            .contains(Action.Application.READ)
+                                    else false
                                 TimelinePartnerDetailed(
                                     id = partner.id,
                                     range = partner.range,
@@ -121,6 +132,7 @@ class TimelineController(private val accessControl: AccessControl) {
                                     modifiedBy = partner.modifiedBy,
                                     modifySource = partner.modifySource,
                                     modifiedByName = partner.modifiedByName,
+                                    originApplicationAccessible = originApplicationAccessible,
                                     createdFromApplication = partner.createdFromApplication,
                                     createdFromApplicationType = partner.createdFromApplicationType,
                                     createdFromApplicationCreated =
@@ -259,6 +271,7 @@ data class TimelinePartnerDetailed(
     val modifiedBy: EvakaUserId?,
     val modifiedByName: String?,
     val modifySource: ModifySource?,
+    val originApplicationAccessible: Boolean,
     val createdFromApplication: ApplicationId?,
     val createdFromApplicationType: ApplicationType?,
     val createdFromApplicationCreated: HelsinkiDateTime?


### PR DESCRIPTION
## Before this change
Partnership metadata in timeline view had a link to the originating application even if the originating application was not accessible for the viewing user.

## After this change
Link to application in timeline view is only show if user has view access to the application and thus can open it. Otherwise it'll simply show the application type and create timestamp as static text.