### PR TITLE
Korjaus sopimuspäivälaskurin näkymiseen

### DIFF
--- a/frontend/src/citizen-frontend/generated/api-clients/children.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/children.ts
@@ -27,7 +27,7 @@ export async function getChildAttendanceSummary(
   }
 ): Promise<AttendanceSummary> {
   const { data: json } = await client.request<JsonOf<AttendanceSummary>>({
-    url: uri`/citizen/children/${request.childId}/attendance-summary/${request.yearMonth.formatExotic('YYYY-MM')}`.toString(),
+    url: uri`/citizen/children/${request.childId}/attendance-summary/${request.yearMonth.formatExotic('yyyy-MM')}`.toString(),
     method: 'GET'
   })
   return json

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -255,10 +255,10 @@ val defaultMetadata =
                 "LocalDate",
                 keyRepresentation = null,
                 deserializeJson = { error("YearMonth in JSON is not supported") },
-                serializePathVariable = { value -> value + ".formatExotic('YYYY-MM')" },
+                serializePathVariable = { value -> value + ".formatExotic('yyyy-MM')" },
                 serializeRequestParam = { value, nullable ->
                     value +
-                        if (nullable) "?.formatExotic('YYYY-MM')" else ".formatExotic('YYYY-MM')"
+                        if (nullable) "?.formatExotic('yyyy-MM')" else ".formatExotic('yyyy-MM')"
                 },
                 Imports.localDate
             )


### PR DESCRIPTION
#### Summary

Use `yyyy` instead of `YYYY` (in `YYYY-MM`) for formatting years to the input `Mon Apr 01 2024 00:00:00 GMT+0300 (Eastern European Summer Time)`; see:
https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md