### PR TITLE
Throttle e-mail jobs and limit concurrency

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -334,7 +334,7 @@ sealed interface AsyncJob : AsyncJobPayload {
         val email =
             AsyncJobRunner.Pool(
                 AsyncJobPool.Id(AsyncJob::class, "email"),
-                AsyncJobPool.Config(concurrency = 4),
+                AsyncJobPool.Config(concurrency = 1),
                 setOf(
                     SendApplicationEmail::class,
                     SendAssistanceNeedDecisionEmail::class,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -18,6 +18,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.env.Environment
 
+// this throttle interval is pessimistic, because it assumes the actual e-mail job is completed
+// instantaneously
+private fun emailThrottleInterval(maxEmailsPerSecondRate: Int, numServiceInstances: Int) =
+    Duration.ofSeconds(1)
+        .dividedBy(maxEmailsPerSecondRate.toLong())
+        .multipliedBy(numServiceInstances.toLong())
+
 @Configuration
 class AsyncJobConfig {
     @Bean
@@ -26,7 +33,10 @@ class AsyncJobConfig {
             AsyncJob::class,
             listOf(
                 AsyncJob.main,
-                AsyncJob.email,
+                // these are reasonable defaults but should probably be configurable
+                AsyncJob.email.withThrottleInterval(
+                    emailThrottleInterval(maxEmailsPerSecondRate = 14, numServiceInstances = 2)
+                ),
                 AsyncJob.urgent,
                 AsyncJob.varda,
                 AsyncJob.suomiFi.withThrottleInterval(


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This config is pessimistic, but should keep us under a 14/s sending quota when 2 service instances are in use.