### PR TITLE
Initial new Varda integration

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.VardaEnv
 import fi.espoo.evaka.varda.integration.VardaClient
 import fi.espoo.evaka.varda.integration.VardaTempTokenProvider
 import fi.espoo.evaka.varda.integration.VardaTokenProvider
+import java.net.URI
 import org.junit.jupiter.api.BeforeAll
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -25,7 +26,7 @@ abstract class VardaIntegrationTest(resetDbBeforeEach: Boolean) :
     @BeforeAll
     override fun beforeAll() {
         super.beforeAll()
-        val vardaBaseUrl = "http://localhost:$httpPort/mock-integration/varda/api"
+        val vardaBaseUrl = URI.create("http://localhost:$httpPort/mock-integration/varda/api")
         val vardaEnv = VardaEnv.fromEnvironment(env).copy(url = vardaBaseUrl)
         vardaTokenProvider = VardaTempTokenProvider(http, jsonMapper, vardaEnv)
         vardaClient = VardaClient(vardaTokenProvider, http, jsonMapper, vardaEnv)

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -294,7 +294,14 @@ data class KoskiEnv(
     }
 }
 
-data class VardaEnv(val url: String, val sourceSystem: String, val basicAuth: Sensitive<String>) {
+data class VardaEnv(
+    val url: URI,
+    val sourceSystem: String,
+    val basicAuth: Sensitive<String>,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
+    val localDevPort: Int?
+) {
     companion object {
         fun fromEnvironment(env: Environment) =
             VardaEnv(
@@ -310,7 +317,12 @@ data class VardaEnv(val url: String, val sourceSystem: String, val basicAuth: Se
                             "evaka.integration.varda.basic_auth",
                             "fi.espoo.integration.varda.basic_auth"
                         ) ?: ""
-                    )
+                    ),
+                startDate = env.lookup("evaka.integration.varda.start_date"),
+                endDate = env.lookup("evaka.integration.varda.end_date"),
+
+                // Port that's forwarded to Varda for local development
+                localDevPort = env.lookup("evaka.integration.varda.local_dev_port")
             )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -275,7 +275,7 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
-    data class VardaUpdateChild(val childId: ChildId) : AsyncJob {
+    data class VardaUpdateChild(val childId: ChildId, val dryRun: Boolean = false) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -275,6 +275,10 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class VardaUpdateChild(val childId: ChildId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     data class ResetVardaChild(val childId: ChildId) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
@@ -379,6 +383,7 @@ sealed interface AsyncJob : AsyncJobPayload {
                 AsyncJobPool.Id(AsyncJob::class, "varda"),
                 AsyncJobPool.Config(concurrency = 1),
                 setOf(
+                    VardaUpdateChild::class,
                     UpdateVardaChild::class,
                     ResetVardaChild::class,
                     DeleteVardaChild::class,

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUnits.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaUnits.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.varda
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.DatabaseEnum
@@ -135,6 +136,18 @@ enum class VardaUnitProviderType(val vardaCode: String) : DatabaseEnum {
     PRIVATE("jm04");
 
     override val sqlType: String = "unit_provider_type"
+
+    companion object {
+        fun fromEvakaProviderType(providerType: ProviderType) =
+            when (providerType) {
+                ProviderType.MUNICIPAL -> MUNICIPAL
+                ProviderType.MUNICIPAL_SCHOOL -> MUNICIPAL_SCHOOL
+                ProviderType.PURCHASED -> PURCHASED
+                ProviderType.EXTERNAL_PURCHASED -> EXTERNAL_PURCHASED
+                ProviderType.PRIVATE_SERVICE_VOUCHER -> PRIVATE_SERVICE_VOUCHER
+                ProviderType.PRIVATE -> PRIVATE
+            }
+    }
 }
 
 // https://virkailija.opintopolku.fi/koodisto-service/rest/json/vardatoimintamuoto/koodi

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/UriUtils.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/UriUtils.kt
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.varda.new
+
+import java.net.URI
+
+fun URI.copy(host: String? = null, port: Int? = null, path: String? = null): URI =
+    URI(
+        this.scheme,
+        this.userInfo,
+        host ?: this.host,
+        port ?: this.port,
+        path ?: this.path,
+        this.query,
+        this.fragment
+    )
+
+fun URI.ensureTrailingSlash(): URI =
+    if (this.path.endsWith("/")) this else this.copy(path = this.path + "/")

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
@@ -13,24 +13,6 @@ import java.math.BigDecimal
 import java.net.URI
 import java.time.LocalDate
 
-fun <Old, New> diff(
-    old: List<Old>,
-    new: List<New>,
-    eq: (Old, New) -> Boolean,
-    onRemoved: (Old) -> Unit = { _ -> },
-    onAdded: (New) -> Unit = { _ -> },
-    onUnchanged: (Old, New) -> Unit = { _, _ -> }
-) {
-    old.filter { oldItem -> new.none { newItem -> eq(oldItem, newItem) } }.forEach(onRemoved)
-    new.filter { newItem -> old.none { oldItem -> eq(oldItem, newItem) } }.forEach(onAdded)
-    old.forEach { oldItem ->
-        val newItem = new.find { eq(oldItem, it) }
-        if (newItem != null) {
-            onUnchanged(oldItem, newItem)
-        }
-    }
-}
-
 data class Lapsi(
     val vakatoimija_oid: String?,
     val oma_organisaatio_oid: String?,

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
@@ -13,21 +13,18 @@ import java.math.BigDecimal
 import java.net.URI
 import java.time.LocalDate
 
-interface Diffable<T> {
-    fun diffEq(other: T): Boolean
-}
-
-fun <Old, New : Diffable<Old>> diff(
+fun <Old, New> diff(
     old: List<Old>,
     new: List<New>,
+    eq: (Old, New) -> Boolean,
     onRemoved: (Old) -> Unit = { _ -> },
     onAdded: (New) -> Unit = { _ -> },
     onUnchanged: (Old, New) -> Unit = { _, _ -> }
 ) {
-    old.filter { oldItem -> new.none { newItem -> newItem.diffEq(oldItem) } }.forEach(onRemoved)
-    new.filter { newItem -> old.none { oldItem -> newItem.diffEq(oldItem) } }.forEach(onAdded)
+    old.filter { oldItem -> new.none { newItem -> eq(oldItem, newItem) } }.forEach(onRemoved)
+    new.filter { newItem -> old.none { oldItem -> eq(oldItem, newItem) } }.forEach(onAdded)
     old.forEach { oldItem ->
-        val newItem = new.find { it.diffEq(oldItem) }
+        val newItem = new.find { eq(oldItem, it) }
         if (newItem != null) {
             onUnchanged(oldItem, newItem)
         }
@@ -38,7 +35,7 @@ data class Lapsi(
     val vakatoimija_oid: String?,
     val oma_organisaatio_oid: String?,
     val paos_organisaatio_oid: String?,
-) : Diffable<VardaClient.LapsiResponse> {
+) {
     companion object {
         fun fromEvaka(data: VardaServiceNeed, omaOrganisaatioOid: String): Lapsi =
             if (data.providerType == ProviderType.PRIVATE_SERVICE_VOUCHER) {
@@ -54,6 +51,13 @@ data class Lapsi(
                     paos_organisaatio_oid = null
                 )
             }
+
+        fun fromVarda(data: VardaClient.LapsiResponse): Lapsi =
+            Lapsi(
+                vakatoimija_oid = data.vakatoimija_oid,
+                oma_organisaatio_oid = data.oma_organisaatio_oid,
+                paos_organisaatio_oid = data.paos_organisaatio_oid,
+            )
     }
 
     fun toVarda(lahdejarjestelma: String, henkilo: URI) =
@@ -64,11 +68,6 @@ data class Lapsi(
             oma_organisaatio_oid = oma_organisaatio_oid,
             paos_organisaatio_oid = paos_organisaatio_oid
         )
-
-    override fun diffEq(other: VardaClient.LapsiResponse): Boolean =
-        vakatoimija_oid == other.vakatoimija_oid &&
-            oma_organisaatio_oid == other.oma_organisaatio_oid &&
-            paos_organisaatio_oid == other.paos_organisaatio_oid
 }
 
 data class Varhaiskasvatuspaatos(
@@ -82,7 +81,7 @@ data class Varhaiskasvatuspaatos(
     val paivittainen_vaka_kytkin: Boolean,
     val kokopaivainen_vaka_kytkin: Boolean,
     val jarjestamismuoto_koodi: String,
-) : Diffable<VardaClient.VarhaiskasvatuspaatosResponse> {
+) {
     companion object {
         fun fromEvaka(data: VardaServiceNeed): Varhaiskasvatuspaatos =
             Varhaiskasvatuspaatos(
@@ -97,6 +96,20 @@ data class Varhaiskasvatuspaatos(
                 vuorohoito_kytkin = data.shiftCare,
                 jarjestamismuoto_koodi =
                     VardaUnitProviderType.fromEvakaProviderType(data.providerType).vardaCode,
+            )
+
+        fun fromVarda(data: VardaClient.VarhaiskasvatuspaatosResponse) =
+            Varhaiskasvatuspaatos(
+                hakemus_pvm = data.hakemus_pvm,
+                alkamis_pvm = data.alkamis_pvm,
+                paattymis_pvm = data.paattymis_pvm,
+                pikakasittely_kytkin = data.pikakasittely_kytkin,
+                tuntimaara_viikossa = data.tuntimaara_viikossa,
+                tilapainen_vaka_kytkin = data.tilapainen_vaka_kytkin,
+                paivittainen_vaka_kytkin = data.paivittainen_vaka_kytkin,
+                kokopaivainen_vaka_kytkin = data.kokopaivainen_vaka_kytkin,
+                vuorohoito_kytkin = data.vuorohoito_kytkin,
+                jarjestamismuoto_koodi = data.jarjestamismuoto_koodi,
             )
     }
 
@@ -115,31 +128,26 @@ data class Varhaiskasvatuspaatos(
             kokopaivainen_vaka_kytkin = kokopaivainen_vaka_kytkin,
             jarjestamismuoto_koodi = jarjestamismuoto_koodi,
         )
-
-    override fun diffEq(other: VardaClient.VarhaiskasvatuspaatosResponse): Boolean =
-        alkamis_pvm == other.alkamis_pvm &&
-            paattymis_pvm == other.paattymis_pvm &&
-            hakemus_pvm == other.hakemus_pvm &&
-            vuorohoito_kytkin == other.vuorohoito_kytkin &&
-            tilapainen_vaka_kytkin == other.tilapainen_vaka_kytkin &&
-            pikakasittely_kytkin == other.pikakasittely_kytkin &&
-            tuntimaara_viikossa == other.tuntimaara_viikossa &&
-            paivittainen_vaka_kytkin == other.paivittainen_vaka_kytkin &&
-            kokopaivainen_vaka_kytkin == other.kokopaivainen_vaka_kytkin &&
-            jarjestamismuoto_koodi == other.jarjestamismuoto_koodi
 }
 
 data class Varhaiskasvatussuhde(
     val toimipaikka_oid: String,
     val alkamis_pvm: LocalDate,
     val paattymis_pvm: LocalDate?,
-) : Diffable<VardaClient.VarhaiskasvatussuhdeResponse> {
+) {
     companion object {
         fun fromEvaka(data: VardaServiceNeed): Varhaiskasvatussuhde =
             Varhaiskasvatussuhde(
                 toimipaikka_oid = data.ophUnitOid,
                 alkamis_pvm = data.range.start,
                 paattymis_pvm = data.range.end,
+            )
+
+        fun fromVarda(data: VardaClient.VarhaiskasvatussuhdeResponse) =
+            Varhaiskasvatussuhde(
+                toimipaikka_oid = data.toimipaikka_oid,
+                alkamis_pvm = data.alkamis_pvm,
+                paattymis_pvm = data.paattymis_pvm,
             )
     }
 
@@ -151,11 +159,6 @@ data class Varhaiskasvatussuhde(
             alkamis_pvm = alkamis_pvm,
             paattymis_pvm = paattymis_pvm,
         )
-
-    override fun diffEq(other: VardaClient.VarhaiskasvatussuhdeResponse): Boolean =
-        toimipaikka_oid == other.toimipaikka_oid &&
-            alkamis_pvm == other.alkamis_pvm &&
-            paattymis_pvm == other.paattymis_pvm
 }
 
 enum class MaksunPerusteKoodi(val code: String) {
@@ -170,9 +173,8 @@ data class Maksutieto(
     val perheen_koko: Int?,
     val maksun_peruste_koodi: String,
     val asiakasmaksu: BigDecimal,
-    val palveluseteli_arvo: BigDecimal?,
-    val paos_organisaatio_oid: String?
-) : Diffable<VardaClient.MaksutietoResponse> {
+    val palveluseteli_arvo: BigDecimal?
+) {
     companion object {
         fun fromEvaka(guardians: List<PersonDTO>, data: VardaFeeData): Maksutieto? {
             val huoltajat =
@@ -211,9 +213,19 @@ data class Maksutieto(
                 asiakasmaksu = BigDecimal(data.totalFee).divide(BigDecimal(100)),
                 palveluseteli_arvo =
                     data.voucherValue?.let { BigDecimal(it).divide(BigDecimal(100)) },
-                paos_organisaatio_oid = data.voucherUnitOrganizerOid,
             )
         }
+
+        fun fromVarda(data: VardaClient.MaksutietoResponse): Maksutieto =
+            Maksutieto(
+                huoltajat = data.huoltajat,
+                alkamis_pvm = data.alkamis_pvm,
+                paattymis_pvm = data.paattymis_pvm,
+                perheen_koko = data.perheen_koko,
+                maksun_peruste_koodi = data.maksun_peruste_koodi,
+                asiakasmaksu = data.asiakasmaksu,
+                palveluseteli_arvo = data.palveluseteli_arvo,
+            )
     }
 
     fun toVarda(lahdejarjestelma: String, lapsi: URI) =
@@ -228,14 +240,4 @@ data class Maksutieto(
             asiakasmaksu = asiakasmaksu,
             perheen_koko = perheen_koko,
         )
-
-    override fun diffEq(other: VardaClient.MaksutietoResponse): Boolean =
-        huoltajat.map { it.henkilo_oid }.toSet() ==
-            other.huoltajat.map { it.henkilo_oid }.toSet() &&
-            alkamis_pvm == other.alkamis_pvm &&
-            paattymis_pvm == other.paattymis_pvm &&
-            maksun_peruste_koodi == other.maksun_peruste_koodi &&
-            palveluseteli_arvo == other.palveluseteli_arvo &&
-            asiakasmaksu == other.asiakasmaksu &&
-            perheen_koko == other.perheen_koko
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.varda.new
+
+import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.varda.VardaUnitProviderType
+import java.net.URI
+import java.time.LocalDate
+
+interface Diffable<T> {
+    fun diffEq(other: T): Boolean
+}
+
+data class DiffResult<Old, New>(
+    val removed: List<Old>,
+    val added: List<New>,
+    val unchanged: List<Pair<Old, New>>,
+)
+
+fun <Old, New : Diffable<Old>> diff(old: List<Old>, new: List<New>): DiffResult<Old, New> {
+    val removed = old.filter { oldItem -> new.none { newItem -> newItem.diffEq(oldItem) } }
+    val added = new.filter { newItem -> old.none { oldItem -> newItem.diffEq(oldItem) } }
+    val unchanged =
+        old.mapNotNull { oldItem ->
+            val newItem = new.find { it.diffEq(oldItem) }
+            if (newItem == null) {
+                null
+            } else {
+                Pair(oldItem, newItem)
+            }
+        }
+    return DiffResult(removed, added, unchanged)
+}
+
+data class Lapsi(
+    val vakatoimija_oid: String?,
+    val oma_organisaatio_oid: String?,
+    val paos_organisaatio_oid: String?,
+) : Diffable<VardaClient.LapsiResponse> {
+    companion object {
+        fun fromEvaka(data: VardaServiceNeed, omaOrganisaatioOid: String): Lapsi =
+            if (data.providerType == ProviderType.PRIVATE_SERVICE_VOUCHER) {
+                Lapsi(
+                    vakatoimija_oid = null,
+                    oma_organisaatio_oid = omaOrganisaatioOid,
+                    paos_organisaatio_oid = data.ophOrganizerOid,
+                )
+            } else {
+                Lapsi(
+                    vakatoimija_oid = data.ophOrganizerOid,
+                    oma_organisaatio_oid = null,
+                    paos_organisaatio_oid = null
+                )
+            }
+    }
+
+    fun toVarda(lahdejarjestelma: String, henkilo: URI) =
+        VardaClient.CreateLapsiRequest(
+            lahdejarjestelma = lahdejarjestelma,
+            henkilo = henkilo,
+            vakatoimija_oid = vakatoimija_oid,
+            oma_organisaatio_oid = oma_organisaatio_oid,
+            paos_organisaatio_oid = paos_organisaatio_oid
+        )
+
+    override fun diffEq(other: VardaClient.LapsiResponse): Boolean =
+        vakatoimija_oid == other.vakatoimija_oid &&
+            oma_organisaatio_oid == other.oma_organisaatio_oid &&
+            paos_organisaatio_oid == other.paos_organisaatio_oid
+}
+
+data class Varhaiskasvatuspaatos(
+    val alkamis_pvm: LocalDate,
+    val paattymis_pvm: LocalDate?,
+    val hakemus_pvm: LocalDate,
+    val vuorohoito_kytkin: Boolean,
+    val tilapainen_vaka_kytkin: Boolean,
+    val pikakasittely_kytkin: Boolean,
+    val tuntimaara_viikossa: Double,
+    val paivittainen_vaka_kytkin: Boolean,
+    val kokopaivainen_vaka_kytkin: Boolean,
+    val jarjestamismuoto_koodi: String,
+) : Diffable<VardaClient.VarhaiskasvatuspaatosResponse> {
+    companion object {
+        fun fromEvaka(data: VardaServiceNeed): Varhaiskasvatuspaatos =
+            Varhaiskasvatuspaatos(
+                hakemus_pvm = data.applicationDate,
+                alkamis_pvm = data.range.start,
+                paattymis_pvm = data.range.end,
+                pikakasittely_kytkin = data.urgent,
+                tuntimaara_viikossa = data.hoursPerWeek,
+                tilapainen_vaka_kytkin = data.temporary,
+                paivittainen_vaka_kytkin = data.daily,
+                kokopaivainen_vaka_kytkin = data.hoursPerWeek >= 25,
+                vuorohoito_kytkin = data.shiftCare,
+                jarjestamismuoto_koodi =
+                    VardaUnitProviderType.fromEvakaProviderType(data.providerType).vardaCode,
+            )
+    }
+
+    fun toVarda(lahdejarjestelma: String, lapsi: URI) =
+        VardaClient.CreateVarhaiskasvatuspaatosRequest(
+            lahdejarjestelma = lahdejarjestelma,
+            lapsi = lapsi,
+            alkamis_pvm = alkamis_pvm,
+            paattymis_pvm = paattymis_pvm,
+            hakemus_pvm = hakemus_pvm,
+            vuorohoito_kytkin = vuorohoito_kytkin,
+            tilapainen_vaka_kytkin = tilapainen_vaka_kytkin,
+            pikakasittely_kytkin = pikakasittely_kytkin,
+            tuntimaara_viikossa = tuntimaara_viikossa,
+            paivittainen_vaka_kytkin = paivittainen_vaka_kytkin,
+            kokopaivainen_vaka_kytkin = kokopaivainen_vaka_kytkin,
+            jarjestamismuoto_koodi = jarjestamismuoto_koodi,
+        )
+
+    override fun diffEq(other: VardaClient.VarhaiskasvatuspaatosResponse): Boolean =
+        alkamis_pvm == other.alkamis_pvm &&
+            paattymis_pvm == other.paattymis_pvm &&
+            hakemus_pvm == other.hakemus_pvm &&
+            vuorohoito_kytkin == other.vuorohoito_kytkin &&
+            tilapainen_vaka_kytkin == other.tilapainen_vaka_kytkin &&
+            pikakasittely_kytkin == other.pikakasittely_kytkin &&
+            tuntimaara_viikossa == other.tuntimaara_viikossa &&
+            paivittainen_vaka_kytkin == other.paivittainen_vaka_kytkin &&
+            kokopaivainen_vaka_kytkin == other.kokopaivainen_vaka_kytkin &&
+            jarjestamismuoto_koodi == other.jarjestamismuoto_koodi
+}
+
+data class Varhaiskasvatussuhde(
+    val toimipaikka_oid: String,
+    val alkamis_pvm: LocalDate,
+    val paattymis_pvm: LocalDate?,
+) : Diffable<VardaClient.VarhaiskasvatussuhdeResponse> {
+    companion object {
+        fun fromEvaka(data: VardaServiceNeed): Varhaiskasvatussuhde =
+            Varhaiskasvatussuhde(
+                toimipaikka_oid = data.ophUnitOid,
+                alkamis_pvm = data.range.start,
+                paattymis_pvm = data.range.end,
+            )
+    }
+
+    fun toVarda(lahdejarjestelma: String, varhaiskasvatuspaatos: URI) =
+        VardaClient.CreateVarhaiskasvatussuhdeRequest(
+            lahdejarjestelma = lahdejarjestelma,
+            varhaiskasvatuspaatos = varhaiskasvatuspaatos,
+            toimipaikka_oid = toimipaikka_oid,
+            alkamis_pvm = alkamis_pvm,
+            paattymis_pvm = paattymis_pvm,
+        )
+
+    override fun diffEq(other: VardaClient.VarhaiskasvatussuhdeResponse): Boolean =
+        toimipaikka_oid == other.toimipaikka_oid &&
+            alkamis_pvm == other.alkamis_pvm &&
+            paattymis_pvm == other.paattymis_pvm
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
@@ -214,7 +214,16 @@ data class Maksutieto(
         VardaClient.CreateMaksutietoRequest(
             lahdejarjestelma = lahdejarjestelma,
             lapsi = lapsi,
-            huoltajat = huoltajat,
+            huoltajat =
+                huoltajat.map {
+                    // Avoid sending both henkilotunnus and henkilo_oid, which would cause Varda to
+                    // reject the request with error HE004
+                    if (it.henkilotunnus != null && it.henkilo_oid != null) {
+                        it.copy(henkilo_oid = null)
+                    } else {
+                        it
+                    }
+                },
             alkamis_pvm = alkamis_pvm,
             paattymis_pvm = paattymis_pvm,
             maksun_peruste_koodi = maksun_peruste_koodi,

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
@@ -1,0 +1,348 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.varda.new
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.FuelManager
+import com.github.kittinunf.fuel.core.Headers
+import com.github.kittinunf.fuel.core.Method
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.ResponseResultOf
+import com.github.kittinunf.fuel.core.extensions.authentication
+import com.github.kittinunf.fuel.core.extensions.jsonBody
+import com.github.kittinunf.result.Result
+import fi.espoo.evaka.shared.utils.responseStringWithRetries
+import fi.espoo.evaka.shared.utils.token
+import fi.espoo.evaka.varda.integration.VardaTokenProvider
+import fi.espoo.voltti.logging.loggers.error
+import java.net.URI
+import java.time.LocalDate
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+class VardaClient(
+    private val tokenProvider: VardaTokenProvider,
+    private val fuel: FuelManager,
+    private val jsonMapper: JsonMapper,
+    vardaBaseUrl: URI
+) {
+    private val baseUrl = vardaBaseUrl.ensureTrailingSlash()
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class VardaPersonSearchRequest(
+        val henkilotunnus: String? = null,
+        val henkilo_oid: String? = null
+    ) {
+        init {
+            check(henkilotunnus != null || henkilo_oid != null) {
+                "Both params ssn and oid must not be null"
+            }
+        }
+
+        override fun toString(): String {
+            val henkilotunnusMasked = henkilotunnus?.let { "${it.slice(0..4)}******" }
+            return "VardaPersonSearchRequest(henkilotunnus=$henkilotunnusMasked, henkilo_oid=$henkilo_oid)"
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class HenkiloResponse(
+        val url: URI,
+        val etunimet: String,
+        val sukunimi: String,
+        val kutsumanimi: String,
+        val henkilo_oid: String,
+        val syntyma_pvm: String?,
+        val lapsi: List<URI>
+    )
+
+    fun haeHenkilo(body: VardaPersonSearchRequest): HenkiloResponse? =
+        post(baseUrl.resolve("v1/hae-henkilo/"), body)
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class CreateHenkiloRequest(
+        val etunimet: String,
+        val sukunimi: String,
+        val kutsumanimi: String,
+        val henkilotunnus: String?,
+        val henkilo_oid: String?
+    )
+
+    fun createHenkilo(body: CreateHenkiloRequest): HenkiloResponse =
+        post(baseUrl.resolve("v1/henkilot/"), body)
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class CreateLapsiRequest(
+        val lahdejarjestelma: String,
+        val henkilo: URI,
+        val vakatoimija_oid: String?,
+        val oma_organisaatio_oid: String?,
+        val paos_organisaatio_oid: String?,
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class LapsiResponse(
+        val url: URI,
+        val lahdejarjestelma: String,
+        val henkilo: URI,
+        val henkilo_oid: String,
+        val vakatoimija: URI,
+        val vakatoimija_oid: String?,
+        val oma_organisaatio_oid: String?,
+        val paos_organisaatio_oid: String?,
+        val paos_kytkin: Boolean,
+    )
+
+    fun createLapsi(child: CreateLapsiRequest): LapsiResponse =
+        post(baseUrl.resolve("v1/lapset/"), child)
+
+    fun getLapsi(childUrl: URI): LapsiResponse = get(childUrl)
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class CreateVarhaiskasvatuspaatosRequest(
+        val lapsi: URI,
+        val hakemus_pvm: LocalDate,
+        val alkamis_pvm: LocalDate,
+        val paattymis_pvm: LocalDate?,
+        val pikakasittely_kytkin: Boolean,
+        val tuntimaara_viikossa: Double,
+        val kokopaivainen_vaka_kytkin: Boolean,
+        val tilapainen_vaka_kytkin: Boolean,
+        val paivittainen_vaka_kytkin: Boolean,
+        val vuorohoito_kytkin: Boolean,
+        val jarjestamismuoto_koodi: String,
+        val lahdejarjestelma: String
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class VarhaiskasvatuspaatosResponse(
+        val url: URI,
+        val lahdejarjestelma: String,
+        val alkamis_pvm: LocalDate,
+        val paattymis_pvm: LocalDate?,
+        val hakemus_pvm: LocalDate,
+        val vuorohoito_kytkin: Boolean,
+        val tilapainen_vaka_kytkin: Boolean,
+        val pikakasittely_kytkin: Boolean,
+        val tuntimaara_viikossa: Double,
+        val paivittainen_vaka_kytkin: Boolean,
+        val kokopaivainen_vaka_kytkin: Boolean,
+        val jarjestamismuoto_koodi: String,
+    )
+
+    fun createVarhaiskasvatuspaatos(
+        body: CreateVarhaiskasvatuspaatosRequest
+    ): VarhaiskasvatuspaatosResponse = post(baseUrl.resolve("v1/varhaiskasvatuspaatokset/"), body)
+
+    fun getVarhaiskasvatuspaatoksetByLapsi(lapsiUrl: URI): List<VarhaiskasvatuspaatosResponse> =
+        getAllPages(lapsiUrl.resolve("varhaiskasvatuspaatokset/"))
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class CreateVarhaiskasvatussuhdeRequest(
+        val lahdejarjestelma: String,
+        val varhaiskasvatuspaatos: URI,
+        val toimipaikka_oid: String,
+        val alkamis_pvm: LocalDate,
+        val paattymis_pvm: LocalDate?,
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class VarhaiskasvatussuhdeResponse(
+        val url: URI,
+        val lahdejarjestelma: String,
+        val varhaiskasvatuspaatos: URI,
+        val toimipaikka_oid: String,
+        val alkamis_pvm: LocalDate,
+        val paattymis_pvm: LocalDate?,
+    )
+
+    fun createVarhaiskasvatussuhde(
+        body: CreateVarhaiskasvatussuhdeRequest
+    ): VarhaiskasvatussuhdeResponse = post(baseUrl.resolve("v1/varhaiskasvatussuhteet/"), body)
+
+    fun getVarhaiskasvatussuhteetByLapsi(lapsiUrl: URI): List<VarhaiskasvatussuhdeResponse> =
+        getAllPages(lapsiUrl.resolve("varhaiskasvatussuhteet/"))
+
+    private inline fun <reified R> get(url: URI): R = request(Method.GET, url)
+
+    private data class PaginatedResponse<T>(
+        val count: Int,
+        val next: URI?,
+        val previous: String?,
+        val results: List<T>
+    )
+
+    private inline fun <reified T> getAllPages(initialUrl: URI): List<T> {
+        val acc = mutableListOf<T>()
+        var url: URI? = initialUrl
+        while (url != null) {
+            val response: PaginatedResponse<T> = get(url)
+            acc += response.results
+            url = response.next
+        }
+        return acc.toList()
+    }
+
+    private inline fun <T, reified R> post(url: URI, body: T): R = request(Method.POST, url, body)
+
+    fun delete(url: URI) = request<Unit>(Method.DELETE, url)
+
+    private inline fun <reified R> request(method: Method, url: URI, body: Any? = null): R {
+        logger.info("requesting $method $url" + if (body == null) "" else " with body $body")
+
+        val (request, _, result) =
+            fuel
+                .request(method, validateUrl(url))
+                .let { if (body != null) it.jsonBody(jsonMapper.writeValueAsString(body)) else it }
+                .authenticatedResponseStringWithRetries()
+
+        return when (result) {
+            is Result.Success -> {
+                logger.info("successfully requested $method $url")
+                if (Unit is R) {
+                    Unit
+                } else {
+                    jsonMapper.readValue(result.get())
+                }
+            }
+            is Result.Failure -> {
+                val message = "failed to request $method $url"
+                if (null !is R) {
+                    vardaError(request, result.error) { err -> "$message: $err" }
+                } else {
+                    logger.warn { "$message: ${result.error}" }
+                    null as R
+                }
+            }
+        }
+    }
+
+    private fun validateUrl(url: URI): String {
+        val result = url.normalize().toString()
+        check(result.startsWith(baseUrl.normalize().toString())) {
+            "URL $url does not start with $baseUrl"
+        }
+        return result
+    }
+
+    private data class VardaRequestError(
+        val method: String,
+        val url: String,
+        val body: String,
+        val errorMessage: String,
+        val errorCode: String?,
+        val errorDescription: String?,
+        val statusCode: String
+    ) {
+        fun asMap() =
+            mapOf(
+                "method" to method,
+                "url" to url,
+                "body" to body,
+                "errorMessage" to errorMessage,
+                "errorCode" to errorCode,
+                "errorDescription" to errorDescription,
+                "statusCode" to statusCode
+            )
+    }
+
+    private fun parseVardaErrorBody(errorString: String): Pair<List<String>, List<String>> {
+        val codes =
+            Regex("\"error_code\":\"(\\w+)\"")
+                .findAll(errorString)
+                .map { it.groupValues[1] }
+                .toList()
+        val descriptions =
+            Regex("\"description\":\"([^\"]+)\"")
+                .findAll(errorString)
+                .map { it.groupValues[1] }
+                .toList()
+        return Pair(codes, descriptions)
+    }
+
+    private fun parseVardaError(request: Request, error: FuelError): VardaRequestError {
+        return try {
+            val errorString = error.errorData.decodeToString()
+            val (errorCodes, descriptions) = parseVardaErrorBody(errorString)
+            VardaRequestError(
+                method = request.method.toString(),
+                url = request.url.toString(),
+                body = request.body.asString("application/json"),
+                errorMessage = errorString,
+                errorCode = errorCodes.first(),
+                errorDescription = descriptions.first(),
+                statusCode = error.response.statusCode.toString()
+            )
+        } catch (e: Exception) {
+            VardaRequestError(
+                method = request.method.toString(),
+                url = request.url.toString(),
+                body = request.body.asString("application/json"),
+                errorMessage = error.errorData.decodeToString(),
+                errorCode = null,
+                errorDescription = null,
+                statusCode = error.response.statusCode.toString()
+            )
+        }
+    }
+
+    private fun vardaError(
+        request: Request,
+        error: FuelError,
+        message: (meta: VardaRequestError) -> String
+    ): Nothing {
+        val meta = parseVardaError(request, error)
+        logger.error(request, meta.asMap()) {
+            "request failed to ${meta.url}, status ${meta.statusCode}, reason ${meta.errorCode}: ${meta.errorDescription}"
+        }
+        error(message(meta))
+    }
+
+    /**
+     * Wrapper for Fuel Request.responseString() that handles API token refreshes and retries when
+     * throttled.
+     *
+     * API token refreshes are only attempted once and don't count as a try of the original request.
+     *
+     * TODO: Make API token usage thread-safe. Now nothing prevents another thread from invalidating
+     *   the token about to be used by another thread.
+     */
+    private fun Request.authenticatedResponseStringWithRetries(
+        maxTries: Int = 3
+    ): ResponseResultOf<String> =
+        tokenProvider.withToken { token, refreshToken ->
+            this.authentication()
+                .token(token)
+                .header(Headers.ACCEPT, "application/json")
+                .responseStringWithRetries(maxTries, 300L) { r, remainingTries ->
+                    when (r.second.statusCode) {
+                        403 ->
+                            when {
+                                jsonMapper.readTree(r.third.error.errorData).get("errors")?.any {
+                                    it.get("error_code").asText() == "PE007"
+                                } ?: false -> {
+                                    logger.info(
+                                        "Varda API token invalid. Refreshing token and retrying original request."
+                                    )
+                                    val newToken = refreshToken()
+                                    // API token refresh should only be attempted once -> don't pass
+                                    // an error handler to let
+                                    // any subsequent errors fall through.
+                                    this.authentication()
+                                        .token(newToken)
+                                        .responseStringWithRetries(remainingTries, 300L)
+                                }
+                                else -> r
+                            }
+                        else -> r
+                    }
+                }
+        }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
@@ -31,6 +31,8 @@ private val logger = KotlinLogging.logger {}
 fun maskHenkilotunnus(henkilotunnus: String?): String? =
     henkilotunnus?.let { "${it.slice(0..4)}******" }
 
+fun maskName(name: String): String = name.take(2) + "*".repeat(name.length - 2)
+
 class VardaClient(
     private val tokenProvider: VardaTokenProvider,
     private val fuel: FuelManager,
@@ -63,7 +65,18 @@ class VardaClient(
         val henkilo_oid: String,
         val syntyma_pvm: String?,
         val lapsi: List<URI>
-    )
+    ) {
+        override fun toString() =
+            "HenkiloResponse(" +
+                "url=$url, " +
+                "etunimet=${maskName(etunimet)}, " +
+                "sukunimi=${maskName(sukunimi)}, " +
+                "kutsumanimi=${maskName(kutsumanimi)}, " +
+                "henkilo_oid=$henkilo_oid, " +
+                "syntyma_pvm=$syntyma_pvm, " +
+                "lapsi=$lapsi" +
+                ")"
+    }
 
     fun haeHenkilo(body: VardaPersonSearchRequest): HenkiloResponse? =
         post(baseUrl.resolve("v1/hae-henkilo/"), body)
@@ -185,7 +198,12 @@ class VardaClient(
         }
 
         override fun toString(): String =
-            "Huoltaja(henkilotunnus=${maskHenkilotunnus(henkilotunnus)}, henkilo_oid=$henkilo_oid, etunimet=$etunimet, sukunimi=$sukunimi)"
+            "Huoltaja(" +
+                "henkilotunnus=${maskHenkilotunnus(henkilotunnus)}, " +
+                "henkilo_oid=$henkilo_oid, " +
+                "etunimet=${maskName(etunimet)}, " +
+                "sukunimi=${maskName(sukunimi)}" +
+                ")"
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.varda.new
+
+import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.ServiceNeedId
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import java.time.LocalDate
+
+private val vardaPlacementTypes =
+    listOf(
+        PlacementType.DAYCARE,
+        PlacementType.DAYCARE_PART_TIME,
+        PlacementType.DAYCARE_FIVE_YEAR_OLDS,
+        PlacementType.DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
+        PlacementType.PRESCHOOL_DAYCARE,
+        PlacementType.PREPARATORY_DAYCARE
+    )
+private val vardaTemporaryPlacementTypes =
+    listOf(PlacementType.TEMPORARY_DAYCARE, PlacementType.TEMPORARY_DAYCARE_PART_DAY)
+
+data class VardaServiceNeed(
+    val id: ServiceNeedId,
+    val serviceNeedUpdated: HelsinkiDateTime,
+    val childId: ChildId,
+    val applicationDate: LocalDate,
+    val range: FiniteDateRange,
+    val urgent: Boolean,
+    val hoursPerWeek: Double,
+    val temporary: Boolean,
+    val daily: Boolean,
+    val shiftCare: Boolean,
+    val providerType: ProviderType,
+    val ophOrganizerOid: String,
+    val ophUnitOid: String
+)
+
+fun Database.Read.getVardaServiceNeeds(childId: ChildId, range: DateRange): List<VardaServiceNeed> {
+    return createQuery {
+            sql(
+                """
+SELECT
+    sn.id,
+    p.child_id AS child_id,
+    daterange(sn.start_date, sn.end_date, '[]') * ${bind(range)} AS range,
+    -- The default application date is set to be 15 days before the start because it's the minimum
+    -- for Varda to not deduce the application as urgent
+    LEAST(COALESCE(application_match.sentdate, application_match.created::date), sn.start_date - interval '15 days') AS application_date,
+    COALESCE((application_match.document ->> 'urgent') :: BOOLEAN, false) AS urgent,
+    sno.daycare_hours_per_week AS hours_per_week,
+    CASE 
+        WHEN sno.valid_placement_type = ANY(${bind(vardaTemporaryPlacementTypes)}::placement_type[]) THEN true
+        ELSE false
+    END AS temporary,
+    NOT sno.part_week AS daily,
+    sn.shift_care = 'FULL' as shift_care,
+    d.provider_type,
+    d.oph_organizer_oid,
+    d.oph_unit_oid,
+    sn.updated AS service_need_updated
+FROM service_need sn
+JOIN service_need_option sno on sn.option_id = sno.id
+JOIN placement p ON p.id = sn.placement_id
+JOIN daycare d ON p.unit_id = d.id
+LEFT JOIN LATERAL (
+    SELECT a.id, a.sentdate, a.created, a.document
+    FROM application a
+    WHERE child_id = p.child_id
+      AND a.status IN ('ACTIVE')
+      AND EXISTS (
+            SELECT 1
+            FROM placement_plan pp
+            WHERE pp.unit_id = p.unit_id AND pp.application_id = a.id
+              AND daterange(pp.start_date, pp.end_date, '[]') && daterange(sn.start_date, sn.end_date, '[]')
+        )
+    ORDER BY a.sentdate, a.id
+    LIMIT 1
+    ) application_match ON true
+WHERE
+    p.child_id = ${bind(childId)} AND
+    daterange(sn.start_date, sn.end_date, '[]') && ${bind(range)} AND
+    p.type = ANY(${bind(vardaPlacementTypes)}::placement_type[]) AND
+    sno.daycare_hours_per_week >= 1 AND
+    d.upload_children_to_varda = true AND
+    d.oph_organizer_oid IS NOT NULL AND
+    d.oph_unit_oid IS NOT NULL
+"""
+            )
+        }
+        .toList<VardaServiceNeed>()
+}
+
+data class VardaPerson(
+    val firstName: String,
+    val lastName: String,
+    val socialSecurityNumber: String?,
+    val ophPersonOid: String?,
+)
+
+fun Database.Read.getVardaPerson(childId: ChildId): VardaPerson =
+    createQuery {
+            sql(
+                """
+                SELECT first_name, last_name, social_security_number, oph_person_oid
+                FROM person
+                WHERE id = ${bind(childId)}
+                """
+            )
+        }
+        .exactlyOne()

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.varda.new
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.github.kittinunf.fuel.core.FuelManager
+import fi.espoo.evaka.OphEnv
+import fi.espoo.evaka.VardaEnv
+import fi.espoo.evaka.pis.updateOphPersonOid
+import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.config.FuelManagerConfig
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.varda.integration.VardaTempTokenProvider
+import java.net.URI
+import java.time.LocalDate
+import org.springframework.stereotype.Service
+
+@Service
+class VardaUpdateServiceNew(
+    asyncJobRunner: AsyncJobRunner<AsyncJob>,
+    globalFuel: FuelManager,
+    mapper: JsonMapper,
+    ophEnv: OphEnv,
+    vardaEnv: VardaEnv
+) {
+    // To test Varda QA environment from your local machine:
+    //
+    // 1. Get the basic auth credentials for your municipality's Varda QA environment
+    //
+    // 2. Set up port forwarding to Varda via a bastion host, e.g.:
+    //
+    //    ssh -L 65443:backend.qa.varda.opintopolku.fi:443 <bastion-host>
+    //
+    // 3. Edit application-local.yml:
+    //
+    //     evaka:
+    //       ...
+    //       integration:
+    //         ...
+    //         varda:
+    //           source_system: 31
+    //           url: "https://backend.qa.varda.opintopolku.fi/api"
+    //           basic_auth: "<your-municipality-basic-auth-credentials>"
+    //           local_dev_port: 65443
+    //
+    private val fuel: FuelManager =
+        if (vardaEnv.localDevPort != null) {
+            // Required to allow overriding the Host header
+            System.setProperty("sun.net.http.allowRestrictedHeaders", "true")
+
+            val fuelManager = FuelManagerConfig().noCertCheckFuelManager()
+            fuelManager.addRequestInterceptor { next ->
+                { request ->
+                    val originalUri = request.url.toURI()
+                    val proxyUri =
+                        originalUri.copy(host = "localhost", port = vardaEnv.localDevPort)
+                    request.url = proxyUri.toURL()
+                    request.header("Host", vardaEnv.url.host)
+                    next(request)
+                }
+            }
+        } else {
+            globalFuel
+        }
+
+    private val client =
+        VardaClient(VardaTempTokenProvider(fuel, mapper, vardaEnv), fuel, mapper, vardaEnv.url)
+
+    private val vardaEnabledRange =
+        DateRange(
+            // PostgreSQL doesn't support LocalDate.MIN, so use an "early enough" date by
+            // default instead
+            vardaEnv.startDate ?: LocalDate.of(2000, 1, 1),
+            vardaEnv.endDate
+        )
+
+    private val omaOrganisaatioOid = ophEnv.organizerOid
+    private val lahdejarjestelma = vardaEnv.sourceSystem
+
+    init {
+        asyncJobRunner.registerHandler(::updateChildJob)
+    }
+
+    fun updateChildJob(
+        dbc: Database.Connection,
+        clock: EvakaClock,
+        job: AsyncJob.VardaUpdateChild
+    ) {
+        updateChild(dbc, job.childId)
+    }
+
+    fun updateChild(dbc: Database.Connection, childId: ChildId) {
+        val person = dbc.read { it.getVardaPerson(childId) }
+        if (person.ophPersonOid == null && person.socialSecurityNumber == null) {
+            throw IllegalStateException("Child $childId has no ophOid or ssn")
+        }
+
+        val serviceNeeds = dbc.read { it.getVardaServiceNeeds(childId, vardaEnabledRange) }
+
+        val henkilo = getOrCreateHenkilo(person)
+        if (person.ophPersonOid == null) {
+            dbc.transaction { it.updateOphPersonOid(childId, henkilo.henkilo_oid) }
+        }
+
+        val vardaLapset =
+            henkilo.lapsi.map { lapsiUrl ->
+                val lapsiResponse = client.getLapsi(lapsiUrl)
+                val paatoksetResponse = client.getVarhaiskasvatuspaatoksetByLapsi(lapsiResponse.url)
+                val varhaiskasvatussuhteetResponse =
+                    client.getVarhaiskasvatussuhteetByLapsi(lapsiResponse.url)
+
+                VardaLapsiNode(
+                    lapsi = lapsiResponse,
+                    varhaiskasvatuspaatokset =
+                        paatoksetResponse.map { paatos ->
+                            VardaVarhaiskasvatuspaatosNode(
+                                varhaiskasvatuspaatos = paatos,
+                                varhaiskasvatussuhteet =
+                                    varhaiskasvatussuhteetResponse.filter {
+                                        it.varhaiskasvatuspaatos == paatos.url
+                                    }
+                            )
+                        }
+                )
+            }
+
+        val uniqueEvakaLapset = serviceNeeds.map { Lapsi.fromEvaka(it, omaOrganisaatioOid) }.toSet()
+        val evakaLapset =
+            uniqueEvakaLapset.map { lapsi ->
+                EvakaLapsiNode(
+                    lapsi = lapsi,
+                    varhaiskasvatuspaatokset =
+                        serviceNeeds.map { serviceNeed ->
+                            EvakaVarhaiskasvatuspaatosNode(
+                                varhaiskasvatuspaatos =
+                                    Varhaiskasvatuspaatos.fromEvaka(serviceNeed),
+                                varhaiskasvatussuhteet =
+                                    listOf(Varhaiskasvatussuhde.fromEvaka(serviceNeed))
+                            )
+                        }
+                )
+            }
+
+        val lapsetDiff = diff(vardaLapset, evakaLapset)
+        lapsetDiff.removed.forEach { deleteLapsiRecursive(it) }
+        lapsetDiff.added.forEach { createLapsiRecursive(it, henkilo.url) }
+        lapsetDiff.unchanged.forEach { (vardaLapsi, evakaLapsi) ->
+            val paatoksetDiff =
+                diff(
+                    vardaLapsi.varhaiskasvatuspaatokset,
+                    evakaLapsi.varhaiskasvatuspaatokset,
+                )
+            paatoksetDiff.removed.forEach { deleteVarhaiskasvatuspaatosRecursive(it) }
+            paatoksetDiff.added.forEach {
+                createVarhaiskasvatuspaatosRecursive(it, vardaLapsi.lapsi.url)
+            }
+            paatoksetDiff.unchanged.forEach { (vardaPaatos, evakaPaatos) ->
+                val suhteetDiff =
+                    diff(vardaPaatos.varhaiskasvatussuhteet, evakaPaatos.varhaiskasvatussuhteet)
+                suhteetDiff.removed.forEach { deleteVarhaiskasvatussuhde(it) }
+                suhteetDiff.added.forEach {
+                    createVarhaiskasvatussuhde(it, vardaPaatos.varhaiskasvatuspaatos.url)
+                }
+            }
+        }
+    }
+
+    fun getOrCreateHenkilo(person: VardaPerson): VardaClient.HenkiloResponse =
+        client.haeHenkilo(
+            if (person.ophPersonOid != null) {
+                VardaClient.VardaPersonSearchRequest(
+                    henkilotunnus = null,
+                    henkilo_oid = person.ophPersonOid
+                )
+            } else {
+                VardaClient.VardaPersonSearchRequest(
+                    henkilotunnus = person.socialSecurityNumber,
+                    henkilo_oid = null
+                )
+            }
+        )
+            ?: client.createHenkilo(
+                VardaClient.CreateHenkiloRequest(
+                    etunimet = person.firstName,
+                    sukunimi = person.lastName,
+                    kutsumanimi = person.firstName.split(" ").first(),
+                    henkilotunnus = person.socialSecurityNumber,
+                    henkilo_oid = person.ophPersonOid
+                )
+            )
+
+    fun deleteLapsiRecursive(vardaLapsi: VardaLapsiNode) {
+        var deleteLapsi = true
+        vardaLapsi.varhaiskasvatuspaatokset.forEach { paatosNode ->
+            val deleted = deleteVarhaiskasvatuspaatosRecursive(paatosNode)
+            if (!deleted) {
+                deleteLapsi = false
+            }
+        }
+        if (deleteLapsi) {
+            client.delete(vardaLapsi.lapsi.url)
+        }
+    }
+
+    fun createLapsiRecursive(evakaLapsi: EvakaLapsiNode, henkiloUrl: URI) {
+        val lapsi = client.createLapsi(evakaLapsi.lapsi.toVarda(lahdejarjestelma, henkiloUrl))
+        evakaLapsi.varhaiskasvatuspaatokset.forEach { paatosNode ->
+            createVarhaiskasvatuspaatosRecursive(paatosNode, lapsi.url)
+        }
+    }
+
+    /** Returns true if the varhaiskasvatuspaatos and associated data was deleted */
+    fun deleteVarhaiskasvatuspaatosRecursive(
+        vardaVarhaiskasvatuspaatos: VardaVarhaiskasvatuspaatosNode
+    ): Boolean {
+        var deletePaatos = true
+        vardaVarhaiskasvatuspaatos.varhaiskasvatussuhteet.forEach { suhde ->
+            val deleted = deleteVarhaiskasvatussuhde(suhde)
+            if (!deleted) {
+                deletePaatos = false
+            }
+        }
+        if (
+            !deletePaatos ||
+                (vardaVarhaiskasvatuspaatos.varhaiskasvatuspaatos.lahdejarjestelma !=
+                    lahdejarjestelma ||
+                    !vardaEnabledRange.contains(
+                        DateRange(
+                            vardaVarhaiskasvatuspaatos.varhaiskasvatuspaatos.alkamis_pvm,
+                            vardaVarhaiskasvatuspaatos.varhaiskasvatuspaatos.paattymis_pvm
+                        )
+                    ))
+        ) {
+            return false
+        }
+        client.delete(vardaVarhaiskasvatuspaatos.varhaiskasvatuspaatos.url)
+        return true
+    }
+
+    fun createVarhaiskasvatuspaatosRecursive(
+        evakaVarhaiskasvatuspaatos: EvakaVarhaiskasvatuspaatosNode,
+        lapsiUrl: URI
+    ) {
+        val paatos =
+            client.createVarhaiskasvatuspaatos(
+                evakaVarhaiskasvatuspaatos.varhaiskasvatuspaatos.toVarda(lahdejarjestelma, lapsiUrl)
+            )
+        evakaVarhaiskasvatuspaatos.varhaiskasvatussuhteet.forEach { suhde ->
+            createVarhaiskasvatussuhde(suhde, paatos.url)
+        }
+    }
+
+    /** Returns true if the varhaiskasvatussuhde was deleted */
+    fun deleteVarhaiskasvatussuhde(
+        vardaVarhaiskasvatussuhde: VardaClient.VarhaiskasvatussuhdeResponse
+    ): Boolean {
+        if (
+            vardaVarhaiskasvatussuhde.lahdejarjestelma != lahdejarjestelma ||
+                !vardaEnabledRange.contains(
+                    DateRange(
+                        vardaVarhaiskasvatussuhde.alkamis_pvm,
+                        vardaVarhaiskasvatussuhde.paattymis_pvm
+                    )
+                )
+        ) {
+            return false
+        }
+        client.delete(vardaVarhaiskasvatussuhde.url)
+        return true
+    }
+
+    fun createVarhaiskasvatussuhde(
+        evakaVarhaiskasvatussuhde: Varhaiskasvatussuhde,
+        paatosUrl: URI
+    ) {
+        client.createVarhaiskasvatussuhde(
+            evakaVarhaiskasvatussuhde.toVarda(lahdejarjestelma, paatosUrl)
+        )
+    }
+
+    data class EvakaLapsiNode(
+        val lapsi: Lapsi,
+        val varhaiskasvatuspaatokset: List<EvakaVarhaiskasvatuspaatosNode>,
+    ) : Diffable<VardaLapsiNode> {
+        override fun diffEq(other: VardaLapsiNode): Boolean = lapsi.diffEq(other.lapsi)
+    }
+
+    data class EvakaVarhaiskasvatuspaatosNode(
+        val varhaiskasvatuspaatos: Varhaiskasvatuspaatos,
+        val varhaiskasvatussuhteet: List<Varhaiskasvatussuhde>,
+    ) : Diffable<VardaVarhaiskasvatuspaatosNode> {
+        override fun diffEq(other: VardaVarhaiskasvatuspaatosNode): Boolean =
+            varhaiskasvatuspaatos.diffEq(other.varhaiskasvatuspaatos)
+    }
+
+    data class VardaLapsiNode(
+        val lapsi: VardaClient.LapsiResponse,
+        val varhaiskasvatuspaatokset: List<VardaVarhaiskasvatuspaatosNode>,
+    )
+
+    data class VardaVarhaiskasvatuspaatosNode(
+        val varhaiskasvatuspaatos: VardaClient.VarhaiskasvatuspaatosResponse,
+        val varhaiskasvatussuhteet: List<VardaClient.VarhaiskasvatussuhdeResponse>,
+    )
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -172,7 +172,8 @@ class VardaUpdateServiceNew(
                 )
             }
 
-        val uniqueEvakaLapset = serviceNeeds.map { Lapsi.fromEvaka(it, omaOrganisaatioOid) }.toSet()
+        val evakaLapsiServiceNeeds =
+            serviceNeeds.groupBy { Lapsi.fromEvaka(it, omaOrganisaatioOid) }
         val evakaFeeData =
             feeData
                 .mapNotNull { fee ->
@@ -181,11 +182,11 @@ class VardaUpdateServiceNew(
                 .groupBy({ it.first }, { it.second })
 
         val evakaLapset =
-            uniqueEvakaLapset.map { lapsi ->
+            evakaLapsiServiceNeeds.map { (lapsi, serviceNeedsOfLapsi) ->
                 EvakaLapsiNode(
                     lapsi = lapsi,
                     varhaiskasvatuspaatokset =
-                        serviceNeeds.map { serviceNeed ->
+                        serviceNeedsOfLapsi.map { serviceNeed ->
                             EvakaVarhaiskasvatuspaatosNode(
                                 varhaiskasvatuspaatos =
                                     Varhaiskasvatuspaatos.fromEvaka(serviceNeed),

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -142,7 +142,7 @@ class VardaUpdateServiceNew(
                 }
 
         val henkilo = getOrCreateHenkilo(person)
-        if (person.ophPersonOid == null) {
+        if (person.ophPersonOid != henkilo.henkilo_oid) {
             dbc.transaction { it.updateOphPersonOid(childId, henkilo.henkilo_oid) }
         }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -76,9 +76,8 @@ class VardaUpdateServiceNew(
 
     private val vardaEnabledRange =
         DateRange(
-            // PostgreSQL doesn't support LocalDate.MIN, so use an "early enough" date by
-            // default instead
-            vardaEnv.startDate ?: LocalDate.of(2000, 1, 1),
+            // 2019-01-01 was the hard-coded cutoff date of the old Varda integration
+            vardaEnv.startDate ?: LocalDate.of(2019, 1, 1),
             vardaEnv.endDate
         )
 

--- a/service/src/test/kotlin/fi/espoo/evaka/varda/integration/VardaClientTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/varda/integration/VardaClientTest.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.VardaEnv
 import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
 import java.io.ByteArrayInputStream
 import java.net.URI
+import java.time.LocalDate
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -69,9 +70,12 @@ class VardaClientTest {
                 fuel,
                 jsonMapper,
                 VardaEnv(
-                    url = "https://example.com/mock-integration/varda/api",
+                    url = URI.create("https://example.com/mock-integration/varda/api"),
                     basicAuth = Sensitive(""),
-                    sourceSystem = "SourceSystemVarda"
+                    sourceSystem = "SourceSystemVarda",
+                    startDate = LocalDate.of(2020, 1, 1),
+                    endDate = null,
+                    localDevPort = null
                 )
             )
 


### PR DESCRIPTION
#### Summary

Supports henkilo, lapsi, varhaiskasvatuspaatos, varhaiskasvatussuhde, maksutieto + huoltajat. Still missing support for toimipaikat.

Allows dry-runs of varda updates with useful logging via manually triggered async jobs.