### PR TITLE
Send missing holiday reservation reminders

### DIFF
--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -884,6 +884,7 @@ export type EmailMessageType =
   | 'DOCUMENT_NOTIFICATION'
   | 'INFORMAL_DOCUMENT_NOTIFICATION'
   | 'MISSING_ATTENDANCE_RESERVATION_NOTIFICATION'
+  | 'MISSING_HOLIDAY_ATTENDANCE_RESERVATION_NOTIFICATION'
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.MockDigitransit.Feature

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsRemindersTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsRemindersTest.kt
@@ -77,7 +77,7 @@ class MissingHolidayReservationsRemindersTest : FullApplicationTest(resetDbBefor
             tx.insert(
                 DevHolidayPeriod(
                     period = holidayPeriod,
-                    reservationDeadline = clockToday.today().plusDays(1)
+                    reservationDeadline = clockToday.today().plusDays(2)
                 )
             )
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsRemindersTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsRemindersTest.kt
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.reservations
+
+import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.absence.AbsenceCategory
+import fi.espoo.evaka.absence.AbsenceType
+import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.emailclient.MockEmailClient
+import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.AreaId
+import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.dev.DevAbsence
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevGuardian
+import fi.espoo.evaka.shared.dev.DevHolidayPeriod
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPersonType
+import fi.espoo.evaka.shared.dev.DevPlacement
+import fi.espoo.evaka.shared.dev.DevReservation
+import fi.espoo.evaka.shared.dev.insert
+import fi.espoo.evaka.shared.dev.insertServiceNeedOption
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.shared.job.ScheduledJobs
+import fi.espoo.evaka.shared.security.PilotFeature
+import fi.espoo.evaka.snDefaultDaycare
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class MissingHolidayReservationsRemindersTest : FullApplicationTest(resetDbBeforeEach = true) {
+    @Autowired private lateinit var scheduledJobs: ScheduledJobs
+    @Autowired private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
+
+    private val clockToday =
+        MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 3, 11), LocalTime.of(22, 0)))
+
+    private val holidayPeriod: FiniteDateRange =
+        FiniteDateRange(clockToday.today().plusDays(2), clockToday.today().plusDays(3))
+    private val guardianEmail = "guardian@example.com"
+    private lateinit var guardian: PersonId
+    private lateinit var child: ChildId
+    private lateinit var daycareId: DaycareId
+    private lateinit var areaId: AreaId
+
+    @BeforeEach
+    fun beforeEach() {
+        db.transaction { tx ->
+            guardian = tx.insert(DevPerson(email = guardianEmail), DevPersonType.ADULT)
+            areaId = tx.insert(DevCareArea())
+            daycareId =
+                tx.insert(
+                    DevDaycare(
+                        areaId = areaId,
+                        enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS)
+                    )
+                )
+            tx.insertServiceNeedOption(snDefaultDaycare)
+            child = tx.insert(DevPerson(), DevPersonType.CHILD)
+            tx.insert(DevGuardian(guardianId = guardian, childId = child))
+            tx.insert(
+                DevHolidayPeriod(
+                    period = holidayPeriod,
+                    reservationDeadline = clockToday.today().plusDays(1)
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Missing holiday reminder is sent 2 days before if there is a placement with a missing reservation`() {
+        db.transaction {
+            it.insert(
+                DevPlacement(
+                    childId = child,
+                    unitId = daycareId,
+                    startDate = holidayPeriod.start,
+                    endDate = holidayPeriod.end,
+                    type = PlacementType.DAYCARE
+                )
+            )
+        }
+
+        assertEquals(listOf(guardianEmail), getHolidayReminderRecipients())
+
+        db.transaction {
+            it.insert(
+                DevReservation(
+                    childId = child,
+                    date = holidayPeriod.start,
+                    startTime = LocalTime.of(8, 0),
+                    endTime = LocalTime.of(16, 0),
+                    createdBy = AuthenticatedUser.SystemInternalUser.evakaUserId
+                )
+            )
+        }
+
+        // 1/2 holiday days still misses a reservation / absence so a reminder is sent
+        assertEquals(listOf(guardianEmail), getHolidayReminderRecipients())
+
+        db.transaction {
+            it.insert(
+                DevAbsence(
+                    childId = child,
+                    absenceType = AbsenceType.PLANNED_ABSENCE,
+                    date = holidayPeriod.end,
+                    absenceCategory = AbsenceCategory.BILLABLE
+                )
+            )
+        }
+
+        // 2/2 holiday days has a reservation / absence so a reminder is not sent
+        assertEquals(emptyList(), getHolidayReminderRecipients())
+    }
+
+    @Test
+    fun `Missing holiday reminder is not sent if child is in service voucher unit`() {
+        db.transaction {
+            val voucherDaycare =
+                it.insert(
+                    DevDaycare(
+                        areaId = areaId,
+                        enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS),
+                        providerType = ProviderType.PRIVATE_SERVICE_VOUCHER
+                    )
+                )
+
+            it.insert(
+                DevPlacement(
+                    childId = child,
+                    unitId = voucherDaycare,
+                    startDate = holidayPeriod.start,
+                    endDate = holidayPeriod.end,
+                    type = PlacementType.DAYCARE
+                )
+            )
+        }
+
+        assertEquals(emptyList(), getHolidayReminderRecipients())
+    }
+
+    private fun getHolidayReminderRecipients(): List<String> {
+        scheduledJobs.sendMissingHolidayReservationReminders(db, clockToday)
+        asyncJobRunner.runPendingJobsSync(clockToday)
+        val emails = MockEmailClient.emails.map { it.toAddress }
+        MockEmailClient.clear()
+        return emails
+    }
+}

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsRemindersTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsRemindersTest.kt
@@ -127,14 +127,14 @@ class MissingHolidayReservationsRemindersTest : FullApplicationTest(resetDbBefor
     }
 
     @Test
-    fun `Missing holiday reminder is not sent if child is in service voucher unit`() {
+    fun `Missing holiday reminder is not sent if child is in unit with disabled reservations`() {
         db.transaction {
             val voucherDaycare =
                 it.insert(
                     DevDaycare(
                         areaId = areaId,
-                        enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS),
-                        providerType = ProviderType.PRIVATE_SERVICE_VOUCHER
+                        // enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS),
+                        providerType = ProviderType.MUNICIPAL
                     )
                 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -257,7 +257,7 @@ $unsubscribeEn
     override fun missingHolidayReservationsNotification(language: Language): EmailContent {
         return EmailContent.fromHtml(
             subject =
-                "Loma-ajan ilmoituksia puuttuu / Anmälan om ditt/dina barns frånvaro i semestertider saknas / There are missing holiday notifications",
+                "Loma-ajan ilmoitus sulkeutuu / Semesteranmälan löper ut / Holiday notification period closing",
             html =
                 """
 <p>Loma-ajan kysely sulkeutuu kahden päivän päästä. Jos lapseltanne/lapsiltanne puuttuu loma-ajan ilmoitus yhdeltä tai useammalta lomapäivältä, teettehän ilmoituksen eVakan kalenterissa mahdollisimman pian: ${calendarLink(Language.fi)}</p>

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -254,6 +254,24 @@ $unsubscribeEn
         )
     }
 
+    override fun missingHolidayReservationsNotification(language: Language): EmailContent {
+        return EmailContent.fromHtml(
+            subject =
+                "Loma-ajan ilmoituksia puuttuu / Anmälan om ditt/dina barns frånvaro i semestertider saknas / There are missing holiday notifications",
+            html =
+                """
+<p>Loma-ajan kysely sulkeutuu kahden päivän päästä. Jos lapseltanne/lapsiltanne puuttuu loma-ajan ilmoitus yhdeltä tai useammalta lomapäivältä, teettehän ilmoituksen eVakan kalenterissa mahdollisimman pian: ${calendarLink(Language.fi)}</p>
+$unsubscribeFi
+<hr>
+<p>Förfrågan om barnets frånvaro i semestertider stängs om två dagar. Om ditt/dina barn saknar anmälan för en eller flera helgdagar, vänligen gör anmälan i eVaka-kalendern så snart som möjligt: ${calendarLink(Language.sv)}</p>
+$unsubscribeSv
+<hr>
+<p>Two days left to submit a holiday notification. If you have not submitted a notification for each day, please submit them through the eVaka calendar as soon as possible: ${calendarLink(Language.en)}</p>
+$unsubscribeEn
+"""
+        )
+    }
+
     override fun assistanceNeedDecisionNotification(language: Language): EmailContent =
         EmailContent.fromHtml(
             subject = "Päätös eVakassa / Beslut i eVaka / Decision on eVaka",

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
@@ -71,6 +71,8 @@ interface IEmailMessageProvider {
         checkedRange: FiniteDateRange
     ): EmailContent
 
+    fun missingHolidayReservationsNotification(language: Language): EmailContent
+
     fun messageNotification(language: Language, thread: MessageThreadStub): EmailContent
 
     fun childDocumentNotification(language: Language, childId: ChildId): EmailContent

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodQueries.kt
@@ -19,6 +19,16 @@ fun Database.Read.getHolidayPeriodsInRange(
         }
         .toList<HolidayPeriod>()
 
+fun Database.Read.getHolidayPeriodsWithReservationDeadline(
+    reservationDeadline: LocalDate,
+): List<HolidayPeriod> =
+    createQuery {
+            sql(
+                "SELECT id, period, reservation_deadline FROM holiday_period h WHERE ${bind(reservationDeadline)} = h.reservation_deadline"
+            )
+        }
+        .toList<HolidayPeriod>()
+
 fun Database.Read.getHolidayPeriods(): List<HolidayPeriod> =
     createQuery {
             sql("SELECT id, period, reservation_deadline FROM holiday_period ORDER BY period")

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalData.kt
@@ -46,7 +46,10 @@ enum class EmailMessageType {
     INFORMAL_DOCUMENT_NOTIFICATION,
 
     /** Reminders about making attendance reservations */
-    MISSING_ATTENDANCE_RESERVATION_NOTIFICATION
+    MISSING_ATTENDANCE_RESERVATION_NOTIFICATION,
+
+    /** Reminders about missing holiday attendance reservations */
+    MISSING_HOLIDAY_ATTENDANCE_RESERVATION_NOTIFICATION
 }
 
 data class EmailNotificationSettings(

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsReminders.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsReminders.kt
@@ -48,7 +48,7 @@ class MissingHolidayReservationsReminders(
             setOf(AsyncJobType(AsyncJob.SendMissingHolidayReservationsReminder::class))
         )
 
-        return tx.getHolidayPeriodsWithReservationDeadline(clock.today().plusDays(1))
+        return tx.getHolidayPeriodsWithReservationDeadline(clock.today().plusDays(2))
             .firstOrNull()
             ?.let { holidayPeriod ->
                 logger.info(

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsReminders.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsReminders.kt
@@ -135,15 +135,14 @@ WHERE
         createQuery {
                 sql(
                     """
-SELECT DISTINCT(COALESCE(g.guardian_id, fp.id)) AS guardian_id
+SELECT DISTINCT(COALESCE(g.guardian_id, fp.parent_id))
 FROM person p
-     LEFT JOIN guardian g ON g.child_id = p.id
-     LEFT JOIN foster_parent fp ON fp.child_id = p.id AND fp.valid_during @> ${bind(today)}   
-WHERE
-    p.id = ANY(${bind(childIds)})
-    AND ((g.guardian_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM guardian_blocklist block where block.guardian_id = g.guardian_id and block.child_id = p.id)) 
-        OR fp.parent_id IS NOT NULL)
-"""
+LEFT JOIN guardian g ON p.id = g.child_id AND NOT EXISTS (SELECT 1 FROM guardian_blocklist block WHERE block.guardian_id = g.guardian_id AND block.child_id = g.child_id)
+LEFT JOIN foster_parent fp ON fp.child_id = p.id AND fp.valid_during @> ${bind(today)}
+WHERE p.id = ANY(${bind(childIds)})
+ AND (g.guardian_id IS NOT NULL OR fp.parent_id IS NOT NULL)
+                    """
+                        .trimIndent()
                 )
             }
             .mapTo<PersonId>()

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsReminders.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsReminders.kt
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.reservations
+
+import fi.espoo.evaka.EmailEnv
+import fi.espoo.evaka.daycare.domain.Language
+import fi.espoo.evaka.emailclient.Email
+import fi.espoo.evaka.emailclient.EmailClient
+import fi.espoo.evaka.emailclient.IEmailMessageProvider
+import fi.espoo.evaka.holidayperiod.getHolidayPeriodsWithReservationDeadline
+import fi.espoo.evaka.pis.EmailMessageType
+import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.FeatureConfig
+import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.async.AsyncJobType
+import fi.espoo.evaka.shared.async.removeUnclaimedJobs
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
+import java.time.LocalDate
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+
+@Service
+class MissingHolidayReservationsReminders(
+    private val featureConfig: FeatureConfig,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
+    private val emailClient: EmailClient,
+    private val emailMessageProvider: IEmailMessageProvider,
+    private val emailEnv: EmailEnv
+) {
+    private val logger = KotlinLogging.logger {}
+
+    init {
+        asyncJobRunner.registerHandler {
+            db,
+            clock,
+            msg: AsyncJob.SendMissingHolidayReservationsReminder ->
+            sendMissingHolidayReminders(db, msg, clock)
+        }
+    }
+
+    fun scheduleReminders(tx: Database.Transaction, clock: EvakaClock): Int {
+        tx.removeUnclaimedJobs(
+            setOf(AsyncJobType(AsyncJob.SendMissingHolidayReservationsReminder::class))
+        )
+
+        return tx.getHolidayPeriodsWithReservationDeadline(clock.today().plusDays(1))
+            .firstOrNull()
+            ?.let { holidayPeriod ->
+                logger.info(
+                    "Holiday ${holidayPeriod.id} reservation deadline is due, sending missing reservation reminders"
+                )
+
+                // Get a rough guess of persons with missing holiday reservations, then do an exact
+                // check per person
+                // in a separate job
+                val personsWithMaybeMissingHolidayReservations =
+                    holidayPeriod.period
+                        .dates()
+                        .map { tx.getPersonsWithChildrenWithMissingReservation(it) }
+                        .flatten()
+                        .toSet()
+
+                logger.info(
+                    "Got ${personsWithMaybeMissingHolidayReservations.size} persons with maybe missing holiday reservations for holiday ${holidayPeriod.period}"
+                )
+
+                asyncJobRunner.plan(
+                    tx,
+                    payloads =
+                        personsWithMaybeMissingHolidayReservations.map {
+                            AsyncJob.SendMissingHolidayReservationsReminder(
+                                it,
+                                holidayPeriod.period
+                            )
+                        },
+                    runAt = clock.now()
+                )
+                1
+            } ?: 0
+    }
+
+    fun Database.Read.getPersonsWithChildrenWithMissingReservation(
+        theDate: LocalDate,
+        personId: PersonId? = null
+    ): List<PersonId> =
+        createQuery {
+                sql(
+                    """
+WITH reservable_placements AS
+     (SELECT p.child_id, p.unit_id
+      FROM placement p
+      WHERE daterange(p.start_date, p.end_date, '[]') @> ${bind(theDate)}
+        AND p.type = ANY
+            (${bind(PlacementType.requiringAttendanceReservations)})
+     )
+SELECT COALESCE(g.guardian_id, fp.id) AS guardian_id -- distinct by storing these in a set in kotlin
+FROM reservable_placements p
+     JOIN daycare d ON d.id = p.unit_id AND extract(isodow FROM ${bind(theDate)}) = ANY(d.operation_days) AND 'RESERVATIONS' = ANY(d.enabled_pilot_features)
+     LEFT JOIN guardian g ON g.child_id = p.child_id
+     LEFT JOIN foster_parent fp ON fp.child_id = p.child_id AND fp.valid_during @> ${bind(theDate)}   
+WHERE
+    NOT EXISTS (
+        SELECT 1
+        FROM attendance_reservation ar
+        WHERE ar.child_id = p.child_id AND ar.date = ${bind(theDate)}
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM absence a
+        WHERE a.child_id = p.child_id AND a.date = ${bind(theDate)}
+    )
+    AND (g.guardian_id IS NOT NULL OR fp.parent_id IS NOT NULL)
+    AND d.provider_type != 'PRIVATE_SERVICE_VOUCHER'
+    ${if (personId == null) "" else "AND guardian_id = ${bind(personId)}"}
+
+"""
+                )
+            }
+            .mapTo<PersonId>()
+            .toList()
+
+    fun sendMissingHolidayReminders(
+        db: Database.Connection,
+        msg: AsyncJob.SendMissingHolidayReservationsReminder,
+        clock: EvakaClock
+    ) {
+        val language = db.read { tx -> getLanguage(tx, msg.guardian) }
+
+        Email.create(
+                dbc = db,
+                personId = msg.guardian,
+                emailType = EmailMessageType.MISSING_HOLIDAY_ATTENDANCE_RESERVATION_NOTIFICATION,
+                fromAddress = emailEnv.sender(language),
+                content = emailMessageProvider.missingHolidayReservationsNotification(language),
+                traceId = msg.guardian.toString(),
+            )
+            ?.also { emailClient.send(it) }
+    }
+
+    private fun getLanguage(tx: Database.Read, personId: PersonId): Language {
+        return tx.createQuery {
+                sql(
+                    """
+SELECT language
+FROM person p
+WHERE p.id = ${bind(personId)}
+AND email IS NOT NULL
+LIMIT 1
+        """
+                        .trimIndent()
+                )
+            }
+            .exactlyOneOrNull {
+                column<String?>("language")?.lowercase()?.let(Language::tryValueOf) ?: Language.fi
+            } ?: Language.fi
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -250,6 +250,13 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class SendMissingHolidayReservationsReminder(
+        val guardian: PersonId,
+        val holidayRange: FiniteDateRange
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     data class UpdateMessageThreadRecipients(
         val threadId: MessageThreadId,
         val recipientIds: Set<MessageAccountId>,
@@ -351,6 +358,7 @@ sealed interface AsyncJob : AsyncJobPayload {
                     SendChildDocumentNotificationEmail::class,
                     SendMessageNotificationEmail::class,
                     SendMissingReservationsReminder::class,
+                    SendMissingHolidayReservationsReminder::class,
                     SendOutdatedIncomeNotificationEmail::class,
                     SendPedagogicalDocumentNotificationEmail::class,
                     SendPendingDecisionEmail::class,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -156,6 +156,18 @@ VALUES (${bind(holiday.date)}, ${bind(holiday.description)})
         .execute()
 }
 
+fun Database.Transaction.insert(holidayPeriod: DevHolidayPeriod) {
+    createUpdate {
+            sql(
+                """
+INSERT INTO holiday_period (id, period, reservation_deadline)
+VALUES (${bind(holidayPeriod.id)}, ${bind(holidayPeriod.period)}, ${bind(holidayPeriod.reservationDeadline)})
+"""
+            )
+        }
+        .execute()
+}
+
 fun Database.Transaction.insert(row: DevDaycare): DaycareId =
     createUpdate {
             sql(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1767,6 +1767,13 @@ data class DevChild(
 
 data class DevHoliday(val date: LocalDate, val description: String = "Test Holiday")
 
+data class DevHolidayPeriod(
+    val id: HolidayPeriodId = HolidayPeriodId(UUID.randomUUID()),
+    val period: FiniteDateRange =
+        FiniteDateRange(LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 1)),
+    val reservationDeadline: LocalDate = LocalDate.of(2024, 3, 1)
+)
+
 data class DevDaycare(
     val id: DaycareId = DaycareId(UUID.randomUUID()),
     val name: String = "Test Daycare",

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -24,6 +24,7 @@ import fi.espoo.evaka.note.child.daily.deleteExpiredNotes
 import fi.espoo.evaka.pis.cleanUpInactivePeople
 import fi.espoo.evaka.pis.clearRolesForInactiveEmployees
 import fi.espoo.evaka.reports.freezeVoucherValueReportRows
+import fi.espoo.evaka.reservations.MissingHolidayReservationsReminders
 import fi.espoo.evaka.reservations.MissingReservationsReminders
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -188,6 +189,7 @@ class ScheduledJobs(
     private val pendingDecisionEmailService: PendingDecisionEmailService,
     private val koskiUpdateService: KoskiUpdateService,
     private val missingReservationsReminders: MissingReservationsReminders,
+    private val missingHolidayReservationsReminders: MissingHolidayReservationsReminders,
     private val outdatedIncomeNotifications: OutdatedIncomeNotifications,
     private val newCustomerIncomeNotification: NewCustomerIncomeNotification,
     private val calendarEventNotificationService: CalendarEventNotificationService,
@@ -342,6 +344,13 @@ WHERE id IN (SELECT id FROM attendances_to_end)
         db.transaction { tx ->
             val count = missingReservationsReminders.scheduleReminders(tx, clock)
             logger.info("Scheduled $count reminders about missing reservations")
+        }
+    }
+
+    fun sendMissingHolidayReservationReminders(db: Database.Connection, clock: EvakaClock) {
+        db.transaction { tx ->
+            val count = missingHolidayReservationsReminders.scheduleReminders(tx, clock)
+            logger.info("Scheduled $count reminders about missing holiday reservations")
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -153,6 +153,10 @@ enum class ScheduledJob(
             schedule = JobSchedule.cron("0 0 18 * * 0") // Sunday 18:00
         )
     ),
+    SendMissingHolidayNotificationReminders(
+        ScheduledJobs::sendMissingHolidayReservationReminders,
+        ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(2, 45)))
+    ),
     SendOutdatedIncomeNotifications(
         ScheduledJobs::sendOutdatedIncomeNotifications,
         ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(6, 45)))


### PR DESCRIPTION
#### Summary
- Send missing holiday reservation email reminder to those guardians or foster parents that have a daycare placed child during a holiday with a reservation deadline day after tomorrow
- On espoo prod for 27.3.2024 the getChildrenWithWithMissingReservations was Execution Time: 102.383 ms
