### PR TITLE
Korjauksia Varda-integraatioon

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.varda
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.VardaEnv
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -27,7 +28,8 @@ class VardaController(
     private val vardaService: VardaUpdateService,
     private val vardaResetService: VardaResetService,
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
-    private val accessControl: AccessControl
+    private val accessControl: AccessControl,
+    private val vardaEnv: VardaEnv
 ) {
     @PostMapping("/start-update")
     fun runFullVardaUpdate(db: Database, user: AuthenticatedUser, clock: EvakaClock) {
@@ -56,7 +58,11 @@ class VardaController(
                         Action.Global.VARDA_OPERATIONS
                     )
                 }
-                vardaResetService.planVardaReset(dbc, clock, true)
+                vardaResetService.planVardaReset(
+                    dbc,
+                    clock,
+                    addNewChildren = !vardaEnv.newIntegrationEnabled
+                )
             }
             .also { Audit.VardaReportOperations.log() }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
@@ -232,7 +232,9 @@ fun Database.Transaction.addNewChildrenForVardaUpdate(migrationSpeed: Int = 0): 
                     INSERT INTO varda_state (child_id, state)
                     SELECT evaka_child_id, null
                     FROM varda_reset_child
-                    WHERE NOT EXISTS (SELECT FROM varda_state WHERE child_id = evaka_child_id)
+                    WHERE
+                        EXISTS (SELECT FROM person WHERE id = evaka_child_id) AND
+                        NOT EXISTS (SELECT FROM varda_state WHERE child_id = evaka_child_id)
                     LIMIT ${bind(migrationSpeed)}
                     RETURNING child_id
                 )


### PR DESCRIPTION
- Ei lisätä lapsia takaisin vanhan Varda-integraation alle kun käyttäjä painaa "Aloita uudelleenvienti"-nappia Varda virheet -raportilla
- Yritetään lisätä vain olemassaolevia lapsia uuden Varda-integraation alle, jotta vältetään constraint-virheet