### PR TITLE
Raakaraportti katsoo tuen tasoa vakassa ja tukitoimia nyt oikein

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -118,10 +118,10 @@ SELECT
 
     (
         an IS NOT NULL
-        OR EXISTS(SELECT FROM assistance_action WHERE child_id = pl.child_id AND valid_during @> t::date)
-        OR EXISTS(SELECT FROM assistance_need WHERE child_id = pl.child_id AND valid_during @> t::date)
-        OR EXISTS(SELECT FROM preschool_assistance WHERE child_id = pl.child_id AND valid_during @> t::date)
-        OR EXISTS(SELECT FROM other_assistance_measure WHERE child_id = pl.child_id AND valid_during @> t::date)
+        OR EXISTS(SELECT FROM assistance_action aa WHERE aa.child_id = pl.child_id AND t::date BETWEEN aa.start_date AND aa.end_date)
+        OR EXISTS(SELECT FROM daycare_assistance da WHERE da.child_id = pl.child_id AND da.valid_during @> t::date)
+        OR EXISTS(SELECT FROM preschool_assistance pa WHERE pa.child_id = pl.child_id AND pa.valid_during @> t::date)
+        OR EXISTS(SELECT FROM other_assistance_measure oam WHERE oam.child_id = pl.child_id AND oam.valid_during @> t::date)
     ) AS has_assistance_need,
 
     coalesce(an.capacity_factor, 1.0) as capacity_factor,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -121,7 +121,6 @@ SELECT
         OR EXISTS(SELECT FROM assistance_action aa WHERE aa.child_id = pl.child_id AND t::date BETWEEN aa.start_date AND aa.end_date)
         OR EXISTS(SELECT FROM daycare_assistance da WHERE da.child_id = pl.child_id AND da.valid_during @> t::date)
         OR EXISTS(SELECT FROM preschool_assistance pa WHERE pa.child_id = pl.child_id AND pa.valid_during @> t::date)
-        OR EXISTS(SELECT FROM other_assistance_measure oam WHERE oam.child_id = pl.child_id AND oam.valid_during @> t::date)
     ) AS has_assistance_need,
 
     coalesce(an.capacity_factor, 1.0) as capacity_factor,


### PR DESCRIPTION
<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->

assistance_need = vanha tuen malli, jota ei kuulu käyttää mihinkään ja pitäisi oikeasti jo poistaa
daycare_assistance = yksi uuden tuen mallin tauluista

assistance_action -taulussa on start_date/end_date eikä valid_during, ja oikeasti katsottiinkin virheellisesti eri taulua

"Muut toimet" -osiota (other_assistance_measure) ei kuulu katsoa mutta katsottiin