### PR TITLE
Bugfix remove future absences and reservations for placement

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceQueries.kt
@@ -167,6 +167,28 @@ fun Database.Transaction.deleteChildAbsences(childId: ChildId, date: LocalDate):
         .executeAndReturnGeneratedKeys()
         .toList<AbsenceId>()
 
+fun Database.Transaction.deleteNonSystemGeneratedAbsencesByCategoryInRange(
+    childId: ChildId,
+    range: DateRange,
+    category: AbsenceCategory
+): List<AbsenceId> =
+    createQuery(
+            """
+DELETE FROM absence
+WHERE
+    child_id = :childId AND
+    between_start_and_end(:range, date) AND
+    category = :category AND
+    modified_by != :systemUserId
+RETURNING id
+"""
+        )
+        .bind("childId", childId)
+        .bind("range", range)
+        .bind("category", category)
+        .bind("systemUserId", AuthenticatedUser.SystemInternalUser.evakaUserId)
+        .toList<AbsenceId>()
+
 fun Database.Transaction.deleteOldGeneratedAbsencesInRange(
     now: HelsinkiDateTime,
     childId: ChildId,

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceQueries.kt
@@ -170,7 +170,7 @@ fun Database.Transaction.deleteChildAbsences(childId: ChildId, date: LocalDate):
 fun Database.Transaction.deleteNonSystemGeneratedAbsencesByCategoryInRange(
     childId: ChildId,
     range: DateRange,
-    category: AbsenceCategory
+    categories: Set<AbsenceCategory>
 ): List<AbsenceId> =
     createQuery(
             """
@@ -178,14 +178,14 @@ DELETE FROM absence
 WHERE
     child_id = :childId AND
     between_start_and_end(:range, date) AND
-    category = :category AND
+    category = ANY (:categories::absence_category[]) AND
     modified_by != :systemUserId
 RETURNING id
 """
         )
         .bind("childId", childId)
         .bind("range", range)
-        .bind("category", category)
+        .bind("categories", categories)
         .bind("systemUserId", AuthenticatedUser.SystemInternalUser.evakaUserId)
         .toList<AbsenceId>()
 

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceService.kt
@@ -273,7 +273,7 @@ fun deleteFutureNonGeneratedAbsencesByCategoryInRange(
     clock: EvakaClock,
     childId: ChildId,
     range: DateRange,
-    categoryToDelete: AbsenceCategory
+    categoriesToDelete: Set<AbsenceCategory>
 ) {
     if (range.start.isBefore(clock.now().toLocalDate().plusDays(1))) {
         throw BadRequest("Could not delete future absences - Range has to be in future ")
@@ -282,10 +282,10 @@ fun deleteFutureNonGeneratedAbsencesByCategoryInRange(
     val futureAbsences = getFutureAbsencesOfChild(tx, clock, childId)
 
     val futureAbsencesToDelete =
-        futureAbsences.filter { absence -> absence.category == categoryToDelete }
+        futureAbsences.filter { absence -> categoriesToDelete.contains(absence.category) }
 
     if (futureAbsencesToDelete.isNotEmpty()) {
-        tx.deleteNonSystemGeneratedAbsencesByCategoryInRange(childId, range, categoryToDelete)
+        tx.deleteNonSystemGeneratedAbsencesByCategoryInRange(childId, range, categoriesToDelete)
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -218,7 +218,7 @@ class PlacementController(
                             tx,
                             childId = body.childId,
                             unitId = body.unitId,
-                            FiniteDateRange(body.startDate, body.endDate),
+                            period = FiniteDateRange(body.startDate, body.endDate),
                             type = body.type,
                             useFiveYearsOldDaycare = useFiveYearsOldDaycare,
                             placeGuarantee = body.placeGuarantee

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -226,13 +226,12 @@ class PlacementController(
                         .also {
                             generateAbsencesFromIrregularDailyServiceTimes(tx, now, body.childId)
 
+                            val future = DateRange(now.toLocalDate().plusDays(1), null)
+                            val range = DateRange(body.startDate, body.endDate).intersection(future)
+
                             // Only proceed with future absence and reservation deletion if
                             // placements range is in future
-                            if (body.endDate.isAfter(now.toLocalDate())) {
-                                val future = DateRange(now.toLocalDate().plusDays(1), null)
-                                val range =
-                                    DateRange(body.startDate, body.endDate).intersection(future)
-
+                            if (range != null) {
                                 // Delete future absences if new absence category is specific
                                 if (
                                     body.type.absenceCategories().size !=
@@ -242,7 +241,7 @@ class PlacementController(
                                         tx,
                                         clock,
                                         body.childId,
-                                        range!!,
+                                        range,
                                         setOf(
                                             when (body.type.absenceCategories().single()) {
                                                 AbsenceCategory.BILLABLE ->
@@ -255,7 +254,7 @@ class PlacementController(
                                 }
                                 tx.clearReservationsForRangeExceptInHolidayPeriod(
                                     body.childId,
-                                    range!!
+                                    range
                                 )
                             }
 


### PR DESCRIPTION
#### Summary
 Added handling to remove placements future absences and reservations that are not in the period range. Operation is done when creating an overlapping future placement, deleting existing placement or editing existing placements period end date that is in future.

