### PR TITLE
Citizen monthly time usage summary

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -293,8 +293,7 @@ const Month = React.memo(function Month({
     () => setMonthlySummaryInfoOpen((prev) => !prev),
     []
   )
-  const displaySummary =
-    featureFlags.monthlyTimeUsageSummary && childSummaries.length > 0
+  const displaySummary = featureFlags.timeUsageInfo && childSummaries.length > 0
   return (
     <ContentArea opaque={false} key={`${month}${year}`}>
       <MonthTitle>
@@ -304,7 +303,7 @@ const Month = React.memo(function Month({
             onClick={onMonthlySummaryInfoClick}
             aria-label={i18n.common.openExpandingInfo}
             margin="zero"
-            data-qa="sensitive-flag-info-button"
+            data-qa={`monthly-summary-info-button-${month}-${year}`}
             open={monthlySummaryInfoOpen}
           />
         )}
@@ -318,6 +317,7 @@ const Month = React.memo(function Month({
               childSummaries={childSummaries}
             />
           }
+          data-qa={`monthly-summary-info-container-${month}-${year}`}
           close={() => setMonthlySummaryInfoOpen(false)}
         />
       )}

--- a/frontend/src/citizen-frontend/calendar/CalendarListView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarListView.tsx
@@ -20,8 +20,8 @@ import { faPlus } from 'lib-icons'
 import { useTranslation } from '../localization'
 import { mobileBottomNavHeight } from '../navigation/const'
 
+import MonthElem, { getSummaryForMonth, groupByMonth } from './MonthElem'
 import { getChildImages } from './RoundChildImages'
-import WeekElem from './WeekElem'
 
 export interface Props {
   childData: ReservationChild[]
@@ -43,22 +43,26 @@ export default React.memo(function CalendarListView({
   events
 }: Props) {
   const i18n = useTranslation()
-  const calendarWeeks = useMemo(() => groupByWeek(calendarDays), [calendarDays])
+  const months = useMemo(() => groupByMonth(calendarDays), [calendarDays])
   const childImages = useMemo(() => getChildImages(childData), [childData])
 
   return (
     <>
       <FixedSpaceColumn spacing="zero">
-        {calendarWeeks.map((w) => (
-          <WeekElem
-            key={`${w.year}-${w.weekNumber}`}
-            weekNumber={w.weekNumber}
-            calendarDays={w.calendarDays}
+        {months.map((m, index) => (
+          <MonthElem
+            key={`month-${index}`}
+            calendarMonth={m}
             selectDate={selectDate}
             dayIsReservable={dayIsReservable}
             dayIsHolidayPeriod={dayIsHolidayPeriod}
             childImages={childImages}
             events={events}
+            childSummaries={getSummaryForMonth(
+              childData,
+              m.year,
+              m.monthNumber
+            )}
           />
         ))}
       </FixedSpaceColumn>
@@ -75,34 +79,12 @@ export default React.memo(function CalendarListView({
   )
 })
 
-export interface CalendarWeek {
-  year: number
-  weekNumber: number
-  calendarDays: ReservationResponseDay[]
-}
-
-export function groupByWeek(days: ReservationResponseDay[]): CalendarWeek[] {
-  const weeks: CalendarWeek[] = []
-  let currentWeek: CalendarWeek | undefined = undefined
-  days.forEach((d) => {
-    if (!currentWeek || currentWeek.weekNumber !== d.date.getIsoWeek()) {
-      currentWeek = {
-        year: d.date.year,
-        weekNumber: d.date.getIsoWeek(),
-        calendarDays: []
-      }
-      weeks.push(currentWeek)
-    }
-    currentWeek.calendarDays.push(d)
-  })
-  return weeks
-}
-
 const HoverButton = styled(Button)`
   position: fixed;
   bottom: calc(${defaultMargins.s} + ${mobileBottomNavHeight}px);
   right: ${defaultMargins.s};
   border-radius: 40px;
+  z-index: 2;
 `
 
 const Icon = styled(FontAwesomeIcon)`

--- a/frontend/src/citizen-frontend/calendar/DayElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayElem.tsx
@@ -1,11 +1,8 @@
-// SPDX-FileCopyrightText: 2017-2022 City of Espoo
-//
-// SPDX-License-Identifier: LGPL-2.1-or-later
-
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCalendar } from 'Icons'
 import sum from 'lodash/sum'
-import React, { Fragment, useCallback, useEffect, useMemo, useRef } from 'react'
-import styled, { css, useTheme } from 'styled-components'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import styled, { useTheme } from 'styled-components'
 
 import { CitizenCalendarEvent } from 'lib-common/generated/api-types/calendarevent'
 import { ReservationResponseDay } from 'lib-common/generated/api-types/reservations'
@@ -13,10 +10,9 @@ import LocalDate from 'lib-common/local-date'
 import { capitalizeFirstLetter } from 'lib-common/string'
 import { scrollToPos } from 'lib-common/utils/scrolling'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
-import { fontWeights, H2, H3 } from 'lib-components/typography'
+import { fontWeights } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
-import { faCalendar } from 'lib-icons'
 
 import { useLang, useTranslation } from '../localization'
 import { headerHeightMobile } from '../navigation/const'
@@ -29,78 +25,6 @@ import { HistoryOverlay } from './HistoryOverlay'
 import { ChildImageData } from './RoundChildImages'
 import { Reservations } from './calendar-elements'
 
-interface Props {
-  weekNumber: number
-  calendarDays: ReservationResponseDay[]
-  selectDate: (date: LocalDate) => void
-  dayIsReservable: (date: LocalDate) => boolean
-  dayIsHolidayPeriod: (date: LocalDate) => boolean
-  childImages: ChildImageData[]
-  events: CitizenCalendarEvent[]
-}
-
-export default React.memo(function WeekElem({
-  weekNumber,
-  calendarDays,
-  dayIsHolidayPeriod,
-  selectDate,
-  dayIsReservable,
-  childImages,
-  events
-}: Props) {
-  const i18n = useTranslation()
-  return (
-    <div>
-      <WeekTitle>
-        {i18n.common.datetime.week} {weekNumber}
-      </WeekTitle>
-      <div>
-        {calendarDays.map((day) => (
-          <Fragment key={day.date.formatIso()}>
-            {day.date.date === 1 && (
-              <MonthTitle>
-                {i18n.common.datetime.months[day.date.month - 1]}
-              </MonthTitle>
-            )}
-            <DayElem
-              key={day.date.formatIso()}
-              calendarDay={day}
-              selectDate={selectDate}
-              isReservable={dayIsReservable(day.date)}
-              isHolidayPeriod={dayIsHolidayPeriod(day.date)}
-              childImages={childImages}
-              events={events}
-            />
-          </Fragment>
-        ))}
-      </div>
-    </div>
-  )
-})
-
-const titleStyles = css`
-  margin: 0;
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  padding: ${defaultMargins.s};
-  background-color: ${(p) => p.theme.colors.main.m4};
-  border-bottom: 1px solid ${colors.grayscale.g15};
-  color: ${(p) => p.theme.colors.grayscale.g100};
-  font-family: 'Open Sans', 'Arial', sans-serif;
-  font-weight: ${fontWeights.semibold};
-`
-
-const WeekTitle = styled(H3)`
-  font-size: 1em;
-  ${titleStyles}
-`
-
-const MonthTitle = styled(H2)`
-  font-size: 1.25em;
-  ${titleStyles}
-`
-
 interface DayProps {
   calendarDay: ReservationResponseDay
   selectDate: (date: LocalDate) => void
@@ -110,7 +34,7 @@ interface DayProps {
   events: CitizenCalendarEvent[]
 }
 
-const DayElem = React.memo(function DayElem({
+export default React.memo(function DayElem({
   calendarDay,
   selectDate,
   isReservable,
@@ -218,11 +142,9 @@ const DayElem = React.memo(function DayElem({
     </Day>
   )
 })
-
 const ReservationsContainer = styled.div`
   flex: 1 0 0;
 `
-
 const Day = styled.button<{
   $today: boolean
   $highlight?: 'nonEditableAbsence' | 'holidayPeriod' | undefined
@@ -253,7 +175,6 @@ const Day = styled.button<{
     outline: 2px solid ${(p) => p.theme.colors.main.m2Focus};
   }
 `
-
 const DayColumn = styled(FixedSpaceColumn)<{
   inactive: boolean
   holiday: boolean

--- a/frontend/src/citizen-frontend/calendar/DayElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayElem.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCalendar } from 'Icons'
 import sum from 'lodash/sum'

--- a/frontend/src/citizen-frontend/calendar/MonthElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthElem.tsx
@@ -134,28 +134,24 @@ export interface CalendarMonth {
 }
 
 export function groupByMonth(days: ReservationResponseDay[]): CalendarMonth[] {
-  return days.reduce((months, day) => {
-    const monthIndex = months.findIndex(
-      (m) => m.monthNumber === day.date.month && m.year === day.date.year
-    )
-
-    if (monthIndex === -1) {
-      // Month does not exist, create new month
-      const newMonth = {
-        year: day.date.year,
-        monthNumber: day.date.month,
-        calendarDays: [day]
+  const months: CalendarMonth[] = []
+  let currentMonth: CalendarMonth | undefined = undefined
+  days.forEach((d) => {
+    if (
+      !currentMonth ||
+      currentMonth.year !== d.date.year ||
+      currentMonth.monthNumber !== d.date.month
+    ) {
+      currentMonth = {
+        year: d.date.year,
+        monthNumber: d.date.month,
+        calendarDays: []
       }
-      return [...months, newMonth]
-    } else {
-      // Month exists, add day to the month
-      return months.map((month, index) =>
-        index === monthIndex
-          ? { ...month, calendarDays: [...month.calendarDays, day] }
-          : month
-      )
+      months.push(currentMonth)
     }
-  }, [] as CalendarMonth[])
+    currentMonth.calendarDays.push(d)
+  })
+  return months
 }
 const titleStyles = css`
   margin: 0;

--- a/frontend/src/citizen-frontend/calendar/MonthElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthElem.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 import React, { useCallback, useState } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -14,6 +18,7 @@ import {
 } from 'lib-components/molecules/ExpandingInfo'
 import { fontWeights, H2, H3 } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
+import { featureFlags } from 'lib-customizations/citizen'
 import colors from 'lib-customizations/common'
 
 import { useTranslation } from '../localization'
@@ -71,17 +76,18 @@ export default React.memo(function MonthElem({
     () => setMonthlySummaryInfoOpen((prev) => !prev),
     []
   )
+  const displaySummary = featureFlags.timeUsageInfo && childSummaries.length > 0
   return (
     <>
       <MonthSummaryContainer>
         <MonthTitle>
           {i18n.common.datetime.months[calendarMonth.monthNumber - 1]}
-          {childSummaries.length > 0 && (
+          {displaySummary && (
             <InlineInfoButton
               onClick={onMonthlySummaryInfoClick}
               aria-label={i18n.common.openExpandingInfo}
               margin="zero"
-              data-qa="sensitive-flag-info-button"
+              data-qa={`mobile-monthly-summary-info-button-${calendarMonth.monthNumber}-${calendarMonth.year}`}
               open={monthlySummaryInfoOpen}
             />
           )}
@@ -95,6 +101,7 @@ export default React.memo(function MonthElem({
                 childSummaries={childSummaries}
               />
             }
+            data-qa={`mobile-monthly-summary-info-container-${calendarMonth.monthNumber}-${calendarMonth.year}`}
             close={() => setMonthlySummaryInfoOpen(false)}
           />
         )}

--- a/frontend/src/citizen-frontend/calendar/MonthElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthElem.tsx
@@ -1,0 +1,194 @@
+import React, { useCallback, useState } from 'react'
+import styled, { css } from 'styled-components'
+
+import { CitizenCalendarEvent } from 'lib-common/generated/api-types/calendarevent'
+import {
+  ReservationChild,
+  ReservationResponseDay
+} from 'lib-common/generated/api-types/reservations'
+import LocalDate from 'lib-common/local-date'
+import { formatPreferredName } from 'lib-common/names'
+import {
+  ExpandingInfoBox,
+  InlineInfoButton
+} from 'lib-components/molecules/ExpandingInfo'
+import { fontWeights, H2, H3 } from 'lib-components/typography'
+import { defaultMargins } from 'lib-components/white-space'
+import colors from 'lib-customizations/common'
+
+import { useTranslation } from '../localization'
+
+import DayElem from './DayElem'
+import MonthlyHoursSummary, { MonthlyTimeSummary } from './MonthlyHoursSummary'
+import { ChildImageData } from './RoundChildImages'
+
+export function getSummaryForMonth(
+  childData: ReservationChild[],
+  year: number,
+  month: number
+): MonthlyTimeSummary[] {
+  return childData.flatMap(({ monthSummaries, firstName, preferredName }) => {
+    const summaryForMonth = monthSummaries?.find(
+      (monthSummary) =>
+        monthSummary.year === year && monthSummary.month === month
+    )
+    if (!summaryForMonth) {
+      return []
+    }
+    return {
+      name: formatPreferredName({
+        firstName,
+        preferredName
+      }),
+      ...summaryForMonth
+    }
+  })
+}
+
+interface MonthProps {
+  calendarMonth: CalendarMonth
+  selectDate: (date: LocalDate) => void
+  dayIsReservable: (date: LocalDate) => boolean
+  dayIsHolidayPeriod: (date: LocalDate) => boolean
+  events: CitizenCalendarEvent[]
+  childImages: ChildImageData[]
+  childSummaries: MonthlyTimeSummary[]
+}
+
+export default React.memo(function MonthElem({
+  calendarMonth,
+  dayIsHolidayPeriod,
+  selectDate,
+  dayIsReservable,
+  events,
+  childImages,
+  childSummaries
+}: MonthProps) {
+  const i18n = useTranslation()
+
+  const [monthlySummaryInfoOpen, setMonthlySummaryInfoOpen] = useState(false)
+  const onMonthlySummaryInfoClick = useCallback(
+    () => setMonthlySummaryInfoOpen((prev) => !prev),
+    []
+  )
+  return (
+    <>
+      <MonthSummaryContainer>
+        <MonthTitle>
+          {i18n.common.datetime.months[calendarMonth.monthNumber - 1]}
+          {childSummaries.length > 0 && (
+            <InlineInfoButton
+              onClick={onMonthlySummaryInfoClick}
+              aria-label={i18n.common.openExpandingInfo}
+              margin="zero"
+              data-qa="sensitive-flag-info-button"
+              open={monthlySummaryInfoOpen}
+            />
+          )}
+        </MonthTitle>
+        {monthlySummaryInfoOpen && (
+          <MonthlySummaryInfoBox
+            info={
+              <MonthlyHoursSummary
+                year={calendarMonth.year}
+                month={calendarMonth.monthNumber}
+                childSummaries={childSummaries}
+              />
+            }
+            close={() => setMonthlySummaryInfoOpen(false)}
+          />
+        )}
+      </MonthSummaryContainer>
+      {calendarMonth.calendarDays.map((day) => (
+        <div key={day.date.formatIso()}>
+          {day.date.getIsoDayOfWeek() === 1 && (
+            <WeekTitle>
+              {i18n.common.datetime.week} {day.date.getIsoWeek()}
+            </WeekTitle>
+          )}
+          <DayElem
+            calendarDay={day}
+            selectDate={selectDate}
+            isReservable={dayIsReservable(day.date)}
+            isHolidayPeriod={dayIsHolidayPeriod(day.date)}
+            childImages={childImages}
+            events={events}
+          />
+        </div>
+      ))}
+    </>
+  )
+})
+
+export interface CalendarMonth {
+  year: number
+  monthNumber: number
+  calendarDays: ReservationResponseDay[]
+}
+
+export function groupByMonth(days: ReservationResponseDay[]): CalendarMonth[] {
+  return days.reduce((months, day) => {
+    const monthIndex = months.findIndex(
+      (m) => m.monthNumber === day.date.month && m.year === day.date.year
+    )
+
+    if (monthIndex === -1) {
+      // Month does not exist, create new month
+      const newMonth = {
+        year: day.date.year,
+        monthNumber: day.date.month,
+        calendarDays: [day]
+      }
+      return [...months, newMonth]
+    } else {
+      // Month exists, add day to the month
+      return months.map((month, index) =>
+        index === monthIndex
+          ? { ...month, calendarDays: [...month.calendarDays, day] }
+          : month
+      )
+    }
+  }, [] as CalendarMonth[])
+}
+const titleStyles = css`
+  margin: 0;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  background-color: ${(p) => p.theme.colors.main.m4};
+  color: ${(p) => p.theme.colors.grayscale.g100};
+  font-family: 'Open Sans', 'Arial', sans-serif;
+  font-weight: ${fontWeights.semibold};
+`
+const MonthTitle = styled(H2)`
+  font-size: 1.25em;
+  padding: 0 ${defaultMargins.s} 0 0;
+  ${titleStyles};
+`
+const WeekTitle = styled(H3)`
+  padding: ${defaultMargins.s};
+  border-bottom: 1px solid ${colors.grayscale.g15};
+  ${titleStyles};
+`
+const MonthSummaryContainer = styled.div`
+  position: sticky;
+  top: 54px;
+  z-index: 1;
+
+  padding: ${defaultMargins.s};
+  background-color: ${(p) => p.theme.colors.main.m4};
+  border-top: 6px solid ${colors.main.m3};
+  color: ${(p) => p.theme.colors.grayscale.g100};
+  font-family: 'Open Sans', 'Arial', sans-serif;
+`
+
+const MonthlySummaryInfoBox = styled(ExpandingInfoBox)`
+  margin-top: 0;
+  margin-bottom: 0;
+  max-height: 400px;
+  overflow-y: auto;
+
+  section {
+    padding-bottom: 0;
+  }
+`

--- a/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import LocalDate from 'lib-common/local-date'
+import { defaultMargins } from 'lib-components/white-space'
+
+import { useTranslation } from '../localization'
+
+const Title = styled.p`
+  font-weight: bold;
+  margin-top: 0;
+  margin-bottom: ${defaultMargins.xs};
+`
+
+const SummaryContainer = styled.div`
+  p {
+    margin-bottom: 0;
+    margin-top: ${defaultMargins.xs};
+  }
+`
+
+const HoursMinutes = ({ minutes }: { minutes: number }) => {
+  const hours = Math.floor(minutes / 60)
+  const extraMinutes = minutes % 60
+
+  const i18n = useTranslation()
+  return (
+    <>
+      {hours} {i18n.calendar.monthSummary.hours}{' '}
+      {!!extraMinutes &&
+        extraMinutes + ' ' + i18n.calendar.monthSummary.minutes}
+    </>
+  )
+}
+export type MonthlyTimeSummary = {
+  name: string
+  reservedMinutes: number
+  serviceNeedMinutes: number
+  usedServiceMinutes: number
+}
+
+export default React.memo(function MonthSummary({
+  year,
+  month,
+  childSummaries
+}: {
+  year: number
+  month: number
+  childSummaries: MonthlyTimeSummary[]
+}) {
+  const start = LocalDate.of(year, month, 1)
+  const end = LocalDate.of(year, month, 1).addMonths(1).subDays(1)
+  const i18n = useTranslation()
+  return (
+    <>
+      <Title>
+        {i18n.calendar.monthSummary.title}{' '}
+        {`${start.format('dd.MM.')} - ${end.format()}`}
+      </Title>
+      {childSummaries.map((summary, index) => (
+        <SummaryContainer key={index}>
+          <p>
+            <strong>{summary.name}</strong>
+          </p>
+          <p>
+            {i18n.calendar.monthSummary.reserved}{' '}
+            {summary.reservedMinutes > summary.serviceNeedMinutes ? (
+              <strong>
+                <HoursMinutes minutes={summary.reservedMinutes} />
+              </strong>
+            ) : (
+              <HoursMinutes minutes={summary.reservedMinutes} />
+            )}{' '}
+            / <HoursMinutes minutes={summary.serviceNeedMinutes} />
+            <br />
+            {i18n.calendar.monthSummary.usedService}{' '}
+            {summary.usedServiceMinutes > summary.serviceNeedMinutes ? (
+              <strong>
+                <HoursMinutes minutes={summary.usedServiceMinutes} />
+              </strong>
+            ) : (
+              <HoursMinutes minutes={summary.usedServiceMinutes} />
+            )}{' '}
+            / <HoursMinutes minutes={summary.serviceNeedMinutes} />
+          </p>
+        </SummaryContainer>
+      ))}
+    </>
+  )
+})

--- a/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 import React from 'react'
 import styled from 'styled-components'
 
@@ -26,9 +30,9 @@ const HoursMinutes = ({ minutes }: { minutes: number }) => {
   const i18n = useTranslation()
   return (
     <>
-      {hours} {i18n.calendar.monthSummary.hours}{' '}
+      {hours} {i18n.calendar.monthSummary.hours}
       {!!extraMinutes &&
-        extraMinutes + ' ' + i18n.calendar.monthSummary.minutes}
+        ' ' + extraMinutes + ' ' + i18n.calendar.monthSummary.minutes}
     </>
   )
 }
@@ -53,12 +57,12 @@ export default React.memo(function MonthSummary({
   const i18n = useTranslation()
   return (
     <>
-      <Title>
+      <Title data-qa="monthly-summary-info-title">
         {i18n.calendar.monthSummary.title}{' '}
         {`${start.format('dd.MM.')} - ${end.format()}`}
       </Title>
       {childSummaries.map((summary, index) => (
-        <SummaryContainer key={index}>
+        <SummaryContainer key={index} data-qa="monthly-summary-info-text">
           <p>
             <strong>{summary.name}</strong>
           </p>

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -559,15 +559,8 @@ class AbsencesModal {
 }
 
 class MonthlySummary extends Element {
-  constructor(root: Element) {
-    super(root)
-  }
-  #title = this.findByDataQa('monthly-summary-info-title')
-  #text = this.findByDataQa('monthly-summary-info-text')
-  async assertContent(title: string, text: string) {
-    await this.#title.assertTextEquals(title)
-    await this.#text.assertTextEquals(text)
-  }
+  title = this.findByDataQa('monthly-summary-info-title')
+  textElement = this.findByDataQa('monthly-summary-info-text')
 }
 
 class DayView extends Element {

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -27,6 +27,8 @@ export default class CitizenCalendarPage {
   )
   dayCell = (date: LocalDate) =>
     this.page.findByDataQa(`${this.type}-calendar-day-${date.formatIso()}`)
+  monthlySummaryInfoButton = (year: number, month: number) =>
+    this.page.findByDataQa(`monthly-summary-info-button-${month}-${year}`)
   reservationModal = this.page.findByDataQa('reservation-modal')
 
   async openDayModal(date: LocalDate) {
@@ -98,6 +100,15 @@ export default class CitizenCalendarPage {
   async openDayView(date: LocalDate) {
     await this.dayCell(date).click()
     return new DayView(this.page, this.page.findByDataQa('calendar-dayview'))
+  }
+
+  async openMonthlySummary(year: number, month: number) {
+    await this.monthlySummaryInfoButton(year, month).click()
+    return new MonthlySummary(
+      this.page.findByDataQa(
+        `monthly-summary-info-container-${month}-${year}-text`
+      )
+    )
   }
 
   async assertHoliday(date: LocalDate) {
@@ -544,6 +555,18 @@ class AbsencesModal {
 
   getAbsenceTypeRequiredError() {
     return this.absenceTypeRequiredError
+  }
+}
+
+class MonthlySummary extends Element {
+  constructor(root: Element) {
+    super(root)
+  }
+  #title = this.findByDataQa('monthly-summary-info-title')
+  #text = this.findByDataQa('monthly-summary-info-text')
+  async assertContent(title: string, text: string) {
+    await this.#title.assertTextEquals(title)
+    await this.#text.assertTextEquals(text)
   }
 }
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-monthly-summary.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-monthly-summary.spec.ts
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
+
+import { resetDatabase } from '../../dev-api'
+import {
+  careAreaFixture,
+  daycareFixture,
+  enduserChildFixtureKaarina,
+  enduserGuardianFixture,
+  Fixture
+} from '../../dev-api/fixtures'
+import CitizenCalendarPage from '../../pages/citizen/citizen-calendar'
+import CitizenHeader from '../../pages/citizen/citizen-header'
+import { Page } from '../../utils/page'
+import { enduserLogin } from '../../utils/user'
+
+const today = LocalDate.of(2022, 1, 14)
+let page: Page
+
+async function openCalendarPage() {
+  page = await Page.open({
+    mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
+  await enduserLogin(page)
+  const header = new CitizenHeader(page, 'desktop')
+  await header.selectTab('calendar')
+  return new CitizenCalendarPage(page, 'desktop')
+}
+describe('Monthly summary', () => {
+  beforeEach(async () => {
+    await resetDatabase()
+
+    await Fixture.careArea().with(careAreaFixture).save()
+    await Fixture.daycare().with(daycareFixture).save()
+    const guardian = await Fixture.person().with(enduserGuardianFixture).save()
+    const child = await Fixture.person().with(enduserChildFixtureKaarina).save()
+    await Fixture.child(enduserChildFixtureKaarina.id).save()
+    await Fixture.guardian(child, guardian).save()
+
+    const daycareSupervisor = await Fixture.employeeUnitSupervisor(
+      daycareFixture.id
+    ).save()
+
+    const serviceNeedOption = await Fixture.serviceNeedOption()
+      .with({
+        validPlacementType: 'DAYCARE',
+        defaultOption: false,
+        nameFi: 'Kokopäiväinen',
+        nameSv: 'Kokopäiväinen (sv)',
+        nameEn: 'Kokopäiväinen (en)',
+        daycareHoursPerMonth: 140
+      })
+      .save()
+
+    const placement = await Fixture.placement()
+      .with({
+        childId: enduserChildFixtureKaarina.id,
+        unitId: daycareFixture.id,
+        type: 'DAYCARE',
+        startDate: today,
+        endDate: today.addYears(1)
+      })
+      .save()
+    await Fixture.serviceNeed()
+      .with({
+        placementId: placement.data.id,
+        startDate: today,
+        endDate: today.addYears(1),
+        optionId: serviceNeedOption.data.id,
+        confirmedBy: daycareSupervisor.data.id
+      })
+      .save()
+  })
+
+  it('Reservation time shown in summary', async () => {
+    await Fixture.attendanceReservation({
+      type: 'RESERVATIONS',
+      date: today,
+      childId: enduserChildFixtureKaarina.id,
+      reservation: {
+        start: LocalTime.of(8, 0),
+        end: LocalTime.of(16, 0)
+      },
+      secondReservation: null
+    }).save()
+
+    const calendarPage = await openCalendarPage()
+    const summary = await calendarPage.openMonthlySummary(
+      today.year,
+      today.month
+    )
+    await summary.assertContent(
+      'Läsnäolot 01.01. - 31.01.2022',
+      'Kaarina\n' + '\n' + 'Suunnitelma 8 h / 140 h\n' + 'Toteuma 0 h / 140 h'
+    )
+  })
+
+  it('Attendance time shown in summary', async () => {
+    await Fixture.childAttendance()
+      .with({
+        childId: enduserChildFixtureKaarina.id,
+        unitId: daycareFixture.id,
+        date: today,
+        arrived: LocalTime.of(8, 0),
+        departed: LocalTime.of(15, 30)
+      })
+      .save()
+
+    const calendarPage = await openCalendarPage()
+    const summary = await calendarPage.openMonthlySummary(
+      today.year,
+      today.month
+    )
+    await summary.assertContent(
+      'Läsnäolot 01.01. - 31.01.2022',
+      'Kaarina\n' +
+        '\n' +
+        'Suunnitelma 0 h / 140 h\n' +
+        'Toteuma 7 h 30 min / 140 h'
+    )
+  })
+})

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-monthly-summary.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-monthly-summary.spec.ts
@@ -93,8 +93,8 @@ describe('Monthly summary', () => {
       today.year,
       today.month
     )
-    await summary.assertContent(
-      'Läsnäolot 01.01. - 31.01.2022',
+    await summary.title.assertTextEquals('Läsnäolot 01.01. - 31.01.2022')
+    await summary.textElement.assertTextEquals(
       'Kaarina\n' + '\n' + 'Suunnitelma 8 h / 140 h\n' + 'Toteuma 0 h / 140 h'
     )
   })
@@ -115,8 +115,8 @@ describe('Monthly summary', () => {
       today.year,
       today.month
     )
-    await summary.assertContent(
-      'Läsnäolot 01.01. - 31.01.2022',
+    await summary.title.assertTextEquals('Läsnäolot 01.01. - 31.01.2022')
+    await summary.textElement.assertTextEquals(
       'Kaarina\n' +
         '\n' +
         'Suunnitelma 0 h / 140 h\n' +

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -415,6 +415,13 @@ const en: Translations = {
     absentDisable: 'Mark as present',
     validationErrors: {
       range: 'Outside opening hours'
+    },
+    monthSummary: {
+      title: 'Attendance summary',
+      reserved: 'Reservations',
+      usedService: 'Realized',
+      minutes: 'min',
+      hours: 'h'
     }
   },
   messages: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -412,6 +412,13 @@ export default {
     absentDisable: 'Merkitse läsnä olevaksi',
     validationErrors: {
       range: 'Yksikön aukiolo ylittyy'
+    },
+    monthSummary: {
+      title: 'Läsnäolot',
+      reserved: 'Suunnitelma',
+      usedService: 'Toteuma',
+      minutes: 'min',
+      hours: 'h'
     }
   },
   messages: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -411,6 +411,13 @@ const sv: Translations = {
     absentDisable: 'Markera som närvarande',
     validationErrors: {
       range: 'Utanför enhetens öppettid'
+    },
+    monthSummary: {
+      title: 'Närvaro',
+      reserved: 'Reserverad tid',
+      usedService: 'Förverkligad tid',
+      minutes: 'min',
+      hours: 'h'
     }
   },
   messages: {

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -36,7 +36,8 @@ const features: Features = {
     personDuplicate: false,
     citizenAttendanceSummary: false,
     intermittentShiftCare: false,
-    noAbsenceType: false
+    noAbsenceType: false,
+    monthlyTimeUsageSummary: true
   },
   staging: {
     citizenShiftCareAbsence: true,
@@ -61,7 +62,8 @@ const features: Features = {
     citizenAttendanceSummary: false,
     voucherUnitPayments: false,
     intermittentShiftCare: false,
-    noAbsenceType: false
+    noAbsenceType: false,
+    monthlyTimeUsageSummary: true
   },
   prod: {
     citizenShiftCareAbsence: true,
@@ -86,7 +88,8 @@ const features: Features = {
     citizenAttendanceSummary: false,
     voucherUnitPayments: false,
     intermittentShiftCare: false,
-    noAbsenceType: false
+    noAbsenceType: false,
+    monthlyTimeUsageSummary: false
   }
 }
 

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -37,7 +37,7 @@ const features: Features = {
     citizenAttendanceSummary: false,
     intermittentShiftCare: false,
     noAbsenceType: false,
-    monthlyTimeUsageSummary: true
+    timeUsageInfo: true
   },
   staging: {
     citizenShiftCareAbsence: true,
@@ -63,7 +63,7 @@ const features: Features = {
     voucherUnitPayments: false,
     intermittentShiftCare: false,
     noAbsenceType: false,
-    monthlyTimeUsageSummary: true
+    timeUsageInfo: true
   },
   prod: {
     citizenShiftCareAbsence: true,
@@ -89,7 +89,7 @@ const features: Features = {
     voucherUnitPayments: false,
     intermittentShiftCare: false,
     noAbsenceType: false,
-    monthlyTimeUsageSummary: false
+    timeUsageInfo: false
   }
 }
 

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -212,6 +212,11 @@ interface BaseFeatureFlags {
    * These flags will either be dropped when features are deemed ready or promoted
    * to top-level flags (moved up, `?` removed).
    */
+
+  /**
+   * Display monthly time usage summary in citizen calendar views
+   */
+  monthlyTimeUsageSummary?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -214,9 +214,9 @@ interface BaseFeatureFlags {
    */
 
   /**
-   * Display monthly time usage summary in citizen calendar views
+   * Display time usage info in citizen calendar views
    */
-  monthlyTimeUsageSummary?: boolean
+  timeUsageInfo?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>


### PR DESCRIPTION
## Before this change
It was hard for citizen to track how many hours they have spent of their monthly service need.

## After this change
Each month has an expandable time usage summary for children that have an hourly based service need. Display of the ℹ️ expand info button behind a front-end feature flag `timeUsageSummary` which defaults to `false` in production environment.
<img width="505" alt="image" src="https://github.com/espoon-voltti/evaka/assets/886091/ccfd4bea-8a59-412d-9862-a1d3750bd44a">
Mobile citizen calendar view

<img width="1038" alt="image" src="https://github.com/espoon-voltti/evaka/assets/886091/f64f0f85-f619-4c32-891e-fa098761930e">
Desktop citizen calendar view