### PR TITLE
Keycloak-lokituskoodin parannuksia

### DIFF
--- a/keycloak/evaka-logging/pom.xml
+++ b/keycloak/evaka-logging/pom.xml
@@ -22,6 +22,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <junit.version>5.10.2</junit.version>
     </properties>
 
     <dependencies>
@@ -55,19 +56,17 @@ SPDX-License-Identifier: LGPL-2.1-or-later
             <version>${keycloak.version}</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>evaka-logging</finalName>
         <plugins>
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/keycloak/evaka-logging/src/main/java/com/espoo/keycloak/events/EvakaLoggingEventListenerProvider.java
+++ b/keycloak/evaka-logging/src/main/java/com/espoo/keycloak/events/EvakaLoggingEventListenerProvider.java
@@ -4,103 +4,33 @@
 
 package com.espoo.keycloak.events;
 
-import org.keycloak.events.log.JBossLoggingEventListenerProvider;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.admin.AdminEvent;
 
-import org.jboss.logging.Logger;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.events.Event;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+public class EvakaLoggingEventListenerProvider implements EventListenerProvider {
+    private final EventListenerProvider inner;
+    private final Preprocessor preprocessor;
 
-import java.util.Base64;
-import java.util.HexFormat;
-import java.util.Map;
-
-public class EvakaLoggingEventListenerProvider extends JBossLoggingEventListenerProvider {
-    private static MessageDigest digest;
-    private boolean hashUsername = false;
-    private boolean dropUsername = false;
-    private boolean hashSessionId = false;
-    private boolean dropSessionId = false;
-    private boolean hashIpAdderss = false;
-    private boolean dropIpAdderss = false;
-    private boolean hashIdentity = false;
-    private boolean dropIdentity = false;
-
-    public EvakaLoggingEventListenerProvider(KeycloakSession session, Logger logger, Logger.Level successLevel,
-            Logger.Level errorLevel, Character quotes, boolean sanitize,
-            boolean hashUsername, boolean dropUsername, boolean hashSessionId,
-            boolean dropSessionId, boolean hashIpAdderss, boolean dropIpAdderss, boolean hashIdentity,
-            boolean dropIdentity) {
-        super(session, logger, successLevel, errorLevel, quotes, sanitize);
-        this.hashUsername = hashUsername;
-        this.dropUsername = dropUsername;
-        this.hashSessionId = hashSessionId;
-        this.dropSessionId = dropSessionId;
-        this.hashIpAdderss = hashIpAdderss;
-        this.dropIpAdderss = dropIpAdderss;
-        this.hashIdentity = hashIdentity;
-        this.dropIdentity = dropIdentity;
-
-        try {
-            if (digest == null) {
-                digest = MessageDigest.getInstance("SHA-256");
-            }
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static String sha256(String source) {
-        byte[] decodedBytes = Base64.getDecoder().decode("encodedUserPassword");
-        return source != null
-                ? HexFormat.of().formatHex(digest.digest(source.getBytes(StandardCharsets.UTF_8))).toLowerCase()
-                : null;
+    public EvakaLoggingEventListenerProvider(EventListenerProvider inner, Preprocessor preprocessor) {
+        this.inner = inner;
+        this.preprocessor = preprocessor;
     }
 
     @Override
     public void onEvent(Event event) {
-        if (dropUsername) {
-            Map<String, String> details = event.getDetails();
-            if (details != null && details.containsKey("username")) {
-                details.remove("username");
-            }
-            event.setDetails(details);
-        } else if (hashUsername) {
-            Map<String, String> details = event.getDetails();
-            if (details != null && details.containsKey("username")) {
-                details.put("username", sha256(details.get("username")));
-            }
-            event.setDetails(details);
-        }
+        this.preprocessor.preprocess(event);
+        this.inner.onEvent(event);
+    }
 
-        if (dropIdentity) {
-            Map<String, String> details = event.getDetails();
-            if (details != null && details.containsKey("identity_provider_identity")) {
-                details.remove("identity_provider_identity");
-            }
-            event.setDetails(details);
-        } else if (hashIdentity) {
-            Map<String, String> details = event.getDetails();
-            if (details != null && details.containsKey("identity_provider_identity")) {
-                details.put("identity_provider_identity", sha256(details.get("identity_provider_identity")));
-            }
-            event.setDetails(details);
-        }
+    @Override
+    public void onEvent(AdminEvent event, boolean includeRepresentation) {
+        this.inner.onEvent(event, includeRepresentation);
+    }
 
-        if (dropSessionId) {
-            event.setSessionId(null);
-        } else if (hashSessionId) {
-            event.setSessionId(sha256(event.getSessionId()));
-        }
-        if (dropIpAdderss) {
-            event.setIpAddress(null);
-        } else if (hashIpAdderss) {
-            event.setIpAddress(sha256(event.getIpAddress()));
-        }
-
-        super.onEvent(event);
+    @Override
+    public void close() {
+        this.inner.close();
     }
 }

--- a/keycloak/evaka-logging/src/main/java/com/espoo/keycloak/events/EvakaLoggingEventListenerProviderFactory.java
+++ b/keycloak/evaka-logging/src/main/java/com/espoo/keycloak/events/EvakaLoggingEventListenerProviderFactory.java
@@ -4,83 +4,28 @@
 
 package com.espoo.keycloak.events;
 
-import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.events.EventListenerProvider;
-import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.events.log.JBossLoggingEventListenerProviderFactory;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.KeycloakSessionFactory;
 
-public class EvakaLoggingEventListenerProviderFactory implements EventListenerProviderFactory {
+public class EvakaLoggingEventListenerProviderFactory extends JBossLoggingEventListenerProviderFactory {
     public static final String ID = "evaka-logging";
 
-    private static final Logger logger = Logger.getLogger("org.keycloak.events");
-
-    private Logger.Level successLevel;
-    private Logger.Level errorLevel;
-    private boolean sanitize;
-    private Character quotes;
-
-    private boolean hashUsername;
-    private boolean dropUsername;
-
-    private boolean hashSessionId;
-    private boolean dropSessionId;
-
-    private boolean hashIpAdderss;
-    private boolean dropIpAdderss;
-
-    private boolean hashIdentity;
-    private boolean dropIdentity;
-
+    private Preprocessor preprocessor;
     @Override
     public EventListenerProvider create(KeycloakSession session) {
-        return new EvakaLoggingEventListenerProvider(session, logger, successLevel, errorLevel, quotes, sanitize,
-                hashUsername, dropUsername, hashSessionId, dropSessionId, hashIpAdderss, dropIpAdderss,
-                hashIdentity, dropIdentity);
-    }
-
-    private boolean getBooleanEnvironment(String variable) {
-        return System.getenv(variable) != null && System.getenv(variable).trim().equals("true");
+        return new EvakaLoggingEventListenerProvider(super.create(session), preprocessor);
     }
 
     @Override
     public void init(Config.Scope config) {
-        successLevel = Logger.Level.valueOf(config.get("success-level", "debug").toUpperCase());
-        errorLevel = Logger.Level.valueOf(config.get("error-level", "warn").toUpperCase());
-        sanitize = config.getBoolean("sanitize", true);
-        String quotesString = config.get("quotes", "\"");
-        if (!quotesString.equals("none") && quotesString.length() > 1) {
-            logger.warn("Invalid quotes configuration, it should be none or one character to use as quotes. Using default \" quotes");
-            quotesString = "\"";
-        }
-        quotes = quotesString.equals("none")? null : quotesString.charAt(0);
-
-        hashUsername = getBooleanEnvironment("LOG_HASH_USERNAME");
-        dropUsername = getBooleanEnvironment("LOG_DROP_USERNAME");
-
-        hashSessionId = getBooleanEnvironment("LOG_HASH_SESSION_ID");
-        dropSessionId = getBooleanEnvironment("LOG_DROP_SESSION_ID");
-
-        hashIpAdderss = getBooleanEnvironment("LOG_HASH_IP_ADDRESS");
-        dropIpAdderss = getBooleanEnvironment("LOG_DROP_IP_ADDRESS");
-
-        hashIdentity = getBooleanEnvironment("LOG_HASH_IDENTITY");
-        dropIdentity = getBooleanEnvironment("LOG_DROP_IDENTITY");
-    }
-
-    @Override
-    public void postInit(KeycloakSessionFactory factory) {
-
-    }
-
-    @Override
-    public void close() {
+        super.init(config);
+        preprocessor = Preprocessor.fromEnvironment(System.getenv());
     }
 
     @Override
     public String getId() {
         return ID;
     }
-
 }

--- a/keycloak/evaka-logging/src/main/java/com/espoo/keycloak/events/PreprocessMode.java
+++ b/keycloak/evaka-logging/src/main/java/com/espoo/keycloak/events/PreprocessMode.java
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package com.espoo.keycloak.events;
+
+/**
+ * Preprocessing mode for a log event property
+ */
+public enum PreprocessMode {
+    /**
+     * Keep the value if it exists
+     */
+    KEEP,
+    /**
+     * Hash the value using SHA-256
+     */
+    HASH,
+    /**
+     * Drop the value from the log event
+     */
+    DROP
+}

--- a/keycloak/evaka-logging/src/main/java/com/espoo/keycloak/events/Preprocessor.java
+++ b/keycloak/evaka-logging/src/main/java/com/espoo/keycloak/events/Preprocessor.java
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package com.espoo.keycloak.events;
+
+import org.keycloak.events.Event;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Preprocessor for log events
+ */
+public record Preprocessor(
+    PreprocessMode username,
+    PreprocessMode sessionId,
+    PreprocessMode ipAddress,
+    PreprocessMode identity
+) {
+    public void preprocess(Event event) {
+        preprocessDetails(this.username, event, "username");
+        preprocessDetails(this.identity, event, "identity_provider_identity");
+        preprocessProperty(this.sessionId, event::getSessionId, event::setSessionId);
+        preprocessProperty(this.ipAddress, event::getIpAddress, event::setIpAddress);
+    }
+    private static void preprocessProperty(PreprocessMode mode, Supplier<String> getter, Consumer<String> setter) {
+        switch (mode) {
+            case KEEP -> {}
+            case HASH -> setter.accept(sha256(getter.get()));
+            case DROP -> setter.accept(null);
+        }
+    }
+    private static void preprocessDetails(PreprocessMode mode, Event event, String key) {
+        switch (mode) {
+            case KEEP -> {}
+            case HASH -> {
+                var input = event.getDetails();
+                var value = input != null ? input.get(key) : null;
+                if (value != null) {
+                    var output = new HashMap<>(input);
+                    output.put(key, sha256(value));
+                    event.setDetails(output);
+                }
+            }
+            case DROP -> {
+                var input = event.getDetails();
+                if (input != null && input.containsKey(key)) {
+                    var output = new HashMap<>(input);
+                    output.remove(key);
+                    event.setDetails(output);
+                }
+            }
+        }
+    }
+
+    private static final HexFormat HEX_FORMAT = HexFormat.of().withLowerCase();
+
+    private static String sha256(String source) {
+        if (source == null) return null;
+        try {
+            var digest = MessageDigest.getInstance("SHA-256");
+            return HEX_FORMAT.formatHex(digest.digest(source.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    public static Preprocessor fromEnvironment(Map<String, String> env) {
+        return new Preprocessor(
+            fromEnv(env, "LOG_DROP_USERNAME", "LOG_HASH_USERNAME"),
+            fromEnv(env, "LOG_DROP_SESSION_ID", "LOG_HASH_SESSION_ID"),
+            fromEnv(env, "LOG_DROP_IP_ADDRESS", "LOG_HASH_IP_ADDRESS"),
+            fromEnv(env, "LOG_DROP_IDENTITY", "LOG_HASH_IDENTITY")
+        );
+    }
+
+    private static PreprocessMode fromEnv(Map<String, String> env, String dropVariable, String hashVariable) {
+        if (getBoolean(env, dropVariable)) return PreprocessMode.DROP;
+        else if (getBoolean(env, hashVariable)) return PreprocessMode.HASH;
+        else return PreprocessMode.KEEP;
+    }
+
+    private static boolean getBoolean(Map<String, String> env, String key) {
+        var value = env.get(key);
+        return value != null && value.trim().equals("true");
+    }
+}

--- a/keycloak/evaka-logging/src/test/java/com/espoo/keycloak/events/PreprocessorTest.java
+++ b/keycloak/evaka-logging/src/test/java/com/espoo/keycloak/events/PreprocessorTest.java
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package com.espoo.keycloak.events;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.events.Event;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class PreprocessorTest {
+    private static final String TEST_IP_ADDRESS = "0.0.0.0";
+    private static final String TEST_SESSION_ID = "session-id";
+    private static final String TEST_USERNAME = "user";
+    private static final String TEST_IDENTITY = "identity";
+
+    @Test
+    public void testPreprocessor() {
+        var env = new HashMap<String, String>();
+        // no config for username -> keep
+        env.put("LOG_HASH_SESSION_ID", "true");
+        env.put("LOG_DROP_IP_ADDRESS", "true");
+        env.put("LOG_HASH_IDENTITY", "true");
+        var preprocessor = Preprocessor.fromEnvironment(env);
+
+        var event = new Event();
+        var details = new HashMap<String, String>();
+        details.put("username", TEST_USERNAME);
+        event.setSessionId(TEST_SESSION_ID);
+        event.setIpAddress(TEST_IP_ADDRESS);
+        details.put("identity_provider_identity", TEST_IDENTITY);
+        event.setDetails(details);
+
+        preprocessor.preprocess(event);
+        assertEquals(TEST_USERNAME, event.getDetails().get("username"));
+        assertEquals("4bdf1e15df716f27ff6ebcc119aa4b8863a221cd54e87772d824888f4aeac5c0", event.getSessionId());
+        assertNull(event.getIpAddress());
+        assertEquals("689f6a627384c7dcb2dcc1487e540223e77bdf9dcd0d8be8a326eda65b0ce9a4", event.getDetails().get("identity_provider_identity"));
+    }
+}


### PR DESCRIPTION
#### Summary
<!--
Describe the change, including rationale and design decisions (not just what but also why).
Write down testing instructions if it's not completely obvious for everyone in the team.
-->

The behaviour should remain the same, but the implementation should be more robust:

- replace a large amount of booleans with simpler enums
- move most "business logic code" to a separate Preprocessor class, which is independently testable without any actual "Keycloak integration"
- use composition in the ListenerProvider so we can remove a lot of copy-paste code and just preprocess the log event before passing it forward
- use inheritance in ListenerProviderFactory so we can remove a lot of copy-paste code. We just need to wrap any ListenerProviders returned by the factory
- fix thread-safety bug: a static shared mutable MessageDigest was used for SHA-256 calculation, which is not thread-safe. If creating a new MessageDigest for every calculation ends up being a performance problem, some kind of pool could be used
- add a basic smoke test. It would be even better to test what *actually* gets logged, but doing such a test is complicated
- remove wildfly-maven-plugin. As far as I can tell, it's not needed since we're just packaging a JAR file
