### PR TITLE
Replace remaining employee_child_daycare_acl usage in rules

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlQueries.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.shared.security
 
 import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.QuerySql
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 
@@ -21,6 +22,18 @@ data class EmployeeChildAclConfig(
             "At least one access mechanism must be enabled"
         }
     }
+
+    /**
+     * Returns a list of ACL queries based on this configuration.
+     *
+     * The queries return (child_id, unit_id, role) rows for the given user.
+     */
+    fun aclQueries(user: AuthenticatedUser.Employee, now: HelsinkiDateTime) =
+        listOfNotNull(
+            if (this.placement) employeeChildAclViaPlacement(user.id, now) else null,
+            if (this.backupCare) employeeChildAclViaBackupCare(user.id, now) else null,
+            if (this.application) employeeChildAclViaApplication(user.id) else null
+        )
 }
 
 fun employeeChildAclViaPlacement(employee: EmployeeId, now: HelsinkiDateTime) =


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Replace employee_child_daycare_acl usage with `ruleViaChildAcl`, or manual `cfg.aclQueries` usage.

This *very likely* affects the performance of all changed queries, hopefully positively because `ruleViaChildAcl` tends to give better query plans than using `employee_child_daycare_acl`