### PR TITLE
Skripti muutoslokin muodostamiseksi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2017-2024 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+name: 'Create a release'
+on:
+  schedule:
+    - cron: '0 23 * * 0'  # Sunday at 23:00
+  workflow_dispatch:
+    inputs:
+      draft:
+        description: "Create a draft release (true/false)"
+        required: true
+      git-tag:
+        description: "Git tag for the release"
+        required: true
+      start-date:
+        description: "Include PRs starting from date, YYYY-MM-DD"
+        required: true
+      end-date:
+        description: "Include PRs up to date (inclusive), YYYY-MM-DD"
+        required: true
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ""
+        id: config
+        run: |
+          echo "start-date=${{ inputs.start-date || '$(date -v -6d ''+%Y-%V'')' }}" >> "$GITHUB_OUTPUT"
+          echo "end-date=${{ inputs.start-date || '$(date ''+%Y-%V'')' }}" >> "$GITHUB_OUTPUT"
+          echo "draft=${{ inputs.draft && 'false' }}" >> "$GITHUB_OUTPUT"
+          echo "tag=${{ inputs.git-tag || 'v$( date ''+%Y%m%d'')' }}" >> "$GITHUB_OUTPUT"
+    outputs:
+      changelog-options: ${{ steps.config.outputs.start-date }} ${{ steps.config.outputs.end-date }}
+      gh-options: ${{ steps.config.outputs.draft == 'true' && '--draft' || '' }} ${{ steps.config.outputs.tag }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - config
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          gh pr list \
+                  --base master \
+                  --state merged \
+                  --limit 100 \
+                  --json title,labels,closedAt,number,url |\
+              bin/changelog.js ${{ needs.config.changelog-options }} |\
+              gh release create --notes-file - ${{ needs.config.gh-options }}

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// Usage:
+//
+// gh pr -R espoon-voltti/evaka list \
+//     --base master \
+//     --state merged \
+//     --limit 100 \
+//     --json title,labels,closedAt,number,url \
+//     | bin/changelog.js <START-DATE> <END-DATE>
+//
+// Give the dates in YYYY-MM-DD format. The end date is inclusive.
+//
+
+function main() {
+  let inputData = ''
+
+  const { startDate, endDate } = parseArgs()
+
+  const stdin = process.stdin;
+  stdin.setEncoding('utf-8')
+  stdin.on('data', (data) => {
+      inputData += data
+  });
+
+  stdin.on('end', () => {
+      let json
+      try {
+          json = JSON.parse(inputData);
+      } catch (error) {
+          console.error("An error occurred while parsing JSON:", error.message);
+      }
+      const grouped = processPrs(json, startDate, endDate)
+      const markdown = toMarkdown(grouped, startDate, endDate)
+      console.log(markdown)
+  });
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2)
+
+  if (args.length != 2) {
+      console.log("Please provide two date arguments in YYYY-MM-DD format")
+      process.exit(1)
+  }
+
+  const startDate = new Date(args[0])
+  const endDate = new Date(args[1])
+
+  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+      console.log("Please provide two date arguments in YYYY-MM-DD format")
+      process.exit(1)
+  }
+
+  return {startDate, endDate}
+}
+
+const labels = {
+  breaking: 'Rikkovat muutokset',
+  enhancement: 'Uudet ominaisuudet ja parannukset',
+  bug: 'Bugikorjaukset',
+  unknown: 'Muut',
+  tech: 'Tekniset',
+  dependencies: 'Riippuvuuksien päivitykset',
+}
+
+function processPrs(json, startDate, endDate) {
+  const min = startDate
+  const maxExclusive = new Date(endDate + 24 * 60 * 60 * 1000)
+  const prsInRange = json.filter((pr) => min <= new Date(pr.closedAt) && new Date(pr.closedAt) < maxExclusive)
+
+  // Sort by closedAt descending
+  prsInRange.sort((a, b) => a.closedAt < b.closedAt ? 1 : -1);
+
+  const grouped = groupBy(prsInRange, (pr) => {
+    for (const label of Object.keys(labels)) {
+      if (hasLabel(pr, label)) return label
+    }
+    return 'unknown'
+  })
+
+  return grouped
+}
+
+function toMarkdown(groups, startDate, endDate) {
+  let markdown = [`# eVakan muutosloki ${formatDate(startDate)}-${formatDate(endDate)}`]
+  for (const [label, title] of Object.entries(labels)) {
+    const prs = groups[label]
+    if (!prs || !prs.length) continue
+
+    const lines = prs.map((pr) => {
+      return `- ${pr.title} [#${pr.number}](${pr.url})`
+    })
+    markdown.push('', `## ${title}`, '', ...lines)
+  }
+  return markdown.join('\n')
+}
+
+function groupBy(arr, fn) {
+  const result = {}
+  arr.forEach((item) => {
+    const key = fn(item)
+    if (result[key] === undefined) {
+      result[key] = []
+    }
+    result[key].push(item)
+  })
+  return result
+}
+
+function hasLabel(pr, labelName) {
+  for (const label of pr.labels) {
+    if (label.name === labelName) return true
+  }
+  return false
+}
+
+function formatDate(date) {
+  const day = String(date.getDate()).padStart(2, '0')
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const year = date.getFullYear()
+
+  return `${day}.${month}.${year}`
+}
+
+main()


### PR DESCRIPTION
`bin/changelog.js STARTDATE ENDDATE` lukee GitHub pull requestien tiedot stdin:stä JSON-muodossa, valikoi annettuna päivämäärävälinä mergetyt (inklusiivinen), ja koostaa niistä labelien perusteella muutoslokin Markdown-muodossa.

