### PR TITLE
Fix apigw datadog tracing

### DIFF
--- a/apigw/Dockerfile
+++ b/apigw/Dockerfile
@@ -63,4 +63,4 @@ LABEL fi.espoo.build="$build" \
       fi.espoo.commit="$commit"
 
 ENTRYPOINT ["./entrypoint.sh"]
-CMD ["node", "dist/index.js"]
+CMD ["node", "--loader", "dd-trace/loader-hook.mjs", "dist/index.js"]

--- a/apigw/src/enduser/app.ts
+++ b/apigw/src/enduser/app.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import cookieParser from 'cookie-parser'
-import { Router } from 'express'
+import express from 'express'
 import passport from 'passport'
 import { requireAuthentication } from '../shared/auth/index.js'
 import { createSuomiFiStrategy } from './suomi-fi-saml.js'
@@ -26,8 +26,8 @@ import { RedisClient } from '../shared/redis-client.js'
 export function enduserGwRouter(
   config: Config,
   redisClient: RedisClient
-): Router {
-  const router = Router()
+): express.Router {
+  const router = express.Router()
 
   const sessions = sessionSupport('enduser', redisClient, config.citizen)
 

--- a/apigw/src/enduser/mapRoutes.ts
+++ b/apigw/src/enduser/mapRoutes.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Router } from 'express'
+import express from 'express'
 import {
   digitransitApiEnabled,
   digitransitApiKey,
@@ -12,7 +12,7 @@ import expressHttpProxy from 'express-http-proxy'
 import { createProxy } from '../shared/proxy-utils.js'
 import { logError, logWarn } from '../shared/logging.js'
 
-const router = Router()
+const router = express.Router()
 
 function createDigitransitProxy(path: string) {
   return expressHttpProxy(digitransitApiUrl, {

--- a/apigw/src/enduser/publicRoutes.ts
+++ b/apigw/src/enduser/publicRoutes.ts
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Router } from 'express'
+import express from 'express'
 import { appCommit } from '../shared/config.js'
 import { createProxy } from '../shared/proxy-utils.js'
 
-const router = Router()
+const router = express.Router()
 const proxy = createProxy()
 
 router.get('/version', (_, res) => {

--- a/apigw/src/enduser/routes.ts
+++ b/apigw/src/enduser/routes.ts
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Router } from 'express'
+import express from 'express'
 import { createProxy } from '../shared/proxy-utils.js'
 
-const router = Router()
+const router = express.Router()
 const proxy = createProxy()
 
 router.all('/citizen/*', createProxy())

--- a/apigw/src/index.ts
+++ b/apigw/src/index.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import './tracer.js'
+
 import sourceMapSupport from 'source-map-support'
 import {
   configFromEnv,
@@ -9,7 +11,6 @@ import {
   httpPort,
   toRedisClientOpts
 } from './shared/config.js'
-import './tracer.js'
 import { logError, loggingMiddleware, logInfo } from './shared/logging.js'
 import { enduserGwRouter } from './enduser/app.js'
 import { internalGwRouter } from './internal/app.js'

--- a/apigw/src/internal/app.ts
+++ b/apigw/src/internal/app.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import cookieParser from 'cookie-parser'
-import express, { Router } from 'express'
+import express from 'express'
 import passport from 'passport'
 import { requireAuthentication } from '../shared/auth/index.js'
 import { createAdSamlStrategy } from './ad-saml.js'
@@ -37,8 +37,8 @@ import { RedisClient } from '../shared/redis-client.js'
 export function internalGwRouter(
   config: Config,
   redisClient: RedisClient
-): Router {
-  const router = Router()
+): express.Router {
+  const router = express.Router()
 
   const sessions = sessionSupport('employee', redisClient, config.employee)
 

--- a/apigw/src/shared/auth/dev-auth.ts
+++ b/apigw/src/shared/auth/dev-auth.ts
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import passport, { Strategy } from 'passport'
-import { Request, Router, urlencoded } from 'express'
+import express from 'express'
+import type { Request } from 'express'
 import { authenticate, EvakaSessionUser, login, logout } from './index.js'
 import { AsyncRequestHandler, toRequestHandler } from '../express.js'
 import { Sessions } from '../session.js'
@@ -36,15 +37,15 @@ export function createDevAuthRouter({
   strategyName,
   verifyUser,
   loginFormHandler
-}: DevAuthRouterOptions): Router {
+}: DevAuthRouterOptions): express.Router {
   passport.use(strategyName, new DevStrategy(verifyUser))
 
-  const router = Router()
+  const router = express.Router()
 
   router.get('/login', toRequestHandler(loginFormHandler))
   router.post(
     `/login/callback`,
-    urlencoded({ extended: false }), // needed to parse the POSTed form
+    express.urlencoded({ extended: false }), // needed to parse the POSTed form
     toRequestHandler(async (req, res) => {
       try {
         const user = await authenticate(strategyName, req, res)

--- a/apigw/src/shared/routes/csp.ts
+++ b/apigw/src/shared/routes/csp.ts
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import express, { Router } from 'express'
+import express from 'express'
 import { logWarn } from '../logging.js'
 
-const router = Router()
+const router = express.Router()
 
 router.post(
   '/csp-report',

--- a/apigw/src/shared/routes/saml.ts
+++ b/apigw/src/shared/routes/saml.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import express, { Router, urlencoded } from 'express'
+import express from 'express'
 import passport from 'passport'
 import passportSaml from '@node-saml/passport-saml'
 import { createLogoutToken, login, logout } from '../auth/index.js'
@@ -18,7 +18,7 @@ import type {
 } from '@node-saml/passport-saml/lib/types.js'
 import { parseRelayState } from '../saml/index.js'
 
-const urlencodedParser = urlencoded({ extended: false })
+const urlencodedParser = express.urlencoded({ extended: false })
 
 function getDefaultPageUrl(req: express.Request): string {
   switch (gatewayRole) {
@@ -166,7 +166,7 @@ function createLogoutHandler({
 // * HTTP POST: the browser makes a POST request with URI-encoded form body
 export default function createSamlRouter(
   endpointConfig: SamlEndpointConfig
-): Router {
+): express.Router {
   const { strategyName, strategy } = endpointConfig
 
   passport.use(strategyName, strategy)
@@ -181,7 +181,7 @@ export default function createSamlRouter(
     )
   })
 
-  const router = Router()
+  const router = express.Router()
 
   // Our application directs the browser to this endpoint to start the login
   // flow. We generate a LoginRequest.


### PR DESCRIPTION
#### Summary

After switching to ES modules, the instrumentation of external libraries (like express) no longer works. Use a module loader provided by dd-trace to fix this, as described here: https://github.com/DataDog/dd-trace-js/issues/2221#issuecomment-1198215673

Also initialize the tracer as early as possible to instrument all code.

