### PR TITLE
Fix typo in partnership retry SQL statement

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PartnershipQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PartnershipQueries.kt
@@ -200,8 +200,8 @@ fun Database.Transaction.retryPartnership(
     createUpdate<Any> {
             sql(
                 """
-        UPDATE fridge_partner SET conflict = false
-        WHERE partnership_id = ${bind(id)}, modified_by = ${bind(modifiedById)}, modified_at = ${bind(modificationDate)}
+        UPDATE fridge_partner SET conflict = false, modified_by = ${bind(modifiedById)}, modified_at = ${bind(modificationDate)}
+        WHERE partnership_id = ${bind(id)}
     """
             )
         }


### PR DESCRIPTION
## Before this change
Endpoint `PUT /partnerships/{id}/retry` was failing with HTTP 500 caused by an SQL syntax error.

## After this change
Typo in SQL statement is fixed and endpoint works as intended.