### PR TITLE
write lock for child documents

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -2187,6 +2187,8 @@ export class Fixture {
       templateId: 'not_set',
       status: 'DRAFT',
       modifiedAt: HelsinkiDateTime.now(),
+      contentModifiedAt: HelsinkiDateTime.now(),
+      contentModifiedBy: null,
       publishedAt: null,
       content: {
         answers: [

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -362,6 +362,8 @@ export interface DevChildAttendance {
 export interface DevChildDocument {
   childId: UUID
   content: DocumentContent
+  contentModifiedAt: HelsinkiDateTime
+  contentModifiedBy: UUID | null
   id: UUID
   modifiedAt: HelsinkiDateTime
   publishedAt: HelsinkiDateTime | null
@@ -1170,6 +1172,7 @@ export function deserializeJsonDevChildDocument(json: JsonOf<DevChildDocument>):
   return {
     ...json,
     content: deserializeJsonDocumentContent(json.content),
+    contentModifiedAt: HelsinkiDateTime.parseIso(json.contentModifiedAt),
     modifiedAt: HelsinkiDateTime.parseIso(json.modifiedAt),
     publishedAt: (json.publishedAt != null) ? HelsinkiDateTime.parseIso(json.publishedAt) : null,
     publishedContent: (json.publishedContent != null) ? deserializeJsonDocumentContent(json.publishedContent) : null

--- a/frontend/src/e2e-test/pages/employee/documents/child-document.ts
+++ b/frontend/src/e2e-test/pages/employee/documents/child-document.ts
@@ -32,4 +32,11 @@ export class ChildDocumentPage {
     await this.page.findByDataQa('next-status-button').click()
     await this.page.findByDataQa('modal-okBtn').click()
   }
+
+  async closeConcurrentEditErrorModal() {
+    await this.page
+      .findByDataQa('concurrent-edit-error-modal')
+      .findByDataQa('modal-okBtn')
+      .click()
+  }
 }

--- a/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
@@ -220,7 +220,7 @@ describe('Employee - Child documents', () => {
     await page.close()
 
     // Admin tries to open the document in edit mode too soon
-    page = await Page.open({ mockedTime: now.addMinutes(5) })
+    page = await Page.open({ mockedTime: now.addMinutes(3) })
     await employeeLogin(page, admin)
     await page.goto(
       `${config.employeeUrl}/child-information/${childFixture.id}`
@@ -237,7 +237,7 @@ describe('Employee - Child documents', () => {
     await page.close()
 
     // Admin opens the document in edit mode after lock expires
-    page = await Page.open({ mockedTime: now.addMinutes(20) })
+    page = await Page.open({ mockedTime: now.addMinutes(6) })
     await employeeLogin(page, admin)
     await page.goto(
       `${config.employeeUrl}/child-information/${childFixture.id}`

--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -34,7 +34,10 @@ import UnitPage from './components/UnitPage'
 import Units from './components/Units'
 import WelcomePage from './components/WelcomePage'
 import ApplicationsPage from './components/applications/ApplicationsPage'
-import ChildDocumentEditor from './components/child-documents/ChildDocumentEditor'
+import {
+  ChildDocumentEditView,
+  ChildDocumentReadView
+} from './components/child-documents/ChildDocumentEditor'
 import AssistanceNeedDecisionEditPage from './components/child-information/assistance-need/decision/AssistanceNeedDecisionEditPage'
 import AssistanceNeedDecisionPage from './components/child-information/assistance-need/decision/AssistanceNeedDecisionPage'
 import AssistanceNeedPreschoolDecisionEditPage from './components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage'
@@ -887,7 +890,15 @@ export default createBrowserRouter(
           path: '/child-documents/:documentId',
           element: (
             <EmployeeRoute>
-              <ChildDocumentEditor />
+              <ChildDocumentReadView />
+            </EmployeeRoute>
+          )
+        },
+        {
+          path: '/child-documents/:documentId/edit',
+          element: (
+            <EmployeeRoute>
+              <ChildDocumentEditView />
             </EmployeeRoute>
           )
         },

--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
@@ -140,7 +140,7 @@ const ConcurrentEditWarning = React.memo(function ConcurrentEditWarning({
     <InfoModal
       data-qa="concurrent-edit-error-modal"
       type="warning"
-      title="Asiakirja on tilapäisesti lukittu"
+      title={i18n.childInformation.childDocuments.editor.lockedErrorTitle}
       text={errorText}
       close={onClose}
       closeLabel={i18n.common.close}
@@ -185,7 +185,7 @@ const ChildDocumentEditViewInner = React.memo(
     const { mutateAsync: updateChildDocumentContent, isPending: submitting } =
       useMutationResult(updateChildDocumentContentMutation)
 
-    // invalidate cached document on onmount
+    // invalidate cached document on unmount
     const queryClient = useQueryClient()
     useEffect(
       () => () => {

--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
@@ -138,6 +138,7 @@ const ConcurrentEditWarning = React.memo(function ConcurrentEditWarning({
 
   return (
     <InfoModal
+      data-qa="concurrent-edit-error-modal"
       type="warning"
       title="Asiakirja on tilapäisesti lukittu"
       text={errorText}

--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
@@ -17,10 +17,13 @@ import React, {
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import styled from 'styled-components'
 
+import { combine } from 'lib-common/api'
 import { useForm } from 'lib-common/form/hooks'
 import {
+  ChildDocumentDetails,
   ChildDocumentWithPermittedActions,
-  DocumentContent
+  DocumentContent,
+  DocumentWriteLock
 } from 'lib-common/generated/api-types/document'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
@@ -41,6 +44,7 @@ import {
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
 import { ConfirmedMutation } from 'lib-components/molecules/ConfirmedMutation'
+import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { H1, H2 } from 'lib-components/typography'
 import { Gap, defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
@@ -52,6 +56,7 @@ import {
   childDocumentNextStatusMutation,
   childDocumentPrevStatusMutation,
   childDocumentQuery,
+  childDocumentWriteLockQuery,
   deleteChildDocumentMutation,
   publishChildDocumentMutation,
   queryKeys,
@@ -71,189 +76,202 @@ const ActionBar = styled.div`
   padding: ${defaultMargins.s} 0;
 `
 
-const ChildDocumentEditorView = React.memo(function ChildDocumentEditorView({
-  documentAndPermissions,
+const DocumentBasics = React.memo(function DocumentBasics({
+  document
+}: {
+  document: ChildDocumentDetails
+}) {
+  const { i18n } = useTranslation()
+
+  return (
+    <FixedSpaceRow justifyContent="space-between" alignItems="center">
+      <FixedSpaceColumn>
+        <H1 noMargin>{document.template.name}</H1>
+        <H2 noMargin>
+          {document.child.firstName} {document.child.lastName} (
+          {document.child.dateOfBirth?.format()})
+        </H2>
+      </FixedSpaceColumn>
+      <FixedSpaceColumn
+        spacing="xxs"
+        justifyContent="start"
+        alignItems="flex-end"
+      >
+        <ChildDocumentStateChip status={document.status} />
+        {document.template.confidential && (
+          <strong>{i18n.documentTemplates.templateEditor.confidential}</strong>
+        )}
+        {!!document.template.legalBasis && (
+          <span>{document.template.legalBasis}</span>
+        )}
+      </FixedSpaceColumn>
+    </FixedSpaceRow>
+  )
+})
+
+const ConcurrentEditWarning = React.memo(function ConcurrentEditWarning({
+  currentLock,
+  documentId,
   childIdFromUrl
 }: {
-  documentAndPermissions: ChildDocumentWithPermittedActions
+  currentLock?: DocumentWriteLock
+  documentId: UUID
   childIdFromUrl: UUID | null
 }) {
-  const { data: document, permittedActions } = documentAndPermissions
   const { i18n } = useTranslation()
-  const { setTitle } = useContext<TitleState>(TitleContext)
-  useEffect(
-    () => setTitle(document.template.name, true),
-    [document.template.name, setTitle]
-  )
   const navigate = useNavigate()
-  const bind = useForm(
-    documentForm,
+
+  const errorText = currentLock
+    ? i18n.childInformation.childDocuments.editor.lockedErrorDetailed(
+        currentLock.modifiedByName,
+        currentLock.opensAt.toLocalTime().format()
+      )
+    : i18n.childInformation.childDocuments.editor.lockedError
+
+  const onClose = useCallback(
     () =>
-      getDocumentFormInitialState(document.template.content, document.content),
-    i18n.validationErrors
-  )
-  const [editMode, setEditMode] = useState(false)
-  const [lastSaved, setLastSaved] = useState(HelsinkiDateTime.now())
-  const [lastSavedContent, setLastSavedContent] = useState(document.content)
-  const { mutateAsync: updateChildDocumentContent, isPending: submitting } =
-    useMutationResult(updateChildDocumentContentMutation)
-
-  // invalidate cached document on onmount
-  const queryClient = useQueryClient()
-  useEffect(
-    () => () => {
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.childDocument(document.id),
-        type: 'all'
-      })
-    },
-    [queryClient, document.id]
-  )
-
-  const save = useCallback(
-    async (content: DocumentContent) => {
-      const result = await updateChildDocumentContent({
-        documentId: document.id,
-        body: content
-      })
-      if (result.isSuccess) {
-        setLastSaved(HelsinkiDateTime.now())
-        setLastSavedContent(content)
-      }
-    },
-    [updateChildDocumentContent, document.id]
-  )
-
-  const saved = useMemo(
-    () => bind.isValid() && isEqual(lastSavedContent, bind.value()),
-    [bind, lastSavedContent]
-  )
-
-  const debouncedValidContent = useDebounce(
-    bind.isValid() ? bind.value() : null,
-    1000
-  )
-
-  useEffect(() => {
-    if (
-      editMode &&
-      debouncedValidContent !== null &&
-      !isEqual(lastSavedContent, debouncedValidContent) &&
-      !submitting
-    ) {
-      void save(debouncedValidContent)
-    }
-  }, [editMode, debouncedValidContent, lastSavedContent, save, submitting])
-
-  const goBack = () =>
-    navigate(`/child-information/${childIdFromUrl ?? document.child.id}`)
-
-  const nextStatus = useMemo(
-    () => getNextDocumentStatus(document.template.type, document.status),
-    [document.template.type, document.status]
-  )
-  const prevStatus = useMemo(
-    () => getPrevDocumentStatus(document.template.type, document.status),
-    [document.template.type, document.status]
-  )
-
-  const publishedUpToDate = useMemo(
-    () =>
-      document.publishedContent !== null &&
-      isEqual(document.publishedContent, lastSavedContent),
-    [document.publishedContent, lastSavedContent]
+      navigate(
+        `/child-documents/${documentId}${childIdFromUrl ? `?childId=${childIdFromUrl}` : ''}`
+      ),
+    [navigate, documentId, childIdFromUrl]
   )
 
   return (
-    <div>
-      <Container>
-        <ContentArea opaque>
-          <FixedSpaceRow justifyContent="space-between" alignItems="center">
-            <FixedSpaceColumn>
-              <H1 noMargin>{document.template.name}</H1>
-              <H2 noMargin>
-                {document.child.firstName} {document.child.lastName} (
-                {document.child.dateOfBirth?.format()})
-              </H2>
-            </FixedSpaceColumn>
-            <FixedSpaceColumn
-              spacing="xxs"
-              justifyContent="start"
-              alignItems="flex-end"
-            >
-              <ChildDocumentStateChip status={document.status} />
-              {document.template.confidential && (
-                <strong>
-                  {i18n.documentTemplates.templateEditor.confidential}
-                </strong>
-              )}
-              {!!document.template.legalBasis && (
-                <span>{document.template.legalBasis}</span>
-              )}
-            </FixedSpaceColumn>
-          </FixedSpaceRow>
-          <Gap size="XXL" />
-          <DocumentView bind={bind} readOnly={!editMode} />
-        </ContentArea>
-      </Container>
+    <InfoModal
+      type="warning"
+      title="Asiakirja on tilapäisesti lukittu"
+      text={errorText}
+      close={onClose}
+      closeLabel={i18n.common.close}
+      resolve={{
+        action: onClose,
+        label: i18n.common.close
+      }}
+    />
+  )
+})
 
-      <ActionBar>
+const ChildDocumentEditViewInner = React.memo(
+  function ChildDocumentEditViewInner({
+    document,
+    childIdFromUrl
+  }: {
+    document: ChildDocumentDetails
+    childIdFromUrl: UUID | null
+  }) {
+    const { i18n } = useTranslation()
+    const navigate = useNavigate()
+    const { setTitle } = useContext<TitleState>(TitleContext)
+    useEffect(
+      () => setTitle(document.template.name, true),
+      [document.template.name, setTitle]
+    )
+
+    const bind = useForm(
+      documentForm,
+      () =>
+        getDocumentFormInitialState(
+          document.template.content,
+          document.content
+        ),
+      i18n.validationErrors
+    )
+
+    const [lastSaved, setLastSaved] = useState(HelsinkiDateTime.now())
+    const [lastSavedContent, setLastSavedContent] = useState(document.content)
+    const [lockError, setLockError] = useState(false)
+
+    const { mutateAsync: updateChildDocumentContent, isPending: submitting } =
+      useMutationResult(updateChildDocumentContentMutation)
+
+    // invalidate cached document on onmount
+    const queryClient = useQueryClient()
+    useEffect(
+      () => () => {
+        void queryClient.invalidateQueries({
+          queryKey: queryKeys.childDocument(document.id),
+          type: 'all'
+        })
+      },
+      [queryClient, document.id]
+    )
+
+    const save = useCallback(
+      async (content: DocumentContent) => {
+        const result = await updateChildDocumentContent({
+          documentId: document.id,
+          body: content
+        })
+        if (result.isSuccess) {
+          setLastSaved(HelsinkiDateTime.now())
+          setLastSavedContent(content)
+        } else {
+          if (result.isFailure && result.errorCode === 'invalid-lock') {
+            setLockError(true)
+          }
+        }
+      },
+      [updateChildDocumentContent, document.id]
+    )
+
+    const saved = useMemo(
+      () => bind.isValid() && isEqual(lastSavedContent, bind.value()),
+      [bind, lastSavedContent]
+    )
+
+    const debouncedValidContent = useDebounce(
+      bind.isValid() ? bind.value() : null,
+      1000
+    )
+
+    useEffect(() => {
+      if (
+        !lockError &&
+        debouncedValidContent !== null &&
+        !isEqual(lastSavedContent, debouncedValidContent) &&
+        !submitting
+      ) {
+        void save(debouncedValidContent)
+      }
+    }, [lockError, debouncedValidContent, lastSavedContent, save, submitting])
+
+    const goBack = () =>
+      navigate(`/child-information/${childIdFromUrl ?? document.child.id}`)
+
+    if (lockError) {
+      return (
+        <ConcurrentEditWarning
+          documentId={document.id}
+          childIdFromUrl={childIdFromUrl}
+        />
+      )
+    }
+
+    return (
+      <div>
         <Container>
-          <FixedSpaceRow justifyContent="space-between" alignItems="center">
-            <FixedSpaceRow alignItems="center">
-              <Button
-                text={i18n.common.goBack}
-                onClick={goBack}
-                // disable while debounce is pending to avoid leaving before saving
-                disabled={
-                  bind.isValid() &&
-                  !isEqual(bind.value(), debouncedValidContent)
-                }
-                data-qa="return-button"
-              />
+          <ContentArea opaque>
+            <DocumentBasics document={document} />
+            <Gap size="XXL" />
+            <DocumentView bind={bind} readOnly={false} />
+          </ContentArea>
+        </Container>
 
-              {!editMode &&
-                permittedActions.includes('DELETE') &&
-                document.status === 'DRAFT' && (
-                  <ConfirmedMutation
-                    buttonText={
-                      i18n.childInformation.childDocuments.editor.deleteDraft
-                    }
-                    mutation={deleteChildDocumentMutation}
-                    onClick={() => ({
-                      documentId: document.id,
-                      childId: document.child.id
-                    })}
-                    onSuccess={goBack}
-                    confirmationTitle={
-                      i18n.childInformation.childDocuments.editor
-                        .deleteDraftConfirmTitle
-                    }
-                  />
-                )}
-              {!editMode &&
-                permittedActions.includes('PREV_STATUS') &&
-                prevStatus != null && (
-                  <ConfirmedMutation
-                    buttonText={
-                      i18n.childInformation.childDocuments.editor
-                        .goToPrevStatus[prevStatus]
-                    }
-                    mutation={childDocumentPrevStatusMutation}
-                    onClick={() => ({
-                      documentId: document.id,
-                      childId: document.child.id,
-                      body: {
-                        newStatus: prevStatus
-                      }
-                    })}
-                    confirmationTitle={
-                      i18n.childInformation.childDocuments.editor
-                        .goToPrevStatusConfirmTitle[prevStatus]
-                    }
-                  />
-                )}
-              {editMode && (
+        <ActionBar>
+          <Container>
+            <FixedSpaceRow justifyContent="space-between" alignItems="center">
+              <FixedSpaceRow alignItems="center">
+                <Button
+                  text={i18n.common.goBack}
+                  onClick={goBack}
+                  // disable while debounce is pending to avoid leaving before saving
+                  disabled={
+                    bind.isValid() &&
+                    !isEqual(bind.value(), debouncedValidContent)
+                  }
+                  data-qa="return-button"
+                />
+
                 <FixedSpaceRow alignItems="center" spacing="xs">
                   <span>
                     {i18n.common.saved}{' '}
@@ -267,136 +285,299 @@ const ChildDocumentEditorView = React.memo(function ChildDocumentEditorView({
                     <Spinner size={defaultMargins.m} data-qa="saving-spinner" />
                   )}
                 </FixedSpaceRow>
-              )}
-            </FixedSpaceRow>
-
-            <FixedSpaceRow>
-              {!editMode &&
-                permittedActions.includes('UPDATE') &&
-                document.status !== 'COMPLETED' && (
-                  <Button
-                    text={i18n.common.edit}
-                    onClick={() => setEditMode(true)}
-                    data-qa="edit-button"
-                  />
-                )}
-              {editMode && (
-                <Button
-                  text={i18n.childInformation.childDocuments.editor.preview}
-                  primary
-                  onClick={() => setEditMode(false)}
-                  disabled={!saved}
-                  data-qa="preview-button"
-                />
-              )}
-              {!editMode &&
-                permittedActions.includes('PUBLISH') &&
-                document.status !== 'COMPLETED' && (
-                  <ConfirmedMutation
-                    buttonText={
-                      i18n.childInformation.childDocuments.editor.publish
-                    }
-                    mutation={publishChildDocumentMutation}
-                    onClick={() => ({
-                      documentId: document.id,
-                      childId: document.child.id
-                    })}
-                    confirmationTitle={
-                      i18n.childInformation.childDocuments.editor
-                        .publishConfirmTitle
-                    }
-                    confirmationText={
-                      i18n.childInformation.childDocuments.editor
-                        .publishConfirmText
-                    }
-                    data-qa="publish-button"
-                  />
-                )}
-              {!editMode &&
-                permittedActions.includes('NEXT_STATUS') &&
-                nextStatus != null && (
-                  <ConfirmedMutation
-                    buttonText={
-                      i18n.childInformation.childDocuments.editor
-                        .goToNextStatus[nextStatus]
-                    }
-                    primary
-                    mutation={childDocumentNextStatusMutation}
-                    onClick={() => ({
-                      documentId: document.id,
-                      childId: document.child.id,
-                      body: {
-                        newStatus: nextStatus
-                      }
-                    })}
-                    confirmationTitle={
-                      i18n.childInformation.childDocuments.editor
-                        .goToNextStatusConfirmTitle[nextStatus]
-                    }
-                    confirmationText={
-                      nextStatus === 'COMPLETED'
-                        ? i18n.childInformation.childDocuments.editor
-                            .goToCompletedConfirmText
-                        : i18n.childInformation.childDocuments.editor
-                            .publishConfirmText
-                    }
-                    data-qa="next-status-button"
-                  />
-                )}
-            </FixedSpaceRow>
-          </FixedSpaceRow>
-          {!editMode && (
-            <>
-              <Gap size="s" />
-              <FixedSpaceRow alignItems="center" justifyContent="flex-end">
-                <FixedSpaceRow alignItems="center" spacing="xs">
-                  {publishedUpToDate ? (
-                    <>
-                      <FontAwesomeIcon
-                        icon={fasCheckCircle}
-                        color={colors.status.success}
-                        size="lg"
-                      />
-                      <span>
-                        {
-                          i18n.childInformation.childDocuments.editor
-                            .fullyPublished
-                        }
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <FontAwesomeIcon
-                        icon={fasExclamationTriangle}
-                        color={colors.status.warning}
-                        size="lg"
-                      />
-                      <span>
-                        {i18n.childInformation.childDocuments.editor.notFullyPublished(
-                          document.publishedAt
-                        )}
-                      </span>
-                    </>
-                  )}
-                </FixedSpaceRow>
               </FixedSpaceRow>
-            </>
-          )}
+
+              <Button
+                text={i18n.childInformation.childDocuments.editor.preview}
+                primary
+                onClick={() =>
+                  navigate(
+                    `/child-documents/${document.id}${childIdFromUrl ? `?childId=${childIdFromUrl}` : ''}`
+                  )
+                }
+                disabled={!saved}
+                data-qa="preview-button"
+              />
+            </FixedSpaceRow>
+          </Container>
+        </ActionBar>
+      </div>
+    )
+  }
+)
+
+export const ChildDocumentEditView = React.memo(
+  function ChildDocumentEditView() {
+    const { documentId } = useRouteParams(['documentId'])
+    const [searchParams] = useSearchParams()
+    const childIdFromUrl = searchParams.get('childId') // duplicate child workaround
+
+    const documentResult = useQueryResult(childDocumentQuery({ documentId }))
+    const lockResult = useQueryResult(
+      childDocumentWriteLockQuery({ documentId })
+    )
+
+    return renderResult(
+      combine(documentResult, lockResult),
+      ([documentAndPermissions, lock], isReloading) => {
+        // do not initialize form with possibly stale data
+        if (isReloading) return null
+
+        if (!lock.lockTakenSuccessfully) {
+          return (
+            <ConcurrentEditWarning
+              documentId={documentId}
+              childIdFromUrl={childIdFromUrl}
+              currentLock={lock.currentLock}
+            />
+          )
+        }
+
+        return (
+          <ChildDocumentEditViewInner
+            document={documentAndPermissions.data}
+            childIdFromUrl={childIdFromUrl}
+          />
+        )
+      }
+    )
+  }
+)
+
+const ChildDocumentReadViewInner = React.memo(
+  function ChildDocumentReadViewInner({
+    documentAndPermissions,
+    childIdFromUrl
+  }: {
+    documentAndPermissions: ChildDocumentWithPermittedActions
+    childIdFromUrl: UUID | null
+  }) {
+    const { data: document, permittedActions } = documentAndPermissions
+    const { i18n } = useTranslation()
+    const navigate = useNavigate()
+    const { setTitle } = useContext<TitleState>(TitleContext)
+    useEffect(
+      () => setTitle(document.template.name, true),
+      [document.template.name, setTitle]
+    )
+
+    const bind = useForm(
+      documentForm,
+      () =>
+        getDocumentFormInitialState(
+          document.template.content,
+          document.content
+        ),
+      i18n.validationErrors
+    )
+
+    const goBack = () =>
+      navigate(`/child-information/${childIdFromUrl ?? document.child.id}`)
+
+    const nextStatus = useMemo(
+      () => getNextDocumentStatus(document.template.type, document.status),
+      [document.template.type, document.status]
+    )
+    const prevStatus = useMemo(
+      () => getPrevDocumentStatus(document.template.type, document.status),
+      [document.template.type, document.status]
+    )
+
+    const publishedUpToDate = useMemo(
+      () =>
+        document.publishedContent !== null &&
+        isEqual(document.publishedContent, document.content),
+      [document]
+    )
+
+    return (
+      <div>
+        <Container>
+          <ContentArea opaque>
+            <DocumentBasics document={document} />
+            <Gap size="XXL" />
+            <DocumentView bind={bind} readOnly={true} />
+          </ContentArea>
         </Container>
-      </ActionBar>
-    </div>
-  )
-})
 
-export default React.memo(function ChildDocumentEditor() {
-  const { documentId } = useRouteParams(['documentId'])
-  const [searchParams] = useSearchParams()
-  const documentResult = useQueryResult(childDocumentQuery({ documentId }))
+        <ActionBar>
+          <Container>
+            <FixedSpaceRow justifyContent="space-between" alignItems="center">
+              <FixedSpaceRow alignItems="center">
+                <Button
+                  text={i18n.common.goBack}
+                  onClick={goBack}
+                  data-qa="return-button"
+                />
+                {permittedActions.includes('DELETE') &&
+                  document.status === 'DRAFT' && (
+                    <ConfirmedMutation
+                      buttonText={
+                        i18n.childInformation.childDocuments.editor.deleteDraft
+                      }
+                      mutation={deleteChildDocumentMutation}
+                      onClick={() => ({
+                        documentId: document.id,
+                        childId: document.child.id
+                      })}
+                      onSuccess={goBack}
+                      confirmationTitle={
+                        i18n.childInformation.childDocuments.editor
+                          .deleteDraftConfirmTitle
+                      }
+                    />
+                  )}
+                {permittedActions.includes('PREV_STATUS') &&
+                  prevStatus != null && (
+                    <ConfirmedMutation
+                      buttonText={
+                        i18n.childInformation.childDocuments.editor
+                          .goToPrevStatus[prevStatus]
+                      }
+                      mutation={childDocumentPrevStatusMutation}
+                      onClick={() => ({
+                        documentId: document.id,
+                        childId: document.child.id,
+                        body: {
+                          newStatus: prevStatus
+                        }
+                      })}
+                      confirmationTitle={
+                        i18n.childInformation.childDocuments.editor
+                          .goToPrevStatusConfirmTitle[prevStatus]
+                      }
+                    />
+                  )}
+              </FixedSpaceRow>
 
-  return renderResult(documentResult, (documentAndPermissions) => (
-    <ChildDocumentEditorView
-      documentAndPermissions={documentAndPermissions}
-      childIdFromUrl={searchParams.get('childId')}
-    />
-  ))
-})
+              <FixedSpaceRow>
+                {permittedActions.includes('UPDATE') &&
+                  document.status !== 'COMPLETED' && (
+                    <Button
+                      text={i18n.common.edit}
+                      onClick={() =>
+                        navigate(
+                          `/child-documents/${document.id}/edit${childIdFromUrl ? `?childId=${childIdFromUrl}` : ''}`
+                        )
+                      }
+                      data-qa="edit-button"
+                    />
+                  )}
+                {permittedActions.includes('PUBLISH') &&
+                  document.status !== 'COMPLETED' && (
+                    <ConfirmedMutation
+                      buttonText={
+                        i18n.childInformation.childDocuments.editor.publish
+                      }
+                      mutation={publishChildDocumentMutation}
+                      onClick={() => ({
+                        documentId: document.id,
+                        childId: document.child.id
+                      })}
+                      confirmationTitle={
+                        i18n.childInformation.childDocuments.editor
+                          .publishConfirmTitle
+                      }
+                      confirmationText={
+                        i18n.childInformation.childDocuments.editor
+                          .publishConfirmText
+                      }
+                      data-qa="publish-button"
+                    />
+                  )}
+                {permittedActions.includes('NEXT_STATUS') &&
+                  nextStatus != null && (
+                    <ConfirmedMutation
+                      buttonText={
+                        i18n.childInformation.childDocuments.editor
+                          .goToNextStatus[nextStatus]
+                      }
+                      primary
+                      mutation={childDocumentNextStatusMutation}
+                      onClick={() => ({
+                        documentId: document.id,
+                        childId: document.child.id,
+                        body: {
+                          newStatus: nextStatus
+                        }
+                      })}
+                      confirmationTitle={
+                        i18n.childInformation.childDocuments.editor
+                          .goToNextStatusConfirmTitle[nextStatus]
+                      }
+                      confirmationText={
+                        nextStatus === 'COMPLETED'
+                          ? i18n.childInformation.childDocuments.editor
+                              .goToCompletedConfirmText
+                          : i18n.childInformation.childDocuments.editor
+                              .publishConfirmText
+                      }
+                      data-qa="next-status-button"
+                    />
+                  )}
+              </FixedSpaceRow>
+            </FixedSpaceRow>
+            <Gap size="s" />
+            <FixedSpaceRow alignItems="center" justifyContent="flex-end">
+              <FixedSpaceRow alignItems="center" spacing="xs">
+                {publishedUpToDate ? (
+                  <>
+                    <FontAwesomeIcon
+                      icon={fasCheckCircle}
+                      color={colors.status.success}
+                      size="lg"
+                    />
+                    <span>
+                      {
+                        i18n.childInformation.childDocuments.editor
+                          .fullyPublished
+                      }
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <FontAwesomeIcon
+                      icon={fasExclamationTriangle}
+                      color={colors.status.warning}
+                      size="lg"
+                    />
+                    <span>
+                      {i18n.childInformation.childDocuments.editor.notFullyPublished(
+                        document.publishedAt
+                      )}
+                    </span>
+                  </>
+                )}
+              </FixedSpaceRow>
+            </FixedSpaceRow>
+          </Container>
+        </ActionBar>
+      </div>
+    )
+  }
+)
+
+export const ChildDocumentReadView = React.memo(
+  function ChildDocumentReadView() {
+    const { documentId } = useRouteParams(['documentId'])
+    const [searchParams] = useSearchParams()
+    const childIdFromUrl = searchParams.get('childId') // duplicate child workaround
+
+    const documentResult = useQueryResult(childDocumentQuery({ documentId }))
+
+    return renderResult(
+      documentResult,
+      (documentAndPermissions, isReloading) => {
+        // do not initialize form with possibly stale data
+        if (isReloading) return null
+
+        return (
+          <ChildDocumentReadViewInner
+            documentAndPermissions={documentAndPermissions}
+            childIdFromUrl={childIdFromUrl}
+          />
+        )
+      }
+    )
+  }
+)

--- a/frontend/src/employee-frontend/components/child-information/queries.ts
+++ b/frontend/src/employee-frontend/components/child-information/queries.ts
@@ -44,6 +44,7 @@ import {
   nextDocumentStatus,
   prevDocumentStatus,
   publishDocument,
+  takeDocumentWriteLock,
   updateDocumentContent
 } from '../../generated/api-clients/document'
 import { createQueryKeys } from '../../query'
@@ -51,6 +52,7 @@ import { createQueryKeys } from '../../query'
 export const queryKeys = createQueryKeys('childInformation', {
   childDocuments: (childId: UUID) => ['childDocuments', childId],
   childDocument: (id: UUID) => ['childDocument', id],
+  childDocumentWriteLock: (id: UUID) => ['childDocument', id, 'lock'],
   assistance: (childId: UUID) => ['assistance', childId],
   assistanceNeedPreschoolDecisionBasics: (childId: UUID) => [
     'assistanceNeedPreschoolDecisionBasics',
@@ -76,6 +78,11 @@ export const childDocumentsQuery = query({
 export const childDocumentQuery = query({
   api: getDocument,
   queryKey: ({ documentId }) => queryKeys.childDocument(documentId)
+})
+
+export const childDocumentWriteLockQuery = query({
+  api: takeDocumentWriteLock,
+  queryKey: ({ documentId }) => queryKeys.childDocumentWriteLock(documentId)
 })
 
 export const createChildDocumentMutation = mutation({

--- a/frontend/src/employee-frontend/generated/api-clients/document.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/document.ts
@@ -9,6 +9,7 @@ import { ChildDocumentCreateRequest } from 'lib-common/generated/api-types/docum
 import { ChildDocumentSummaryWithPermittedActions } from 'lib-common/generated/api-types/document'
 import { ChildDocumentWithPermittedActions } from 'lib-common/generated/api-types/document'
 import { DocumentContent } from 'lib-common/generated/api-types/document'
+import { DocumentLockResponse } from 'lib-common/generated/api-types/document'
 import { DocumentTemplate } from 'lib-common/generated/api-types/document'
 import { DocumentTemplateBasicsRequest } from 'lib-common/generated/api-types/document'
 import { DocumentTemplateContent } from 'lib-common/generated/api-types/document'
@@ -22,6 +23,7 @@ import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonChildDocumentSummaryWithPermittedActions } from 'lib-common/generated/api-types/document'
 import { deserializeJsonChildDocumentWithPermittedActions } from 'lib-common/generated/api-types/document'
+import { deserializeJsonDocumentLockResponse } from 'lib-common/generated/api-types/document'
 import { deserializeJsonDocumentTemplate } from 'lib-common/generated/api-types/document'
 import { deserializeJsonDocumentTemplateSummary } from 'lib-common/generated/api-types/document'
 import { deserializeJsonExportedDocumentTemplate } from 'lib-common/generated/api-types/document'
@@ -348,6 +350,22 @@ export async function publishDocument(
     method: 'PUT'
   })
   return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.document.childdocument.ChildDocumentController.takeDocumentWriteLock
+*/
+export async function takeDocumentWriteLock(
+  request: {
+    documentId: UUID
+  }
+): Promise<DocumentLockResponse> {
+  const { data: json } = await client.request<JsonOf<DocumentLockResponse>>({
+    url: uri`/child-documents/${request.documentId}/lock`.toString(),
+    method: 'PUT'
+  })
+  return deserializeJsonDocumentLockResponse(json)
 }
 
 

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/document.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/document.ts
@@ -5,10 +5,6 @@
 // GENERATED FILE: no manual modifications
 
 import DateRange from 'lib-common/date-range'
-import { ChildDocumentCreateRequest } from 'lib-common/generated/api-types/document'
-import { ChildDocumentSummaryWithPermittedActions } from 'lib-common/generated/api-types/document'
-import { ChildDocumentWithPermittedActions } from 'lib-common/generated/api-types/document'
-import { DocumentContent } from 'lib-common/generated/api-types/document'
 import { DocumentTemplate } from 'lib-common/generated/api-types/document'
 import { DocumentTemplateBasicsRequest } from 'lib-common/generated/api-types/document'
 import { DocumentTemplateContent } from 'lib-common/generated/api-types/document'
@@ -20,8 +16,6 @@ import { StatusChangeRequest } from 'lib-common/generated/api-types/document'
 import { UUID } from 'lib-common/types'
 import { client } from '../../client'
 import { createUrlSearchParams } from 'lib-common/api'
-import { deserializeJsonChildDocumentSummaryWithPermittedActions } from 'lib-common/generated/api-types/document'
-import { deserializeJsonChildDocumentWithPermittedActions } from 'lib-common/generated/api-types/document'
 import { deserializeJsonDocumentTemplate } from 'lib-common/generated/api-types/document'
 import { deserializeJsonDocumentTemplateSummary } from 'lib-common/generated/api-types/document'
 import { deserializeJsonExportedDocumentTemplate } from 'lib-common/generated/api-types/document'
@@ -231,23 +225,6 @@ export async function updateTemplateValidity(
 
 
 /**
-* Generated from fi.espoo.evaka.document.childdocument.ChildDocumentController.createDocument
-*/
-export async function createDocument(
-  request: {
-    body: ChildDocumentCreateRequest
-  }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
-    url: uri`/child-documents`.toString(),
-    method: 'POST',
-    data: request.body satisfies JsonCompatible<ChildDocumentCreateRequest>
-  })
-  return json
-}
-
-
-/**
 * Generated from fi.espoo.evaka.document.childdocument.ChildDocumentController.deleteDraftDocument
 */
 export async function deleteDraftDocument(
@@ -260,42 +237,6 @@ export async function deleteDraftDocument(
     method: 'DELETE'
   })
   return json
-}
-
-
-/**
-* Generated from fi.espoo.evaka.document.childdocument.ChildDocumentController.getDocument
-*/
-export async function getDocument(
-  request: {
-    documentId: UUID
-  }
-): Promise<ChildDocumentWithPermittedActions> {
-  const { data: json } = await client.request<JsonOf<ChildDocumentWithPermittedActions>>({
-    url: uri`/child-documents/${request.documentId}`.toString(),
-    method: 'GET'
-  })
-  return deserializeJsonChildDocumentWithPermittedActions(json)
-}
-
-
-/**
-* Generated from fi.espoo.evaka.document.childdocument.ChildDocumentController.getDocuments
-*/
-export async function getDocuments(
-  request: {
-    childId: UUID
-  }
-): Promise<ChildDocumentSummaryWithPermittedActions[]> {
-  const params = createUrlSearchParams(
-    ['childId', request.childId]
-  )
-  const { data: json } = await client.request<JsonOf<ChildDocumentSummaryWithPermittedActions[]>>({
-    url: uri`/child-documents`.toString(),
-    method: 'GET',
-    params
-  })
-  return json.map(e => deserializeJsonChildDocumentSummaryWithPermittedActions(e))
 }
 
 
@@ -346,24 +287,6 @@ export async function publishDocument(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/child-documents/${request.documentId}/publish`.toString(),
     method: 'PUT'
-  })
-  return json
-}
-
-
-/**
-* Generated from fi.espoo.evaka.document.childdocument.ChildDocumentController.updateDocumentContent
-*/
-export async function updateDocumentContent(
-  request: {
-    documentId: UUID,
-    body: DocumentContent
-  }
-): Promise<void> {
-  const { data: json } = await client.request<JsonOf<void>>({
-    url: uri`/child-documents/${request.documentId}/content`.toString(),
-    method: 'PUT',
-    data: request.body satisfies JsonCompatible<DocumentContent>
   })
   return json
 }

--- a/frontend/src/lib-common/generated/api-types/document.ts
+++ b/frontend/src/lib-common/generated/api-types/document.ts
@@ -200,6 +200,14 @@ export type DocumentLanguage =
   | 'SV'
 
 /**
+* Generated from fi.espoo.evaka.document.childdocument.ChildDocumentController.DocumentLockResponse
+*/
+export interface DocumentLockResponse {
+  currentLock: DocumentWriteLock
+  lockTakenSuccessfully: boolean
+}
+
+/**
 * Generated from fi.espoo.evaka.document.childdocument.DocumentStatus
 */
 export type DocumentStatus =
@@ -265,6 +273,15 @@ export const documentTypes = [
 ] as const
 
 export type DocumentType = typeof documentTypes[number]
+
+/**
+* Generated from fi.espoo.evaka.document.childdocument.DocumentWriteLock
+*/
+export interface DocumentWriteLock {
+  modifiedBy: UUID
+  modifiedByName: string
+  opensAt: HelsinkiDateTime
+}
 
 /**
 * Generated from fi.espoo.evaka.document.ExportedDocumentTemplate
@@ -492,6 +509,14 @@ export function deserializeJsonDocumentContent(json: JsonOf<DocumentContent>): D
 }
 
 
+export function deserializeJsonDocumentLockResponse(json: JsonOf<DocumentLockResponse>): DocumentLockResponse {
+  return {
+    ...json,
+    currentLock: deserializeJsonDocumentWriteLock(json.currentLock)
+  }
+}
+
+
 export function deserializeJsonDocumentTemplate(json: JsonOf<DocumentTemplate>): DocumentTemplate {
   return {
     ...json,
@@ -512,6 +537,14 @@ export function deserializeJsonDocumentTemplateSummary(json: JsonOf<DocumentTemp
   return {
     ...json,
     validity: DateRange.parseJson(json.validity)
+  }
+}
+
+
+export function deserializeJsonDocumentWriteLock(json: JsonOf<DocumentWriteLock>): DocumentWriteLock {
+  return {
+    ...json,
+    opensAt: HelsinkiDateTime.parseIso(json.opensAt)
   }
 }
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -826,6 +826,10 @@ export const fi = {
         COMPLETED: 'Valmis'
       },
       editor: {
+        lockedError:
+          'Toinen käyttäjä muokkaa asiakirjaa. Yritä myöhemmin uudelleen.',
+        lockedErrorDetailed: (modifiedByName: string, opensAt: string) =>
+          `Käyttäjä ${modifiedByName} on muokkaamassa asiakirjaa. Asiakirjan lukitus vapautuu ${opensAt} mikäli muokkaamista ei jatketa. Yritä myöhemmin uudelleen.`,
         preview: 'Esikatsele',
         publish: 'Julkaise huoltajalle',
         publishConfirmTitle: 'Haluatko varmasti julkaista huoltajalle?',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -826,6 +826,7 @@ export const fi = {
         COMPLETED: 'Valmis'
       },
       editor: {
+        lockedErrorTitle: 'Asiakirja on tilapäisesti lukittu',
         lockedError:
           'Toinen käyttäjä muokkaa asiakirjaa. Yritä myöhemmin uudelleen.',
         lockedErrorDetailed: (modifiedByName: string, opensAt: string) =>

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerCitizenIntegrationTest.kt
@@ -109,6 +109,8 @@ class ChildDocumentControllerCitizenIntegrationTest :
                     content = documentContent,
                     publishedContent = null,
                     modifiedAt = clock.now(),
+                    contentModifiedAt = clock.now(),
+                    contentModifiedBy = employeeUser.id,
                     publishedAt = null
                 )
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerIntegrationTest.kt
@@ -572,85 +572,85 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
         assertTrue(lock.lockTakenSuccessfully)
         assertEquals(employeeUser.id, lock.currentLock.modifiedBy)
         assertEquals(
-            HelsinkiDateTime.of(LocalDate.of(2022, 1, 1), LocalTime.of(11, 15)),
+            HelsinkiDateTime.of(LocalDate.of(2022, 1, 1), LocalTime.of(11, 5)),
             lock.currentLock.opensAt
         )
 
-        // user 1 updates document and re-takes a lock at 11:05
+        // user 1 updates document and re-takes a lock at 11:02
         controller.updateDocumentContent(
             dbInstance(),
             employeeUser,
-            MockEvakaClock(2022, 1, 1, 11, 5),
+            MockEvakaClock(2022, 1, 1, 11, 2),
             documentId,
             DocumentContent(answers = listOf(AnsweredQuestion.TextAnswer("q1", "hello")))
         )
 
-        // user 1 updates document at 11:30, which extends the expired lock as no one else has taken
+        // user 1 updates document at 11:20, which extends the expired lock as no one else has taken
         // it in between
         controller.updateDocumentContent(
             dbInstance(),
             employeeUser,
-            MockEvakaClock(2022, 1, 1, 11, 30),
+            MockEvakaClock(2022, 1, 1, 11, 20),
             documentId,
             DocumentContent(answers = listOf(AnsweredQuestion.TextAnswer("q1", "hello2")))
         )
 
-        // user 2 tries to take a lock at 11:35, which is not yet possible
+        // user 2 tries to take a lock at 11:22, which is not yet possible
         lock =
             controller.takeDocumentWriteLock(
                 dbInstance(),
                 unitSupervisorUser,
-                MockEvakaClock(2022, 1, 1, 11, 35),
+                MockEvakaClock(2022, 1, 1, 11, 22),
                 documentId
             )
         assertFalse(lock.lockTakenSuccessfully)
         assertEquals(employeeUser.id, lock.currentLock.modifiedBy)
         assertEquals(
-            HelsinkiDateTime.of(LocalDate.of(2022, 1, 1), LocalTime.of(11, 45)),
+            HelsinkiDateTime.of(LocalDate.of(2022, 1, 1), LocalTime.of(11, 25)),
             lock.currentLock.opensAt
         )
 
-        // user 2 tries to update the document without owning the lock, which fails
+        // user 2 tries to update the document at 11:22 without owning the lock, which fails
         assertThrows<Conflict> {
             controller.updateDocumentContent(
                 dbInstance(),
                 unitSupervisorUser,
-                MockEvakaClock(2022, 1, 1, 11, 37),
+                MockEvakaClock(2022, 1, 1, 11, 22),
                 documentId,
                 DocumentContent(answers = listOf(AnsweredQuestion.TextAnswer("q1", "hello3")))
             )
         }
 
-        // user 2 takes a lock at 11:50
+        // user 2 takes a lock at 11:27
         lock =
             controller.takeDocumentWriteLock(
                 dbInstance(),
                 unitSupervisorUser,
-                MockEvakaClock(2022, 1, 1, 11, 50),
+                MockEvakaClock(2022, 1, 1, 11, 27),
                 documentId
             )
         assertTrue(lock.lockTakenSuccessfully)
         assertEquals(unitSupervisorUser.id, lock.currentLock.modifiedBy)
         assertEquals(
-            HelsinkiDateTime.of(LocalDate.of(2022, 1, 1), LocalTime.of(12, 5)),
+            HelsinkiDateTime.of(LocalDate.of(2022, 1, 1), LocalTime.of(11, 32)),
             lock.currentLock.opensAt
         )
 
-        // user 2 updates the document at 11:55
+        // user 2 updates the document at 11:28
         controller.updateDocumentContent(
             dbInstance(),
             unitSupervisorUser,
-            MockEvakaClock(2022, 1, 1, 11, 55),
+            MockEvakaClock(2022, 1, 1, 11, 28),
             documentId,
             DocumentContent(answers = listOf(AnsweredQuestion.TextAnswer("q1", "hello4")))
         )
 
-        // user 1 cannot update the document at 12:00
+        // user 1 cannot update the document at 11:30
         assertThrows<Conflict> {
             controller.updateDocumentContent(
                 dbInstance(),
                 employeeUser,
-                MockEvakaClock(2022, 1, 1, 12, 0),
+                MockEvakaClock(2022, 1, 1, 11, 30),
                 documentId,
                 DocumentContent(answers = listOf(AnsweredQuestion.TextAnswer("q1", "hello5")))
             )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerIntegrationTest.kt
@@ -54,8 +54,8 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
     @Autowired lateinit var controller: ChildDocumentController
 
     lateinit var areaId: AreaId
-    lateinit var employeeUser: AuthenticatedUser
-    lateinit var unitSupervisorUser: AuthenticatedUser
+    lateinit var employeeUser: AuthenticatedUser.Employee
+    lateinit var unitSupervisorUser: AuthenticatedUser.Employee
 
     final val clock = MockEvakaClock(2022, 1, 1, 15, 0)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentServiceIntegrationTest.kt
@@ -118,6 +118,8 @@ class ChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
                     content = content,
                     publishedContent = null,
                     modifiedAt = clock.now(),
+                    contentModifiedAt = clock.now(),
+                    contentModifiedBy = null,
                     publishedAt = null
                 )
             )
@@ -130,6 +132,8 @@ class ChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
                     content = content,
                     publishedContent = updatedContent,
                     modifiedAt = clock.now(),
+                    contentModifiedAt = clock.now(),
+                    contentModifiedBy = null,
                     publishedAt =
                         HelsinkiDateTime.Companion.of(
                             clock.today().minusMonths(1),
@@ -146,6 +150,8 @@ class ChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
                     content = content,
                     publishedContent = updatedContent,
                     modifiedAt = clock.now().minusMonths(1),
+                    contentModifiedAt = clock.now().minusMonths(1),
+                    contentModifiedBy = null,
                     publishedAt = clock.now().minusMonths(1)
                 )
             )
@@ -189,6 +195,8 @@ class ChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
                     content = content,
                     publishedContent = content,
                     modifiedAt = clock.now(),
+                    contentModifiedAt = clock.now(),
+                    contentModifiedBy = null,
                     publishedAt =
                         HelsinkiDateTime.Companion.of(
                             clock.today().minusMonths(1),

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -150,6 +150,7 @@ enum class Audit(
     ChildDocumentPrevStatus,
     ChildDocumentPublish,
     ChildDocumentRead,
+    ChildDocumentTryTakeLockOnContent,
     ChildDocumentUnreadCount,
     ChildDocumentUpdateContent,
     ChildFeeAlterationsCreate,

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
 
-const val lockMinutes = 15
+const val lockMinutes = 5
 
 fun Database.Transaction.insertChildDocument(
     document: ChildDocumentCreateRequest,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -1549,8 +1549,8 @@ fun Database.Transaction.insert(row: DevChildDocument): ChildDocumentId =
     createUpdate {
             sql(
                 """
-INSERT INTO child_document (id, status, child_id, template_id, content, published_content, modified_at, published_at)
-VALUES (${bind(row.id)}, ${bind(row.status)}, ${bind(row.childId)}, ${bind(row.templateId)}, ${bind(row.content)}, ${bind(row.publishedContent)}, ${bind(row.modifiedAt)}, ${bind(row.publishedAt)})
+INSERT INTO child_document (id, status, child_id, template_id, content, published_content, modified_at, content_modified_at, content_modified_by, published_at)
+VALUES (${bind(row.id)}, ${bind(row.status)}, ${bind(row.childId)}, ${bind(row.templateId)}, ${bind(row.content)}, ${bind(row.publishedContent)}, ${bind(row.modifiedAt)}, ${bind(row.contentModifiedAt)}, ${bind(row.contentModifiedBy)}, ${bind(row.publishedAt)})
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -2232,6 +2232,8 @@ data class DevChildDocument(
     @Json val content: DocumentContent,
     @Json val publishedContent: DocumentContent?,
     val modifiedAt: HelsinkiDateTime,
+    val contentModifiedAt: HelsinkiDateTime,
+    val contentModifiedBy: EmployeeId?,
     val publishedAt: HelsinkiDateTime?
 )
 

--- a/service/src/main/resources/db/migration/V394__child_document_content_modification_info.sql
+++ b/service/src/main/resources/db/migration/V394__child_document_content_modification_info.sql
@@ -1,0 +1,5 @@
+ALTER TABLE child_document ADD COLUMN content_modified_at timestamp with time zone;
+UPDATE child_document SET content_modified_at = modified_at;
+ALTER TABLE child_document ALTER COLUMN content_modified_at SET NOT NULL;
+
+ALTER TABLE child_document ADD COLUMN content_modified_by uuid REFERENCES employee(id);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -390,3 +390,4 @@ V390__add_migrated_document_types.sql
 V391__calendar_event_type.sql
 V392__add_document_key_to_child_document.sql
 V393__jamix_customer_id.sql
+V394__child_document_content_modification_info.sql


### PR DESCRIPTION
#### Summary

- Child document employee read view and edit view split to separate components/routes.
- Added `content_modified_at` and `content_modified_by` columns.
- If `content_modified_at` is within 15 min, then the employee in `content_modified_by` owns the lock. If someone else tries to update the content, an error is shown.
- When entering the edit view, a `PUT /child-documents/{documentId}/lock` request is made, which tries to acquire a lock and then returns info about the current lock holder, so that in a failure case a detailed error can be shown.