### PR TITLE
mobile bugfixes

### DIFF
--- a/frontend/src/employee-mobile-frontend/child-attendance/api.ts
+++ b/frontend/src/employee-mobile-frontend/child-attendance/api.ts
@@ -143,6 +143,18 @@ export async function createFullDayAbsence({
     .then(() => undefined)
 }
 
+export async function cancelFullDayAbsence({
+  unitId,
+  childId
+}: {
+  unitId: string
+  childId: string
+}): Promise<void> {
+  return client
+    .delete(`/attendances/units/${unitId}/children/${childId}/full-day-absence`)
+    .then(() => undefined)
+}
+
 export async function postAbsenceRange(
   unitId: string,
   childId: string,

--- a/frontend/src/employee-mobile-frontend/child-attendance/queries.ts
+++ b/frontend/src/employee-mobile-frontend/child-attendance/queries.ts
@@ -25,7 +25,8 @@ import {
   uploadChildImage,
   getChildExpectedAbsencesOnDeparture,
   getUnitConfirmedDayReservations,
-  getUnitConfirmedDaysReservationStatistics
+  getUnitConfirmedDaysReservationStatistics,
+  cancelFullDayAbsence
 } from './api'
 
 const queryKeys = createQueryKeys('childAttendance', {
@@ -145,6 +146,13 @@ export const returnToPresentMutation = mutation({
 
 export const returnToComingMutation = mutation({
   api: returnToComing,
+  invalidateQueryKeys: ({ unitId }) => [
+    attendanceStatusesQuery(unitId).queryKey
+  ]
+})
+
+export const cancelAbsenceMutation = mutation({
+  api: cancelFullDayAbsence,
   invalidateQueryKeys: ({ unitId }) => [
     attendanceStatusesQuery(unitId).queryKey
   ]

--- a/frontend/src/employee-mobile-frontend/child-info/ArrivalAndDeparture.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/ArrivalAndDeparture.tsx
@@ -26,18 +26,12 @@ export default React.memo(function ArrivalAndDeparture({
 }: Props) {
   const { i18n } = useTranslation()
 
-  const latestArrival = attendances.length > 0 ? attendances[0].arrived : null
-
-  if (!latestArrival) {
-    return null
-  }
-
-  const arrivalDate = latestArrival.toLocalDate()
-  const dateInfo = arrivalDate.isEqual(LocalDate.todayInSystemTz())
-    ? ''
-    : arrivalDate.isEqual(LocalDate.todayInSystemTz().subDays(1))
-      ? i18n.common.yesterday
-      : arrivalDate.format('d.M.')
+  const dateInfo = (date: LocalDate) =>
+    date.isEqual(LocalDate.todayInSystemTz())
+      ? ''
+      : date.isEqual(LocalDate.todayInSystemTz().subDays(1))
+        ? i18n.common.yesterday
+        : date.format('d.M.')
 
   return (
     <ArrivalTimeContainer>
@@ -47,7 +41,7 @@ export default React.memo(function ArrivalAndDeparture({
             <FixedSpaceRow justifyContent="center" alignItems="center">
               <ArrivalTime data-qa="arrival-time">
                 <span>{i18n.attendances.arrivalTime}</span>
-                <span>{`${dateInfo} ${arrived.toLocalTime().format()}`}</span>
+                <span>{`${dateInfo(arrived.toLocalDate())} ${arrived.toLocalTime().format()}`}</span>
               </ArrivalTime>
               {!departed && (
                 <InlineButton

--- a/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
@@ -234,6 +234,7 @@ export default React.memo(function AttendanceChildPage() {
                       <AttendanceChildComing
                         child={child}
                         groupRoute={groupRoute}
+                        attendances={childAttendance.attendances}
                       />
                     )}
                     {childAttendance.status === 'PRESENT' && (

--- a/frontend/src/employee-mobile-frontend/child-info/child-state-pages/AttendanceChildAbsent.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/child-state-pages/AttendanceChildAbsent.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 import { useMutationResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 
-import { returnToComingMutation } from '../../child-attendance/queries'
+import { cancelAbsenceMutation } from '../../child-attendance/queries'
 import { InlineWideAsyncButton } from '../../common/components'
 import { useTranslation } from '../../common/i18n'
 
@@ -22,14 +22,14 @@ export default React.memo(function AttendanceChildAbsent({
 }: Props) {
   const { i18n } = useTranslation()
 
-  const { mutateAsync: returnToComing } = useMutationResult(
-    returnToComingMutation
+  const { mutateAsync: cancelAbsence } = useMutationResult(
+    cancelAbsenceMutation
   )
 
   return (
     <InlineWideAsyncButton
-      text={i18n.attendances.actions.returnToComing}
-      onClick={() => returnToComing({ unitId, childId })}
+      text={i18n.attendances.actions.cancelAbsence}
+      onClick={() => cancelAbsence({ unitId, childId })}
       onSuccess={() => undefined}
       data-qa="delete-attendance"
     />

--- a/frontend/src/employee-mobile-frontend/child-info/child-state-pages/AttendanceChildComing.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/child-state-pages/AttendanceChildComing.tsx
@@ -4,7 +4,10 @@
 
 import React, { Fragment } from 'react'
 
-import { AttendanceChild } from 'lib-common/generated/api-types/attendance'
+import {
+  AttendanceChild,
+  AttendanceTimes
+} from 'lib-common/generated/api-types/attendance'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { Gap } from 'lib-components/white-space'
 
@@ -13,14 +16,23 @@ import { WideLinkButton } from '../../pairing/components'
 
 interface Props {
   child: AttendanceChild
+  attendances: AttendanceTimes[]
   groupRoute: string
 }
 
 export default React.memo(function AttendanceChildComing({
   child,
+  attendances,
   groupRoute
 }: Props) {
   const { i18n } = useTranslation()
+
+  const hasBeenPresentToday = attendances.some(
+    (a) =>
+      a.arrived.toLocalDate().isToday() ||
+      a.departed == null ||
+      a.departed.toLocalDate().isToday()
+  )
 
   return (
     <Fragment>
@@ -33,12 +45,14 @@ export default React.memo(function AttendanceChildComing({
           {i18n.attendances.actions.markPresent}
         </WideLinkButton>
 
-        <WideLinkButton
-          data-qa="mark-absent-link"
-          to={`${groupRoute}/child-attendance/${child.id}/mark-absent`}
-        >
-          {i18n.attendances.actions.markAbsent}
-        </WideLinkButton>
+        {!hasBeenPresentToday && (
+          <WideLinkButton
+            data-qa="mark-absent-link"
+            to={`${groupRoute}/child-attendance/${child.id}/mark-absent`}
+          >
+            {i18n.attendances.actions.markAbsent}
+          </WideLinkButton>
+        )}
       </FixedSpaceColumn>
       <Gap size="s" />
     </Fragment>

--- a/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
+++ b/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
@@ -162,6 +162,7 @@ export const fi = {
     groupSelectError: 'Valitun ryhmän nimeä ei löytynyt',
     actions: {
       markAbsent: 'Merkitse poissaolevaksi',
+      cancelAbsence: 'Peruuta poissaolo',
       markPresent: 'Merkitse saapuneeksi',
       markDeparted: 'Merkitse lähteneeksi',
       returnToComing: 'Palauta tulossa oleviin',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceQueriesTest.kt
@@ -206,7 +206,7 @@ class AttendanceQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `attendance started yesterday, ended less than 30 minutes ago`() {
+    fun `attendance started yesterday`() {
         db.transaction { tx ->
             tx.insertTestChildAttendance(
                 unitId = testDaycare.id,
@@ -218,7 +218,7 @@ class AttendanceQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 unitId = testDaycare.id,
                 childId = testChild_1.id,
                 arrived = now.atStartOfDay(),
-                departed = now.minusMinutes(29),
+                departed = now.minusMinutes(45),
             )
         }
         val attendances = db.read { it.getUnitChildAttendances(testDaycare.id, now) }
@@ -226,30 +226,10 @@ class AttendanceQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             mapOf(
                 testChild_1.id to
                     listOf(
-                        AttendanceTimes(arrived = now.minusDays(1), departed = now.minusMinutes(29))
+                        AttendanceTimes(arrived = now.minusDays(1), departed = now.minusMinutes(45))
                     )
             ),
             attendances
         )
-    }
-
-    @Test
-    fun `attendance started yesterday, ended 30 minutes ago`() {
-        db.transaction { tx ->
-            tx.insertTestChildAttendance(
-                unitId = testDaycare.id,
-                childId = testChild_1.id,
-                arrived = now.minusDays(1),
-                departed = now.minusDays(1).atEndOfDay(),
-            )
-            tx.insertTestChildAttendance(
-                unitId = testDaycare.id,
-                childId = testChild_1.id,
-                arrived = now.atStartOfDay(),
-                departed = now.minusMinutes(30),
-            )
-        }
-        val attendances = db.read { it.getUnitChildAttendances(testDaycare.id, now) }
-        assertTrue(attendances.isEmpty())
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
@@ -228,8 +228,8 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest(resetDbBeforeEa
         val departed = LocalTime.of(9, 30)
         val absenceType = AbsenceType.SICKLEAVE
         markDeparted(departed, absenceType, absenceType)
-        val child = expectOneAttendanceStatus()
 
+        val child = expectOneAttendanceStatus()
         assertEquals(AttendanceStatus.DEPARTED, child.status)
         assertNotNull(child.attendances)
         assertEquals(
@@ -243,13 +243,27 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest(resetDbBeforeEa
     }
 
     @Test
-    fun `post child departs - multi day attendance`() {
+    fun `post child departs - multi day attendance - departed less than 30 min ago`() {
         givenChildPlacement(PlacementType.DAYCARE)
         givenChildPresent(LocalTime.of(20, 50), mockClock.today().minusDays(1))
 
-        val departed = LocalTime.of(13, 0)
+        val departed = mockClock.now().toLocalTime().minusMinutes(20)
         markDeparted(departed, null, null)
-        expectNoAttendanceStatuses()
+
+        val child = expectOneAttendanceStatus()
+        assertEquals(AttendanceStatus.DEPARTED, child.status)
+    }
+
+    @Test
+    fun `post child departs - multi day attendance - departed more than 30 min ago`() {
+        givenChildPlacement(PlacementType.DAYCARE)
+        givenChildPresent(LocalTime.of(20, 50), mockClock.today().minusDays(1))
+
+        val departed = mockClock.now().toLocalTime().minusMinutes(40)
+        markDeparted(departed, null, null)
+
+        val child = expectOneAttendanceStatus()
+        assertEquals(AttendanceStatus.COMING, child.status)
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/GetAttendancesIntegrationTest.kt
@@ -304,6 +304,25 @@ class GetAttendancesIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                 departed = departed
             )
         }
+
+        val child = expectOneChildAttendance()
+        assertEquals(AttendanceStatus.COMING, child.status)
+        assertEquals(1, child.attendances.size)
+    }
+
+    @Test
+    fun `yesterday's arrival is not shown if departed yesterday`() {
+        val arrived = now.minusDays(1).withTime(LocalTime.of(12, 30))
+        val departed = now.minusDays(1).withTime(LocalTime.of(22, 45))
+        db.transaction {
+            it.insertTestChildAttendance(
+                childId = testChild_1.id,
+                unitId = testDaycare.id,
+                arrived = arrived,
+                departed = departed
+            )
+        }
+
         expectNoChildAttendances()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -122,6 +122,7 @@ enum class Audit(
     ChildAttendancesDepartureRead,
     ChildAttendancesDepartureCreate,
     ChildAttendancesFullDayAbsenceCreate,
+    ChildAttendancesFullDayAbsenceDelete,
     ChildAttendancesAbsenceRangeCreate,
     ChildAttendancesReturnToComing,
     ChildAttendancesReturnToPresent,

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceQueries.kt
@@ -500,6 +500,9 @@ fun Database.Read.getAbsencesOfChildByRange(childId: ChildId, range: DateRange):
         }
     )
 
+fun Database.Read.getAbsencesOfChildByDate(childId: ChildId, date: LocalDate): List<Absence> =
+    getAbsences(Predicate { where("$it.date = ${bind(date)} AND $it.child_id = ${bind(childId)}") })
+
 fun Database.Read.getAbsencesCitizen(
     today: LocalDate,
     guardianId: PersonId,

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendanceQueries.kt
@@ -268,55 +268,56 @@ private data class UnitChildAttendancesRow(
 
 fun Database.Read.getUnitChildAttendances(
     unitId: DaycareId,
-    now: HelsinkiDateTime,
+    now: HelsinkiDateTime
 ): Map<ChildId, List<AttendanceTimes>> {
-    return createQuery(
-            """
+    // get attendances for last week to include possible overnight stays
+    val range = FiniteDateRange(now.toLocalDate().minusWeeks(1), now.toLocalDate())
+    return createQuery<Any> {
+            sql(
+                """
 SELECT
     child_id,
     (ca.date + ca.start_time) AT TIME ZONE 'Europe/Helsinki' AS arrived,
     (ca.date + ca.end_time) AT TIME ZONE 'Europe/Helsinki' AS departed
 FROM child_attendance ca
 WHERE
-    ca.unit_id = :unitId AND (
-        ca.end_time IS NULL OR
-        (ca.date = :today AND ca.start_time != '00:00'::time) OR
-        -- An overnight attendance is included for 30 minutes after child has departed
-        (ca.date = :today AND ca.start_time = '00:00'::time AND :departedThreshold < ca.end_time) OR
-        (ca.date = :today - 1 AND ca.end_time = '23:59'::time)
+    ca.unit_id = ${bind(unitId)} AND (
+        between_start_and_end(${bind(range)}, ca.date) OR (ca.date <= ${bind(range.end)} AND ca.end_time IS NULL)
     )
 """
-        )
-        .bind("unitId", unitId)
-        .bind("today", now.toLocalDate())
-        .bind("departedThreshold", now.toLocalTime().minusMinutes(30))
+            )
+        }
         .toList<UnitChildAttendancesRow>()
-        .groupBy { it.childId }
+        .groupBy(
+            keySelector = { it.childId },
+            valueTransform = { AttendanceTimes(it.arrived, it.departed) }
+        )
         .mapValues {
-            it.value
-                .sortedByDescending { att -> att.arrived }
-                .fold(listOf<AttendanceTimes>()) { result, attendance ->
-                    // Merge overnight attendances as one
-                    val departed = attendance.departed
-                    if (
-                        result.isNotEmpty() &&
-                            departed != null &&
-                            departed.hour == 23 &&
-                            departed.minute == 59 &&
-                            result.isNotEmpty()
-                    ) {
-                        result.dropLast(1) + result.last().copy(arrived = attendance.arrived)
-                    } else {
-                        result + AttendanceTimes(attendance.arrived, departed)
-                    }
-                }
-                .filterNot { att ->
-                    // Remove yesterday's stray attendance that wasn't merged because the child
-                    // departed > 30 minutes ago
-                    att.departed != null && att.departed.toLocalDate() != now.toLocalDate()
-                }
+            mergeOverNightRanges(it.value)
+                // filter out attendances not overlapping current day
+                .filter { it.departed?.toLocalDate()?.isBefore(now.toLocalDate()) != true }
+                .sortedByDescending { it.arrived }
         }
         .filter { it.value.isNotEmpty() }
+}
+
+private fun mergeOverNightRanges(attendances: List<AttendanceTimes>): List<AttendanceTimes> {
+    return attendances
+        .sortedBy { it.arrived }
+        .fold(emptyList()) { acc, attendance ->
+            val previous = acc.lastOrNull()
+            if (
+                previous?.departed != null &&
+                    previous.departed.toLocalDate() ==
+                        attendance.arrived.toLocalDate().minusDays(1) &&
+                    previous.departed.toLocalTime() == LocalTime.of(23, 59) &&
+                    attendance.arrived.toLocalTime() == LocalTime.of(0, 0)
+            ) {
+                acc.dropLast(1) + AttendanceTimes(previous.arrived, attendance.departed)
+            } else {
+                acc + attendance
+            }
+        }
 }
 
 fun Database.Read.getUnitChildAbsences(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -952,7 +952,8 @@ sealed interface Action {
         ),
         DELETE_ABSENCE(
             HasGlobalRole(ADMIN),
-            HasUnitRole(UNIT_SUPERVISOR, STAFF, SPECIAL_EDUCATION_TEACHER).inPlacementUnitOfChild()
+            HasUnitRole(UNIT_SUPERVISOR, STAFF, SPECIAL_EDUCATION_TEACHER).inPlacementUnitOfChild(),
+            IsMobile(requirePinLogin = false).inPlacementUnitOfChild()
         ),
         DELETE_ABSENCE_RANGE(
             HasGlobalRole(ADMIN),


### PR DESCRIPTION
#### Summary
- Return all attendances that overlap current day, because frontend needs them for validations
- Instead move the 30min logic inside status calculation function (if last attendance started yesterday and ended more than 30min ago then child is seen as COMING instead of DEPARTED
- After marking a full day absence it was not possible to cancel it, because the button reused "return-to-coming" endpoint which no longer deletes absences. Created a new endpoint specific for cancelling today's full day absence.
- Fixed bug in merging over night attendances
- Fixed bug in displaying 'yesterday' label before arrival time
- Fixed bug where full day absence could be marked although child had been present today after overnight absence
