### PR TITLE
Korjauksia uuteen Varda-integraatioon (ei vielä käytössä)

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.varda.VardaUnitProviderType
-import java.math.BigDecimal
 import java.net.URI
 import java.time.LocalDate
 
@@ -182,8 +181,8 @@ data class Maksutieto(
     val paattymis_pvm: LocalDate?,
     val perheen_koko: Int?,
     val maksun_peruste_koodi: String,
-    val asiakasmaksu: BigDecimal,
-    val palveluseteli_arvo: BigDecimal
+    val asiakasmaksu: Double,
+    val palveluseteli_arvo: Double
 ) {
     companion object {
         fun fromEvaka(guardians: List<PersonDTO>, data: VardaFeeData): Maksutieto? {
@@ -220,9 +219,8 @@ data class Maksutieto(
                         }
                         .code,
                 perheen_koko = data.familySize,
-                asiakasmaksu = BigDecimal(data.totalFee).divide(BigDecimal(100)),
-                palveluseteli_arvo =
-                    (data.voucherValue ?: 0).let { BigDecimal(it).divide(BigDecimal(100)) }
+                asiakasmaksu = data.totalFee.toDouble() / 100,
+                palveluseteli_arvo = (data.voucherValue ?: 0).toDouble() / 100
             )
         }
 
@@ -234,7 +232,7 @@ data class Maksutieto(
                 perheen_koko = data.perheen_koko,
                 maksun_peruste_koodi = data.maksun_peruste_koodi,
                 asiakasmaksu = data.asiakasmaksu,
-                palveluseteli_arvo = data.palveluseteli_arvo ?: BigDecimal(0),
+                palveluseteli_arvo = data.palveluseteli_arvo ?: 0.0,
             )
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
@@ -219,7 +219,7 @@ data class Maksutieto(
                         }
                         .code,
                 perheen_koko = data.familySize,
-                asiakasmaksu = data.totalFee.toDouble() / 100,
+                asiakasmaksu = data.childFee.toDouble() / 100,
                 palveluseteli_arvo = (data.voucherValue ?: 0).toDouble() / 100
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
@@ -4,7 +4,6 @@
 
 package fi.espoo.evaka.varda.new
 
-import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.placement.PlacementType
@@ -46,7 +45,9 @@ data class Lapsi(
 ) {
     companion object {
         fun fromEvaka(data: VardaServiceNeed, omaOrganisaatioOid: String): Lapsi =
-            if (data.providerType == ProviderType.PRIVATE_SERVICE_VOUCHER) {
+            if (data.ophOrganizerOid != omaOrganisaatioOid) {
+                // Unit's organizer is not the municipal organizer, so the child is in PAOS
+                // (Palvelusetelillä järjestetty ja ostopalveluna hankittu varhaiskasvatus)
                 Lapsi(
                     vakatoimija_oid = null,
                     oma_organisaatio_oid = omaOrganisaatioOid,
@@ -54,7 +55,7 @@ data class Lapsi(
                 )
             } else {
                 Lapsi(
-                    vakatoimija_oid = data.ophOrganizerOid,
+                    vakatoimija_oid = omaOrganisaatioOid,
                     oma_organisaatio_oid = null,
                     paos_organisaatio_oid = null
                 )
@@ -76,6 +77,12 @@ data class Lapsi(
             oma_organisaatio_oid = oma_organisaatio_oid,
             paos_organisaatio_oid = paos_organisaatio_oid
         )
+
+    val effectiveOrganizerOid: String
+        get() =
+            paos_organisaatio_oid
+                ?: vakatoimija_oid
+                ?: throw IllegalStateException("No organizer OID found")
 }
 
 data class Varhaiskasvatuspaatos(

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
@@ -92,7 +92,9 @@ data class Varhaiskasvatuspaatos(
     companion object {
         fun fromEvaka(data: VardaServiceNeed): Varhaiskasvatuspaatos =
             Varhaiskasvatuspaatos(
-                hakemus_pvm = data.applicationDate,
+                // If there's no matching application, set hakemus_pvm to be 15 days before the
+                // start because it's the minimum for Varda to not deduce the application as urgent
+                hakemus_pvm = data.applicationDate ?: data.range.start.minusDays(15),
                 alkamis_pvm = data.range.start,
                 paattymis_pvm = data.range.end,
                 tuntimaara_viikossa = data.hoursPerWeek,

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
@@ -63,7 +63,9 @@ interface VardaReadClient {
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class LapsiResponse(
         override val url: URI,
-        val lahdejarjestelma: String,
+        // Based on Varda's API documentation, lahdejarjestelma is required, but the Varda response
+        // sometimes doesn't include it.
+        val lahdejarjestelma: String?,
         val vakatoimija_oid: String?,
         val oma_organisaatio_oid: String?,
         val paos_organisaatio_oid: String?,

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
@@ -316,11 +316,12 @@ class VardaClient(
                 }
             }
             is Result.Failure -> {
-                val message = "failed to request $method $url"
-                if (null !is R) {
-                    vardaError(request, result.error) { err -> "$message: $err" }
+                if (null !is R || result.error.response.statusCode != 404) {
+                    vardaError(request, result.error) { err ->
+                        "failed to request $method $url: ${err.toString().trim()}"
+                    }
                 } else {
-                    logger.warn { "$message: ${result.error}" }
+                    logger.info("successfully requested $method $url: not found")
                     null as R
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
@@ -21,7 +21,6 @@ import fi.espoo.evaka.shared.utils.responseStringWithRetries
 import fi.espoo.evaka.shared.utils.token
 import fi.espoo.evaka.varda.integration.VardaTokenProvider
 import fi.espoo.voltti.logging.loggers.error
-import java.math.BigDecimal
 import java.net.URI
 import java.time.LocalDate
 import mu.KotlinLogging
@@ -111,8 +110,8 @@ interface VardaReadClient {
         val alkamis_pvm: LocalDate,
         val paattymis_pvm: LocalDate?,
         val maksun_peruste_koodi: String,
-        val palveluseteli_arvo: BigDecimal?,
-        val asiakasmaksu: BigDecimal,
+        val palveluseteli_arvo: Double?,
+        val asiakasmaksu: Double,
         val perheen_koko: Int?,
     ) : VardaEntity
 
@@ -189,8 +188,8 @@ interface VardaWriteClient {
         val alkamis_pvm: LocalDate,
         val paattymis_pvm: LocalDate?,
         val maksun_peruste_koodi: String,
-        val palveluseteli_arvo: BigDecimal?,
-        val asiakasmaksu: BigDecimal,
+        val palveluseteli_arvo: Double?,
+        val asiakasmaksu: Double,
         val perheen_koko: Int?,
     )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
@@ -104,7 +104,7 @@ data class VardaFeeData(
     val partnerId: PersonId?,
     val placementType: PlacementType?,
     val familySize: Int,
-    val totalFee: Int,
+    val childFee: Int,
     val voucherValue: Int?,
     val voucherUnitOrganizerOid: String?
 )
@@ -119,7 +119,7 @@ SELECT
     fd.partner_id,
     fdc.placement_type,
     fd.family_size,
-    fd.total_fee,
+    fdc.final_fee AS child_fee,
     NULL AS voucher_value,
     NULL AS voucher_unit_organizer_oid
 FROM fee_decision fd
@@ -137,7 +137,7 @@ SELECT
     vvd.partner_id,
     vvd.placement_type,
     vvd.family_size,
-    vvd.final_co_payment AS total_fee,
+    vvd.final_co_payment AS child_fee,
     vvd.voucher_value,
     u.oph_organizer_oid AS voucher_unit_organizer_oid
 FROM voucher_value_decision vvd

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
@@ -92,6 +92,7 @@ WHERE
     u.upload_children_to_varda AND
     u.oph_organizer_oid IS NOT NULL AND
     u.oph_unit_oid IS NOT NULL
+ORDER BY sn.start_date
 """
             )
         }
@@ -147,6 +148,8 @@ WHERE
     daterange(vvd.valid_from, vvd.valid_to, '[]') && ${bind(range)} AND
     vvd.child_id = ${bind(childId)} AND
     placement_type IS NOT NULL
+
+ORDER BY valid_during
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
@@ -106,8 +106,8 @@ data class VardaFeeData(
     val placementType: PlacementType?,
     val familySize: Int,
     val childFee: Int,
-    val voucherValue: Int?,
-    val voucherUnitOrganizerOid: String?
+    val ophOrganizerOid: String,
+    val voucherValue: Int?
 )
 
 fun Database.Read.getVardaFeeData(childId: ChildId, range: FiniteDateRange): List<VardaFeeData> =
@@ -121,10 +121,11 @@ SELECT
     fdc.placement_type,
     fd.family_size,
     fdc.final_fee AS child_fee,
-    NULL AS voucher_value,
-    NULL AS voucher_unit_organizer_oid
+    u.oph_organizer_oid,
+    NULL AS voucher_value
 FROM fee_decision fd
 JOIN fee_decision_child fdc ON fdc.fee_decision_id = fd.id
+JOIN daycare u ON u.id = fdc.placement_unit_id
 WHERE
     fd.status = 'SENT' AND
     fd.valid_during && ${bind(range)} AND
@@ -139,8 +140,8 @@ SELECT
     vvd.placement_type,
     vvd.family_size,
     vvd.final_co_payment AS child_fee,
-    vvd.voucher_value,
-    u.oph_organizer_oid AS voucher_unit_organizer_oid
+    u.oph_organizer_oid,
+    vvd.voucher_value
 FROM voucher_value_decision vvd
 JOIN daycare u ON u.id = vvd.placement_unit_id
 WHERE

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
@@ -39,8 +39,7 @@ data class VardaServiceNeed(
     val shiftCare: Boolean,
     val providerType: ProviderType,
     val ophOrganizerOid: String,
-    val ophUnitOid: String,
-    val unitInvoicedByMunicipality: Boolean,
+    val ophUnitOid: String
 )
 
 fun Database.Read.getVardaServiceNeeds(childId: ChildId, range: DateRange): List<VardaServiceNeed> {
@@ -64,8 +63,7 @@ SELECT
     sn.shift_care = 'FULL' as shift_care,
     d.provider_type,
     d.oph_organizer_oid,
-    d.oph_unit_oid,
-    d.invoiced_by_municipality AS unit_invoiced_by_municipality
+    d.oph_unit_oid
 FROM service_need sn
 JOIN service_need_option sno on sn.option_id = sno.id
 JOIN placement p ON p.id = sn.placement_id
@@ -83,7 +81,7 @@ LEFT JOIN LATERAL (
         )
     ORDER BY a.sentdate, a.id
     LIMIT 1
-    ) application_match ON true
+) application_match ON true
 WHERE
     p.child_id = ${bind(childId)} AND
     daterange(sn.start_date, sn.end_date, '[]') && ${bind(range)} AND

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -357,10 +357,10 @@ class VardaUpdater(
 
     /** Returns true if the lapsi and associated data were deleted */
     private fun VardaWriteClient.deleteLapsiDeep(vardaLapsi: VardaLapsiNode): Boolean {
+        val maksutiedotDeleted = vardaLapsi.maksutiedot.allSucceed { deleteMaksutieto(it) }
         val varhaiskasvatuspaatoksetDeleted =
             vardaLapsi.varhaiskasvatuspaatokset.allSucceed { deleteVarhaiskasvatuspaatosDeep(it) }
-        val maksutiedotDeleted = vardaLapsi.maksutiedot.allSucceed { deleteMaksutieto(it) }
-        return if (varhaiskasvatuspaatoksetDeleted && maksutiedotDeleted) {
+        return if (maksutiedotDeleted && varhaiskasvatuspaatoksetDeleted) {
             delete(vardaLapsi.lapsi)
             true
         } else {

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -182,7 +182,7 @@ class VardaUpdater(
         val evakaFeeData =
             feeData
                 .mapNotNull { fee ->
-                    Maksutieto.fromEvaka(guardians, fee)?.let { fee.voucherUnitOrganizerOid to it }
+                    Maksutieto.fromEvaka(guardians, fee)?.let { fee.ophOrganizerOid to it }
                 }
                 .groupBy({ it.first }, { it.second })
 
@@ -203,10 +203,7 @@ class VardaUpdater(
                                                 listOf(Varhaiskasvatussuhde.fromEvaka(serviceNeed))
                                         )
                                     },
-                            maksutiedot =
-                                // If lapsi.paos_organisaatio_oid is null, we'll get the fee data
-                                // for municipal daycare
-                                evakaFeeData[lapsi.paos_organisaatio_oid] ?: emptyList()
+                            maksutiedot = evakaFeeData[lapsi.effectiveOrganizerOid] ?: emptyList()
                         )
                         .takeIf { it.varhaiskasvatuspaatokset.isNotEmpty() }
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -175,10 +175,7 @@ class VardaUpdater(
                 } else {
                     emptyList()
                 }
-                .filter { fee ->
-                    val serviceNeed = serviceNeeds.find { it.range.overlaps(fee.validDuring) }
-                    serviceNeed != null && serviceNeed.unitInvoicedByMunicipality
-                }
+                .filter { fee -> serviceNeeds.any { it.range.overlaps(fee.validDuring) } }
 
         val evakaLapsiServiceNeeds =
             serviceNeeds.groupBy { Lapsi.fromEvaka(it, omaOrganisaatioOid) }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -111,9 +111,7 @@ class VardaUpdateServiceNew(
                 evakaState.henkilo.henkilo_oid
             )
 
-        logger.info(
-            mapOf("varda" to vardaState?.toPrettyString(), "evaka" to evakaState.toPrettyString())
-        ) {
+        logger.info(mapOf("varda" to vardaState?.toString(), "evaka" to evakaState.toString())) {
             "Varda update state for ${job.childId} (see the meta.varda and meta.evaka fields)"
         }
 
@@ -461,12 +459,7 @@ class VardaUpdater(
         createMaksutieto(evakaMaksutieto.toVarda(lahdejarjestelma, lapsiUrl))
     }
 
-    data class EvakaHenkiloNode(val henkilo: Henkilo, val lapset: List<EvakaLapsiNode>) {
-        fun toPrettyString(): String =
-            "Henkilo(\n  $henkilo,\n  lapset = [\n" +
-                lapset.joinToString(",\n") { "    $it" } +
-                "  ]\n)"
-    }
+    data class EvakaHenkiloNode(val henkilo: Henkilo, val lapset: List<EvakaLapsiNode>)
 
     data class EvakaLapsiNode(
         val lapsi: Lapsi,
@@ -482,15 +475,7 @@ class VardaUpdater(
     data class VardaHenkiloNode(
         val henkilo: VardaReadClient.HenkiloResponse,
         val lapset: List<VardaLapsiNode>
-    ) {
-        fun toPrettyString(): String =
-            "HenkiloResponse(\n" +
-                "  henkilo = $henkilo,\n" +
-                "  lapset = [\n" +
-                lapset.joinToString(",\n") { "    $it" } +
-                "  ]\n" +
-                ")"
-    }
+    )
 
     data class VardaLapsiNode(
         val lapsi: VardaReadClient.LapsiResponse,


### PR DESCRIPTION
- Lokituksen parannuksia
- Ei vaadita `lahdejarjestelma`-tietoa lapsitietuiessa koska Varda ei näemmä aina palauta sitä
- Maksutietojen vertailu korjattu
- Maksutietojen summa korjattu maksupäätösten tapauksessa: käytetään lapsikohtaista maksua päätöksen yhteenlasketun maksun sijaan
- Ei päätellä mitään yksikön "laskutetaan eVakasta"-asetuksen perusteella, vaan lähetetään kaikki eVakassa luotujen asiakasmaksupäätösten tiedot
- Ei luoda Vardaan lainkaan henkiloa jolle ei tultaisi lähettämään dataa
- Yritetään löytää palveluntarvetta vastaava hakemus tarkemmin kuin aikaisemmin
- Prosessoidaan evakan data aikajärjestyksessä johdonmukaisuuden ja testattavuuden vuoksi
- Aina kun poistetaan dataa, poistetaan maksutiedot ensimmäisenä konfliktien välttämiseksi
- Lasketaan kunnallinen/PAOS -tieto järjestäjän OID:n perusteella sijoitustyypin sijaan