### PR TITLE
respect sfi rate limit and do not generate decision pdf twice

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -1274,9 +1274,9 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 assertEquals(1, messages.size)
             } else {
                 assertEquals(2, messages.size)
-                assertEquals(1, messages.filter { it.first.ssn == secondDecisionTo.ssn }.size)
+                assertEquals(1, messages.filter { it.ssn == secondDecisionTo.ssn }.size)
             }
-            assertEquals(1, messages.filter { it.first.ssn == applier.ssn }.size)
+            assertEquals(1, messages.filter { it.ssn == applier.ssn }.size)
         }
     }
 
@@ -1405,7 +1405,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             }
             val messages = MockSfiMessagesClient.getMessages()
             assertEquals(2, messages.size)
-            assertEquals(2, messages.filter { it.first.ssn == testAdult_1.ssn }.size)
+            assertEquals(2, messages.filter { it.ssn == testAdult_1.ssn }.size)
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
@@ -426,10 +426,10 @@ class AssistanceNeedDecisionIntegrationTest : FullApplicationTest(resetDbBeforeE
 
         val messages = MockSfiMessagesClient.getMessages()
         assertEquals(1, messages.size)
-        assertContains(messages[0].first.messageContent, "päätös tuesta")
+        assertContains(messages[0].messageContent, "päätös tuesta")
         assertEquals(
             "assistance-need-decisions/assistance_need_decision_${assistanceNeedDecision.id}.pdf",
-            messages[0].first.documentKey
+            messages[0].documentKey
         )
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
@@ -427,7 +427,10 @@ class AssistanceNeedDecisionIntegrationTest : FullApplicationTest(resetDbBeforeE
         val messages = MockSfiMessagesClient.getMessages()
         assertEquals(1, messages.size)
         assertContains(messages[0].first.messageContent, "päätös tuesta")
-        assertNotNull(messages[0].second)
+        assertEquals(
+            "assistance-need-decisions/assistance_need_decision_${assistanceNeedDecision.id}.pdf",
+            messages[0].first.documentKey
+        )
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedPreschoolDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedPreschoolDecisionIntegrationTest.kt
@@ -282,10 +282,10 @@ class AssistanceNeedPreschoolDecisionIntegrationTest :
 
         val messages = MockSfiMessagesClient.getMessages()
         assertEquals(1, messages.size)
-        assertContains(messages[0].first.messageContent, "päätös tuesta")
+        assertContains(messages[0].messageContent, "päätös tuesta")
         assertEquals(
             "assistance-need-preschool-decisions/assistance_need_preschool_decision_${decision.id}.pdf",
-            messages[0].first.documentKey
+            messages[0].documentKey
         )
 
         annulDecision(decision.id, "oops", decisionMaker)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedPreschoolDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedPreschoolDecisionIntegrationTest.kt
@@ -283,7 +283,10 @@ class AssistanceNeedPreschoolDecisionIntegrationTest :
         val messages = MockSfiMessagesClient.getMessages()
         assertEquals(1, messages.size)
         assertContains(messages[0].first.messageContent, "päätös tuesta")
-        assertNotNull(messages[0].second)
+        assertEquals(
+            "assistance-need-preschool-decisions/assistance_need_preschool_decision_${decision.id}.pdf",
+            messages[0].first.documentKey
+        )
 
         annulDecision(decision.id, "oops", decisionMaker)
         val annulled = getDecision(decision.id)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/sficlient/SoapStackIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/sficlient/SoapStackIntegrationTest.kt
@@ -173,7 +173,7 @@ class SoapStackIntegrationTest {
                 ::dummyGetDocument
             )
         server.service.implementation.set { viranomainen, _ -> successResponse(viranomainen) }
-        val exception = assertThrows<Exception> { client.send(message, null) }
+        val exception = assertThrows<Exception> { client.send(message) }
         val cause = exception.cause as WebServiceFaultException
         assertEquals(
             QName("http://ws.apache.org/wss4j", "SecurityError"),
@@ -194,7 +194,7 @@ class SoapStackIntegrationTest {
                 ::dummyGetDocument
             )
         server.service.implementation.set { viranomainen, _ -> successResponse(viranomainen) }
-        val exception = assertThrows<Exception> { client.send(message, null) }
+        val exception = assertThrows<Exception> { client.send(message) }
         val cause = exception.cause as WebServiceIOException
         assertTrue(cause.contains(SSLHandshakeException::class.java))
     }
@@ -249,7 +249,7 @@ class SoapStackIntegrationTest {
 
             successResponse(viranomainen)
         }
-        client.send(message, null)
+        client.send(message)
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionController.kt
@@ -408,9 +408,7 @@ class AssistanceNeedDecisionController(
                         asyncJobRunner.plan(
                             tx,
                             listOf(
-                                AsyncJob.SendAssistanceNeedDecisionEmail(id),
                                 AsyncJob.CreateAssistanceNeedDecisionPdf(id),
-                                AsyncJob.SendAssistanceNeedDecisionSfiMessage(id)
                             ),
                             runAt = clock.now()
                         )

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
@@ -27,7 +27,6 @@ import fi.espoo.evaka.pis.service.getChildGuardiansAndFosterParents
 import fi.espoo.evaka.s3.Document
 import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.sficlient.SfiMessage
-import fi.espoo.evaka.sficlient.SfiMessagesClient
 import fi.espoo.evaka.shared.AssistanceNeedDecisionId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -56,17 +55,58 @@ class AssistanceNeedDecisionService(
     private val documentClient: DocumentService,
     private val templateProvider: ITemplateProvider,
     private val messageProvider: IMessageProvider,
-    private val sfiClient: SfiMessagesClient,
     bucketEnv: BucketEnv,
     private val emailEnv: EmailEnv,
-    asyncJobRunner: AsyncJobRunner<AsyncJob>
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     private val bucket = bucketEnv.data
 
     init {
-        asyncJobRunner.registerHandler(::runSendAssistanceNeedDecisionEmail)
         asyncJobRunner.registerHandler(::runCreateAssistanceNeedDecisionPdf)
+        asyncJobRunner.registerHandler(::runSendAssistanceNeedDecisionEmail)
         asyncJobRunner.registerHandler(::runSendSfiDecision)
+    }
+
+    fun runCreateAssistanceNeedDecisionPdf(
+        db: Database.Connection,
+        clock: EvakaClock,
+        msg: AsyncJob.CreateAssistanceNeedDecisionPdf
+    ) {
+        val decisionId = msg.decisionId
+        db.transaction { tx ->
+            val decision = tx.getAssistanceNeedDecisionById(decisionId)
+
+            check(!decision.hasDocument) {
+                "Assistance need decision $decisionId has a document key already"
+            }
+
+            val pdf = generatePdf(clock.today(), decision)
+            val key =
+                documentClient
+                    .upload(
+                        bucket,
+                        Document(
+                            "${assistanceNeedDecisionsBucketPrefix}assistance_need_decision_$decisionId.pdf",
+                            pdf,
+                            "application/pdf"
+                        )
+                    )
+                    .key
+            tx.updateAssistanceNeedDocumentKey(decision.id, key)
+
+            asyncJobRunner.plan(
+                tx,
+                listOf(
+                    AsyncJob.SendAssistanceNeedDecisionEmail(msg.decisionId),
+                    AsyncJob.SendAssistanceNeedDecisionSfiMessage(msg.decisionId)
+                ),
+                runAt = clock.now()
+            )
+
+            logger.info {
+                "Successfully created assistance need decision pdf (id: ${msg.decisionId})."
+            }
+        }
     }
 
     fun runSendAssistanceNeedDecisionEmail(
@@ -74,16 +114,10 @@ class AssistanceNeedDecisionService(
         clock: EvakaClock,
         msg: AsyncJob.SendAssistanceNeedDecisionEmail
     ) {
-        this.sendDecisionEmail(db, msg.decisionId, clock.today())
-        logger.info { "Successfully sent assistance need decision email (id: ${msg.decisionId})." }
-    }
+        val decisionId = msg.decisionId
+        val today = clock.today()
 
-    fun sendDecisionEmail(
-        dbc: Database.Connection,
-        decisionId: AssistanceNeedDecisionId,
-        today: LocalDate
-    ) {
-        val decision = dbc.read { tx -> tx.getAssistanceNeedDecisionById(decisionId) }
+        val decision = db.read { tx -> tx.getAssistanceNeedDecisionById(decisionId) }
 
         if (decision.child?.id == null) {
             throw IllegalStateException(
@@ -94,7 +128,7 @@ class AssistanceNeedDecisionService(
         logger.info { "Sending assistance need decision email (decisionId: $decision)" }
 
         val guardians =
-            dbc.read { tx -> tx.getChildGuardiansAndFosterParents(decision.child.id, today) }
+            db.read { tx -> tx.getChildGuardiansAndFosterParents(decision.child.id, today) }
 
         val language =
             when (decision.language) {
@@ -106,7 +140,7 @@ class AssistanceNeedDecisionService(
 
         guardians.forEach { guardianId ->
             Email.create(
-                    dbc,
+                    db,
                     guardianId,
                     EmailMessageType.DECISION_NOTIFICATION,
                     fromAddress,
@@ -115,19 +149,8 @@ class AssistanceNeedDecisionService(
                 )
                 ?.also { emailClient.send(it) }
         }
-    }
 
-    fun runCreateAssistanceNeedDecisionPdf(
-        db: Database.Connection,
-        clock: EvakaClock,
-        msg: AsyncJob.CreateAssistanceNeedDecisionPdf
-    ) {
-        db.transaction { tx ->
-            this.createDecisionPdf(tx, clock, msg.decisionId)
-            logger.info {
-                "Successfully created assistance need decision pdf (id: ${msg.decisionId})."
-            }
-        }
+        logger.info { "Successfully sent assistance need decision email (id: ${msg.decisionId})." }
     }
 
     fun runSendSfiDecision(
@@ -135,97 +158,75 @@ class AssistanceNeedDecisionService(
         clock: EvakaClock,
         msg: AsyncJob.SendAssistanceNeedDecisionSfiMessage
     ) {
+        val decisionId = msg.decisionId
         db.transaction { tx ->
-            this.createAndSendSfiDecisionPdf(tx, clock, msg.decisionId)
-            logger.info {
-                "Successfully created assistance need decision pdf for Suomi.fi (id: ${msg.decisionId})."
-            }
-        }
-    }
+            val decision = tx.getAssistanceNeedDecisionById(decisionId)
 
-    fun createDecisionPdf(
-        tx: Database.Transaction,
-        clock: EvakaClock,
-        decisionId: AssistanceNeedDecisionId
-    ) {
-        val decision = tx.getAssistanceNeedDecisionById(decisionId)
-
-        check(!decision.hasDocument) {
-            "Assistance need decision $decisionId has a document key already"
-        }
-
-        val pdf = generatePdf(clock.today(), decision)
-        val key =
-            documentClient
-                .upload(
-                    bucket,
-                    Document(
-                        "${assistanceNeedDecisionsBucketPrefix}assistance_need_decision_$decisionId.pdf",
-                        pdf,
-                        "application/pdf"
-                    )
+            if (decision.child?.id == null) {
+                throw IllegalStateException(
+                    "Assistance need decision has to be associated with a child"
                 )
-                .key
-        tx.updateAssistanceNeedDocumentKey(decision.id, key)
-    }
+            }
 
-    fun createAndSendSfiDecisionPdf(
-        tx: Database.Transaction,
-        clock: EvakaClock,
-        decisionId: AssistanceNeedDecisionId
-    ) {
-        val decision = tx.getAssistanceNeedDecisionById(decisionId)
+            val documentKey =
+                tx.getAssistanceNeedDecisionDocumentKey(decisionId)
+                    ?: throw IllegalStateException(
+                        "Assistance need decision pdf has not yet been generated"
+                    )
 
-        if (decision.child?.id == null) {
-            throw IllegalStateException(
-                "Assistance need decision has to be associated with a child"
-            )
-        }
+            val lang =
+                if (decision.language == AssistanceNeedDecisionLanguage.SV) DocumentLang.SV
+                else DocumentLang.FI
 
-        val lang =
-            if (decision.language == AssistanceNeedDecisionLanguage.SV) DocumentLang.SV
-            else DocumentLang.FI
-
-        tx.getChildGuardiansAndFosterParents(decision.child.id, clock.today())
-            .mapNotNull { tx.getPersonById(it) }
-            .forEach { guardian ->
-                if (guardian.identity !is ExternalIdentifier.SSN) {
-                    logger.info {
-                        "Cannot deliver assistance need decision ${decision.id} to guardian via Sfi. SSN is missing."
+            tx.getChildGuardiansAndFosterParents(decision.child.id, clock.today())
+                .mapNotNull { tx.getPersonById(it) }
+                .forEach { guardian ->
+                    if (guardian.identity !is ExternalIdentifier.SSN) {
+                        logger.info {
+                            "Cannot deliver assistance need decision ${decision.id} to guardian via Sfi. SSN is missing."
+                        }
+                        return@forEach
                     }
-                    return@forEach
+
+                    val sendAddress = getSendAddress(messageProvider, guardian, lang)
+
+                    val messageHeader =
+                        messageProvider.getAssistanceNeedDecisionHeader(lang.messageLang)
+                    val messageContent =
+                        messageProvider.getAssistanceNeedDecisionContent(lang.messageLang)
+                    val messageId = "${decision.id}_${guardian.id}"
+
+                    asyncJobRunner.plan(
+                        tx,
+                        listOf(
+                            AsyncJob.SendMessage(
+                                SfiMessage(
+                                    messageId = messageId,
+                                    documentId = messageId,
+                                    documentDisplayName =
+                                        suomiFiDocumentFileName(decision.language),
+                                    documentKey = documentKey,
+                                    documentBucket = bucket,
+                                    language = lang.langCode,
+                                    firstName = guardian.firstName,
+                                    lastName = guardian.lastName,
+                                    streetAddress = sendAddress.street,
+                                    postalCode = sendAddress.postalCode,
+                                    postOffice = sendAddress.postOffice,
+                                    ssn = guardian.identity.ssn,
+                                    messageHeader = messageHeader,
+                                    messageContent = messageContent
+                                )
+                            )
+                        ),
+                        runAt = clock.now()
+                    )
                 }
 
-                val sendAddress = getSendAddress(messageProvider, guardian, lang)
-
-                val pdf = generatePdf(clock.today(), decision, sendAddress, guardian)
-
-                val messageHeader =
-                    messageProvider.getAssistanceNeedDecisionHeader(lang.messageLang)
-                val messageContent =
-                    messageProvider.getAssistanceNeedDecisionContent(lang.messageLang)
-                val messageId = "${decision.id}_${guardian.id}"
-
-                sfiClient.send(
-                    SfiMessage(
-                        messageId = messageId,
-                        documentId = messageId,
-                        documentDisplayName = suomiFiDocumentFileName(decision.language),
-                        documentKey = "",
-                        documentBucket = "",
-                        language = lang.langCode,
-                        firstName = guardian.firstName,
-                        lastName = guardian.lastName,
-                        streetAddress = sendAddress.street,
-                        postalCode = sendAddress.postalCode,
-                        postOffice = sendAddress.postOffice,
-                        ssn = guardian.identity.ssn,
-                        messageHeader = messageHeader,
-                        messageContent = messageContent
-                    ),
-                    pdf
-                )
+            logger.info {
+                "Successfully scheduled assistance need decision pdf for Suomi.fi sending (id: ${msg.decisionId})."
             }
+        }
     }
 
     fun getDecisionPdfResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
@@ -77,7 +77,7 @@ class AssistanceNeedDecisionService(
             val decision = tx.getAssistanceNeedDecisionById(decisionId)
 
             check(!decision.hasDocument) {
-                "Assistance need decision $decisionId has a document key already"
+                "A pdf already exists for the assistance need decision $decisionId"
             }
 
             val pdf = generatePdf(clock.today(), decision)

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionController.kt
@@ -237,11 +237,7 @@ class AssistanceNeedPreschoolDecisionController(
                     if (decided) {
                         asyncJobRunner.plan(
                             tx,
-                            listOf(
-                                AsyncJob.SendAssistanceNeedPreschoolDecisionEmail(id),
-                                AsyncJob.CreateAssistanceNeedPreschoolDecisionPdf(id),
-                                AsyncJob.SendAssistanceNeedPreschoolDecisionSfiMessage(id)
-                            ),
+                            listOf(AsyncJob.CreateAssistanceNeedPreschoolDecisionPdf(id)),
                             runAt = clock.now()
                         )
                     }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionService.kt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -25,7 +25,6 @@ import fi.espoo.evaka.pis.service.getChildGuardiansAndFosterParents
 import fi.espoo.evaka.s3.Document
 import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.sficlient.SfiMessage
-import fi.espoo.evaka.sficlient.SfiMessagesClient
 import fi.espoo.evaka.shared.AssistanceNeedPreschoolDecisionId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -53,17 +52,64 @@ class AssistanceNeedPreschoolDecisionService(
     private val documentClient: DocumentService,
     private val templateProvider: ITemplateProvider,
     private val messageProvider: IMessageProvider,
-    private val sfiClient: SfiMessagesClient,
     bucketEnv: BucketEnv,
     private val emailEnv: EmailEnv,
-    asyncJobRunner: AsyncJobRunner<AsyncJob>
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     private val bucket = bucketEnv.data
 
     init {
-        asyncJobRunner.registerHandler(::runSendAssistanceNeedPreschoolDecisionEmail)
         asyncJobRunner.registerHandler(::runCreateAssistanceNeedPreschoolDecisionPdf)
+        asyncJobRunner.registerHandler(::runSendAssistanceNeedPreschoolDecisionEmail)
         asyncJobRunner.registerHandler(::runSendSfiDecision)
+    }
+
+    fun runCreateAssistanceNeedPreschoolDecisionPdf(
+        db: Database.Connection,
+        clock: EvakaClock,
+        msg: AsyncJob.CreateAssistanceNeedPreschoolDecisionPdf
+    ) {
+        val decisionId = msg.decisionId
+        db.transaction { tx ->
+            val decision = tx.getAssistanceNeedPreschoolDecisionById(decisionId)
+            val endDate =
+                tx.getAssistanceNeedPreschoolDecisionsByChildId(decision.child.id)
+                    .find { it.id == decisionId }
+                    ?.validTo
+
+            check(!decision.hasDocument) {
+                "Assistance need preschool decision $decisionId already has a document key"
+            }
+
+            val pdf = generatePdf(clock.today(), decision, endDate)
+
+            val key =
+                documentClient
+                    .upload(
+                        bucket,
+                        Document(
+                            "${assistanceNeedDecisionsBucketPrefix}assistance_need_preschool_decision_$decisionId.pdf",
+                            pdf,
+                            "application/pdf"
+                        )
+                    )
+                    .key
+
+            tx.updateAssistanceNeedPreschoolDocumentKey(decision.id, key)
+
+            asyncJobRunner.plan(
+                tx,
+                listOf(
+                    AsyncJob.SendAssistanceNeedPreschoolDecisionEmail(decisionId),
+                    AsyncJob.SendAssistanceNeedPreschoolDecisionSfiMessage(decisionId)
+                ),
+                runAt = clock.now()
+            )
+
+            logger.info {
+                "Successfully created assistance need preschool decision pdf (id: $decisionId)."
+            }
+        }
     }
 
     fun runSendAssistanceNeedPreschoolDecisionEmail(
@@ -71,20 +117,12 @@ class AssistanceNeedPreschoolDecisionService(
         clock: EvakaClock,
         msg: AsyncJob.SendAssistanceNeedPreschoolDecisionEmail
     ) {
-        this.sendDecisionEmail(db, msg.decisionId, clock.today())
-        logger.info {
-            "Successfully sent assistance need preschool decision email (id: ${msg.decisionId})."
-        }
-    }
+        val decisionId = msg.decisionId
+        val today = clock.today()
 
-    fun sendDecisionEmail(
-        dbc: Database.Connection,
-        decisionId: AssistanceNeedPreschoolDecisionId,
-        today: LocalDate
-    ) {
-        val decision = dbc.read { tx -> tx.getAssistanceNeedPreschoolDecisionById(decisionId) }
+        val decision = db.read { tx -> tx.getAssistanceNeedPreschoolDecisionById(decisionId) }
 
-        logger.info { "Sending assistance need decision email (decisionId: $decision)" }
+        logger.info { "Sending assistance need preschool decision email (decisionId: $decision)" }
 
         val language =
             when (decision.form.language) {
@@ -95,10 +133,10 @@ class AssistanceNeedPreschoolDecisionService(
         val content = emailMessageProvider.assistanceNeedPreschoolDecisionNotification(language)
 
         val guardians =
-            dbc.read { tx -> tx.getChildGuardiansAndFosterParents(decision.child.id, today) }
+            db.read { tx -> tx.getChildGuardiansAndFosterParents(decision.child.id, today) }
         guardians.forEach { guardianId ->
             Email.create(
-                    dbc,
+                    db,
                     guardianId,
                     EmailMessageType.DECISION_NOTIFICATION,
                     fromAddress,
@@ -107,51 +145,80 @@ class AssistanceNeedPreschoolDecisionService(
                 )
                 ?.also { emailClient.send(it) }
         }
+
+        logger.info {
+            "Successfully sent assistance need preschool decision email (id: $decisionId)."
+        }
     }
 
-    fun runCreateAssistanceNeedPreschoolDecisionPdf(
+    fun runSendSfiDecision(
         db: Database.Connection,
         clock: EvakaClock,
-        msg: AsyncJob.CreateAssistanceNeedPreschoolDecisionPdf
+        msg: AsyncJob.SendAssistanceNeedPreschoolDecisionSfiMessage
     ) {
+        val decisionId = msg.decisionId
         db.transaction { tx ->
-            this.createDecisionPdf(tx, clock, msg.decisionId)
+            val decision = tx.getAssistanceNeedPreschoolDecisionById(decisionId)
+
+            val documentKey =
+                tx.getAssistanceNeedPreschoolDecisionDocumentKey(decisionId)
+                    ?: throw IllegalStateException(
+                        "Assistance need preschool decision pdf has not yet been generated"
+                    )
+
+            val lang =
+                if (decision.form.language == AssistanceNeedDecisionLanguage.SV) DocumentLang.SV
+                else DocumentLang.FI
+
+            tx.getChildGuardiansAndFosterParents(decision.child.id, clock.today())
+                .mapNotNull { tx.getPersonById(it) }
+                .forEach { guardian ->
+                    if (guardian.identity !is ExternalIdentifier.SSN) {
+                        logger.info {
+                            "Cannot deliver assistance need decision ${decision.id} to guardian via Sfi. SSN is missing."
+                        }
+                        return@forEach
+                    }
+
+                    val sendAddress = getSendAddress(messageProvider, guardian, lang)
+
+                    val messageHeader =
+                        messageProvider.getAssistanceNeedPreschoolDecisionHeader(lang.messageLang)
+                    val messageContent =
+                        messageProvider.getAssistanceNeedPreschoolDecisionContent(lang.messageLang)
+                    val messageId = "${decision.id}_${guardian.id}"
+
+                    asyncJobRunner.plan(
+                        tx,
+                        listOf(
+                            AsyncJob.SendMessage(
+                                SfiMessage(
+                                    messageId = messageId,
+                                    documentId = messageId,
+                                    documentDisplayName =
+                                        suomiFiDocumentFileName(decision.form.language),
+                                    documentKey = documentKey,
+                                    documentBucket = bucket,
+                                    language = lang.langCode,
+                                    firstName = guardian.firstName,
+                                    lastName = guardian.lastName,
+                                    streetAddress = sendAddress.street,
+                                    postalCode = sendAddress.postalCode,
+                                    postOffice = sendAddress.postOffice,
+                                    ssn = guardian.identity.ssn,
+                                    messageHeader = messageHeader,
+                                    messageContent = messageContent
+                                )
+                            )
+                        ),
+                        runAt = clock.now()
+                    )
+                }
+
             logger.info {
-                "Successfully created assistance need decision pdf (id: ${msg.decisionId})."
+                "Successfully scheduled assistance need preschool decision pdf for Suomi.fi sending (id: $decisionId)."
             }
         }
-    }
-
-    fun createDecisionPdf(
-        tx: Database.Transaction,
-        clock: EvakaClock,
-        decisionId: AssistanceNeedPreschoolDecisionId
-    ) {
-        val decision = tx.getAssistanceNeedPreschoolDecisionById(decisionId)
-        val endDate =
-            tx.getAssistanceNeedPreschoolDecisionsByChildId(decision.child.id)
-                .find { it.id == decisionId }
-                ?.validTo
-
-        check(!decision.hasDocument) {
-            "Assistance need preschool decision $decisionId already has a document key"
-        }
-
-        val pdf = generatePdf(clock.today(), decision, endDate)
-
-        val key =
-            documentClient
-                .upload(
-                    bucket,
-                    Document(
-                        "${assistanceNeedDecisionsBucketPrefix}assistance_need_preschool_decision_$decisionId.pdf",
-                        pdf,
-                        "application/pdf"
-                    )
-                )
-                .key
-
-        tx.updateAssistanceNeedPreschoolDocumentKey(decision.id, key)
     }
 
     fun getDecisionPdfResponse(
@@ -187,76 +254,6 @@ class AssistanceNeedPreschoolDecisionService(
                 }
             )
         )
-    }
-
-    fun runSendSfiDecision(
-        db: Database.Connection,
-        clock: EvakaClock,
-        msg: AsyncJob.SendAssistanceNeedPreschoolDecisionSfiMessage
-    ) {
-        db.transaction { tx ->
-            this.createAndSendSfiDecisionPdf(tx, clock, msg.decisionId)
-            logger.info {
-                "Successfully created assistance need decision pdf for Suomi.fi (id: ${msg.decisionId})."
-            }
-        }
-    }
-
-    fun createAndSendSfiDecisionPdf(
-        tx: Database.Transaction,
-        clock: EvakaClock,
-        decisionId: AssistanceNeedPreschoolDecisionId
-    ) {
-        val decision = tx.getAssistanceNeedPreschoolDecisionById(decisionId)
-        val endDate =
-            tx.getAssistanceNeedPreschoolDecisionsByChildId(decision.child.id)
-                .find { it.id == decisionId }
-                ?.validTo
-
-        val lang =
-            if (decision.form.language == AssistanceNeedDecisionLanguage.SV) DocumentLang.SV
-            else DocumentLang.FI
-
-        tx.getChildGuardiansAndFosterParents(decision.child.id, clock.today())
-            .mapNotNull { tx.getPersonById(it) }
-            .forEach { guardian ->
-                if (guardian.identity !is ExternalIdentifier.SSN) {
-                    logger.info {
-                        "Cannot deliver assistance need decision ${decision.id} to guardian via Sfi. SSN is missing."
-                    }
-                    return@forEach
-                }
-
-                val sendAddress = getSendAddress(messageProvider, guardian, lang)
-
-                val pdf = generatePdf(clock.today(), decision, endDate, sendAddress, guardian)
-
-                val messageHeader =
-                    messageProvider.getAssistanceNeedPreschoolDecisionHeader(lang.messageLang)
-                val messageContent =
-                    messageProvider.getAssistanceNeedPreschoolDecisionContent(lang.messageLang)
-                val messageId = "${decision.id}_${guardian.id}"
-
-                sfiClient.send(
-                    SfiMessage(
-                        messageId = messageId,
-                        documentId = messageId,
-                        documentDisplayName = suomiFiDocumentFileName(decision.form.language),
-                        documentKey = "",
-                        documentBucket = "",
-                        language = lang.langCode,
-                        firstName = guardian.firstName,
-                        lastName = guardian.lastName,
-                        streetAddress = sendAddress.street,
-                        postalCode = sendAddress.postalCode,
-                        postOffice = sendAddress.postOffice,
-                        ssn = guardian.identity.ssn,
-                        messageHeader = messageHeader,
-                        messageContent = messageContent
-                    ),
-                    pdf
-                )
-            }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionService.kt
@@ -78,7 +78,7 @@ class AssistanceNeedPreschoolDecisionService(
                     ?.validTo
 
             check(!decision.hasDocument) {
-                "Assistance need preschool decision $decisionId already has a document key"
+                "A pdf already exists for the assistance need preschool decision $decisionId"
             }
 
             val pdf = generatePdf(clock.today(), decision, endDate)

--- a/service/src/main/kotlin/fi/espoo/evaka/sficlient/MockSfiMessagesClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sficlient/MockSfiMessagesClient.kt
@@ -14,23 +14,16 @@ private typealias MessageId = String
 class MockSfiMessagesClient : SfiMessagesClient {
     private val logger = KotlinLogging.logger {}
 
-    override fun send(msg: SfiMessage, bytes: ByteArray?) {
+    override fun send(msg: SfiMessage) {
         logger.info("Mock message client got $msg")
-        lock.write {
-            data[msg.messageId] = msg
-            if (bytes != null) {
-                dataBytes[msg.messageId] = bytes
-            }
-        }
+        lock.write { data[msg.messageId] = msg }
     }
 
     companion object {
         private val data = mutableMapOf<MessageId, SfiMessage>()
-        private val dataBytes = mutableMapOf<MessageId, ByteArray?>()
         private val lock = ReentrantReadWriteLock()
 
-        fun getMessages() =
-            lock.read { data.values.toList().map { Pair(it, dataBytes[it.messageId]) } }
+        fun getMessages() = lock.read { data.values.toList() }
 
         fun clearMessages() = lock.write { data.clear() }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiAsyncJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiAsyncJobs.kt
@@ -20,6 +20,6 @@ class SfiAsyncJobs(
     }
 
     fun sendMessagePDF(msg: SfiMessage) {
-        sfiClient.send(msg, null)
+        sfiClient.send(msg)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiMessagesClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiMessagesClient.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.sficlient
 
 interface SfiMessagesClient {
-    fun send(msg: SfiMessage, bytes: ByteArray?)
+    fun send(msg: SfiMessage)
 }
 
 data class SfiMessage(

--- a/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiMessagesSoapClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiMessagesSoapClient.kt
@@ -130,8 +130,8 @@ class SfiMessagesSoapClient(
 
     private val logger = KotlinLogging.logger {}
 
-    override fun send(msg: SfiMessage, bytes: ByteArray?) {
-        val pdfBytes = bytes ?: getDocument(msg.documentBucket, msg.documentKey).bytes
+    override fun send(msg: SfiMessage) {
+        val pdfBytes = getDocument(msg.documentBucket, msg.documentKey).bytes
 
         logger.info(
             mapOf("meta" to mapOf("caseId" to msg.documentId, "messageId" to msg.messageId))

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -775,7 +775,7 @@ RETURNING id
 
     @GetMapping("/messages")
     fun getMessages(db: Database): List<SfiMessage> {
-        return MockSfiMessagesClient.getMessages().map { it.first }
+        return MockSfiMessagesClient.getMessages()
     }
 
     @PostMapping("/messages/clean-up")


### PR DESCRIPTION
#### Summary

- Make async jobs more serial so that email and sfi sending jobs are planned after pdf generation
- This way pdf does not need to be generated twice, but sfi job can use the pdf from s3
- Sfi sending now plans AsyncJob.SendMessage instead of calling sfiClient, so that the ratelimit is shared correctly together with other sfi messages
- Remove second argument from sfiClient? It is now always null and apparently should never be used
