### PR TITLE
Muutoksia työntekijöiden deaktivointiin

### DIFF
--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -73,7 +73,6 @@ export interface Translations {
   loginErrorModal: {
     header: string
     message: string
-    inactiveUserMessage: string
     returnMessage: string
   }
   messages: {

--- a/frontend/src/lib-components/molecules/modals/LoginErrorModal.tsx
+++ b/frontend/src/lib-components/molecules/modals/LoginErrorModal.tsx
@@ -26,7 +26,6 @@ export const LoginErrorModal = React.memo(function LoginErrorModal() {
   const [errorModalVisible, setErrorModalVisible] = useState<boolean>(
     queryParams.get(queryParamName) === 'true'
   )
-  const [errorCode] = useState(queryParams.get('errorCode'))
 
   function onClose(event?: React.UIEvent<unknown>) {
     setErrorModalVisible(false)
@@ -45,11 +44,7 @@ export const LoginErrorModal = React.memo(function LoginErrorModal() {
       type="danger"
       icon={faTimes}
     >
-      <P centered>
-        {errorCode === 'inactiveUser'
-          ? i18n.loginErrorModal.inactiveUserMessage
-          : i18n.loginErrorModal.message}
-      </P>
+      <P centered>{i18n.loginErrorModal.message}</P>
       <ReturnContainer>
         <P centered>
           <a href="#" onClick={onClose}>

--- a/frontend/src/lib-components/utils/TestContextProvider.tsx
+++ b/frontend/src/lib-components/utils/TestContextProvider.tsx
@@ -78,7 +78,6 @@ export const testTranslations: Translations = {
   loginErrorModal: {
     header: '',
     message: '',
-    inactiveUserMessage: '',
     returnMessage: ''
   },
   messages: {

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -93,8 +93,6 @@ const components: Translations = {
     header: 'Login failed',
     message:
       'The identification process failed or was stopped. To log in, go back and try again.',
-    inactiveUserMessage:
-      'The user has been deactivated. Please contact the system admin user.',
     returnMessage: 'Go back'
   },
   messages: {

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -92,7 +92,6 @@ const components: Translations = {
     header: 'Kirjautuminen epäonnistui',
     message:
       'Palveluun tunnistautuminen epäonnistui tai se keskeytettiin. Kirjautuaksesi sisään palaa takaisin ja yritä uudelleen.',
-    inactiveUserMessage: 'Käyttäjä on deaktivoitu. Ota yhteys pääkäyttäjään.',
     returnMessage: 'Palaa takaisin'
   },
   messages: {

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -93,8 +93,6 @@ const components: Translations = {
     header: 'Inloggningen misslyckades',
     message:
       'Autentiseringen för tjänsten misslyckades eller avbröts. För att logga in gå tillbaka och försök på nytt.',
-    inactiveUserMessage:
-      'Användaren har avaktiverats. Vänligen kontakta systemadministratören.',
     returnMessage: 'Gå tillbaka till inloggningen'
   },
   messages: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/controllers/UnitAclControllerIntegrationTest.kt
@@ -10,8 +10,8 @@ import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.attendance.getOccupancyCoefficientsByUnit
 import fi.espoo.evaka.pis.TemporaryEmployee
-import fi.espoo.evaka.pis.clearRolesForInactiveEmployees
 import fi.espoo.evaka.pis.controllers.PinCode
+import fi.espoo.evaka.pis.deactivateInactiveEmployees
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -305,7 +305,7 @@ class UnitAclControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
             .isEqualTo(createdTemporary)
         assertThrows<NotFound> { getTemporaryEmployee(clock, testDaycare2.id, temporaryEmployeeId) }
         dbInstance().connect { dbc ->
-            dbc.transaction { tx -> tx.clearRolesForInactiveEmployees(dateTime.plusMonths(1)) }
+            dbc.transaction { tx -> tx.deactivateInactiveEmployees(dateTime.plusMonths(1)) }
         }
         assertThat(getTemporaryEmployee(clock, testDaycare.id, temporaryEmployeeId))
             .isEqualTo(createdTemporary)
@@ -343,7 +343,7 @@ class UnitAclControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
         assertThat(getTemporaryEmployee(clock, testDaycare.id, temporaryEmployeeId))
             .isEqualTo(updatedTemporary)
         dbInstance().connect { dbc ->
-            dbc.transaction { tx -> tx.clearRolesForInactiveEmployees(dateTime.plusMonths(1)) }
+            dbc.transaction { tx -> tx.deactivateInactiveEmployees(dateTime.plusMonths(1)) }
         }
         assertThat(getTemporaryEmployee(clock, testDaycare.id, temporaryEmployeeId))
             .isEqualTo(updatedTemporary)

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
@@ -22,7 +22,6 @@ import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
-import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.AccessControlCitizen
@@ -125,9 +124,6 @@ class SystemController(
                         )
                     }
                     val inserted = it.loginEmployee(clock, request.toNewEmployee())
-                    if (!inserted.active) {
-                        throw Forbidden("User is not active", errorCode = "inactiveUser")
-                    }
                     val roles = it.getEmployeeRoles(inserted.id)
                     val employee =
                         EmployeeUser(

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.pis.EmployeeWithDaycareRoles
 import fi.espoo.evaka.pis.NewEmployee
 import fi.espoo.evaka.pis.PagedEmployeesWithDaycareRoles
 import fi.espoo.evaka.pis.createEmployee
+import fi.espoo.evaka.pis.deactivateEmployeeRemoveRolesAndPin
 import fi.espoo.evaka.pis.deleteEmployee
 import fi.espoo.evaka.pis.deleteEmployeeDaycareRoles
 import fi.espoo.evaka.pis.getEmployee
@@ -222,10 +223,10 @@ class EmployeeController(private val accessControl: AccessControl) {
         @PathVariable id: EmployeeId
     ) {
         db.connect { dbc ->
-            dbc.transaction {
-                accessControl.requirePermissionFor(it, user, clock, Action.Employee.DEACTIVATE, id)
+            dbc.transaction { tx ->
+                accessControl.requirePermissionFor(tx, user, clock, Action.Employee.DEACTIVATE, id)
 
-                it.updateEmployeeActive(id = id, active = false)
+                tx.deactivateEmployeeRemoveRolesAndPin(id)
             }
         }
         Audit.EmployeeDeactivate.log(targetId = id)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -22,7 +22,7 @@ import fi.espoo.evaka.invoicing.service.OutdatedIncomeNotifications
 import fi.espoo.evaka.koski.KoskiUpdateService
 import fi.espoo.evaka.note.child.daily.deleteExpiredNotes
 import fi.espoo.evaka.pis.cleanUpInactivePeople
-import fi.espoo.evaka.pis.clearRolesForInactiveEmployees
+import fi.espoo.evaka.pis.deactivateInactiveEmployees
 import fi.espoo.evaka.reports.freezeVoucherValueReportRows
 import fi.espoo.evaka.reservations.MissingHolidayReservationsReminders
 import fi.espoo.evaka.reservations.MissingReservationsReminders
@@ -339,7 +339,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
 
     fun inactiveEmployeesRoleReset(db: Database.Connection, clock: EvakaClock) {
         db.transaction {
-            val ids = it.clearRolesForInactiveEmployees(clock.now())
+            val ids = it.deactivateInactiveEmployees(clock.now())
             logger.info { "Roles cleared for ${ids.size} inactive employees: $ids" }
         }
     }


### PR DESCRIPTION
#### Summary

- Työntekijät deaktivoidaan 45 päivän inaktiivisuuden jälkeen (oli 3kk)
- Käyttäjä deaktivoidaan vaikka hänellä ei olisi rooleja/luvituksia
- Deaktivoinnissa tyhjennetään myös pin-koodi (roolien ja luvitusten poiston sekä deaktivoiduksi merkitsemisen lisäksi)
- Deaktivoitu käyttäjä voi kirjautua sisään jolloin käyttäjä aktivoituu automaattisesti ja se voidaan luvittaa uudelleen

