### PR TITLE
Field rename in varda units api

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaUnitIntegrationTest.kt
@@ -55,7 +55,7 @@ class VardaUnitIntegrationTest : VardaIntegrationTest(resetDbBeforeEach = true) 
             vardaClient.sourceSystem,
             mockEndpoint.units.values.elementAt(0).lahdejarjestelma
         )
-        assertEquals("[FI]", mockEndpoint.units.values.elementAt(0).asiointikieli_koodi.toString())
+        assertEquals("[FI]", mockEndpoint.units.values.elementAt(0).toimintakieli_koodi.toString())
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUnits.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUnits.kt
@@ -237,7 +237,7 @@ data class VardaUnit(
                     }
                     else -> null
                 },
-            asiointikieli_koodi = listOfNotNull(language.vardaCode),
+            toimintakieli_koodi = listOfNotNull(language.vardaCode),
             kielipainotus_kytkin = languageEmphasisId?.let { true } ?: false
         )
 }
@@ -265,6 +265,6 @@ data class VardaUnitRequest(
     val kasvatusopillinen_jarjestelma_koodi: String? = VardaUnitEducationSystem.NONE.vardaCode,
     val jarjestamismuoto_koodi: List<String>,
     val toimintamuoto_koodi: String?,
-    val asiointikieli_koodi: List<String>,
+    val toimintakieli_koodi: List<String>,
     val kielipainotus_kytkin: Boolean
 )

--- a/service/src/test/kotlin/fi/espoo/evaka/varda/VardaUnitModelTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/varda/VardaUnitModelTest.kt
@@ -15,7 +15,7 @@ class VardaUnitModelTest {
     fun `data output is in correct form`() {
         assertEquals(listOf("jm01"), testUnit.toVardaUnitRequest().jarjestamismuoto_koodi)
         assertEquals("tm01", testUnit.toVardaUnitRequest().toimintamuoto_koodi)
-        assertEquals(listOf("FI"), testUnit.toVardaUnitRequest().asiointikieli_koodi)
+        assertEquals(listOf("FI"), testUnit.toVardaUnitRequest().toimintakieli_koodi)
     }
 
     @Test
@@ -75,7 +75,7 @@ val testUnit =
 
 val testUnitJson =
     """
-{"vakajarjestaja":"http://path.to.organizer","kayntiosoite":"Testiosoite 6","postiosoite":"Postiosoite 4","nimi":"Testipäiväkoti","kayntiosoite_postinumero":"00200","kayntiosoite_postitoimipaikka":"Espoo","postinumero":"00100","postitoimipaikka":"Espoo","kunta_koodi":"049","puhelinnumero":"+3581233222","sahkopostiosoite":"testi@testi.com","kasvatusopillinen_jarjestelma_koodi":"kj98","toimintamuoto_koodi":"tm01","asiointikieli_koodi":["FI"],"jarjestamismuoto_koodi":["jm01"],"varhaiskasvatuspaikat":21,"toiminnallinenpainotus_kytkin":false,"kielipainotus_kytkin":false,"alkamis_pvm":"2000-01-01","lahdejarjestelma":"ss"}
+{"vakajarjestaja":"http://path.to.organizer","kayntiosoite":"Testiosoite 6","postiosoite":"Postiosoite 4","nimi":"Testipäiväkoti","kayntiosoite_postinumero":"00200","kayntiosoite_postitoimipaikka":"Espoo","postinumero":"00100","postitoimipaikka":"Espoo","kunta_koodi":"049","puhelinnumero":"+3581233222","sahkopostiosoite":"testi@testi.com","kasvatusopillinen_jarjestelma_koodi":"kj98","toimintamuoto_koodi":"tm01","toimintakieli_koodi":["FI"],"jarjestamismuoto_koodi":["jm01"],"varhaiskasvatuspaikat":21,"toiminnallinenpainotus_kytkin":false,"kielipainotus_kytkin":false,"alkamis_pvm":"2000-01-01","lahdejarjestelma":"ss"}
     """
         .trimIndent()
 val testUnitFamily = testUnit.copy(unitType = listOf(VardaUnitType.FAMILY))


### PR DESCRIPTION
#### Summary
Hei järjestelmätoimittajat,
 
Muistutuksena:
 
Kesäkuussa Vardan toimipaikan asiointikieli -tietokenttä muutettiin toimintakieleksi. Vuoden alusta lähtien (1.1.2024) kentän nimi muuttuu rajapinnassa: asiointikieli_koodi à  toimintakieli_koodi. Tällä hetkellä rajapinnassa on molemmat käytössä ja asiointikielestä on redirect toimintakieleen. Ilmoitamme järjestelmätoimittajille, kun muutos on Vardan testiympäristössä testattavissa.
 
Kerrottehan, mikäli muutosta ei ole mahdollista toteuttaa annetussa aikataulussa ja sillä on osaltanne vaikutuksia varhaiskasvatustietojen integraatioihin Vardassa.
 
Yhteistyöterveisin,
Opetushallituksen Varda-tiimi
[varda@opintopolku.fi](mailto:varda@opintopolku.fi)
