### PR TITLE
Bust Docker caches in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches:
     - master
+  schedule:
+    # Build every Monday at 01:00. With the cache-bust mechanism, this
+    # effectively updates all operating system packages.
+    - cron: "0 1 * * 1"
   workflow_dispatch:
     inputs:
       push:
@@ -33,6 +37,15 @@ permissions:
   actions: read
 
 jobs:
+  cache-bust:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Cache bust"
+        id: cache-bust
+        run: echo "cache-bust=$(date '+%Y-%V')" >> "$GITHUB_OUTPUT"
+    outputs:
+      cache-bust: ${{ steps.cache-bust.outputs.cache-bust }}
+
   lint-shell:
     runs-on: ubuntu-latest
     steps:
@@ -48,6 +61,8 @@ jobs:
 
   keycloak:
     runs-on: ubuntu-latest
+    needs:
+      - cache-bust
     steps:
       - uses: actions/checkout@v4
 
@@ -72,6 +87,7 @@ jobs:
           path: ./keycloak
           push: ${{ inputs.push || 'true' }}
           build-args: |
+            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -84,6 +100,8 @@ jobs:
 
   frontend-common:
     runs-on: ubuntu-latest
+    needs:
+      - cache-bust
     steps:
       - uses: actions/checkout@v4
 
@@ -107,6 +125,7 @@ jobs:
           path: ./frontend
           push: ${{ inputs.push || 'true' }}
           build-args: |
+            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             SENTRY_PUBLISH_ENABLED=false
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
@@ -126,6 +145,7 @@ jobs:
           target: builder
           push: ${{ inputs.push || 'true' }}
           build-args: |
+            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             SENTRY_PUBLISH_ENABLED=false
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
@@ -145,6 +165,8 @@ jobs:
 
   frontend:
     runs-on: ubuntu-latest
+    needs:
+      - cache-bust
     steps:
       - uses: actions/checkout@v4
 
@@ -192,6 +214,7 @@ jobs:
           path: ./frontend
           push: ${{ inputs.push || 'true' }}
           build-args: |
+            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             SENTRY_PUBLISH_ENABLED=${{ github.ref_name == 'master' && 'true' || 'false' }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
@@ -249,6 +272,8 @@ jobs:
 
   api-gateway:
     runs-on: ubuntu-latest
+    needs:
+      - cache-bust
     steps:
       - uses: actions/checkout@v4
 
@@ -275,6 +300,7 @@ jobs:
           load: true
           target: test
           build-args: |
+            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -288,6 +314,7 @@ jobs:
           path: ./apigw
           push: ${{ inputs.push || 'true' }}
           build-args: |
+            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -303,6 +330,8 @@ jobs:
 
   service:
     runs-on: ubuntu-latest
+    needs:
+      - cache-bust
     steps:
       - uses: actions/checkout@v4
 
@@ -328,6 +357,7 @@ jobs:
           dockerfile: service/Dockerfile
           push: ${{ inputs.push || 'true' }}
           build-args: |
+            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -344,6 +374,7 @@ jobs:
           dockerfile: service/Dockerfile
           push: ${{ inputs.push || 'true' }}
           build-args: |
+            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -359,6 +390,7 @@ jobs:
 
   service-test:
     needs:
+      - cache-bust
       - service
     runs-on: ubuntu-latest
     steps:
@@ -387,6 +419,7 @@ jobs:
           push: false
           load: true
           build-args: |
+            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
             BASE_IMAGE=${{ needs.service.outputs.builder_image }}

--- a/apigw/Dockerfile
+++ b/apigw/Dockerfile
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+ARG CACHE_BUST
+
 FROM node:20.11.0-bookworm-slim AS base
 
 WORKDIR /project
-
-ARG CACHE_BUST=2023-02-08
 
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+ARG CACHE_BUST
 ARG NGINX_VERSION=1.25.1
 
 FROM node:20.11.0-bookworm-slim AS builder

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -27,6 +27,8 @@ RUN mkdir -p /mnt/rootfs \
 
 ## Base containers ##
 
+ARG CACHE_BUST
+
 FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} as base
 
 USER root

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+ARG CACHE_BUST
+
 FROM eclipse-temurin:21-jammy as base
 
 LABEL maintainer="https://github.com/espoon-voltti/evaka"
-
-ARG CACHE_BUST=2023-02-08
 
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8


### PR DESCRIPTION
#### Summary

Use `YEAR-WEEK` as `CACHE_BUST` build arg for Docker builds to force clean builds each week. This way we should get base image and operating system updates at least once a week.