### PR TITLE
Add an experimental feature flag to hide option to create a club application in citizen UI

### DIFF
--- a/frontend/src/citizen-frontend/applications/ApplicationCreation.tsx
+++ b/frontend/src/citizen-frontend/applications/ApplicationCreation.tsx
@@ -117,17 +117,19 @@ export default React.memo(function ApplicationCreation() {
                 <Gap size="s" />
               </>
             )}
-            <ExpandingInfo
-              data-qa="club-expanding-info"
-              info={t.applications.creation.clubInfo}
-            >
-              <Radio
-                checked={selectedType === 'CLUB'}
-                onChange={() => setSelectedType('CLUB')}
-                label={t.applications.creation.clubLabel}
-                data-qa="type-radio-CLUB"
-              />
-            </ExpandingInfo>
+            {!featureFlags.hideClubApplication && (
+              <ExpandingInfo
+                data-qa="club-expanding-info"
+                info={t.applications.creation.clubInfo}
+              >
+                <Radio
+                  checked={selectedType === 'CLUB'}
+                  onChange={() => setSelectedType('CLUB')}
+                  label={t.applications.creation.clubLabel}
+                  data-qa="type-radio-CLUB"
+                />
+              </ExpandingInfo>
+            )}
             <Gap size="m" />
             {duplicateExists ? (
               <>

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -222,6 +222,11 @@ interface BaseFeatureFlags {
    * Display time usage info in citizen calendar views
    */
   timeUsageInfo?: boolean
+
+  /**
+   * Hide option to create a club application in citizen UI
+   */
+  hideClubApplication?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>


### PR DESCRIPTION
Add an experimental feature flag to hide option to create a club application in citizen UI (Not used in treVaka Vesilahti/Hämeenkyrö etc.)

