### PR TITLE
Ei pushata imageja ajastettujen CI-ajojen päätteeksi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
+      - master
   schedule:
     # Build every Monday at 01:00. With the cache-bust mechanism, this
     # effectively updates all operating system packages.
@@ -37,14 +37,18 @@ permissions:
   actions: read
 
 jobs:
-  cache-bust:
+  global-vars:
     runs-on: ubuntu-latest
     steps:
       - name: "Cache bust"
         id: cache-bust
         run: echo "cache-bust=$(date '+%Y-%V')" >> "$GITHUB_OUTPUT"
+      - name: "Determine whether to push images"
+        id: push
+        run: echo "push=${{ inputs.push || (github.event_name == 'schedule' && 'false') || 'true' }}" >> "$GITHUB_OUTPUT"
     outputs:
       cache-bust: ${{ steps.cache-bust.outputs.cache-bust }}
+      push: ${{ steps.push.outputs.push }}
 
   lint-shell:
     runs-on: ubuntu-latest
@@ -62,7 +66,7 @@ jobs:
   keycloak:
     runs-on: ubuntu-latest
     needs:
-      - cache-bust
+      - global-vars
     steps:
       - uses: actions/checkout@v4
 
@@ -85,9 +89,9 @@ jobs:
           registry: ${{ steps.setup.outputs.ecr_registry }}
           name: evaka/keycloak
           path: ./keycloak
-          push: ${{ inputs.push || 'true' }}
+          push: ${{ needs.global-vars.outputs.push }}
           build-args: |
-            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
+            CACHE_BUST=${{ needs.global-vars.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -101,7 +105,7 @@ jobs:
   frontend-common:
     runs-on: ubuntu-latest
     needs:
-      - cache-bust
+      - global-vars
     steps:
       - uses: actions/checkout@v4
 
@@ -123,9 +127,9 @@ jobs:
           registry: ghcr.io/espoon-voltti
           name: evaka/frontend-common
           path: ./frontend
-          push: ${{ inputs.push || 'true' }}
+          push: ${{ needs.global-vars.outputs.push }}
           build-args: |
-            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
+            CACHE_BUST=${{ needs.global-vars.outputs.cache-bust }}
             SENTRY_PUBLISH_ENABLED=false
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
@@ -143,9 +147,9 @@ jobs:
           cache_from: ${{ steps.build.outputs.image_cache }}
           path: ./frontend
           target: builder
-          push: ${{ inputs.push || 'true' }}
+          push: ${{ needs.global-vars.outputs.push }}
           build-args: |
-            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
+            CACHE_BUST=${{ needs.global-vars.outputs.cache-bust }}
             SENTRY_PUBLISH_ENABLED=false
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
@@ -166,7 +170,7 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     needs:
-      - cache-bust
+      - global-vars
     steps:
       - uses: actions/checkout@v4
 
@@ -212,9 +216,9 @@ jobs:
           registry: ${{ steps.setup.outputs.ecr_registry }}
           name: evaka/frontend
           path: ./frontend
-          push: ${{ inputs.push || 'true' }}
+          push: ${{ needs.global-vars.outputs.push }}
           build-args: |
-            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
+            CACHE_BUST=${{ needs.global-vars.outputs.cache-bust }}
             SENTRY_PUBLISH_ENABLED=${{ github.ref_name == 'master' && 'true' || 'false' }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
@@ -273,7 +277,7 @@ jobs:
   api-gateway:
     runs-on: ubuntu-latest
     needs:
-      - cache-bust
+      - global-vars
     steps:
       - uses: actions/checkout@v4
 
@@ -300,7 +304,7 @@ jobs:
           load: true
           target: test
           build-args: |
-            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
+            CACHE_BUST=${{ needs.global-vars.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -312,9 +316,9 @@ jobs:
           registry: ${{ steps.setup.outputs.ecr_registry }}
           name: evaka/api-gateway
           path: ./apigw
-          push: ${{ inputs.push || 'true' }}
+          push: ${{ needs.global-vars.outputs.push }}
           build-args: |
-            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
+            CACHE_BUST=${{ needs.global-vars.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -331,7 +335,7 @@ jobs:
   service:
     runs-on: ubuntu-latest
     needs:
-      - cache-bust
+      - global-vars
     steps:
       - uses: actions/checkout@v4
 
@@ -355,9 +359,9 @@ jobs:
           name: evaka/service
           path: .
           dockerfile: service/Dockerfile
-          push: ${{ inputs.push || 'true' }}
+          push: ${{ needs.global-vars.outputs.push }}
           build-args: |
-            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
+            CACHE_BUST=${{ needs.global-vars.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -372,9 +376,9 @@ jobs:
           cache_from: ${{ steps.build.outputs.image_cache }}
           path: .
           dockerfile: service/Dockerfile
-          push: ${{ inputs.push || 'true' }}
+          push: ${{ needs.global-vars.outputs.push }}
           build-args: |
-            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
+            CACHE_BUST=${{ needs.global-vars.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -390,7 +394,7 @@ jobs:
 
   service-test:
     needs:
-      - cache-bust
+      - global-vars
       - service
     runs-on: ubuntu-latest
     steps:
@@ -419,7 +423,7 @@ jobs:
           push: false
           load: true
           build-args: |
-            CACHE_BUST=${{ needs.cache-bust.outputs.cache-bust }}
+            CACHE_BUST=${{ needs.global-vars.outputs.cache-bust }}
             build=${{ github.run_number }}
             commit=${{ github.event.pull_request.head.sha || github.sha }}
             BASE_IMAGE=${{ needs.service.outputs.builder_image }}


### PR DESCRIPTION
Sunnuntai-iltaisin ajetun ajastetun buildin imaget saivat samat tagit kuin aiemmin buildatut "varsinaiset" imaget, koska tagina käytetään commit id:tä. Tämä vaikeutti tuotantoonvientiä maanantaisin, koska ajossa olevaa imagea ei enää löytynyt.