### PR TITLE
Show used service time and warnings in citizen day view

### DIFF
--- a/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
+++ b/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
@@ -37,7 +37,7 @@ function AttendanceInfoWithSimpleThreshold({
       <ReservationAttendanceHeading>
         {i18n.calendar.attendance}
       </ReservationAttendanceHeading>
-      <div>
+      <div data-qa="attendances">
         {attendances.length > 0
           ? attendances.map((timeInterval) => (
               <div key={timeInterval.format()}>{timeInterval.format()}</div>
@@ -100,7 +100,7 @@ function AttendanceInfoWithServiceUsage({
       <ReservationAttendanceHeading>
         {i18n.calendar.attendance}
       </ReservationAttendanceHeading>
-      <div>
+      <div data-qa="attendances">
         {attendances.length > 0 ? (
           <>
             {attendances.map((timeInterval, index, array) => (
@@ -131,14 +131,14 @@ function AttendanceInfoWithServiceUsage({
         )}
       </div>
       {showAttendanceWarning && (
-        <ReservationAttendanceSection>
+        <ReservationAttendanceSection data-qa="service-usage-warning">
           <AlertBox message={attendanceWarning} wide />
         </ReservationAttendanceSection>
       )}
       <ReservationAttendanceHeading>
         {i18n.calendar.usedService}
       </ReservationAttendanceHeading>
-      <div>
+      <div data-qa="used-service">
         {usedService.usedServiceRanges.length > 0 ||
         usedService.usedServiceMinutes > 0 ? (
           <>

--- a/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
+++ b/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
@@ -11,6 +11,7 @@ import {
 import { reservationsAndAttendancesDiffer } from 'lib-common/reservations'
 import TimeInterval from 'lib-common/time-interval'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
+import { featureFlags } from 'lib-customizations/citizen'
 
 import { useTranslation } from '../localization'
 
@@ -169,7 +170,7 @@ export default React.memo(function AttendanceInfo({
   reservations,
   usedService
 }: AttendanceInfoProps) {
-  return usedService ? (
+  return featureFlags.timeUsageInfo && usedService ? (
     <AttendanceInfoWithServiceUsage
       attendances={attendances}
       reservations={reservations}

--- a/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
+++ b/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
@@ -6,10 +6,10 @@ import React from 'react'
 
 import {
   ReservationResponse,
-  TimeInterval,
   UsedServiceResult
 } from 'lib-common/generated/api-types/reservations'
 import { reservationsAndAttendancesDiffer } from 'lib-common/reservations'
+import TimeInterval from 'lib-common/time-interval'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 
 import { useTranslation } from '../localization'
@@ -36,15 +36,9 @@ function AttendanceInfoWithSimpleThreshold({
       </ReservationAttendanceHeading>
       <div>
         {attendances.length > 0
-          ? attendances.map(({ startTime, endTime }) => {
-              const start = startTime.format()
-              const end = endTime?.format() ?? ''
-              return (
-                <div key={`${start}-${end}`}>
-                  {start} – {end}
-                </div>
-              )
-            })
+          ? attendances.map((timeInterval) => (
+              <div key={timeInterval.format()}>{timeInterval.format()}</div>
+            ))
           : '–'}
 
         {showAttendanceWarning && (
@@ -80,13 +74,13 @@ function AttendanceInfoWithServiceUsage({
     attendances.length === 1 &&
     reservations.length === 1 &&
     reservations[0].type === 'TIMES' &&
-    attendances[0].startTime < reservations[0].startTime
+    attendances[0].start < reservations[0].range.start
   const simpleExceedEnd =
     attendances.length === 1 &&
     reservations.length === 1 &&
     reservations[0].type === 'TIMES' &&
-    !!attendances[0].endTime &&
-    attendances[0].endTime > reservations[0].endTime
+    !!attendances[0].end &&
+    attendances[0].end > reservations[0].range.end
   const simpleExceedWarning =
     (simpleExceedStart ? i18n.calendar.exceedStart + ' ' : '') +
     (simpleExceedEnd ? i18n.calendar.exceedEnd : '')
@@ -106,18 +100,17 @@ function AttendanceInfoWithServiceUsage({
       <div>
         {attendances.length > 0 ? (
           <>
-            {attendances.map(({ startTime, endTime }) => {
-              const start = startTime.format()
-              const end = endTime?.format() ?? ''
-              return (
-                <div key={`${start}-${end}`}>
-                  <TimeDisplay highlight={simpleExceedStart}>
-                    {start}
-                  </TimeDisplay>
-                  –<TimeDisplay highlight={simpleExceedEnd}>{end}</TimeDisplay>
-                </div>
-              )
-            })}
+            {attendances.map((timeInterval) => (
+              <div key={timeInterval.format()}>
+                <TimeDisplay highlight={simpleExceedStart}>
+                  {timeInterval.formatStart()}
+                </TimeDisplay>
+                –
+                <TimeDisplay highlight={simpleExceedEnd}>
+                  {timeInterval.formatEnd()}
+                </TimeDisplay>
+              </div>
+            ))}
             {extraUsageMinutes > 0 && (
               <>
                 (

--- a/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
+++ b/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
@@ -14,7 +14,10 @@ import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 
 import { useTranslation } from '../localization'
 
-import { ReservationAttendanceHeading } from './DayView'
+import {
+  ReservationAttendanceSection,
+  ReservationAttendanceHeading
+} from './DayView'
 import { HoursMinutes } from './MonthlyHoursSummary'
 
 function AttendanceInfoWithSimpleThreshold({
@@ -74,13 +77,13 @@ function AttendanceInfoWithServiceUsage({
     attendances.length === 1 &&
     reservations.length === 1 &&
     reservations[0].type === 'TIMES' &&
-    attendances[0].start < reservations[0].range.start
+    attendances[0].start.isBefore(reservations[0].range.start)
   const simpleExceedEnd =
     attendances.length === 1 &&
     reservations.length === 1 &&
     reservations[0].type === 'TIMES' &&
     !!attendances[0].end &&
-    attendances[0].end > reservations[0].range.end
+    attendances[0].end.isAfter(reservations[0].range.end)
   const simpleExceedWarning =
     (simpleExceedStart ? i18n.calendar.exceedStart + ' ' : '') +
     (simpleExceedEnd ? i18n.calendar.exceedEnd : '')
@@ -100,8 +103,8 @@ function AttendanceInfoWithServiceUsage({
       <div>
         {attendances.length > 0 ? (
           <>
-            {attendances.map((timeInterval) => (
-              <div key={timeInterval.format()}>
+            {attendances.map((timeInterval, index, array) => (
+              <React.Fragment key={index}>
                 <TimeDisplay highlight={simpleExceedStart}>
                   {timeInterval.formatStart()}
                 </TimeDisplay>
@@ -109,10 +112,12 @@ function AttendanceInfoWithServiceUsage({
                 <TimeDisplay highlight={simpleExceedEnd}>
                   {timeInterval.formatEnd()}
                 </TimeDisplay>
-              </div>
+                {index < array.length - 1 && ', '}
+              </React.Fragment>
             ))}
             {extraUsageMinutes > 0 && (
               <>
+                {' '}
                 (
                 <strong>
                   + <HoursMinutes minutes={extraUsageMinutes} />
@@ -123,9 +128,13 @@ function AttendanceInfoWithServiceUsage({
           </>
         ) : (
           '–'
-        )}{' '}
-        {showAttendanceWarning && <AlertBox message={attendanceWarning} wide />}
+        )}
       </div>
+      {showAttendanceWarning && (
+        <ReservationAttendanceSection>
+          <AlertBox message={attendanceWarning} wide />
+        </ReservationAttendanceSection>
+      )}
       <ReservationAttendanceHeading>
         {i18n.calendar.usedService}
       </ReservationAttendanceHeading>
@@ -133,9 +142,12 @@ function AttendanceInfoWithServiceUsage({
         {usedService.usedServiceRanges.length > 0 ||
         usedService.usedServiceMinutes > 0 ? (
           <>
-            {usedService.usedServiceRanges.map((timeRange, index) => (
-              <div key={index}>{timeRange.format()}</div>
-            ))}
+            {usedService.usedServiceRanges.map((timeRange, index, array) => (
+              <React.Fragment key={index}>
+                {timeRange.format()}
+                {index < array.length - 1 && ', '}
+              </React.Fragment>
+            ))}{' '}
             (<HoursMinutes minutes={usedService.usedServiceMinutes} />)
           </>
         ) : (

--- a/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
+++ b/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+
+import {
+  ReservationResponse,
+  TimeInterval,
+  UsedServiceResult
+} from 'lib-common/generated/api-types/reservations'
+import { reservationsAndAttendancesDiffer } from 'lib-common/reservations'
+import { AlertBox } from 'lib-components/molecules/MessageBoxes'
+
+import { useTranslation } from '../localization'
+
+import { ReservationAttendanceHeading } from './DayView'
+import { HoursMinutes } from './MonthlyHoursSummary'
+
+function AttendanceInfoWithSimpleThreshold({
+  attendances,
+  reservations
+}: {
+  attendances: TimeInterval[]
+  reservations: ReservationResponse[]
+}) {
+  const i18n = useTranslation()
+  const showAttendanceWarning = reservationsAndAttendancesDiffer(
+    reservations,
+    attendances
+  )
+  return (
+    <>
+      <ReservationAttendanceHeading>
+        {i18n.calendar.attendance}
+      </ReservationAttendanceHeading>
+      <div>
+        {attendances.length > 0
+          ? attendances.map(({ startTime, endTime }) => {
+              const start = startTime.format()
+              const end = endTime?.format() ?? ''
+              return (
+                <div key={`${start}-${end}`}>
+                  {start} – {end}
+                </div>
+              )
+            })
+          : '–'}
+
+        {showAttendanceWarning && (
+          <AlertBox message={i18n.calendar.attendanceWarning} wide />
+        )}
+      </div>
+    </>
+  )
+}
+
+const TimeDisplay = ({
+  children,
+  highlight
+}: {
+  children: React.ReactNode
+  highlight: boolean
+}) => (highlight ? <strong>{children}</strong> : <>{children}</>)
+
+function AttendanceInfoWithServiceUsage({
+  attendances,
+  reservations,
+  usedService
+}: {
+  attendances: TimeInterval[]
+  reservations: ReservationResponse[]
+  usedService: UsedServiceResult
+}) {
+  const i18n = useTranslation()
+  const extraUsageMinutes =
+    usedService.usedServiceMinutes - usedService.reservedMinutes
+
+  const simpleExceedStart =
+    attendances.length === 1 &&
+    reservations.length === 1 &&
+    reservations[0].type === 'TIMES' &&
+    attendances[0].startTime < reservations[0].startTime
+  const simpleExceedEnd =
+    attendances.length === 1 &&
+    reservations.length === 1 &&
+    reservations[0].type === 'TIMES' &&
+    !!attendances[0].endTime &&
+    attendances[0].endTime > reservations[0].endTime
+  const simpleExceedWarning =
+    (simpleExceedStart ? i18n.calendar.exceedStart + ' ' : '') +
+    (simpleExceedEnd ? i18n.calendar.exceedEnd : '')
+
+  const showAttendanceWarning = extraUsageMinutes > 0
+  const usageFromMonthlyAverage = usedService.usedServiceRanges.length === 0
+  const attendanceWarning = usageFromMonthlyAverage
+    ? i18n.calendar.calculatedUsedServiceTime
+    : simpleExceedWarning != ''
+      ? simpleExceedWarning
+      : i18n.calendar.exceedGeneric
+  return (
+    <>
+      <ReservationAttendanceHeading>
+        {i18n.calendar.attendance}
+      </ReservationAttendanceHeading>
+      <div>
+        {attendances.length > 0 ? (
+          <>
+            {attendances.map(({ startTime, endTime }) => {
+              const start = startTime.format()
+              const end = endTime?.format() ?? ''
+              return (
+                <div key={`${start}-${end}`}>
+                  <TimeDisplay highlight={simpleExceedStart}>
+                    {start}
+                  </TimeDisplay>
+                  –<TimeDisplay highlight={simpleExceedEnd}>{end}</TimeDisplay>
+                </div>
+              )
+            })}
+            {extraUsageMinutes > 0 && (
+              <>
+                (
+                <strong>
+                  + <HoursMinutes minutes={extraUsageMinutes} />
+                </strong>
+                )
+              </>
+            )}
+          </>
+        ) : (
+          '–'
+        )}{' '}
+        {showAttendanceWarning && <AlertBox message={attendanceWarning} wide />}
+      </div>
+      <ReservationAttendanceHeading>
+        {i18n.calendar.usedService}
+      </ReservationAttendanceHeading>
+      <div>
+        {usedService.usedServiceRanges.length > 0 ||
+        usedService.usedServiceMinutes > 0 ? (
+          <>
+            {usedService.usedServiceRanges.map((timeRange, index) => (
+              <div key={index}>{timeRange.format()}</div>
+            ))}
+            (<HoursMinutes minutes={usedService.usedServiceMinutes} />)
+          </>
+        ) : (
+          '–'
+        )}
+      </div>
+    </>
+  )
+}
+
+interface AttendanceInfoProps {
+  attendances: TimeInterval[]
+  reservations: ReservationResponse[]
+  usedService: UsedServiceResult | null
+}
+
+export default React.memo(function AttendanceInfo({
+  attendances,
+  reservations,
+  usedService
+}: AttendanceInfoProps) {
+  return usedService ? (
+    <AttendanceInfoWithServiceUsage
+      attendances={attendances}
+      reservations={reservations}
+      usedService={usedService}
+    />
+  ) : (
+    <AttendanceInfoWithSimpleThreshold
+      attendances={attendances}
+      reservations={reservations}
+    />
+  )
+})

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -28,15 +28,15 @@ import {
   DailyReservationRequest,
   ReservableTimeRange,
   Reservation,
+  ReservationResponse,
   ReservationResponseDay,
-  ReservationsResponse
+  ReservationsResponse,
+  TimeInterval,
+  UsedServiceResult
 } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
 import { formatFirstName } from 'lib-common/names'
-import {
-  reservationHasTimes,
-  reservationsAndAttendancesDiffer
-} from 'lib-common/reservations'
+import { reservationHasTimes } from 'lib-common/reservations'
 import { UUID } from 'lib-common/types'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Button, { StyledButton } from 'lib-components/atoms/buttons/Button'
@@ -54,7 +54,6 @@ import {
   ExpandingInfoBox,
   InfoButton
 } from 'lib-components/molecules/ExpandingInfo'
-import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 import {
   ModalCloseButton,
   ModalHeader,
@@ -68,6 +67,7 @@ import { faChevronLeft, faChevronRight } from 'lib-icons'
 import ModalAccessibilityWrapper from '../ModalAccessibilityWrapper'
 import { Translations, useLang, useTranslation } from '../localization'
 
+import AttendanceInfo from './AttendanceInfo'
 import { BottomFooterContainer } from './BottomFooterContainer'
 import { CalendarModalBackground, CalendarModalSection } from './CalendarModal'
 import {
@@ -391,22 +391,17 @@ const DayModal = React.memo(function DayModal({
 
                       <Gap size="s" />
 
-                      <ReservationTable>
-                        <NonGridLabelLike>
+                      <ReservationAttendanceInfo>
+                        <ReservationAttendanceHeading>
                           {i18n.calendar.reservation}
-                        </NonGridLabelLike>
+                        </ReservationAttendanceHeading>
                         {renderReservation(childIndex)}
-                        <NonGridLabelLike>
-                          {i18n.calendar.realized}
-                        </NonGridLabelLike>
-                        <div>{row.attendances}</div>
-                      </ReservationTable>
-                      {row.showAttendanceWarning && (
-                        <AlertBox
-                          message={i18n.calendar.attendanceWarning}
-                          wide
+                        <AttendanceInfo
+                          attendances={row.attendances}
+                          reservations={row.reservations}
+                          usedService={row.usedService}
                         />
-                      )}
+                      </ReservationAttendanceInfo>
 
                       {row.events.length > 0 && (
                         <>
@@ -472,8 +467,9 @@ interface ModalRow {
   lastName: string
   image: ChildImageData
   duplicateInfo: string | undefined
-  attendances: React.ReactNode
-  showAttendanceWarning: boolean
+  attendances: TimeInterval[]
+  usedService: UsedServiceResult | null
+  reservations: ReservationResponse[]
   events: ModalRowEvent[]
 }
 
@@ -518,16 +514,9 @@ function computeModalData(
       lastName: person.lastName,
       image,
       duplicateInfo: duplicateChildInfo[child.childId],
-      attendances:
-        child.attendances.length > 0
-          ? child.attendances.map((attendance) => (
-              <div key={attendance.format()}>{attendance.format()}</div>
-            ))
-          : '–',
-      showAttendanceWarning: reservationsAndAttendancesDiffer(
-        child.reservations,
-        child.attendances
-      ),
+      attendances: child.attendances,
+      reservations: child.reservations,
+      usedService: child.usedService,
       events: events.flatMap((event) => {
         const currentAttending = event.attendingChildren?.[child.childId]?.find(
           ({ periods }) => periods.some((period) => period.includes(date))
@@ -825,14 +814,7 @@ const EmptyButtonFooterElement = styled.div`
   }
 `
 
-const ReservationTable = styled.div`
-  @media not all and (max-width: ${tabletMin}) {
-    display: grid;
-    grid-template-columns: 35% 65%;
-    grid-auto-rows: minmax(38px, max-content);
-    row-gap: ${defaultMargins.xxs};
-  }
-
+const ReservationAttendanceInfo = styled.div`
   @media (max-width: ${tabletMin}) {
     margin-left: ${defaultMargins.xs};
   }
@@ -842,10 +824,8 @@ const Colspan2 = styled.div`
   grid-column: 1 / span 2;
 `
 
-const NonGridLabelLike = styled(LabelLike)`
-  @media (max-width: ${tabletMin}) {
-    margin: ${defaultMargins.xs} 0px ${defaultMargins.xs} 0px;
-  }
+export const ReservationAttendanceHeading = styled(LabelLike)`
+  margin: ${defaultMargins.xs} 0px ${defaultMargins.xs} 0px;
 `
 const ReservationRow = styled.p`
   margin-top: 0px;

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -670,13 +670,13 @@ const Absence = React.memo(function Absence({
         </FixedSpaceColumn>
       </FixedSpaceRow>
       {open && (
-        <Colspan2>
+        <ReservationAttendanceSection>
           <ExpandingInfoBox
             width="auto"
             info={i18n.calendar.contactStaffToEditAbsence}
             close={onClick}
           />
-        </Colspan2>
+        </ReservationAttendanceSection>
       )}
     </>
   )
@@ -706,10 +706,11 @@ const Reservations = React.memo(function Reservations({
     </ReservationStatus>
   ) : withTimes.length > 0 ? (
     <div data-qa="reservations">
-      {withTimes.map((reservation, i) => (
-        <ReservationRow data-qa={`reservation-output-${i}`} key={`res-${i}`}>
+      {withTimes.map((reservation, i, array) => (
+        <React.Fragment key={`res-${i}`}>
           {formatReservation(reservation, reservableTimeRange, i18n)}
-        </ReservationRow>
+          {i < array.length - 1 && ', '}
+        </React.Fragment>
       ))}
     </div>
   ) : (
@@ -815,19 +816,24 @@ const EmptyButtonFooterElement = styled.div`
 `
 
 const ReservationAttendanceInfo = styled.div`
+  @media not all and (max-width: ${tabletMin}) {
+    display: grid;
+    grid-template-columns: 45% 55%;
+    grid-auto-rows: minmax(38px, max-content);
+    row-gap: ${defaultMargins.xxs};
+  }
+
   @media (max-width: ${tabletMin}) {
     margin-left: ${defaultMargins.xs};
   }
 `
 
-const Colspan2 = styled.div`
+export const ReservationAttendanceSection = styled.div`
   grid-column: 1 / span 2;
 `
 
 export const ReservationAttendanceHeading = styled(LabelLike)`
-  margin: ${defaultMargins.xs} 0px ${defaultMargins.xs} 0px;
-`
-const ReservationRow = styled.p`
-  margin-top: 0px;
-  margin-bottom: ${defaultMargins.xs};
+  @media (max-width: ${tabletMin}) {
+    margin: ${defaultMargins.xs} 0px ${defaultMargins.xs} 0px;
+  }
 `

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -31,12 +31,12 @@ import {
   ReservationResponse,
   ReservationResponseDay,
   ReservationsResponse,
-  TimeInterval,
   UsedServiceResult
 } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
 import { formatFirstName } from 'lib-common/names'
 import { reservationHasTimes } from 'lib-common/reservations'
+import TimeInterval from 'lib-common/time-interval'
 import { UUID } from 'lib-common/types'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Button, { StyledButton } from 'lib-components/atoms/buttons/Button'

--- a/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
@@ -23,14 +23,18 @@ const SummaryContainer = styled.div`
   }
 `
 
-const HoursMinutes = ({ minutes }: { minutes: number }) => {
+export const HoursMinutes = ({ minutes }: { minutes: number }) => {
   const hours = Math.floor(minutes / 60)
   const extraMinutes = minutes % 60
 
   const i18n = useTranslation()
   return (
     <>
-      {hours} {i18n.calendar.monthSummary.hours}
+      {hours > 0 && (
+        <>
+          {hours} {i18n.calendar.monthSummary.hours}
+        </>
+      )}
       {!!extraMinutes &&
         ' ' + extraMinutes + ' ' + i18n.calendar.monthSummary.minutes}
     </>

--- a/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
@@ -28,6 +28,9 @@ export const HoursMinutes = ({ minutes }: { minutes: number }) => {
   const extraMinutes = minutes % 60
 
   const i18n = useTranslation()
+  if (hours === 0 && minutes === 0) {
+    return '-'
+  }
   return (
     <>
       {hours > 0 && (
@@ -35,7 +38,7 @@ export const HoursMinutes = ({ minutes }: { minutes: number }) => {
           {hours} {i18n.calendar.monthSummary.hours}
         </>
       )}
-      {!!extraMinutes &&
+      {extraMinutes != 0 &&
         ' ' + extraMinutes + ' ' + i18n.calendar.monthSummary.minutes}
     </>
   )

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -46,7 +46,8 @@ export const Reservations = React.memo(function Reservations({
   const i18n = useTranslation()
   const showAttendanceWarning = data.children.some(
     ({ reservations, attendances, usedService }) =>
-      (usedService != null &&
+      (featureFlags.timeUsageInfo &&
+        usedService != null &&
         usedService.usedServiceMinutes > usedService.reservedMinutes) ||
       reservationsAndAttendancesDiffer(reservations, attendances)
   )

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -45,7 +45,9 @@ export const Reservations = React.memo(function Reservations({
 }) {
   const i18n = useTranslation()
   const showAttendanceWarning = data.children.some(
-    ({ reservations, attendances }) =>
+    ({ reservations, attendances, usedService }) =>
+      (usedService != null &&
+        usedService.usedServiceMinutes > usedService.reservedMinutes) ||
       reservationsAndAttendancesDiffer(reservations, attendances)
   )
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -591,12 +591,11 @@ class DayView extends Element {
       r: FormatterReservation
     ) => `${r.startTime}–${r.endTime}`
   ) {
-    const child = this.#childSection(childId)
-    for (const [i, res] of reservations.entries()) {
-      await child
-        .findByDataQa(`reservation-output-${i}`)
-        .assertTextEquals(formatter(res))
-    }
+    const reservationsElement =
+      this.#childSection(childId).findByDataQa('reservations')
+    await reservationsElement.assertTextEquals(
+      reservations.map(formatter).join(', ')
+    )
   }
 
   async assertAbsence(childId: UUID, value: string) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -597,6 +597,12 @@ class DayView extends Element {
       reservations.map(formatter).join(', ')
     )
   }
+  getServiceUsageWarning(childId: UUID) {
+    return this.#childSection(childId).findByDataQa('service-usage-warning')
+  }
+  getUsedService(childId: UUID) {
+    return this.#childSection(childId).findByDataQa('used-service')
+  }
 
   async assertAbsence(childId: UUID, value: string) {
     await this.#childSection(childId)

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-monthly-summary.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-monthly-summary.spec.ts
@@ -94,7 +94,7 @@ describe('Monthly summary', () => {
     )
     await summary.title.assertTextEquals('Läsnäolot 01.01. - 31.01.2022')
     await summary.textElement.assertTextEquals(
-      'Kaarina\n' + '\n' + 'Suunnitelma 8 h / 140 h\n' + 'Toteuma 0 h / 140 h'
+      'Kaarina\n' + '\n' + 'Suunnitelma 8 h / 140 h\n' + 'Toteuma - / 140 h'
     )
   })
 
@@ -118,7 +118,7 @@ describe('Monthly summary', () => {
     await summary.textElement.assertTextEquals(
       'Kaarina\n' +
         '\n' +
-        'Suunnitelma 0 h / 140 h\n' +
+        'Suunnitelma - / 140 h\n' +
         'Toteuma 7 h 30 min / 140 h'
     )
   })

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-show-service-usage.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-show-service-usage.spec.ts
@@ -20,6 +20,7 @@ import { Page } from '../../utils/page'
 import { enduserLogin } from '../../utils/user'
 
 const today = LocalDate.of(2022, 1, 14)
+const yesterday = today.subDays(1)
 let page: Page
 
 async function openCalendarPage() {
@@ -32,7 +33,7 @@ async function openCalendarPage() {
   return new CitizenCalendarPage(page, 'desktop')
 }
 
-describe('Monthly summary', () => {
+describe('Service time usage', () => {
   beforeEach(async () => {
     await resetDatabase()
 
@@ -63,14 +64,14 @@ describe('Monthly summary', () => {
         childId: enduserChildFixtureKaarina.id,
         unitId: daycareFixture.id,
         type: 'DAYCARE',
-        startDate: today,
+        startDate: yesterday,
         endDate: today.addYears(1)
       })
       .save()
     await Fixture.serviceNeed()
       .with({
         placementId: placement.data.id,
-        startDate: today,
+        startDate: yesterday,
         endDate: today.addYears(1),
         optionId: serviceNeedOption.data.id,
         confirmedBy: daycareSupervisor.data.id
@@ -78,10 +79,10 @@ describe('Monthly summary', () => {
       .save()
   })
 
-  it('Reservation time shown in summary', async () => {
+  it('Reservation time shown in monthly summary', async () => {
     await Fixture.attendanceReservation({
       type: 'RESERVATIONS',
-      date: today,
+      date: yesterday,
       childId: enduserChildFixtureKaarina.id,
       reservation: new TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0)),
       secondReservation: null
@@ -94,16 +95,16 @@ describe('Monthly summary', () => {
     )
     await summary.title.assertTextEquals('Läsnäolot 01.01. - 31.01.2022')
     await summary.textElement.assertTextEquals(
-      'Kaarina\n' + '\n' + 'Suunnitelma 8 h / 140 h\n' + 'Toteuma - / 140 h'
+      'Kaarina\n' + '\n' + 'Suunnitelma 8 h / 140 h\n' + 'Toteuma 8 h / 140 h'
     )
   })
 
-  it('Attendance time shown in summary', async () => {
+  it('Attendance time shown in monthly summary', async () => {
     await Fixture.childAttendance()
       .with({
         childId: enduserChildFixtureKaarina.id,
         unitId: daycareFixture.id,
-        date: today,
+        date: yesterday,
         arrived: LocalTime.of(8, 0),
         departed: LocalTime.of(15, 30)
       })
@@ -121,5 +122,72 @@ describe('Monthly summary', () => {
         'Suunnitelma - / 140 h\n' +
         'Toteuma 7 h 30 min / 140 h'
     )
+  })
+
+  it('Service time usage based on reservation shown in day view', async () => {
+    await Fixture.attendanceReservation({
+      type: 'RESERVATIONS',
+      date: yesterday,
+      childId: enduserChildFixtureKaarina.id,
+      reservation: new TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0)),
+      secondReservation: null
+    }).save()
+
+    const calendarPage = await openCalendarPage()
+    const dayView = await calendarPage.openDayView(yesterday)
+    await dayView
+      .getUsedService(enduserChildFixtureKaarina.id)
+      .assertTextEquals('08:00–16:00 (8 h)')
+  })
+
+  it('Service time usage based on attendance shown in day view', async () => {
+    await Fixture.childAttendance()
+      .with({
+        childId: enduserChildFixtureKaarina.id,
+        unitId: daycareFixture.id,
+        date: today,
+        arrived: LocalTime.of(8, 0),
+        departed: LocalTime.of(15, 30)
+      })
+      .save()
+
+    const calendarPage = await openCalendarPage()
+    const dayView = await calendarPage.openDayView(today)
+    await dayView
+      .getUsedService(enduserChildFixtureKaarina.id)
+      .assertTextEquals('08:00–15:30 (7 h 30 min)')
+    await dayView
+      .getServiceUsageWarning(enduserChildFixtureKaarina.id)
+      .assertTextEquals('Toteunut läsnäoloaika ylittää ilmoitetun ajan.')
+  })
+
+  it('Service time warning when attendance is longer than reservation', async () => {
+    await Fixture.attendanceReservation({
+      type: 'RESERVATIONS',
+      date: today,
+      childId: enduserChildFixtureKaarina.id,
+      reservation: new TimeRange(LocalTime.of(8, 0), LocalTime.of(15, 30)),
+      secondReservation: null
+    }).save()
+    await Fixture.childAttendance()
+      .with({
+        childId: enduserChildFixtureKaarina.id,
+        unitId: daycareFixture.id,
+        date: today,
+        arrived: LocalTime.of(7, 55),
+        departed: LocalTime.of(16, 0)
+      })
+      .save()
+
+    const calendarPage = await openCalendarPage()
+    const dayView = await calendarPage.openDayView(today)
+    await dayView
+      .getUsedService(enduserChildFixtureKaarina.id)
+      .assertTextEquals('07:55–16:00 (8 h 5 min)')
+    await dayView
+      .getServiceUsageWarning(enduserChildFixtureKaarina.id)
+      .assertTextEquals(
+        'Saapunut ilmoitettua aikaisemmin. Lähtenyt ilmoitettua myöhemmin.'
+      )
   })
 })

--- a/frontend/src/lib-common/reservations.ts
+++ b/frontend/src/lib-common/reservations.ts
@@ -26,11 +26,11 @@ function timeToMinutes(value: LocalTime): number {
  * The functionality can be improved once the reservation data model supports
  * reservations that span multiple days.
  */
-export function attendanceTimeDiffers(
+function attendanceTimeDiffers(
   first: LocalTime | null | undefined,
-  second: LocalTime | null | undefined,
-  thresholdMinutes = 15
+  second: LocalTime | null | undefined
 ): boolean {
+  const thresholdMinutes = 15
   if (!(first && second)) {
     return false
   }

--- a/frontend/src/lib-components/typography.ts
+++ b/frontend/src/lib-components/typography.ts
@@ -178,7 +178,7 @@ export const H4 = styled.h4<HeadingProps>`
   }
 `
 
-interface LabelProps {
+export interface LabelProps {
   inputRow?: boolean
   primary?: boolean
   white?: boolean

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -330,8 +330,13 @@ const en: Translations = {
     termBreak: 'No teaching today',
     reservation: 'Registered attendance',
     reservationNoTimes: 'Present',
-    attendance: 'Realized',
-    usedService: 'Used service time',
+    attendance: 'Actual attendance',
+    exceedStart: 'Arrived earlier than reported.',
+    exceedEnd: 'Departed later than reported.',
+    exceedGeneric: 'Actual attendance time exceeds reported time.',
+    calculatedUsedServiceTime:
+      'Used service need is determined by the monthly service need.',
+    usedService: 'Used service need',
     reservationsAndRealized: 'Period of attendance',
     events: 'Events of the day',
     noActivePlacements:

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -330,7 +330,8 @@ const en: Translations = {
     termBreak: 'No teaching today',
     reservation: 'Registered attendance',
     reservationNoTimes: 'Present',
-    realized: 'Realized',
+    attendance: 'Realized',
+    usedService: 'Used service time',
     reservationsAndRealized: 'Period of attendance',
     events: 'Events of the day',
     noActivePlacements:

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -325,9 +325,15 @@ export default {
     missingReservation: 'Ilmoitus puuttuu',
     reservationNotRequired: 'Ilmoitusta ei tarvita',
     termBreak: 'Ei opetusta tänään',
-    reservation: 'Ilmoitettu aika',
+    reservation: 'Ilmoitettu läsnäolo',
     reservationNoTimes: 'Läsnä',
-    realized: 'Toteutunut aika',
+    attendance: 'Toteutunut läsnäolo',
+    exceedStart: 'Saapunut ilmoitettua aikaisemmin.',
+    exceedEnd: 'Lähtenyt ilmoitettua myöhemmin.',
+    exceedGeneric: 'Toteunut läsnäoloaika ylittää ilmoitetun ajan.',
+    calculatedUsedServiceTime:
+      'Käytetty palveluntarve määräytyy kuukauden palveluntarpeen mukaan.',
+    usedService: 'Käytetty palveluntarve',
     reservationsAndRealized: 'Läsnäoloaika',
     events: 'Päivän tapahtumat',
     noActivePlacements:

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -327,7 +327,8 @@ const sv: Translations = {
     termBreak: 'Ingen undervisning idag',
     reservation: 'Närvarande',
     reservationNoTimes: 'Närvarande',
-    realized: 'Förverkligad',
+    attendance: 'Förverkligad',
+    usedService: 'TODO: Used service time',
     reservationsAndRealized: 'Närvaroperiod',
     events: 'Dagens händelser',
     noActivePlacements:

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -325,10 +325,15 @@ const sv: Translations = {
     missingReservation: 'Ingen närvaro',
     reservationNotRequired: 'Närvaroanmälan krävs inte',
     termBreak: 'Ingen undervisning idag',
-    reservation: 'Närvarande',
+    reservation: 'Anmäld närvaro',
     reservationNoTimes: 'Närvarande',
-    attendance: 'Förverkligad',
-    usedService: 'TODO: Used service time',
+    attendance: 'Förverkligad närvaro',
+    exceedStart: 'Kommit i förtid.',
+    exceedEnd: 'Blivit avhämtad senare än vad anmälts.',
+    exceedGeneric: 'Förverkligad närvarotid överstiger anmäld tid.',
+    calculatedUsedServiceTime:
+      'Använt servicebehov bestäms enligt månadens servicebehov.',
+    usedService: 'Använt servicebehov',
     reservationsAndRealized: 'Närvaroperiod',
     events: 'Dagens händelser',
     noActivePlacements:


### PR DESCRIPTION
## Before this change
It was not possible to track service time usage per day in citizen front-end.
## After this change
Citizen day view displays used service time and highlights attendances that exceed planned time.

The new service time usage component is only used when feature flag `timeUsageInfo` is enabled and child's `ServiceNeed` contains a `daycareHoursPerMonth` value.


<img width="612" alt="image" src="https://github.com/espoon-voltti/evaka/assets/886091/faf28ed5-205f-4956-8609-e6685114dab4">

Child departure after reservation end; Both ends of attendance exceed reserved time


<img width="615" alt="07 ei ilmoitusta, ei paikalla joten keskiarvo" src="https://github.com/espoon-voltti/evaka/assets/886091/52aec109-690e-42df-8612-c4be5a3b6239">

No reservation / absence provided -> using monthly service time divided by 21