### PR TITLE
Kuntakohtaiset ruokatilausintegraation ateriatunnisteet

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/income.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/income.spec.ts
@@ -238,7 +238,6 @@ describe('Income', () => {
 
     await incomesSection.deleteIncomeAttachment(0)
     await incomesSection.cancelEdit()
-
     await waitUntilEqual(() => incomesSection.getAttachmentCount(), 0)
   })
 

--- a/frontend/src/lib-common/generated/api-types/mealintegration.ts
+++ b/frontend/src/lib-common/generated/api-types/mealintegration.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// GENERATED FILE: no manual modifications
+
+/**
+* Generated from fi.espoo.evaka.mealintegration.MealType
+*/
+export type MealType =
+  | 'BREAKFAST'
+  | 'LUNCH'
+  | 'LUNCH_PRESCHOOL'
+  | 'SNACK'
+  | 'SUPPER'
+  | 'EVENING_SNACK'

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -15,6 +15,7 @@ import { AssistanceNeedDecisionStatus } from './assistanceneed'
 import { DaycareAssistanceLevel } from './assistance'
 import { DecisionType } from './decision'
 import { JsonOf } from '../../json'
+import { MealType } from './mealintegration'
 import { OccupancyValues } from './occupancy'
 import { OtherAssistanceMeasureType } from './assistance'
 import { PlacementType } from './placement'
@@ -465,17 +466,6 @@ export interface MealReportRow {
   mealId: number
   mealType: MealType
 }
-
-/**
-* Generated from fi.espoo.evaka.reports.MealType
-*/
-export type MealType =
-  | 'BREAKFAST'
-  | 'LUNCH'
-  | 'LUNCH_PRESCHOOL'
-  | 'SNACK'
-  | 'SUPPER'
-  | 'EVENING_SNACK'
 
 /**
 * Generated from fi.espoo.evaka.reports.MissingHeadOfFamilyReportRow

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -21,6 +21,8 @@ import fi.espoo.evaka.invoicing.service.EspooIncomeTypesProvider
 import fi.espoo.evaka.invoicing.service.IncomeCoefficientMultiplierProvider
 import fi.espoo.evaka.invoicing.service.IncomeTypesProvider
 import fi.espoo.evaka.invoicing.service.InvoiceProductProvider
+import fi.espoo.evaka.mealintegration.DefaultMealTypeMapper
+import fi.espoo.evaka.mealintegration.MealTypeMapper
 import fi.espoo.evaka.reports.patu.PatuIntegrationClient
 import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.db.Database
@@ -197,6 +199,8 @@ class SharedIntegrationTestConfig {
         object : TitaniaEmployeeIdConverter {
             override fun fromTitania(employeeId: String): String = employeeId.trimStart('0')
         }
+
+    @Bean fun mealTypeMapper(): MealTypeMapper = DefaultMealTypeMapper
 }
 
 val testFeatureConfig =

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -28,6 +28,8 @@ import fi.espoo.evaka.invoicing.service.IncomeCoefficientMultiplierProvider
 import fi.espoo.evaka.invoicing.service.IncomeTypesProvider
 import fi.espoo.evaka.invoicing.service.InvoiceProductProvider
 import fi.espoo.evaka.logging.defaultAccessLoggingValve
+import fi.espoo.evaka.mealintegration.DefaultMealTypeMapper
+import fi.espoo.evaka.mealintegration.MealTypeMapper
 import fi.espoo.evaka.reports.patu.EspooPatuIntegrationClient
 import fi.espoo.evaka.reports.patu.PatuAsyncJobProcessor
 import fi.espoo.evaka.reports.patu.PatuIntegrationClient
@@ -207,6 +209,8 @@ class EspooConfig {
         espooAsyncJobRunner: AsyncJobRunner<EspooAsyncJob>,
         env: ScheduledJobsEnv<EspooScheduledJob>
     ): EspooScheduledJobs = EspooScheduledJobs(patuReportingService, espooAsyncJobRunner, env)
+
+    @Bean fun espooMealTypeMapper(): MealTypeMapper = DefaultMealTypeMapper
 }
 
 data class EspooEnv(

--- a/service/src/main/kotlin/fi/espoo/evaka/mealintegration/MealType.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/mealintegration/MealType.kt
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.mealintegration
+
+enum class MealType {
+    BREAKFAST,
+    LUNCH,
+    LUNCH_PRESCHOOL,
+    SNACK,
+    SUPPER,
+    EVENING_SNACK
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/mealintegration/MealTypeMapper.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/mealintegration/MealTypeMapper.kt
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+package fi.espoo.evaka.mealintegration
+
+interface MealTypeMapper {
+    fun toMealId(mealType: MealType, specialDiet: Boolean): Int
+}
+
+/** Kangasala mappings */
+object DefaultMealTypeMapper : MealTypeMapper {
+    override fun toMealId(mealType: MealType, specialDiet: Boolean): Int =
+        if (specialDiet) {
+            when (mealType) {
+                MealType.BREAKFAST -> 143
+                MealType.LUNCH -> 145
+                MealType.LUNCH_PRESCHOOL -> 24
+                MealType.SNACK -> 160
+                MealType.SUPPER -> 28
+                MealType.EVENING_SNACK -> 31
+            }
+        } else
+            when (mealType) {
+                MealType.BREAKFAST -> 162
+                MealType.LUNCH -> 175
+                MealType.LUNCH_PRESCHOOL -> 22
+                MealType.SNACK -> 152
+                MealType.SUPPER -> 27
+                MealType.EVENING_SNACK -> 30
+            }
+}

