### PR TITLE
Change report field from yes/no to actual content of otherInfo

### DIFF
--- a/frontend/src/employee-frontend/components/reports/PlacementSketching.tsx
+++ b/frontend/src/employee-frontend/components/reports/PlacementSketching.tsx
@@ -251,7 +251,7 @@ export default React.memo(function PlacementSketching() {
                 applicationStatus:
                   i18n.application.statuses[row.applicationStatus],
                 otherPreferredUnits: formatOtherPreferredUnits(row),
-                hasAdditionalInfo: row.hasAdditionalInfo ? 'k' : 'e'
+                additionalInfo: row.additionalInfo
               }))}
               headers={[
                 {
@@ -320,7 +320,7 @@ export default React.memo(function PlacementSketching() {
                 },
                 {
                   label: i18n.reports.placementSketching.additionalInfo,
-                  key: 'hasAdditionalInfo'
+                  key: 'additionalInfo'
                 },
                 {
                   label: i18n.reports.placementSketching.childMovingDate,
@@ -430,7 +430,7 @@ export default React.memo(function PlacementSketching() {
                     <Td data-qa="other-preferred-units">
                       {formatOtherPreferredUnits(row)}
                     </Td>
-                    <Td>{yesNo(row.hasAdditionalInfo)}</Td>
+                    <Td>{row.additionalInfo}</Td>
                     <Td>{row.childMovingDate?.format()}</Td>
                     <Td>{row.childCorrectedStreetAddress}</Td>
                     <Td>{row.childCorrectedPostalCode}</Td>

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -548,6 +548,7 @@ export interface PlacementGuaranteeReportRow {
 * Generated from fi.espoo.evaka.reports.PlacementSketchingReportRow
 */
 export interface PlacementSketchingReportRow {
+  additionalInfo: string
   applicationId: UUID
   applicationStatus: ApplicationStatus
   areaName: string
@@ -567,7 +568,6 @@ export interface PlacementSketchingReportRow {
   currentUnitName: string | null
   guardianEmail: string | null
   guardianPhoneNumber: string | null
-  hasAdditionalInfo: boolean
   otherPreferredUnits: string[]
   preferredStartDate: LocalDate
   preparatoryEducation: boolean | null

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PlacementSketchingReport.kt
@@ -138,9 +138,7 @@ SELECT
      JOIN (SELECT unnest(preferredUnits) 
            FROM application_view view 
            WHERE view.id = application.id) pu ON daycare.id = pu.unnest) AS other_preferred_units,
-    (application.document -> 'additionalDetails' ->> 'otherInfo' <> ''
-        OR application.document -> 'additionalDetails' ->> 'dietType' <> ''
-        OR application.document -> 'additionalDetails' ->> 'allergyType' <> '') as hasAdditionalInfo,
+    (application.document -> 'additionalDetails' ->> 'otherInfo') as additionalInfo,
     unrestricted_corrected_child_address_details.childMovingDate,
     COALESCE(unrestricted_corrected_child_address_details.childCorrectedStreetAddress,'') as childCorrectedStreetAddress,
     COALESCE(unrestricted_corrected_child_address_details.childCorrectedPostalCode,'') as childCorrectedPostalCode,
@@ -203,7 +201,7 @@ data class PlacementSketchingReportRow(
     val guardianPhoneNumber: String?,
     val guardianEmail: String?,
     val otherPreferredUnits: List<String>,
-    val hasAdditionalInfo: Boolean,
+    val additionalInfo: String,
     val childMovingDate: LocalDate?,
     val childCorrectedStreetAddress: String,
     val childCorrectedPostalCode: String,


### PR DESCRIPTION
Changes the `hasAdditionalInfo` boolean field of the report to `additionalInfo` containing the actual additional info from the application document.

NB! Previously the existence of additional info has been evaluated by checking all of the additional info fields (diet, allergies, other info). The new replacement field contains only the contents of the "other info" field as this was deemed the only actually useful information for the report.