### PR TITLE
limit selectable absence types in week calendar

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar-child-date-modal.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar-child-date-modal.spec.ts
@@ -185,12 +185,12 @@ test('Add absences for child in preschool daycare for tomorrow then update one a
 
   const modal = await reservationsTable.openChildDateModal(childId, date)
   await modal.addBillableAbsenceBtn.click()
-  await modal.billableAbsenceType.selectOption('PLANNED_ABSENCE')
+  await modal.billableAbsenceType.selectOption('SICKLEAVE')
 
   await modal.addNonbillableAbsenceBtn.click()
   await waitUntilEqual(
     () => modal.nonbillableAbsenceType.selectedOption,
-    'PLANNED_ABSENCE' // defaults from the other absence
+    'SICKLEAVE' // defaults from the other absence
   )
   await modal.nonbillableAbsenceType.selectOption('UNKNOWN_ABSENCE')
   await modal.submit()
@@ -199,17 +199,17 @@ test('Add absences for child in preschool daycare for tomorrow then update one a
   await reservationsTable
     .reservationCells(childId, date)
     .nth(0)
-    .assertTextEquals('P\nVuorotyö*')
+    .assertTextEquals('Sairaus*')
 
   await reservationsTable.openChildDateModal(childId, date)
   await modal.nonbillableAbsenceRemove.click()
-  await modal.billableAbsenceType.selectOption('SICKLEAVE')
+  await modal.billableAbsenceType.selectOption('OTHER_ABSENCE')
   await modal.submit()
 
   await reservationsTable
     .reservationCells(childId, date)
     .nth(0)
-    .assertTextEquals('Sairaus*')
+    .assertTextEquals('Poissaolo*')
 
   // reservation times are shown if partially absent
   await reservationsTable.openChildDateModal(childId, date)
@@ -232,12 +232,12 @@ test('Add absences for child in preschool daycare for tomorrow then update one a
   // reservation times are not shown if fully absent
   await reservationsTable.openChildDateModal(childId, date)
   await modal.addNonbillableAbsenceBtn.click()
-  await modal.nonbillableAbsenceType.selectOption('SICKLEAVE')
+  await modal.nonbillableAbsenceType.selectOption('OTHER_ABSENCE')
   await modal.submit()
   await reservationsTable
     .reservationCells(childId, date)
     .nth(0)
-    .assertTextEquals('Sairaus*')
+    .assertTextEquals('Poissaolo*')
   await reservationsTable
     .reservationCells(childId, date)
     .nth(1)

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDateModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDateModal.tsx
@@ -129,6 +129,16 @@ const form = transformed(
   }
 )
 
+const excludedAbsenceTypes: AbsenceType[] = [
+  'FREE_ABSENCE',
+  'PARENTLEAVE',
+  'PLANNED_ABSENCE',
+  'FORCE_MAJEURE'
+]
+const basicAbsenceTypes = absenceTypes.filter(
+  (t) => !excludedAbsenceTypes.includes(t)
+)
+
 export default React.memo(function ChildDateModal({
   target: { date, dateInfo, child, childDayRecord },
   unitId,
@@ -143,7 +153,34 @@ export default React.memo(function ChildDateModal({
   const today = LocalDate.todayInHelsinkiTz()
   const editingFuture = date.isAfter(today)
 
-  const absenceOptions = absenceTypes.map((at) => ({
+  const availableBillableAbsences = [...basicAbsenceTypes]
+  if (
+    childDayRecord.absenceBillable &&
+    !availableBillableAbsences.includes(
+      childDayRecord.absenceBillable.absenceType
+    )
+  ) {
+    availableBillableAbsences.push(childDayRecord.absenceBillable.absenceType)
+  }
+  const absenceOptionsBillable = availableBillableAbsences.map((at) => ({
+    domValue: at,
+    value: at,
+    label: i18n.absences.absenceTypes[at],
+    dataQa: at
+  }))
+
+  const availableNonbillableAbsences = [...basicAbsenceTypes]
+  if (
+    childDayRecord.absenceNonbillable &&
+    !availableNonbillableAbsences.includes(
+      childDayRecord.absenceNonbillable.absenceType
+    )
+  ) {
+    availableNonbillableAbsences.push(
+      childDayRecord.absenceNonbillable.absenceType
+    )
+  }
+  const absenceOptionsNonbillable = availableNonbillableAbsences.map((at) => ({
     domValue: at,
     value: at,
     label: i18n.absences.absenceTypes[at],
@@ -183,7 +220,7 @@ export default React.memo(function ChildDateModal({
             domValue: childDayRecord.absenceBillable
               ? childDayRecord.absenceBillable.absenceType
               : '',
-            options: absenceOptions
+            options: absenceOptionsBillable
           }
         : {
             domValue: '',
@@ -196,7 +233,7 @@ export default React.memo(function ChildDateModal({
             domValue: childDayRecord.absenceNonbillable
               ? childDayRecord.absenceNonbillable.absenceType
               : '',
-            options: absenceOptions
+            options: absenceOptionsNonbillable
           }
         : {
             domValue: '',

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDateModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDateModal.tsx
@@ -138,6 +138,21 @@ const excludedAbsenceTypes: AbsenceType[] = [
 const basicAbsenceTypes = absenceTypes.filter(
   (t) => !excludedAbsenceTypes.includes(t)
 )
+const getAbsenceTypeOptions = (
+  currentSelection: AbsenceType | null,
+  names: Record<AbsenceType, string>
+) => {
+  const availableTypes = [...basicAbsenceTypes]
+  if (currentSelection && !availableTypes.includes(currentSelection)) {
+    availableTypes.push(currentSelection)
+  }
+  return availableTypes.map((at) => ({
+    domValue: at,
+    value: at,
+    label: names[at],
+    dataQa: at
+  }))
+}
 
 export default React.memo(function ChildDateModal({
   target: { date, dateInfo, child, childDayRecord },
@@ -152,40 +167,6 @@ export default React.memo(function ChildDateModal({
 
   const today = LocalDate.todayInHelsinkiTz()
   const editingFuture = date.isAfter(today)
-
-  const availableBillableAbsences = [...basicAbsenceTypes]
-  if (
-    childDayRecord.absenceBillable &&
-    !availableBillableAbsences.includes(
-      childDayRecord.absenceBillable.absenceType
-    )
-  ) {
-    availableBillableAbsences.push(childDayRecord.absenceBillable.absenceType)
-  }
-  const absenceOptionsBillable = availableBillableAbsences.map((at) => ({
-    domValue: at,
-    value: at,
-    label: i18n.absences.absenceTypes[at],
-    dataQa: at
-  }))
-
-  const availableNonbillableAbsences = [...basicAbsenceTypes]
-  if (
-    childDayRecord.absenceNonbillable &&
-    !availableNonbillableAbsences.includes(
-      childDayRecord.absenceNonbillable.absenceType
-    )
-  ) {
-    availableNonbillableAbsences.push(
-      childDayRecord.absenceNonbillable.absenceType
-    )
-  }
-  const absenceOptionsNonbillable = availableNonbillableAbsences.map((at) => ({
-    domValue: at,
-    value: at,
-    label: i18n.absences.absenceTypes[at],
-    dataQa: at
-  }))
 
   const boundForm = useForm(
     form,
@@ -220,7 +201,10 @@ export default React.memo(function ChildDateModal({
             domValue: childDayRecord.absenceBillable
               ? childDayRecord.absenceBillable.absenceType
               : '',
-            options: absenceOptionsBillable
+            options: getAbsenceTypeOptions(
+              childDayRecord.absenceBillable?.absenceType ?? null,
+              i18n.absences.absenceTypes
+            )
           }
         : {
             domValue: '',
@@ -233,7 +217,10 @@ export default React.memo(function ChildDateModal({
             domValue: childDayRecord.absenceNonbillable
               ? childDayRecord.absenceNonbillable.absenceType
               : '',
-            options: absenceOptionsNonbillable
+            options: getAbsenceTypeOptions(
+              childDayRecord.absenceNonbillable?.absenceType ?? null,
+              i18n.absences.absenceTypes
+            )
           }
         : {
             domValue: '',


### PR DESCRIPTION
#### Summary
In week calendar edit modal the available absence types are limited to common cases unless there's an existing absence of a different type. Rare cases should be added through the month calendar which is generally used by less people.