### PR TITLE
Replace mobile_device_daycare_acl_view in most places

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlQueries.kt
@@ -5,11 +5,12 @@
 package fi.espoo.evaka.shared.security
 
 import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.QuerySql
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 
-data class EmployeeChildAclConfig(
+data class ChildAclConfig(
     /** Enables access via direct placements */
     val placement: Boolean = true,
     /** Enables access via backup care placements */
@@ -24,7 +25,7 @@ data class EmployeeChildAclConfig(
     }
 
     /**
-     * Returns a list of ACL queries based on this configuration.
+     * Returns a list of employee ACL queries based on this configuration.
      *
      * The queries return (child_id, unit_id, role) rows for the given user.
      */
@@ -33,6 +34,18 @@ data class EmployeeChildAclConfig(
             if (this.placement) employeeChildAclViaPlacement(user.id, now) else null,
             if (this.backupCare) employeeChildAclViaBackupCare(user.id, now) else null,
             if (this.application) employeeChildAclViaApplication(user.id) else null
+        )
+
+    /**
+     * Returns a list of mobile device ACL queries based on this configuration.
+     *
+     * The queries return (child_id) rows for the given mobile device.
+     */
+    fun aclQueries(user: AuthenticatedUser.MobileDevice, now: HelsinkiDateTime) =
+        listOfNotNull(
+            if (this.placement) mobileChildAclViaPlacement(user.id, now) else null,
+            if (this.backupCare) mobileChildAclViaBackupCare(user.id, now) else null,
+            if (this.application) mobileChildAclViaApplication(user.id) else null
         )
 }
 
@@ -73,6 +86,55 @@ JOIN daycare_acl ON pp.unit_id = daycare_acl.daycare_id
 WHERE a.status = ANY ('{SENT,WAITING_PLACEMENT,WAITING_CONFIRMATION,WAITING_DECISION,WAITING_MAILING,WAITING_UNIT_CONFIRMATION}'::application_status_type[])
 AND NOT (role = 'SPECIAL_EDUCATION_TEACHER' AND coalesce((a.document -> 'careDetails' ->> 'assistanceNeeded')::boolean, FALSE) IS FALSE)
 AND daycare_acl.employee_id = ${bind(employee)}
+"""
+        )
+    }
+
+fun mobileChildAclViaPlacement(mobileDevice: MobileDeviceId, now: HelsinkiDateTime) =
+    QuerySql.of<Any> {
+        sql(
+            """
+SELECT pl.child_id
+FROM placement pl
+WHERE ${bind(now.toLocalDate())} < pl.end_date + INTERVAL '1 month'
+AND EXISTS (
+    SELECT FROM mobile_device md
+    LEFT JOIN daycare_acl acl ON md.employee_id = acl.employee_id
+    WHERE md.id = ${bind(mobileDevice)} AND (md.unit_id = pl.unit_id OR acl.daycare_id = pl.unit_id)
+)
+"""
+        )
+    }
+
+fun mobileChildAclViaBackupCare(mobileDevice: MobileDeviceId, now: HelsinkiDateTime) =
+    QuerySql.of<Any> {
+        sql(
+            """
+SELECT bc.child_id
+FROM backup_care bc
+WHERE ${bind(now.toLocalDate())} < bc.end_date + INTERVAL '1 month'
+AND EXISTS (
+    SELECT FROM mobile_device md
+    LEFT JOIN daycare_acl acl ON md.employee_id = acl.employee_id
+    WHERE md.id = ${bind(mobileDevice)} AND (md.unit_id = bc.unit_id OR acl.daycare_id = bc.unit_id)
+)
+"""
+        )
+    }
+
+fun mobileChildAclViaApplication(mobileDevice: MobileDeviceId) =
+    QuerySql.of<Any> {
+        sql(
+            """
+SELECT a.child_id
+FROM placement_plan pp
+JOIN application a ON pp.application_id = a.id
+WHERE a.status = ANY ('{SENT,WAITING_PLACEMENT,WAITING_CONFIRMATION,WAITING_DECISION,WAITING_MAILING,WAITING_UNIT_CONFIRMATION}'::application_status_type[])
+AND EXISTS (
+    SELECT FROM mobile_device md
+    LEFT JOIN daycare_acl acl ON md.employee_id = acl.employee_id
+    WHERE md.id = ${bind(mobileDevice)} AND (md.unit_id = pp.unit_id OR acl.daycare_id = pp.unit_id)
+)
 """
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
@@ -49,7 +49,7 @@ import fi.espoo.evaka.shared.db.QuerySql
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.toFiniteDateRange
 import fi.espoo.evaka.shared.security.AccessControlDecision
-import fi.espoo.evaka.shared.security.EmployeeChildAclConfig
+import fi.espoo.evaka.shared.security.ChildAclConfig
 import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.shared.utils.emptyEnumSet
 import fi.espoo.evaka.shared.utils.toEnumSet
@@ -109,7 +109,7 @@ SELECT EXISTS (
      * @param idChildQuery a query that must return rows with columns `id` and `child_id`
      */
     private fun <T : Id<*>> ruleViaChildAcl(
-        cfg: EmployeeChildAclConfig,
+        cfg: ChildAclConfig,
         idChildQuery:
             QuerySql.Builder<T>.(
                 user: AuthenticatedUser.Employee, now: HelsinkiDateTime
@@ -264,7 +264,7 @@ ${if (onlyAllowDeletedForTypes != null) "AND (a.type = ANY(${bind(onlyAllowDelet
 
     fun inPlacementUnitOfChildOfAssistanceAction(
         hidePastAssistance: Boolean,
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<AssistanceActionId>(cfg) { _, now ->
             sql(
@@ -296,7 +296,7 @@ AND aa.end_date >= ${bind(now.toLocalDate())}"""
 
     fun inPlacementUnitOfChildOfAssistanceFactor(
         hidePastAssistance: Boolean,
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<AssistanceFactorId>(cfg) { _, now ->
             sql(
@@ -328,7 +328,7 @@ AND NOT af.valid_during << ${bind(now.toLocalDate().toFiniteDateRange())}"""
 
     fun inPlacementUnitOfChildOfAssistanceNeedDecision(
         hidePastAssistance: Boolean,
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<AssistanceNeedDecisionId>(cfg) { _, now ->
             sql(
@@ -360,7 +360,7 @@ AND NOT ad.validity_period << ${bind(now.toLocalDate().toFiniteDateRange())}"""
 
     fun inPlacementUnitOfChildOfAcceptedAssistanceNeedDecision(
         hidePastAssistance: Boolean,
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<AssistanceNeedDecisionId>(cfg) { _, now ->
             sql(
@@ -392,7 +392,7 @@ AND NOT ad.validity_period << ${bind(now.toLocalDate().toFiniteDateRange())}
         }
 
     fun inPlacementUnitOfChildOfAcceptedAssistanceNeedPreschoolDecision(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<AssistanceNeedPreschoolDecisionId>(cfg) { _, _ ->
             sql(
@@ -406,7 +406,7 @@ WHERE apd.status = 'ACCEPTED'
 
     fun inPlacementUnitOfChildOfDaycareAssistance(
         hidePastAssistance: Boolean,
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<DaycareAssistanceId>(cfg) { _, now ->
             sql(
@@ -438,7 +438,7 @@ AND NOT da.valid_during << ${bind(now.toLocalDate().toFiniteDateRange())}"""
 
     fun inPlacementUnitOfChildOfOtherAssistanceMeasure(
         hidePastAssistance: Boolean,
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<OtherAssistanceMeasureId>(cfg) { _, now ->
             sql(
@@ -470,7 +470,7 @@ AND NOT oam.valid_during << ${bind(now.toLocalDate().toFiniteDateRange())}"""
 
     fun inPlacementUnitOfChildOfPreschoolAssistance(
         hidePastAssistance: Boolean,
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<PreschoolAssistanceId>(cfg) { _, now ->
             sql(
@@ -500,9 +500,7 @@ AND NOT pa.valid_during << ${bind(now.toLocalDate().toFiniteDateRange())}"""
             )
         }
 
-    fun inSelectedUnitOfAssistanceNeedDecision(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun inSelectedUnitOfAssistanceNeedDecision(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<AssistanceNeedDecisionId>(cfg) { _, _ ->
             sql("""
 SELECT ad.id, child_id
@@ -511,9 +509,7 @@ FROM assistance_need_decision ad
         }
 
     // For Tampere
-    fun andIsDecisionMakerForAssistanceNeedDecision(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun andIsDecisionMakerForAssistanceNeedDecision(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<AssistanceNeedDecisionId>(cfg) { user, _ ->
             sql(
                 """
@@ -526,7 +522,7 @@ WHERE ad.decision_maker_employee_id = ${bind(user.id)}
         }
 
     fun inPlacementUnitOfChildOfAssistanceNeedPreschoolDecision(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<AssistanceNeedPreschoolDecisionId>(cfg) { _, _ ->
             sql(
@@ -537,9 +533,7 @@ FROM assistance_need_preschool_decision ad
             )
         }
 
-    fun inSelectedUnitOfAssistanceNeedPreschoolDecision(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun inSelectedUnitOfAssistanceNeedPreschoolDecision(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<AssistanceNeedPreschoolDecisionId>(cfg) { _, _ ->
             sql(
                 """
@@ -551,7 +545,7 @@ FROM assistance_need_preschool_decision ad
 
     // For Tampere
     fun andIsDecisionMakerForAssistanceNeedPreschoolDecision(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<AssistanceNeedPreschoolDecisionId>(cfg) { user, _ ->
             sql(
@@ -565,7 +559,7 @@ WHERE ad.decision_maker_employee_id = ${bind(user.id)}
         }
 
     fun inPlacementUnitOfChildOfAssistanceNeedVoucherCoefficientWithServiceVoucherPlacement(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<AssistanceNeedVoucherCoefficientId>(cfg) { _, _ ->
             sql(
@@ -582,7 +576,7 @@ WHERE EXISTS(
             )
         }
 
-    fun inPlacementUnitOfChildOfBackupCare(cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()) =
+    fun inPlacementUnitOfChildOfBackupCare(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<BackupCareId>(cfg) { _, _ ->
             sql("""
 SELECT bc.id, child_id
@@ -590,9 +584,7 @@ FROM backup_care bc
             """)
         }
 
-    fun inPlacementUnitOfChildOfBackupPickup(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun inPlacementUnitOfChildOfBackupPickup(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<BackupPickupId>(cfg) { _, _ ->
             sql("""
 SELECT bp.id, child_id
@@ -600,7 +592,7 @@ FROM backup_pickup bp
             """)
         }
 
-    fun inPlacementUnitOfChild(cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()) =
+    fun inPlacementUnitOfChild(cfg: ChildAclConfig = ChildAclConfig()) =
         rule<ChildId> { user, now ->
             union(
                 all = true,
@@ -617,9 +609,7 @@ FROM (${subquery(aclQuery)}) acl
             )
         }
 
-    fun inPlacementUnitOfChildOfChildDailyNote(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun inPlacementUnitOfChildOfChildDailyNote(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<ChildDailyNoteId>(cfg) { _, _ ->
             sql("""
 SELECT child_daily_note.id, child_id
@@ -627,9 +617,7 @@ FROM child_daily_note
 """)
         }
 
-    fun inPlacementUnitOfChildOfChildStickyNote(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun inPlacementUnitOfChildOfChildStickyNote(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<ChildStickyNoteId>(cfg) { _, _ ->
             sql("""
 SELECT csn.id, child_id
@@ -637,7 +625,7 @@ FROM child_sticky_note csn
             """)
         }
 
-    fun inPlacementUnitOfChildOfChildImage(cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()) =
+    fun inPlacementUnitOfChildOfChildImage(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<ChildImageId>(cfg) { _, _ ->
             sql("""
 SELECT img.id, child_id
@@ -681,9 +669,7 @@ WHERE employee_id = ${bind(user.id)}
             )
         }
 
-    fun inPlacementUnitOfChildOfPedagogicalDocument(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun inPlacementUnitOfChildOfPedagogicalDocument(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<PedagogicalDocumentId>(cfg) { _, _ ->
             sql("""
 SELECT pd.id, child_id
@@ -692,7 +678,7 @@ FROM pedagogical_document pd
         }
 
     fun inPlacementUnitOfChildOfPedagogicalDocumentOfAttachment(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<AttachmentId>(cfg) { _, _ ->
             sql(
@@ -756,7 +742,7 @@ WHERE employee_id = ${bind(user.id)}
         editable: Boolean = false,
         deletable: Boolean = false,
         publishable: Boolean = false,
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<ChildDocumentId>(cfg) { _, _ ->
             sql(
@@ -772,7 +758,7 @@ ${if (publishable) "AND status <> 'COMPLETED'" else ""}
         }
 
     fun inPlacementUnitOfDuplicateChildOfHojksChildDocument(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<ChildDocumentId>(cfg) { _, _ ->
             sql(
@@ -786,9 +772,7 @@ WHERE document_template.type = 'HOJKS'
             )
         }
 
-    fun inPlacementUnitOfChildOfVasuDocument(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun inPlacementUnitOfChildOfVasuDocument(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<VasuDocumentId>(cfg) { _, _ ->
             sql("""
 SELECT curriculum_document.id, child_id
@@ -797,7 +781,7 @@ FROM curriculum_document
         }
 
     fun inPlacementUnitOfDuplicateChildOfDaycareCurriculumDocument(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<VasuDocumentId>(cfg) { _, _ ->
             sql(
@@ -817,7 +801,7 @@ WHERE ct.type = 'DAYCARE' AND cd.created = (
         }
 
     fun inPlacementUnitOfDuplicateChildOfPreschoolCurriculumDocument(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig()
     ) =
         ruleViaChildAcl<VasuDocumentId>(cfg) { _, _ ->
             sql(
@@ -831,9 +815,7 @@ WHERE curriculum_template.type = 'PRESCHOOL'
             )
         }
 
-    fun inPlacementUnitOfChildOfDailyServiceTime(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun inPlacementUnitOfChildOfDailyServiceTime(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<DailyServiceTimesId>(cfg) { _, _ ->
             sql("""
 SELECT dst.id, child_id
@@ -841,9 +823,7 @@ FROM daily_service_time dst
             """)
         }
 
-    fun inPlacementUnitOfChildOfFutureDailyServiceTime(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun inPlacementUnitOfChildOfFutureDailyServiceTime(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<DailyServiceTimesId>(cfg) { _, now ->
             sql(
                 """
@@ -954,9 +934,7 @@ AND attachment.type = 'EXTENDED_CARE'
             )
         }
 
-    fun inPlacementUnitOfChildWithServiceVoucherPlacement(
-        cfg: EmployeeChildAclConfig = EmployeeChildAclConfig()
-    ) =
+    fun inPlacementUnitOfChildWithServiceVoucherPlacement(cfg: ChildAclConfig = ChildAclConfig()) =
         rule<ChildId> { user, now ->
             union(
                 all = true,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- rename `EmployeeChildAclConfig` and use it for mobile devices in rules where the permission is given via a child
- replace `mobile_device_daycare_acl_view` in other rules

This should greatly reduce the performance impact of many permission checks. For example, `inPlacementUnitOfChildOfChildImage` checks currently have a worst case duration of >1 s (!!), which is crazy considering we're checking the permission for one mobile device to access one child image.