### PR TITLE
Improve family contacts query

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/sensitive/GetChildSensitiveInfoQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sensitive/GetChildSensitiveInfoQueries.kt
@@ -23,7 +23,7 @@ fun Database.Read.getChildSensitiveInfo(
     val placementType = getCurrentPlacementForChild(clock, childId)?.let { it.type }
     val child = getChild(childId)
     val backupPickups = getBackupPickupsForChild(childId)
-    val familyContacts = fetchFamilyContacts(clock, childId)
+    val familyContacts = fetchFamilyContacts(clock.today(), childId)
 
     return ChildSensitiveInformation(
         id = person.id,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- fetch data (just a few rows for a child) in CTEs, then do set operations based on the data
- do sorting in Kotlin code since there's no advantage to doing it in SQL and we're already doing so in some cases
- also fixes a bug where `LOCAL_SIBLING` did not check the validity period correctly (the *sibling's* `fc2` date range was not checked and the targeted child `fc1` was checked twice)

These changes give a massive performance increase, and the old ~1s query changes into a <10ms query.