### PR TITLE
Fix default page url after failed login/logout

### DIFF
--- a/apigw/src/enduser/app.ts
+++ b/apigw/src/enduser/app.ts
@@ -58,7 +58,8 @@ export function enduserGwRouter(
       createSamlRouter({
         sessions,
         strategyName: 'suomifi',
-        strategy: createSuomiFiStrategy(sessions, suomifiSamlConfig)
+        strategy: createSuomiFiStrategy(sessions, suomifiSamlConfig),
+        defaultPageUrl: '/'
       })
     )
   }
@@ -77,7 +78,8 @@ export function enduserGwRouter(
       strategy: createKeycloakCitizenSamlStrategy(
         sessions,
         keycloakCitizenConfig
-      )
+      ),
+      defaultPageUrl: '/'
     })
   )
   router.get('/auth/status', csrf, csrfCookie('enduser'), authStatus)

--- a/apigw/src/internal/app.ts
+++ b/apigw/src/internal/app.ts
@@ -84,7 +84,8 @@ export function internalGwRouter(
             config.ad.saml,
             redisCacheProvider(redisClient, { keyPrefix: 'ad-saml-resp:' })
           )
-        )
+        ),
+        defaultPageUrl: '/employee'
       })
     )
   }
@@ -103,7 +104,8 @@ export function internalGwRouter(
       strategy: createKeycloakEmployeeSamlStrategy(
         sessions,
         keycloakEmployeeConfig
-      )
+      ),
+      defaultPageUrl: '/employee'
     })
   )
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This fixes a bug where a unified gateway (undefined gatewayRole) redirected the user to the citizen home page even when using authentication mechanisms meant for the employee-side app