### PR TITLE
Warn citizen about exceeding service need in calendar view month summary

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -9,8 +9,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
-  useState
+  useRef
 } from 'react'
 import styled, { css, useTheme } from 'styled-components'
 
@@ -45,6 +44,7 @@ import {
 } from './CalendarEventCount'
 import { HistoryOverlay } from './HistoryOverlay'
 import { getSummaryForMonth, InlineWarningIcon } from './MonthElem'
+import { useSummaryInfo } from './MonthInfoOpenHook'
 import MonthlyHoursSummary, { MonthlyTimeSummary } from './MonthlyHoursSummary'
 import ReportHolidayLabel from './ReportHolidayLabel'
 import { ChildImageData, getChildImages } from './RoundChildImages'
@@ -288,16 +288,6 @@ const Month = React.memo(function Month({
 }) {
   const i18n = useTranslation()
 
-  const [monthlySummaryInfoOpen, setMonthlySummaryInfoOpen] = useState(() =>
-    childSummaries.some(
-      ({ reservedMinutes, serviceNeedMinutes }) =>
-        reservedMinutes > serviceNeedMinutes
-    )
-  )
-  const onMonthlySummaryInfoClick = useCallback(
-    () => setMonthlySummaryInfoOpen((prev) => !prev),
-    []
-  )
   const displaySummary = featureFlags.timeUsageInfo && childSummaries.length > 0
   const displayAlert =
     displaySummary &&
@@ -306,22 +296,23 @@ const Month = React.memo(function Month({
         reservedMinutes > serviceNeedMinutes ||
         usedServiceMinutes > serviceNeedMinutes
     )
+  const { summaryInfoOpen, toggleSummaryInfo } = useSummaryInfo(childSummaries)
   return (
     <ContentArea opaque={false} key={`${month}${year}`}>
       <MonthTitle>
         {`${i18n.common.datetime.months[month - 1]} ${year}`}
         {displaySummary && (
           <InlineInfoButton
-            onClick={onMonthlySummaryInfoClick}
+            onClick={toggleSummaryInfo}
             aria-label={i18n.common.openExpandingInfo}
             margin="zero"
             data-qa={`monthly-summary-info-button-${month}-${year}`}
-            open={monthlySummaryInfoOpen}
+            open={summaryInfoOpen}
           />
         )}
         {displayAlert && <InlineWarningIcon />}
       </MonthTitle>
-      {monthlySummaryInfoOpen && (
+      {summaryInfoOpen && (
         <MonthSummaryInfoBox
           info={
             <MonthlyHoursSummary
@@ -331,7 +322,7 @@ const Month = React.memo(function Month({
             />
           }
           data-qa={`monthly-summary-info-container-${month}-${year}`}
-          close={() => setMonthlySummaryInfoOpen(false)}
+          close={toggleSummaryInfo}
         />
       )}
       <CalendarHeader includeWeekends={includeWeekends}>

--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -44,7 +44,7 @@ import {
   CalendarEventCountContainer
 } from './CalendarEventCount'
 import { HistoryOverlay } from './HistoryOverlay'
-import { getSummaryForMonth } from './MonthElem'
+import { getSummaryForMonth, InlineWarningIcon } from './MonthElem'
 import MonthlyHoursSummary, { MonthlyTimeSummary } from './MonthlyHoursSummary'
 import ReportHolidayLabel from './ReportHolidayLabel'
 import { ChildImageData, getChildImages } from './RoundChildImages'
@@ -288,12 +288,24 @@ const Month = React.memo(function Month({
 }) {
   const i18n = useTranslation()
 
-  const [monthlySummaryInfoOpen, setMonthlySummaryInfoOpen] = useState(false)
+  const [monthlySummaryInfoOpen, setMonthlySummaryInfoOpen] = useState(() =>
+    childSummaries.some(
+      ({ reservedMinutes, serviceNeedMinutes }) =>
+        reservedMinutes > serviceNeedMinutes
+    )
+  )
   const onMonthlySummaryInfoClick = useCallback(
     () => setMonthlySummaryInfoOpen((prev) => !prev),
     []
   )
   const displaySummary = featureFlags.timeUsageInfo && childSummaries.length > 0
+  const displayAlert =
+    displaySummary &&
+    childSummaries.some(
+      ({ reservedMinutes, usedServiceMinutes, serviceNeedMinutes }) =>
+        reservedMinutes > serviceNeedMinutes ||
+        usedServiceMinutes > serviceNeedMinutes
+    )
   return (
     <ContentArea opaque={false} key={`${month}${year}`}>
       <MonthTitle>
@@ -307,6 +319,7 @@ const Month = React.memo(function Month({
             open={monthlySummaryInfoOpen}
           />
         )}
+        {displayAlert && <InlineWarningIcon />}
       </MonthTitle>
       {monthlySummaryInfoOpen && (
         <MonthSummaryInfoBox

--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -44,11 +44,11 @@ import {
 } from './CalendarEventCount'
 import { HistoryOverlay } from './HistoryOverlay'
 import { getSummaryForMonth, InlineWarningIcon } from './MonthElem'
-import { useSummaryInfo } from './MonthInfoOpenHook'
 import MonthlyHoursSummary, { MonthlyTimeSummary } from './MonthlyHoursSummary'
 import ReportHolidayLabel from './ReportHolidayLabel'
 import { ChildImageData, getChildImages } from './RoundChildImages'
 import { Reservations } from './calendar-elements'
+import { useSummaryInfo } from './hooks'
 import { activeQuestionnaireQuery, holidayPeriodsQuery } from './queries'
 import { isQuestionnaireAvailable } from './utils'
 
@@ -289,14 +289,8 @@ const Month = React.memo(function Month({
   const i18n = useTranslation()
 
   const displaySummary = featureFlags.timeUsageInfo && childSummaries.length > 0
-  const displayAlert =
-    displaySummary &&
-    childSummaries.some(
-      ({ reservedMinutes, usedServiceMinutes, serviceNeedMinutes }) =>
-        reservedMinutes > serviceNeedMinutes ||
-        usedServiceMinutes > serviceNeedMinutes
-    )
-  const { summaryInfoOpen, toggleSummaryInfo } = useSummaryInfo(childSummaries)
+  const { summaryInfoOpen, toggleSummaryInfo, displayAlert } =
+    useSummaryInfo(childSummaries)
   return (
     <ContentArea opaque={false} key={`${month}${year}`}>
       <MonthTitle>

--- a/frontend/src/citizen-frontend/calendar/MonthElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthElem.tsx
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { fasExclamationTriangle } from 'Icons'
 import React, { useCallback, useState } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -71,14 +73,26 @@ export default React.memo(function MonthElem({
 }: MonthProps) {
   const i18n = useTranslation()
 
-  const [monthlySummaryInfoOpen, setMonthlySummaryInfoOpen] = useState(false)
+  const [monthlySummaryInfoOpen, setMonthlySummaryInfoOpen] = useState(() =>
+    childSummaries.some(
+      ({ reservedMinutes, serviceNeedMinutes }) =>
+        reservedMinutes > serviceNeedMinutes
+    )
+  )
   const onMonthlySummaryInfoClick = useCallback(
     () => setMonthlySummaryInfoOpen((prev) => !prev),
     []
   )
   const displaySummary = featureFlags.timeUsageInfo && childSummaries.length > 0
+  const displayAlert =
+    displaySummary &&
+    childSummaries.some(
+      ({ reservedMinutes, usedServiceMinutes, serviceNeedMinutes }) =>
+        reservedMinutes > serviceNeedMinutes ||
+        usedServiceMinutes > serviceNeedMinutes
+    )
   return (
-    <>
+    <div>
       <MonthSummaryContainer>
         <MonthTitle>
           {i18n.common.datetime.months[calendarMonth.monthNumber - 1]}
@@ -91,6 +105,8 @@ export default React.memo(function MonthElem({
               open={monthlySummaryInfoOpen}
             />
           )}
+
+          {displayAlert && <InlineWarningIcon />}
         </MonthTitle>
         {monthlySummaryInfoOpen && (
           <MonthlySummaryInfoBox
@@ -123,7 +139,7 @@ export default React.memo(function MonthElem({
           />
         </div>
       ))}
-    </>
+    </div>
   )
 })
 
@@ -195,3 +211,15 @@ const MonthlySummaryInfoBox = styled(ExpandingInfoBox)`
     padding-bottom: 0;
   }
 `
+const InlineIconContainer = styled.div`
+  margin-left: ${defaultMargins.xs};
+`
+
+export const InlineWarningIcon = () => (
+  <InlineIconContainer>
+    <FontAwesomeIcon
+      icon={fasExclamationTriangle}
+      color={colors.status.warning}
+    />
+  </InlineIconContainer>
+)

--- a/frontend/src/citizen-frontend/calendar/MonthElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthElem.tsx
@@ -26,9 +26,9 @@ import colors from 'lib-customizations/common'
 import { useTranslation } from '../localization'
 
 import DayElem from './DayElem'
-import { useSummaryInfo } from './MonthInfoOpenHook'
 import MonthlyHoursSummary, { MonthlyTimeSummary } from './MonthlyHoursSummary'
 import { ChildImageData } from './RoundChildImages'
+import { useSummaryInfo } from './hooks'
 
 export function getSummaryForMonth(
   childData: ReservationChild[],
@@ -75,14 +75,9 @@ export default React.memo(function MonthElem({
   const i18n = useTranslation()
 
   const displaySummary = featureFlags.timeUsageInfo && childSummaries.length > 0
-  const displayAlert =
-    displaySummary &&
-    childSummaries.some(
-      ({ reservedMinutes, usedServiceMinutes, serviceNeedMinutes }) =>
-        reservedMinutes > serviceNeedMinutes ||
-        usedServiceMinutes > serviceNeedMinutes
-    )
-  const { summaryInfoOpen, toggleSummaryInfo } = useSummaryInfo(childSummaries)
+
+  const { summaryInfoOpen, toggleSummaryInfo, displayAlert } =
+    useSummaryInfo(childSummaries)
   return (
     <div>
       <MonthSummaryContainer>

--- a/frontend/src/citizen-frontend/calendar/MonthElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthElem.tsx
@@ -4,7 +4,7 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { fasExclamationTriangle } from 'Icons'
-import React, { useCallback, useEffect, useState } from 'react'
+import React from 'react'
 import styled, { css } from 'styled-components'
 
 import { CitizenCalendarEvent } from 'lib-common/generated/api-types/calendarevent'
@@ -26,6 +26,7 @@ import colors from 'lib-customizations/common'
 import { useTranslation } from '../localization'
 
 import DayElem from './DayElem'
+import { useSummaryInfo } from './MonthInfoOpenHook'
 import MonthlyHoursSummary, { MonthlyTimeSummary } from './MonthlyHoursSummary'
 import { ChildImageData } from './RoundChildImages'
 
@@ -73,20 +74,6 @@ export default React.memo(function MonthElem({
 }: MonthProps) {
   const i18n = useTranslation()
 
-  const [summaryExplicitlyClosed, setSummaryExplicitlyClosed] = useState(false)
-  const [summaryInfoOpen, setSummaryInfoOpen] = useState(() =>
-    childSummaries.some(
-      ({ reservedMinutes, serviceNeedMinutes }) =>
-        reservedMinutes > serviceNeedMinutes
-    )
-  )
-  const onMonthlySummaryInfoClick = useCallback(() => {
-    if (summaryInfoOpen) {
-      setSummaryExplicitlyClosed(true)
-      setSummaryInfoOpen(false)
-    }
-    setSummaryInfoOpen(true)
-  }, [summaryInfoOpen])
   const displaySummary = featureFlags.timeUsageInfo && childSummaries.length > 0
   const displayAlert =
     displaySummary &&
@@ -95,17 +82,7 @@ export default React.memo(function MonthElem({
         reservedMinutes > serviceNeedMinutes ||
         usedServiceMinutes > serviceNeedMinutes
     )
-  useEffect(() => {
-    if (
-      !summaryExplicitlyClosed &&
-      childSummaries.some(
-        ({ reservedMinutes, serviceNeedMinutes }) =>
-          reservedMinutes > serviceNeedMinutes
-      )
-    ) {
-      setSummaryInfoOpen(true)
-    }
-  }, [childSummaries, summaryExplicitlyClosed])
+  const { summaryInfoOpen, toggleSummaryInfo } = useSummaryInfo(childSummaries)
   return (
     <div>
       <MonthSummaryContainer>
@@ -113,7 +90,7 @@ export default React.memo(function MonthElem({
           {i18n.common.datetime.months[calendarMonth.monthNumber - 1]}
           {displaySummary && (
             <InlineInfoButton
-              onClick={onMonthlySummaryInfoClick}
+              onClick={toggleSummaryInfo}
               aria-label={i18n.common.openExpandingInfo}
               margin="zero"
               data-qa={`mobile-monthly-summary-info-button-${calendarMonth.monthNumber}-${calendarMonth.year}`}
@@ -133,10 +110,7 @@ export default React.memo(function MonthElem({
               />
             }
             data-qa={`mobile-monthly-summary-info-container-${calendarMonth.monthNumber}-${calendarMonth.year}`}
-            close={() => {
-              setSummaryExplicitlyClosed(true)
-              setSummaryInfoOpen(false)
-            }}
+            close={toggleSummaryInfo}
           />
         )}
       </MonthSummaryContainer>

--- a/frontend/src/citizen-frontend/calendar/MonthInfoOpenHook.ts
+++ b/frontend/src/citizen-frontend/calendar/MonthInfoOpenHook.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState, useEffect } from 'react'
+
+import { MonthlyTimeSummary } from './MonthlyHoursSummary'
+
+export function useSummaryInfo(childSummaries: MonthlyTimeSummary[]) {
+  const [summaryExplicitlyClosed, setSummaryExplicitlyClosed] = useState(false)
+  const [summaryInfoOpen, setSummaryInfoOpen] = useState(() =>
+    childSummaries.some(
+      ({ reservedMinutes, serviceNeedMinutes }) =>
+        reservedMinutes > serviceNeedMinutes
+    )
+  )
+
+  const toggleSummaryInfo = useCallback(() => {
+    setSummaryInfoOpen((prev) => {
+      const newState = !prev
+      if (!newState) {
+        setSummaryExplicitlyClosed(true)
+      }
+      return newState
+    })
+  }, [])
+
+  useEffect(() => {
+    if (
+      !summaryExplicitlyClosed &&
+      childSummaries.some(
+        ({ reservedMinutes, serviceNeedMinutes }) =>
+          reservedMinutes > serviceNeedMinutes
+      )
+    ) {
+      setSummaryInfoOpen(true)
+    }
+  }, [childSummaries, summaryExplicitlyClosed])
+
+  return { summaryInfoOpen, toggleSummaryInfo }
+}

--- a/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
@@ -76,19 +76,19 @@ export default React.memo(function MonthSummary({
         ({ usedServiceMinutes, serviceNeedMinutes }) =>
           usedServiceMinutes > serviceNeedMinutes
       ) ? (
-        <>
+        <div data-qa="monthly-summary-warning">
           <LeftWarningIcon />
           Läsnäoloja sopimuksen ylittävä määrä:
-        </>
+        </div>
       ) : (
         childSummaries.some(
           ({ reservedMinutes, serviceNeedMinutes }) =>
             reservedMinutes > serviceNeedMinutes
         ) && (
-          <>
+          <div data-qa="monthly-summary-warning">
             <LeftWarningIcon />
-            Läsnäoloja suunniteltu sopimuksen ylittävä määrä
-          </>
+            Läsnäoloja suunniteltu sopimuksen ylittävä määrä:
+          </div>
         )
       )}
       {childSummaries.map((summary, index) => (

--- a/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
@@ -78,7 +78,7 @@ export default React.memo(function MonthSummary({
       ) ? (
         <div data-qa="monthly-summary-warning">
           <LeftWarningIcon />
-          Läsnäoloja sopimuksen ylittävä määrä:
+          {i18n.calendar.monthSummary.warningUsedServiceExceeded}
         </div>
       ) : (
         childSummaries.some(
@@ -87,7 +87,7 @@ export default React.memo(function MonthSummary({
         ) && (
           <div data-qa="monthly-summary-warning">
             <LeftWarningIcon />
-            Läsnäoloja suunniteltu sopimuksen ylittävä määrä:
+            {i18n.calendar.monthSummary.warningPlannedServiceExceeded}
           </div>
         )
       )}

--- a/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
@@ -2,11 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { fasExclamationTriangle } from 'Icons'
 import React from 'react'
 import styled from 'styled-components'
 
 import LocalDate from 'lib-common/local-date'
 import { defaultMargins } from 'lib-components/white-space'
+import colors from 'lib-customizations/common'
 
 import { useTranslation } from '../localization'
 
@@ -68,6 +71,26 @@ export default React.memo(function MonthSummary({
         {i18n.calendar.monthSummary.title}{' '}
         {`${start.format('dd.MM.')} - ${end.format()}`}
       </Title>
+      {}
+      {childSummaries.some(
+        ({ usedServiceMinutes, serviceNeedMinutes }) =>
+          usedServiceMinutes > serviceNeedMinutes
+      ) ? (
+        <>
+          <LeftWarningIcon />
+          Läsnäoloja sopimuksen ylittävä määrä:
+        </>
+      ) : (
+        childSummaries.some(
+          ({ reservedMinutes, serviceNeedMinutes }) =>
+            reservedMinutes > serviceNeedMinutes
+        ) && (
+          <>
+            <LeftWarningIcon />
+            Läsnäoloja suunniteltu sopimuksen ylittävä määrä
+          </>
+        )
+      )}
       {childSummaries.map((summary, index) => (
         <SummaryContainer key={index} data-qa="monthly-summary-info-text">
           <p>
@@ -99,3 +122,17 @@ export default React.memo(function MonthSummary({
     </>
   )
 })
+
+const LeftIconContainer = styled.div`
+  position: absolute;
+  margin-left: -34px;
+`
+
+const LeftWarningIcon = () => (
+  <LeftIconContainer>
+    <FontAwesomeIcon
+      icon={fasExclamationTriangle}
+      color={colors.status.warning}
+    />
+  </LeftIconContainer>
+)

--- a/frontend/src/citizen-frontend/calendar/hooks.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/hooks.spec.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { renderHook, act } from '@testing-library/react'
+
+import { MonthlyTimeSummary } from './MonthlyHoursSummary'
+import { useSummaryInfo } from './hooks'
+
+describe('useSummaryInfo', () => {
+  it('initializes summary info open state based on child summaries', () => {
+    const { result } = renderHook(() =>
+      useSummaryInfo([
+        { reservedMinutes: 100, serviceNeedMinutes: 80 }
+      ] as MonthlyTimeSummary[])
+    )
+    expect(result.current.summaryInfoOpen).toBe(true)
+  })
+  it('initializes summary info closed state based on child summaries', () => {
+    const { result } = renderHook(() =>
+      useSummaryInfo([
+        { reservedMinutes: 80, serviceNeedMinutes: 180 }
+      ] as MonthlyTimeSummary[])
+    )
+    expect(result.current.summaryInfoOpen).toBe(false)
+  })
+
+  it("Opens summary info when child's new reservations exceed service time", () => {
+    const { result, rerender } = renderHook(
+      ({ childSummaries }) => useSummaryInfo(childSummaries),
+      {
+        initialProps: {
+          childSummaries: [
+            { reservedMinutes: 80, serviceNeedMinutes: 180 }
+          ] as MonthlyTimeSummary[]
+        }
+      }
+    )
+
+    // Initial state with summaries not initially open
+    expect(result.current.summaryInfoOpen).toBe(false)
+
+    // Rerender with new summary that should open the summary info
+    rerender({
+      childSummaries: [
+        { reservedMinutes: 120, serviceNeedMinutes: 100 }
+      ] as MonthlyTimeSummary[]
+    })
+
+    expect(result.current.summaryInfoOpen).toBe(true)
+  })
+
+  it("Keeps summary info closed when it's explicitly closed", () => {
+    const { result, rerender } = renderHook(
+      ({ childSummaries }) => useSummaryInfo(childSummaries),
+      {
+        initialProps: {
+          childSummaries: [
+            { reservedMinutes: 120, serviceNeedMinutes: 80 }
+          ] as MonthlyTimeSummary[]
+        }
+      }
+    )
+
+    expect(result.current.summaryInfoOpen).toBe(true)
+
+    act(() => {
+      result.current.toggleSummaryInfo()
+    })
+    expect(result.current.summaryInfoOpen).toBe(false)
+
+    rerender({
+      childSummaries: [
+        { reservedMinutes: 180, serviceNeedMinutes: 80 }
+      ] as MonthlyTimeSummary[]
+    })
+
+    expect(result.current.summaryInfoOpen).toBe(false)
+  })
+})

--- a/frontend/src/citizen-frontend/calendar/hooks.ts
+++ b/frontend/src/citizen-frontend/calendar/hooks.ts
@@ -1,8 +1,22 @@
+// SPDX-FileCopyrightText: 2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 import { useCallback, useState, useEffect } from 'react'
+
+import { featureFlags } from 'lib-customizations/citizen'
 
 import { MonthlyTimeSummary } from './MonthlyHoursSummary'
 
 export function useSummaryInfo(childSummaries: MonthlyTimeSummary[]) {
+  const displayAlert = !!(
+    featureFlags.timeUsageInfo &&
+    childSummaries.some(
+      ({ reservedMinutes, usedServiceMinutes, serviceNeedMinutes }) =>
+        reservedMinutes > serviceNeedMinutes ||
+        usedServiceMinutes > serviceNeedMinutes
+    )
+  )
   const [summaryExplicitlyClosed, setSummaryExplicitlyClosed] = useState(false)
   const [summaryInfoOpen, setSummaryInfoOpen] = useState(() =>
     childSummaries.some(
@@ -33,5 +47,5 @@ export function useSummaryInfo(childSummaries: MonthlyTimeSummary[]) {
     }
   }, [childSummaries, summaryExplicitlyClosed])
 
-  return { summaryInfoOpen, toggleSummaryInfo }
+  return { summaryInfoOpen, displayAlert, toggleSummaryInfo }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -101,14 +101,17 @@ export default class CitizenCalendarPage {
     await this.dayCell(date).click()
     return new DayView(this.page, this.page.findByDataQa('calendar-dayview'))
   }
-
-  async openMonthlySummary(year: number, month: number) {
-    await this.monthlySummaryInfoButton(year, month).click()
+  getMonthlySummary(year: number, month: number) {
     return new MonthlySummary(
       this.page.findByDataQa(
         `monthly-summary-info-container-${month}-${year}-text`
       )
     )
+  }
+
+  async openMonthlySummary(year: number, month: number) {
+    await this.monthlySummaryInfoButton(year, month).click()
+    return this.getMonthlySummary(year, month)
   }
 
   async assertHoliday(date: LocalDate) {
@@ -560,6 +563,7 @@ class AbsencesModal {
 
 class MonthlySummary extends Element {
   title = this.findByDataQa('monthly-summary-info-title')
+  warningElement = this.findByDataQa('monthly-summary-warning')
   textElement = this.findByDataQa('monthly-summary-info-text')
 }
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-show-service-usage.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-show-service-usage.spec.ts
@@ -260,7 +260,23 @@ describe('Service time alert', () => {
         })
         .save()
     }
-    i = 1
+
+    const calendarPage = await openCalendarPage()
+    const summary = await calendarPage.openMonthlySummary(
+      today.year,
+      today.month
+    )
+    await summary.title.assertTextEquals('Läsnäolot 01.01. - 31.01.2022')
+    await summary.textElement.assertTextEquals(
+      'Kaarina\n' +
+        '\n' +
+        'Suunnitelma 60 h / 75 h\n' +
+        'Toteuma 75 h 20 min / 75 h'
+    )
+  })
+
+  it('Too much reservations show info box initially', async () => {
+    let i = 1
     while (i < 15) {
       const date = LocalDate.of(2022, 2, i)
       i++
@@ -273,29 +289,16 @@ describe('Service time alert', () => {
         secondReservation: null
       }).save()
     }
-    i = 1
-    while (i < 10) {
-      const date = LocalDate.of(2022, 3, i)
-      i++
-      if (date.getIsoDayOfWeek() === 6 || date.getIsoDayOfWeek() === 7) continue
-      await Fixture.attendanceReservation({
-        type: 'RESERVATIONS',
-        date: date,
-        childId: enduserChildFixtureKaarina.id,
-        reservation: new TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0)),
-        secondReservation: null
-      }).save()
-    }
 
     const calendarPage = await openCalendarPage()
-    await page.pause()
-    const summary = await calendarPage.openMonthlySummary(
-      today.year,
-      today.month
+    // Should be open initially, so we call getMonthlySummary instead of openMonthlySummary
+    const summary = calendarPage.getMonthlySummary(today.year, 2)
+    await summary.title.assertTextEquals('Läsnäolot 01.02. - 28.02.2022')
+    await summary.warningElement.assertTextEquals(
+      'Läsnäoloja suunniteltu sopimuksen ylittävä määrä:'
     )
-    await summary.title.assertTextEquals('Läsnäolot 01.01. - 31.01.2022')
     await summary.textElement.assertTextEquals(
-      'Kaarina\n' + '\n' + 'Suunnitelma 8 h / 140 h\n' + 'Toteuma 8 h / 140 h'
+      'Kaarina\n' + '\n' + 'Suunnitelma 80 h / 75 h\n' + 'Toteuma - / 75 h'
     )
   })
 })

--- a/frontend/src/lib-components/messages/MessageEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageEditor.tsx
@@ -135,7 +135,7 @@ const FlagsInfoContent = React.memo(function FlagsInfoContent({
   return (
     <UlNoMargin>
       <li>{i18n.messageEditor.flags.urgent.info}</li>
-      <li>{i18n.messageEditor.flags.sensitive.info}</li>)
+      <li>{i18n.messageEditor.flags.sensitive.info}</li>
     </UlNoMargin>
   )
 })

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -444,7 +444,10 @@ const en: Translations = {
       reserved: 'Reservations',
       usedService: 'Realized',
       minutes: 'min',
-      hours: 'h'
+      hours: 'h',
+      warningUsedServiceExceeded: 'Attendance in excess of the contract:',
+      warningPlannedServiceExceeded:
+        'Attendance planned in excess of the contract:'
     }
   },
   messages: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -441,7 +441,10 @@ export default {
       reserved: 'Suunnitelma',
       usedService: 'Toteuma',
       minutes: 'min',
-      hours: 'h'
+      hours: 'h',
+      warningUsedServiceExceeded: 'Läsnäoloja sopimuksen ylittävä määrä:',
+      warningPlannedServiceExceeded:
+        'Läsnäoloja suunniteltu sopimuksen ylittävä määrä:'
     }
   },
   messages: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -440,7 +440,9 @@ const sv: Translations = {
       reserved: 'Reserverad tid',
       usedService: 'Förverkligad tid',
       minutes: 'min',
-      hours: 'h'
+      hours: 'h',
+      warningUsedServiceExceeded: 'Närvaro utöver vad som anges i avtalet:',
+      warningPlannedServiceExceeded: 'Planerad närvaro utöver kontraktet:'
     }
   },
   messages: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -887,8 +887,8 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
         val employee = DevEmployee()
 
         val adult = DevPerson()
-        val child1 = DevPerson()
-        val child2 = DevPerson()
+        val child1 = DevPerson(dateOfBirth = mockToday.minusYears(4))
+        val child2 = DevPerson(dateOfBirth = mockToday.minusYears(3))
 
         db.transaction { tx ->
             tx.insert(area)


### PR DESCRIPTION
## Before this change
It was hard for citizens to notice when reservations or realized attendance exceeds service need.

## After this change
Monthly summaries display a warning icon when a child has exceeded service need. If reservations exceed service need, the info box is initially open.

<img width="398" alt="image" src="https://github.com/espoon-voltti/evaka/assets/886091/0a700e3f-3737-424c-b7d5-063e1f38bce9">
