### PR TITLE
JWT refactor, part 1

### DIFF
--- a/apigw/src/enduser/dev-sfi-auth.ts
+++ b/apigw/src/enduser/dev-sfi-auth.ts
@@ -64,7 +64,7 @@ export function createDevSfiRouter(sessions: Sessions): Router {
       })
       return {
         id: person.id,
-        userType: 'ENDUSER',
+        userType: 'CITIZEN_STRONG',
         globalRoles: [],
         allScopedRoles: []
       }

--- a/apigw/src/enduser/suomi-fi-saml.ts
+++ b/apigw/src/enduser/suomi-fi-saml.ts
@@ -38,8 +38,8 @@ export function createSuomiFiStrategy(
     })
     return {
       id: person.id,
-      userType: 'ENDUSER',
-      globalRoles: ['END_USER'],
+      userType: 'CITIZEN_STRONG',
+      globalRoles: [],
       allScopedRoles: []
     }
   })

--- a/apigw/src/shared/auth/index.ts
+++ b/apigw/src/shared/auth/index.ts
@@ -94,12 +94,45 @@ export function createAuthHeader(user: EvakaSessionUser): string {
   return `Bearer ${createJwtToken(user)}`
 }
 
+export function createUserHeader(user: EvakaSessionUser): string {
+  return JSON.stringify(
+    ((): object => {
+      switch (user.userType) {
+        case 'CITIZEN_WEAK':
+          return { type: 'citizen_weak', id: user.id }
+        case 'ENDUSER':
+        case 'CITIZEN_STRONG':
+          return { type: 'citizen', id: user.id }
+        case 'EMPLOYEE':
+          return {
+            type: 'employee',
+            id: user.id,
+            globalRoles: user.globalRoles,
+            allScopedRoles: user.allScopedRoles
+          }
+        case 'MOBILE':
+          return {
+            type: 'mobile',
+            id: user.id,
+            employeeId: user.mobileEmployeeId
+          }
+        case 'SYSTEM':
+          return { type: 'system' }
+        case undefined:
+          throw new Error('User type is undefined')
+      }
+    })()
+  )
+}
+
 export function createIntegrationAuthHeader(): string {
   return `Bearer ${createJwt({
     sub: '00000000-0000-0000-0000-000000000000',
     evaka_type: 'integration'
   })}`
 }