PR sisältää myös uuden CI-jobin, joka luo eVakasta uuden GitHub releasen joka sunnuntai klo 23:00 UTC. Releasen kuvaukseksi tulee muutosloki kuluvan viikon ajalta.

Esimerkki: Komento
```
gh pr -R espoon-voltti/evaka list \
    --base master \
    --state merged \
    --limit 100 \
    --json title,labels,closedAt,number,url \
    | bin/changelog.js 2024-04-08 2024-04-14

```
tuottaa:

---

# eVakan muutosloki 08.04.2024-14.04.2024

## Uudet ominaisuudet ja parannukset

- Näytetään viestin vastaanottajamäärä ja varoitetaan jos enemmän kuin kaksi [#4993](https://github.com/espoon-voltti/evaka/pull/4993)
- Muutoksia työntekijöiden deaktivointiin [#4996](https://github.com/espoon-voltti/evaka/pull/4996)
- List voucher values for each service need [#4967](https://github.com/espoon-voltti/evaka/pull/4967)
- Meal times per unit [#4952](https://github.com/espoon-voltti/evaka/pull/4952)

## Bugikorjaukset

- Kun tuleva sijoitus poistetaan poistetaan ainoastaan siihen osuvat varaukset [#4998](https://github.com/espoon-voltti/evaka/pull/4998)
- Näytetään yksikön kalenterissa puuttuva lomavarausindikaatio vain jos yksiköllä on varaukset päällä [#4968](https://github.com/espoon-voltti/evaka/pull/4968)
- Bugikorjaus vasumigraatioon [#5005](https://github.com/espoon-voltti/evaka/pull/5005)
- Palveluseteliraportin logiikan korjaus [#4997](https://github.com/espoon-voltti/evaka/pull/4997)
- Mobile unit confusion bug [#4946](https://github.com/espoon-voltti/evaka/pull/4946)
- Voucher value report fix [#4973](https://github.com/espoon-voltti/evaka/pull/4973)

## Tekniset

- HTTP-pyyntöjen rate limittien kasvatus ja parempi dokumentointi [#5002](https://github.com/espoon-voltti/evaka/pull/5002)
- Korjauksia uuteen Varda-integraatioon (ei vielä käytössä) [#4999](https://github.com/espoon-voltti/evaka/pull/4999)
- Don't use reverse at all [#4975](https://github.com/espoon-voltti/evaka/pull/4975)
- Fixes to the new Varda integration [#4995](https://github.com/espoon-voltti/evaka/pull/4995)
- Use correct function name [#4990](https://github.com/espoon-voltti/evaka/pull/4990)

## Riippuvuuksien päivitykset

- Yarnin päivitys versioon 4.1.1 [#4971](https://github.com/espoon-voltti/evaka/pull/4971)
- Keycloakin päivitys versioon 24.0.2 [#4974](https://github.com/espoon-voltti/evaka/pull/4974)
- Bump tar from 6.1.11 to 6.2.1 in /frontend [#5001](https://github.com/espoon-voltti/evaka/pull/5001)
- Bump tar from 6.1.11 to 6.2.1 in /apigw [#5000](https://github.com/espoon-voltti/evaka/pull/5000)
- Bump downshift from 8.5.0 to 9.0.4 in /frontend [#4994](https://github.com/espoon-voltti/evaka/pull/4994)
- Bump @types/node from 20.11.0 to 20.12.5 in /frontend [#4992](https://github.com/espoon-voltti/evaka/pull/4992)
- Bump css-loader from 6.10.0 to 7.0.0 in /frontend [#4991](https://github.com/espoon-voltti/evaka/pull/4991)
- Bump date-fns from 2.30.0 to 3.6.0 in /frontend [#4919](https://github.com/espoon-voltti/evaka/pull/4919)
- Bump the lint group in /apigw with 3 updates [#4977](https://github.com/espoon-voltti/evaka/pull/4977)
- Bump node from 20.12.0-bookworm-slim to 20.12.1-bookworm-slim in /apigw [#4989](https://github.com/espoon-voltti/evaka/pull/4989)
- Bump the playwright group in /frontend with 2 updates [#4987](https://github.com/espoon-voltti/evaka/pull/4987)
- Bump the jest group in /frontend with 5 updates [#4984](https://github.com/espoon-voltti/evaka/pull/4984)
- Bump node from 20.12.0-bookworm-slim to 20.12.1-bookworm-slim in /frontend [#4986](https://github.com/espoon-voltti/evaka/pull/4986)
- Bump jakarta.annotation:jakarta.annotation-api from 2.1.1 to 3.0.0 in /service [#4983](https://github.com/espoon-voltti/evaka/pull/4983)
- Bump bouncycastle from 1.77 to 1.78 in /service [#4981](https://github.com/espoon-voltti/evaka/pull/4981)
- Bump flyway from 10.10.0 to 10.11.0 in /service [#4980](https://github.com/espoon-voltti/evaka/pull/4980)
- Bump pino from 8.19.0 to 8.20.0 in /apigw [#4979](https://github.com/espoon-voltti/evaka/pull/4979)
- Bump dd-trace from 5.9.0 to 5.10.0 in /apigw [#4978](https://github.com/espoon-voltti/evaka/pull/4978)
- Bump the jest group in /apigw with 2 updates [#4976](https://github.com/espoon-voltti/evaka/pull/4976)