### PR TITLE
Vasu&Leops migration part 1

### DIFF
--- a/frontend/src/employee-frontend/components/child-documents/statuses.ts
+++ b/frontend/src/employee-frontend/components/child-documents/statuses.ts
@@ -10,7 +10,9 @@ import {
 const statusesByType: Record<DocumentType, DocumentStatus[]> = {
   PEDAGOGICAL_ASSESSMENT: ['DRAFT', 'COMPLETED'],
   PEDAGOGICAL_REPORT: ['DRAFT', 'COMPLETED'],
-  HOJKS: ['DRAFT', 'PREPARED', 'COMPLETED']
+  HOJKS: ['DRAFT', 'PREPARED', 'COMPLETED'],
+  MIGRATED_VASU: ['COMPLETED'],
+  MIGRATED_LEOPS: ['COMPLETED']
 }
 
 export const getNextDocumentStatus = (

--- a/frontend/src/employee-frontend/components/child-information/ChildDocuments.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildDocuments.tsx
@@ -175,7 +175,7 @@ const ChildDocumentsList = React.memo(function ChildDocumentsList({
           !documents.some(
             ({ data: doc }) =>
               doc.templateId === template.id && doc.status !== 'COMPLETED'
-          )
+          ) && !template.type.startsWith('MIGRATED_')
       )
 
       return (

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateContentEditor.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateContentEditor.tsx
@@ -244,11 +244,13 @@ const BasicsEditor = React.memo(function BasicsEditor({
 
   const typeOptions = useMemo(
     () =>
-      documentTypes.map((option) => ({
-        domValue: option,
-        value: option,
-        label: i18n.documentTemplates.documentTypes[option]
-      })),
+      documentTypes
+        .filter((type) => !type.startsWith('MIGRATED_'))
+        .map((option) => ({
+          domValue: option,
+          value: option,
+          label: i18n.documentTemplates.documentTypes[option]
+        })),
     [i18n.documentTemplates]
   )
 

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
@@ -73,11 +73,13 @@ export default React.memo(function TemplateModal({ onClose, mode }: Props) {
 
   const typeOptions = useMemo(
     () =>
-      documentTypes.map((option) => ({
-        domValue: option,
-        value: option,
-        label: i18n.documentTemplates.documentTypes[option]
-      })),
+      documentTypes
+        .filter((type) => !type.startsWith('MIGRATED_'))
+        .map((option) => ({
+          domValue: option,
+          value: option,
+          label: i18n.documentTemplates.documentTypes[option]
+        })),
     [i18n.documentTemplates]
   )
 

--- a/frontend/src/employee-frontend/components/vasu/templates/VasuTemplatesPage.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/VasuTemplatesPage.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { faFileExport } from 'Icons'
 import React, { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
@@ -9,6 +10,7 @@ import { Loading, Result, wrapResult } from 'lib-common/api'
 import { VasuTemplateSummary } from 'lib-common/generated/api-types/vasu'
 import { useRestApi } from 'lib-common/utils/useRestApi'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
+import AsyncIconButton from 'lib-components/atoms/buttons/AsyncIconButton'
 import IconButton from 'lib-components/atoms/buttons/IconButton'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
@@ -20,7 +22,8 @@ import { faPen, faTrash } from 'lib-icons'
 
 import {
   deleteTemplate,
-  getTemplates
+  getTemplates,
+  migrateVasuDocuments
 } from '../../../generated/api-clients/vasu'
 import { useTranslation } from '../../../state/i18n'
 
@@ -29,6 +32,7 @@ import CreateTemplateModal from './CreateOrEditTemplateModal'
 
 const getTemplatesResult = wrapResult(getTemplates)
 const deleteTemplateResult = wrapResult(deleteTemplate)
+const migrateVasuDocumentsResult = wrapResult(migrateVasuDocuments)
 
 export default React.memo(function VasuTemplatesPage() {
   const { i18n } = useTranslation()
@@ -87,6 +91,13 @@ export default React.memo(function VasuTemplatesPage() {
                     <Td>{template.documentCount}</Td>
                     <Td>
                       <FixedSpaceRow spacing="s">
+                        <AsyncIconButton
+                          icon={faFileExport}
+                          onClick={() =>
+                            migrateVasuDocumentsResult({ id: template.id })
+                          }
+                          onSuccess={() => undefined}
+                        />
                         <IconButton
                           icon={faPen}
                           onClick={() => setTemplateToEdit(template)}

--- a/frontend/src/employee-frontend/generated/api-clients/vasu.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/vasu.ts
@@ -218,6 +218,22 @@ export async function getTemplates(
 
 
 /**
+* Generated from fi.espoo.evaka.vasu.VasuTemplateController.migrateVasuDocuments
+*/
+export async function migrateVasuDocuments(
+  request: {
+    id: UUID
+  }
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/vasu/templates/${request.id}/migrate`.toString(),
+    method: 'PUT'
+  })
+  return json
+}
+
+
+/**
 * Generated from fi.espoo.evaka.vasu.VasuTemplateController.postTemplate
 */
 export async function postTemplate(

--- a/frontend/src/lib-common/generated/api-types/document.ts
+++ b/frontend/src/lib-common/generated/api-types/document.ts
@@ -258,7 +258,9 @@ export interface DocumentTemplateSummary {
 export const documentTypes = [
   'PEDAGOGICAL_REPORT',
   'PEDAGOGICAL_ASSESSMENT',
-  'HOJKS'
+  'HOJKS',
+  'MIGRATED_VASU',
+  'MIGRATED_LEOPS'
 ] as const
 
 export type DocumentType = typeof documentTypes[number]

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4243,7 +4243,9 @@ export const fi = {
     documentTypes: {
       PEDAGOGICAL_REPORT: 'Pedagoginen selvitys',
       PEDAGOGICAL_ASSESSMENT: 'Pedagoginen arvio',
-      HOJKS: 'HOJKS'
+      HOJKS: 'HOJKS',
+      MIGRATED_VASU: 'Varhaiskasvatussuunnitelma',
+      MIGRATED_LEOPS: 'Esiopetuksen oppimissuunnitelma'
     },
     languages: {
       FI: 'Suomenkielinen',

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -476,6 +476,7 @@ enum class Audit(
     VasuTemplateDelete,
     VasuTemplateRead,
     VasuTemplateUpdate,
+    VasuTemplateMigrate,
     VoucherValueDecisionHeadOfFamilyCreateRetroactive,
     VoucherValueDecisionHeadOfFamilyRead,
     VoucherValueDecisionIgnore,

--- a/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplate.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplate.kt
@@ -106,7 +106,9 @@ data class Section(
 enum class DocumentType(val statuses: List<DocumentStatus>) {
     PEDAGOGICAL_REPORT(listOf(DocumentStatus.DRAFT, DocumentStatus.COMPLETED)),
     PEDAGOGICAL_ASSESSMENT(listOf(DocumentStatus.DRAFT, DocumentStatus.COMPLETED)),
-    HOJKS(listOf(DocumentStatus.DRAFT, DocumentStatus.PREPARED, DocumentStatus.COMPLETED))
+    HOJKS(listOf(DocumentStatus.DRAFT, DocumentStatus.PREPARED, DocumentStatus.COMPLETED)),
+    MIGRATED_VASU(listOf(DocumentStatus.COMPLETED)),
+    MIGRATED_LEOPS(listOf(DocumentStatus.COMPLETED))
 }
 
 enum class DocumentLanguage {

--- a/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplate.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplate.kt
@@ -108,7 +108,9 @@ enum class DocumentType(val statuses: List<DocumentStatus>) {
     PEDAGOGICAL_ASSESSMENT(listOf(DocumentStatus.DRAFT, DocumentStatus.COMPLETED)),
     HOJKS(listOf(DocumentStatus.DRAFT, DocumentStatus.PREPARED, DocumentStatus.COMPLETED)),
     MIGRATED_VASU(listOf(DocumentStatus.COMPLETED)),
-    MIGRATED_LEOPS(listOf(DocumentStatus.COMPLETED))
+    MIGRATED_LEOPS(listOf(DocumentStatus.COMPLETED));
+
+    fun isMigrated() = this in listOf(MIGRATED_VASU, MIGRATED_LEOPS)
 }
 
 enum class DocumentLanguage {

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentController.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.document.childdocument
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.document.DocumentTemplateContent
+import fi.espoo.evaka.document.DocumentType
 import fi.espoo.evaka.document.getTemplate
 import fi.espoo.evaka.pis.listPersonByDuplicateOf
 import fi.espoo.evaka.shared.ChildDocumentId
@@ -18,6 +19,7 @@ import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
+import fi.espoo.evaka.vasu.VASU_MIGRATION_COMPLETED
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -100,11 +102,18 @@ class ChildDocumentController(
                             clock,
                             documents.map { it.id }
                         )
-                    documents.mapNotNull { document ->
-                        permittedActions[document.id]
-                            ?.takeIf { it.contains(Action.ChildDocument.READ) }
-                            ?.let { ChildDocumentSummaryWithPermittedActions(document, it) }
-                    }
+                    documents
+                        .mapNotNull { document ->
+                            permittedActions[document.id]
+                                ?.takeIf { it.contains(Action.ChildDocument.READ) }
+                                ?.let { ChildDocumentSummaryWithPermittedActions(document, it) }
+                        }
+                        .filter {
+                            VASU_MIGRATION_COMPLETED ||
+                                user.isAdmin ||
+                                it.data.type !in
+                                    listOf(DocumentType.MIGRATED_VASU, DocumentType.MIGRATED_LEOPS)
+                        }
                 }
             }
             .also { Audit.ChildDocumentRead.log(targetId = childId) }
@@ -133,8 +142,12 @@ class ChildDocumentController(
                     )
 
                     val document =
-                        tx.getChildDocument(documentId)
-                            ?: throw NotFound("Document $documentId not found")
+                        tx.getChildDocument(documentId)?.takeIf {
+                            VASU_MIGRATION_COMPLETED ||
+                                user.isAdmin ||
+                                it.template.type !in
+                                    listOf(DocumentType.MIGRATED_VASU, DocumentType.MIGRATED_LEOPS)
+                        } ?: throw NotFound("Document $documentId not found")
 
                     val permittedActions =
                         accessControl.getPermittedActions<ChildDocumentId, Action.ChildDocument>(

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueriesCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueriesCitizen.kt
@@ -4,13 +4,11 @@
 
 package fi.espoo.evaka.document.childdocument
 
-import fi.espoo.evaka.document.DocumentType
 import fi.espoo.evaka.shared.ChildDocumentId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
-import fi.espoo.evaka.vasu.VASU_MIGRATION_COMPLETED
 
 fun Database.Read.getChildDocumentCitizenSummaries(
     user: AuthenticatedUser.Citizen,
@@ -31,10 +29,7 @@ fun Database.Read.getChildDocumentCitizenSummaries(
             )
         }
         .toList<ChildDocumentCitizenSummary>()
-        .filter {
-            VASU_MIGRATION_COMPLETED ||
-                it.type !in listOf(DocumentType.MIGRATED_VASU, DocumentType.MIGRATED_LEOPS)
-        }
+        .filter { !it.type.isMigrated() }
 }
 
 fun Database.Read.getCitizenChildDocument(id: ChildDocumentId): ChildDocumentCitizenDetails? {
@@ -67,10 +62,7 @@ fun Database.Read.getCitizenChildDocument(id: ChildDocumentId): ChildDocumentCit
             )
         }
         .exactlyOneOrNull<ChildDocumentCitizenDetails>()
-        ?.takeIf {
-            VASU_MIGRATION_COMPLETED ||
-                it.template.type !in listOf(DocumentType.MIGRATED_VASU, DocumentType.MIGRATED_LEOPS)
-        }
+        ?.takeIf { !it.template.type.isMigrated() }
 }
 
 fun Database.Transaction.markChildDocumentAsRead(

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueriesCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueriesCitizen.kt
@@ -4,11 +4,13 @@
 
 package fi.espoo.evaka.document.childdocument
 
+import fi.espoo.evaka.document.DocumentType
 import fi.espoo.evaka.shared.ChildDocumentId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.vasu.VASU_MIGRATION_COMPLETED
 
 fun Database.Read.getChildDocumentCitizenSummaries(
     user: AuthenticatedUser.Citizen,
@@ -29,6 +31,10 @@ fun Database.Read.getChildDocumentCitizenSummaries(
             )
         }
         .toList<ChildDocumentCitizenSummary>()
+        .filter {
+            VASU_MIGRATION_COMPLETED ||
+                it.type !in listOf(DocumentType.MIGRATED_VASU, DocumentType.MIGRATED_LEOPS)
+        }
 }
 
 fun Database.Read.getCitizenChildDocument(id: ChildDocumentId): ChildDocumentCitizenDetails? {
@@ -61,6 +67,10 @@ fun Database.Read.getCitizenChildDocument(id: ChildDocumentId): ChildDocumentCit
             )
         }
         .exactlyOneOrNull<ChildDocumentCitizenDetails>()
+        ?.takeIf {
+            VASU_MIGRATION_COMPLETED ||
+                it.template.type !in listOf(DocumentType.MIGRATED_VASU, DocumentType.MIGRATED_LEOPS)
+        }
 }
 
 fun Database.Transaction.markChildDocumentAsRead(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -302,6 +302,10 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class MigrateVasuDocument(val documentId: VasuDocumentId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     companion object {
         val main =
             AsyncJobRunner.Pool(
@@ -376,6 +380,12 @@ sealed interface AsyncJob : AsyncJobPayload {
                     ResetVardaChildOld::class,
                     DeleteVardaChildOld::class,
                 )
+            )
+        val vasuMigration =
+            AsyncJobRunner.Pool(
+                AsyncJobPool.Id(AsyncJob::class, "vasuMigration"),
+                AsyncJobPool.Config(concurrency = 1),
+                setOf(MigrateVasuDocument::class)
             )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -37,7 +37,8 @@ class AsyncJobConfig {
                 AsyncJob.varda,
                 AsyncJob.suomiFi.withThrottleInterval(
                     Duration.ofSeconds(1).takeIf { env.activeProfiles.contains("production") }
-                )
+                ),
+                AsyncJob.vasuMigration
             ),
             jdbi,
             tracer

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/DocumentMigrator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/DocumentMigrator.kt
@@ -176,16 +176,8 @@ private fun toBasicsRequest(vasu: VasuDocument): DocumentTemplateBasicsRequest {
         confidential = true,
         legalBasis =
             when (vasu.type) {
-                CurriculumType.DAYCARE ->
-                    when (vasu.language) {
-                        VasuLanguage.FI -> translations.lawVasu
-                        VasuLanguage.SV -> translations.lawVasu
-                    }
-                CurriculumType.PRESCHOOL ->
-                    when (vasu.language) {
-                        VasuLanguage.FI -> translations.lawLeops
-                        VasuLanguage.SV -> translations.lawLeops
-                    }
+                CurriculumType.DAYCARE -> translations.lawVasu
+                CurriculumType.PRESCHOOL -> translations.lawLeops
             },
         validity = vasu.templateRange.asDateRange()
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/DocumentMigrator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/DocumentMigrator.kt
@@ -1,0 +1,550 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.vasu
+
+import fi.espoo.evaka.document.DocumentLanguage
+import fi.espoo.evaka.document.DocumentTemplateBasicsRequest
+import fi.espoo.evaka.document.DocumentTemplateContent
+import fi.espoo.evaka.document.DocumentType
+import fi.espoo.evaka.document.Question
+import fi.espoo.evaka.document.Section
+import fi.espoo.evaka.document.childdocument.AnsweredQuestion
+import fi.espoo.evaka.document.childdocument.DocumentContent
+import fi.espoo.evaka.document.insertTemplate
+import fi.espoo.evaka.document.publishTemplate
+import fi.espoo.evaka.document.updateDraftTemplateContent
+import fi.espoo.evaka.shared.ChildDocumentId
+import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.DocumentTemplateId
+import fi.espoo.evaka.shared.VasuDocumentId
+import fi.espoo.evaka.shared.VasuTemplateId
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import org.springframework.stereotype.Service
+
+// consider moving to env if we need different settings in different envs
+const val VASU_MIGRATION_COMPLETED = false
+
+@Service
+class VasuMigratorService(private val asyncJobRunner: AsyncJobRunner<AsyncJob>) {
+    init {
+        asyncJobRunner.registerHandler<AsyncJob.MigrateVasuDocument> { db, clock, msg ->
+            db.transaction { tx -> migrateVasu(tx, clock.today(), msg.documentId) }
+        }
+    }
+
+    fun planMigrationJobs(
+        tx: Database.Transaction,
+        now: HelsinkiDateTime,
+        vasuTemplateId: VasuTemplateId
+    ) {
+        val vasuDocumentIds =
+            tx.createQuery {
+                    sql(
+                        """
+            SELECT id FROM curriculum_document 
+            WHERE template_id = ${bind(vasuTemplateId)}
+        """
+                    )
+                }
+                .toList<VasuDocumentId>()
+
+        asyncJobRunner.plan(
+            tx,
+            payloads = vasuDocumentIds.map { AsyncJob.MigrateVasuDocument(it) },
+            retryCount = 3,
+            runAt = now
+        )
+    }
+}
+
+fun migrateVasu(tx: Database.Transaction, today: LocalDate, id: VasuDocumentId) {
+    val vasuDocument =
+        tx.getLatestPublishedVasuDocument(today, id)?.takeIf {
+            it.documentState == VasuDocumentState.CLOSED && it.publishedAt != null
+        } ?: return
+
+    val templateBasics = toBasicsRequest(vasuDocument)
+    val (templateContent, documentContent) = migrateContents(vasuDocument)
+
+    val templateId = getOrCreateTemplate(tx, templateBasics, templateContent)
+
+    val documentId = ChildDocumentId(vasuDocument.id.raw)
+    tx.deletePreviouslyMigratedChildDocument(documentId)
+    tx.insertMigratedChildDocument(
+        documentId,
+        vasuDocument.basics.child.id,
+        templateId,
+        documentContent,
+        vasuDocument.modifiedAt,
+        vasuDocument.publishedAt!!
+    )
+}
+
+private val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+private val checkboxTrue = "[x]"
+private val checkboxFalse = "[ ]"
+private val emptyField = "___________"
+
+private fun getOrCreateTemplate(
+    tx: Database.Transaction,
+    templateBasics: DocumentTemplateBasicsRequest,
+    templateContent: DocumentTemplateContent
+): DocumentTemplateId {
+    tx.createUpdate { sql("LOCK TABLE document_template") }.execute()
+    return getMatchingTemplate(tx, templateBasics, templateContent)
+        ?: tx.insertTemplate(templateBasics)
+            .id
+            .also { tx.updateDraftTemplateContent(it, templateContent) }
+            .also { tx.publishTemplate(it) }
+}
+
+private fun getMatchingTemplate(
+    tx: Database.Transaction,
+    templateBasics: DocumentTemplateBasicsRequest,
+    templateContent: DocumentTemplateContent
+): DocumentTemplateId? =
+    tx.createQuery {
+            sql(
+                """
+    SELECT id FROM document_template
+    WHERE name = ${bind(templateBasics.name)}
+     AND type = ${bind(templateBasics.type)}
+     AND language = ${bind(templateBasics.language)}
+     AND confidential = ${bind(templateBasics.confidential)}
+     AND legal_basis = ${bind(templateBasics.legalBasis)}
+     AND validity = ${bind(templateBasics.validity)}
+     AND content = ${bind(templateContent)}::jsonb
+"""
+            )
+        }
+        .exactlyOneOrNull()
+
+private fun Database.Transaction.deletePreviouslyMigratedChildDocument(id: ChildDocumentId) {
+    createUpdate {
+            sql(
+                """
+        DELETE FROM child_document cd WHERE id = ${bind(id)} AND EXISTS(
+            SELECT 1 FROM document_template dt
+            WHERE cd.template_id = dt.id AND dt.type IN ('MIGRATED_VASU', 'MIGRATED_LEOPS')
+        )
+    """
+            )
+        }
+        .execute()
+}
+
+private fun Database.Transaction.insertMigratedChildDocument(
+    id: ChildDocumentId,
+    childId: ChildId,
+    templateId: DocumentTemplateId,
+    content: DocumentContent,
+    modifiedAt: HelsinkiDateTime,
+    publishedAt: HelsinkiDateTime
+) {
+    createUpdate {
+            sql(
+                """
+INSERT INTO child_document(id, child_id, template_id, status, content, published_content, modified_at, published_at)
+VALUES (${bind(id)}, ${bind(childId)}, ${bind(templateId)}, 'COMPLETED', ${bind(content)}, ${bind(content)}, ${bind(modifiedAt)}, ${bind(publishedAt)})
+"""
+            )
+        }
+        .execute()
+}
+
+private fun toBasicsRequest(vasu: VasuDocument): DocumentTemplateBasicsRequest {
+    val translations = getTranslations(vasu.language)
+    return DocumentTemplateBasicsRequest(
+        name = vasu.templateName,
+        type =
+            when (vasu.type) {
+                CurriculumType.DAYCARE -> DocumentType.MIGRATED_VASU
+                CurriculumType.PRESCHOOL -> DocumentType.MIGRATED_LEOPS
+            },
+        language =
+            when (vasu.language) {
+                VasuLanguage.FI -> DocumentLanguage.FI
+                VasuLanguage.SV -> DocumentLanguage.SV
+            },
+        confidential = true,
+        legalBasis =
+            when (vasu.type) {
+                CurriculumType.DAYCARE ->
+                    when (vasu.language) {
+                        VasuLanguage.FI -> translations.lawVasu
+                        VasuLanguage.SV -> translations.lawVasu
+                    }
+                CurriculumType.PRESCHOOL ->
+                    when (vasu.language) {
+                        VasuLanguage.FI -> translations.lawLeops
+                        VasuLanguage.SV -> translations.lawLeops
+                    }
+            },
+        validity = vasu.templateRange.asDateRange()
+    )
+}
+
+private fun migrateContents(
+    vasuDocument: VasuDocument
+): Pair<DocumentTemplateContent, DocumentContent> {
+    val sections =
+        if (vasuDocument.content.hasDynamicFirstSection == true) {
+            vasuDocument.content.sections
+        } else {
+            val basicsSection =
+                VasuSection(
+                    name = getTranslations(vasuDocument.language).basicsTitle,
+                    questions = listOf(VasuQuestion.StaticInfoSubSection())
+                )
+            listOf(basicsSection) + vasuDocument.content.sections
+        }
+    val sectionsAndAnswers =
+        sections.mapIndexed { i, s ->
+            migrateTemplateSection(document = vasuDocument, vasuSection = s, sectionIndex = i)
+        }
+    val templateContent = DocumentTemplateContent(sections = sectionsAndAnswers.map { it.first })
+    val documentContent = DocumentContent(answers = sectionsAndAnswers.flatMap { it.second })
+    return templateContent to documentContent
+}
+
+private fun migrateTemplateSection(
+    document: VasuDocument,
+    vasuSection: VasuSection,
+    sectionIndex: Int
+): Pair<Section, List<AnsweredQuestion<*>>> {
+    val questionsAndAnswer =
+        vasuSection.questions.flatMapIndexed { i, q ->
+            migrateTemplateQuestion(
+                document = document,
+                vasuQuestion = q,
+                sectionIndex = sectionIndex,
+                questionIndex = i
+            )
+        }
+    return Section(
+        id = "section-$sectionIndex",
+        label = vasuSection.name,
+        questions = questionsAndAnswer.map { it.first }
+    ) to questionsAndAnswer.map { it.second }
+}
+
+/** maps vasu question to one or more question-answer pairs */
+private fun migrateTemplateQuestion(
+    document: VasuDocument,
+    vasuQuestion: VasuQuestion,
+    sectionIndex: Int,
+    questionIndex: Int
+): List<Pair<Question, AnsweredQuestion<*>>> {
+    val id = "section-$sectionIndex-question-$questionIndex"
+    return when (vasuQuestion) {
+        is VasuQuestion.TextQuestion -> {
+            val question =
+                Question.TextQuestion(
+                    id = id,
+                    label = vasuQuestion.name,
+                    infoText = vasuQuestion.info,
+                    multiline = vasuQuestion.multiline
+                )
+            val answer = AnsweredQuestion.TextAnswer(questionId = id, answer = vasuQuestion.value)
+            listOf(question to answer)
+        }
+        is VasuQuestion.CheckboxQuestion -> {
+            val questionAndAnswer =
+                if (vasuQuestion.label.isNullOrBlank()) {
+                    Question.CheckboxQuestion(
+                        id = id,
+                        label = vasuQuestion.name,
+                        infoText = vasuQuestion.info
+                    ) to
+                        AnsweredQuestion.CheckboxAnswer(
+                            questionId = id,
+                            answer = vasuQuestion.value
+                        )
+                } else if (vasuQuestion.name.isBlank()) {
+                    Question.CheckboxQuestion(
+                        id = id,
+                        label = vasuQuestion.label,
+                        infoText = vasuQuestion.info
+                    ) to
+                        AnsweredQuestion.CheckboxAnswer(
+                            questionId = id,
+                            answer = vasuQuestion.value
+                        )
+                } else {
+                    Question.TextQuestion(
+                        id = id,
+                        label = vasuQuestion.name,
+                        infoText = vasuQuestion.info,
+                        multiline = false
+                    ) to
+                        AnsweredQuestion.TextAnswer(
+                            questionId = id,
+                            answer =
+                                if (vasuQuestion.value) "$checkboxTrue ${vasuQuestion.label}"
+                                else "$checkboxFalse ${vasuQuestion.label}"
+                        )
+                }
+            listOf(questionAndAnswer)
+        }
+        is VasuQuestion.RadioGroupQuestion -> {
+            val question =
+                Question.TextQuestion(
+                    id = id,
+                    label = vasuQuestion.name,
+                    infoText = vasuQuestion.info,
+                    multiline = true
+                )
+
+            val answerText =
+                vasuQuestion.value
+                    ?.let { vasuQuestion.options.find { opt -> opt.key == it } }
+                    ?.let { opt ->
+                        listOfNotNull(
+                                opt.name,
+                                if (opt.dateRange) {
+                                    vasuQuestion.dateRange?.let {
+                                        "${it.start.format(dateFormatter)} - ${it.end.format(dateFormatter)}"
+                                    } ?: emptyField
+                                } else null
+                            )
+                            .joinToString(separator = " : ")
+                    } ?: "-"
+
+            val answer = AnsweredQuestion.TextAnswer(questionId = id, answer = answerText)
+
+            listOf(question to answer)
+        }
+        is VasuQuestion.MultiSelectQuestion -> {
+            val question =
+                Question.TextQuestion(
+                    id = id,
+                    label = vasuQuestion.name,
+                    infoText = vasuQuestion.info,
+                    multiline = true
+                )
+            val optionAnswers =
+                vasuQuestion.options.map { opt ->
+                    if (opt.isIntervention) return@map "\n${opt.name}\n"
+                    val selected = vasuQuestion.value.contains(opt.key)
+                    val answerParts =
+                        listOfNotNull(
+                            " ",
+                            if (selected) checkboxTrue else checkboxFalse,
+                            opt.name,
+                            if (selected && opt.dateRange) {
+                                vasuQuestion.dateRangeValue?.get(opt.key)?.let {
+                                    "${it.start.format(dateFormatter)} - ${it.end.format(dateFormatter)}"
+                                } ?: emptyField
+                            } else null,
+                            if (selected && opt.date) {
+                                vasuQuestion.dateValue?.get(opt.key)?.format(dateFormatter)
+                                    ?: emptyField
+                            } else null,
+                            if (selected && opt.textAnswer) {
+                                vasuQuestion.textValue[opt.key]?.takeIf { it.isNotBlank() }
+                                    ?: emptyField
+                            } else null
+                        )
+                    answerParts.joinToString(separator = " ")
+                }
+            val answer =
+                AnsweredQuestion.TextAnswer(
+                    questionId = id,
+                    answer = optionAnswers.joinToString(separator = "\n")
+                )
+            listOf(question to answer)
+        }
+        is VasuQuestion.MultiField -> {
+            if (vasuQuestion.separateRows) {
+                val header =
+                    Question.StaticTextDisplayQuestion(
+                        id = "$id-header",
+                        label = vasuQuestion.name,
+                        infoText = vasuQuestion.info
+                    ) to
+                        AnsweredQuestion.StaticTextDisplayAnswer(
+                            questionId = "$id-header",
+                            answer = null
+                        )
+                val subQuestions =
+                    vasuQuestion.keys.mapIndexed { i, field ->
+                        Question.TextQuestion(
+                            id = "$id-$i",
+                            label = field.name,
+                            infoText = field.info ?: "",
+                            multiline = false
+                        ) to
+                            AnsweredQuestion.TextAnswer(
+                                questionId = "$id-$i",
+                                answer = vasuQuestion.value[i]
+                            )
+                    }
+                listOf(header) + subQuestions
+            } else {
+                val question =
+                    Question.GroupedTextFieldsQuestion(
+                        id = id,
+                        label = vasuQuestion.name,
+                        fieldLabels = vasuQuestion.keys.map { it.name },
+                        infoText = vasuQuestion.info,
+                        allowMultipleRows = false
+                    )
+                val answer =
+                    AnsweredQuestion.GroupedTextFieldsAnswer(
+                        questionId = id,
+                        answer = listOf(vasuQuestion.value)
+                    )
+                listOf(question to answer)
+            }
+        }
+        is VasuQuestion.MultiFieldList -> {
+            val question =
+                Question.GroupedTextFieldsQuestion(
+                    id = id,
+                    label = vasuQuestion.name,
+                    fieldLabels = vasuQuestion.keys.map { it.name },
+                    infoText = vasuQuestion.info,
+                    allowMultipleRows = true
+                )
+            val answer =
+                AnsweredQuestion.GroupedTextFieldsAnswer(
+                    questionId = id,
+                    answer = vasuQuestion.value
+                )
+            listOf(question to answer)
+        }
+        is VasuQuestion.DateQuestion -> {
+            val question =
+                Question.DateQuestion(
+                    id = id,
+                    label = vasuQuestion.name,
+                    infoText = vasuQuestion.info
+                )
+            val answer = AnsweredQuestion.DateAnswer(questionId = id, answer = vasuQuestion.value)
+            listOf(question to answer)
+        }
+        is VasuQuestion.Followup -> {
+            val question =
+                Question.TextQuestion(
+                    id = id,
+                    label = vasuQuestion.title,
+                    infoText = vasuQuestion.info,
+                    multiline = true
+                )
+            val answer =
+                AnsweredQuestion.TextAnswer(
+                    questionId = id,
+                    answer =
+                        if (vasuQuestion.value.isEmpty()) "-"
+                        else {
+                            vasuQuestion.value.joinToString("\n\n") {
+                                "${it.date.format(dateFormatter)}: ${it.text.trim()}"
+                            }
+                        }
+                )
+
+            listOf(question to answer)
+        }
+        is VasuQuestion.Paragraph -> {
+            listOf(
+                Question.StaticTextDisplayQuestion(
+                    id = id,
+                    label = vasuQuestion.title,
+                    text = vasuQuestion.paragraph
+                ) to AnsweredQuestion.StaticTextDisplayAnswer(questionId = id, answer = null)
+            )
+        }
+        is VasuQuestion.StaticInfoSubSection -> {
+            val translations = getTranslations(document.language)
+            listOf(
+                Question.TextQuestion(id = "$id-0", label = translations.name) to
+                    AnsweredQuestion.TextAnswer(
+                        questionId = "$id-0",
+                        answer =
+                            "${document.basics.child.firstName} ${document.basics.child.lastName}"
+                    ),
+                Question.TextQuestion(id = "$id-1", label = translations.dateOfBirth) to
+                    AnsweredQuestion.TextAnswer(
+                        questionId = "$id-1",
+                        answer = document.basics.child.dateOfBirth.format(dateFormatter)
+                    ),
+                Question.TextQuestion(
+                    id = "$id-2",
+                    label = translations.guardians,
+                    multiline = true
+                ) to
+                    AnsweredQuestion.TextAnswer(
+                        questionId = "$id-2",
+                        answer =
+                            document.basics.guardians.joinToString("\n") {
+                                "${it.firstName} ${it.lastName}"
+                            }
+                    ),
+                Question.TextQuestion(
+                    id = "$id-3",
+                    label =
+                        when (document.type) {
+                            CurriculumType.DAYCARE -> translations.placementsVasu
+                            CurriculumType.PRESCHOOL -> translations.placementsLeops
+                        },
+                    multiline = true
+                ) to
+                    AnsweredQuestion.TextAnswer(
+                        questionId = "$id-3",
+                        answer =
+                            document.basics.placements?.joinToString("\n") {
+                                "${it.unitName} ${it.groupName} ${it.range.start.format(dateFormatter)} - ${it.range.end.format(dateFormatter)}"
+                            } ?: "-"
+                    )
+            )
+        }
+    }
+}
+
+private data class Translations(
+    val basicsTitle: String,
+    val name: String,
+    val dateOfBirth: String,
+    val guardians: String,
+    val placementsVasu: String,
+    val placementsLeops: String,
+    val lawVasu: String,
+    val lawLeops: String,
+)
+
+private val translationsFi =
+    Translations(
+        basicsTitle = "Perustiedot",
+        name = "Lapsen nimi",
+        dateOfBirth = "Lapsen syntymäaika",
+        guardians = "Huoltaja(t) tai muu laillinen edustaja",
+        placementsVasu = "Varhaiskasvatusyksikkö ja ryhmä",
+        placementsLeops = "Esiopetusyksikkö ja ryhmä",
+        lawVasu = "Varhaiskasvatuslaki (540/2018) 40§:n 3 mom.",
+        lawLeops = "JulkL 24.1 §:n kohdat 25 ja 30"
+    )
+
+private val translationsSv =
+    Translations(
+        basicsTitle = "Basuppgifter",
+        name = "Barnets namn",
+        dateOfBirth = "Barnets födelsedatum",
+        guardians = "Vårdnadshavare eller annan laglig företrädare",
+        placementsVasu = "Enhet och grupp inom småbarnspedagogiken",
+        placementsLeops = "Enhet och grupp inom förskoleundervisningen",
+        lawVasu = "40 § 3 mom. i lagen om småbarnspedagogik (540/2018)",
+        lawLeops = "OffentlighetsL 24.1 §§ punkt 25 och 30"
+    )
+
+private fun getTranslations(language: VasuLanguage) =
+    when (language) {
+        VasuLanguage.FI -> translationsFi
+        VasuLanguage.SV -> translationsSv
+    }

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/DocumentMigrator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/DocumentMigrator.kt
@@ -28,9 +28,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import org.springframework.stereotype.Service
 
-// consider moving to env if we need different settings in different envs
-const val VASU_MIGRATION_COMPLETED = false
-
 @Service
 class VasuMigratorService(private val asyncJobRunner: AsyncJobRunner<AsyncJob>) {
     init {

--- a/service/src/main/resources/db/migration/V390__add_migrated_document_types.sql
+++ b/service/src/main/resources/db/migration/V390__add_migrated_document_types.sql
@@ -1,0 +1,7 @@
+ALTER TYPE document_template_type ADD VALUE 'MIGRATED_VASU';
+ALTER TYPE document_template_type ADD VALUE 'MIGRATED_LEOPS';
+
+ALTER TABLE child_document_read
+    DROP CONSTRAINT child_document_read_document_id_fkey,
+    ADD CONSTRAINT child_document_read_document_id_fkey
+        FOREIGN KEY (document_id) REFERENCES child_document ON DELETE CASCADE;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -386,3 +386,4 @@ V386__async_job_permit.sql
 V387__generate_id_for_incomes.sql
 V388__preschool_assistance_decision_valid_to.sql
 V389__resync_personal_accounts_with_acl.sql
+V390__add_migrated_document_types.sql


### PR DESCRIPTION
#### Summary

- Admin can trigger migration of curriculum_documents to document_templates and child_documents
- Migration can be ran repeatedly (although some orphan document_templates may be left as garbage) so that we can iterate the logic after checking results with real data 
- For now only admin sees the created documents and templates so that the results can be validated after each iteration
- Only published vasus&leops in COMPLETED state are migrated so the final migration run should be done during summer after current season has ended