### PR TITLE
Used service fixes

### DIFF
--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -386,7 +386,6 @@ export interface UnitDateInfo {
 * Generated from fi.espoo.evaka.reservations.UsedServiceResult
 */
 export interface UsedServiceResult {
-  attendedMinutes: number
   reservedMinutes: number
   usedServiceMinutes: number
   usedServiceRanges: TimeRange[]

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -586,7 +586,6 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                 usedService =
                                     UsedServiceResult(
                                         reservedMinutes = 420,
-                                        attendedMinutes = 400,
                                         usedServiceMinutes = 420,
                                         usedServiceRanges =
                                             listOf(
@@ -620,7 +619,6 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                 usedService =
                                     UsedServiceResult(
                                         reservedMinutes = 420,
-                                        attendedMinutes = 455,
                                         usedServiceMinutes = 455,
                                         listOf(TimeRange(LocalTime.of(8, 45), LocalTime.of(16, 20)))
                                     ),
@@ -645,7 +643,6 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                 usedService =
                                     UsedServiceResult(
                                         reservedMinutes = 0,
-                                        attendedMinutes = 480,
                                         usedServiceMinutes = 480,
                                         listOf(TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0)))
                                     ),
@@ -664,7 +661,6 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                 usedService =
                                     UsedServiceResult(
                                         reservedMinutes = 0,
-                                        attendedMinutes = 0,
                                         usedServiceMinutes = (120.0 * 60 / 21).roundToLong(),
                                         usedServiceRanges = emptyList()
                                     ),
@@ -1281,7 +1277,6 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                             usedService =
                                 UsedServiceResult(
                                     reservedMinutes = 0,
-                                    attendedMinutes = 0,
                                     usedServiceMinutes = 0,
                                     usedServiceRanges = emptyList()
                                 )

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceService.kt
@@ -107,7 +107,8 @@ fun getGroupMonthCalendar(
                                 serviceNeed?.daycareHoursPerMonth?.let { daycareHoursPerMonth ->
                                     val usedService =
                                         computeUsedService(
-                                            isDateInFuture = date > today,
+                                            today = today,
+                                            date = date,
                                             serviceNeedHours = daycareHoursPerMonth,
                                             placementType = placement.type,
                                             preschoolTime = placement.preschoolTime,
@@ -121,11 +122,7 @@ fun getGroupMonthCalendar(
                                                     it.reservation.asTimeRange()
                                                 },
                                             attendances =
-                                                childAttendances.mapNotNull {
-                                                    it.endTime?.let { endTime ->
-                                                        TimeRange(it.startTime, endTime)
-                                                    }
-                                                }
+                                                childAttendances.map { it.asTimeInterval() }
                                         )
                                     usedServiceByChild.updateKey(child.id) {
                                         (it ?: UsedServiceData(daycareHoursPerMonth)).let { totals

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/ChildAttendance.kt
@@ -16,6 +16,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.TimeInterval
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -59,7 +60,9 @@ data class ChildAttendanceRow(
     val date: LocalDate,
     val startTime: LocalTime,
     val endTime: LocalTime?
-)
+) {
+    fun asTimeInterval(): TimeInterval = TimeInterval(startTime, endTime)
+}
 
 data class AttendanceTimes(val arrived: HelsinkiDateTime, val departed: HelsinkiDateTime?)
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ExceededServiceNeedsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ExceededServiceNeedsReport.kt
@@ -152,12 +152,11 @@ private fun exceededServiceNeedReport(
                             it.reservation.asTimeRange()
                         }
                     val childAttendances =
-                        (attendances[child.id to date] ?: emptyList()).mapNotNull {
-                            it.endTime?.let { endTime -> TimeRange(it.startTime, endTime) }
-                        }
+                        (attendances[child.id to date] ?: emptyList()).map { it.asTimeInterval() }
                     child.id to
                         computeUsedService(
-                            isDateInFuture = date > today,
+                            today = today,
+                            date = date,
                             serviceNeedHours = serviceNeed.daycareHoursPerMonth,
                             placementType = serviceNeed.placementType,
                             preschoolTime = serviceNeed.dailyPreschoolTime,

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -159,17 +159,12 @@ class ReservationControllerCitizen(
                                                         val childAttendances =
                                                             attendances[key] ?: listOf()
 
-                                                        val isFuture =
-                                                            date > today ||
-                                                                date == today &&
-                                                                    childAttendances.all {
-                                                                        it.end == null
-                                                                    }
                                                         val usedServiceResult =
                                                             placementDay.daycareHoursPerMonth
                                                                 ?.let { daycareHoursPerMonth ->
                                                                     computeUsedService(
-                                                                        isFuture,
+                                                                        today = today,
+                                                                        date = date,
                                                                         daycareHoursPerMonth,
                                                                         placementDay.placementType,
                                                                         placementDay.preschoolTime,
@@ -186,9 +181,6 @@ class ReservationControllerCitizen(
                                                                                 it.asTimeRange()
                                                                             },
                                                                         childAttendances
-                                                                            .mapNotNull {
-                                                                                it.asTimeRange()
-                                                                            }
                                                                     )
                                                                 }
                                                         ReservationResponseDayChild(

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -522,7 +522,6 @@ private fun Database.Transaction.insertReservation(
 
 data class UsedServiceResult(
     val reservedMinutes: Long,
-    val attendedMinutes: Long,
     val usedServiceMinutes: Long,
     val usedServiceRanges: List<TimeRange>
 )
@@ -551,7 +550,6 @@ fun computeUsedService(
     if (!isOperationDay && shiftCareType != ShiftCareType.INTERMITTENT) {
         return UsedServiceResult(
             reservedMinutes = 0,
-            attendedMinutes = 0,
             usedServiceMinutes = 0,
             usedServiceRanges = emptyList()
         )
@@ -579,7 +577,6 @@ fun computeUsedService(
     if (isDateInFuture) {
         return UsedServiceResult(
             reservedMinutes = minutesOf(effectiveReservations),
-            attendedMinutes = 0,
             usedServiceMinutes = 0,
             usedServiceRanges = emptyList()
         )
@@ -594,7 +591,6 @@ fun computeUsedService(
     if (endedAttendances.isEmpty() && isPlannedAbsence) {
         return UsedServiceResult(
             reservedMinutes = 0,
-            attendedMinutes = 0,
             usedServiceMinutes = 0,
             usedServiceRanges = emptyList()
         )
@@ -605,7 +601,6 @@ fun computeUsedService(
         val dailyAverage = serviceNeedHours.toDouble() * 60 / daysInMonth
         return UsedServiceResult(
             reservedMinutes = 0,
-            attendedMinutes = 0,
             usedServiceMinutes = maxOf(0, dailyAverage.roundToLong() - freeMinutes),
             usedServiceRanges = emptyList()
         )
@@ -616,7 +611,6 @@ fun computeUsedService(
 
     return UsedServiceResult(
         reservedMinutes = minutesOf(effectiveReservations),
-        attendedMinutes = effectiveAttendances.ranges().sumOf { it.duration.toMinutes() },
         usedServiceMinutes = minutesOf(usedService),
         usedServiceRanges = usedService.ranges().toList()
     )


### PR DESCRIPTION
#### Summary

- Subtract 4 hours also from reserved minutes for five-year-olds
- Make "is day in future" computation consistent
- While at it, remove an unused `attendanceMinutes` field