--- a/service/src/test/kotlin/fi/espoo/evaka/reports/MealReportTests.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/reports/MealReportTests.kt
@@ -9,6 +9,8 @@ import fi.espoo.evaka.daycare.DaycareInfo
 import fi.espoo.evaka.daycare.DaycareMealtimes
 import fi.espoo.evaka.daycare.DaycareTimeProps
 import fi.espoo.evaka.daycare.PreschoolTerm
+import fi.espoo.evaka.mealintegration.DefaultMealTypeMapper
+import fi.espoo.evaka.mealintegration.MealType
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.reservations.AbsenceTypeResponse
 import fi.espoo.evaka.reservations.ChildData
@@ -69,7 +71,8 @@ class MealReportTests {
                 children = childInfo,
                 date = testDate,
                 preschoolTerms = preschoolTerms,
-                reportName = "Test Report"
+                reportName = "Test Report",
+                DefaultMealTypeMapper
             )
 
         assertTrue(report.meals.isEmpty(), "Expected no meals for absent child")
@@ -109,7 +112,8 @@ class MealReportTests {
                 children = childInfo,
                 date = testDate,
                 preschoolTerms = preschoolTerms,
-                reportName = "Test Report No Reservations"
+                reportName = "Test Report No Reservations",
+                DefaultMealTypeMapper
             )
 
         val expectedMeals = setOf(MealType.BREAKFAST, MealType.LUNCH, MealType.SNACK)
@@ -171,7 +175,8 @@ class MealReportTests {
                 children = childInfo,
                 date = testDate,
                 preschoolTerms = preschoolTerms,
-                reportName = "Test Report Preschool"
+                reportName = "Test Report Preschool",
+                DefaultMealTypeMapper
             )
 
         val expectedMealTypes = setOf(MealType.LUNCH_PRESCHOOL, MealType.SNACK)
@@ -280,7 +285,8 @@ class MealReportTests {
                 children = childInfo,
                 date = testDate,
                 preschoolTerms = preschoolTerms,
-                reportName = "Test Report Special Diet"
+                reportName = "Test Report Special Diet",
+                DefaultMealTypeMapper
             )
 
         val expectedRowsForElla =
@@ -430,7 +436,8 @@ class MealReportTests {
                 children = childInfo,
                 date = testDate,
                 preschoolTerms = preschoolTerms,
-                reportName = "Test Report No Special Diet"
+                reportName = "Test Report No Special Diet",
+                DefaultMealTypeMapper
             )
 
         val expectedMealCounts =
@@ -517,7 +524,7 @@ class MealReportTests {
                 preschoolTerms = emptyList()
             )
 
-        val report = getMealReportForUnit(unitData, testDate)
+        val report = getMealReportForUnit(unitData, testDate, DefaultMealTypeMapper)
 
         assertTrue(report?.meals.isNullOrEmpty(), "Expected no meals on a Sunday for a normal unit")
     }
@@ -614,7 +621,7 @@ class MealReportTests {
                 preschoolTerms = emptyList()
             )
 
-        val report = getMealReportForUnit(unitData, testDate)
+        val report = getMealReportForUnit(unitData, testDate, DefaultMealTypeMapper)
         assertFalse(
             report?.meals.isNullOrEmpty(),
             "Expected meals based on reservations for a round-the-clock unit on weekends"
@@ -700,7 +707,7 @@ class MealReportTests {
                 preschoolTerms = emptyList()
             )
 
-        val report = getMealReportForUnit(unitData, testDate)
+        val report = getMealReportForUnit(unitData, testDate, DefaultMealTypeMapper)
 
         assertTrue(
             report?.meals.isNullOrEmpty(),
@@ -782,7 +789,7 @@ class MealReportTests {
                 preschoolTerms = emptyList()
             )
 
-        val report = getMealReportForUnit(unitData, testDate)
+        val report = getMealReportForUnit(unitData, testDate, DefaultMealTypeMapper)
 
         assertFalse(
             report?.meals.isNullOrEmpty(),


### PR DESCRIPTION
## Ennen tätä muutosta
Kaikkialla oli käytössä Kangasalan `MealType` -> `mealID` mapperi
## Tämän muutoksen jälkeen
Kullekkin kunnalle on mahdollista määrittää oma `MealType` -> `mealID` mapperi

