### PR TITLE
Add async job permit mechanism for cluster-wide throttling

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -393,3 +393,5 @@ data class ClaimedJobRef<T : AsyncJobPayload>(
     val txId: Long,
     val remainingAttempts: Int
 )
+
+data class WorkPermit(val availableAt: HelsinkiDateTime)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -18,12 +18,8 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.env.Environment
 
-// this throttle interval is pessimistic, because it assumes the actual e-mail job is completed
-// instantaneously
-private fun emailThrottleInterval(maxEmailsPerSecondRate: Int, numServiceInstances: Int) =
-    Duration.ofSeconds(1)
-        .dividedBy(maxEmailsPerSecondRate.toLong())
-        .multipliedBy(numServiceInstances.toLong())
+private fun emailThrottleInterval(maxEmailsPerSecondRate: Int) =
+    Duration.ofSeconds(1).dividedBy(maxEmailsPerSecondRate.toLong())
 
 @Configuration
 class AsyncJobConfig {
@@ -33,9 +29,9 @@ class AsyncJobConfig {
             AsyncJob::class,
             listOf(
                 AsyncJob.main,
-                // these are reasonable defaults but should probably be configurable
+                // this is a reasonable default but should probably be configurable
                 AsyncJob.email.withThrottleInterval(
-                    emailThrottleInterval(maxEmailsPerSecondRate = 14, numServiceInstances = 2)
+                    emailThrottleInterval(maxEmailsPerSecondRate = 14)
                 ),
                 AsyncJob.urgent,
                 AsyncJob.varda,

--- a/service/src/main/resources/db/migration/V386__async_job_permit.sql
+++ b/service/src/main/resources/db/migration/V386__async_job_permit.sql
@@ -1,0 +1,4 @@
+CREATE TABLE async_job_work_permit (
+    pool_id text PRIMARY KEY,
+    available_at timestamp with time zone NOT NULL
+);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -382,3 +382,4 @@ V382__absence_categories_preschool_preparatory_only.sql
 V383__calendar_event_timestamps.sql
 V384__read_at_partial_index.sql
 V385__new_customer_income_notification_type.sql
+V386__async_job_permit.sql


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Since we don't actually need to accurately limit cluster-wide *concurrency* of executed jobs, it's enough to throttle *claiming of jobs* and not their execution. This kind of simple per-pool "work permit" (= global lock) held while claiming a job should be enough.
