### PR TITLE
Disable static resource serving from service

### DIFF
--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -35,6 +35,9 @@ spring:
     init:
       continue-on-error: false
       encoding: "UTF-8"
+  web:
+    resources:
+      add-mappings: false
 server:
   port: 8888
   tomcat:


### PR DESCRIPTION
## Before this change
It was possible to request static resources from `tomcat-docbase` directory by e.g. `GET http://localhost:9099/api/internal/foobar.txt`. All these requests failed with HTTP 404 as the docbase directory is empty causing just unnecessary filesystem IO.
## After this change
Static resource serving is disabled in Spring Boot, so it doesn't even try to lookup files from the empty docbase directory.