### PR TITLE
Korjauksia Varda-integraatioon

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceIntegrationTest.kt
@@ -174,19 +174,6 @@ class VardaUpdateServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         assertEquals(allChildIds - plannedChildIds, remainingChildren)
     }
 
-    private fun addChildToVardaState(
-        childId: ChildId,
-        state: VardaUpdater.EvakaHenkiloNode? = null
-    ) {
-        db.transaction { tx ->
-            tx.execute {
-                sql(
-                    "INSERT INTO varda_state (child_id, state) VALUES (${bind(childId)}, ${bindJson(state)})"
-                )
-            }
-        }
-    }
-
     private fun getVardaStateChildIds(): Set<ChildId> =
         db.read { tx -> tx.getVardaUpdateChildIds() }.toSet()
 

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -185,6 +185,11 @@ class VardaUpdater(
         logger.info { "Starting Varda update for child $childId" }
 
         val evakaState = dbc.read { tx -> getEvakaState(tx, today, childId) }
+        if (evakaState == null) {
+            logger.info { "Cannot compute Varda state for $childId" }
+            return
+        }
+
         val vardaState =
             getVardaState(
                 readClient,
@@ -193,7 +198,7 @@ class VardaUpdater(
             )
 
         logger.info(mapOf("varda" to vardaState?.toString(), "evaka" to evakaState.toString())) {
-            "Varda update state for $childId (see the meta.varda and meta.evaka fields)"
+            "Varda state for $childId (see the meta.varda and meta.evaka fields)"
         }
 
         val henkiloOidInVarda = diffAndUpdate(writeClient, vardaState, evakaState)
@@ -208,10 +213,8 @@ class VardaUpdater(
         }
     }
 
-    fun getEvakaState(tx: Database.Read, today: LocalDate, childId: ChildId): EvakaHenkiloNode {
-        val (_, evakaState, _) = getEvakaStates(tx, today, listOf(childId)).first()
-        return evakaState
-    }
+    fun getEvakaState(tx: Database.Read, today: LocalDate, childId: ChildId): EvakaHenkiloNode? =
+        getEvakaStates(tx, today, listOf(childId)).firstOrNull()?.second
 
     fun getEvakaStates(
         tx: Database.Read,
@@ -223,20 +226,22 @@ class VardaUpdater(
         val serviceNeeds = tx.getVardaServiceNeeds(childIds, vardaEnabledRange)
         val feeData = tx.getVardaFeeData(childIds, vardaEnabledRange)
         val updateStates = tx.getVardaUpdateState<EvakaHenkiloNode>(childIds)
-        return childIds.map {
-            val evakaState =
-                computeEvakaState(
+        return children.entries.mapNotNull { (childId, child) ->
+            computeEvakaState(
                     today,
-                    children[it] ?: error("Child $it not found"),
-                    guardians[it] ?: emptyList(),
-                    serviceNeeds[it] ?: emptyList(),
-                    feeData[it] ?: emptyList(),
+                    child,
+                    guardians[childId] ?: emptyList(),
+                    serviceNeeds[childId] ?: emptyList(),
+                    feeData[childId] ?: emptyList(),
                 )
-            Triple(
-                it,
-                evakaState,
-                if (evakaState == updateStates[it]) Status.UP_TO_DATE else Status.NEEDS_UPDATE
-            )
+                ?.let { evakaState ->
+                    Triple(
+                        childId,
+                        evakaState,
+                        if (evakaState == updateStates[childId]) Status.UP_TO_DATE
+                        else Status.NEEDS_UPDATE
+                    )
+                }
         }
     }
 
@@ -246,9 +251,10 @@ class VardaUpdater(
         guardians: List<VardaGuardian>,
         serviceNeeds: List<VardaServiceNeed>,
         feeData: List<VardaFeeData>
-    ): EvakaHenkiloNode {
+    ): EvakaHenkiloNode? {
         if (child.ophPersonOid == null && child.socialSecurityNumber == null) {
-            throw IllegalStateException("Child ${child.id} has no ophOid or ssn")
+            // Child has no identifiers, so we can't send data to Varda
+            return null
         }
 
         // Only fee data after 2019-09-01 can be sent to Varda (error code MA019)

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -107,7 +107,9 @@ class VardaUpdateServiceNew(
 
         val childIds =
             dbc.transaction { tx ->
-                tx.addNewChildrenForVardaUpdate(migrationSpeed)
+                val count = tx.addNewChildrenForVardaUpdate(migrationSpeed)
+                logger.info { "Added $count new children for Varda update" }
+
                 tx.getVardaUpdateChildIds()
             }
 


### PR DESCRIPTION
- Varda-ajo ei enää kaadu jos `varda_state`-taulussa on lapsi jolta puuttuu sekä henkilötunnus että OPH OID.
- Lokitusta parannettu