### PR TITLE
replace deprecated datepicker to improve unit page date filter ux

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-attendances-page.ts
@@ -12,7 +12,6 @@ import {
   AsyncButton,
   Checkbox,
   DatePicker,
-  DatePickerDeprecated,
   Element,
   Modal,
   Page,
@@ -193,7 +192,7 @@ export class UnitAttendancesSection {
   }
 
   async setFilterStartDate(date: LocalDate) {
-    await new DatePickerDeprecated(
+    await new DatePicker(
       this.page.find('[data-qa="unit-filter-start-date"]')
     ).fill(date.format())
     await this.waitUntilLoaded()

--- a/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
@@ -4,6 +4,7 @@
 
 import { waitUntilDefined, waitUntilEqual, waitUntilTrue } from '../../../utils'
 import {
+  DatePicker,
   DatePickerDeprecated,
   Element,
   Modal,
@@ -36,7 +37,7 @@ export class UnitGroupsPage {
   }
 
   async setFilterStartDate(date: string) {
-    await new DatePickerDeprecated(
+    await new DatePicker(
       this.page.find('[data-qa="unit-filter-start-date"]')
     ).fill(date)
     await this.waitUntilLoaded()

--- a/frontend/src/employee-frontend/components/unit/UnitDataFilters.tsx
+++ b/frontend/src/employee-frontend/components/unit/UnitDataFilters.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import LocalDate from 'lib-common/local-date'
 import { SelectionChip } from 'lib-components/atoms/Chip'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
-import { DatePickerDeprecated } from 'lib-components/molecules/DatePickerDeprecated'
+import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
 
 import { useTranslation } from '../../state/i18n'
 import { UnitFilters } from '../../utils/UnitFilters'
@@ -34,22 +34,22 @@ export default React.memo(function UnitDataFilters({
   filters,
   setFilters
 }: Props) {
-  const { i18n } = useTranslation()
+  const { i18n, lang } = useTranslation()
   const { startDate, endDate, period } = filters
 
   return (
     <FixedSpaceRow>
       <DatePickersContainer>
         {canEdit ? (
-          <DatePickerDeprecated
+          <DatePicker
             data-qa="unit-filter-start-date"
             date={startDate}
-            onChange={(date) => setFilters(filters.withStartDate(date))}
-            type="half-width"
-            minDate={LocalDate.of(2000, 1, 1)}
-            options={{
-              todayButton: i18n.common.today
+            onChange={(date) => {
+              if (date) setFilters(filters.withStartDate(date))
             }}
+            locale={lang}
+            minDate={LocalDate.of(2000, 1, 1)}
+            required
           />
         ) : (
           <div>{startDate.format()}</div>


### PR DESCRIPTION
#### Summary
fixes issue "Yksikön kalenterisivun yläreunan päivämäärä menee vuoteen 2020 kun sitä lähtee muokkaamaan"
