### PR TITLE
Deduplicate identical working time events in the Titania request

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/titania/TitaniaService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/titania/TitaniaService.kt
@@ -131,7 +131,7 @@ class TitaniaService(private val idConverter: TitaniaEmployeeIdConverter) {
                             } else {
                                 plans.add(next)
                             }
-                            plans
+                            plans.distinct().toMutableList()
                         }
                 }
 


### PR DESCRIPTION
Titania seems to occasionally create duplicated working time events which do not show in the Titania UI, so filter them out at eVaka's end
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

