### PR TITLE
Hide month hours summary when featureflag is disabled

### DIFF
--- a/frontend/src/citizen-frontend/calendar/hooks.ts
+++ b/frontend/src/citizen-frontend/calendar/hooks.ts
@@ -18,11 +18,13 @@ export function useSummaryInfo(childSummaries: MonthlyTimeSummary[]) {
     )
   )
   const [summaryExplicitlyClosed, setSummaryExplicitlyClosed] = useState(false)
-  const [summaryInfoOpen, setSummaryInfoOpen] = useState(() =>
-    childSummaries.some(
-      ({ reservedMinutes, serviceNeedMinutes }) =>
-        reservedMinutes > serviceNeedMinutes
-    )
+  const [summaryInfoOpen, setSummaryInfoOpen] = useState(
+    () =>
+      featureFlags.timeUsageInfo &&
+      childSummaries.some(
+        ({ reservedMinutes, serviceNeedMinutes }) =>
+          reservedMinutes > serviceNeedMinutes
+      )
   )
 
   const toggleSummaryInfo = useCallback(() => {
@@ -37,6 +39,7 @@ export function useSummaryInfo(childSummaries: MonthlyTimeSummary[]) {
 
   useEffect(() => {
     if (
+      featureFlags.timeUsageInfo &&
       !summaryExplicitlyClosed &&
       childSummaries.some(
         ({ reservedMinutes, serviceNeedMinutes }) =>


### PR DESCRIPTION
## Before this change
Summary became visible if alert logic was triggered even when `timeUsageInfo` was disabled
## After this change
Summary is not show if feature flag `timeUsageInfo` is disabled