### PR TITLE
Remove extra check from reservable min/max range

### DIFF
--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -730,7 +730,7 @@ export class DayProperties {
     let maxDate: LocalDate | undefined = undefined
 
     calendarDays.forEach((day) => {
-      if (reservableRange.includes(day.date) && day.children.length > 0) {
+      if (reservableRange.includes(day.date)) {
         if (!minDate || day.date.isBefore(minDate)) {
           minDate = day.date
         }


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

This extra check is unnecessary and causes extra confusion. If the end of the reservable range is on a non-operational day, it's still ok to submit reservations and the backend will just ignore the days when reservations should not be added.