### PR TITLE
Korjauksia Varda-integraatioon

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/Varda.kt
@@ -76,11 +76,10 @@ data class Lapsi(
             paos_organisaatio_oid = paos_organisaatio_oid
         )
 
-    val effectiveOrganizerOid: String
-        get() =
-            paos_organisaatio_oid
-                ?: vakatoimija_oid
-                ?: throw IllegalStateException("No organizer OID found")
+    fun effectiveOrganizerOid(): String =
+        paos_organisaatio_oid
+            ?: vakatoimija_oid
+            ?: throw IllegalStateException("No organizer OID found")
 }
 
 data class Varhaiskasvatuspaatos(

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
@@ -404,7 +404,7 @@ class VardaClient(
     ): Nothing {
         val meta = parseVardaError(request, error)
         logger.error(request, meta.asMap()) {
-            "request failed to ${meta.url}, status ${meta.statusCode}, reason ${meta.errorCode}: ${meta.errorDescription}"
+            "request failed ${meta.method} ${meta.url}, status ${meta.statusCode}, reason ${meta.errorCode}: ${meta.errorDescription}"
         }
         error(message(meta))
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -316,7 +316,7 @@ class VardaUpdater(
                                                 listOf(Varhaiskasvatussuhde.fromEvaka(serviceNeed))
                                         )
                                     },
-                            maksutiedot = evakaFeeData[lapsi.effectiveOrganizerOid] ?: emptyList()
+                            maksutiedot = evakaFeeData[lapsi.effectiveOrganizerOid()] ?: emptyList()
                         )
                         .takeIf { it.varhaiskasvatuspaatokset.isNotEmpty() }
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -254,7 +254,7 @@ class VardaUpdater(
         serviceNeeds: List<VardaServiceNeed>,
         feeData: List<VardaFeeData>
     ): EvakaHenkiloNode? {
-        if (child.ophPersonOid == null && child.socialSecurityNumber == null) {
+        if (child.ophPersonOid.isNullOrBlank() && child.socialSecurityNumber == null) {
             // Child has no identifiers, so we can't send data to Varda
             return null
         }
@@ -330,7 +330,7 @@ class VardaUpdater(
     ): VardaHenkiloNode? {
         return client
             .haeHenkilo(
-                if (ophPersonOid != null) {
+                if (!ophPersonOid.isNullOrBlank()) {
                     VardaReadClient.HaeHenkiloRequest(
                         henkilotunnus = null,
                         henkilo_oid = ophPersonOid


### PR DESCRIPTION
- JSON-deserialisointibugi aiheutti sen, että Varda-päivitys ajettiin liian monelle lapselle.
- Skipataan lapset joiden OPH OID on tyhjä merkkijono
- Virhelokitusta parannettu