### PR TITLE
Fix URL encoding bug in employee attachment download

### DIFF
--- a/frontend/src/employee-frontend/api/attachments.ts
+++ b/frontend/src/employee-frontend/api/attachments.ts
@@ -120,5 +120,6 @@ export function getAttachmentUrl(
   attachmentId: UUID,
   requestedFilename: string
 ): string {
-  return `${API_URL}/attachments/${attachmentId}/download/${requestedFilename}`
+  const encodedFilename = encodeURIComponent(requestedFilename)
+  return `${API_URL}/attachments/${attachmentId}/download/${encodedFilename}`
 }


### PR DESCRIPTION
#### Summary

Fix a bug which causes attachments whose file names contain semicolons to be undownloadable by employees due to missing URL encoding
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

