### PR TITLE
Use zod for parsing, not just validation

### DIFF
--- a/apigw/src/enduser/keycloak-citizen-saml.ts
+++ b/apigw/src/enduser/keycloak-citizen-saml.ts
@@ -20,18 +20,15 @@ export function createKeycloakCitizenSamlStrategy(
   config: SamlConfig
 ): SamlStrategy {
   return createSamlStrategy(sessions, config, Profile, async (profile) => {
-    const asString = (value: unknown) =>
-      value == null ? undefined : String(value)
-
-    const socialSecurityNumber = asString(profile['socialSecurityNumber'])
+    const socialSecurityNumber = profile.socialSecurityNumber
     if (!socialSecurityNumber)
       throw Error('No socialSecurityNumber in evaka IDP SAML data')
 
     const person = await citizenLogin({
       socialSecurityNumber,
-      firstName: asString(profile['firstName']) ?? '',
-      lastName: asString(profile['lastName']) ?? '',
-      keycloakEmail: asString(profile['email']) ?? ''
+      firstName: profile.firstName ?? '',
+      lastName: profile.lastName ?? '',
+      keycloakEmail: profile.email ?? ''
     })
 
     return {

--- a/apigw/src/enduser/suomi-fi-saml.ts
+++ b/apigw/src/enduser/suomi-fi-saml.ts
@@ -26,15 +26,12 @@ export function createSuomiFiStrategy(
   config: SamlConfig
 ): Strategy {
   return createSamlStrategy(sessions, config, Profile, async (profile) => {
-    const asString = (value: unknown) =>
-      value == null ? undefined : String(value)
-
-    const socialSecurityNumber = asString(profile[SUOMI_FI_SSN_KEY])
+    const socialSecurityNumber = profile[SUOMI_FI_SSN_KEY]
     if (!socialSecurityNumber) throw Error('No SSN in SAML data')
     const person = await citizenLogin({
       socialSecurityNumber,
-      firstName: asString(profile[SUOMI_FI_GIVEN_NAME_KEY]) ?? '',
-      lastName: asString(profile[SUOMI_FI_SURNAME_KEY]) ?? ''
+      firstName: profile[SUOMI_FI_GIVEN_NAME_KEY] ?? '',
+      lastName: profile[SUOMI_FI_SURNAME_KEY] ?? ''
     })
     return {
       id: person.id,

--- a/apigw/src/internal/ad-saml.ts
+++ b/apigw/src/internal/ad-saml.ts
@@ -31,17 +31,14 @@ export function createAdSamlStrategy(
     [AD_EMPLOYEE_NUMBER_KEY]: z.string().toLowerCase().optional()
   })
   return createSamlStrategy(sessions, samlConfig, Profile, async (profile) => {
-    const asString = (value: unknown) =>
-      value == null ? undefined : String(value)
-
     const aad = profile[config.userIdKey]
     if (!aad) throw Error('No user ID in SAML data')
     const person = await employeeLogin({
       externalId: `${config.externalIdPrefix}:${aad}`,
-      firstName: asString(profile[AD_GIVEN_NAME_KEY]) ?? '',
-      lastName: asString(profile[AD_FAMILY_NAME_KEY]) ?? '',
-      email: asString(profile[AD_EMAIL_KEY]),
-      employeeNumber: asString(profile[AD_EMPLOYEE_NUMBER_KEY])
+      firstName: profile[AD_GIVEN_NAME_KEY] ?? '',
+      lastName: profile[AD_FAMILY_NAME_KEY] ?? '',
+      email: profile[AD_EMAIL_KEY],
+      employeeNumber: profile[AD_EMPLOYEE_NUMBER_KEY]
     })
     return {
       id: person.id,

--- a/apigw/src/internal/keycloak-employee-saml.ts
+++ b/apigw/src/internal/keycloak-employee-saml.ts
@@ -20,16 +20,13 @@ export function createKeycloakEmployeeSamlStrategy(
   config: SamlConfig
 ): SamlStrategy {
   return createSamlStrategy(sessions, config, Profile, async (profile) => {
-    const asString = (value: unknown) =>
-      value == null ? undefined : String(value)
-
-    const id = asString(profile['id'])
+    const id = profile.id
     if (!id) throw Error('No user ID in evaka IDP SAML data')
     const person = await employeeLogin({
       externalId: `evaka:${id}`,
-      firstName: asString(profile['firstName']) ?? '',
-      lastName: asString(profile['lastName']) ?? '',
-      email: asString(profile['email'])
+      firstName: profile.firstName ?? '',
+      lastName: profile.lastName ?? '',
+      email: profile.email
     })
     return {
       id: person.id,


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Invalid profiles will now return an error instead of just a warning.

Also fixes employee number lower case transformation, because we now use the profile parsed by zod and not the original value