### PR TITLE
Näytetään viestin vastaanottajamäärä ja varoitetaan jos enemmän kuin kaksi

### DIFF
--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -191,7 +191,8 @@ export class MessageEditor extends Element {
     sensitive?: boolean
     attachmentCount?: number
     sender?: string
-    receiver?: string
+    receivers?: string[]
+    confirmManyRecipients?: boolean
   }) {
     const attachmentCount = message.attachmentCount ?? 0
 
@@ -202,10 +203,12 @@ export class MessageEditor extends Element {
       await this.senderSelection.fillAndSelectFirst(message.sender)
     }
 
-    if (message.receiver) {
+    if (message.receivers) {
       await this.receiverSelection.open()
       await this.receiverSelection.expandAll()
-      await this.receiverSelection.option(message.receiver).check()
+      for (const receiver of message.receivers) {
+        await this.receiverSelection.option(receiver).check()
+      }
       await this.receiverSelection.close()
     } else {
       await this.receiverSelection.open()
@@ -228,7 +231,11 @@ export class MessageEditor extends Element {
         )
       }
     }
+
     await this.sendButton.click()
+    if (message.confirmManyRecipients) {
+      await this.findByDataQa('modal-okBtn').click()
+    }
     await this.waitUntilHidden()
   }
 

--- a/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
@@ -231,7 +231,7 @@ describe('Sending and receiving sensitive messages', () => {
     const sensitiveMessage = {
       ...defaultMessage,
       sensitive: true,
-      receiver: enduserChildFixtureKaarina.id
+      receivers: [enduserChildFixtureKaarina.id]
     }
 
     await initStaffPage(mockedDateAt10)
@@ -263,7 +263,7 @@ describe('Staff copies', () => {
     const message = {
       title: 'Ilmoitus',
       content: 'Ilmoituksen sisältö',
-      receiver: fixtures.daycareFixture.id
+      receivers: [fixtures.daycareFixture.id]
     }
     const messageEditor = await new MessagesPage(
       unitSupervisorPage
@@ -285,7 +285,7 @@ describe('Staff copies', () => {
     const message = {
       title: 'Ilmoitus',
       content: 'Ilmoituksen sisältö',
-      receiver: fixtures.enduserChildFixtureKaarina.id
+      receivers: [fixtures.enduserChildFixtureKaarina.id]
     }
     const messageEditor = await new MessagesPage(
       unitSupervisorPage
@@ -305,7 +305,7 @@ describe('Staff copies', () => {
       title: 'Ilmoitus',
       content: 'Ilmoituksen sisältö',
       sender: `${fixtures.daycareFixture.name} - ${daycareGroupFixture.name}`,
-      receiver: daycareGroupFixture.id
+      receivers: [daycareGroupFixture.id]
     }
     const messageEditor = await new MessagesPage(
       unitSupervisorPage

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -221,7 +221,7 @@ describe('Sending and receiving messages', () => {
         const messageEditor = await messagesPage.openMessageEditor()
         await messageEditor.sendNewMessage({
           ...defaultMessage,
-          receiver: enduserChildFixtureKaarina.id
+          receivers: [enduserChildFixtureKaarina.id]
         })
         await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 

--- a/frontend/src/e2e-test/specs/7_messaging/municipal-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/municipal-messaging.spec.ts
@@ -100,19 +100,23 @@ beforeEach(async () => {
         })
         .save()
     )
+  const guardian2 = Fixture.person().with({ ssn: undefined })
+  await guardian2.save()
+  const guardian3 = Fixture.person().with({ ssn: undefined })
+  await guardian3.save()
   await insertGuardians({
     body: [
       {
         childId: childInAreaA.id,
         guardianId: fixtures.enduserGuardianFixture.id
-      }
-    ]
-  })
-  await insertGuardians({
-    body: [
+      },
       {
         childId: childInAreaB.id,
-        guardianId: fixtures.enduserGuardianFixture.id
+        guardianId: guardian2.data.id
+      },
+      {
+        childId: childInAreaB.id,
+        guardianId: guardian3.data.id
       }
     ]
   })
@@ -151,7 +155,11 @@ describe('Municipal messaging -', () => {
     await messagingPage.goto(`${config.employeeUrl}/messages`)
     const messagesPage = new MessagesPage(messagingPage)
     const messageEditor = await messagesPage.openMessageEditor()
-    await messageEditor.sendNewMessage(defaultMessage)
+    await messageEditor.sendNewMessage({
+      ...defaultMessage,
+      receivers: [fixtures.careAreaFixture.id, careArea2Fixture.id],
+      confirmManyRecipients: true
+    })
     await runPendingAsyncJobs(messageSendTime.addMinutes(1))
 
     await openCitizenPage(messageReadTime)
@@ -167,7 +175,7 @@ describe('Municipal messaging -', () => {
     const messageEditor = await messagesPage.openMessageEditor()
     await messageEditor.sendNewMessage({
       ...defaultMessage,
-      receiver: fixtures.careAreaFixture.id
+      receivers: [fixtures.careAreaFixture.id]
     })
 
     const sentMessagesPage = await messagesPage.openSentMessages()
@@ -187,7 +195,7 @@ describe('Municipal messaging -', () => {
     const messageEditor = await messagesPage.openMessageEditor()
     await messageEditor.sendNewMessage({
       ...defaultMessage,
-      receiver: fixtures.careAreaFixture.id
+      receivers: [fixtures.careAreaFixture.id]
     })
     await runPendingAsyncJobs(messageSendTime.addMinutes(1))
 

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -679,30 +679,31 @@ export default React.memo(function MessageEditor({
             />
           </FixedSpaceRow>
         </BottomBar>
+
+        {confirmLargeSend && preflightResult.isSuccess && (
+          <InfoModal
+            type="warning"
+            icon={faQuestion}
+            title={i18n.messages.messageEditor.manyRecipientsWarning.title}
+            text={i18n.messages.messageEditor.manyRecipientsWarning.text(
+              preflightResult.value.numberOfRecipientAccounts
+            )}
+            close={() => setConfirmLargeSend(false)}
+            closeLabel={i18n.common.cancel}
+            resolve={{
+              label: i18n.messages.messageEditor.send,
+              action: () => {
+                sendHandler()
+                setConfirmLargeSend(false)
+              }
+            }}
+            reject={{
+              label: i18n.common.cancel,
+              action: () => setConfirmLargeSend(false)
+            }}
+          />
+        )}
       </Container>
-      {confirmLargeSend && preflightResult.isSuccess && (
-        <InfoModal
-          type="warning"
-          icon={faQuestion}
-          title={i18n.messages.messageEditor.manyRecipientsWarning.title}
-          text={i18n.messages.messageEditor.manyRecipientsWarning.text(
-            preflightResult.value.numberOfRecipientAccounts
-          )}
-          close={() => setConfirmLargeSend(false)}
-          closeLabel={i18n.common.cancel}
-          resolve={{
-            label: i18n.messages.messageEditor.send,
-            action: () => {
-              sendHandler()
-              setConfirmLargeSend(false)
-            }
-          }}
-          reject={{
-            label: i18n.common.cancel,
-            action: () => setConfirmLargeSend(false)
-          }}
-        />
-      )}
     </FullScreenContainer>
   )
 })

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -11,6 +11,7 @@ import React, {
 } from 'react'
 import styled from 'styled-components'
 
+import MessageEditor from 'employee-frontend/components/messages/MessageEditor'
 import { Failure, Result, wrapResult } from 'lib-common/api'
 import {
   MessageReceiversResponse,
@@ -21,7 +22,6 @@ import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Container from 'lib-components/layout/Container'
-import MessageEditor from 'lib-components/messages/MessageEditor'
 import { defaultMargins } from 'lib-components/white-space'
 
 import { getAttachmentUrl, saveMessageAttachment } from '../../api/attachments'

--- a/frontend/src/employee-frontend/components/messages/queries.ts
+++ b/frontend/src/employee-frontend/components/messages/queries.ts
@@ -2,9 +2,26 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { mutation } from 'lib-common/query'
+import { mutation, query } from 'lib-common/query'
+import { Arg0 } from 'lib-common/types'
 
-import { replyToThread } from '../../generated/api-clients/messaging'
+import {
+  createMessagePreflightCheck,
+  replyToThread
+} from '../../generated/api-clients/messaging'
+import { createQueryKeys } from '../../query'
+
+export const queryKeys = createQueryKeys('messaging', {
+  preflight: (arg: Arg0<typeof createMessagePreflightCheck>) => [
+    'preflight',
+    arg
+  ]
+})
+
+export const createMessagePreflightCheckQuery = query({
+  api: createMessagePreflightCheck,
+  queryKey: queryKeys.preflight
+})
 
 export const replyToThreadMutation = mutation({
   api: replyToThread

--- a/frontend/src/employee-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/messaging.ts
@@ -15,6 +15,8 @@ import { PagedMessageCopies } from 'lib-common/generated/api-types/messaging'
 import { PagedMessageThreads } from 'lib-common/generated/api-types/messaging'
 import { PagedSentMessages } from 'lib-common/generated/api-types/messaging'
 import { PostMessageBody } from 'lib-common/generated/api-types/messaging'
+import { PostMessagePreflightBody } from 'lib-common/generated/api-types/messaging'
+import { PostMessagePreflightResponse } from 'lib-common/generated/api-types/messaging'
 import { Recipient } from 'lib-common/generated/api-types/messaging'
 import { ReplyToMessageBody } from 'lib-common/generated/api-types/messaging'
 import { ThreadReply } from 'lib-common/generated/api-types/messaging'
@@ -98,6 +100,24 @@ export async function createMessage(
     url: uri`/messages/${request.accountId}`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<PostMessageBody>
+  })
+  return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.messaging.MessageController.createMessagePreflightCheck
+*/
+export async function createMessagePreflightCheck(
+  request: {
+    accountId: UUID,
+    body: PostMessagePreflightBody
+  }
+): Promise<PostMessagePreflightResponse> {
+  const { data: json } = await client.request<JsonOf<PostMessagePreflightResponse>>({
+    url: uri`/messages/${request.accountId}/preflight-check`.toString(),
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<PostMessagePreflightBody>
   })
   return json
 }

--- a/frontend/src/employee-frontend/query.ts
+++ b/frontend/src/employee-frontend/query.ts
@@ -19,6 +19,7 @@ export type QueryKeyPrefix =
   | 'vasu'
   | 'personProfile'
   | 'calendarEvent'
+  | 'messaging'
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/messaging.ts
@@ -15,6 +15,8 @@ import { PagedMessageCopies } from 'lib-common/generated/api-types/messaging'
 import { PagedMessageThreads } from 'lib-common/generated/api-types/messaging'
 import { PagedSentMessages } from 'lib-common/generated/api-types/messaging'
 import { PostMessageBody } from 'lib-common/generated/api-types/messaging'
+import { PostMessagePreflightBody } from 'lib-common/generated/api-types/messaging'
+import { PostMessagePreflightResponse } from 'lib-common/generated/api-types/messaging'
 import { Recipient } from 'lib-common/generated/api-types/messaging'
 import { ReplyToMessageBody } from 'lib-common/generated/api-types/messaging'
 import { ThreadReply } from 'lib-common/generated/api-types/messaging'
@@ -98,6 +100,24 @@ export async function createMessage(
     url: uri`/messages/${request.accountId}`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<PostMessageBody>
+  })
+  return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.messaging.MessageController.createMessagePreflightCheck
+*/
+export async function createMessagePreflightCheck(
+  request: {
+    accountId: UUID,
+    body: PostMessagePreflightBody
+  }
+): Promise<PostMessagePreflightResponse> {
+  const { data: json } = await client.request<JsonOf<PostMessagePreflightResponse>>({
+    url: uri`/messages/${request.accountId}/preflight-check`.toString(),
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<PostMessagePreflightBody>
   })
   return json
 }

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -272,6 +272,20 @@ export interface PostMessageBody {
 }
 
 /**
+* Generated from fi.espoo.evaka.messaging.MessageController.PostMessagePreflightBody
+*/
+export interface PostMessagePreflightBody {
+  recipients: MessageRecipient[]
+}
+
+/**
+* Generated from fi.espoo.evaka.messaging.MessageController.PostMessagePreflightResponse
+*/
+export interface PostMessagePreflightResponse {
+  numberOfRecipientAccounts: number
+}
+
+/**
 * Generated from fi.espoo.evaka.messaging.Recipient
 */
 export interface Recipient {

--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -91,35 +91,6 @@ export interface Translations {
       urgent: string
     }
   }
-  messageEditor: {
-    newMessage: string
-    to: {
-      label: string
-      placeholder: string
-      noOptions: string
-    }
-    type: {
-      label: string
-      message: string
-      bulletin: string
-    }
-    flags: {
-      heading: string
-      urgent: {
-        info: string
-        label: string
-      }
-      sensitive: {
-        info: string
-        label: string
-        whyDisabled: string
-      }
-    }
-    sender: string
-    recipientsPlaceholder: string
-    title: string
-    deleteDraft: string
-  }
   messageReplyEditor: {
     messagePlaceholder: string | undefined
     discard: string

--- a/frontend/src/lib-components/utils/TestContextProvider.tsx
+++ b/frontend/src/lib-components/utils/TestContextProvider.tsx
@@ -96,35 +96,6 @@ export const testTranslations: Translations = {
       urgent: ''
     }
   },
-  messageEditor: {
-    newMessage: '',
-    to: {
-      label: '',
-      placeholder: '',
-      noOptions: ''
-    },
-    type: {
-      label: '',
-      message: '',
-      bulletin: ''
-    },
-    flags: {
-      heading: '',
-      urgent: {
-        info: '',
-        label: ''
-      },
-      sensitive: {
-        info: '',
-        label: '',
-        whyDisabled: ''
-      }
-    },
-    sender: '',
-    recipientsPlaceholder: '',
-    title: '',
-    deleteDraft: ''
-  },
   messageReplyEditor: {
     discard: '',
     messagePlaceholder: undefined,

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -112,36 +112,6 @@ const components: Translations = {
       urgent: 'Urgent'
     }
   },
-  messageEditor: {
-    // Currently only used for Finnish frontends
-    newMessage: '',
-    to: {
-      label: '',
-      placeholder: '',
-      noOptions: ''
-    },
-    type: {
-      label: '',
-      message: '',
-      bulletin: ''
-    },
-    flags: {
-      heading: '',
-      urgent: {
-        info: '',
-        label: ''
-      },
-      sensitive: {
-        info: '',
-        label: '',
-        whyDisabled: ''
-      }
-    },
-    sender: '',
-    recipientsPlaceholder: '',
-    title: '',
-    deleteDraft: ''
-  },
   messageReplyEditor: {
     // Currently only used for Finnish frontends
     discard: '',

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -110,36 +110,6 @@ const components: Translations = {
       urgent: 'Kiireellinen'
     }
   },
-  messageEditor: {
-    newMessage: 'Uusi viesti',
-    to: {
-      label: 'Vastaanottaja',
-      placeholder: 'Valitse ryhmä',
-      noOptions: 'Ei ryhmiä'
-    },
-    type: {
-      label: 'Viestin tyyppi',
-      message: 'Viesti',
-      bulletin: 'Tiedote (ei voi vastata)'
-    },
-    flags: {
-      heading: 'Viestin lisämerkinnät',
-      urgent: {
-        info: 'Lähetä viesti kiireellisenä vain, jos haluat että huoltaja lukee sen työpäivän aikana.',
-        label: 'Kiireellinen'
-      },
-      sensitive: {
-        info: 'Arkaluontoisen viestin avaaminen vaatii kuntalaiselta vahvan tunnistautumisen.',
-        label: 'Arkaluontoinen',
-        whyDisabled:
-          'Arkaluontoisen viestin voi lähettää vain henkilökohtaisesta käyttäjätilistä yksittäisen lapsen huoltajille.'
-      }
-    },
-    sender: 'Lähettäjä',
-    recipientsPlaceholder: 'Valitse...',
-    title: 'Otsikko',
-    deleteDraft: 'Hylkää luonnos'
-  },
   messageReplyEditor: {
     messagePlaceholder: undefined,
     discard: 'Hylkää',

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -112,36 +112,6 @@ const components: Translations = {
       urgent: 'Akut'
     }
   },
-  messageEditor: {
-    // Currently only used for Finnish frontends
-    newMessage: '',
-    to: {
-      label: '',
-      placeholder: '',
-      noOptions: ''
-    },
-    type: {
-      label: '',
-      message: '',
-      bulletin: ''
-    },
-    flags: {
-      heading: '',
-      urgent: {
-        info: '',
-        label: ''
-      },
-      sensitive: {
-        info: '',
-        label: '',
-        whyDisabled: ''
-      }
-    },
-    sender: '',
-    recipientsPlaceholder: '',
-    title: '',
-    deleteDraft: ''
-  },
   messageReplyEditor: {
     // Currently only used for Finnish frontends
     discard: '',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4242,7 +4242,41 @@ export const fi = {
       secondsLeft: (s: number) =>
         s === 1 ? '1 sekunti aikaa' : `${s} sekuntia aikaa`
     },
-    sensitive: 'arkaluontoinen'
+    sensitive: 'arkaluontoinen',
+    messageEditor: {
+      message: 'Viesti',
+      newMessage: 'Uusi viesti',
+      to: {
+        label: 'Vastaanottaja',
+        placeholder: 'Valitse ryhmä',
+        noOptions: 'Ei ryhmiä'
+      },
+      recipients: 'Vastaanottajat',
+      type: {
+        label: 'Viestin tyyppi',
+        message: 'Viesti',
+        bulletin: 'Tiedote (ei voi vastata)'
+      },
+      flags: {
+        heading: 'Viestin lisämerkinnät',
+        urgent: {
+          info: 'Lähetä viesti kiireellisenä vain, jos haluat että huoltaja lukee sen työpäivän aikana.',
+          label: 'Kiireellinen'
+        },
+        sensitive: {
+          info: 'Arkaluontoisen viestin avaaminen vaatii kuntalaiselta vahvan tunnistautumisen.',
+          label: 'Arkaluontoinen',
+          whyDisabled:
+            'Arkaluontoisen viestin voi lähettää vain henkilökohtaisesta käyttäjätilistä yksittäisen lapsen huoltajille.'
+        }
+      },
+      sender: 'Lähettäjä',
+      recipientsPlaceholder: 'Valitse...',
+      title: 'Otsikko',
+      deleteDraft: 'Hylkää luonnos',
+      send: 'Lähetä',
+      sending: 'Lähetetään'
+    }
   },
   pinCode: {
     title: 'eVaka-mobiilin PIN-koodi',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4252,6 +4252,12 @@ export const fi = {
         noOptions: 'Ei ryhmiä'
       },
       recipients: 'Vastaanottajat',
+      recipientCount: 'Vastaanottajia',
+      manyRecipientsWarning: {
+        title: 'Viestillä on suuri määrä vastaanottajia.',
+        text: (count: number) =>
+          `Tämä viesti on lähdössä ${count} vastaanottajalle. Oletko varma, että haluat lähettää viestin?`
+      },
       type: {
         label: 'Viestin tyyppi',
         message: 'Viesti',

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -309,6 +309,7 @@ enum class Audit(
     MessagingReceivedMessageCopiesRead,
     MessagingMessagesInFolderRead,
     MessagingSentMessagesRead,
+    MessagingNewMessagePreflightCheck,
     MessagingNewMessageWrite,
     MessagingDraftsRead,
     MessagingCreateDraft,

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -326,6 +326,38 @@ class MessageController(
             }
     }
 
+    data class PostMessagePreflightBody(val recipients: Set<MessageRecipient>)
+
+    data class PostMessagePreflightResponse(val numberOfRecipientAccounts: Int)
+
+    @PostMapping("/{accountId}/preflight-check")
+    fun createMessagePreflightCheck(
+        db: Database,
+        user: AuthenticatedUser,
+        clock: EvakaClock,
+        @PathVariable accountId: MessageAccountId,
+        @RequestBody body: PostMessagePreflightBody
+    ): PostMessagePreflightResponse {
+        return db.connect { dbc ->
+                dbc.read { tx ->
+                    requireMessageAccountAccess(dbc, user, clock, accountId)
+
+                    val numberOfRecipientAccounts = if(body.recipients.isEmpty()) {
+                        0
+                    } else {
+                        tx.getMessageAccountsForRecipients(
+                            accountId = accountId,
+                            recipients = body.recipients,
+                            date = clock.today()
+                        ).size
+                    }
+
+                    PostMessagePreflightResponse(numberOfRecipientAccounts)
+                }
+            }
+            .also { Audit.MessagingNewMessagePreflightCheck.log(targetId = accountId) }
+    }
+
     data class PostMessageBody(
         val title: String,
         val content: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -339,22 +339,22 @@ class MessageController(
         @RequestBody body: PostMessagePreflightBody
     ): PostMessagePreflightResponse {
         return db.connect { dbc ->
-                dbc.read { tx ->
-                    requireMessageAccountAccess(dbc, user, clock, accountId)
+            requireMessageAccountAccess(dbc, user, clock, accountId)
+            dbc.read { tx ->
 
-                    val numberOfRecipientAccounts = if(body.recipients.isEmpty()) {
-                        0
-                    } else {
-                        tx.getMessageAccountsForRecipients(
-                            accountId = accountId,
-                            recipients = body.recipients,
-                            date = clock.today()
-                        ).size
-                    }
-
-                    PostMessagePreflightResponse(numberOfRecipientAccounts)
+                val numberOfRecipientAccounts = if(body.recipients.isEmpty()) {
+                    0
+                } else {
+                    tx.getMessageAccountsForRecipients(
+                        accountId = accountId,
+                        recipients = body.recipients,
+                        date = clock.today()
+                    ).size
                 }
+
+                PostMessagePreflightResponse(numberOfRecipientAccounts)
             }
+        }
             .also { Audit.MessagingNewMessagePreflightCheck.log(targetId = accountId) }
     }
 


### PR DESCRIPTION
#### Summary

- refactor MessageEditor from lib-components to employee-frontend since it is not used elsewhere and does not seem to be close to reusable anyway
- fetch and display recipient count (number of guardians)
- if 3 or more recipients, display warning and require confirmation before sending
- not implemented for employee-mobile in this PR