### PR TITLE
Fix flaky Titania test

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/titania/TitaniaService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/titania/TitaniaService.kt
@@ -172,6 +172,8 @@ class TitaniaService(private val idConverter: TitaniaEmployeeIdConverter) {
         val persons =
             attendances
                 .groupBy { EmployeeKey(it.employeeId, it.firstName, it.lastName) }
+                .asSequence()
+                .sortedWith(compareBy({ it.key.id }, { it.key.firstName }, { it.key.lastName }))
                 .map { (employee, attendances) ->
                     val employeePlans = plans[employee.id]
                     val convertedEmployeeNumber = employeeIdToNumber[employee.id]!!
@@ -274,6 +276,7 @@ class TitaniaService(private val idConverter: TitaniaEmployeeIdConverter) {
                             )
                     )
                 }
+                .toList()
 
         val response =
             GetStampedWorkingTimeEventsResponse(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The test expectations specify persons in a certain order, but in reality the order was random and dependant on how the database returned the rows.