### PR TITLE
Service need exceeded report group calendar links

### DIFF
--- a/frontend/src/employee-frontend/components/reports/ExceededServiceNeeds.tsx
+++ b/frontend/src/employee-frontend/components/reports/ExceededServiceNeeds.tsx
@@ -152,6 +152,7 @@ const Report = React.memo(function Report({
                 <Thead>
                   <Tr>
                     <Th>{i18n.reports.common.childName}</Th>
+                    <Th>{i18n.reports.exceededServiceNeed.groupLinkHeading}</Th>
                     <Th>{i18n.reports.exceededServiceNeed.serviceNeedHours}</Th>
                     <Th>{i18n.reports.exceededServiceNeed.usedServiceHours}</Th>
                     <Th>{i18n.reports.exceededServiceNeed.excessHours}</Th>
@@ -170,6 +171,17 @@ const Report = React.memo(function Report({
                               true
                             )}
                           </Link>
+                        </Td>
+                        <Td>
+                          {!!row.groupId && (
+                            <>
+                              <Link
+                                to={`/units/${row.unitId}/calendar?group=${row.groupId}&date=${year.value()}-${String(month.value()).padStart(2, '0')}-01&mode=week`}
+                              >
+                                {row.groupName}
+                              </Link>
+                            </>
+                          )}
                         </Td>
                         <Td>{row.serviceNeedHoursPerMonth}</Td>
                         <Td>{row.usedServiceHours}</Td>

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -263,7 +263,10 @@ export interface ExceededServiceNeedReportRow {
   childId: UUID
   childLastName: string
   excessHours: number
+  groupId: UUID | null
+  groupName: string | null
   serviceNeedHoursPerMonth: number
+  unitId: UUID
   usedServiceHours: number
 }
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3636,6 +3636,7 @@ export const fi = {
         'Raportti listaa lapset, joiden palveluntarpeen tunnit on ylitetty.',
       serviceNeedHours: 'Palvelun tarve (h)',
       usedServiceHours: 'Käytetty (h)',
+      groupLinkHeading: 'Yksikön viikkokalenteri',
       excessHours: 'Ylitys (h)'
     },
     units: {

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -737,3 +737,9 @@ data class DaycareBasics(
     val enabledPilotFeatures: List<PilotFeature>,
     val language: Language
 )
+
+data class ChildDaycareGroupPlacement(
+    val childId: ChildId,
+    val groupId: GroupId,
+    val groupName: String
+)


### PR DESCRIPTION
## Before this change
It was tiresome to open the group calendar view with correct dates to inspect what is causing the service need exceed
## After this change
There's a direct link to the group calendar week view on each row of the report.
<img width="1191" alt="image" src="https://github.com/espoon-voltti/evaka/assets/886091/84ba5a8f-3938-4f57-ae5d-6d610b5dcff1">
