### PR TITLE
Cache JWT token to session

### DIFF
--- a/apigw/src/internal/mobile-device-session.ts
+++ b/apigw/src/internal/mobile-device-session.ts
@@ -104,6 +104,7 @@ export const pinLoginRequestHandler = (redisClient: RedisClient) =>
     })
 
     req.session.employeeIdToken = token
+    req.session.jwt = undefined // Trigger JWT regeneration
     res.status(200).send(response)
   })
 
@@ -113,6 +114,7 @@ export const pinLogoutRequestHandler = (redisClient: RedisClient) =>
     if (token) {
       await redisClient.del(toMobileEmployeeIdKey(token))
       req.session.employeeIdToken = undefined
+      req.session.jwt = undefined // Trigger JWT regeneration
       if (req.user) req.user.mobileEmployeeId = undefined
     }
 

--- a/apigw/src/shared/auth/index.ts
+++ b/apigw/src/shared/auth/index.ts
@@ -46,7 +46,7 @@ export interface EvakaSessionUser {
   mobileEmployeeId?: string | undefined
 }
 
-function createJwtToken(user: EvakaSessionUser): string {
+export function createJwtToken(user: EvakaSessionUser): string {
   const type =
     user.userType ?? (gatewayRole === 'enduser' ? 'ENDUSER' : 'EMPLOYEE')
 
@@ -87,10 +87,6 @@ function createJwtToken(user: EvakaSessionUser): string {
     default:
       throw new Error(`Unsupported user type ${type}`)
   }
-}
-
-export function createAuthHeader(user: EvakaSessionUser): string {
-  return `Bearer ${createJwtToken(user)}`
 }
 
 export function createIntegrationAuthHeader(): string {

--- a/apigw/src/shared/express.ts
+++ b/apigw/src/shared/express.ts
@@ -54,6 +54,10 @@ declare module 'express-session' {
     idpProvider?: string | null
     logoutToken?: LogoutToken
     employeeIdToken?: string
+    jwt?: {
+      token: string
+      generatedAt: number
+    }
   }
 }
 


### PR DESCRIPTION
#### Summary

A significant share of apigw's processing time seems to be used for computing JWT tokens. To fix this, compute JWT token once every 10 minutes and cache it with the session.

Alternative approach: #4549 