### PR TITLE
Content modification timestamp for calendar events

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -2092,7 +2092,8 @@ export class Fixture {
       period: new FiniteDateRange(
         LocalDate.of(2020, 1, 1),
         LocalDate.of(2020, 1, 1)
-      )
+      ),
+      modifiedAt: LocalDate.of(2020, 1, 1).toHelsinkiDateTime(LocalTime.MIN)
     })
   }
 

--- a/frontend/src/e2e-test/dev-api/types.ts
+++ b/frontend/src/e2e-test/dev-api/types.ts
@@ -637,6 +637,7 @@ export interface DevCalendarEvent {
   title: string
   description: string
   period: FiniteDateRange
+  modifiedAt: HelsinkiDateTime
 }
 
 export interface DevCalendarEventAttendee {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
@@ -79,7 +80,8 @@ beforeEach(async () => {
       id: groupEventId,
       title: 'Group-wide event',
       description: 'Whole group',
-      period: new FiniteDateRange(today, today)
+      period: new FiniteDateRange(today, today),
+      modifiedAt: HelsinkiDateTime.fromLocal(today, LocalTime.MIN)
     })
     .save()
 
@@ -96,7 +98,8 @@ beforeEach(async () => {
       id: individualEventId,
       title: 'Individual event',
       description: 'Just Jari',
-      period: new FiniteDateRange(today, today)
+      period: new FiniteDateRange(today, today),
+      modifiedAt: HelsinkiDateTime.fromLocal(today, LocalTime.MIN)
     })
     .save()
 
@@ -114,7 +117,8 @@ beforeEach(async () => {
       id: unitEventId,
       title: 'Unit event',
       description: 'For everyone in the unit',
-      period: new FiniteDateRange(today.addDays(1), today.addDays(2))
+      period: new FiniteDateRange(today.addDays(1), today.addDays(2)),
+      modifiedAt: HelsinkiDateTime.fromLocal(today, LocalTime.MIN)
     })
     .save()
 

--- a/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
@@ -485,7 +485,8 @@ test('Foster parent can see calendar events for foster children', async () => {
       id: groupEventId,
       title: 'Group-wide event',
       description: 'Whole group',
-      period: new FiniteDateRange(mockedDate, mockedDate)
+      period: new FiniteDateRange(mockedDate, mockedDate),
+      modifiedAt: HelsinkiDateTime.fromLocal(mockedDate, LocalTime.MIN)
     })
     .save()
   await Fixture.calendarEventAttendee()

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
@@ -25,6 +25,7 @@ import {
   GroupInfo,
   IndividualChild
 } from 'lib-common/generated/api-types/calendarevent'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -72,6 +73,7 @@ async function getCalendarEvents(
       data.map((event) => ({
         ...event,
         period: FiniteDateRange.parseJson(event.period),
+        contentModifiedAt: HelsinkiDateTime.parseIso(event.contentModifiedAt),
         times: event.times.map((time) => ({
           ...time,
           date: LocalDate.parseIso(time.date),

--- a/frontend/src/lib-common/generated/api-types/calendarevent.ts
+++ b/frontend/src/lib-common/generated/api-types/calendarevent.ts
@@ -6,6 +6,7 @@
 /* eslint-disable import/order, prettier/prettier, @typescript-eslint/no-namespace, @typescript-eslint/no-redundant-type-constituents */
 
 import FiniteDateRange from '../../finite-date-range'
+import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import LocalTime from '../../local-time'
 import { UUID } from '../../types'
@@ -24,6 +25,7 @@ export interface AttendingChild {
 * Generated from fi.espoo.evaka.calendarevent.CalendarEvent
 */
 export interface CalendarEvent {
+  contentModifiedAt: HelsinkiDateTime
   description: string
   groups: GroupInfo[]
   id: UUID

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationQueriesTest.kt
@@ -326,6 +326,7 @@ class CalendarEventNotificationQueriesTest : PureJdbiTest(resetDbBeforeEach = tr
                         title = title,
                         description = description,
                         period = period,
+                        modifiedAt = created
                     )
                 )
 
@@ -333,7 +334,7 @@ class CalendarEventNotificationQueriesTest : PureJdbiTest(resetDbBeforeEach = tr
                     sql(
                         """
                     UPDATE calendar_event
-                    SET created = ${bind(created)} WHERE id = ${bind(eventId)}
+                    SET created_at = ${bind(created)} WHERE id = ${bind(eventId)}
                     """
                     )
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEvent.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEvent.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
 import java.time.LocalTime
 import org.jdbi.v3.json.Json
@@ -26,7 +27,8 @@ data class CalendarEvent(
     val title: String,
     val description: String,
     val period: FiniteDateRange,
-    @Json val times: Set<CalendarEventTime>
+    @Json val times: Set<CalendarEventTime>,
+    val contentModifiedAt: HelsinkiDateTime
 )
 
 data class CalendarEventTime(

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventController.kt
@@ -205,7 +205,7 @@ class CalendarEventController(private val accessControl: AccessControl) {
                         Action.CalendarEvent.UPDATE,
                         id
                     )
-                    tx.updateCalendarEvent(id, body)
+                    tx.updateCalendarEvent(id, clock.now(), body)
                 }
             }
             .also { Audit.CalendarEventUpdate.log(targetId = id) }
@@ -238,7 +238,7 @@ class CalendarEventController(private val accessControl: AccessControl) {
                             childId = childId
                         )
                     }
-                    tx.updateCalendarEvent(id, body)
+                    tx.updateCalendarEvent(id, clock.now(), body)
                     tx.deleteCalendarEventAttendees(id)
                     tx.createCalendarEventAttendees(id, event.unitId, body.tree)
                 }
@@ -263,7 +263,9 @@ class CalendarEventController(private val accessControl: AccessControl) {
                         Action.CalendarEvent.UPDATE,
                         id
                     )
-                    tx.createCalendarEventTime(id, body, clock.now(), user.evakaUserId)
+                    val cetId = tx.createCalendarEventTime(id, body, clock.now(), user.evakaUserId)
+                    tx.setCalendarEventContentModifiedAt(id, clock.now())
+                    cetId
                 }
             }
             .also { Audit.CalendarEventTimeCreate.log(targetId = id) }
@@ -285,6 +287,8 @@ class CalendarEventController(private val accessControl: AccessControl) {
                         Action.CalendarEventTime.DELETE,
                         id
                     )
+                    val calendarEventId = tx.getCalendarEventIdByTimeId(id)
+                    tx.setCalendarEventContentModifiedAt(calendarEventId!!, clock.now())
                     tx.deleteCalendarEventTime(id)
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.emailclient.CalendarEventNotificationData
 import fi.espoo.evaka.shared.CalendarEventId
 import fi.espoo.evaka.shared.CalendarEventTimeId
 import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.DatabaseTable
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.GroupId
@@ -240,14 +241,15 @@ fun Database.Transaction.setCalendarEventContentModifiedAt(
     eventId: CalendarEventId,
     modifiedAt: HelsinkiDateTime
 ) =
-    this.createUpdate(
-            """
+    this.createUpdate<DatabaseTable.CalendarEvent> {
+            sql(
+                """
 UPDATE calendar_event
 SET content_modified_at = :modifiedAt
 WHERE id = :eventId
         """
-                .trimIndent()
-        )
+            )
+        }
         .bind("eventId", eventId)
         .bind("modifiedAt", modifiedAt)
         .updateExactlyOne()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -1481,8 +1481,8 @@ fun Database.Transaction.insert(calendarEvent: DevCalendarEvent) =
     insertTestDataRow(
             calendarEvent,
             """
-INSERT INTO calendar_event (id, title, description, period)
-VALUES (:id, :title, :description, :period)
+INSERT INTO calendar_event (id, title, description, period, modified_at, content_modified_at)
+VALUES (:id, :title, :description, :period, :modifiedAt, :modifiedAt)
 RETURNING id
 """
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -2147,7 +2147,8 @@ data class DevCalendarEvent(
     val id: CalendarEventId = CalendarEventId(UUID.randomUUID()),
     val title: String,
     val description: String,
-    val period: FiniteDateRange
+    val period: FiniteDateRange,
+    val modifiedAt: HelsinkiDateTime
 )
 
 data class DevCalendarEventAttendee(

--- a/service/src/main/resources/db/migration/V383__calendar_event_timestamps.sql
+++ b/service/src/main/resources/db/migration/V383__calendar_event_timestamps.sql
@@ -1,0 +1,22 @@
+ALTER TABLE calendar_event
+    ADD COLUMN modified_at         timestamp with time zone,
+    ADD COLUMN content_modified_at timestamp with time zone;
+
+UPDATE calendar_event
+SET modified_at = updated, content_modified_at = updated;
+
+ALTER TABLE calendar_event
+    ALTER COLUMN modified_at SET NOT NULL,
+    ALTER COLUMN content_modified_at SET NOT NULL;
+
+ALTER TABLE calendar_event
+    RENAME COLUMN created TO created_at;
+
+DROP TRIGGER set_timestamp ON calendar_event;
+ALTER TABLE calendar_event
+    RENAME COLUMN updated TO updated_at;
+CREATE TRIGGER set_timestamp
+    BEFORE UPDATE
+    ON calendar_event
+    FOR EACH ROW
+EXECUTE PROCEDURE trigger_refresh_updated_at();

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -379,3 +379,4 @@ V379__attachments_fk_indexes.sql
 V380__drop_child_consent.sql
 V381__placement_type_preschool_preparatory_only.sql
 V382__absence_categories_preschool_preparatory_only.sql
+V383__calendar_event_timestamps.sql


### PR DESCRIPTION
Changes:
- `calendar_event` table
  - adds `modified_at` column
    - depicts latest endpoint originating update to the row 
  - adds `content_modified_at` column
    - depicts latest endpoint originating update to the row, attendees or times
    - used to inform user of general event state
  - renames columns `updated` ->  `updated_at`, `created` -> `created_at`
  - migration for existing data rows
- integration testing for `content_modified_at` updates
- compatibility changes for test fixture helpers
- adds `contentModifiedAt` to calendar event DTO and timestamp parsing to frontend API function