### PR TITLE
Poistetaan sunnuntain ajastettu build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
-  schedule:
-    # Build every Monday at 01:00. With the cache-bust mechanism, this
-    # effectively updates all operating system packages.
-    - cron: "0 1 * * 1"
+      - master
   workflow_dispatch:
     inputs:
       push:


### PR DESCRIPTION
Sunnuntai-iltaisin ajetun ajastetun buildin imaget saavat samat tagit kuin aiemmin buildatut "varsinaiset" imaget, koska tagina käytetään commit id:tä. Tämä vaikeuttaa tuotantoonvientiä maanantaisin, koska ajossa olevaa imagea ei enää löydy. Siispä ei enää buildata automaattisesti sunnuntaisin.

Imaget päivittyvät silti maanantain ensimmäisissä buildeissa, koska cache bust -mekanismi pakottaa dockerin tekemään uuden buildin alusta asti.