### PR TITLE
Make creating service times permission enabled only in Espoo

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.daycare.insertPreschoolTerm
 import fi.espoo.evaka.daycare.service.AbsenceCategory
 import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.daycare.service.getAbsencesOfChildByRange
+import fi.espoo.evaka.espoo.EspooActionRuleMapping
 import fi.espoo.evaka.insertServiceNeedOptions
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementType
@@ -43,6 +44,7 @@ import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.domain.TimeRange
+import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.snDaycareContractDays10
 import fi.espoo.evaka.snDaycareFullDay35
@@ -56,6 +58,7 @@ import fi.espoo.evaka.testChild_4
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDecisionMaker_1
 import fi.espoo.evaka.testRoundTheClockDaycare
+import io.opentracing.noop.NoopTracerFactory
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
@@ -69,7 +72,6 @@ import org.springframework.beans.factory.annotation.Autowired
 
 class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     @Autowired private lateinit var reservationControllerCitizen: ReservationControllerCitizen
-    @Autowired private lateinit var dailyServiceTimesController: DailyServiceTimesController
 
     // Monday
     private val mockToday: LocalDate = LocalDate.of(2021, 11, 1)
@@ -507,6 +509,10 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
 
     @Test
     fun `irregular daily service time absences are non-editable`() {
+        val dailyServiceTimesController =
+            DailyServiceTimesController(
+                AccessControl(EspooActionRuleMapping(), NoopTracerFactory.create())
+            )
         db.transaction { tx ->
             tx.insertDaycareAclRow(testDaycare.id, testDecisionMaker_1.id, UserRole.UNIT_SUPERVISOR)
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooActionRuleMapping.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooActionRuleMapping.kt
@@ -61,6 +61,21 @@ class EspooActionRuleMapping : ActionRuleMapping {
                             .inPlacementUnitOfChild() as ScopedActionRule<in T>
                     )
             }
+            Action.Child.CREATE_DAILY_SERVICE_TIME -> {
+                @Suppress("UNCHECKED_CAST")
+                sequenceOf(
+                    HasGlobalRole(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN)
+                        as ScopedActionRule<in T>
+                ) +
+                    sequenceOf(
+                        HasUnitRole(
+                                UserRole.UNIT_SUPERVISOR,
+                                UserRole.SPECIAL_EDUCATION_TEACHER,
+                                UserRole.STAFF
+                            )
+                            .inPlacementUnitOfChild() as ScopedActionRule<in T>
+                    )
+            }
             Action.Citizen.Child.READ_DAILY_SERVICE_TIMES -> {
                 @Suppress("UNCHECKED_CAST")
                 sequenceOf(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -1094,10 +1094,7 @@ sealed interface Action {
             IsMobile(requirePinLogin = false).inPlacementUnitOfChild()
         ),
         READ_DAILY_SERVICE_TIMES(),
-        CREATE_DAILY_SERVICE_TIME(
-            HasGlobalRole(ADMIN, SERVICE_WORKER, FINANCE_ADMIN),
-            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER, STAFF).inPlacementUnitOfChild()
-        ),
+        CREATE_DAILY_SERVICE_TIME(),
         READ_PLACEMENT(
             HasGlobalRole(ADMIN, SERVICE_WORKER, FINANCE_ADMIN, FINANCE_STAFF),
             HasUnitRole(


### PR DESCRIPTION
## Before this change
It was possible to create service times in other municipalities than Espoo.
## After this change
Like reading service times, also creating service times permission is only enabled in Espoo.