### PR TITLE
Fix citizen vasu mobile layout

### DIFF
--- a/frontend/src/citizen-frontend/children/sections/vasu-and-leops/vasu/sections/CitizenVasuHeader.tsx
+++ b/frontend/src/citizen-frontend/children/sections/vasu-and-leops/vasu/sections/CitizenVasuHeader.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { VasuDocument } from 'lib-common/generated/api-types/vasu'
+import { tabletMin } from 'lib-components/breakpoints'
 import { ContentArea } from 'lib-components/layout/Container'
 import { fontWeights, H1, H2 } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
@@ -15,9 +16,12 @@ import { useTranslation } from '../../../../../localization'
 import { VasuStateChip } from '../components/VasuStateChip'
 
 const HeaderSection = styled(ContentArea)`
-  display: flex;
-  justify-content: space-between;
   padding: ${defaultMargins.L};
+
+  @media (min-width: ${tabletMin}) {
+    display: flex;
+    justify-content: space-between;
+  }
 `
 const Titles = styled.div`
   ${H1} {
@@ -30,8 +34,14 @@ const Titles = styled.div`
 const StateAndConfidentiality = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  text-align: end;
+  @media (min-width: ${tabletMin}) {
+    align-items: flex-end;
+    text-align: end;
+    margin-top: 0;
+  }
+  align-items: flex-start;
+  text-align: start;
+  margin-top: ${defaultMargins.m};
 `
 const Confidential = styled.div`
   margin-top: ${defaultMargins.xs};


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

If the document name has long words, having all the information side-by-side is not feasible on mobile -> arrange vertically instead

**Old:**

![Screenshot from 2024-01-25 10-44-15](https://github.com/espoon-voltti/evaka/assets/94033/d9fb5ff6-84b6-4b23-b086-c4e84a5367cd)

**New:**
![Screenshot from 2024-01-25 10-45-03](https://github.com/espoon-voltti/evaka/assets/94033/61be5eca-06d9-4049-9cfc-b43f923625ce)
