### PR TITLE
Keep correct reservations when marking absences

### DIFF
--- a/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkAbsentBeforehand.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkAbsentBeforehand.tsx
@@ -76,13 +76,13 @@ export default React.memo(function MarkAbsentBeforehand() {
 
   const postAbsence = useCallback(
     (absenceType: AbsenceType) =>
-      postAbsenceRange(
-        unitId,
-        childId,
+      postAbsenceRange(unitId, childId, {
         absenceType,
-        LocalDate.parseIso(startDate),
-        LocalDate.parseIso(endDate)
-      ),
+        range: new FiniteDateRange(
+          LocalDate.parseIso(startDate),
+          LocalDate.parseIso(endDate)
+        )
+      }),
     [childId, endDate, startDate, unitId]
   )
 

--- a/frontend/src/employee-mobile-frontend/child-attendance/api.ts
+++ b/frontend/src/employee-mobile-frontend/child-attendance/api.ts
@@ -8,6 +8,7 @@ import { Failure, Result, Success } from 'lib-common/api'
 import { parseDailyServiceTimes } from 'lib-common/api-types/daily-service-times'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import {
+  AbsenceRangeRequest,
   AbsenceThreshold,
   AttendanceChild,
   ChildAttendanceStatusResponse
@@ -139,18 +140,12 @@ export async function createFullDayAbsence({
 export async function postAbsenceRange(
   unitId: string,
   childId: string,
-  absenceType: AbsenceType,
-  startDate: LocalDate,
-  endDate: LocalDate
+  body: AbsenceRangeRequest
 ): Promise<Result<void>> {
   return client
     .post<JsonOf<void>>(
       `/attendances/units/${unitId}/children/${childId}/absence-range`,
-      {
-        absenceType,
-        startDate,
-        endDate
-      }
+      body
     )
     .then(() => Success.of())
     .catch((e) => Failure.fromError(e))

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 /* eslint-disable import/order, prettier/prettier, @typescript-eslint/no-namespace, @typescript-eslint/no-redundant-type-constituents */
 
+import FiniteDateRange from '../../finite-date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import LocalTime from '../../local-time'
@@ -25,8 +26,7 @@ import { UUID } from '../../types'
 */
 export interface AbsenceRangeRequest {
   absenceType: AbsenceType
-  endDate: LocalDate
-  startDate: LocalDate
+  range: FiniteDateRange
 }
 
 /**

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/AbsenceControllerIntegrationTest.kt
@@ -14,10 +14,14 @@ import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.AbsenceId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.EvakaUserId
-import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
 import fi.espoo.evaka.shared.dev.DevAbsence
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevDaycareGroup
+import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.DevReservation
 import fi.espoo.evaka.shared.dev.insert
@@ -25,12 +29,6 @@ import fi.espoo.evaka.shared.dev.insertTestPlacement
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.MockEvakaClock
-import fi.espoo.evaka.testArea
-import fi.espoo.evaka.testChild_1
-import fi.espoo.evaka.testChild_2
-import fi.espoo.evaka.testDaycare
-import fi.espoo.evaka.testDaycareGroup
-import fi.espoo.evaka.testDecisionMaker_1
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
@@ -44,35 +42,35 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
     private val now = HelsinkiDateTime.of(LocalDate.of(2023, 6, 1), LocalTime.of(8, 0))
     private val today = now.toLocalDate()
-    private val employee = AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf())
 
     private val mockId = AbsenceId(UUID.randomUUID())
 
+    private lateinit var daycare: DevDaycare
+    private lateinit var group: DevDaycareGroup
+    private lateinit var employee: DevEmployee
+    private lateinit var child1: DevPerson
+
     @BeforeEach
     fun beforeEach() {
+        val area = DevCareArea()
+        daycare = DevDaycare(areaId = area.id)
+        group = DevDaycareGroup(daycareId = daycare.id)
+        employee = DevEmployee()
+
+        child1 = DevPerson()
+
         db.transaction { tx ->
-            tx.insert(testArea)
-            tx.insert(testDaycare)
-            tx.insert(testDaycareGroup)
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(group)
 
-            tx.insert(testDecisionMaker_1)
-            tx.insertDaycareAclRow(testDaycare.id, testDecisionMaker_1.id, UserRole.UNIT_SUPERVISOR)
+            tx.insert(employee)
+            tx.insertDaycareAclRow(daycare.id, employee.id, UserRole.UNIT_SUPERVISOR)
 
-            tx.insert(testChild_1, DevPersonType.CHILD)
-
+            tx.insert(child1, DevPersonType.CHILD)
             tx.insertTestPlacement(
-                childId = testChild_1.id,
-                unitId = testDaycare.id,
-                startDate = today,
-                endDate = today.plusYears(1),
-                type = PlacementType.PRESCHOOL_DAYCARE
-            )
-
-            tx.insert(testChild_2, DevPersonType.CHILD)
-
-            tx.insertTestPlacement(
-                childId = testChild_2.id,
-                unitId = testDaycare.id,
+                childId = child1.id,
+                unitId = daycare.id,
                 startDate = today,
                 endDate = today.plusYears(1),
                 type = PlacementType.PRESCHOOL_DAYCARE
@@ -82,20 +80,31 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
     @Test
     fun `correct absences are deleted`() {
+        val child2 = DevPerson()
+
         val firstAbsenceDate = today
         val lastAbsenceDate = today.plusDays(1)
         db.transaction { tx ->
+            tx.insert(child2, DevPersonType.CHILD)
+            tx.insertTestPlacement(
+                childId = child2.id,
+                unitId = daycare.id,
+                startDate = today,
+                endDate = today.plusYears(1),
+                type = PlacementType.PRESCHOOL_DAYCARE
+            )
+
             FiniteDateRange(firstAbsenceDate, lastAbsenceDate).dates().forEach { date ->
                 tx.insert(
                     DevAbsence(
-                        childId = testChild_1.id,
+                        childId = child1.id,
                         date = date,
                         absenceCategory = AbsenceCategory.BILLABLE
                     )
                 )
                 tx.insert(
                     DevAbsence(
-                        childId = testChild_1.id,
+                        childId = child1.id,
                         date = date,
                         absenceCategory = AbsenceCategory.NONBILLABLE
                     )
@@ -105,7 +114,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             // Unrelated absence
             tx.insert(
                 DevAbsence(
-                    childId = testChild_2.id,
+                    childId = child2.id,
                     date = firstAbsenceDate,
                     absenceCategory = AbsenceCategory.BILLABLE
                 )
@@ -115,12 +124,12 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
         addPresences(
             listOf(
                 Presence(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = firstAbsenceDate,
                     category = AbsenceCategory.BILLABLE
                 ),
                 Presence(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = lastAbsenceDate,
                     category = AbsenceCategory.NONBILLABLE
                 )
@@ -131,32 +140,32 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             listOf(
                 Absence(
                     id = mockId,
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = firstAbsenceDate,
                     category = AbsenceCategory.NONBILLABLE,
                     absenceType = AbsenceType.OTHER_ABSENCE
                 ),
                 Absence(
                     id = mockId,
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = lastAbsenceDate,
                     category = AbsenceCategory.BILLABLE,
                     absenceType = AbsenceType.OTHER_ABSENCE
                 ),
             ),
-            getAbsencesOfChild(testChild_1.id).sortedWith(compareBy({ it.date }, { it.category }))
+            getAbsencesOfChild(child1.id).sortedWith(compareBy({ it.date }, { it.category }))
         )
         assertEquals(
             listOf(
                 Absence(
                     id = mockId,
-                    childId = testChild_2.id,
+                    childId = child2.id,
                     date = firstAbsenceDate,
                     category = AbsenceCategory.BILLABLE,
                     absenceType = AbsenceType.OTHER_ABSENCE
                 ),
             ),
-            getAbsencesOfChild(testChild_2.id)
+            getAbsencesOfChild(child2.id)
         )
     }
 
@@ -178,7 +187,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
             tx.insert(
                 DevReservation(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate.plusDays(1),
                     startTime = LocalTime.of(8, 0),
                     endTime = LocalTime.of(16, 0),
@@ -187,7 +196,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             )
             tx.insert(
                 DevReservation(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate.plusDays(2),
                     startTime = null,
                     endTime = null,
@@ -200,11 +209,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             FiniteDateRange(startDate, endDate)
                 .dates()
                 .map { date ->
-                    Presence(
-                        childId = testChild_1.id,
-                        date = date,
-                        category = AbsenceCategory.BILLABLE
-                    )
+                    Presence(childId = child1.id, date = date, category = AbsenceCategory.BILLABLE)
                 }
                 .toList()
         )
@@ -212,13 +217,13 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
         assertEquals(
             listOf(
                 Reservation(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate.plusDays(1),
                     startTime = LocalTime.of(8, 0),
                     endTime = LocalTime.of(16, 0)
                 ),
                 Reservation(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate.plusDays(2),
                     startTime = null,
                     endTime = null
@@ -226,7 +231,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
                 // This was added
                 Reservation(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate.plusDays(3),
                     startTime = null,
                     endTime = null
@@ -256,7 +261,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
             tx.insert(
                 DevReservation(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate,
                     startTime = LocalTime.of(8, 0),
                     endTime = LocalTime.of(16, 0),
@@ -265,7 +270,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             )
             tx.insert(
                 DevReservation(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate.plusDays(1),
                     startTime = LocalTime.of(8, 0),
                     endTime = LocalTime.of(16, 0),
@@ -274,7 +279,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             )
             tx.insert(
                 DevReservation(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate.plusDays(2),
                     startTime = null,
                     endTime = null,
@@ -284,14 +289,14 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
 
             tx.insert(
                 DevAbsence(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate,
                     absenceCategory = AbsenceCategory.BILLABLE
                 )
             )
             tx.insert(
                 DevAbsence(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate.plusDays(1),
                     absenceCategory = AbsenceCategory.BILLABLE
                 )
@@ -303,7 +308,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
                 .dates()
                 .map { date ->
                     AbsenceController.HolidayReservationsDelete(
-                        childId = testChild_1.id,
+                        childId = child1.id,
                         date = date,
                     )
                 }
@@ -314,7 +319,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             listOf(
                 // This was kept
                 Reservation(
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate,
                     startTime = LocalTime.of(8, 0),
                     endTime = LocalTime.of(16, 0)
@@ -328,13 +333,13 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
                 // This was kept
                 Absence(
                     id = mockId,
-                    childId = testChild_1.id,
+                    childId = child1.id,
                     date = startDate,
                     category = AbsenceCategory.BILLABLE,
                     absenceType = AbsenceType.OTHER_ABSENCE
                 ),
             ),
-            getAbsencesOfChild(testChild_1.id)
+            getAbsencesOfChild(child1.id)
         )
     }
 
@@ -342,7 +347,7 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
         return absenceController
             .absencesOfChild(
                 dbInstance(),
-                employee,
+                employee.user(setOf()),
                 MockEvakaClock(now),
                 childId,
                 today.year,
@@ -355,9 +360,9 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
     private fun addPresences(absences: List<Presence>) {
         absenceController.addPresences(
             dbInstance(),
-            employee,
+            employee.user(setOf()),
             MockEvakaClock(now),
-            testDaycareGroup.id,
+            group.id,
             absences
         )
     }
@@ -367,9 +372,9 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
     ) {
         absenceController.deleteHolidayReservations(
             dbInstance(),
-            employee,
+            employee.user(setOf()),
             MockEvakaClock(now),
-            testDaycareGroup.id,
+            group.id,
             deletions
         )
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerIntegrationTest.kt
@@ -57,6 +57,7 @@ class HolidayPeriodControllerIntegrationTest : FullApplicationTest(resetDbBefore
         db.transaction { tx ->
             tx.upsertFullDayAbsences(
                 EvakaUserId(testAdult_1.id.raw),
+                now,
                 listOf(
                     // Outside holiday period
                     FullDayAbsenseUpsert(
@@ -74,6 +75,7 @@ class HolidayPeriodControllerIntegrationTest : FullApplicationTest(resetDbBefore
             )
             tx.upsertFullDayAbsences(
                 EvakaUserId(testDecisionMaker_1.id.raw),
+                now,
                 listOf(
                     // Inside holiday period, but marked by employee
                     FullDayAbsenseUpsert(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerIntegrationTest.kt
@@ -6,9 +6,9 @@ package fi.espoo.evaka.holidayperiod
 
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.daycare.service.AbsenceType
+import fi.espoo.evaka.daycare.service.FullDayAbsenseUpsert
+import fi.espoo.evaka.daycare.service.upsertFullDayAbsences
 import fi.espoo.evaka.insertGeneralTestFixtures
-import fi.espoo.evaka.reservations.AbsenceInsert
-import fi.espoo.evaka.reservations.insertAbsences
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
@@ -55,24 +55,28 @@ class HolidayPeriodControllerIntegrationTest : FullApplicationTest(resetDbBefore
     @Test
     fun `existing reservations and absences are deleted when a holiday period is created`() {
         db.transaction { tx ->
-            tx.insertAbsences(
+            tx.upsertFullDayAbsences(
                 EvakaUserId(testAdult_1.id.raw),
                 listOf(
                     // Outside holiday period
-                    AbsenceInsert(
+                    FullDayAbsenseUpsert(
                         testChild_1.id,
                         holidayPeriodStart.minusDays(1),
                         AbsenceType.OTHER_ABSENCE
                     ),
                     // Inside holiday period
-                    AbsenceInsert(testChild_1.id, holidayPeriodStart, AbsenceType.OTHER_ABSENCE)
+                    FullDayAbsenseUpsert(
+                        testChild_1.id,
+                        holidayPeriodStart,
+                        AbsenceType.OTHER_ABSENCE
+                    )
                 )
             )
-            tx.insertAbsences(
+            tx.upsertFullDayAbsences(
                 EvakaUserId(testDecisionMaker_1.id.raw),
                 listOf(
                     // Inside holiday period, but marked by employee
-                    AbsenceInsert(
+                    FullDayAbsenseUpsert(
                         testChild_1.id,
                         holidayPeriodStart.plusDays(1),
                         AbsenceType.OTHER_ABSENCE

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
@@ -9,7 +9,9 @@ import fi.espoo.evaka.dailyservicetimes.DailyServiceTimesController
 import fi.espoo.evaka.dailyservicetimes.DailyServiceTimesValue
 import fi.espoo.evaka.daycare.service.AbsenceCategory
 import fi.espoo.evaka.daycare.service.AbsenceType
+import fi.espoo.evaka.daycare.service.FullDayAbsenseUpsert
 import fi.espoo.evaka.daycare.service.getAbsencesOfChildByRange
+import fi.espoo.evaka.daycare.service.upsertFullDayAbsences
 import fi.espoo.evaka.espoo.EspooActionRuleMapping
 import fi.espoo.evaka.holidayperiod.insertHolidayPeriod
 import fi.espoo.evaka.pis.service.insertGuardian
@@ -1172,15 +1174,15 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
             )
             it.insertGuardian(guardianId = adult.id, childId = child.id)
             it.insertHolidayPeriod(holidayPeriod, beforeThreshold.toLocalDate().minusDays(1))
-            it.insertAbsences(
+            it.upsertFullDayAbsences(
                 adult.user(CitizenAuthLevel.STRONG).evakaUserId,
                 listOf(
-                    AbsenceInsert(
+                    FullDayAbsenseUpsert(
                         childId = child.id,
                         date = holidayPeriodStart,
                         absenceType = AbsenceType.OTHER_ABSENCE,
                     ),
-                    AbsenceInsert(
+                    FullDayAbsenseUpsert(
                         childId = child.id,
                         date = holidayPeriodStart.plusDays(1),
                         absenceType = AbsenceType.OTHER_ABSENCE,
@@ -1255,10 +1257,10 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
             )
             it.insertGuardian(guardianId = adult.id, childId = child.id)
             it.insertHolidayPeriod(holidayPeriod, beforeThreshold.toLocalDate().minusDays(1))
-            it.insertAbsences(
+            it.upsertFullDayAbsences(
                 adult.user(CitizenAuthLevel.STRONG).evakaUserId,
                 listOf(
-                    AbsenceInsert(
+                    FullDayAbsenseUpsert(
                         childId = child.id,
                         date = holidayPeriodStart,
                         absenceType = AbsenceType.OTHER_ABSENCE,
@@ -1385,10 +1387,10 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
             )
             it.insertGuardian(guardianId = adult.id, childId = child.id)
             it.insertHolidayPeriod(holidayPeriod, beforeThreshold.toLocalDate().minusDays(1))
-            it.insertAbsences(
+            it.upsertFullDayAbsences(
                 adult.user(CitizenAuthLevel.STRONG).evakaUserId,
                 listOf(
-                    AbsenceInsert(
+                    FullDayAbsenseUpsert(
                         childId = child.id,
                         date = holidayPeriodStart,
                         absenceType = AbsenceType.OTHER_ABSENCE,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
@@ -1176,6 +1176,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
             it.insertHolidayPeriod(holidayPeriod, beforeThreshold.toLocalDate().minusDays(1))
             it.upsertFullDayAbsences(
                 adult.user(CitizenAuthLevel.STRONG).evakaUserId,
+                HelsinkiDateTime.now(),
                 listOf(
                     FullDayAbsenseUpsert(
                         childId = child.id,
@@ -1259,6 +1260,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
             it.insertHolidayPeriod(holidayPeriod, beforeThreshold.toLocalDate().minusDays(1))
             it.upsertFullDayAbsences(
                 adult.user(CitizenAuthLevel.STRONG).evakaUserId,
+                HelsinkiDateTime.now(),
                 listOf(
                     FullDayAbsenseUpsert(
                         childId = child.id,
@@ -1389,6 +1391,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
             it.insertHolidayPeriod(holidayPeriod, beforeThreshold.toLocalDate().minusDays(1))
             it.upsertFullDayAbsences(
                 adult.user(CitizenAuthLevel.STRONG).evakaUserId,
+                HelsinkiDateTime.now(),
                 listOf(
                     FullDayAbsenseUpsert(
                         childId = child.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.reservations
 
 import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.allWeekOpTimes
 import fi.espoo.evaka.dailyservicetimes.DailyServiceTimesController
 import fi.espoo.evaka.dailyservicetimes.DailyServiceTimesValue
 import fi.espoo.evaka.daycare.insertPreschoolTerm
@@ -19,16 +20,15 @@ import fi.espoo.evaka.placement.ScheduleType
 import fi.espoo.evaka.preschoolTerm2021
 import fi.espoo.evaka.serviceneed.ShiftCareType
 import fi.espoo.evaka.shared.ChildId
-import fi.espoo.evaka.shared.DaycareId
-import fi.espoo.evaka.shared.EmployeeId
-import fi.espoo.evaka.shared.EvakaUserId
-import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
 import fi.espoo.evaka.shared.data.DateSet
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.insert
 import fi.espoo.evaka.shared.dev.insertServiceNeedOption
@@ -49,19 +49,9 @@ import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.snDaycareContractDays10
 import fi.espoo.evaka.snDaycareFullDay35
 import fi.espoo.evaka.snPreschoolDaycareContractDays13
-import fi.espoo.evaka.testAdult_1
-import fi.espoo.evaka.testArea
-import fi.espoo.evaka.testChild_1
-import fi.espoo.evaka.testChild_2
-import fi.espoo.evaka.testChild_3
-import fi.espoo.evaka.testChild_4
-import fi.espoo.evaka.testDaycare
-import fi.espoo.evaka.testDecisionMaker_1
-import fi.espoo.evaka.testRoundTheClockDaycare
 import io.opentracing.noop.NoopTracerFactory
 import java.time.LocalDate
 import java.time.LocalTime
-import java.util.UUID
 import kotlin.test.assertEquals
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.groups.Tuple
@@ -88,39 +78,47 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
     private val startTime = LocalTime.of(9, 0)
     private val endTime = LocalTime.of(17, 0)
 
-    private val testStaffId = EmployeeId(UUID.randomUUID())
-
-    private lateinit var testChild1PlacementId: PlacementId
-
     @BeforeEach
     fun before() {
         db.transaction { tx ->
             tx.insertServiceNeedOptions()
             tx.insertServiceNeedOption(snPreschoolDaycareContractDays13)
+        }
+    }
 
-            tx.insert(testArea)
-            tx.insert(testDaycare)
+    @Test
+    fun `get reservations returns correct children every day in range`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+        val employee = DevEmployee()
 
-            tx.insert(testDecisionMaker_1)
-            tx.insert(DevEmployee(testStaffId))
+        val adult = DevPerson()
+        val child1 = DevPerson(dateOfBirth = LocalDate.of(2015, 1, 1))
+        val child2 = DevPerson(dateOfBirth = LocalDate.of(2016, 1, 1))
+        val child3 = DevPerson(dateOfBirth = LocalDate.of(2017, 1, 1))
 
-            tx.insert(testAdult_1, DevPersonType.ADULT)
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(employee)
 
-            listOf(testChild_1, testChild_2).forEach { child ->
+            tx.insert(adult, DevPersonType.ADULT)
+            listOf(child1, child2, child3).forEach { child ->
                 tx.insert(child, DevPersonType.CHILD)
+                tx.insertGuardian(adult.id, child.id)
             }
 
-            testChild1PlacementId =
-                tx.insertTestPlacement(
-                    childId = testChild_1.id,
-                    unitId = testDaycare.id,
-                    type = PlacementType.PRESCHOOL_DAYCARE,
-                    startDate = monday,
-                    endDate = tuesday
-                )
             tx.insertTestPlacement(
-                    childId = testChild_2.id,
-                    unitId = testDaycare.id,
+                childId = child1.id,
+                unitId = daycare.id,
+                type = PlacementType.PRESCHOOL_DAYCARE,
+                startDate = monday,
+                endDate = tuesday
+            )
+            tx.insertTestPlacement(
+                    childId = child2.id,
+                    unitId = daycare.id,
                     type = PlacementType.DAYCARE,
                     startDate = fridayLastWeek,
                     endDate = tuesday
@@ -128,43 +126,37 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                 .also { placementId ->
                     // contract days on monday and tuesday
                     tx.insertTestServiceNeed(
-                        confirmedBy = EvakaUserId(testDecisionMaker_1.id.raw),
+                        confirmedBy = employee.evakaUserId,
                         placementId = placementId,
                         period = FiniteDateRange(monday, tuesday),
                         optionId = snDaycareContractDays10.id,
                         shiftCare = ShiftCareType.NONE
                     )
                 }
-            tx.insertGuardian(guardianId = testAdult_1.id, childId = testChild_1.id)
-            tx.insertGuardian(guardianId = testAdult_1.id, childId = testChild_2.id)
-        }
-    }
-
-    @Test
-    fun `get reservations returns correct children every day in range`() {
-        db.transaction { tx ->
-            tx.insertTestHoliday(wednesday)
-
-            tx.insert(testChild_3, DevPersonType.CHILD)
 
             // Fixed schedule (PRESCHOOL)
             tx.insertTestPlacement(
-                childId = testChild_3.id,
-                unitId = testDaycare.id,
+                childId = child3.id,
+                unitId = daycare.id,
                 type = PlacementType.PRESCHOOL,
                 startDate = monday,
                 endDate = thursday
             )
 
+            // Holiday on wednesday
+            tx.insertTestHoliday(wednesday)
+
             // Term break on thursday
             tx.insertPreschoolTerm(
                 preschoolTerm2021.copy(termBreaks = DateSet.of(FiniteDateRange(thursday, thursday)))
             )
-
-            tx.insertGuardian(guardianId = testAdult_1.id, childId = testChild_3.id)
         }
 
-        val res = getReservations(FiniteDateRange(sundayLastWeek, thursday))
+        val res =
+            getReservations(
+                adult.user(CitizenAuthLevel.WEAK),
+                FiniteDateRange(sundayLastWeek, thursday)
+            )
 
         assertEquals(
             ReservationsResponse(
@@ -177,27 +169,27 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                     // Sorted by date of birth, oldest child first
                     listOf(
                         ReservationChild(
-                            id = testChild_2.id,
-                            firstName = testChild_2.firstName,
-                            lastName = testChild_2.lastName,
-                            preferredName = "",
-                            duplicateOf = null,
-                            imageId = null,
-                            upcomingPlacementType = PlacementType.DAYCARE,
-                        ),
-                        ReservationChild(
-                            id = testChild_1.id,
-                            firstName = testChild_1.firstName,
-                            lastName = testChild_1.lastName,
+                            id = child1.id,
+                            firstName = child1.firstName,
+                            lastName = child1.lastName,
                             preferredName = "",
                             duplicateOf = null,
                             imageId = null,
                             upcomingPlacementType = PlacementType.PRESCHOOL_DAYCARE,
                         ),
                         ReservationChild(
-                            id = testChild_3.id,
-                            firstName = testChild_3.firstName,
-                            lastName = testChild_3.lastName,
+                            id = child2.id,
+                            firstName = child2.firstName,
+                            lastName = child2.lastName,
+                            preferredName = "",
+                            duplicateOf = null,
+                            imageId = null,
+                            upcomingPlacementType = PlacementType.DAYCARE,
+                        ),
+                        ReservationChild(
+                            id = child3.id,
+                            firstName = child3.firstName,
+                            lastName = child3.lastName,
                             preferredName = "",
                             duplicateOf = null,
                             imageId = null,
@@ -218,25 +210,25 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             children =
                                 listOf(
                                         dayChild(
-                                            testChild_1.id,
+                                            child1.id,
                                             reservableTimeRange =
                                                 ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[0]!!
+                                                    daycare.operationTimes[0]!!
                                                 )
                                         ),
                                         dayChild(
-                                            testChild_2.id,
+                                            child2.id,
                                             reservableTimeRange =
                                                 ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[0]!!
+                                                    daycare.operationTimes[0]!!
                                                 )
                                         ),
                                         dayChild(
-                                            testChild_3.id,
+                                            child3.id,
                                             scheduleType = ScheduleType.FIXED_SCHEDULE,
                                             reservableTimeRange =
                                                 ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[0]!!
+                                                    daycare.operationTimes[0]!!
                                                 )
                                         )
                                     )
@@ -248,25 +240,25 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             children =
                                 listOf(
                                         dayChild(
-                                            testChild_1.id,
+                                            child1.id,
                                             reservableTimeRange =
                                                 ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[1]!!
+                                                    daycare.operationTimes[1]!!
                                                 )
                                         ),
                                         dayChild(
-                                            testChild_2.id,
+                                            child2.id,
                                             reservableTimeRange =
                                                 ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[1]!!
+                                                    daycare.operationTimes[1]!!
                                                 )
                                         ),
                                         dayChild(
-                                            testChild_3.id,
+                                            child3.id,
                                             scheduleType = ScheduleType.FIXED_SCHEDULE,
                                             reservableTimeRange =
                                                 ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[1]!!
+                                                    daycare.operationTimes[1]!!
                                                 )
                                         )
                                     )
@@ -283,12 +275,10 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             children =
                                 listOf(
                                     dayChild(
-                                        testChild_3.id,
+                                        child3.id,
                                         scheduleType = ScheduleType.TERM_BREAK,
                                         reservableTimeRange =
-                                            ReservableTimeRange.Normal(
-                                                testDaycare.operationTimes[0]!!
-                                            )
+                                            ReservableTimeRange.Normal(daycare.operationTimes[0]!!)
                                     )
                                 )
                         )
@@ -300,51 +290,69 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
 
     @Test
     fun `get reservations returns correct children every day in range with children in shift care`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
         val roundTheClockDaycare =
-            testRoundTheClockDaycare.copy(
-                id = DaycareId(UUID.randomUUID()),
+            DevDaycare(
+                areaId = area.id,
                 enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS),
+                roundTheClock = true,
+                operationTimes = allWeekOpTimes,
             )
+        val employee = DevEmployee()
+
+        val adult = DevPerson()
+        val child1 = DevPerson(dateOfBirth = LocalDate.of(2015, 1, 1))
+        val child2 = DevPerson(dateOfBirth = LocalDate.of(2016, 1, 1))
 
         db.transaction { tx ->
-            tx.insertTestHoliday(tuesday)
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(roundTheClockDaycare)
+            tx.insert(employee)
 
-            listOf(testChild_3, testChild_4).forEach { child ->
+            tx.insert(adult, DevPersonType.ADULT)
+            listOf(child1, child2).forEach { child ->
                 tx.insert(child, DevPersonType.CHILD)
+                tx.insertGuardian(adult.id, child.id)
             }
 
             // Normal shift care
-            tx.insert(roundTheClockDaycare)
             tx.insertTestPlacement(
-                childId = testChild_3.id,
+                childId = child1.id,
                 unitId = roundTheClockDaycare.id,
                 type = PlacementType.DAYCARE,
                 startDate = sundayLastWeek,
                 endDate = tuesday
             )
-            tx.insertGuardian(guardianId = testAdult_1.id, childId = testChild_3.id)
 
             // Intermittent shift care
             tx.insertTestPlacement(
-                    childId = testChild_4.id,
-                    unitId = testDaycare.id,
+                    childId = child2.id,
+                    unitId = daycare.id,
                     type = PlacementType.DAYCARE,
                     startDate = sundayLastWeek,
                     endDate = wednesday
                 )
                 .also { placementId ->
                     tx.insertTestServiceNeed(
-                        confirmedBy = EvakaUserId(testDecisionMaker_1.id.raw),
+                        confirmedBy = employee.evakaUserId,
                         placementId = placementId,
                         period = FiniteDateRange(sundayLastWeek, tuesday),
                         optionId = snDaycareFullDay35.id,
                         shiftCare = ShiftCareType.INTERMITTENT,
                     )
                 }
-            tx.insertGuardian(guardianId = testAdult_1.id, childId = testChild_4.id)
+
+            tx.insertTestHoliday(tuesday)
         }
 
-        val res = getReservations(FiniteDateRange(sundayLastWeek, wednesday))
+        val res =
+            getReservations(
+                adult.user(CitizenAuthLevel.WEAK),
+                FiniteDateRange(sundayLastWeek, wednesday)
+            )
 
         assertEquals(
             ReservationsResponse(
@@ -357,36 +365,18 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                     // Sorted by date of birth, oldest child first
                     listOf(
                         ReservationChild(
-                            id = testChild_2.id,
-                            firstName = testChild_2.firstName,
-                            lastName = testChild_2.lastName,
+                            id = child1.id,
+                            firstName = child1.firstName,
+                            lastName = child1.lastName,
                             preferredName = "",
                             duplicateOf = null,
                             imageId = null,
                             upcomingPlacementType = PlacementType.DAYCARE,
                         ),
                         ReservationChild(
-                            id = testChild_1.id,
-                            firstName = testChild_1.firstName,
-                            lastName = testChild_1.lastName,
-                            preferredName = "",
-                            duplicateOf = null,
-                            imageId = null,
-                            upcomingPlacementType = PlacementType.PRESCHOOL_DAYCARE,
-                        ),
-                        ReservationChild(
-                            id = testChild_3.id,
-                            firstName = testChild_3.firstName,
-                            lastName = testChild_3.lastName,
-                            preferredName = "",
-                            duplicateOf = null,
-                            imageId = null,
-                            upcomingPlacementType = PlacementType.DAYCARE,
-                        ),
-                        ReservationChild(
-                            id = testChild_4.id,
-                            firstName = testChild_4.firstName,
-                            lastName = testChild_4.lastName,
+                            id = child2.id,
+                            firstName = child2.firstName,
+                            lastName = child2.lastName,
                             preferredName = "",
                             duplicateOf = null,
                             imageId = null,
@@ -402,7 +392,7 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                 listOf(
                                         // Sunday, only shift care is eligible
                                         dayChild(
-                                            testChild_3.id,
+                                            child1.id,
                                             shiftCare = true,
                                             reservableTimeRange =
                                                 ReservableTimeRange.Normal(
@@ -410,7 +400,7 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                                 )
                                         ),
                                         dayChild(
-                                            testChild_4.id,
+                                            child2.id,
                                             shiftCare = true,
                                             reservableTimeRange =
                                                 ReservableTimeRange.IntermittentShiftCare(
@@ -427,21 +417,7 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             children =
                                 listOf(
                                         dayChild(
-                                            testChild_1.id,
-                                            reservableTimeRange =
-                                                ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[0]!!
-                                                )
-                                        ),
-                                        dayChild(
-                                            testChild_2.id,
-                                            reservableTimeRange =
-                                                ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[0]!!
-                                                )
-                                        ),
-                                        dayChild(
-                                            testChild_3.id,
+                                            child1.id,
                                             shiftCare = true,
                                             reservableTimeRange =
                                                 ReservableTimeRange.Normal(
@@ -449,11 +425,11 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                                 )
                                         ),
                                         dayChild(
-                                            testChild_4.id,
+                                            child2.id,
                                             shiftCare = true,
                                             reservableTimeRange =
                                                 ReservableTimeRange.IntermittentShiftCare(
-                                                    testDaycare.operationTimes[0]!!
+                                                    daycare.operationTimes[0]!!
                                                 )
                                         ),
                                     )
@@ -466,15 +442,15 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                 listOf(
                                         // Holiday, only shift care is eligible
                                         dayChild(
-                                            testChild_3.id,
+                                            child1.id,
                                             shiftCare = true,
                                             reservableTimeRange =
                                                 ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[1]!!
+                                                    daycare.operationTimes[1]!!
                                                 )
                                         ),
                                         dayChild(
-                                            testChild_4.id,
+                                            child2.id,
                                             shiftCare = true,
                                             reservableTimeRange =
                                                 ReservableTimeRange.IntermittentShiftCare(
@@ -492,12 +468,10 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                 listOf(
                                     // Intermittent shift care ended on Tuesday
                                     dayChild(
-                                        testChild_4.id,
+                                        child2.id,
                                         shiftCare = false,
                                         reservableTimeRange =
-                                            ReservableTimeRange.Normal(
-                                                testDaycare.operationTimes[2]!!
-                                            )
+                                            ReservableTimeRange.Normal(daycare.operationTimes[2]!!)
                                     ),
                                 )
                         )
@@ -513,15 +487,39 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             DailyServiceTimesController(
                 AccessControl(EspooActionRuleMapping(), NoopTracerFactory.create())
             )
+
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+        val employee = DevEmployee()
+
+        val adult = DevPerson()
+        val child = DevPerson()
+
         db.transaction { tx ->
-            tx.insertDaycareAclRow(testDaycare.id, testDecisionMaker_1.id, UserRole.UNIT_SUPERVISOR)
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(employee)
+            tx.insertDaycareAclRow(daycare.id, employee.id, UserRole.UNIT_SUPERVISOR)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
+
+            tx.insertTestPlacement(
+                childId = child.id,
+                unitId = daycare.id,
+                type = PlacementType.DAYCARE,
+                startDate = monday,
+                endDate = tuesday
+            )
         }
 
         dailyServiceTimesController.postDailyServiceTimes(
             dbInstance(),
-            AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf()),
+            employee.user(setOf()),
             MockEvakaClock(HelsinkiDateTime.of(mockToday, LocalTime.of(12, 0))),
-            testChild_1.id,
+            child.id,
             DailyServiceTimesValue.IrregularTimes(
                 validityPeriod = DateRange(mockToday.plusDays(1), null),
                 monday = null,
@@ -534,7 +532,8 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             )
         )
 
-        val res = getReservations(FiniteDateRange(monday, tuesday))
+        val res =
+            getReservations(adult.user(CitizenAuthLevel.WEAK), FiniteDateRange(monday, tuesday))
 
         assertEquals(
             ReservationsResponse(
@@ -547,22 +546,13 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                     // Sorted by date of birth, oldest child first
                     listOf(
                         ReservationChild(
-                            id = testChild_2.id,
-                            firstName = testChild_2.firstName,
-                            lastName = testChild_2.lastName,
+                            id = child.id,
+                            firstName = child.firstName,
+                            lastName = child.lastName,
                             preferredName = "",
                             duplicateOf = null,
                             imageId = null,
                             upcomingPlacementType = PlacementType.DAYCARE,
-                        ),
-                        ReservationChild(
-                            id = testChild_1.id,
-                            firstName = testChild_1.firstName,
-                            lastName = testChild_1.lastName,
-                            preferredName = "",
-                            duplicateOf = null,
-                            imageId = null,
-                            upcomingPlacementType = PlacementType.PRESCHOOL_DAYCARE,
                         ),
                     ),
                 days =
@@ -572,49 +562,29 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             holiday = false,
                             children =
                                 listOf(
-                                        dayChild(
-                                            testChild_1.id,
-                                            absence =
-                                                AbsenceInfo(
-                                                    AbsenceType.OTHER_ABSENCE,
-                                                    editable = false
-                                                ),
-                                            reservableTimeRange =
-                                                ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[0]!!
-                                                )
-                                        ),
-                                        dayChild(
-                                            testChild_2.id,
-                                            reservableTimeRange =
-                                                ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[0]!!
-                                                )
-                                        ),
-                                    )
-                                    .sortedBy { it.childId }
+                                    dayChild(
+                                        child.id,
+                                        absence =
+                                            AbsenceInfo(
+                                                AbsenceType.OTHER_ABSENCE,
+                                                editable = false
+                                            ),
+                                        reservableTimeRange =
+                                            ReservableTimeRange.Normal(daycare.operationTimes[0]!!)
+                                    ),
+                                )
                         ),
                         ReservationResponseDay(
                             date = tuesday,
                             holiday = false,
                             children =
                                 listOf(
-                                        dayChild(
-                                            testChild_1.id,
-                                            reservableTimeRange =
-                                                ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[1]!!
-                                                )
-                                        ),
-                                        dayChild(
-                                            testChild_2.id,
-                                            reservableTimeRange =
-                                                ReservableTimeRange.Normal(
-                                                    testDaycare.operationTimes[1]!!
-                                                )
-                                        ),
-                                    )
-                                    .sortedBy { it.childId }
+                                    dayChild(
+                                        child.id,
+                                        reservableTimeRange =
+                                            ReservableTimeRange.Normal(daycare.operationTimes[1]!!)
+                                    ),
+                                )
                         ),
                     )
             ),
@@ -624,8 +594,45 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
 
     @Test
     fun `adding reservations works in a basic case`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+        val employee = DevEmployee()
+
+        val adult = DevPerson()
+        val child1 = DevPerson()
+        val child2 = DevPerson()
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(employee)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            listOf(child1, child2).forEach { child ->
+                tx.insert(child, DevPersonType.CHILD)
+                tx.insertGuardian(adult.id, child.id)
+            }
+
+            tx.insertTestPlacement(
+                childId = child1.id,
+                unitId = daycare.id,
+                type = PlacementType.PRESCHOOL_DAYCARE,
+                startDate = monday,
+                endDate = tuesday
+            )
+            tx.insertTestPlacement(
+                childId = child2.id,
+                unitId = daycare.id,
+                type = PlacementType.DAYCARE,
+                startDate = fridayLastWeek,
+                endDate = tuesday
+            )
+        }
+
         postReservations(
-            listOf(testChild_1.id, testChild_2.id).flatMap { child ->
+            adult.user(CitizenAuthLevel.WEAK),
+            listOf(child1.id, child2.id).flatMap { child ->
                 listOf(
                     DailyReservationRequest.Reservations(
                         child,
@@ -641,28 +648,29 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             }
         )
 
-        val res = getReservations(FiniteDateRange(monday, wednesday))
+        val res =
+            getReservations(adult.user(CitizenAuthLevel.WEAK), FiniteDateRange(monday, wednesday))
 
         assertEquals(
             listOf(
                 ReservationChild(
-                    id = testChild_2.id,
-                    firstName = testChild_2.firstName,
-                    lastName = testChild_2.lastName,
+                    id = child1.id,
+                    firstName = child1.firstName,
+                    lastName = child1.lastName,
+                    preferredName = "",
+                    duplicateOf = null,
+                    imageId = null,
+                    upcomingPlacementType = PlacementType.PRESCHOOL_DAYCARE,
+                ),
+                ReservationChild(
+                    id = child2.id,
+                    firstName = child2.firstName,
+                    lastName = child2.lastName,
                     preferredName = "",
                     duplicateOf = null,
                     imageId = null,
                     upcomingPlacementType = PlacementType.DAYCARE,
                 ),
-                ReservationChild(
-                    id = testChild_1.id,
-                    firstName = testChild_1.firstName,
-                    lastName = testChild_1.lastName,
-                    preferredName = "",
-                    duplicateOf = null,
-                    imageId = null,
-                    upcomingPlacementType = PlacementType.PRESCHOOL_DAYCARE,
-                )
             ),
             res.children
         )
@@ -674,16 +682,16 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(
                 listOf(
                         dayChild(
-                            testChild_1.id,
+                            child1.id,
                             reservations = listOf(Reservation.Times(startTime, endTime)),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[0]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[0]!!)
                         ),
                         dayChild(
-                            testChild_2.id,
+                            child2.id,
                             reservations = listOf(Reservation.Times(startTime, endTime)),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[0]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[0]!!)
                         )
                     )
                     .sortedBy { it.childId },
@@ -696,16 +704,16 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(
                 listOf(
                         dayChild(
-                            testChild_1.id,
+                            child1.id,
                             reservations = listOf(Reservation.Times(startTime, endTime)),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[1]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[1]!!)
                         ),
                         dayChild(
-                            testChild_2.id,
+                            child2.id,
                             reservations = listOf(Reservation.Times(startTime, endTime)),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[1]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[1]!!)
                         )
                     )
                     .sortedBy { it.childId },
@@ -721,21 +729,49 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
 
     @Test
     fun `adding a reservation and an absence works`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+        val employee = DevEmployee()
+
+        val adult = DevPerson()
+        val child = DevPerson()
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(employee)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
+
+            tx.insertTestPlacement(
+                childId = child.id,
+                unitId = daycare.id,
+                type = PlacementType.PRESCHOOL_DAYCARE,
+                startDate = monday,
+                endDate = tuesday
+            )
+        }
+
         postReservations(
+            adult.user(CitizenAuthLevel.WEAK),
             listOf(
                 DailyReservationRequest.Reservations(
-                    testChild_1.id,
+                    child.id,
                     monday,
                     TimeRange(startTime, endTime),
                 ),
                 DailyReservationRequest.Absent(
-                    testChild_1.id,
+                    child.id,
                     tuesday,
                 )
             )
         )
 
-        val res = getReservations(FiniteDateRange(monday, wednesday))
+        val res =
+            getReservations(adult.user(CitizenAuthLevel.WEAK), FiniteDateRange(monday, wednesday))
 
         assertEquals(3, res.days.size)
 
@@ -743,19 +779,13 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(monday, day.date)
             assertEquals(
                 listOf(
-                        dayChild(
-                            testChild_1.id,
-                            reservations = listOf(Reservation.Times(startTime, endTime)),
-                            reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[0]!!)
-                        ),
-                        dayChild(
-                            testChild_2.id,
-                            reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[0]!!)
-                        )
+                    dayChild(
+                        child.id,
+                        reservations = listOf(Reservation.Times(startTime, endTime)),
+                        reservableTimeRange =
+                            ReservableTimeRange.Normal(daycare.operationTimes[0]!!)
                     )
-                    .sortedBy { it.childId },
+                ),
                 day.children
             )
         }
@@ -765,16 +795,11 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(
                 listOf(
                         dayChild(
-                            testChild_1.id,
+                            child.id,
                             absence =
                                 AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[1]!!)
-                        ),
-                        dayChild(
-                            testChild_2.id,
-                            reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[1]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[1]!!)
                         )
                     )
                     .sortedBy { it.childId },
@@ -790,52 +815,125 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
 
     @Test
     fun `adding reservations fails if past citizen reservation threshold setting`() {
-        val request =
-            listOf(testChild_1.id, testChild_2.id).flatMap { child ->
-                listOf(
-                    DailyReservationRequest.Reservations(
-                        child,
-                        mockToday,
-                        TimeRange(startTime, endTime),
-                    ),
-                    DailyReservationRequest.Reservations(
-                        child,
-                        mockToday.plusDays(1),
-                        TimeRange(startTime, endTime),
-                    )
-                )
-            }
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+        val employee = DevEmployee()
 
-        assertThrows<BadRequest> { postReservations(request) }
+        val adult = DevPerson()
+        val child = DevPerson()
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(employee)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
+
+            tx.insertTestPlacement(
+                childId = child.id,
+                unitId = daycare.id,
+                type = PlacementType.PRESCHOOL_DAYCARE,
+                startDate = monday,
+                endDate = tuesday
+            )
+        }
+
+        val request =
+            listOf(
+                DailyReservationRequest.Reservations(
+                    child.id,
+                    mockToday,
+                    TimeRange(startTime, endTime),
+                ),
+                DailyReservationRequest.Reservations(
+                    child.id,
+                    mockToday.plusDays(1),
+                    TimeRange(startTime, endTime),
+                )
+            )
+
+        assertThrows<BadRequest> { postReservations(adult.user(CitizenAuthLevel.WEAK), request) }
+            .also { exception -> assertEquals("Some days are not reservable", exception.message) }
     }
 
     @Test
     fun `adding absences works`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+        val employee = DevEmployee()
+
+        val adult = DevPerson()
+        val child1 = DevPerson()
+        val child2 = DevPerson()
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(employee)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            listOf(child1, child2).forEach { child ->
+                tx.insert(child, DevPersonType.CHILD)
+                tx.insertGuardian(adult.id, child.id)
+            }
+
+            tx.insertTestPlacement(
+                childId = child1.id,
+                unitId = daycare.id,
+                type = PlacementType.PRESCHOOL_DAYCARE,
+                startDate = monday,
+                endDate = tuesday
+            )
+            tx.insertTestPlacement(
+                    childId = child2.id,
+                    unitId = daycare.id,
+                    type = PlacementType.DAYCARE,
+                    startDate = fridayLastWeek,
+                    endDate = tuesday
+                )
+                .also { placementId ->
+                    // contract days on monday and tuesday
+                    tx.insertTestServiceNeed(
+                        confirmedBy = employee.evakaUserId,
+                        placementId = placementId,
+                        period = FiniteDateRange(monday, tuesday),
+                        optionId = snDaycareContractDays10.id,
+                        shiftCare = ShiftCareType.NONE
+                    )
+                }
+        }
+
         val request =
             AbsenceRequest(
-                childIds = setOf(testChild_1.id, testChild_2.id),
+                childIds = setOf(child1.id, child2.id),
                 dateRange = FiniteDateRange(fridayLastWeek, wednesday),
                 absenceType = AbsenceType.OTHER_ABSENCE
             )
-        postAbsences(request)
+        postAbsences(adult.user(CitizenAuthLevel.WEAK), request)
 
-        val res = getReservations(FiniteDateRange(fridayLastWeek, wednesday))
+        val res =
+            getReservations(
+                adult.user(CitizenAuthLevel.WEAK),
+                FiniteDateRange(fridayLastWeek, wednesday)
+            )
         assertEquals(6, res.days.size)
 
         res.days[0].let { day ->
             assertEquals(fridayLastWeek, day.date)
             assertEquals(
                 listOf(
-                        dayChild(
-                            testChild_2.id,
-                            // no contract days -> OTHER_ABSENCE was kept
-                            absence =
-                                AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
-                            reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[0]!!)
-                        )
+                    dayChild(
+                        child2.id,
+                        // no contract days -> OTHER_ABSENCE was kept
+                        absence = AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
+                        reservableTimeRange =
+                            ReservableTimeRange.Normal(daycare.operationTimes[0]!!)
                     )
-                    .sortedBy { it.childId },
+                ),
                 day.children
             )
         }
@@ -855,19 +953,19 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(
                 listOf(
                         dayChild(
-                            testChild_1.id,
+                            child1.id,
                             absence =
                                 AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[1]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[1]!!)
                         ),
                         dayChild(
-                            testChild_2.id,
+                            child2.id,
                             absence =
                                 // contract days -> OTHER_ABSENCE changed to PLANNED_ABSENCE
                                 AbsenceInfo(type = AbsenceType.PLANNED_ABSENCE, editable = true),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[1]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[1]!!)
                         )
                     )
                     .sortedBy { it.childId },
@@ -880,19 +978,19 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(
                 listOf(
                         dayChild(
-                            testChild_1.id,
+                            child1.id,
                             absence =
                                 AbsenceInfo(type = AbsenceType.OTHER_ABSENCE, editable = true),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[1]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[1]!!)
                         ),
                         dayChild(
-                            testChild_2.id,
+                            child2.id,
                             absence =
                                 // contract days -> OTHER_ABSENCE changed to PLANNED_ABSENCE
                                 AbsenceInfo(type = AbsenceType.PLANNED_ABSENCE, editable = true),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[1]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[1]!!)
                         )
                     )
                     .sortedBy { it.childId },
@@ -906,11 +1004,11 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
         }
 
         // PRESCHOOL_DAYCARE generates two absences per day (nonbillable and billable)
-        assertAbsenceCounts(testChild_1.id, listOf(monday to 2, tuesday to 2))
+        assertAbsenceCounts(child1.id, listOf(monday to 2, tuesday to 2))
 
         // DAYCARE generates one absence per day
         assertAbsenceCounts(
-            testChild_2.id,
+            child2.id,
             listOf(
                 fridayLastWeek to 1,
                 // TODO: Absences are also generated for the weekend even though the unit is closed.
@@ -925,19 +1023,41 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
 
     @Test
     fun `cannot add absences to the past`() {
-        assertThrows<BadRequest> {
-            postAbsences(
-                AbsenceRequest(
-                    childIds = setOf(testChild_1.id, testChild_2.id),
-                    dateRange = FiniteDateRange(mockToday.minusDays(1), mockToday.plusDays(1)),
-                    absenceType = AbsenceType.OTHER_ABSENCE
-                )
-            )
+        val adult = DevPerson()
+        val child = DevPerson()
+
+        db.transaction { tx ->
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
         }
+
+        assertThrows<BadRequest> {
+                postAbsences(
+                    adult.user(CitizenAuthLevel.WEAK),
+                    AbsenceRequest(
+                        childIds = setOf(child.id),
+                        dateRange = FiniteDateRange(mockToday.minusDays(1), mockToday.plusDays(1)),
+                        absenceType = AbsenceType.OTHER_ABSENCE
+                    )
+                )
+            }
+            .also { exception ->
+                assertEquals("Cannot mark absences for past days", exception.message)
+            }
     }
 
     @Test
     fun `cannot add prohibited absence types`() {
+        val adult = DevPerson()
+        val child = DevPerson()
+
+        db.transaction { tx ->
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
+        }
+
         listOf(
                 AbsenceType.FREE_ABSENCE,
                 AbsenceType.UNAUTHORIZED_ABSENCE,
@@ -947,38 +1067,73 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             )
             .forEach { absenceType ->
                 assertThrows<BadRequest> {
-                    postAbsences(
-                        AbsenceRequest(
-                            childIds = setOf(testChild_1.id, testChild_2.id),
-                            dateRange = FiniteDateRange(monday, monday),
-                            absenceType = absenceType
+                        postAbsences(
+                            adult.user(CitizenAuthLevel.WEAK),
+                            AbsenceRequest(
+                                childIds = setOf(child.id),
+                                dateRange = FiniteDateRange(monday, monday),
+                                absenceType = absenceType
+                            )
                         )
-                    )
-                }
+                    }
+                    .also { exception -> assertEquals("Invalid absence type", exception.message) }
             }
     }
 
     @Test
     fun `citizen cannot override an absence that was added by staff`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+        val employee = DevEmployee()
+
+        val adult = DevPerson()
+        val child = DevPerson()
+
         db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(employee)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
+
+            tx.insertTestPlacement(
+                    childId = child.id,
+                    unitId = daycare.id,
+                    type = PlacementType.DAYCARE,
+                    startDate = monday,
+                    endDate = tuesday
+                )
+                .let { placementId ->
+                    tx.insertTestServiceNeed(
+                        confirmedBy = employee.evakaUserId,
+                        placementId = placementId,
+                        period = FiniteDateRange(monday, tuesday),
+                        optionId = snDaycareContractDays10.id
+                    )
+                }
+
             tx.insertTestAbsence(
-                childId = testChild_2.id,
+                childId = child.id,
                 date = monday,
                 category = AbsenceCategory.BILLABLE,
                 absenceType = AbsenceType.PLANNED_ABSENCE,
-                modifiedBy = EvakaUserId(testStaffId.raw)
+                modifiedBy = employee.evakaUserId,
             )
         }
 
         val request =
             AbsenceRequest(
-                childIds = setOf(testChild_2.id),
+                childIds = setOf(child.id),
                 dateRange = FiniteDateRange(monday, tuesday),
                 absenceType = AbsenceType.OTHER_ABSENCE
             )
-        postAbsences(request)
+        postAbsences(adult.user(CitizenAuthLevel.WEAK), request)
 
-        val res = getReservations(FiniteDateRange(monday, tuesday))
+        val res =
+            getReservations(adult.user(CitizenAuthLevel.WEAK), FiniteDateRange(monday, tuesday))
         assertEquals(2, res.days.size)
 
         res.days[0].let { day ->
@@ -986,16 +1141,11 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(
                 listOf(
                         dayChild(
-                            testChild_1.id,
-                            reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[0]!!)
-                        ),
-                        dayChild(
-                            testChild_2.id,
+                            child.id,
                             absence =
                                 AbsenceInfo(type = AbsenceType.PLANNED_ABSENCE, editable = false),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[0]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[0]!!)
                         ),
                     )
                     .sortedBy { it.childId },
@@ -1008,17 +1158,12 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(
                 listOf(
                         dayChild(
-                            testChild_1.id,
-                            reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[1]!!)
-                        ),
-                        dayChild(
-                            testChild_2.id,
+                            child.id,
                             absence =
                                 // contract days -> OTHER_ABSENCE changed to PLANNED_ABSENCE
                                 AbsenceInfo(type = AbsenceType.PLANNED_ABSENCE, editable = true),
                             reservableTimeRange =
-                                ReservableTimeRange.Normal(testDaycare.operationTimes[1]!!)
+                                ReservableTimeRange.Normal(daycare.operationTimes[1]!!)
                         )
                     )
                     .sortedBy { it.childId },
@@ -1026,38 +1171,64 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             )
         }
 
-        assertAbsenceCounts(testChild_2.id, listOf(monday to 1, tuesday to 1))
+        assertAbsenceCounts(child.id, listOf(monday to 1, tuesday to 1))
     }
 
     @Test
     fun `citizen can override billable planned absence in contract day placement with sick leave before threshold`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+        val employee = DevEmployee()
+
+        val adult = DevPerson()
+        val child = DevPerson()
+
         db.transaction { tx ->
-            tx.insertTestServiceNeed(
-                confirmedBy = EvakaUserId(testDecisionMaker_1.id.raw),
-                placementId = testChild1PlacementId,
-                period = FiniteDateRange(monday, tuesday),
-                optionId = snPreschoolDaycareContractDays13.id,
-                shiftCare = ShiftCareType.NONE
-            )
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(employee)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
+
+            tx.insertTestPlacement(
+                    childId = child.id,
+                    unitId = daycare.id,
+                    type = PlacementType.PRESCHOOL_DAYCARE,
+                    startDate = monday,
+                    endDate = tuesday
+                )
+                .let { placementId ->
+                    tx.insertTestServiceNeed(
+                        confirmedBy = employee.evakaUserId,
+                        placementId = placementId,
+                        period = FiniteDateRange(monday, tuesday),
+                        optionId = snPreschoolDaycareContractDays13.id
+                    )
+                }
+
             tx.insertTestAbsence(
-                childId = testChild_1.id,
+                childId = child.id,
                 date = monday,
                 category = AbsenceCategory.NONBILLABLE,
                 absenceType = AbsenceType.PLANNED_ABSENCE,
-                modifiedBy = EvakaUserId(testAdult_1.id.raw)
+                modifiedBy = adult.evakaUserId,
             )
             tx.insertTestAbsence(
-                childId = testChild_1.id,
+                childId = child.id,
                 date = monday,
                 category = AbsenceCategory.BILLABLE,
                 absenceType = AbsenceType.PLANNED_ABSENCE,
-                modifiedBy = EvakaUserId(testAdult_1.id.raw)
+                modifiedBy = adult.evakaUserId,
             )
         }
 
         postAbsences(
+            adult.user(CitizenAuthLevel.WEAK),
             AbsenceRequest(
-                childIds = setOf(testChild_1.id),
+                childIds = setOf(child.id),
                 dateRange = FiniteDateRange(monday, tuesday),
                 absenceType = AbsenceType.SICKLEAVE
             ),
@@ -1066,9 +1237,7 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
         )
 
         assertThat(
-                db.read { tx ->
-                    tx.getAbsencesOfChildByRange(testChild_1.id, DateRange(monday, tuesday))
-                }
+                db.read { tx -> tx.getAbsencesOfChildByRange(child.id, DateRange(monday, tuesday)) }
             )
             .extracting({ it.date }, { it.absenceType }, { it.category })
             .containsExactlyInAnyOrder(
@@ -1081,26 +1250,51 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
 
     @Test
     fun `citizen can override billable planned absence in non contract day placement with sick leave after threshold`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+        val employee = DevEmployee()
+
+        val adult = DevPerson()
+        val child = DevPerson()
+
         db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(employee)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
+
+            tx.insertTestPlacement(
+                childId = child.id,
+                unitId = daycare.id,
+                type = PlacementType.PRESCHOOL_DAYCARE,
+                startDate = monday,
+                endDate = tuesday
+            )
+
             tx.insertTestAbsence(
-                childId = testChild_1.id,
+                childId = child.id,
                 date = monday,
                 category = AbsenceCategory.NONBILLABLE,
                 absenceType = AbsenceType.PLANNED_ABSENCE,
-                modifiedBy = EvakaUserId(testAdult_1.id.raw)
+                modifiedBy = adult.evakaUserId,
             )
             tx.insertTestAbsence(
-                childId = testChild_1.id,
+                childId = child.id,
                 date = monday,
                 category = AbsenceCategory.BILLABLE,
                 absenceType = AbsenceType.PLANNED_ABSENCE,
-                modifiedBy = EvakaUserId(testAdult_1.id.raw)
+                modifiedBy = adult.evakaUserId,
             )
         }
 
         postAbsences(
+            adult.user(CitizenAuthLevel.WEAK),
             AbsenceRequest(
-                childIds = setOf(testChild_1.id),
+                childIds = setOf(child.id),
                 dateRange = FiniteDateRange(monday, tuesday),
                 absenceType = AbsenceType.SICKLEAVE
             ),
@@ -1109,9 +1303,7 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
         )
 
         assertThat(
-                db.read { tx ->
-                    tx.getAbsencesOfChildByRange(testChild_1.id, DateRange(monday, tuesday))
-                }
+                db.read { tx -> tx.getAbsencesOfChildByRange(child.id, DateRange(monday, tuesday)) }
             )
             .extracting({ it.date }, { it.absenceType }, { it.category })
             .containsExactlyInAnyOrder(
@@ -1124,33 +1316,59 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
 
     @Test
     fun `citizen cannot override billable planned absence in contract day placement with sick leave after threshold`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+        val employee = DevEmployee()
+
+        val adult = DevPerson()
+        val child = DevPerson()
+
         db.transaction { tx ->
-            tx.insertTestServiceNeed(
-                confirmedBy = EvakaUserId(testDecisionMaker_1.id.raw),
-                placementId = testChild1PlacementId,
-                period = FiniteDateRange(monday, tuesday),
-                optionId = snPreschoolDaycareContractDays13.id,
-                shiftCare = ShiftCareType.NONE
-            )
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(employee)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
+
+            tx.insertTestPlacement(
+                    childId = child.id,
+                    unitId = daycare.id,
+                    type = PlacementType.PRESCHOOL_DAYCARE,
+                    startDate = monday,
+                    endDate = tuesday
+                )
+                .let { placementId ->
+                    tx.insertTestServiceNeed(
+                        confirmedBy = employee.evakaUserId,
+                        placementId = placementId,
+                        period = FiniteDateRange(monday, tuesday),
+                        optionId = snPreschoolDaycareContractDays13.id,
+                    )
+                }
+
             tx.insertTestAbsence(
-                childId = testChild_1.id,
+                childId = child.id,
                 date = monday,
                 category = AbsenceCategory.NONBILLABLE,
                 absenceType = AbsenceType.PLANNED_ABSENCE,
-                modifiedBy = EvakaUserId(testAdult_1.id.raw)
+                modifiedBy = adult.evakaUserId
             )
             tx.insertTestAbsence(
-                childId = testChild_1.id,
+                childId = child.id,
                 date = monday,
                 category = AbsenceCategory.BILLABLE,
                 absenceType = AbsenceType.PLANNED_ABSENCE,
-                modifiedBy = EvakaUserId(testAdult_1.id.raw)
+                modifiedBy = adult.evakaUserId
             )
         }
 
         postAbsences(
+            adult.user(CitizenAuthLevel.WEAK),
             AbsenceRequest(
-                childIds = setOf(testChild_1.id),
+                childIds = setOf(child.id),
                 dateRange = FiniteDateRange(monday, tuesday),
                 absenceType = AbsenceType.SICKLEAVE
             ),
@@ -1159,9 +1377,7 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
         )
 
         assertThat(
-                db.read { tx ->
-                    tx.getAbsencesOfChildByRange(testChild_1.id, DateRange(monday, tuesday))
-                }
+                db.read { tx -> tx.getAbsencesOfChildByRange(child.id, DateRange(monday, tuesday)) }
             )
             .extracting({ it.date }, { it.absenceType }, { it.category })
             .containsExactlyInAnyOrder(
@@ -1174,23 +1390,42 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
 
     @Test
     fun `cannot add absences to day which already contains attendance`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+
+        val adult = DevPerson()
+        val child = DevPerson()
+
         db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
+
             tx.insertTestChildAttendance(
-                unitId = testDaycare.id,
-                childId = testChild_1.id,
+                unitId = daycare.id,
+                childId = child.id,
                 arrived = HelsinkiDateTime.of(mockToday, LocalTime.of(9, 0, 0)),
                 departed = HelsinkiDateTime.of(mockToday, LocalTime.of(11, 0, 0)),
             )
         }
         assertThrows<BadRequest> {
-            postAbsences(
-                AbsenceRequest(
-                    childIds = setOf(testChild_1.id, testChild_2.id),
-                    dateRange = FiniteDateRange(mockToday, mockToday),
-                    absenceType = AbsenceType.SICKLEAVE
+                postAbsences(
+                    adult.user(CitizenAuthLevel.WEAK),
+                    AbsenceRequest(
+                        childIds = setOf(child.id, child.id),
+                        dateRange = FiniteDateRange(mockToday, mockToday),
+                        absenceType = AbsenceType.SICKLEAVE
+                    )
                 )
-            )
-        }
+            }
+            .also { exception ->
+                assertEquals("ATTENDANCE_ALREADY_EXISTS", exception.errorCode)
+                assertEquals("Attendance already exists for given dates", exception.message)
+            }
     }
 
     private fun dayChild(
@@ -1212,31 +1447,38 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             reservableTimeRange
         )
 
-    private fun postReservations(request: List<DailyReservationRequest>) {
+    private fun postReservations(
+        user: AuthenticatedUser.Citizen,
+        request: List<DailyReservationRequest>
+    ) {
         reservationControllerCitizen.postReservations(
             dbInstance(),
-            AuthenticatedUser.Citizen(testAdult_1.id, CitizenAuthLevel.STRONG),
+            user,
             MockEvakaClock(HelsinkiDateTime.of(mockToday, LocalTime.of(0, 0))),
             request
         )
     }
 
     private fun postAbsences(
+        user: AuthenticatedUser.Citizen,
         request: AbsenceRequest,
         clock: EvakaClock = MockEvakaClock(HelsinkiDateTime.of(mockToday, LocalTime.of(12, 0)))
     ) {
         reservationControllerCitizen.postAbsences(
             dbInstance(),
-            AuthenticatedUser.Citizen(testAdult_1.id, CitizenAuthLevel.STRONG),
+            user,
             clock,
             request,
         )
     }
 
-    private fun getReservations(range: FiniteDateRange): ReservationsResponse {
+    private fun getReservations(
+        user: AuthenticatedUser.Citizen,
+        range: FiniteDateRange
+    ): ReservationsResponse {
         return reservationControllerCitizen.getReservations(
             dbInstance(),
-            AuthenticatedUser.Citizen(testAdult_1.id, CitizenAuthLevel.STRONG),
+            user,
             MockEvakaClock(HelsinkiDateTime.of(mockToday, LocalTime.of(12, 0))),
             range.start,
             range.end,

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceQueries.kt
@@ -37,11 +37,12 @@ fun Database.Transaction.insertAbsences(
     now: HelsinkiDateTime,
     userId: EvakaUserId,
     absences: List<AbsenceUpsert>
-) {
+): List<AbsenceId> {
     val sql =
         """
         INSERT INTO absence (child_id, date, category, absence_type, modified_by, modified_at)
         VALUES (:childId, :date, :category, :absenceType, :userId, :now)
+        RETURNING id
         """
 
     val batch = prepareBatch(sql)
@@ -49,7 +50,7 @@ fun Database.Transaction.insertAbsences(
         batch.bindKotlin(absence).bind("userId", userId).bind("now", now).add()
     }
 
-    batch.execute()
+    return batch.executeAndReturn().toList()
 }
 
 /** Updates the details if an absence already exists */

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/AbsenceQueries.kt
@@ -218,7 +218,7 @@ RETURNING id
  */
 fun Database.Transaction.clearOldCitizenEditableAbsences(
     childDatePairs: List<Pair<ChildId, LocalDate>>,
-    reservableRange: FiniteDateRange? = null
+    reservableRange: FiniteDateRange
 ): List<AbsenceId> {
     val batch =
         prepareBatch(
@@ -227,14 +227,14 @@ DELETE FROM absence a
 WHERE child_id = :childId
 AND date = :date
 AND absence_type <> 'FREE_ABSENCE'::absence_type
-${if (reservableRange != null) """
+-- Planned absences cannot be deleted from confirmed range if the child has a contract days service need
 AND (:reservableRange @> date OR absence_type <> 'PLANNED_ABSENCE'::absence_type OR category = 'NONBILLABLE' OR NOT EXISTS (
     SELECT
     FROM service_need_option sno
     JOIN service_need sn ON sn.option_id = sno.id AND a.date BETWEEN sn.start_date AND sn.end_date
     JOIN placement p ON p.id = sn.placement_id AND p.child_id = a.child_id AND a.date BETWEEN p.start_date AND p.end_date
     WHERE sno.contract_days_per_month IS NOT NULL
-))""" else ""}
+))
 AND modified_by IN (SELECT id FROM evaka_user where type = 'CITIZEN')
 RETURNING id
 """

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -5,12 +5,12 @@
 package fi.espoo.evaka.holidayperiod
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.daycare.service.FullDayAbsenseUpsert
 import fi.espoo.evaka.daycare.service.clearOldCitizenEditableAbsences
-import fi.espoo.evaka.reservations.AbsenceInsert
+import fi.espoo.evaka.daycare.service.upsertFullDayAbsences
 import fi.espoo.evaka.reservations.clearOldReservations
 import fi.espoo.evaka.reservations.deleteAbsencesCreatedFromQuestionnaire
 import fi.espoo.evaka.reservations.getReservableRange
-import fi.espoo.evaka.reservations.insertAbsences
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.HolidayQuestionnaireId
@@ -161,7 +161,7 @@ class HolidayPeriodControllerCitizen(
                 val absences =
                     body.fixedPeriods.entries.flatMap { (childId, period) ->
                         period?.dates()?.map {
-                            AbsenceInsert(
+                            FullDayAbsenseUpsert(
                                 childId = childId,
                                 date = it,
                                 absenceType = questionnaire.absenceType,
@@ -180,7 +180,7 @@ class HolidayPeriodControllerCitizen(
                         tx.clearOldCitizenEditableAbsences(it, reservableRange)
                     }
                 tx.deleteAbsencesCreatedFromQuestionnaire(questionnaire.id, childIds)
-                tx.insertAbsences(user.evakaUserId, absences)
+                tx.upsertFullDayAbsences(user.evakaUserId, absences)
                 tx.insertQuestionnaireAnswers(
                     user.id,
                     body.fixedPeriods.entries.map { (childId, period) ->

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -180,7 +180,7 @@ class HolidayPeriodControllerCitizen(
                         tx.clearOldCitizenEditableAbsences(it, reservableRange)
                     }
                 tx.deleteAbsencesCreatedFromQuestionnaire(questionnaire.id, childIds)
-                tx.upsertFullDayAbsences(user.evakaUserId, absences)
+                tx.upsertFullDayAbsences(user.evakaUserId, now, absences)
                 tx.insertQuestionnaireAnswers(
                     user.id,
                     body.fixedPeriods.entries.map { (childId, period) ->

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -9,8 +9,10 @@ import fi.espoo.evaka.daycare.service.clearOldCitizenEditableAbsences
 import fi.espoo.evaka.reservations.AbsenceInsert
 import fi.espoo.evaka.reservations.clearOldReservations
 import fi.espoo.evaka.reservations.deleteAbsencesCreatedFromQuestionnaire
+import fi.espoo.evaka.reservations.getReservableRange
 import fi.espoo.evaka.reservations.insertAbsences
 import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.HolidayQuestionnaireId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
@@ -34,7 +36,10 @@ data class ActiveQuestionnaire(
 
 @RestController
 @RequestMapping("/citizen/holiday-period")
-class HolidayPeriodControllerCitizen(private val accessControl: AccessControl) {
+class HolidayPeriodControllerCitizen(
+    private val accessControl: AccessControl,
+    private val featureConfig: FeatureConfig
+) {
     @GetMapping
     fun getHolidayPeriods(
         db: Database,
@@ -112,6 +117,8 @@ class HolidayPeriodControllerCitizen(private val accessControl: AccessControl) {
         @PathVariable id: HolidayQuestionnaireId,
         @RequestBody body: FixedPeriodsBody
     ) {
+        val now = clock.now()
+        val today = now.toLocalDate()
         val childIds = body.fixedPeriods.keys
 
         db.connect { dbc ->
@@ -125,13 +132,13 @@ class HolidayPeriodControllerCitizen(private val accessControl: AccessControl) {
                 )
                 val questionnaire =
                     tx.getFixedPeriodQuestionnaire(id)?.also {
-                        if (!it.active.includes(clock.today()))
+                        if (!it.active.includes(today))
                             throw BadRequest("Questionnaire is not open")
                     } ?: throw BadRequest("Questionnaire not found")
                 if (questionnaire.conditions.continuousPlacement != null) {
                     val eligibleChildren =
                         tx.getChildrenWithContinuousPlacement(
-                            clock.today(),
+                            today,
                             user.id,
                             questionnaire.conditions.continuousPlacement
                         )
@@ -163,11 +170,14 @@ class HolidayPeriodControllerCitizen(private val accessControl: AccessControl) {
                         } ?: emptySequence()
                     }
 
+                val reservableRange =
+                    getReservableRange(now, featureConfig.citizenReservationThresholdHours)
+
                 absences
                     .map { absence -> absence.childId to absence.date }
                     .let {
                         tx.clearOldReservations(it)
-                        tx.clearOldCitizenEditableAbsences(it)
+                        tx.clearOldCitizenEditableAbsences(it, reservableRange)
                     }
                 tx.deleteAbsencesCreatedFromQuestionnaire(questionnaire.id, childIds)
                 tx.insertAbsences(user.evakaUserId, absences)

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -198,14 +198,6 @@ class ReservationControllerCitizen(
                         children
                     )
 
-                    val reservableRange =
-                        getReservableRange(
-                            clock.now(),
-                            featureConfig.citizenReservationThresholdHours,
-                        )
-                    if (!body.all { request -> reservableRange.includes(request.date) }) {
-                        throw BadRequest("Some days are not reservable", "NON_RESERVABLE_DAYS")
-                    }
                     createReservationsAndAbsences(
                         tx,
                         clock.now(),

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -16,7 +16,9 @@ import fi.espoo.evaka.daycare.service.AbsenceType
 import fi.espoo.evaka.daycare.service.AbsenceType.OTHER_ABSENCE
 import fi.espoo.evaka.daycare.service.AbsenceType.PLANNED_ABSENCE
 import fi.espoo.evaka.daycare.service.AbsenceType.SICKLEAVE
+import fi.espoo.evaka.daycare.service.FullDayAbsenseUpsert
 import fi.espoo.evaka.daycare.service.clearOldCitizenEditableAbsences
+import fi.espoo.evaka.daycare.service.upsertFullDayAbsences
 import fi.espoo.evaka.placement.ScheduleType
 import fi.espoo.evaka.serviceneed.ShiftCareType
 import fi.espoo.evaka.shared.ChildId
@@ -279,11 +281,11 @@ class ReservationControllerCitizen(
                             )
                         }
                     val insertedAbsences =
-                        tx.insertAbsences(
+                        tx.upsertFullDayAbsences(
                             user.evakaUserId,
                             body.childIds.flatMap { childId ->
                                 body.dateRange.dates().map { date ->
-                                    AbsenceInsert(
+                                    FullDayAbsenseUpsert(
                                         childId,
                                         date,
                                         if (

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -301,7 +301,7 @@ fun createReservationsAndAbsences(
         }
     val upsertedAbsences =
         if (absences.isNotEmpty()) {
-            tx.upsertFullDayAbsences(userId, absences)
+            tx.upsertFullDayAbsences(userId, now, absences)
         } else {
             emptyList()
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -13,9 +13,11 @@ import fi.espoo.evaka.daycare.getClubTerms
 import fi.espoo.evaka.daycare.getPreschoolTerms
 import fi.espoo.evaka.daycare.service.AbsenceCategory
 import fi.espoo.evaka.daycare.service.AbsenceType
+import fi.espoo.evaka.daycare.service.FullDayAbsenseUpsert
 import fi.espoo.evaka.daycare.service.clearOldAbsences
 import fi.espoo.evaka.daycare.service.clearOldCitizenEditableAbsences
 import fi.espoo.evaka.daycare.service.getAbsenceDatesForChildrenInRange
+import fi.espoo.evaka.daycare.service.upsertFullDayAbsences
 import fi.espoo.evaka.holidayperiod.getHolidayPeriodsInRange
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.ScheduleType
@@ -287,7 +289,7 @@ fun createReservationsAndAbsences(
     val absences =
         validated.filterIsInstance<DailyReservationRequest.Absent>().map {
             val hasContractDays = contractDayRanges[it.childId]?.includes(it.date) ?: false
-            AbsenceInsert(
+            FullDayAbsenseUpsert(
                 it.childId,
                 it.date,
                 if (hasContractDays && reservableRange.includes(it.date))
@@ -297,7 +299,7 @@ fun createReservationsAndAbsences(
         }
     val upsertedAbsences =
         if (absences.isNotEmpty()) {
-            tx.insertAbsences(userId, absences)
+            tx.upsertFullDayAbsences(userId, absences)
         } else {
             emptyList()
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -252,8 +252,14 @@ fun createReservationsAndAbsences(
             }
 
     val deletedAbsences =
-        if (isCitizen) tx.clearOldCitizenEditableAbsences(validated.map { it.childId to it.date })
-        else tx.clearOldAbsences(validated.map { it.childId to it.date })
+        if (isCitizen) {
+            tx.clearOldCitizenEditableAbsences(
+                validated.map { it.childId to it.date },
+                reservableRange
+            )
+        } else {
+            tx.clearOldAbsences(validated.map { it.childId to it.date })
+        }
 
     // Keep old reservations in the confirmed range if absences are added on top of them
     val (absenceRequests, otherRequests) =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -2023,6 +2023,11 @@ data class DevPerson(
             invoicingPostOffice = this.invoicingPostOffice,
             ophPersonOid = this.ophPersonOid
         )
+
+    val evakaUserId: EvakaUserId
+        get() = EvakaUserId(id.raw)
+
+    fun user(authLevel: CitizenAuthLevel) = AuthenticatedUser.Citizen(id, authLevel)
 }
 
 data class DevParentship(
@@ -2044,7 +2049,12 @@ data class DevEmployee(
     val roles: Set<UserRole> = setOf(),
     val lastLogin: HelsinkiDateTime? = HelsinkiDateTime.now(),
     val active: Boolean = true
-)
+) {
+    val evakaUserId: EvakaUserId
+        get() = EvakaUserId(id.raw)
+
+    fun user(globalRoles: Set<UserRole>) = AuthenticatedUser.Employee(id, globalRoles)
+}
 
 data class DevMobileDevice(
     val id: MobileDeviceId = MobileDeviceId(UUID.randomUUID()),

--- a/service/src/main/resources/db/migration/V375__absence_modified_at_drop_default.sql
+++ b/service/src/main/resources/db/migration/V375__absence_modified_at_drop_default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE absence ALTER COLUMN modified_at DROP DEFAULT;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -371,3 +371,4 @@ V371__drop_child_discussion_table.sql
 V372__partner_modifier_column.sql
 V373__calendar_event_time_reservation.sql
 V374__daycare_preschool_and_preparatory_times.sql
+V375__absence_modified_at_drop_default.sql


### PR DESCRIPTION
#### Summary

When absences are added, keep reservations in the confirmed range but delete them from the unconfirmed range.
There are many ways to add absences, so this change touches many places in the code.

While at it, refactor many tests to avoid using global test data. Also make some other refactorings related to absences.