+
+export const integrationUserHeader = JSON.stringify({ type: 'integration' })
 
 export function createLogoutToken(
   nameID: Required<Profile>['nameID'],

--- a/apigw/src/shared/proxy-utils.ts
+++ b/apigw/src/shared/proxy-utils.ts
@@ -4,8 +4,10 @@
 
 import expressHttpProxy from 'express-http-proxy'
 import type express from 'express'
+import _ from 'lodash'
 import { evakaServiceUrl } from './config.js'
 import { createServiceRequestHeaders } from './service-client.js'
+import { OutgoingHttpHeaders } from 'node:http'
 
 interface ProxyOptions {
   path?: string | ((req: express.Request) => string)
@@ -20,12 +22,24 @@ export function createProxy({
     parseReqBody: false,
     proxyReqPathResolver: typeof path === 'string' ? () => path : path,
     proxyReqOptDecorator: (proxyReqOpts, srcReq) => {
-      const headers = createServiceRequestHeaders(srcReq)
+      const originalHeaders = lowercaseHeaderNames(proxyReqOpts.headers ?? {})
+
+      // Remove sensitive headers
+      delete originalHeaders['authorization']
+      delete originalHeaders['x-user']
+
+      const serviceHeaders = lowercaseHeaderNames(
+        createServiceRequestHeaders(srcReq)
+      )
       proxyReqOpts.headers = {
-        ...proxyReqOpts.headers,
-        ...headers
+        ...originalHeaders,
+        ...serviceHeaders
       }
       return proxyReqOpts
     }
   })
+}
+
+function lowercaseHeaderNames(obj: OutgoingHttpHeaders): OutgoingHttpHeaders {
+  return _.mapKeys(obj, (_, key) => key.toLowerCase())
 }

--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -8,7 +8,9 @@ import { evakaServiceUrl } from './config.js'
 import {
   createAuthHeader,
   createIntegrationAuthHeader,
-  EvakaSessionUser
+  EvakaSessionUser,
+  integrationUserHeader,
+  createUserHeader
 } from './auth/index.js'
 
 export const client = axios.create({
@@ -48,6 +50,7 @@ export type ServiceRequestHeader =
   | 'Authorization'
   | 'X-Request-ID'
   | 'EvakaMockedTime'
+  | 'X-User'
 
 export type ServiceRequestHeaders = { [H in ServiceRequestHeader]?: string }
 
@@ -55,12 +58,20 @@ export function createServiceRequestHeaders(
   req: express.Request | undefined,
   user: EvakaSessionUser | undefined | null = req?.user
 ) {
-  const headers: ServiceRequestHeaders = {}
+  let headers: ServiceRequestHeaders = {}
   if (req?.path.startsWith('/integration/')) {
-    headers.Authorization = createIntegrationAuthHeader()
+    headers = {
+      // TODO: Use empty JWT
+      Authorization: createIntegrationAuthHeader(),
+      'X-User': integrationUserHeader
+    }
   }
   if (user) {
-    headers.Authorization = createAuthHeader(user)
+    headers = {
+      // TODO: Use empty JWT
+      Authorization: createAuthHeader(user),
+      'X-User': createUserHeader(user)
+    }
   }
   if (req?.traceId) {
     headers['X-Request-ID'] = req.traceId

--- a/frontend/proxy/files/etc/nginx/proxy_params.template
+++ b/frontend/proxy/files/etc/nginx/proxy_params.template
@@ -10,6 +10,10 @@ proxy_set_header X-Original-Forwarded-Proto $http_x_forwarded_proto;
 proxy_set_header X-Request-ID $request_id;
 proxy_set_header Connection "";
 
+# Prevent forwarding of sensitive headers
+proxy_set_header Authorization "";
+proxy_set_header X-User "";
+
 # Actual caching headers should be set by downstream API Gateways;
 # this is just to prevent caching at the proxy level.
 proxy_no_cache 1;

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/ServerSmokeTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/ServerSmokeTest.kt
@@ -30,7 +30,7 @@ class ServerSmokeTest : FullApplicationTest(resetDbBeforeEach = false) {
     }
 
     @Test
-    fun `a valid JWT token is required in API requests`() {
+    fun `a valid JWT token and user header are required in API requests`() {
         val (_, res, _) = http.get("/daycares").responseString()
         assertEquals(401, res.statusCode)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/FuelRequestSigning.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/FuelRequestSigning.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.shared.auth
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.fasterxml.jackson.module.kotlin.jsonMapper
 import com.github.kittinunf.fuel.core.Request
 import java.security.KeyFactory
 import java.security.interfaces.RSAPrivateKey
@@ -17,16 +18,16 @@ import org.bouncycastle.util.encoders.Base64
 fun Request.asUser(user: AuthenticatedUser, clock: Clock? = Clock.systemDefaultZone()): Request {
     val now = ZonedDateTime.now(clock)
     val token =
-        user
-            .applyToJwt(
-                JWT.create()
-                    .withKeyId("integration-test")
-                    .withIssuer("integration-test")
-                    .withIssuedAt(now.toInstant())
-                    .withExpiresAt(now.plusHours(12).toInstant())
-            )
+        JWT.create()
+            .withKeyId("integration-test")
+            .withIssuer("integration-test")
+            .withIssuedAt(now.toInstant())
+            .withExpiresAt(now.plusHours(12).toInstant())
             .sign(algorithm)
-    return this.header("Authorization", "Bearer $token")
+    this.header("Authorization", "Bearer $token")
+    this.header("X-User", jsonMapper().writeValueAsString(user))
+
+    return this
 }
 
 private val privateKeyText =

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/FuelRequestSigning.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/auth/FuelRequestSigning.kt
@@ -15,18 +15,9 @@ import java.time.Clock
 import java.time.ZonedDateTime
 import org.bouncycastle.util.encoders.Base64
 
-fun Request.asUser(user: AuthenticatedUser, clock: Clock? = Clock.systemDefaultZone()): Request {
-    val now = ZonedDateTime.now(clock)
-    val token =
-        JWT.create()
-            .withKeyId("integration-test")
-            .withIssuer("integration-test")
-            .withIssuedAt(now.toInstant())
-            .withExpiresAt(now.plusHours(12).toInstant())
-            .sign(algorithm)
-    this.header("Authorization", "Bearer $token")
+fun Request.asUser(user: AuthenticatedUser): Request {
+    this.header("Authorization", "Bearer $emptyJwt")
     this.header("X-User", jsonMapper().writeValueAsString(user))
-
     return this
 }
 
@@ -89,4 +80,14 @@ private val algorithm: Algorithm by lazy {
     val kf = KeyFactory.getInstance("RSA")
     val pk = kf.generatePrivate(PKCS8EncodedKeySpec(Base64.decode(privateKeyText))) as RSAPrivateKey
     Algorithm.RSA256(null, pk)
+}
+
+private val emptyJwt: String by lazy {
+    val now = ZonedDateTime.now(Clock.systemDefaultZone())
+    JWT.create()
+        .withKeyId("integration-test")
+        .withIssuer("integration-test")
+        .withIssuedAt(now.toInstant())
+        .withExpiresAt(now.plusHours(12).toInstant())
+        .sign(algorithm)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonDeserializer.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AuthenticatedUserJsonDeserializer.kt
@@ -14,16 +14,16 @@ import java.util.UUID
 
 class AuthenticatedUserJsonDeserializer : JsonDeserializer<AuthenticatedUser>() {
     private data class AllFields(
-        val type: AuthenticatedUserType,
-        val id: UUID?,
+        val type: AuthenticatedUserType? = null,
+        val id: UUID? = null,
         val globalRoles: Set<UserRole> = emptySet(),
         val allScopedRoles: Set<UserRole> = emptySet(),
-        val employeeId: EmployeeId?
+        val employeeId: EmployeeId? = null
     )
 
     override fun deserialize(p: JsonParser, ctx: DeserializationContext): AuthenticatedUser {
         val user = p.readValueAs(AllFields::class.java)
-        return when (user.type) {
+        return when (user.type!!) {
             AuthenticatedUserType.citizen ->
                 AuthenticatedUser.Citizen(PersonId(user.id!!), CitizenAuthLevel.STRONG)
             AuthenticatedUserType.citizen_weak ->

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/JwtTokens.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/JwtTokens.kt
@@ -4,7 +4,6 @@
 
 package fi.espoo.evaka.shared.auth
 
-import com.auth0.jwt.JWTCreator
 import com.auth0.jwt.interfaces.DecodedJWT
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.MobileDeviceId
@@ -41,17 +40,3 @@ fun DecodedJWT.toAuthenticatedUser(): AuthenticatedUser? =
             null -> null
         }
     }
-
-fun AuthenticatedUser.applyToJwt(jwt: JWTCreator.Builder): JWTCreator.Builder =
-    jwt.withSubject(rawId().toString())
-        .withClaim("evaka_type", this.type.toString())
-        .also {
-            if (this is AuthenticatedUser.Employee) {
-                it.withClaim("scope", (globalRoles + allScopedRoles).joinToString(" "))
-            }
-        }
-        .also {
-            if (this is AuthenticatedUser.MobileDevice && employeeId != null) {
-                it.withClaim("evaka_employee_id", employeeId.toString())
-            }
-        }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/RequestToAuthenticatedUser.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/RequestToAuthenticatedUser.kt
@@ -22,7 +22,7 @@ fun HttpServletRequest.getAuthenticatedUser(): AuthenticatedUser? =
 
 fun HttpServletRequest.setAuthenticatedUser(user: AuthenticatedUser) = setAttribute(ATTR_USER, user)
 
-class JwtToAuthenticatedUser(private val tracer: Tracer) : HttpFilter() {
+class RequestToAuthenticatedUser(private val tracer: Tracer) : HttpFilter() {
     override fun doFilter(
         request: HttpServletRequest,
         response: HttpServletResponse,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.shared.config
 import com.auth0.jwt.interfaces.JWTVerifier
 import fi.espoo.evaka.shared.Tracing
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.JwtToAuthenticatedUser
+import fi.espoo.evaka.shared.auth.RequestToAuthenticatedUser
 import fi.espoo.evaka.shared.auth.getAuthenticatedUser
 import fi.espoo.evaka.shared.randomTracingId
 import fi.espoo.voltti.auth.JwtTokenDecoder
@@ -41,8 +41,8 @@ class HttpFilterConfig {
         }
 
     @Bean
-    fun jwtToAuthenticatedUser(tracer: Tracer) =
-        FilterRegistrationBean(JwtToAuthenticatedUser(tracer)).apply {
+    fun requestToAuthenticatedUser(tracer: Tracer) =
+        FilterRegistrationBean(RequestToAuthenticatedUser(tracer)).apply {
             setName("jwtToAuthenticatedUser")
             urlPatterns = listOf("/*")
             order = -9


### PR DESCRIPTION
#### Summary

Send the same user fields in HTTP headers that are already sent in JWT. Read the fields from headers, but fall back to JWT if the headers don't exist. If the headers exist, JWT payload can be empty, but the JWT needs to be valid in either case.

In integration tests, use empty cached JWT and send user fields in headers only.

Also, stop creating sessions where user's type is `ENDUSER`. Always use `CITIZEN_STRONG` instead.

After this has been deployed to production, the fallback of reading user fields from JWT can be removed and apigw can start sending an empty JWT which can be cached for a longer time. The support for for `ENDUSER` user type can also be removed.