### PR TITLE
Spring boot 3.2

### DIFF
--- a/service/entrypoint.sh
+++ b/service/entrypoint.sh
@@ -38,8 +38,8 @@ if [ "${DD_PROFILING_ENABLED:-false}" = "true" ]; then
     -Ddd.trace.sample.rate=1 \
     -javaagent:/opt/dd-java-agent.jar \
     -XX:FlightRecorderOptions=stackdepth=256 \
-    -cp . -server $JAVA_OPTS org.springframework.boot.loader.JarLauncher "$@"
+    -cp . -server $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher "$@"
 else
   # shellcheck disable=SC2086
-  exec java -cp . -server $JAVA_OPTS org.springframework.boot.loader.JarLauncher "$@"
+  exec java -cp . -server $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher "$@"
 fi

--- a/service/evaka-bom/build.gradle.kts
+++ b/service/evaka-bom/build.gradle.kts
@@ -48,7 +48,6 @@ dependencies {
         api("org.thymeleaf:thymeleaf:3.1.2.RELEASE")
         api(libs.flyingsaucer.core)
         api(libs.flyingsaucer.pdf.openpdf)
-        api("org.yaml:snakeyaml:2.2")
         api(libs.ktlint.cli.ruleset.core)
         api(libs.ktlint.rule.engine.core)
         api(libs.ktlint.test)
@@ -57,6 +56,9 @@ dependencies {
 
     api(platform("com.fasterxml.jackson:jackson-bom:2.16.0"))
     api(platform("org.apache.cxf:cxf-bom:4.0.3"))
+    // Spring Boot specifies a version constraint for Jetty, but we have other libraries relying
+    // on an older version -> we enforce a specific Jetty BOM version and ignore Spring Boot
+    api(enforcedPlatform("org.eclipse.jetty:jetty-bom:11.0.20"))
     api(platform("org.jdbi:jdbi3-bom:3.45.0"))
     api(platform(libs.kotlin.bom))
     api(platform("org.junit:junit-bom:5.10.0"))

--- a/service/gradle/libs.versions.toml
+++ b/service/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ ktlint-gradle = "12.1.0"
 mockito = "5.11.0"
 opentracing = "0.33.0"
 owasp = "9.0.2"
-spring-boot = "3.1.9"
+spring-boot = "3.2.3"
 versions = "0.51.0"
 
 [libraries]

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ExceptionHandler.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/controllers/ExceptionHandler.kt
@@ -68,11 +68,12 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
             .body(ErrorResponse(errorCode = ex.errorCode))
     }
 
-    @ExceptionHandler(value = [MaxUploadSizeExceededException::class])
-    fun maxUploadSizeExceeded(
-        req: HttpServletRequest,
-        ex: MaxUploadSizeExceededException
-    ): ResponseEntity<ErrorResponse> {
+    override fun handleMaxUploadSizeExceededException(
+        ex: MaxUploadSizeExceededException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any>? {
         logger.warn("Max upload size exceeded (${ex.message})", ex)
         return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(ErrorResponse())
     }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

- upgrade to Spring Boot 3.2
- force old Jetty version to keep Apache CXF and Javalin happy. We don't use Spring Boot's embedded Jetty
- fix exception handler incompatibility
- update launcher class name in Docker entrypoint
