### PR TITLE
Jamix-integraatio

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1230,7 +1230,8 @@ export const daycareGroupFixture: DevDaycareGroup = {
   daycareId: daycareFixture.id,
   name: 'Kosmiset vakiot',
   startDate: LocalDate.of(2000, 1, 1),
-  endDate: null
+  endDate: null,
+  jamixCustomerId: null
 }
 
 export function createDaycarePlacementFixture(
@@ -1321,7 +1322,8 @@ export class Fixture {
       daycareId: '',
       name: `daycareGroup_${id}`,
       startDate: LocalDate.of(2020, 1, 1),
-      endDate: null
+      endDate: null,
+      jamixCustomerId: null
     })
   }
 

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -337,6 +337,7 @@ export interface DevChild {
   additionalInfo: string
   allergies: string
   diet: string
+  dietId: number | null
   id: UUID
   languageAtHome: string
   languageAtHomeDetails: string
@@ -443,6 +444,11 @@ export interface DevDaycare {
   language: Language
   location: Coordinate | null
   mailingAddress: MailingAddress
+  mealtimeBreakfast: TimeRange | null
+  mealtimeEveningSnack: TimeRange | null
+  mealtimeLunch: TimeRange | null
+  mealtimeSnack: TimeRange | null
+  mealtimeSupper: TimeRange | null
   name: string
   openingDate: LocalDate | null
   operationTimes: (TimeRange | null)[]
@@ -481,6 +487,7 @@ export interface DevDaycareGroup {
   daycareId: UUID
   endDate: LocalDate | null
   id: UUID
+  jamixCustomerId: number | null
   name: string
   startDate: LocalDate
 }
@@ -1233,6 +1240,11 @@ export function deserializeJsonDevDaycare(json: JsonOf<DevDaycare>): DevDaycare 
     dailyPreparatoryTime: (json.dailyPreparatoryTime != null) ? TimeRange.parseJson(json.dailyPreparatoryTime) : null,
     dailyPreschoolTime: (json.dailyPreschoolTime != null) ? TimeRange.parseJson(json.dailyPreschoolTime) : null,
     daycareApplyPeriod: (json.daycareApplyPeriod != null) ? DateRange.parseJson(json.daycareApplyPeriod) : null,
+    mealtimeBreakfast: (json.mealtimeBreakfast != null) ? TimeRange.parseJson(json.mealtimeBreakfast) : null,
+    mealtimeEveningSnack: (json.mealtimeEveningSnack != null) ? TimeRange.parseJson(json.mealtimeEveningSnack) : null,
+    mealtimeLunch: (json.mealtimeLunch != null) ? TimeRange.parseJson(json.mealtimeLunch) : null,
+    mealtimeSnack: (json.mealtimeSnack != null) ? TimeRange.parseJson(json.mealtimeSnack) : null,
+    mealtimeSupper: (json.mealtimeSupper != null) ? TimeRange.parseJson(json.mealtimeSupper) : null,
     openingDate: (json.openingDate != null) ? LocalDate.parseIso(json.openingDate) : null,
     operationTimes: json.operationTimes.map(e => (e != null) ? TimeRange.parseJson(e) : null),
     preschoolApplyPeriod: (json.preschoolApplyPeriod != null) ? DateRange.parseJson(json.preschoolApplyPeriod) : null

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -105,7 +105,8 @@ beforeEach(async () => {
         daycareId: backupDaycareId,
         name: 'Varayksikön ryhmä',
         startDate: LocalDate.of(2000, 1, 1),
-        endDate: null
+        endDate: null,
+        jamixCustomerId: null
       }
     ]
   })

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/jamix/JamixIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/jamix/JamixIntegrationTest.kt
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.jamix
+
+import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.absence.AbsenceCategory
+import fi.espoo.evaka.mealintegration.DefaultMealTypeMapper
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.dev.DevAbsence
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevChild
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevDaycareGroup
+import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPersonType
+import fi.espoo.evaka.shared.dev.DevReservation
+import fi.espoo.evaka.shared.dev.insert
+import fi.espoo.evaka.shared.dev.insertTestDaycareGroupPlacement
+import fi.espoo.evaka.shared.dev.insertTestPlacement
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.shared.domain.TimeRange
+import fi.espoo.evaka.specialdiet.SpecialDiet
+import fi.espoo.evaka.specialdiet.setSpecialDiets
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class JamixIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
+    @Autowired private lateinit var jamixService: JamixService
+
+    @Test
+    fun `meal order jobs for the next week are planned`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(
+                areaId = area.id,
+                mealtimeBreakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                mealtimeLunch = TimeRange(LocalTime.of(11, 15), LocalTime.of(11, 45)),
+                mealtimeSnack = TimeRange(LocalTime.of(13, 30), LocalTime.of(13, 50)),
+            )
+        val group1 = DevDaycareGroup(daycareId = daycare.id, jamixCustomerId = 88)
+        val group2 = DevDaycareGroup(daycareId = daycare.id, jamixCustomerId = 99)
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(group1)
+            tx.insert(group2)
+        }
+
+        // Tuesday
+        val now = HelsinkiDateTime.of(LocalDate.of(2024, 4, 2), LocalTime.of(2, 25))
+
+        jamixService.planOrders(db, MockEvakaClock(now))
+
+        val jobs =
+            db.read { tx ->
+                tx.createQuery {
+                        sql("SELECT payload FROM async_job WHERE type = 'SendJamixOrder'")
+                    }
+                    .map { jsonColumn<AsyncJob.SendJamixOrder>("payload") }
+                    .toList()
+            }
+
+        val mondayNextWeek = LocalDate.of(2024, 4, 8)
+        val sundayNextWeek = LocalDate.of(2024, 4, 14)
+        val dates = FiniteDateRange(mondayNextWeek, sundayNextWeek).dates().toList()
+        val customerIds = listOf(88, 99)
+        assertEquals(
+            dates.flatMap { date ->
+                customerIds.map { customerId -> AsyncJob.SendJamixOrder(customerId, date) }
+            },
+            jobs.sortedWith(compareBy({ it.date }, { it.customerId }))
+        )
+    }
+
+    @Test
+    fun `orders are sent correctly`() {
+        val monday = LocalDate.of(2024, 4, 8)
+        val tuesday = LocalDate.of(2024, 4, 9)
+        val wednesday = LocalDate.of(2024, 4, 10)
+
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(
+                areaId = area.id,
+                mealtimeBreakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                mealtimeLunch = TimeRange(LocalTime.of(11, 15), LocalTime.of(11, 45)),
+                mealtimeSnack = TimeRange(LocalTime.of(13, 30), LocalTime.of(13, 50)),
+            )
+        val group1 = DevDaycareGroup(daycareId = daycare.id, jamixCustomerId = 88)
+        val group2 = DevDaycareGroup(daycareId = daycare.id, jamixCustomerId = 99)
+        val employee = DevEmployee()
+
+        val child = DevPerson()
+        val childWithSpecialDiet = DevPerson(firstName = "Diet", lastName = "Johnson")
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(group1)
+            tx.insert(group2)
+            tx.insert(employee)
+
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertTestPlacement(
+                    unitId = daycare.id,
+                    childId = child.id,
+                    startDate = monday,
+                    endDate = tuesday,
+                )
+                .also { placementId ->
+                    tx.insertTestDaycareGroupPlacement(
+                        daycarePlacementId = placementId,
+                        groupId = group1.id,
+                        startDate = monday,
+                        endDate = tuesday
+                    )
+                }
+            listOf(
+                    // All three meals on Monday
+                    DevReservation(
+                        childId = child.id,
+                        date = monday,
+                        startTime = LocalTime.of(8, 0),
+                        endTime = LocalTime.of(16, 0),
+                        createdBy = employee.evakaUserId
+                    ),
+                    // Breakfast only on Tuesday
+                    DevReservation(
+                        childId = child.id,
+                        date = tuesday,
+                        startTime = LocalTime.of(8, 0),
+                        endTime = LocalTime.of(9, 0),
+                        createdBy = employee.evakaUserId
+                    )
+                )
+                .forEach { tx.insert(it) }
+
+            tx.setSpecialDiets(listOf(SpecialDiet(1, "diet name", "diet abbreviation")))
+
+            tx.insert(childWithSpecialDiet, DevPersonType.RAW_ROW)
+            tx.insert(DevChild(id = childWithSpecialDiet.id, dietId = 1))
+            tx.insertTestPlacement(
+                    unitId = daycare.id,
+                    childId = childWithSpecialDiet.id,
+                    startDate = monday,
+                    endDate = tuesday
+                )
+                .also { placementId ->
+                    tx.insertTestDaycareGroupPlacement(
+                        daycarePlacementId = placementId,
+                        groupId = group2.id,
+                        startDate = monday,
+                        endDate = tuesday
+                    )
+                }
+            // Lunch only on Monday
+            tx.insert(
+                DevReservation(
+                    childId = childWithSpecialDiet.id,
+                    date = monday,
+                    startTime = LocalTime.of(11, 0),
+                    endTime = LocalTime.of(12, 0),
+                    createdBy = employee.evakaUserId
+                )
+            )
+            // Absent on Tuesday
+            tx.insert(
+                DevAbsence(
+                    childId = childWithSpecialDiet.id,
+                    date = tuesday,
+                    absenceCategory = AbsenceCategory.BILLABLE
+                )
+            )
+        }
+
+        val client = TestJamixClient()
+        sendOrders(client, 88, monday)
+        sendOrders(client, 88, tuesday)
+        sendOrders(client, 99, monday)
+        sendOrders(client, 99, tuesday)
+
+        // Empty orders should not be sent
+        sendOrders(client, 123, wednesday) // No groups with customer id 123
+        sendOrders(client, 88, wednesday) // No placements on Wednesday
+
+        assertEquals(
+            listOf(
+                JamixClient.MealOrder(
+                    deliveryDate = monday,
+                    customerID = 88,
+                    mealOrderRows =
+                        listOf(
+                            JamixClient.MealOrderRow(
+                                orderAmount = 1,
+                                mealTypeID = 162,
+                                dietID = null,
+                                additionalInfo = null
+                            ),
+                            JamixClient.MealOrderRow(
+                                orderAmount = 1,
+                                mealTypeID = 175,
+                                dietID = null,
+                                additionalInfo = null
+                            ),
+                            JamixClient.MealOrderRow(
+                                orderAmount = 1,
+                                mealTypeID = 152,
+                                dietID = null,
+                                additionalInfo = null
+                            )
+                        )
+                ),
+                JamixClient.MealOrder(
+                    deliveryDate = tuesday,
+                    customerID = 88,
+                    mealOrderRows =
+                        listOf(
+                            JamixClient.MealOrderRow(
+                                orderAmount = 1,
+                                mealTypeID = 162,
+                                dietID = null,
+                                additionalInfo = null
+                            ),
+                        )
+                ),
+                JamixClient.MealOrder(
+                    deliveryDate = monday,
+                    customerID = 99,
+                    mealOrderRows =
+                        listOf(
+                            JamixClient.MealOrderRow(
+                                orderAmount = 1,
+                                mealTypeID = 145,
+                                dietID = 1,
+                                additionalInfo = "Johnson Diet"
+                            )
+                        )
+                )
+            ),
+            client.orders
+        )
+    }
+
+    private fun sendOrders(client: JamixClient, customerId: Int, date: LocalDate) {
+        createAndSendJamixOrder(client, db, DefaultMealTypeMapper, customerId, date)
+    }
+}
+
+class TestJamixClient : JamixClient {
+    val orders = mutableListOf<JamixClient.MealOrder>()
+
+    override fun createMealOrder(order: JamixClient.MealOrder) {
+        orders.add(order)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -26,6 +26,7 @@ data class EvakaEnv(
     val sfiEnabled: Boolean,
     val vtjEnabled: Boolean,
     val webPushEnabled: Boolean,
+    val jamixEnabled: Boolean,
     val awsRegion: Region,
     val asyncJobRunnerDisabled: Boolean,
     val frontendBaseUrlFi: String,
@@ -53,6 +54,7 @@ data class EvakaEnv(
                     env.lookup("evaka.integration.vtj.enabled", "fi.espoo.voltti.vtj.enabled")
                         ?: false,
                 webPushEnabled = env.lookup("evaka.web_push.enabled") ?: false,
+                jamixEnabled = env.lookup("evaka.integration.jamix.enabled") ?: false,
                 awsRegion = Region.of(env.lookup("evaka.aws.region", "aws.region")),
                 asyncJobRunnerDisabled =
                     env.lookup("evaka.async_job_runner.disable_runner") ?: false,
@@ -822,6 +824,19 @@ data class CitizenCalendarEnv(val calendarOpenBeforePlacementDays: Int) {
             return CitizenCalendarEnv(
                 calendarOpenBeforePlacementDays =
                     env.lookup("evaka.citizen.calendar.calendar_open_before_placement_days") ?: 14
+            )
+        }
+    }
+}
+
+data class JamixEnv(val url: URI, val user: String, val password: Sensitive<String>) {
+    companion object {
+        fun fromEnvironment(env: Environment): JamixEnv {
+            return JamixEnv(
+                // URL up to the operation name, e.g. https://fi.jamix.cloud/japi/pirnet/
+                url = URI.create(env.lookup("evaka.integration.jamix.url")),
+                user = env.lookup("evaka.integration.jamix.user"),
+                password = Sensitive(env.lookup("evaka.integration.jamix.password"))
             )
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/CareArea.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/CareArea.kt
@@ -32,12 +32,6 @@ data class MailingAddress(
     val postOffice: String? = null
 )
 
-interface DaycareTimeProps {
-    val dailyPreschoolTime: TimeRange?
-    val dailyPreparatoryTime: TimeRange?
-    val mealTimes: DaycareMealtimes
-}
-
 data class Daycare(
     val id: DaycareId,
     override val name: String,
@@ -82,14 +76,27 @@ data class Daycare(
     @Nested("mealtime_") override val mealTimes: DaycareMealtimes
 ) : DaycareInfo
 
-interface DaycareInfo : DaycareTimeProps, HasName, HasOperationDays
-
-interface HasName {
+interface DaycareInfo {
     val name: String
+    val operationDays: Set<Int>
+    val dailyPreschoolTime: TimeRange?
+    val dailyPreparatoryTime: TimeRange?
+    val mealTimes: DaycareMealtimes
 }
 
-interface HasOperationDays {
-    val operationDays: Set<Int>
+fun isUnitOperationDay(
+    operationDays: Set<Int>,
+    holidays: Set<LocalDate>,
+    date: LocalDate
+): Boolean {
+    if (!operationDays.contains(date.dayOfWeek.value)) return false
+
+    val isRoundTheClockUnit = operationDays == setOf(1, 2, 3, 4, 5, 6, 7)
+    if (!isRoundTheClockUnit && holidays.contains(date)) {
+        return false
+    }
+
+    return true
 }
 
 data class DaycareMealtimes(

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
@@ -162,6 +162,13 @@ fun Database.Read.getDaycares(
     return createQuery(daycaresQuery(filter.toPredicate().and(predicate))).toList<Daycare>()
 }
 
+fun Database.Read.getDaycaresById(ids: Set<DaycareId>): Map<DaycareId, Daycare> {
+    if (ids.isEmpty()) return emptyMap()
+    return createQuery(daycaresQuery(Predicate { where("$it.id = ANY(${bind(ids)})") }))
+        .mapTo<Daycare>()
+        .useSequence { rows -> rows.associateBy { it.id } }
+}
+
 data class UnitApplyPeriods(
     val id: DaycareId,
     val daycareApplyPeriod: DateRange?,

--- a/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixQueries.kt
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.jamix
+
+import fi.espoo.evaka.absence.AbsenceCategory
+import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.TimeRange
+import java.time.LocalDate
+import org.jdbi.v3.json.Json
+
+data class JamixChildData(
+    val childId: ChildId,
+    val unitId: DaycareId,
+    val placementType: PlacementType,
+    val firstName: String,
+    val lastName: String,
+    @Json val reservations: List<TimeRange>,
+    val absences: Set<AbsenceCategory>
+)
+
+fun Database.Read.getJamixCustomerIds(): Set<Int> =
+    createQuery { sql("SELECT DISTINCT jamix_customer_id FROM daycare_group") }.toSet()
+
+fun Database.Read.getJamixChildData(jamixCustomerId: Int, date: LocalDate): List<JamixChildData> =
+    createQuery {
+            sql(
+                """
+SELECT
+    rp.child_id,
+    rp.unit_id,
+    rp.placement_type,
+    p.first_name,
+    p.last_name,
+    coalesce((
+        SELECT jsonb_agg(jsonb_build_object('start', ar.start_time, 'end', ar.end_time))
+        FROM attendance_reservation ar
+        JOIN evaka_user eu ON ar.created_by = eu.id
+        WHERE
+            ar.child_id = rp.child_id AND
+            ar.date = ${bind(date)} AND
+            -- Ignore NO_TIMES reservations
+            ar.start_time IS NOT NULL AND ar.end_time IS NOT NULL
+    ), '[]'::jsonb) AS reservations,
+    coalesce((
+        SELECT array_agg(a.category)
+        FROM absence a
+        WHERE a.child_id = rp.child_id AND a.date = ${bind(date)}
+    ), '{}'::absence_category[]) AS absences
+FROM realized_placement_one(${bind(date)}) rp
+JOIN daycare_group dg ON dg.id = rp.group_id
+JOIN person p ON p.id = rp.child_id
+WHERE dg.jamix_customer_id = ${bind(jamixCustomerId)}
+                    """
+            )
+        }
+        .toList()

--- a/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.jamix
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.github.kittinunf.fuel.core.FuelManager
+import com.github.kittinunf.fuel.core.extensions.authentication
+import com.github.kittinunf.fuel.core.extensions.jsonBody
+import com.github.kittinunf.result.Result
+import fi.espoo.evaka.JamixEnv
+import fi.espoo.evaka.daycare.getDaycaresById
+import fi.espoo.evaka.daycare.getPreschoolTerms
+import fi.espoo.evaka.mealintegration.MealTypeMapper
+import fi.espoo.evaka.reports.MealReportChildInfo
+import fi.espoo.evaka.reports.mealReportData
+import fi.espoo.evaka.reports.specialDietsForChildren
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.getHolidays
+import java.time.Duration
+import java.time.LocalDate
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class JamixService(
+    env: JamixEnv?,
+    fuel: FuelManager,
+    jsonMapper: JsonMapper,
+    private val mealTypeMapper: MealTypeMapper,
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
+) {
+    private val client = env?.let { JamixHttpClient(it, fuel, jsonMapper) }
+
+    init {
+        asyncJobRunner.registerHandler(::sendOrder)
+    }
+
+    fun planOrders(dbc: Database.Connection, clock: EvakaClock) {
+        val now = clock.now()
+        val range = now.toLocalDate().startOfNextWeek().weekSpan()
+        dbc.transaction { tx ->
+            val customerIds = tx.getJamixCustomerIds()
+            asyncJobRunner.plan(
+                tx,
+                range.dates().flatMap { date ->
+                    customerIds.map { customerId -> AsyncJob.SendJamixOrder(customerId, date) }
+                },
+                runAt = now,
+                retryInterval = Duration.ofHours(1),
+                retryCount = 3
+            )
+        }
+    }
+
+    fun sendOrder(dbc: Database.Connection, clock: EvakaClock, job: AsyncJob.SendJamixOrder) {
+        if (client == null) error("Cannot send Jamix order: JamixEnv is not configured")
+        try {
+            createAndSendJamixOrder(client, dbc, mealTypeMapper, job.customerId, job.date)
+            logger.info { "Sent Jamix order for date ${job.date} for customer ${job.customerId}" }
+        } catch (e: Exception) {
+            logger.error(e) {
+                "Failed to send meal order to Jamix: customerId=${job.customerId}, date=${job.date}, error=${e.localizedMessage}"
+            }
+            throw e
+        }
+    }
+}
+
+fun createAndSendJamixOrder(
+    client: JamixClient,
+    dbc: Database.Connection,
+    mealTypeMapper: MealTypeMapper,
+    customerId: Int,
+    date: LocalDate
+) {
+    val (preschoolTerms, children) =
+        dbc.read { tx ->
+            val preschoolTerms = tx.getPreschoolTerms()
+            val children = getChildInfos(tx, customerId, date)
+            preschoolTerms to children
+        }
+    val order =
+        JamixClient.MealOrder(
+            customerID = customerId,
+            deliveryDate = date,
+            mealOrderRows =
+                mealReportData(children, date, preschoolTerms, mealTypeMapper).map {
+                    JamixClient.MealOrderRow(
+                        orderAmount = it.mealCount,
+                        mealTypeID = it.mealId,
+                        dietID = it.dietId,
+                        additionalInfo = it.additionalInfo
+                    )
+                }
+        )
+
+    if (order.mealOrderRows.isNotEmpty()) {
+        client.createMealOrder(order)
+    }
+}
+
+private fun getChildInfos(
+    tx: Database.Read,
+    jamixCustomerId: Int,
+    date: LocalDate
+): List<MealReportChildInfo> {
+    val holidays = tx.getHolidays(FiniteDateRange(date, date))
+
+    val childData = tx.getJamixChildData(jamixCustomerId, date)
+    val unitIds = childData.map { it.unitId }.toSet()
+    val childIds = childData.map { it.childId }.toSet()
+
+    val specialDiets = tx.specialDietsForChildren(childIds)
+    val units = tx.getDaycaresById(unitIds)
+
+    return childData.mapNotNull { child ->
+        val unit = units[child.unitId] ?: error("Daycare not found for unitId ${child.unitId}")
+
+        if (!unit.operationDays.contains(date.dayOfWeek.value)) return@mapNotNull null
+
+        val isRoundTheClockUnit = unit.operationDays == setOf(1, 2, 3, 4, 5, 6, 7)
+        if (!isRoundTheClockUnit && holidays.contains(date)) {
+            return@mapNotNull null
+        }
+
+        MealReportChildInfo(
+            placementType = child.placementType,
+            firstName = child.firstName,
+            lastName = child.lastName,
+            reservations = child.reservations,
+            absences = child.absences,
+            dietInfo = specialDiets[child.childId],
+            daycare = unit
+        )
+    }
+}
+
+interface JamixClient {
+    data class MealOrder(
+        val customerID: Int,
+        val deliveryDate: LocalDate,
+        val mealOrderRows: List<MealOrderRow>
+    )
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class MealOrderRow(
+        val orderAmount: Int,
+        val mealTypeID: Int,
+        val dietID: Int?,
+        val additionalInfo: String?
+    )
+
+    fun createMealOrder(order: MealOrder)
+}
+
+class JamixHttpClient(
+    private val env: JamixEnv,
+    private val fuel: FuelManager,
+    private val jsonMapper: JsonMapper
+) : JamixClient {
+    override fun createMealOrder(order: JamixClient.MealOrder) {
+        val url = env.url.resolve("v2/mealorders").toString()
+        val (request, response, result) =
+            fuel
+                .post(url)
+                .authentication()
+                .basic(env.user, env.password.value)
+                .jsonBody(jsonMapper.writeValueAsString(order))
+                .response()
+        if (result is Result.Failure) {
+            error(
+                "Failed to send meal order to Jamix: ${request.method} ${request.url}, status=${response.statusCode} error=${result.error.errorData.decodeToString()}"
+            )
+        }
+    }
+}
+
+private fun LocalDate.startOfNextWeek(): LocalDate {
+    val daysUntilNextMonday = (8 - this.dayOfWeek.value) % 7
+    return this.plusDays(daysUntilNextMonday.toLong())
+}
+
+private fun LocalDate.weekSpan(): FiniteDateRange {
+    val start = this.startOfNextWeek()
+    val end = start.plusDays(6)
+    return FiniteDateRange(start, end)
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
@@ -13,6 +13,7 @@ import com.github.kittinunf.result.Result
 import fi.espoo.evaka.JamixEnv
 import fi.espoo.evaka.daycare.getDaycaresById
 import fi.espoo.evaka.daycare.getPreschoolTerms
+import fi.espoo.evaka.daycare.isUnitOperationDay
 import fi.espoo.evaka.mealintegration.MealTypeMapper
 import fi.espoo.evaka.reports.MealReportChildInfo
 import fi.espoo.evaka.reports.mealReportData
@@ -124,13 +125,7 @@ private fun getChildInfos(
 
     return childData.mapNotNull { child ->
         val unit = units[child.unitId] ?: error("Daycare not found for unitId ${child.unitId}")
-
-        if (!unit.operationDays.contains(date.dayOfWeek.value)) return@mapNotNull null
-
-        val isRoundTheClockUnit = unit.operationDays == setOf(1, 2, 3, 4, 5, 6, 7)
-        if (!isRoundTheClockUnit && holidays.contains(date)) {
-            return@mapNotNull null
-        }
+        if (!isUnitOperationDay(unit.operationDays, holidays, date)) return@mapNotNull null
 
         MealReportChildInfo(
             placementType = child.placementType,
@@ -139,7 +134,9 @@ private fun getChildInfos(
             reservations = child.reservations,
             absences = child.absences,
             dietInfo = specialDiets[child.childId],
-            daycare = unit
+            dailyPreschoolTime = unit.dailyPreschoolTime,
+            dailyPreparatoryTime = unit.dailyPreparatoryTime,
+            mealTimes = unit.mealTimes
         )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -36,6 +36,7 @@ import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.varda.VardaChildCalculatedServiceNeedChanges
 import java.time.Duration
+import java.time.LocalDate
 import java.util.UUID
 import kotlin.reflect.KClass
 
@@ -321,6 +322,10 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class SendJamixOrder(val customerId: Int, val date: LocalDate) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     companion object {
         val main =
             AsyncJobRunner.Pool(
@@ -345,6 +350,7 @@ sealed interface AsyncJob : AsyncJobPayload {
                     SendAssistanceNeedDecisionSfiMessage::class,
                     SendAssistanceNeedPreschoolDecisionSfiMessage::class,
                     SendDecision::class,
+                    SendJamixOrder::class,
                     SendPatuReport::class,
                     UpdateFromVtj::class,
                     UploadToKoski::class,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/EnvConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/EnvConfig.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.DatabaseEnv
 import fi.espoo.evaka.DvvModificationsEnv
 import fi.espoo.evaka.EmailEnv
 import fi.espoo.evaka.EvakaEnv
+import fi.espoo.evaka.JamixEnv
 import fi.espoo.evaka.JwtEnv
 import fi.espoo.evaka.KoskiEnv
 import fi.espoo.evaka.OphEnv
@@ -82,6 +83,13 @@ class EnvConfig {
     fun webPushEnv(evakaEnv: EvakaEnv, env: Environment): WebPushEnv? =
         when (evakaEnv.webPushEnabled) {
             true -> WebPushEnv.fromEnvironment(env)
+            false -> null
+        }
+
+    @Bean
+    fun jamixEnv(evakaEnv: EvakaEnv, env: Environment): JamixEnv? =
+        when (evakaEnv.jamixEnabled) {
+            true -> JamixEnv.fromEnvironment(env)
             false -> null
         }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -185,7 +185,8 @@ INSERT INTO daycare (
     unit_manager_name, unit_manager_phone, unit_manager_email,
     decision_daycare_name, decision_preschool_name, decision_handler, decision_handler_address,
     oph_unit_oid, oph_organizer_oid, round_the_clock, operation_times, enabled_pilot_features,
-    finance_decision_handler, business_id, iban, provider_id
+    finance_decision_handler, business_id, iban, provider_id, mealtime_breakfast, mealtime_lunch, mealtime_snack,
+    mealtime_supper, mealtime_evening_snack
 ) VALUES (
     ${bind(row.id)}, ${bind(row.name)}, ${bind(row.openingDate)}, ${bind(row.closingDate)}, ${bind(row.areaId)},
     ${bind(row.type)}::care_types[], ${bind(row.dailyPreschoolTime)}, ${bind(row.dailyPreparatoryTime)}, ${bind(row.daycareApplyPeriod)},
@@ -199,7 +200,9 @@ INSERT INTO daycare (
     ${bind(row.decisionCustomization.daycareName)}, ${bind(row.decisionCustomization.preschoolName)}, ${bind(row.decisionCustomization.handler)},
     ${bind(row.decisionCustomization.handlerAddress)}, ${bind(row.ophUnitOid)}, ${bind(row.ophOrganizerOid)}, ${bind(row.roundTheClock)},
     ${bind(row.operationTimes)}, ${bind(row.enabledPilotFeatures)}::pilot_feature[], ${bind(row.financeDecisionHandler)}, ${bind(row.businessId)},
-    ${bind(row.iban)}, ${bind(row.providerId)})
+    ${bind(row.iban)}, ${bind(row.providerId)}, ${bind(row.mealtimeBreakfast)}, ${bind(row.mealtimeLunch)}, ${bind(row.mealtimeSnack)},
+    ${bind(row.mealtimeSupper)}, ${bind(row.mealtimeEveningSnack)}
+)
 RETURNING id
 """
             )
@@ -512,10 +515,10 @@ fun Database.Transaction.insert(row: DevChild): ChildId =
     createUpdate {
             sql(
                 """
-INSERT INTO child (id, allergies, diet, medication, additionalinfo, language_at_home, language_at_home_details)
-VALUES (${bind(row.id)}, ${bind(row.allergies)}, ${bind(row.diet)}, ${bind(row.medication)}, ${bind(row.additionalInfo)}, ${bind(row.languageAtHome)}, ${bind(row.languageAtHomeDetails)})
+INSERT INTO child (id, allergies, diet, medication, additionalinfo, language_at_home, language_at_home_details, diet_id)
+VALUES (${bind(row.id)}, ${bind(row.allergies)}, ${bind(row.diet)}, ${bind(row.medication)}, ${bind(row.additionalInfo)}, ${bind(row.languageAtHome)}, ${bind(row.languageAtHomeDetails)}, ${bind(row.dietId)})
 ON CONFLICT(id) DO UPDATE
-SET id = ${bind(row.id)}, allergies = ${bind(row.allergies)}, diet = ${bind(row.diet)}, medication = ${bind(row.medication)}, additionalInfo = ${bind(row.additionalInfo)}, language_at_home = ${bind(row.languageAtHome)}, language_at_home_details = ${bind(row.languageAtHomeDetails)}
+SET id = ${bind(row.id)}, allergies = ${bind(row.allergies)}, diet = ${bind(row.diet)}, medication = ${bind(row.medication)}, additionalInfo = ${bind(row.additionalInfo)}, language_at_home = ${bind(row.languageAtHome)}, language_at_home_details = ${bind(row.languageAtHomeDetails)}, diet_id = ${bind(row.dietId)}
 RETURNING id
     """
             )
@@ -709,8 +712,8 @@ fun Database.Transaction.insert(row: DevDaycareGroup): GroupId =
     createUpdate {
             sql(
                 """
-INSERT INTO daycare_group (id, daycare_id, name, start_date, end_date)
-VALUES (${bind(row.id)}, ${bind(row.daycareId)}, ${bind(row.name)}, ${bind(row.startDate)}, ${bind(row.endDate)})
+INSERT INTO daycare_group (id, daycare_id, name, start_date, end_date, jamix_customer_id)
+VALUES (${bind(row.id)}, ${bind(row.daycareId)}, ${bind(row.name)}, ${bind(row.startDate)}, ${bind(row.endDate)}, ${bind(row.jamixCustomerId)})
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1781,7 +1781,8 @@ data class DevChild(
     val medication: String = "",
     val additionalInfo: String = "",
     val languageAtHome: String = "",
-    val languageAtHomeDetails: String = ""
+    val languageAtHomeDetails: String = "",
+    val dietId: Int? = null
 )
 
 data class DevHoliday(val date: LocalDate, val description: String = "Test Holiday")
@@ -1849,7 +1850,12 @@ data class DevDaycare(
     val financeDecisionHandler: EmployeeId? = null,
     val businessId: String = "",
     val iban: String = "",
-    val providerId: String = ""
+    val providerId: String = "",
+    val mealtimeBreakfast: TimeRange? = null,
+    val mealtimeLunch: TimeRange? = null,
+    val mealtimeSnack: TimeRange? = null,
+    val mealtimeSupper: TimeRange? = null,
+    val mealtimeEveningSnack: TimeRange? = null
 )
 
 data class DevDaycareGroup(
@@ -1857,7 +1863,8 @@ data class DevDaycareGroup(
     val daycareId: DaycareId,
     val name: String = "Testiläiset",
     val startDate: LocalDate = LocalDate.of(2019, 1, 1),
-    val endDate: LocalDate? = null
+    val endDate: LocalDate? = null,
+    val jamixCustomerId: Int? = null
 )
 
 data class DevDaycareGroupPlacement(

--- a/service/src/test/kotlin/fi/espoo/evaka/reports/MealReportTests.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/reports/MealReportTests.kt
@@ -6,7 +6,6 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.absence.AbsenceCategory
 import fi.espoo.evaka.daycare.DaycareInfo
 import fi.espoo.evaka.daycare.DaycareMealtimes
-import fi.espoo.evaka.daycare.DaycareTimeProps
 import fi.espoo.evaka.daycare.PreschoolTerm
 import fi.espoo.evaka.mealintegration.DefaultMealTypeMapper
 import fi.espoo.evaka.mealintegration.MealType
@@ -29,7 +28,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MealReportTests {
-
     @Test
     fun `mealReportData should return no meals for absent child`() {
         val testDate = LocalDate.of(2023, 4, 15)
@@ -42,19 +40,16 @@ class MealReportTests {
                     reservations = listOf(), // No reservations
                     absences = setOf(AbsenceCategory.BILLABLE),
                     dietInfo = null,
-                    daycare =
-                        object : DaycareTimeProps {
-                            override val dailyPreschoolTime = null
-                            override val dailyPreparatoryTime = null
-                            override val mealTimes =
-                                DaycareMealtimes(
-                                    breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
-                                    lunch = TimeRange(LocalTime.of(11, 0), LocalTime.of(11, 20)),
-                                    snack = TimeRange(LocalTime.of(14, 0), LocalTime.of(14, 20)),
-                                    supper = null,
-                                    eveningSnack = null
-                                )
-                        }
+                    dailyPreschoolTime = null,
+                    dailyPreparatoryTime = null,
+                    mealTimes =
+                        DaycareMealtimes(
+                            breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                            lunch = TimeRange(LocalTime.of(11, 0), LocalTime.of(11, 20)),
+                            snack = TimeRange(LocalTime.of(14, 0), LocalTime.of(14, 20)),
+                            supper = null,
+                            eveningSnack = null
+                        )
                 )
             )
         val preschoolTerms = emptyList<PreschoolTerm>()
@@ -82,19 +77,16 @@ class MealReportTests {
                     reservations = emptyList(), // No reservations
                     absences = null, // No absences
                     dietInfo = null,
-                    daycare =
-                        object : DaycareTimeProps {
-                            override val dailyPreschoolTime = null
-                            override val dailyPreparatoryTime = null
-                            override val mealTimes =
-                                DaycareMealtimes(
-                                    breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
-                                    lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
-                                    snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
-                                    supper = null,
-                                    eveningSnack = null
-                                )
-                        }
+                    dailyPreschoolTime = null,
+                    dailyPreparatoryTime = null,
+                    mealTimes =
+                        DaycareMealtimes(
+                            breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                            lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
+                            snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
+                            supper = null,
+                            eveningSnack = null
+                        )
                 )
             )
         val preschoolTerms = emptyList<PreschoolTerm>()
@@ -129,20 +121,16 @@ class MealReportTests {
                     reservations = listOf(), // No specific reservations
                     absences = null, // No absences
                     dietInfo = null,
-                    daycare =
-                        object : DaycareTimeProps {
-                            override val dailyPreschoolTime =
-                                TimeRange(LocalTime.of(10, 0), LocalTime.of(14, 30))
-                            override val dailyPreparatoryTime = null
-                            override val mealTimes =
-                                DaycareMealtimes(
-                                    breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
-                                    lunch = TimeRange(LocalTime.of(11, 0), LocalTime.of(11, 20)),
-                                    snack = TimeRange(LocalTime.of(14, 0), LocalTime.of(14, 20)),
-                                    supper = null,
-                                    eveningSnack = null
-                                )
-                        }
+                    dailyPreschoolTime = TimeRange(LocalTime.of(10, 0), LocalTime.of(14, 30)),
+                    dailyPreparatoryTime = null,
+                    mealTimes =
+                        DaycareMealtimes(
+                            breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                            lunch = TimeRange(LocalTime.of(11, 0), LocalTime.of(11, 20)),
+                            snack = TimeRange(LocalTime.of(14, 0), LocalTime.of(14, 20)),
+                            supper = null,
+                            eveningSnack = null
+                        )
                 )
             )
         val preschoolTerms =
@@ -193,19 +181,16 @@ class MealReportTests {
                     reservations = listOf(TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0))),
                     absences = null, // No absences
                     dietInfo = glutenFreeDiet,
-                    daycare =
-                        object : DaycareTimeProps {
-                            override val dailyPreschoolTime = null
-                            override val dailyPreparatoryTime = null
-                            override val mealTimes =
-                                DaycareMealtimes(
-                                    breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
-                                    lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
-                                    snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
-                                    supper = null,
-                                    eveningSnack = null
-                                )
-                        }
+                    dailyPreschoolTime = null,
+                    dailyPreparatoryTime = null,
+                    mealTimes =
+                        DaycareMealtimes(
+                            breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                            lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
+                            snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
+                            supper = null,
+                            eveningSnack = null
+                        )
                 ),
                 MealReportChildInfo( // child with glutenFreeDiet
                     placementType = PlacementType.DAYCARE,
@@ -214,19 +199,16 @@ class MealReportTests {
                     reservations = listOf(TimeRange(LocalTime.of(12, 0), LocalTime.of(13, 0))),
                     absences = null, // No absences
                     dietInfo = glutenFreeDiet,
-                    daycare =
-                        object : DaycareTimeProps {
-                            override val dailyPreschoolTime = null
-                            override val dailyPreparatoryTime = null
-                            override val mealTimes =
-                                DaycareMealtimes(
-                                    breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
-                                    lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
-                                    snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
-                                    supper = null,
-                                    eveningSnack = null
-                                )
-                        }
+                    dailyPreschoolTime = null,
+                    dailyPreparatoryTime = null,
+                    mealTimes =
+                        DaycareMealtimes(
+                            breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                            lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
+                            snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
+                            supper = null,
+                            eveningSnack = null
+                        )
                 ),
                 MealReportChildInfo( // child with lactoseFreeDiet
                     placementType = PlacementType.DAYCARE,
@@ -235,19 +217,16 @@ class MealReportTests {
                     reservations = listOf(TimeRange(LocalTime.of(12, 0), LocalTime.of(13, 0))),
                     absences = null, // No absences
                     dietInfo = lactoseFreeDiet,
-                    daycare =
-                        object : DaycareTimeProps {
-                            override val dailyPreschoolTime = null
-                            override val dailyPreparatoryTime = null
-                            override val mealTimes =
-                                DaycareMealtimes(
-                                    breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
-                                    lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
-                                    snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
-                                    supper = null,
-                                    eveningSnack = null
-                                )
-                        }
+                    dailyPreschoolTime = null,
+                    dailyPreparatoryTime = null,
+                    mealTimes =
+                        DaycareMealtimes(
+                            breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                            lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
+                            snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
+                            supper = null,
+                            eveningSnack = null
+                        )
                 )
             )
         val preschoolTerms = emptyList<PreschoolTerm>()
@@ -351,19 +330,16 @@ class MealReportTests {
                     reservations = listOf(TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0))),
                     absences = null, // No absences
                     dietInfo = null,
-                    daycare =
-                        object : DaycareTimeProps {
-                            override val dailyPreschoolTime = null
-                            override val dailyPreparatoryTime = null
-                            override val mealTimes =
-                                DaycareMealtimes(
-                                    breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
-                                    lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
-                                    snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
-                                    supper = null,
-                                    eveningSnack = null
-                                )
-                        }
+                    dailyPreschoolTime = null,
+                    dailyPreparatoryTime = null,
+                    mealTimes =
+                        DaycareMealtimes(
+                            breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                            lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
+                            snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
+                            supper = null,
+                            eveningSnack = null
+                        )
                 ),
                 MealReportChildInfo(
                     placementType = PlacementType.DAYCARE,
@@ -372,19 +348,16 @@ class MealReportTests {
                     reservations = listOf(TimeRange(LocalTime.of(10, 0), LocalTime.of(16, 0))),
                     absences = null, // No absences
                     dietInfo = null,
-                    daycare =
-                        object : DaycareTimeProps {
-                            override val dailyPreschoolTime = null
-                            override val dailyPreparatoryTime = null
-                            override val mealTimes =
-                                DaycareMealtimes(
-                                    breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
-                                    lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
-                                    snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
-                                    supper = null,
-                                    eveningSnack = null
-                                )
-                        }
+                    dailyPreschoolTime = null,
+                    dailyPreparatoryTime = null,
+                    mealTimes =
+                        DaycareMealtimes(
+                            breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                            lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
+                            snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
+                            supper = null,
+                            eveningSnack = null
+                        )
                 )
             )
         val preschoolTerms = emptyList<PreschoolTerm>()

--- a/service/src/test/kotlin/fi/espoo/evaka/reports/MealReportTests.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/reports/MealReportTests.kt
@@ -4,7 +4,6 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.absence.AbsenceCategory
-import fi.espoo.evaka.absence.AbsenceType
 import fi.espoo.evaka.daycare.DaycareInfo
 import fi.espoo.evaka.daycare.DaycareMealtimes
 import fi.espoo.evaka.daycare.DaycareTimeProps
@@ -12,7 +11,6 @@ import fi.espoo.evaka.daycare.PreschoolTerm
 import fi.espoo.evaka.mealintegration.DefaultMealTypeMapper
 import fi.espoo.evaka.mealintegration.MealType
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.reservations.AbsenceTypeResponse
 import fi.espoo.evaka.reservations.ChildData
 import fi.espoo.evaka.reservations.ReservationResponse
 import fi.espoo.evaka.reservations.UnitAttendanceReservations
@@ -20,7 +18,6 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.PreschoolTermId
 import fi.espoo.evaka.shared.data.DateSet
 import fi.espoo.evaka.shared.domain.FiniteDateRange
-import fi.espoo.evaka.shared.domain.TimeInterval
 import fi.espoo.evaka.shared.domain.TimeRange
 import fi.espoo.evaka.specialdiet.SpecialDiet
 import java.time.LocalDate
@@ -43,11 +40,7 @@ class MealReportTests {
                     firstName = "John",
                     lastName = "Doe",
                     reservations = listOf(), // No reservations
-                    absences =
-                        mapOf(
-                            AbsenceCategory.BILLABLE to
-                                AbsenceTypeResponse(AbsenceType.PLANNED_ABSENCE, false)
-                        ),
+                    absences = setOf(AbsenceCategory.BILLABLE),
                     dietInfo = null,
                     daycare =
                         object : DaycareTimeProps {
@@ -71,11 +64,10 @@ class MealReportTests {
                 children = childInfo,
                 date = testDate,
                 preschoolTerms = preschoolTerms,
-                reportName = "Test Report",
                 DefaultMealTypeMapper
             )
 
-        assertTrue(report.meals.isEmpty(), "Expected no meals for absent child")
+        assertTrue(report.isEmpty(), "Expected no meals for absent child")
     }
 
     @Test
@@ -112,12 +104,11 @@ class MealReportTests {
                 children = childInfo,
                 date = testDate,
                 preschoolTerms = preschoolTerms,
-                reportName = "Test Report No Reservations",
                 DefaultMealTypeMapper
             )
 
         val expectedMeals = setOf(MealType.BREAKFAST, MealType.LUNCH, MealType.SNACK)
-        val actualMeals = report.meals.map { it.mealType }.toSet()
+        val actualMeals = report.map { it.mealType }.toSet()
 
         assertEquals(
             expectedMeals,
@@ -175,12 +166,11 @@ class MealReportTests {
                 children = childInfo,
                 date = testDate,
                 preschoolTerms = preschoolTerms,
-                reportName = "Test Report Preschool",
                 DefaultMealTypeMapper
             )
 
         val expectedMealTypes = setOf(MealType.LUNCH_PRESCHOOL, MealType.SNACK)
-        val actualMealTypes = report.meals.map { it.mealType }.toSet()
+        val actualMealTypes = report.map { it.mealType }.toSet()
 
         assertEquals(
             expectedMealTypes,
@@ -200,13 +190,7 @@ class MealReportTests {
                     placementType = PlacementType.DAYCARE,
                     firstName = "Ella",
                     lastName = "Brown",
-                    reservations =
-                        listOf(
-                            ReservationResponse.Times(
-                                TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0)),
-                                false
-                            ),
-                        ),
+                    reservations = listOf(TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0))),
                     absences = null, // No absences
                     dietInfo = glutenFreeDiet,
                     daycare =
@@ -227,13 +211,7 @@ class MealReportTests {
                     placementType = PlacementType.DAYCARE,
                     firstName = "Mike",
                     lastName = "Brown",
-                    reservations =
-                        listOf(
-                            ReservationResponse.Times(
-                                TimeRange(LocalTime.of(12, 0), LocalTime.of(13, 0)),
-                                false
-                            ),
-                        ),
+                    reservations = listOf(TimeRange(LocalTime.of(12, 0), LocalTime.of(13, 0))),
                     absences = null, // No absences
                     dietInfo = glutenFreeDiet,
                     daycare =
@@ -254,13 +232,7 @@ class MealReportTests {
                     placementType = PlacementType.DAYCARE,
                     firstName = "Mikko",
                     lastName = "Mallikas",
-                    reservations =
-                        listOf(
-                            ReservationResponse.Times(
-                                TimeRange(LocalTime.of(12, 0), LocalTime.of(13, 0)),
-                                false
-                            ),
-                        ),
+                    reservations = listOf(TimeRange(LocalTime.of(12, 0), LocalTime.of(13, 0))),
                     absences = null, // No absences
                     dietInfo = lactoseFreeDiet,
                     daycare =
@@ -285,7 +257,6 @@ class MealReportTests {
                 children = childInfo,
                 date = testDate,
                 preschoolTerms = preschoolTerms,
-                reportName = "Test Report Special Diet",
                 DefaultMealTypeMapper
             )
 
@@ -319,7 +290,7 @@ class MealReportTests {
                     "Brown Ella"
                 )
             )
-        val rowsForElla = report.meals.filter { it.additionalInfo.equals("Brown Ella") }.toSet()
+        val rowsForElla = report.filter { it.additionalInfo.equals("Brown Ella") }.toSet()
 
         assertEquals(
             expectedRowsForElla,
@@ -339,7 +310,7 @@ class MealReportTests {
                     "Brown Mike"
                 ),
             )
-        val rowsForMike = report.meals.filter { it.additionalInfo.equals("Brown Mike") }.toSet()
+        val rowsForMike = report.filter { it.additionalInfo.equals("Brown Mike") }.toSet()
 
         assertEquals(
             expectedRowsForMike,
@@ -359,8 +330,7 @@ class MealReportTests {
                     "Mallikas Mikko"
                 ),
             )
-        val rowsForMikko =
-            report.meals.filter { it.additionalInfo.equals("Mallikas Mikko") }.toSet()
+        val rowsForMikko = report.filter { it.additionalInfo.equals("Mallikas Mikko") }.toSet()
 
         assertEquals(
             expectedRowsForMikko,
@@ -378,13 +348,7 @@ class MealReportTests {
                     placementType = PlacementType.DAYCARE,
                     firstName = "Ella",
                     lastName = "Brown",
-                    reservations =
-                        listOf(
-                            ReservationResponse.Times(
-                                TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0)),
-                                false
-                            ),
-                        ),
+                    reservations = listOf(TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0))),
                     absences = null, // No absences
                     dietInfo = null,
                     daycare =
@@ -405,13 +369,7 @@ class MealReportTests {
                     placementType = PlacementType.DAYCARE,
                     firstName = "Mike",
                     lastName = "Johnson",
-                    reservations =
-                        listOf(
-                            ReservationResponse.Times( // Arrives after breakfast
-                                TimeRange(LocalTime.of(10, 0), LocalTime.of(16, 0)),
-                                false
-                            ),
-                        ),
+                    reservations = listOf(TimeRange(LocalTime.of(10, 0), LocalTime.of(16, 0))),
                     absences = null, // No absences
                     dietInfo = null,
                     daycare =
@@ -436,16 +394,13 @@ class MealReportTests {
                 children = childInfo,
                 date = testDate,
                 preschoolTerms = preschoolTerms,
-                reportName = "Test Report No Special Diet",
                 DefaultMealTypeMapper
             )
 
         val expectedMealCounts =
             mapOf(MealType.BREAKFAST to 1, MealType.LUNCH to 2, MealType.SNACK to 2)
         val actualMealCounts =
-            report.meals
-                .groupBy { it.mealType }
-                .mapValues { entry -> entry.value.sumOf { it.mealCount } }
+            report.groupBy { it.mealType }.mapValues { entry -> entry.value.sumOf { it.mealCount } }
 
         assertEquals(
             expectedMealCounts,
@@ -477,9 +432,9 @@ class MealReportTests {
                                 dateOfBirth = LocalDate.of(2020, 1, 1),
                                 preferredName = ""
                             ),
-                        reservations = mapOf<LocalDate, List<ReservationResponse>>(),
-                        absences = mapOf<LocalDate, Map<AbsenceCategory, AbsenceTypeResponse>>(),
-                        attendances = mapOf<LocalDate, List<TimeInterval>>()
+                        reservations = mapOf(),
+                        absences = mapOf(),
+                        attendances = mapOf()
                     ),
                 childId2 to
                     ChildData(
@@ -492,9 +447,9 @@ class MealReportTests {
                                 dateOfBirth = LocalDate.of(2020, 1, 1),
                                 preferredName = ""
                             ),
-                        reservations = mapOf<LocalDate, List<ReservationResponse>>(),
-                        absences = mapOf<LocalDate, Map<AbsenceCategory, AbsenceTypeResponse>>(),
-                        attendances = mapOf<LocalDate, List<TimeInterval>>()
+                        reservations = mapOf(),
+                        absences = mapOf(),
+                        attendances = mapOf()
                     )
             )
 


### PR DESCRIPTION
Lähetetään seuraavan viikon ateriatilaukset Jamixiin ajastetussa jobissa (oletuksena joka tiistai klo 02:25).

Integraation saa päälle konfiguroimalla seuraavat Spring propertyt:
- `evaka.job.send_jamix_orders.enabled = true`
- `evaka.integration.jamix.enabled = true`
- `evaka.integration.jamix.url`: Jamix-rajapinnan URL operaation nimeen asti, esim. `https://fi.jamix.cloud/japi/pirnet/`
- `evaka.integration.jamix.user`: HTTP Basic Auth -käyttäjätunnus
- `evaka.integration.jamix.password`: HTTP Basic Auth -salasana