### PR TITLE
Korjauksia uuteen Varda-integraatioon (ei vielä käytössä)

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
@@ -183,7 +183,7 @@ data class Maksutieto(
     val perheen_koko: Int?,
     val maksun_peruste_koodi: String,
     val asiakasmaksu: BigDecimal,
-    val palveluseteli_arvo: BigDecimal?
+    val palveluseteli_arvo: BigDecimal
 ) {
     companion object {
         fun fromEvaka(guardians: List<PersonDTO>, data: VardaFeeData): Maksutieto? {
@@ -222,7 +222,7 @@ data class Maksutieto(
                 perheen_koko = data.familySize,
                 asiakasmaksu = BigDecimal(data.totalFee).divide(BigDecimal(100)),
                 palveluseteli_arvo =
-                    data.voucherValue?.let { BigDecimal(it).divide(BigDecimal(100)) },
+                    (data.voucherValue ?: 0).let { BigDecimal(it).divide(BigDecimal(100)) }
             )
         }
 
@@ -234,7 +234,7 @@ data class Maksutieto(
                 perheen_koko = data.perheen_koko,
                 maksun_peruste_koodi = data.maksun_peruste_koodi,
                 asiakasmaksu = data.asiakasmaksu,
-                palveluseteli_arvo = data.palveluseteli_arvo,
+                palveluseteli_arvo = data.palveluseteli_arvo ?: BigDecimal(0),
             )
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -194,25 +194,26 @@ class VardaUpdater(
         return EvakaHenkiloNode(
             henkilo = Henkilo.fromEvaka(person),
             lapset =
-                evakaLapsiServiceNeeds.map { (lapsi, serviceNeedsOfLapsi) ->
+                evakaLapsiServiceNeeds.mapNotNull { (lapsi, serviceNeedsOfLapsi) ->
                     EvakaLapsiNode(
-                        lapsi = lapsi,
-                        varhaiskasvatuspaatokset =
-                            serviceNeedsOfLapsi
-                                .filter { it.range.start <= today }
-                                .map { serviceNeed ->
-                                    EvakaVarhaiskasvatuspaatosNode(
-                                        varhaiskasvatuspaatos =
-                                            Varhaiskasvatuspaatos.fromEvaka(serviceNeed),
-                                        varhaiskasvatussuhteet =
-                                            listOf(Varhaiskasvatussuhde.fromEvaka(serviceNeed))
-                                    )
-                                },
-                        maksutiedot =
-                            // If lapsi.paos_organisaatio_oid is null, we'll get the fee data for
-                            // municipal daycare
-                            evakaFeeData[lapsi.paos_organisaatio_oid] ?: emptyList()
-                    )
+                            lapsi = lapsi,
+                            varhaiskasvatuspaatokset =
+                                serviceNeedsOfLapsi
+                                    .filter { it.range.start <= today }
+                                    .map { serviceNeed ->
+                                        EvakaVarhaiskasvatuspaatosNode(
+                                            varhaiskasvatuspaatos =
+                                                Varhaiskasvatuspaatos.fromEvaka(serviceNeed),
+                                            varhaiskasvatussuhteet =
+                                                listOf(Varhaiskasvatussuhde.fromEvaka(serviceNeed))
+                                        )
+                                    },
+                            maksutiedot =
+                                // If lapsi.paos_organisaatio_oid is null, we'll get the fee data
+                                // for municipal daycare
+                                evakaFeeData[lapsi.paos_organisaatio_oid] ?: emptyList()
+                        )
+                        .takeIf { it.varhaiskasvatuspaatokset.isNotEmpty() }
                 }
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -86,6 +86,9 @@ class VardaUpdateServiceNew(
         )
 
     init {
+        check(vardaEnabledRange.start >= LocalDate.of(2019, 1, 1)) {
+            "Varda enabled range must start after 2019-01-01"
+        }
         asyncJobRunner.registerHandler(::updateChildJob)
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -286,12 +286,19 @@ class VardaUpdater(
             eq = { vardaNode, evakaNode -> Lapsi.fromVarda(vardaNode.lapsi) == evakaNode.lapsi },
             onDeleted = { client.deleteLapsiDeep(it) },
             onUnchanged = { vardaLapsi, evakaLapsi ->
-                // Maksutieto must be *removed first* and *added last* to avoid validation
-                // errors
+                // - Maksutieto must be *removed first* and *added last* to avoid validation
+                //   errors.
+                // - Neither Varda nor eVaka track children's guardian history, so only the current
+                //   state of guardians is recorded to the maksutieto. Ignore guardians when
+                //   comparing maksutiedot to not trigger an update if nothing else than guardians
+                //   have changed.
                 diff(
                     old = vardaLapsi.maksutiedot,
                     new = evakaLapsi.maksutiedot,
-                    eq = { varda, evaka -> Maksutieto.fromVarda(varda) == evaka },
+                    eq = { varda, evaka ->
+                        Maksutieto.fromVarda(varda).copy(huoltajat = emptyList()) ==
+                            evaka.copy(huoltajat = emptyList())
+                    },
                     onDeleted = { client.deleteMaksutieto(it) },
                 )
                 diff(
@@ -321,7 +328,10 @@ class VardaUpdater(
                 diff(
                     old = vardaLapsi.maksutiedot,
                     new = evakaLapsi.maksutiedot,
-                    eq = { varda, evaka -> Maksutieto.fromVarda(varda) == evaka },
+                    eq = { varda, evaka ->
+                        Maksutieto.fromVarda(varda).copy(huoltajat = emptyList()) ==
+                            evaka.copy(huoltajat = emptyList())
+                    },
                     onAdded = { client.createMaksutieto(vardaLapsi.lapsi.url, it) },
                 )
             },


### PR DESCRIPTION
- Tarkistetaan, että Varda-integraation alkupäivä on vähintään 1.1.2019 (Vardan pään vaatimus)
- Ei luoda `lapsi`-tietueita, joilla ei ole yhtään `varhaiskasvatuspaatos`-tietuetta
- Asetetaan `palveluseteli_arvo`-kentän arvoksi 0 maksupäätösten tapauksessa (vastaa vanhan Varda-integraation toimintaa)
- Ei päivitetä `maksutieto`-tietueita jos vain huoltajat ovat muuttuneet, koska historiallisia huoltajuussuhteita ei tallenneta, eikä haluta lähettää sellaisen lapsen tietoja uudestaan jonka huoltajat ovat muuttuneet. 