### PR TITLE
Yksikön viikkonäkymän läsnäolokalenterin UI korjaus

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -1007,7 +1007,7 @@ const AttendanceCell = styled.div`
 
 const AttendanceTime = styled.span`
   font-weight: ${fontWeights.semibold};
-  flex: 1 0 54px;
+  flex: 1 0 30px;
   text-align: center;
   white-space: nowrap;
 `


### PR DESCRIPTION
Läsnäolovaraustaulukko skaalautuu nyt järkevästi pieniresoluutioisella näytöllä.
<img width="754" alt="Screenshot 2024-05-06 at 12 03 14" src="https://github.com/espoon-voltti/evaka/assets/158767/1392b0c6-62d4-4a38-9a2e-e8a367cce24d">

ja sama normaalinäytöllä

<img width="1410" alt="Screenshot 2024-05-06 at 12 03 22" src="https://github.com/espoon-voltti/evaka/assets/158767/3df9edc4-c2ca-4653-b436-1012feafb9ce">
