### PR TITLE
Sort before adding default priorities

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/FamilyController.kt
@@ -316,6 +316,7 @@ LEFT JOIN family_contact ON family_contact.contact_person_id = contact.id AND fa
             )
         }
         .toList<FamilyContact>()
+        .sortedBy { it.role.ordinal }
         .let(::addDefaultPriorities)
         .sortedWith(compareBy({ it.priority ?: Int.MAX_VALUE }, { it.role.ordinal }))
 


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

addDefaultPriorities is sensitive to ordering, so we need to sort twice or change its implementation.

Fixes flaky ordering caused by non-deterministic ordering