### PR TITLE
Testi lisätty että uuden asiakkaan tulotietomuistutus näkyy profiilisivulla

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/income.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/income.spec.ts
@@ -274,14 +274,26 @@ describe('Income', () => {
       })
       .save()
 
+    await Fixture.incomeNotification()
+      .with({
+        receiverId: personId,
+        notificationType: 'NEW_CUSTOMER',
+        created: incomeEndDate.subDays(1).toHelsinkiDateTime(LocalTime.of(6, 0))
+      })
+      .save()
+
     await page.reload()
-    await waitUntilEqual(() => incomesSection.incomeNotificationRows.count(), 2)
+    await waitUntilEqual(() => incomesSection.incomeNotificationRows.count(), 3)
     await incomesSection.incomeNotificationRows
       .nth(0)
       .assertTextEquals('15.02.2020 06:00')
     await incomesSection.incomeNotificationRows
       .nth(1)
       .assertTextEquals('22.02.2020 06:00')
+
+    await incomesSection.incomeNotificationRows
+      .nth(2)
+      .assertTextEquals('28.02.2020 06:00')
   })
 
   it('Income notification sent title is not shown if none has been sent', async () => {


### PR DESCRIPTION
<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
