### PR TITLE
API path prefix preparations

### DIFF
--- a/frontend/src/employee-frontend/generated/api-clients/attachment.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attachment.ts
@@ -19,7 +19,7 @@ export async function deleteAttachmentHandler(
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
-    url: uri`/attachments/citizen/${request.attachmentId}`.toString(),
+    url: uri`/attachments/${request.attachmentId}`.toString(),
     method: 'DELETE'
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/pis.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/pis.ts
@@ -848,7 +848,7 @@ export async function getPersonIdentity(
   }
 ): Promise<PersonJSON> {
   const { data: json } = await client.request<JsonOf<PersonJSON>>({
-    url: uri`/person/identity/${request.personId}`.toString(),
+    url: uri`/person/details/${request.personId}`.toString(),
     method: 'GET'
   })
   return deserializeJsonPersonJSON(json)

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/attachment.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/attachment.ts
@@ -19,7 +19,7 @@ export async function deleteAttachmentHandler(
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
-    url: uri`/attachments/citizen/${request.attachmentId}`.toString(),
+    url: uri`/attachments/${request.attachmentId}`.toString(),
     method: 'DELETE'
   })
   return json

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/pis.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/pis.ts
@@ -768,7 +768,7 @@ export async function getPersonIdentity(
   }
 ): Promise<PersonJSON> {
   const { data: json } = await client.request<JsonOf<PersonJSON>>({
-    url: uri`/person/identity/${request.personId}`.toString(),
+    url: uri`/person/details/${request.personId}`.toString(),
     method: 'GET'
   })
   return deserializeJsonPersonJSON(json)

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/ApiFiles.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/ApiFiles.kt
@@ -22,7 +22,8 @@ fun generateApiFiles(): Map<TsFile, String> {
             .filterNot {
                 it.isDeprecated ||
                     it.path.startsWith("/integration") ||
-                    it.path.startsWith("/system")
+                    it.path.startsWith("/system") ||
+                    endpointExcludes.contains(it.path)
             }
     endpoints.forEach { it.validate() }
 
@@ -217,7 +218,12 @@ fun generateApiClients(
         endpoints
             .groupBy { Pair(it.controllerClass, it.controllerMethod) }
             .values
-            .map { duplicates -> duplicates.minBy { it.pathIndex } }
+            .map { duplicates ->
+                require(duplicates.size == 1) {
+                    "Endpoint conflict:\n${duplicates.joinToString("\n")}"
+                }
+                duplicates.single()
+            }
             .sortedWith(
                 compareBy(
                     { it.controllerClass.jvmName },

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -40,6 +40,42 @@ val forceIncludes: Set<KType> =
         typeOf<CurriculumTemplateError>()
     )
 
+// these endpoint paths are deprecated, and API clients should not call them
+private val deprecatedEndpoints =
+    setOf(
+        "/attachments/citizen/{attachmentId}",
+        "/decisions/confirm",
+        "/decisions/head-of-family/{id}",
+        "/decisions/head-of-family/{id}/create-retroactive",
+        "/decisions/{id}",
+        "/decisions/ignore",
+        "/decisions/mark-sent",
+        "/decisions/search",
+        "/decisions/set-type/{id}",
+        "/decisions/unignore",
+        "/person/identity/{personId}",
+        "/units",
+    )
+
+// these endpoint paths are planned, and API clients should not call them *yet*
+private val plannedEndpoints =
+    setOf(
+        "/citizen/public/club-terms",
+        "/citizen/public/preschool-terms",
+        "/citizen/public/service-needs/options",
+        "/citizen/public/units/{applicationType}",
+        "/citizen/units",
+        "/employee-mobile/public/pairings/challenge",
+        "/employee-mobile/public/pairings/{id}/status",
+        "/employee/public/club-terms",
+        "/employee/public/preschool-terms",
+        "/employee/public/service-needs/options",
+        "/employee/public/units/{applicationType}",
+        "/employee/units",
+    )
+
+val endpointExcludes = plannedEndpoints + deprecatedEndpoints
+
 object Imports {
     val localDate = TsImport.Default(LibCommon / "local-date.ts", "LocalDate")
     val localTime = TsImport.Default(LibCommon / "local-time.ts", "LocalTime")

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/LocationController.kt
@@ -26,7 +26,15 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class LocationController {
-    @GetMapping(value = ["/units", "/public/units"])
+    @GetMapping(
+        value =
+            [
+                "/units", // deprecated
+                "/public/units", // deprecated
+                "/citizen/units",
+                "/employee/units",
+            ]
+    )
     fun getApplicationUnits(
         db: Database,
         user: AuthenticatedUser,
@@ -46,7 +54,14 @@ class LocationController {
         }
     }
 
-    @GetMapping("/public/units/{applicationType}")
+    @GetMapping(
+        path =
+            [
+                "/public/units/{applicationType}", // deprecated
+                "/citizen/public/units/{applicationType}",
+                "/employee/public/units/{applicationType}"
+            ]
+    )
     fun getAllApplicableUnits(
         db: Database,
         @PathVariable applicationType: ApplicationType

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/TermsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/TermsController.kt
@@ -42,12 +42,26 @@ private val logger = KotlinLogging.logger {}
 @RestController
 class TermsController(private val accessControl: AccessControl) {
 
-    @GetMapping("/public/club-terms")
+    @GetMapping(
+        path =
+            [
+                "/public/club-terms", // deprecated
+                "/citizen/public/club-terms",
+                "/employee/public/club-terms",
+            ]
+    )
     fun getClubTerms(db: Database): List<ClubTerm> {
         return db.connect { dbc -> dbc.read { it.getClubTerms() } }
     }
 
-    @GetMapping("/public/preschool-terms")
+    @GetMapping(
+        path =
+            [
+                "/public/preschool-terms", // deprecated
+                "/citizen/public/preschool-terms",
+                "/employee/public/preschool-terms",
+            ]
+    )
     fun getPreschoolTerms(db: Database): List<PreschoolTerm> {
         return db.connect { dbc -> dbc.read { it.getPreschoolTerms() } }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingsController.kt
@@ -99,7 +99,13 @@ class PairingsController(
      */
     data class PostPairingChallengeReq(val challengeKey: String)
 
-    @PostMapping("/public/pairings/challenge")
+    @PostMapping(
+        path =
+            [
+                "/public/pairings/challenge", // deprecated
+                "/employee-mobile/public/pairings/challenge"
+            ]
+    )
     fun postPairingChallenge(
         db: Database,
         clock: EvakaClock,
@@ -223,7 +229,13 @@ class PairingsController(
      */
     data class PairingStatusRes(val status: PairingStatus)
 
-    @GetMapping("/public/pairings/{id}/status")
+    @GetMapping(
+        path =
+            [
+                "/public/pairings/{id}/status", // deprecated
+                "/employee-mobile/public/pairings/{id}/status"
+            ]
+    )
     fun getPairingStatus(
         db: Database,
         clock: EvakaClock,

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/ServiceNeedController.kt
@@ -166,7 +166,14 @@ class ServiceNeedController(
             .also { Audit.ServiceNeedOptionsRead.log(meta = mapOf("count" to it.size)) }
     }
 
-    @GetMapping("/public/service-needs/options")
+    @GetMapping(
+        path =
+            [
+                "/public/service-needs/options", // deprecated
+                "/citizen/public/service-needs/options",
+                "/employee/public/service-needs/options"
+            ]
+    )
     fun getServiceNeedOptionPublicInfos(
         db: Database,
         @RequestParam(required = true) placementTypes: List<PlacementType>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/HttpFilterConfig.kt
@@ -80,6 +80,9 @@ class HttpFilterConfig {
         private fun HttpServletRequest.requiresAuthentication(): Boolean =
             when {
                 isHealthCheck() -> false
+                requestURI.startsWith("/citizen/public/") -> false
+                requestURI.startsWith("/employee/public/") -> false
+                requestURI.startsWith("/employee-mobile/public/") -> false
                 requestURI.startsWith("/public/") -> false
                 mockIntegrationEnabled && requestURI.startsWith("/mock-integration/") -> false
                 devApiEnabled && requestURI.startsWith("/dev-api/") -> false
@@ -90,6 +93,8 @@ class HttpFilterConfig {
             when {
                 requestURI.startsWith("/system/") -> user is AuthenticatedUser.SystemInternalUser
                 requestURI.startsWith("/citizen/") -> user is AuthenticatedUser.Citizen
+                requestURI.startsWith("/employee/") -> user is AuthenticatedUser.Employee
+                requestURI.startsWith("/employee-mobile/") -> user is AuthenticatedUser.MobileDevice
                 requestURI.startsWith("/integration/") -> user is AuthenticatedUser.Integration
                 else -> true
             }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

Prepare public API endpoints for the new path prefix scheme where each API endpoint unambiguously belongs to exactly one frontend and AuthenticatedUser type (`/citizen`, `/citizen/public`, `/employee`, `/employee/public`, `/employee-mobile`, `/employee-mobile/public`)