### PR TITLE
Fix Flyway Gradle plugin

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -9,6 +9,9 @@ buildscript {
     repositories {
         mavenCentral()
     }
+    dependencies {
+        classpath(libs.flyway.database.postgresql)
+    }
 }
 
 plugins {


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Gradle commands like `./gradlew flywayMigrate` don't currently work, because Flyway Postgres support package is not in the Gradle build classpath
