### PR TITLE
Better E2E mocked time API

### DIFF
--- a/frontend/src/citizen-frontend/api-client.ts
+++ b/frontend/src/citizen-frontend/api-client.ts
@@ -4,7 +4,7 @@
 
 import axios, { AxiosError } from 'axios'
 
-import { isAutomatedTest, mockNow } from 'lib-common/utils/helpers'
+import { isAutomatedTest } from 'lib-common/utils/helpers'
 
 export const API_URL = '/api/application'
 
@@ -14,7 +14,10 @@ export const client = axios.create({
 
 if (isAutomatedTest) {
   client.interceptors.request.use((config) => {
-    const mockedTime = mockNow()?.toISOString()
+    const mockedTime =
+      typeof window !== 'undefined'
+        ? window.evaka?.mockedTime?.toISOString()
+        : undefined
     if (mockedTime) {
       config.headers.set('EvakaMockedTime', mockedTime)
     }

--- a/frontend/src/e2e-test/browser.ts
+++ b/frontend/src/e2e-test/browser.ts
@@ -12,6 +12,7 @@ import playwright, {
   Page
 } from 'playwright'
 
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { JsonOf } from 'lib-common/json'
 import {
   CitizenCustomizations,
@@ -83,7 +84,7 @@ window.evaka = window.evaka ?? {}
 window.evaka.automatedTest = true
 ${
   mockedTime
-    ? `window.evaka.mockedTime = new Date('${mockedTime.toISOString()}')`
+    ? `window.evaka.mockedTime = new Date('${mockedTime.toString()}')`
     : ''
 }
 ${override('citizenCustomizations')}
@@ -181,7 +182,7 @@ function configurePage(page: Page) {
 }
 
 export interface EvakaBrowserContextOptions {
-  mockedTime?: Date
+  mockedTime?: HelsinkiDateTime
   citizenCustomizations?: DeepPartial<JsonOf<CitizenCustomizations>>
   employeeCustomizations?: DeepPartial<JsonOf<EmployeeCustomizations>>
   employeeMobileCustomizations?: DeepPartial<

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-applications-list.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-applications-list.spec.ts
@@ -31,7 +31,7 @@ beforeEach(async () => {
   fixtures = await initializeAreaAndPersonData()
 
   page = await Page.open({
-    mockedTime: now.toSystemTzDate()
+    mockedTime: now
   })
   await enduserLogin(page)
   header = new CitizenHeader(page)

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
@@ -4,6 +4,7 @@
 
 import FiniteDateRange from 'lib-common/finite-date-range'
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
 
 import { insertDaycarePlacementFixtures, resetDatabase } from '../../dev-api'
@@ -135,7 +136,7 @@ describe.each(e)('Citizen calendar (%s)', (env) => {
     page = await Page.open({
       viewport,
       screen: viewport,
-      mockedTime: today.toSystemTzDate()
+      mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
     })
     await enduserLogin(page)
     header = new CitizenHeader(page, env)

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-documents.spec.ts
@@ -106,7 +106,7 @@ beforeEach(async () => {
       .save()
   ).data.id
 
-  page = await Page.open({ mockedTime: mockedNow.toSystemTzDate() })
+  page = await Page.open({ mockedTime: mockedNow })
   header = new CitizenHeader(page, 'desktop')
   await enduserLogin(page, fixtures.enduserGuardianFixture.ssn)
 })

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-page.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-page.spec.ts
@@ -40,7 +40,9 @@ describe('Citizen children page', () => {
     await resetDatabase()
     fixtures = await initializeAreaAndPersonData()
 
-    page = await Page.open({ mockedTime: mockedDate.toSystemTzDate() })
+    page = await Page.open({
+      mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0))
+    })
   })
 
   test('Citizen can see its children and navigate to their page', async () => {
@@ -574,7 +576,7 @@ describe.each(['desktop', 'mobile'] as const)(
       page = await Page.open({
         viewport,
         screen: viewport,
-        mockedTime: mockedDate.toSystemTzDate()
+        mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0))
       })
     })
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-club-application.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-club-application.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 
 import { getApplication, resetDatabase } from '../../dev-api'
 import {
@@ -26,7 +27,9 @@ beforeEach(async () => {
   await resetDatabase()
   fixtures = await initializeAreaAndPersonData()
 
-  page = await Page.open({ mockedTime: mockedDate.toSystemTzDate() })
+  page = await Page.open({
+    mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
   await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -43,7 +43,7 @@ beforeEach(async () => {
   await resetDatabase()
   fixtures = await initializeAreaAndPersonData()
 
-  page = await Page.open({ mockedTime: mockedNow.toSystemTzDate() })
+  page = await Page.open({ mockedTime: mockedNow })
   await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)
@@ -254,7 +254,7 @@ describe('Citizen daycare applications', () => {
     await editorPage.verifyAndSend({ hasOtherGuardian: true })
 
     const otherGuardianPage = await Page.open({
-      mockedTime: mockedNow.toSystemTzDate()
+      mockedTime: mockedNow
     })
     await enduserLogin(
       otherGuardianPage,

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
@@ -40,7 +40,7 @@ beforeEach(async () => {
   fixtures = await initializeAreaAndPersonData()
   decisionMaker = (await Fixture.employeeServiceWorker().save()).data
 
-  page = await Page.open({ mockedTime: now.toSystemTzDate() })
+  page = await Page.open({ mockedTime: now })
   header = new CitizenHeader(page)
   citizenDecisionsPage = new CitizenDecisionsPage(page)
   await enduserLogin(page)

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-finance-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-finance-decisions.spec.ts
@@ -90,7 +90,7 @@ const parsePersonNames = (persons: PersonDetail[]) =>
 
 describe('Citizen finance decisions', () => {
   test('Head of family sees their decisions with strong auth', async () => {
-    page = await Page.open({ mockedTime: now.toSystemTzDate() })
+    page = await Page.open({ mockedTime: now })
     header = new CitizenHeader(page)
     citizenDecisionsPage = new CitizenDecisionsPage(page)
     await enduserLogin(page)
@@ -114,7 +114,7 @@ describe('Citizen finance decisions', () => {
   })
 
   test('Partner sees their decisions with strong auth', async () => {
-    page = await Page.open({ mockedTime: now.toSystemTzDate() })
+    page = await Page.open({ mockedTime: now })
     header = new CitizenHeader(page)
     citizenDecisionsPage = new CitizenDecisionsPage(page)
     await enduserLogin(page, partner.ssn)

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
@@ -4,6 +4,7 @@
 
 import FiniteDateRange from 'lib-common/finite-date-range'
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
 
 import { resetDatabase } from '../../dev-api'
@@ -78,7 +79,9 @@ async function assertCalendarDayRange(
 
 beforeEach(async () => {
   await resetDatabase()
-  page = await Page.open({ mockedTime: mockedDate.toSystemTzDate() })
+  page = await Page.open({
+    mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
 
   daycare = await Fixture.daycare()
     .with(daycareFixture)

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income.spec.ts
@@ -110,7 +110,7 @@ describe.each(e)('Citizen income (%s)', (env) => {
     page = await Page.open({
       viewport,
       screen: viewport,
-      mockedTime: today.toSystemTzDate()
+      mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
     })
   })
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-pedagogical-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-pedagogical-documents.spec.ts
@@ -57,7 +57,7 @@ beforeEach(async () => {
     fixtures.enduserGuardianFixture.id
   )
 
-  page = await Page.open({ mockedTime: mockedNow.toSystemTzDate() })
+  page = await Page.open({ mockedTime: mockedNow })
   await enduserLogin(page)
   header = new CitizenHeader(page)
   pedagogicalDocumentsPage = new CitizenPedagogicalDocumentsPage(page)

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-preschool-application.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-preschool-application.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 
 import { getApplication, resetDatabase } from '../../dev-api'
 import {
@@ -29,7 +30,9 @@ beforeEach(async () => {
   await resetDatabase()
   fixtures = await initializeAreaAndPersonData()
 
-  page = await Page.open({ mockedTime: mockedDate.toSystemTzDate() })
+  page = await Page.open({
+    mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
   await enduserLogin(page)
   header = new CitizenHeader(page)
   applicationsPage = new CitizenApplicationsPage(page)

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -52,7 +52,7 @@ async function openCalendarPage(
   page = await Page.open({
     viewport,
     screen: viewport,
-    mockedTime: today.toSystemTzDate(),
+    mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0)),
     citizenCustomizations: {
       featureFlags: options?.featureFlags
     }
@@ -892,7 +892,7 @@ describe('Citizen calendar child visibility', () => {
     ])
 
     page = await Page.open({
-      mockedTime: today.toSystemTzDate()
+      mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
     })
     await enduserLogin(page)
     header = new CitizenHeader(page, 'desktop')
@@ -1029,7 +1029,7 @@ describe('Citizen calendar visibility', () => {
     ])
 
     page = await Page.open({
-      mockedTime: today.toSystemTzDate()
+      mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
     })
     await enduserLogin(page)
 
@@ -1048,7 +1048,7 @@ describe('Citizen calendar visibility', () => {
     ])
 
     page = await Page.open({
-      mockedTime: today.toSystemTzDate()
+      mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
     })
 
     await enduserLogin(page)
@@ -1070,7 +1070,7 @@ describe('Citizen calendar visibility', () => {
     ])
 
     page = await Page.open({
-      mockedTime: today.toSystemTzDate()
+      mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
     })
 
     await enduserLogin(page)
@@ -1104,7 +1104,7 @@ describe.each(e)('Citizen calendar shift care reservations', (env) => {
       )
     ])
     page = await Page.open({
-      mockedTime: today.toSystemTzDate()
+      mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
     })
     await enduserLogin(page)
   })

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-vasu.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-vasu.spec.ts
@@ -74,7 +74,7 @@ beforeEach(async () => {
     fixtures.enduserGuardianFixture.id
   )
 
-  page = await Page.open({ mockedTime: mockedNow.toSystemTzDate() })
+  page = await Page.open({ mockedTime: mockedNow })
   header = new CitizenHeader(page, 'desktop')
   await enduserLogin(page)
 })

--- a/frontend/src/e2e-test/specs/0_citizen/feature-flag-citizen-reservations-intermittent-shif-care.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/feature-flag-citizen-reservations-intermittent-shif-care.spec.ts
@@ -204,7 +204,7 @@ async function openCalendarPage(
   const page = await Page.open({
     viewport,
     screen: viewport,
-    mockedTime: time.toSystemTzDate(),
+    mockedTime: time,
     citizenCustomizations: {
       featureFlags: { intermittentShiftCare: true }
     }

--- a/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
@@ -6,6 +6,7 @@ import DateRange from 'lib-common/date-range'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 
 import config from '../../config'
 import {
@@ -65,7 +66,7 @@ beforeEach(async () => {
   ])
 
   activeRelationshipPage = await Page.open({
-    mockedTime: mockedNow.toSystemTzDate()
+    mockedTime: mockedNow
   })
   await enduserLogin(activeRelationshipPage)
   activeRelationshipHeader = new CitizenHeader(activeRelationshipPage)
@@ -73,7 +74,7 @@ beforeEach(async () => {
 
 async function openEndedRelationshipPage() {
   const endedRelationshipPage = await Page.open({
-    mockedTime: mockedDate.addDays(1).toSystemTzDate()
+    mockedTime: mockedDate.addDays(1).toHelsinkiDateTime(LocalTime.of(12, 0))
   })
   await enduserLogin(endedRelationshipPage)
   const endedRelationshipHeader = new CitizenHeader(endedRelationshipPage)
@@ -234,7 +235,7 @@ test('Foster parent can receive and reply to messages', async () => {
   const unitSupervisor = await Fixture.employeeUnitSupervisor(unitId).save()
   await upsertMessageAccounts()
   let unitSupervisorPage = await Page.open({
-    mockedTime: mockedNow.subMinutes(1).toSystemTzDate()
+    mockedTime: mockedNow.subMinutes(1)
   })
   await employeeLogin(unitSupervisorPage, unitSupervisor.data)
 
@@ -257,7 +258,7 @@ test('Foster parent can receive and reply to messages', async () => {
   await waitUntilEqual(() => citizenMessagesPage.getMessageCount(), 2)
 
   unitSupervisorPage = await Page.open({
-    mockedTime: mockedNow.addMinutes(1).toSystemTzDate()
+    mockedTime: mockedNow.addMinutes(1)
   })
   await employeeLogin(unitSupervisorPage, unitSupervisor.data)
   messagesPage = new MessagesPage(unitSupervisorPage)

--- a/frontend/src/e2e-test/specs/4_finance/income-staments.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/income-staments.spec.ts
@@ -39,7 +39,7 @@ beforeEach(async () => {
 
   page = await Page.open({
     acceptDownloads: true,
-    mockedTime: now.toSystemTzDate()
+    mockedTime: now
   })
 
   const financeAdmin = await Fixture.employeeFinanceAdmin().save()

--- a/frontend/src/e2e-test/specs/4_finance/value-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/value-decisions.spec.ts
@@ -105,7 +105,7 @@ describe('Value decisions', () => {
   beforeEach(async () => {
     page = await Page.open({
       acceptDownloads: true,
-      mockedTime: now.toSystemTzDate()
+      mockedTime: now
     })
 
     const financeAdmin = await Fixture.employeeFinanceAdmin().save()
@@ -234,7 +234,7 @@ describe('Value decisions with finance decision handler select enabled', () => {
           financeDecisionHandlerSelect: true
         }
       },
-      mockedTime: now.toSystemTzDate()
+      mockedTime: now
     })
 
     const financeAdmin = await Fixture.employeeFinanceAdmin().save()

--- a/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
@@ -54,7 +54,9 @@ beforeEach(async () => {
   await insertDefaultServiceNeedOptions()
   await Fixture.feeThresholds().save()
 
-  page = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  page = await Page.open({
+    mockedTime: mockedTime.toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
   applicationWorkbench = new ApplicationWorkbenchPage(page)
   applicationReadView = new ApplicationReadView(page)
 })
@@ -723,7 +725,9 @@ describe('Application transitions', () => {
       const page = await Page.open({
         mockedTime:
           addDays !== 0
-            ? LocalDate.todayInSystemTz().addDays(addDays).toSystemTzDate()
+            ? LocalDate.todayInSystemTz()
+                .addDays(addDays)
+                .toHelsinkiDateTime(LocalTime.of(12, 0))
             : undefined
       })
 

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
 
 import config from '../../config'
@@ -94,7 +95,11 @@ beforeEach(async () => {
 })
 
 const openPage = async (addDays = 0) =>
-  await Page.open({ mockedTime: mockedTime.addDays(addDays).toSystemTzDate() })
+  await Page.open({
+    mockedTime: mockedTime
+      .addDays(addDays)
+      .toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
 
 describe('Assistance Need Decisions - Edit page', () => {
   beforeEach(async () => {

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
 
 import config from '../../config'
@@ -65,7 +66,9 @@ beforeEach(async () => {
 
 describe('Assistance need decisions report', () => {
   beforeEach(async () => {
-    page = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+    page = await Page.open({
+      mockedTime: mockedTime.toHelsinkiDateTime(LocalTime.of(12, 0))
+    })
   })
 
   const baseReportRow = {

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-preschool-decision.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-preschool-decision.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
 
 import config from '../../config'
@@ -70,7 +71,11 @@ beforeEach(async () => {
 })
 
 const openPage = async (addDays = 0) =>
-  await Page.open({ mockedTime: mockedTime.addDays(addDays).toSystemTzDate() })
+  await Page.open({
+    mockedTime: mockedTime
+      .addDays(addDays)
+      .toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
 
 describe('Assistance Need Preschool Decisions - Editing', () => {
   beforeEach(async () => {

--- a/frontend/src/e2e-test/specs/5_employee/backup-care.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/backup-care.spec.ts
@@ -70,7 +70,7 @@ beforeEach(async () => {
   )
   await insertBackupCareFixtures([backupCareFixture])
 
-  page = await Page.open({ mockedTime: now.toSystemTzDate() })
+  page = await Page.open({ mockedTime: now })
   await employeeLogin(page, unitSupervisor.data)
   const unitPage = new UnitPage(page)
   await unitPage.navigateToUnit(fixtures.daycareFixture.id)

--- a/frontend/src/e2e-test/specs/5_employee/child-document.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-document.spec.ts
@@ -89,7 +89,7 @@ describe('child document with person duplicate', () => {
       })
       .save()
 
-    const page = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+    const page = await Page.open({ mockedTime })
     await employeeLogin(page, daycareSupervisor.data)
     await page.goto(`${config.employeeUrl}/child-documents/${document.data.id}`)
     const childDocumentPage = new ChildDocumentPage(page)
@@ -134,7 +134,7 @@ describe('child document with person duplicate', () => {
       })
       .save()
 
-    const page = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+    const page = await Page.open({ mockedTime })
     await employeeLogin(page, daycareSupervisor.data)
     await page.goto(`${config.employeeUrl}/child-information/${child.data.id}`)
     const childInformationPage = new ChildInformationPage(page)
@@ -186,7 +186,7 @@ describe('child document with person duplicate', () => {
       })
       .save()
 
-    const page = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+    const page = await Page.open({ mockedTime })
     await employeeLogin(page, admin.data)
     await page.goto(`${config.employeeUrl}/child-information/${child.data.id}`)
     const childInformationPage = new ChildInformationPage(page)

--- a/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
@@ -55,7 +55,7 @@ describe('Employee - Child documents', () => {
   test('Full basic workflow for hojks', async () => {
     // Admin creates a template
 
-    page = await Page.open({ mockedTime: now.toSystemTzDate() })
+    page = await Page.open({ mockedTime: now })
     await employeeLogin(page, admin)
     await page.goto(config.employeeUrl)
     const nav = new EmployeeNav(page)
@@ -90,7 +90,7 @@ describe('Employee - Child documents', () => {
     // End of admin creates a template
 
     // Unit supervisor creates a child document
-    page = await Page.open({ mockedTime: now.toSystemTzDate() })
+    page = await Page.open({ mockedTime: now })
     await employeeLogin(page, unitSupervisor)
     await page.goto(
       `${config.employeeUrl}/child-information/${childFixture.id}`
@@ -146,7 +146,7 @@ describe('Employee - Child documents', () => {
 
     // go to next status twice
     const later = now.addHours(1)
-    page = await Page.open({ mockedTime: later.toSystemTzDate() })
+    page = await Page.open({ mockedTime: later })
     await employeeLogin(page, unitSupervisor)
     await page.goto(documentUrl)
     childDocument = new ChildDocumentPage(page)
@@ -175,7 +175,7 @@ describe('Employee - Child documents', () => {
       .save()
 
     // Unit supervisor creates a child document
-    page = await Page.open({ mockedTime: now.toSystemTzDate() })
+    page = await Page.open({ mockedTime: now })
     await employeeLogin(page, unitSupervisor)
     await page.goto(
       `${config.employeeUrl}/child-information/${childFixture.id}`

--- a/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
@@ -193,7 +193,7 @@ describe('Child Information placement create (feature flag place guarantee = tru
 
   async function openPage() {
     return await Page.open({
-      mockedTime: mockedTime.toSystemTzDate(),
+      mockedTime,
       employeeCustomizations: { featureFlags: { placementGuarantee: true } }
     })
   }
@@ -242,7 +242,7 @@ describe('Child Information placement create (feature flag place guarantee = fal
 
   async function openPage() {
     return await Page.open({
-      mockedTime: mockedTime.toSystemTzDate(),
+      mockedTime,
       employeeCustomizations: { featureFlags: { placementGuarantee: false } }
     })
   }

--- a/frontend/src/e2e-test/specs/5_employee/child-information.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information.spec.ts
@@ -4,6 +4,7 @@
 
 import { EmployeeDetail } from 'e2e-test/dev-api/types'
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
 
 import config from '../../config'
@@ -72,7 +73,9 @@ beforeEach(async () => {
   // is up to date or will return wrong results
   await forceFullVtjRefresh(childId)
 
-  page = await Page.open({ mockedTime: mockedDate.toSystemTzDate() })
+  page = await Page.open({
+    mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
   await employeeLogin(page, admin)
   await page.goto(config.employeeUrl + '/child-information/' + childId)
   childInformationPage = new ChildInformationPage(page)
@@ -218,7 +221,7 @@ describe('Child Information - daily service times', () => {
 
     // Status changes to active tomorrow
     const pageTomorrow = await Page.open({
-      mockedTime: tomorrowDate.toSystemTzDate()
+      mockedTime: tomorrowDate.toHelsinkiDateTime(LocalTime.of(12, 0))
     })
     await employeeLogin(pageTomorrow, admin)
     await pageTomorrow.goto(
@@ -475,7 +478,9 @@ describe('Child information - guardian information', () => {
     const unitSupervisor: EmployeeDetail = (
       await Fixture.employeeUnitSupervisor(fixtures.daycareFixture.id).save()
     ).data
-    page = await Page.open({ mockedTime: mockedDate.toSystemTzDate() })
+    page = await Page.open({
+      mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0))
+    })
     await employeeLogin(page, unitSupervisor)
     await page.goto(config.employeeUrl + '/child-information/' + childId)
     childInformationPage = new ChildInformationPage(page)

--- a/frontend/src/e2e-test/specs/5_employee/curriculum-document.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/curriculum-document.spec.ts
@@ -90,7 +90,7 @@ describe('curriculum document with person duplicate', () => {
     })
     const documentId = await insertVasuDocument(duplicate.data.id, templateId)
 
-    const page = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+    const page = await Page.open({ mockedTime })
     await employeeLogin(page, daycareSupervisor.data)
     await page.goto(`${config.employeeUrl}/vasu/${documentId}`)
     const vasuPage = new VasuPage(page)
@@ -112,7 +112,7 @@ describe('curriculum document with person duplicate', () => {
       preschoolTemplateId
     )
 
-    const page = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+    const page = await Page.open({ mockedTime })
     await employeeLogin(page, daycareSupervisor.data)
     await page.goto(`${config.employeeUrl}/child-information/${child.data.id}`)
     const childInformationPage = new ChildInformationPage(page)
@@ -135,7 +135,7 @@ describe('curriculum document with person duplicate', () => {
     })
     const documentId = await insertVasuDocument(child.data.id, templateId)
 
-    const page = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+    const page = await Page.open({ mockedTime })
     await employeeLogin(page, preschoolSupervisor.data)
     await page.goto(`${config.employeeUrl}/vasu/${documentId}`)
     const vasuPage = new VasuPage(page)
@@ -157,7 +157,7 @@ describe('curriculum document with person duplicate', () => {
     })
     await insertVasuDocument(child.data.id, preschoolTemplateId)
 
-    const page = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+    const page = await Page.open({ mockedTime })
     await employeeLogin(page, preschoolSupervisor.data)
     await page.goto(
       `${config.employeeUrl}/child-information/${duplicate.data.id}`
@@ -193,7 +193,7 @@ describe('curriculum document with person duplicate', () => {
       preschoolTemplateId
     )
 
-    const page = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+    const page = await Page.open({ mockedTime })
     await employeeLogin(page, admin.data)
     await page.goto(`${config.employeeUrl}/child-information/${child.data.id}`)
     const childInformationPage = new ChildInformationPage(page)

--- a/frontend/src/e2e-test/specs/5_employee/evaka-rights.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/evaka-rights.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 
 import { resetDatabase } from '../../dev-api'
 import {
@@ -25,7 +26,9 @@ beforeEach(async () => {
   await resetDatabase()
   fixtures = await initializeAreaAndPersonData()
 
-  page = await Page.open({ mockedTime: mockedDate.toSystemTzDate() })
+  page = await Page.open({
+    mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
   const admin = (await Fixture.employeeAdmin().save()).data
   await employeeLogin(page, admin)
   childInformation = new ChildInformationPage(page)

--- a/frontend/src/e2e-test/specs/5_employee/feature-flag-decision-draft-multiple-units.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/feature-flag-decision-draft-multiple-units.spec.ts
@@ -46,7 +46,7 @@ beforeEach(async () => {
   await Fixture.feeThresholds().save()
 
   page = await Page.open({
-    mockedTime: mockedTime.toSystemTzDate(),
+    mockedTime: mockedTime.toHelsinkiDateTime(LocalTime.of(12, 0)),
     employeeCustomizations: {
       featureFlags: { decisionDraftMultipleUnits: true }
     }

--- a/frontend/src/e2e-test/specs/5_employee/feature-flag-preschool-application-connected-daycare-preferred-start-date.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/feature-flag-preschool-application-connected-daycare-preferred-start-date.spec.ts
@@ -29,7 +29,7 @@ beforeEach(async () => {
   const admin = await Fixture.employeeAdmin().save()
 
   page = await Page.open({
-    mockedTime: now.toSystemTzDate(),
+    mockedTime: now,
     employeeCustomizations: {
       featureFlags: {
         preschoolApplication: {

--- a/frontend/src/e2e-test/specs/5_employee/feature-flag-preschool-application-service-need-option.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/feature-flag-preschool-application-service-need-option.spec.ts
@@ -35,7 +35,7 @@ beforeEach(async () => {
   const admin = await Fixture.employeeAdmin().save()
 
   page = await Page.open({
-    mockedTime: now.toSystemTzDate(),
+    mockedTime: now,
     employeeCustomizations: {
       featureFlags: {
         preschoolApplication: {

--- a/frontend/src/e2e-test/specs/5_employee/fridge-head-information.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/fridge-head-information.spec.ts
@@ -87,7 +87,7 @@ beforeEach(async () => {
   const admin = await Fixture.employeeAdmin().save()
 
   page = await Page.open({
-    mockedTime: mockToday.toSystemTzDate()
+    mockedTime: mockToday.toHelsinkiDateTime(LocalTime.of(12, 0))
   })
   await employeeLogin(page, admin.data)
 

--- a/frontend/src/e2e-test/specs/5_employee/guardian-income-statements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/guardian-income-statements.spec.ts
@@ -40,7 +40,7 @@ beforeEach(async () => {
 
   const financeAdmin = await Fixture.employeeFinanceAdmin().save()
 
-  page = await Page.open({ mockedTime: mockedNow.toSystemTzDate() })
+  page = await Page.open({ mockedTime: mockedNow })
   await employeeLogin(page, financeAdmin.data)
 })
 

--- a/frontend/src/e2e-test/specs/5_employee/holiday-period.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/holiday-period.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 
 import config from '../../config'
 import { resetDatabase } from '../../dev-api'
@@ -20,7 +21,9 @@ beforeEach(async () => {
   await resetDatabase()
   const admin = await Fixture.employeeAdmin().save()
   page = await Page.open({
-    mockedTime: LocalDate.of(2021, 11, 1).toSystemTzDate()
+    mockedTime: LocalDate.of(2021, 11, 1).toHelsinkiDateTime(
+      LocalTime.of(12, 0)
+    )
   })
   await employeeLogin(page, admin.data)
   await page.goto(config.employeeUrl)

--- a/frontend/src/e2e-test/specs/5_employee/manual-duplication-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/manual-duplication-report.spec.ts
@@ -32,9 +32,7 @@ describe('Manual duplication report', () => {
     const child = await Fixture.person().with({ ssn: undefined }).save()
 
     const page = await Page.open({
-      mockedTime: mockedToday
-        .toHelsinkiDateTime(LocalTime.of(8, 0))
-        .toSystemTzDate()
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0))
     })
 
     const application1Id = uuidv4()

--- a/frontend/src/e2e-test/specs/5_employee/missing-head-of-family-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/missing-head-of-family-report.spec.ts
@@ -49,9 +49,7 @@ describe('Missing head of family report', () => {
       .save()
 
     const page = await Page.open({
-      mockedTime: mockedToday
-        .toHelsinkiDateTime(LocalTime.of(8, 0))
-        .toSystemTzDate(),
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0)),
       employeeCustomizations: {
         featureFlags: { personDuplicate: true }
       }

--- a/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
@@ -40,7 +40,7 @@ beforeEach(async () => {
   ).save()
 
   page = await Page.open({
-    mockedTime: today.toHelsinkiDateTime(LocalTime.of(8, 0)).toSystemTzDate()
+    mockedTime: today.toHelsinkiDateTime(LocalTime.of(8, 0))
   })
   await employeeLogin(page, unitSupervisor.data)
   unitPage = new UnitPage(page)

--- a/frontend/src/e2e-test/specs/5_employee/non-ssn-children-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/non-ssn-children-report.spec.ts
@@ -93,9 +93,7 @@ describe('Non SSN children report', () => {
     const admin = await Fixture.employeeAdmin().save()
 
     const page = await Page.open({
-      mockedTime: mockedToday
-        .toHelsinkiDateTime(LocalTime.of(8, 0))
-        .toSystemTzDate(),
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0)),
       employeeCustomizations: {
         featureFlags: { personDuplicate: true }
       }
@@ -109,9 +107,7 @@ describe('Non SSN children report', () => {
     const financeAdmin = await Fixture.employeeFinanceAdmin().save()
 
     const page = await Page.open({
-      mockedTime: mockedToday
-        .toHelsinkiDateTime(LocalTime.of(8, 0))
-        .toSystemTzDate()
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0))
     })
 
     const report = await navigateToReport(page, financeAdmin.data)
@@ -122,9 +118,7 @@ describe('Non SSN children report', () => {
     const serviceWorker = await Fixture.employeeServiceWorker().save()
 
     const page = await Page.open({
-      mockedTime: mockedToday
-        .toHelsinkiDateTime(LocalTime.of(8, 0))
-        .toSystemTzDate(),
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0)),
       employeeCustomizations: {
         featureFlags: { personDuplicate: true }
       }

--- a/frontend/src/e2e-test/specs/5_employee/paper-application.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/paper-application.spec.ts
@@ -29,7 +29,7 @@ beforeEach(async () => {
   await insertDaycareGroupFixtures([daycareGroupFixture])
   const admin = await Fixture.employeeAdmin().save()
 
-  page = await Page.open({ mockedTime: now.toSystemTzDate() })
+  page = await Page.open({ mockedTime: now })
   await employeeLogin(page, admin.data)
 
   childInformationPage = new ChildInformationPage(page)

--- a/frontend/src/e2e-test/specs/5_employee/placement-guarantee-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/placement-guarantee-report.spec.ts
@@ -45,9 +45,7 @@ describe('Placement guarantee report', () => {
       .save()
 
     const page = await Page.open({
-      mockedTime: mockedToday
-        .toHelsinkiDateTime(LocalTime.of(8, 0))
-        .toSystemTzDate()
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0))
     })
 
     const report = await navigateToReport(page, admin.data)
@@ -89,9 +87,7 @@ describe('Placement guarantee report', () => {
       .save()
 
     const page = await Page.open({
-      mockedTime: mockedToday
-        .toHelsinkiDateTime(LocalTime.of(8, 0))
-        .toSystemTzDate()
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0))
     })
 
     const report = await navigateToReport(page, admin.data)
@@ -146,9 +142,7 @@ describe('Placement guarantee report', () => {
       .save()
 
     const page = await Page.open({
-      mockedTime: mockedToday
-        .toHelsinkiDateTime(LocalTime.of(8, 0))
-        .toSystemTzDate()
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0))
     })
 
     const report = await navigateToReport(page, admin.data)
@@ -221,9 +215,7 @@ describe('Placement guarantee report', () => {
       .save()
 
     const page = await Page.open({
-      mockedTime: mockedToday
-        .toHelsinkiDateTime(LocalTime.of(8, 0))
-        .toSystemTzDate()
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0))
     })
 
     const report = await navigateToReport(page, admin.data)

--- a/frontend/src/e2e-test/specs/5_employee/placement-sketching-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/placement-sketching-report.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 
 import config from '../../config'
 import {
@@ -36,7 +37,9 @@ beforeEach(async () => {
   fixtures = await initializeAreaAndPersonData()
   const admin = (await Fixture.employeeAdmin().save()).data
 
-  page = await Page.open({ mockedTime: mockToday.toSystemTzDate() })
+  page = await Page.open({
+    mockedTime: mockToday.toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
   await employeeLogin(page, admin)
 })
 

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -119,9 +119,7 @@ beforeEach(async () => {
 
   page = await Page.open({
     viewport: { width: 1440, height: 720 },
-    mockedTime: mockedToday
-      .toHelsinkiDateTime(LocalTime.of(18, 0))
-      .toSystemTzDate()
+    mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(18, 0))
   })
 
   await employeeLogin(page, unitSupervisor)

--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar-child-date-modal.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar-child-date-modal.spec.ts
@@ -98,7 +98,7 @@ const navigateToTestView = async ({
   intermittentShiftCareEnabled?: boolean
 } = {}) => {
   page = await Page.open({
-    mockedTime: today.toSystemTzDate(),
+    mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0)),
     employeeCustomizations: {
       featureFlags: {
         intermittentShiftCare: intermittentShiftCareEnabled

--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
@@ -135,7 +135,9 @@ const insertTestDataAndLogin = async ({
     })
     .save()
 
-  page = await Page.open({ mockedTime: mockedToday.toSystemTzDate() })
+  page = await Page.open({
+    mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
   await employeeLogin(page, unitSupervisor)
 }
 

--- a/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
@@ -111,9 +111,7 @@ beforeEach(async () => {
     .save()
 
   page = await Page.open({
-    mockedTime: mockedToday
-      .toHelsinkiDateTime(LocalTime.of(12, 0))
-      .toSystemTzDate()
+    mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(12, 0))
   })
   await employeeLogin(page, unitSupervisor)
   unitPage = new UnitPage(page)

--- a/frontend/src/e2e-test/specs/5_employee/units.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/units.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 
 import { insertDefaultServiceNeedOptions, resetDatabase } from '../../dev-api'
 import { initializeAreaAndPersonData } from '../../dev-api/data-init'
@@ -60,7 +61,9 @@ beforeEach(async () => {
   const admin = await Fixture.employeeAdmin().save()
 
   page = await Page.open({
-    mockedTime: LocalDate.of(2022, 12, 1).toSystemTzDate()
+    mockedTime: LocalDate.of(2022, 12, 1).toHelsinkiDateTime(
+      LocalTime.of(12, 0)
+    )
   })
   await employeeLogin(page, admin.data)
 })

--- a/frontend/src/e2e-test/specs/5_employee/vasu.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/vasu.spec.ts
@@ -7,6 +7,7 @@ import assert from 'assert'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
 
 import config from '../../config'
@@ -97,7 +98,11 @@ beforeAll(async () => {
 })
 
 const openPage = async (addDays = 0) =>
-  await Page.open({ mockedTime: mockedTime.addDays(addDays).toSystemTzDate() })
+  await Page.open({
+    mockedTime: mockedTime
+      .addDays(addDays)
+      .toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
 
 describe('Child Information - Vasu documents section', () => {
   let section: ChildDocumentsSection

--- a/frontend/src/e2e-test/specs/6_mobile/child-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/child-attendances.spec.ts
@@ -71,7 +71,7 @@ beforeEach(async () => {
     .with({ roles: ['ADMIN'] })
     .save()
 
-  page = await Page.open({ mockedTime: now.toSystemTzDate() })
+  page = await Page.open({ mockedTime: now })
 
   listPage = new MobileListPage(page)
   childPage = new MobileChildPage(page)

--- a/frontend/src/e2e-test/specs/6_mobile/confirmed-day-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/confirmed-day-reservations.spec.ts
@@ -46,7 +46,7 @@ beforeEach(async () => {
   await insertConfirmedDaysTestData()
 
   const mobileSignupUrl = await pairMobileDevice(daycareFixture.id)
-  page = await Page.open({ mockedTime: now.toSystemTzDate() })
+  page = await Page.open({ mockedTime: now })
 
   await page.goto(mobileSignupUrl)
 

--- a/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
@@ -200,7 +200,7 @@ beforeEach(async () => {
     }
   ])
 
-  page = await Page.open({ mockedTime: mockedDateAt11.toSystemTzDate() })
+  page = await Page.open({ mockedTime: mockedDateAt11 })
   listPage = new MobileListPage(page)
   childPage = new MobileChildPage(page)
   unreadMessageCountsPage = new UnreadMobileMessagesPage(page)
@@ -213,7 +213,7 @@ beforeEach(async () => {
 })
 
 async function initCitizenPage(mockedTime: HelsinkiDateTime) {
-  citizenPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  citizenPage = await Page.open({ mockedTime })
   await enduserLogin(citizenPage)
 }
 
@@ -488,7 +488,7 @@ describe('Messages page', () => {
     // Add child's guardians to block list
     const admin = (await Fixture.employeeAdmin().save()).data
     const adminPage = await Page.open({
-      mockedTime: mockedDateAt10.toSystemTzDate()
+      mockedTime: mockedDateAt10
     })
     await employeeLogin(adminPage, admin)
     await adminPage.goto(`${config.employeeUrl}/child-information/${child.id}`)

--- a/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts
@@ -103,7 +103,7 @@ beforeEach(async () => {
 })
 
 const initPages = async (
-  mockedTime: Date,
+  mockedTime: HelsinkiDateTime,
   featureFlags: Partial<FeatureFlags> = {}
 ) => {
   page = await Page.open({
@@ -120,7 +120,7 @@ const initPages = async (
 
 describe('Realtime staff attendance page', () => {
   test('Staff member can be marked as arrived and departed', async () => {
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 6, 0).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 6, 0))
     const arrivalTime = '05:59'
     const departureTime = '12:45'
 
@@ -139,7 +139,7 @@ describe('Realtime staff attendance page', () => {
       `Paikalla ${arrivalTime}–`
     ])
 
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 13, 30).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 13, 30))
     await staffAttendancePage.assertPresentStaffCount(1)
 
     await staffAttendancePage.selectTab('present')
@@ -156,7 +156,7 @@ describe('Realtime staff attendance page', () => {
 
   test('Staff member cannot use departure time that is before last arrival time', async () => {
     const arrivalTime = '05:59'
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 6, 0).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 6, 0))
 
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.selectTab('absent')
@@ -189,7 +189,7 @@ describe('Realtime staff attendance page', () => {
   })
 
   test('Staff member cannot use arrival time that is before last departure time', async () => {
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 8, 0).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 8, 0))
 
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.selectTab('absent')
@@ -222,7 +222,7 @@ describe('Realtime staff attendance page', () => {
   })
 
   test('Staff member can use arrival time that is equal to last departure time', async () => {
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 8, 0).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 8, 0))
 
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.selectTab('absent')
@@ -254,9 +254,7 @@ describe('Realtime staff attendance page', () => {
 
   test('Staff member cannot be marked as arrived on a non-operational day', async () => {
     const saturday = LocalDate.of(2022, 5, 7)
-    await initPages(
-      HelsinkiDateTime.fromLocal(saturday, LocalTime.of(16, 0)).toSystemTzDate()
-    )
+    await initPages(HelsinkiDateTime.fromLocal(saturday, LocalTime.of(16, 0)))
 
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.selectTab('absent')
@@ -269,7 +267,7 @@ describe('Realtime staff attendance page', () => {
   })
 
   test('Staff arrival page behaves correctly with different time values when no plan exists', async () => {
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 12, 0).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 12, 0))
 
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.selectTab('absent')
@@ -306,7 +304,7 @@ describe('Realtime staff attendance page', () => {
       .save()
 
     // Now it is 7:30
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 7, 30).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 7, 30))
 
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.selectTab('absent')
@@ -353,7 +351,7 @@ describe('Realtime staff attendance page', () => {
       .save()
 
     // Now it is 8:30
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 8, 30).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 8, 30))
 
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.selectTab('absent')
@@ -406,7 +404,7 @@ describe('Realtime staff attendance page', () => {
       .save()
 
     // Now it is 15:30
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 15, 30).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 15, 30))
 
     await staffAttendancePage.assertPresentStaffCount(1)
     await staffAttendancePage.selectTab('present')
@@ -452,7 +450,7 @@ describe('Realtime staff attendance page', () => {
       .save()
 
     // Now it is 16:30
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 16, 30).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 16, 30))
 
     await staffAttendancePage.assertPresentStaffCount(1)
     await staffAttendancePage.selectTab('present')
@@ -507,7 +505,7 @@ describe('Realtime staff attendance page', () => {
       .save()
 
     // Now it is 14:02
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 14, 2).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 14, 2))
     await staffAttendancePage.assertPresentStaffCount(1)
     await staffAttendancePage.selectTab('present')
     await staffAttendancePage.openStaffPage(employeeName)
@@ -554,7 +552,7 @@ describe('Realtime staff attendance page', () => {
       .save()
 
     // Now it is 14:02
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 14, 2).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 14, 2))
     await staffAttendancePage.assertPresentStaffCount(1)
     await staffAttendancePage.selectTab('present')
     await staffAttendancePage.openStaffPage(employeeName)
@@ -573,7 +571,7 @@ describe('Realtime staff attendance page', () => {
       'Paikalla 08:02–14:02'
     )
 
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 15, 0).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 15, 0))
     await staffAttendancePage.openStaffPage(employeeName)
 
     await staffAttendancePage.clickStaffArrivedAndSetPin(pin)
@@ -600,7 +598,7 @@ describe('Realtime staff attendance page', () => {
       })
       .save()
 
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 12, 4).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 12, 4))
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.selectTab('absent')
     await staffAttendancePage.openStaffPage(employeeName)
@@ -621,7 +619,7 @@ describe('Realtime staff attendance page', () => {
     )
 
     // Clock is now 14:02
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 14, 2).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 14, 2))
     await staffAttendancePage.assertPresentStaffCount(1)
     await staffAttendancePage.selectTab('present')
     await staffAttendancePage.openStaffPage(employeeName)
@@ -642,7 +640,7 @@ describe('Realtime staff attendance page', () => {
   })
 
   test('New external staff member can be added and marked as departed', async () => {
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 16, 0).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 16, 0))
 
     const name = 'Nomen Estomen'
     const arrivalTime = '03:20'
@@ -666,7 +664,7 @@ describe('Realtime staff attendance page', () => {
   })
 
   test('External staff member cannot use departure time that is before arrival', async () => {
-    await initPages(HelsinkiDateTime.of(2022, 5, 5, 16, 0).toSystemTzDate())
+    await initPages(HelsinkiDateTime.of(2022, 5, 5, 16, 0))
 
     const name = 'Nomen Estomen'
     const arrivalTime = '08:00'
@@ -694,9 +692,7 @@ describe('Realtime staff attendance page', () => {
 
   test('New external staff member cannot be added on a non-operational day', async () => {
     const saturday = LocalDate.of(2022, 5, 7)
-    await initPages(
-      HelsinkiDateTime.fromLocal(saturday, LocalTime.of(16, 0)).toSystemTzDate()
-    )
+    await initPages(HelsinkiDateTime.fromLocal(saturday, LocalTime.of(16, 0)))
 
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.assertMarkNewExternalStaffDisabled()
@@ -720,10 +716,9 @@ describe('Realtime staff attendance edit page', () => {
       })
       .save()
 
-    await initPages(
-      HelsinkiDateTime.fromLocal(date, LocalTime.of(16, 0)).toSystemTzDate(),
-      { staffAttendanceTypes: false }
-    )
+    await initPages(HelsinkiDateTime.fromLocal(date, LocalTime.of(16, 0)), {
+      staffAttendanceTypes: false
+    })
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.openStaffPage(employeeName)
     await staffAttendancePage.editButton.click()
@@ -757,9 +752,7 @@ describe('Realtime staff attendance edit page', () => {
       })
       .save()
 
-    await initPages(
-      HelsinkiDateTime.fromLocal(date, LocalTime.of(16, 0)).toSystemTzDate()
-    )
+    await initPages(HelsinkiDateTime.fromLocal(date, LocalTime.of(16, 0)))
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.openStaffPage(employeeName)
     await staffAttendancePage.editButton.click()
@@ -796,9 +789,7 @@ describe('Realtime staff attendance edit page', () => {
       })
       .save()
 
-    await initPages(
-      HelsinkiDateTime.fromLocal(date, LocalTime.of(16, 0)).toSystemTzDate()
-    )
+    await initPages(HelsinkiDateTime.fromLocal(date, LocalTime.of(16, 0)))
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.openStaffPage(employeeName)
     await staffAttendancePage.editButton.click()
@@ -834,9 +825,7 @@ describe('Realtime staff attendance edit page', () => {
       })
       .save()
 
-    await initPages(
-      HelsinkiDateTime.fromLocal(date, LocalTime.of(16, 0)).toSystemTzDate()
-    )
+    await initPages(HelsinkiDateTime.fromLocal(date, LocalTime.of(16, 0)))
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.openStaffPage(employeeName)
     await staffAttendancePage.editButton.click()
@@ -870,9 +859,7 @@ describe('Realtime staff attendance edit page', () => {
       })
       .save()
 
-    await initPages(
-      HelsinkiDateTime.fromLocal(date, LocalTime.of(16, 0)).toSystemTzDate()
-    )
+    await initPages(HelsinkiDateTime.fromLocal(date, LocalTime.of(16, 0)))
     await staffAttendancePage.assertPresentStaffCount(0)
     await staffAttendancePage.openStaffPage(employeeName)
     await staffAttendancePage.editButton.click()
@@ -900,9 +887,7 @@ describe('Realtime staff attendance edit page', () => {
       })
       .save()
 
-    await initPages(
-      HelsinkiDateTime.fromLocal(date, LocalTime.of(2, 0)).toSystemTzDate()
-    )
+    await initPages(HelsinkiDateTime.fromLocal(date, LocalTime.of(2, 0)))
     await staffAttendancePage.assertPresentStaffCount(1)
     await staffAttendancePage.selectTab('present')
     await staffAttendancePage.openStaffPage(employeeName)

--- a/frontend/src/e2e-test/specs/6_mobile/reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/reservations.spec.ts
@@ -376,10 +376,7 @@ describe('when unit is open every day', () => {
 
 const loginToMobile = async (today: LocalDate, unitId: UUID) => {
   const page = await Page.open({
-    mockedTime: HelsinkiDateTime.fromLocal(
-      today,
-      LocalTime.of(14, 50)
-    ).toSystemTzDate()
+    mockedTime: HelsinkiDateTime.fromLocal(today, LocalTime.of(14, 50))
   })
   await page.goto(await pairMobileDevice(unitId))
   return page

--- a/frontend/src/e2e-test/specs/6_mobile/staff.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/staff.spec.ts
@@ -44,7 +44,7 @@ beforeEach(async () => {
     })
     .save()
 
-  page = await Page.open({ mockedTime: now.toSystemTzDate() })
+  page = await Page.open({ mockedTime: now })
   nav = new MobileNav(page)
 
   mobileSignupUrl = await pairMobileDevice(fixtures.daycareFixture.id)

--- a/frontend/src/e2e-test/specs/6_mobile/unit-list.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/unit-list.spec.ts
@@ -40,7 +40,7 @@ beforeEach(async () => {
     })
     .save()
 
-  page = await Page.open({ mockedTime: mockedNow.toSystemTzDate() })
+  page = await Page.open({ mockedTime: mockedNow })
 
   const unitSupervisor = await Fixture.employeeUnitSupervisor(unit.data.id)
     .withDaycareAcl(fixtures.preschoolFixture.id, 'UNIT_SUPERVISOR')

--- a/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
@@ -125,24 +125,24 @@ beforeEach(async () => {
 })
 
 async function initStaffPage(mockedTime: HelsinkiDateTime) {
-  staffPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  staffPage = await Page.open({ mockedTime })
   await employeeLogin(staffPage, staff)
 }
 
 async function initUnitSupervisorPage(mockedTime: HelsinkiDateTime) {
   unitSupervisorPage = await Page.open({
-    mockedTime: mockedTime.toSystemTzDate()
+    mockedTime: mockedTime
   })
   await employeeLogin(unitSupervisorPage, unitSupervisor)
 }
 
 async function initCitizenPage(mockedTime: HelsinkiDateTime) {
-  citizenPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  citizenPage = await Page.open({ mockedTime })
   await enduserLogin(citizenPage)
 }
 
 async function initCitizenPageWeak(mockedTime: HelsinkiDateTime) {
-  citizenPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  citizenPage = await Page.open({ mockedTime })
   await enduserLoginWeak(citizenPage)
 }
 

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -117,21 +117,21 @@ beforeEach(async () => {
 
 async function openSupervisorPage(mockedTime: HelsinkiDateTime) {
   unitSupervisorPage = await Page.open({
-    mockedTime: mockedTime.toSystemTzDate()
+    mockedTime: mockedTime
   })
   await employeeLogin(unitSupervisorPage, unitSupervisor)
 }
 
 async function openCitizenPage(mockedTime: HelsinkiDateTime) {
   citizenPage = await Page.open({
-    mockedTime: mockedTime.toSystemTzDate()
+    mockedTime: mockedTime
   })
   await enduserLogin(citizenPage)
 }
 
 async function openCitizenPageWeak(mockedTime: HelsinkiDateTime) {
   citizenPage = await Page.open({
-    mockedTime: mockedTime.toSystemTzDate()
+    mockedTime: mockedTime
   })
   await enduserLoginWeak(citizenPage)
 }

--- a/frontend/src/e2e-test/specs/7_messaging/municipal-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/municipal-messaging.spec.ts
@@ -121,17 +121,17 @@ beforeEach(async () => {
 })
 
 async function openMessagingPage(mockedTime: HelsinkiDateTime) {
-  messagingPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  messagingPage = await Page.open({ mockedTime })
   await employeeLogin(messagingPage, messenger)
 }
 
 async function openStaffPage(mockedTime: HelsinkiDateTime) {
-  staffPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  staffPage = await Page.open({ mockedTime })
   await employeeLogin(staffPage, staff)
 }
 
 async function openCitizenPage(mockedTime: HelsinkiDateTime) {
-  citizenPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  citizenPage = await Page.open({ mockedTime })
   await enduserLogin(citizenPage)
 }
 

--- a/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
@@ -58,7 +58,7 @@ beforeEach(async () => {
 })
 
 async function openCitizenPage(mockedTime: HelsinkiDateTime) {
-  citizenPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  citizenPage = await Page.open({ mockedTime })
   await enduserLogin(citizenPage)
 }
 
@@ -66,7 +66,7 @@ async function openStaffPage(
   mockedTime: HelsinkiDateTime,
   employee: EmployeeDetail
 ) {
-  staffPage = await Page.open({ mockedTime: mockedTime.toSystemTzDate() })
+  staffPage = await Page.open({ mockedTime })
   await employeeLogin(staffPage, employee)
   await staffPage.goto(config.employeeUrl)
 }

--- a/frontend/src/employee-frontend/api/client.ts
+++ b/frontend/src/employee-frontend/api/client.ts
@@ -4,7 +4,7 @@
 
 import axios, { AxiosError } from 'axios'
 
-import { isAutomatedTest, mockNow } from 'lib-common/utils/helpers'
+import { isAutomatedTest } from 'lib-common/utils/helpers'
 
 export const API_URL = '/api/internal'
 
@@ -15,7 +15,10 @@ export const client = axios.create({
 
 if (isAutomatedTest) {
   client.interceptors.request.use((config) => {
-    const evakaMockedTime = mockNow()?.toISOString()
+    const evakaMockedTime =
+      typeof window !== 'undefined'
+        ? window.evaka?.mockedTime?.toISOString()
+        : undefined
     if (evakaMockedTime) {
       config.headers.set('EvakaMockedTime', evakaMockedTime)
     }

--- a/frontend/src/employee-mobile-frontend/client.ts
+++ b/frontend/src/employee-mobile-frontend/client.ts
@@ -4,7 +4,7 @@
 
 import axios, { AxiosError } from 'axios'
 
-import { isAutomatedTest, mockNow } from 'lib-common/utils/helpers'
+import { isAutomatedTest } from 'lib-common/utils/helpers'
 
 export const API_URL = '/api/internal'
 
@@ -15,7 +15,10 @@ export const client = axios.create({
 
 if (isAutomatedTest) {
   client.interceptors.request.use((config) => {
-    const evakaMockedTime = mockNow()?.toISOString()
+    const evakaMockedTime =
+      typeof window !== 'undefined'
+        ? window.evaka?.mockedTime?.toISOString()
+        : undefined
     if (evakaMockedTime) {
       config.headers.set('EvakaMockedTime', evakaMockedTime)
     }

--- a/frontend/src/lib-common/helsinki-date-time.ts
+++ b/frontend/src/lib-common/helsinki-date-time.ts
@@ -15,7 +15,7 @@ import { formatInTimeZone, utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz'
 import LocalDate from './local-date'
 import LocalTime from './local-time'
 import { Ordered } from './ordered'
-import { isAutomatedTest, mockNow } from './utils/helpers'
+import { isAutomatedTest } from './utils/helpers'
 
 const EUROPE_HELSINKI = 'Europe/Helsinki'
 
@@ -206,7 +206,10 @@ export default class HelsinkiDateTime implements Ordered<HelsinkiDateTime> {
    * Current timestamp in Europe/Helsinki timezone.
    */
   static now(): HelsinkiDateTime {
-    const timestamp = (isAutomatedTest ? mockNow() : undefined) ?? new Date()
+    const timestamp =
+      (isAutomatedTest && typeof window !== 'undefined'
+        ? window.evaka?.mockedTime
+        : undefined) ?? new Date()
     return HelsinkiDateTime.fromSystemTzDate(timestamp)
   }
 

--- a/frontend/src/lib-common/local-date.ts
+++ b/frontend/src/lib-common/local-date.ts
@@ -35,7 +35,7 @@ import { DateFormat, DateFormatWithWeekday, locales } from './date'
 import HelsinkiDateTime from './helsinki-date-time'
 import LocalTime from './local-time'
 import { Ordered } from './ordered'
-import { isAutomatedTest, mockNow } from './utils/helpers'
+import { isAutomatedTest } from './utils/helpers'
 
 const isoPattern = /^([0-9]+)-([0-9]+)-([0-9]+)$/
 const fiPattern = /^(\d{1,2})\.(\d{1,2})\.(\d{4})$/
@@ -153,7 +153,10 @@ export default class LocalDate implements Ordered<LocalDate> {
   }
   isToday(): boolean {
     return isAutomatedTest
-      ? isSameDay(mockNow() ?? new Date(), this.toSystemTzDate())
+      ? isSameDay(
+          LocalDate.todayInSystemTz().toSystemTzDate(),
+          this.toSystemTzDate()
+        )
       : isToday(this.toSystemTzDate())
   }
   isWeekend(): boolean {
@@ -210,7 +213,10 @@ export default class LocalDate implements Ordered<LocalDate> {
    * Current date in system (= browser local) timezone.
    */
   static todayInSystemTz(): LocalDate {
-    const timestamp = (isAutomatedTest ? mockNow() : undefined) ?? new Date()
+    const timestamp =
+      (isAutomatedTest && typeof window !== 'undefined'
+        ? window.evaka?.mockedTime
+        : undefined) ?? new Date()
     return LocalDate.fromSystemTzDate(timestamp)
   }
   /**

--- a/frontend/src/lib-common/local-time.ts
+++ b/frontend/src/lib-common/local-time.ts
@@ -8,7 +8,7 @@ import isInteger from 'lodash/isInteger'
 import { isValidTime } from './date'
 import HelsinkiDateTime from './helsinki-date-time'
 import { Ordered } from './ordered'
-import { isAutomatedTest, mockNow } from './utils/helpers'
+import { isAutomatedTest } from './utils/helpers'
 
 // ISO local time with nanosecond precision
 const isoPattern = /^(\d{2}):(\d{2}):(\d{2})(?:.(\d{9}))?$/
@@ -90,7 +90,10 @@ export default class LocalTime implements Ordered<LocalTime> {
    * Current time in system (= browser local) timezone.
    */
   static nowInSystemTz(): LocalTime {
-    const timestamp = (isAutomatedTest ? mockNow() : undefined) ?? new Date()
+    const timestamp =
+      (isAutomatedTest && typeof window !== 'undefined'
+        ? window.evaka?.mockedTime
+        : undefined) ?? new Date()
     return LocalTime.of(
       timestamp.getHours(),
       timestamp.getMinutes(),

--- a/frontend/src/lib-common/utils/helpers.ts
+++ b/frontend/src/lib-common/utils/helpers.ts
@@ -50,9 +50,15 @@ declare global {
   }
 }
 
+/**
+ * @deprecated use HelsinkiDateTime.now() instead
+ */
 export const mockNow = (): Date | undefined =>
   typeof window !== 'undefined' ? window.evaka?.mockedTime : undefined
 
+/**
+ * @deprecated use LocalDate.todayInHelsinkiTz() or LocalDate.todayInSystemTz() instead
+ */
 export function mockToday(): LocalDate | undefined {
   const mockedTime = mockNow()
   return mockedTime ? LocalDate.fromSystemTzDate(mockedTime) : undefined


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- expect a HelsinkiDateTime to avoid ambiguous JS Dates
- inline relevant part of mockNow to the places where it's supposed to be used
- deprecate mockNow to discourage its use elsewhere
- deprecate mockToday which is unnecessary and ambiguous about its timezone