### PR TITLE
Fix css problems on different browsers

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayCommons.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayCommons.tsx
@@ -20,7 +20,6 @@ export const TimesRow = styled.div`
   flex-wrap: nowrap;
   justify-content: space-evenly;
   padding: ${defaultMargins.xs};
-  gap: ${defaultMargins.xs};
 `
 
 export const TimeCell = styled.div<{ warning?: boolean }>`

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayReservation.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayReservation.tsx
@@ -207,6 +207,7 @@ export const ReservationDateCell = styled(DateCell)`
   margin: 5px 0px 5px 0px;
   position: relative;
   height: 38px;
+  padding-right: 12px;
 
   &:hover {
     ${DetailsToggle} {
@@ -218,6 +219,5 @@ export const ReservationDateCell = styled(DateCell)`
 const ReservationTooltip = styled(Tooltip)`
   display: flex;
   justify-content: space-evenly;
-  padding: 8px;
-  gap: 8px;
+  width: 100%;
 `


### PR DESCRIPTION
#### Summary
Css layout of having both reservations and attendances fixed on chromium, chrome, firefox and safari


<img width="902" alt="Screenshot 2024-03-05 at 8 15 21" src="https://github.com/espoon-voltti/evaka/assets/158767/cceb7a90-c124-4d15-acc0-f0ffee485c66">
