### PR TITLE
Hour based service need changes

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -36,7 +36,8 @@ data class EvakaEnv(
     val fiveYearsOldDaycareEnabled: Boolean,
     val mockClock: Boolean,
     val nrOfDaysFeeDecisionCanBeSentInAdvance: Long,
-    val nrOfDaysVoucherValueDecisionCanBeSentInAdvance: Long
+    val nrOfDaysVoucherValueDecisionCanBeSentInAdvance: Long,
+    val plannedAbsenceEnabledForHourBasedServiceNeeds: Boolean
 ) {
     companion object {
         fun fromEnvironment(env: Environment): EvakaEnv {
@@ -81,7 +82,10 @@ data class EvakaEnv(
                 nrOfDaysFeeDecisionCanBeSentInAdvance =
                     env.lookup("evaka.fee_decision.days_in_advance") ?: 0,
                 nrOfDaysVoucherValueDecisionCanBeSentInAdvance =
-                    env.lookup("evaka.voucher_value_decision.days_in_advance") ?: 0
+                    env.lookup("evaka.voucher_value_decision.days_in_advance") ?: 0,
+                plannedAbsenceEnabledForHourBasedServiceNeeds =
+                    env.lookup("evaka.planned_absence.enabled_for_hour_based_service_needs")
+                        ?: false
             )
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.reservations
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.absence.AbsenceCategory
 import fi.espoo.evaka.absence.AbsenceType
 import fi.espoo.evaka.absence.ChildServiceNeedInfo
@@ -61,7 +62,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/attendance-reservations")
 class AttendanceReservationController(
     private val ac: AccessControl,
-    private val featureConfig: FeatureConfig
+    private val featureConfig: FeatureConfig,
+    private val env: EvakaEnv
 ) {
     @GetMapping
     fun getAttendanceReservations(
@@ -214,7 +216,8 @@ class AttendanceReservationController(
                         clock.now(),
                         user,
                         body,
-                        featureConfig.citizenReservationThresholdHours
+                        featureConfig.citizenReservationThresholdHours,
+                        env.plannedAbsenceEnabledForHourBasedServiceNeeds
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -171,7 +171,8 @@ class ReservationControllerCitizen(
                                                                         placementDay
                                                                             .preparatoryTime,
                                                                         childAbsences.map {
-                                                                            it.category
+                                                                            it.absenceType to
+                                                                                it.category
                                                                         },
                                                                         childReservations
                                                                             .mapNotNull {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -993,7 +993,8 @@ class DevApi(
                     clock.now(),
                     fakeAdmin,
                     body,
-                    featureConfig.citizenReservationThresholdHours
+                    featureConfig.citizenReservationThresholdHours,
+                    true
                 )
             }
         }


### PR DESCRIPTION
#### Summary

- Add `evaka.planned_absence.enabled_for_hour_based_service_needs` env variable to...
- ... use the same planned absence logic with hour based service need that is already in use with contract days: If an absence is marked to a reservable (unlocked) calendar day, change it to a planned absence
- Compute 0 hours as used service for days with planned absences. With all other absence types, use the reservation, or the month's average if a reservation doesn't exist.