### PR TITLE
Allow reservations when placement starts after holiday period deadline

### DIFF
--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -64,7 +64,7 @@ const emptyChild: ReservationResponseDayChild = {
     type: 'NORMAL',
     range: defaultReservableTimeRange
   },
-  reservationLockedDueHolidayPeriod: true
+  lockedByHolidayPeriod: true
 }
 
 const timeInputState = (
@@ -1472,7 +1472,7 @@ describe('resetTimes', () => {
         ]
       })
     })
-    it('Closed holiday period + reservationLockedDueHolidayPeriod = false', () => {
+    it('Closed holiday period + lockedByHolidayPeriod = false', () => {
       const holidayPeriods = [
         { period: selectedRange, state: 'closed' as const }
       ]
@@ -1480,7 +1480,11 @@ describe('resetTimes', () => {
         (day) => ({
           ...day,
           children: [
-            { ...emptyChild, reservationLockedDueHolidayPeriod: false }
+            { ...emptyChild, lockedByHolidayPeriod: false },
+            {
+              ...emptyChild,
+              childId: 'child-2'
+            }
           ]
         })
       )
@@ -1495,7 +1499,7 @@ describe('resetTimes', () => {
         resetTimes(dayProperties, undefined, {
           repetition: 'WEEKLY',
           selectedRange,
-          selectedChildren: [emptyChild.childId]
+          selectedChildren: [emptyChild.childId, 'child-2']
         })
       ).toEqual({
         branch: 'weeklyTimes',

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -1472,6 +1472,48 @@ describe('resetTimes', () => {
         ]
       })
     })
+    it('Closed holiday period + reservationLockedDueHolidayPeriod = false', () => {
+      const holidayPeriods = [
+        { period: selectedRange, state: 'closed' as const }
+      ]
+      const calendarDays: ReservationResponseDay[] = emptyCalendarDays.map(
+        (day) => ({
+          ...day,
+          children: [
+            { ...emptyChild, reservationLockedDueHolidayPeriod: false }
+          ]
+        })
+      )
+
+      const dayProperties = new DayProperties(
+        calendarDays,
+        reservableRange,
+        holidayPeriods
+      )
+
+      expect(
+        resetTimes(dayProperties, undefined, {
+          repetition: 'WEEKLY',
+          selectedRange,
+          selectedChildren: [emptyChild.childId]
+        })
+      ).toEqual({
+        branch: 'weeklyTimes',
+        state: [1, 2, 3, 4, 5].map((weekDay) => ({
+          weekDay,
+          day: {
+            branch: 'reservation',
+            state: {
+              validTimeRange: defaultReservableTimeRange,
+              reservation: {
+                branch: 'timeRanges',
+                state: [timeInputState('', '')]
+              }
+            }
+          }
+        }))
+      })
+    })
 
     it('Open holiday period covers the whole period', () => {
       // mo tu we th fr sa su | MO TU WE TH FR SA SU | MO TU we th fr sa su

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -63,7 +63,8 @@ const emptyChild: ReservationResponseDayChild = {
   reservableTimeRange: {
     type: 'NORMAL',
     range: defaultReservableTimeRange
-  }
+  },
+  reservationLockedDueHolidayPeriod: false
 }
 
 const timeInputState = (

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -64,7 +64,7 @@ const emptyChild: ReservationResponseDayChild = {
     type: 'NORMAL',
     range: defaultReservableTimeRange
   },
-  reservationLockedDueHolidayPeriod: false
+  reservationLockedDueHolidayPeriod: true
 }
 
 const timeInputState = (

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -606,10 +606,9 @@ const allChildrenAreLockedDueHolidayPeriod = (
   selectedChildren: string[]
 ) =>
   calendarDays.every((day) =>
-    selectedChildren.some((childId) =>
+    selectedChildren.every((childId) =>
       day.children.some(
-        (child) =>
-          child.childId === childId && child.reservationLockedDueHolidayPeriod
+        (child) => child.childId === childId && child.lockedByHolidayPeriod
       )
     )
   )

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -537,7 +537,8 @@ export function resetDay(
 
   if (
     holidayPeriodState === 'closed' &&
-    hasNoReservationsForSomeChild(calendarDays, selectedChildren)
+    hasNoReservationsForSomeChild(calendarDays, selectedChildren) &&
+    allChildrenAreLockedDueHolidayPeriod(calendarDays, selectedChildren)
   ) {
     return { branch: 'readOnly', state: 'reservationClosed' }
   }
@@ -596,6 +597,19 @@ const hasNoReservationsForSomeChild = (
           child.scheduleType === 'RESERVATION_REQUIRED' &&
           child.reservations.length === 0 &&
           child.absence === null
+      )
+    )
+  )
+
+const allChildrenAreLockedDueHolidayPeriod = (
+  calendarDays: ReservationResponseDay[],
+  selectedChildren: string[]
+) =>
+  calendarDays.every((day) =>
+    selectedChildren.some((childId) =>
+      day.children.some(
+        (child) =>
+          child.childId === childId && child.reservationLockedDueHolidayPeriod
       )
     )
   )

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-start-after-holiday-deadline.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-start-after-holiday-deadline.spec.ts
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import FiniteDateRange from 'lib-common/finite-date-range'
+import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
+
+import {
+  careAreaFixture,
+  DaycareBuilder,
+  daycareFixture,
+  daycareGroupFixture,
+  enduserChildFixtureJari,
+  enduserGuardianFixture,
+  Fixture,
+  PersonBuilder
+} from '../../dev-api/fixtures'
+import { resetDatabase } from '../../generated/api-clients'
+import CitizenCalendarPage from '../../pages/citizen/citizen-calendar'
+import CitizenHeader from '../../pages/citizen/citizen-header'
+import { Page } from '../../utils/page'
+import { enduserLogin } from '../../utils/user'
+
+let page: Page
+
+const startDate = LocalDate.of(2024, 6, 3)
+const period = new FiniteDateRange(startDate, LocalDate.of(2024, 8, 15))
+const child = enduserChildFixtureJari
+const mockedDate = LocalDate.of(2024, 5, 25)
+let daycare: DaycareBuilder
+let guardian: PersonBuilder
+
+beforeEach(async () => {
+  await resetDatabase()
+  page = await Page.open({
+    mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0))
+  })
+
+  daycare = await Fixture.daycare()
+    .with(daycareFixture)
+    .careArea(await Fixture.careArea().with(careAreaFixture).save())
+    .save()
+  await Fixture.daycareGroup().with(daycareGroupFixture).daycare(daycare).save()
+
+  guardian = await Fixture.person().with(enduserGuardianFixture).save()
+  const child1 = await Fixture.person().with(child).save()
+  await Fixture.child(child1.data.id).save()
+  await Fixture.guardian(child1, guardian).save()
+  await Fixture.placement()
+    .child(child1)
+    .daycare(daycare)
+    .with({
+      startDate: startDate,
+      endDate: LocalDate.of(2026, 6, 30)
+    })
+    .save()
+  await Fixture.holidayPeriod()
+    .with({
+      period,
+      reservationDeadline: LocalDate.of(2024, 5, 10)
+    })
+    .save()
+})
+
+describe('Placement start after deadline end', () => {
+  test('citizen can mark repeating attendances', async () => {
+    await enduserLogin(page)
+    await new CitizenHeader(page).selectTab('calendar')
+    const calendar = new CitizenCalendarPage(page, 'desktop')
+
+    await calendar.assertDay(startDate, [
+      {
+        childIds: [child.id],
+        text: 'Ilmoitus puuttuu'
+      }
+    ])
+
+    const reservationsModal = await calendar.openReservationsModal()
+    await reservationsModal.createRepeatingDailyReservation(
+      new FiniteDateRange(startDate, LocalDate.of(2024, 6, 7)),
+      '08:00',
+      '16:00'
+    )
+
+    for (let index = 0; index <= 4; index++) {
+      await calendar.assertDay(startDate.addDays(index), [
+        {
+          childIds: [child.id],
+          text: '08:00–16:00'
+        }
+      ])
+    }
+  })
+  test('citizen can mark single day attendances', async () => {
+    await enduserLogin(page)
+    await new CitizenHeader(page).selectTab('calendar')
+    const calendar = new CitizenCalendarPage(page, 'desktop')
+
+    await calendar.assertDay(startDate, [
+      {
+        childIds: [child.id],
+        text: 'Ilmoitus puuttuu'
+      }
+    ])
+
+    const dayView = await calendar.openDayView(startDate)
+    const editor = await dayView.edit()
+    const childView = editor.childSection(child.id)
+
+    const reservation = {
+      startTime: '08:00',
+      endTime: '16:00'
+    }
+
+    await childView.reservationStart.fill(reservation.startTime)
+    await childView.reservationEnd.fill(reservation.endTime)
+    await editor.saveButton.click()
+
+    await dayView.assertReservations(child.id, [reservation])
+    await dayView.close()
+
+    await calendar.assertDay(startDate, [
+      {
+        childIds: [child.id],
+        text: '08:00–16:00'
+      }
+    ])
+  })
+})

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -347,6 +347,7 @@ export interface ReservationResponseDayChild {
   attendances: TimeInterval[]
   childId: UUID
   reservableTimeRange: ReservableTimeRange
+  reservationLockedDueHolidayPeriod: boolean
   reservations: ReservationResponse[]
   scheduleType: ScheduleType
   shiftCare: boolean

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -346,8 +346,8 @@ export interface ReservationResponseDayChild {
   absence: AbsenceInfo | null
   attendances: TimeInterval[]
   childId: UUID
+  lockedByHolidayPeriod: boolean
   reservableTimeRange: ReservableTimeRange
-  reservationLockedDueHolidayPeriod: boolean
   reservations: ReservationResponse[]
   scheduleType: ScheduleType
   shiftCare: boolean

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
@@ -1055,7 +1055,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
             it.insertTestPlacement(
                 childId = child.id,
                 unitId = daycare.id,
-                startDate = monday,
+                startDate = beforeThreshold.toLocalDate().minusDays(2),
                 endDate = monday.plusYears(1)
             )
             it.insertGuardian(guardianId = adult.id, childId = child.id)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -1891,7 +1891,8 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             reservations,
             attendances,
             usedService,
-            reservableTimeRange
+            reservableTimeRange,
+            reservationLockedDueHolidayPeriod = false
         )
 
     private fun postReservations(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -1892,7 +1892,7 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             attendances,
             usedService,
             reservableTimeRange,
-            reservationLockedDueHolidayPeriod = false
+            lockedByHolidayPeriod = false
         )
 
     private fun postReservations(

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -205,8 +205,8 @@ class ReservationControllerCitizen(
                                                             usedService = usedServiceResult,
                                                             reservableTimeRange =
                                                                 placementDay.reservableTimeRange,
-                                                            reservationLockedDueHolidayPeriod =
-                                                                isReservationLockedDueHolidayPeriod(
+                                                            lockedByHolidayPeriod =
+                                                                isLockedByHolidayPeriod(
                                                                     holidayPeriods,
                                                                     date,
                                                                     today,
@@ -241,7 +241,7 @@ class ReservationControllerCitizen(
             }
     }
 
-    private fun isReservationLockedDueHolidayPeriod(
+    private fun isLockedByHolidayPeriod(
         holidayPeriods: List<HolidayPeriod>,
         date: LocalDate,
         today: LocalDate,
@@ -580,7 +580,7 @@ data class ReservationResponseDayChild(
     val attendances: List<TimeInterval>,
     val usedService: UsedServiceResult?,
     val reservableTimeRange: ReservableTimeRange,
-    val reservationLockedDueHolidayPeriod: Boolean
+    val lockedByHolidayPeriod: Boolean
 )
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -24,6 +24,8 @@ import fi.espoo.evaka.daycare.ClubTerm
 import fi.espoo.evaka.daycare.PreschoolTerm
 import fi.espoo.evaka.daycare.getClubTerms
 import fi.espoo.evaka.daycare.getPreschoolTerms
+import fi.espoo.evaka.holidayperiod.HolidayPeriod
+import fi.espoo.evaka.holidayperiod.getHolidayPeriods
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.ScheduleType
 import fi.espoo.evaka.serviceneed.ShiftCareType
@@ -81,11 +83,13 @@ class ReservationControllerCitizen(
                         Action.Citizen.Person.READ_RESERVATIONS,
                         user.id
                     )
+                    val holidayPeriods = tx.getHolidayPeriods()
                     val holidays = tx.getHolidays(requestedRange)
                     val preschoolTerms = tx.getPreschoolTerms()
                     val clubTerms = tx.getClubTerms()
                     val children = tx.getReservationChildren(user.id, today)
                     val childIds = children.map { it.id }.toSet()
+                    val childStartDates = tx.getFirstPlacementStartDateByChild(childIds)
                     val placements =
                         tx.getReservationPlacements(
                             childIds,
@@ -200,7 +204,14 @@ class ReservationControllerCitizen(
                                                                 },
                                                             usedService = usedServiceResult,
                                                             reservableTimeRange =
-                                                                placementDay.reservableTimeRange
+                                                                placementDay.reservableTimeRange,
+                                                            reservationLockedDueHolidayPeriod =
+                                                                isReservationLockedDueHolidayPeriod(
+                                                                    holidayPeriods,
+                                                                    date,
+                                                                    today,
+                                                                    childStartDates[child.id]!!
+                                                                )
                                                         )
                                                     }
                                             }
@@ -228,6 +239,18 @@ class ReservationControllerCitizen(
                     meta = mapOf("from" to from, "to" to to)
                 )
             }
+    }
+
+    private fun isReservationLockedDueHolidayPeriod(
+        holidayPeriods: List<HolidayPeriod>,
+        date: LocalDate,
+        today: LocalDate,
+        placementStartDate: LocalDate
+    ): Boolean {
+        val holidayPeriod = holidayPeriods.find { it.period.includes(date) }
+        return holidayPeriod != null &&
+            holidayPeriod.reservationDeadline < today &&
+            placementStartDate < holidayPeriod.reservationDeadline
     }
 
     @PostMapping("/citizen/reservations")
@@ -556,7 +579,8 @@ data class ReservationResponseDayChild(
     val reservations: List<ReservationResponse>,
     val attendances: List<TimeInterval>,
     val usedService: UsedServiceResult?,
-    val reservableTimeRange: ReservableTimeRange
+    val reservableTimeRange: ReservableTimeRange,
+    val reservationLockedDueHolidayPeriod: Boolean
 )
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -600,3 +600,14 @@ GROUP BY a.date, a.affected_group_id
         .toList<GroupReservationStatisticsRow>()
         .groupBy { it.date }
 }
+
+fun Database.Read.getFirstPlacementStartDateByChild(
+    childIds: Set<PersonId>
+): Map<ChildId, LocalDate> {
+    return createQuery {
+            sql(
+                "SELECT child_id, MIN(start_date) AS start_date FROM placement WHERE child_id = ANY(${bind(childIds)}) GROUP BY child_id"
+            )
+        }
+        .toMap { columnPair("child_id", "start_date") }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -216,7 +216,9 @@ fun createReservationsAndAbsences(
     val placementStartAfterHolidayDeadline = { req: DailyReservationRequest ->
         val holidayPeriod = holidayPeriods.find { it.period.includes(req.date) }
         val placementStartDate = childStartDates[req.childId]
-        holidayPeriod != null && placementStartDate != null && placementStartDate > holidayPeriod.reservationDeadline
+        holidayPeriod != null &&
+            placementStartDate != null &&
+            placementStartDate > holidayPeriod.reservationDeadline
     }
 
     val validated =


### PR DESCRIPTION
## Before this change
It was not possible to create reservations during a holiday period if there was no "NO_TIMES" reservations for the dates.
## After this change
It's possible to add reservations during a holiday period if child's first placement started after holiday period deadline