### PR TITLE
Indicate staff made absence records in week calendar

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar-child-date-modal.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar-child-date-modal.spec.ts
@@ -199,7 +199,7 @@ test('Add absences for child in preschool daycare for tomorrow then update one a
   await reservationsTable
     .reservationCells(childId, date)
     .nth(0)
-    .assertTextEquals('P\nVuorotyö')
+    .assertTextEquals('P\nVuorotyö*')
 
   await reservationsTable.openChildDateModal(childId, date)
   await modal.nonbillableAbsenceRemove.click()
@@ -209,7 +209,7 @@ test('Add absences for child in preschool daycare for tomorrow then update one a
   await reservationsTable
     .reservationCells(childId, date)
     .nth(0)
-    .assertTextEquals('Sairaus')
+    .assertTextEquals('Sairaus*')
 
   // reservation times are shown if partially absent
   await reservationsTable.openChildDateModal(childId, date)
@@ -237,7 +237,7 @@ test('Add absences for child in preschool daycare for tomorrow then update one a
   await reservationsTable
     .reservationCells(childId, date)
     .nth(0)
-    .assertTextEquals('Sairaus')
+    .assertTextEquals('Sairaus*')
   await reservationsTable
     .reservationCells(childId, date)
     .nth(1)
@@ -259,7 +259,7 @@ test('Add absence for child in preschool for yesterday', async () => {
   await reservationsTable
     .reservationCells(childId, date)
     .nth(0)
-    .assertTextEquals('Poissaolo')
+    .assertTextEquals('Poissaolo*')
 })
 
 test('Add absence for child in daycare for yesterday', async () => {
@@ -279,7 +279,7 @@ test('Add absence for child in daycare for yesterday', async () => {
   await reservationsTable
     .reservationCells(childId, date)
     .nth(0)
-    .assertTextEquals('Poissaolo')
+    .assertTextEquals('Poissaolo*')
 })
 
 test('Absence warnings for child in daycare', async () => {

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
+import styled from 'styled-components'
 
 import { AbsenceType } from 'lib-common/generated/api-types/daycare'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
+import Tooltip from 'lib-components/atoms/Tooltip'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { absenceColors, absenceIcons } from 'lib-customizations/common'
 
@@ -13,18 +15,35 @@ import { useTranslation } from '../../../state/i18n'
 
 interface Props {
   type: AbsenceType
+  staffCreated: boolean
 }
 
-export default React.memo(function AbsenceDay({ type }: Props) {
+export default React.memo(function AbsenceDay({ type, staffCreated }: Props) {
   const { i18n } = useTranslation()
   return (
     <FixedSpaceRow spacing="xs" alignItems="center" data-qa="absence">
-      <RoundIcon
-        content={absenceIcons[type]}
-        color={absenceColors[type]}
-        size="m"
-      />
-      <span>{i18n.absences.absenceTypesShort[type]}</span>
+      <AbsenceTooltip
+        tooltip={
+          staffCreated && i18n.unit.attendanceReservations.createdByEmployee
+        }
+      >
+        <RoundIcon
+          content={absenceIcons[type]}
+          color={absenceColors[type]}
+          size="m"
+        />
+        <span>
+          {i18n.absences.absenceTypesShort[type]}
+          {staffCreated && '*'}
+        </span>
+      </AbsenceTooltip>
     </FixedSpaceRow>
   )
 })
+
+const AbsenceTooltip = styled(Tooltip)`
+  display: flex;
+  justify-content: space-evenly;
+  padding: 8px;
+  gap: 8px;
+`

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDateModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDateModal.tsx
@@ -180,7 +180,9 @@ export default React.memo(function ChildDateModal({
         'BILLABLE'
       )
         ? {
-            domValue: childDayRecord.absenceBillable ?? '',
+            domValue: childDayRecord.absenceBillable
+              ? childDayRecord.absenceBillable.absenceType
+              : '',
             options: absenceOptions
           }
         : {
@@ -191,7 +193,9 @@ export default React.memo(function ChildDateModal({
         'NONBILLABLE'
       )
         ? {
-            domValue: childDayRecord.absenceNonbillable ?? '',
+            domValue: childDayRecord.absenceNonbillable
+              ? childDayRecord.absenceNonbillable.absenceType
+              : '',
             options: absenceOptions
           }
         : {

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayReservation.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayReservation.tsx
@@ -41,6 +41,7 @@ interface Props {
   dateInfo: UnitDateInfo
   reservation: ReservationResponse | undefined
   absence: AbsenceType | null
+  absenceStaffCreated: boolean | undefined
   dailyServiceTimes: DailyServiceTimesValue | null
   inOtherUnit: boolean
   isInBackupGroup: boolean
@@ -55,6 +56,7 @@ export default React.memo(function ChildDayReservation({
   dateInfo,
   reservation,
   absence,
+  absenceStaffCreated,
   dailyServiceTimes,
   inOtherUnit,
   isInBackupGroup,
@@ -102,7 +104,7 @@ export default React.memo(function ChildDayReservation({
           </TimeCell>
         ) : absence ? (
           reservationIndex === 0 ? (
-            <AbsenceDay type={absence} />
+            <AbsenceDay type={absence} staffCreated={!!absenceStaffCreated} />
           ) : null
         ) : reservation && reservation.type === 'TIMES' ? (
           <ReservationTooltip

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildReservationsTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildReservationsTable.tsx
@@ -214,7 +214,10 @@ const ChildRowGroup = React.memo(function ChildRowGroup({
                     reservationIndex={index}
                     dateInfo={dateInfo}
                     reservation={child.reservations[index]}
-                    absence={displayAbsence ? absence : null}
+                    absence={
+                      displayAbsence && absence ? absence.absenceType : null
+                    }
+                    absenceStaffCreated={absence?.staffCreated}
                     dailyServiceTimes={child.dailyServiceTimes}
                     inOtherUnit={child.inOtherUnit}
                     isInBackupGroup={

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -35,6 +35,14 @@ export interface AbsenceRequest {
 }
 
 /**
+* Generated from fi.espoo.evaka.reservations.AbsenceTypeResponse
+*/
+export interface AbsenceTypeResponse {
+  absenceType: AbsenceType
+  staffCreated: boolean
+}
+
+/**
 * Generated from fi.espoo.evaka.reservations.UnitAttendanceReservations.Child
 */
 export interface Child {
@@ -63,8 +71,8 @@ export interface ChildDatePresence {
 * Generated from fi.espoo.evaka.reservations.UnitAttendanceReservations.ChildRecordOfDay
 */
 export interface ChildRecordOfDay {
-  absenceBillable: AbsenceType | null
-  absenceNonbillable: AbsenceType | null
+  absenceBillable: AbsenceTypeResponse | null
+  absenceNonbillable: AbsenceTypeResponse | null
   attendances: OpenTimeRange[]
   backupGroupId: UUID | null
   childId: UUID

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/AttendanceReservationsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/AttendanceReservationsControllerIntegrationTest.kt
@@ -401,7 +401,7 @@ class AttendanceReservationsControllerIntegrationTest :
                             childId = testChild_1.id,
                             reservations = emptyList(),
                             attendances = emptyList(),
-                            absenceBillable = AbsenceType.OTHER_ABSENCE,
+                            absenceBillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true),
                             absenceNonbillable = null,
                             possibleAbsenceCategories = setOf(AbsenceCategory.BILLABLE),
                             dailyServiceTimes = null,
@@ -902,8 +902,8 @@ class AttendanceReservationsControllerIntegrationTest :
                     ),
                 attendances =
                     listOf(OpenTimeRange(startTime = LocalTime.of(12, 30), endTime = null)),
-                absenceBillable = AbsenceType.OTHER_ABSENCE,
-                absenceNonbillable = AbsenceType.OTHER_ABSENCE,
+                absenceBillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true),
+                absenceNonbillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true),
                 possibleAbsenceCategories =
                     setOf(AbsenceCategory.NONBILLABLE, AbsenceCategory.BILLABLE),
                 dailyServiceTimes = null,
@@ -966,8 +966,8 @@ class AttendanceReservationsControllerIntegrationTest :
                             endTime = LocalTime.of(17, 0)
                         )
                     ),
-                absenceBillable = AbsenceType.FORCE_MAJEURE,
-                absenceNonbillable = AbsenceType.OTHER_ABSENCE,
+                absenceBillable = AbsenceTypeResponse(AbsenceType.FORCE_MAJEURE, true),
+                absenceNonbillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true),
                 possibleAbsenceCategories =
                     setOf(AbsenceCategory.NONBILLABLE, AbsenceCategory.BILLABLE),
                 dailyServiceTimes = null,

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -574,7 +574,7 @@ SELECT pcd.child_id,
        -- absence roll up
        (SELECT coalesce(jsonb_agg(json_build_object(
                'category', s.category)), '[]'::jsonb)
-        FROM (SELECT ab.category, eu.type = 'EMPLOYEE' as staff_created
+        FROM (SELECT ab.category
               FROM absence ab
               JOIN evaka_user eu ON ab.modified_by = eu.id
               WHERE ab.child_id = pcd.child_id

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -130,6 +130,8 @@ sealed class Reservation : Comparable<Reservation> {
     }
 }
 
+data class AbsenceTypeResponse(val absenceType: AbsenceType, val staffCreated: Boolean)
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 sealed class ReservationResponse : Comparable<ReservationResponse> {
     @JsonTypeName("NO_TIMES") data class NoTimes(val staffCreated: Boolean) : ReservationResponse()


### PR DESCRIPTION
## Before this change

It was not possible to distinguish between staff made absence records and citizen made absence records.

## After this change

Employee week view shows an asterisk and tooltip info on absence records that are made by staff.

<img width="1353" alt="image" src="https://github.com/espoon-voltti/evaka/assets/886091/57aaa0fa-70ce-4f9b-99f1-94076f65ab47">
