### PR TITLE
Mahdollisuus päättää edellisen vaka-järjestelmän Varda-tiedot

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -106,6 +106,9 @@ dependencies {
     implementation("com.github.kittinunf.fuel:fuel")
     implementation("com.github.kittinunf.fuel:fuel-jackson")
 
+    // OkHttp
+    implementation("com.squareup.okhttp3:okhttp")
+
     // Jackson
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/service/evaka-bom/build.gradle.kts
+++ b/service/evaka-bom/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     api(enforcedPlatform("org.eclipse.jetty:jetty-bom:11.0.20"))
     api(platform("org.jdbi:jdbi3-bom:3.45.0"))
     api(platform(libs.kotlin.bom))
+    api(platform(libs.okhttp.bom))
     api(platform("org.junit:junit-bom:5.10.0"))
     api(platform(libs.spring.boot.dependencies))
     api(platform("org.springframework:spring-framework-bom:6.1.6")) // only needed for CVE fix

--- a/service/gradle/libs.versions.toml
+++ b/service/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ ktfmt = "0.18.0"
 ktlint = "1.2.1"
 ktlint-gradle = "12.1.0"
 mockito = "5.11.0"
+okhttp = "4.12.0"
 opentracing = "0.33.0"
 owasp = "9.1.0"
 spring-boot = "3.2.4"
@@ -36,6 +37,7 @@ ktlint-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-co
 ktlint-test = { module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlint" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 opentracing-api = { module = "io.opentracing:opentracing-api", version.ref = "opentracing" }
 opentracing-util = { module = "io.opentracing:opentracing-util", version.ref = "opentracing" }
 spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/new/VardaUpdaterIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/new/VardaUpdaterIntegrationTest.kt
@@ -2396,6 +2396,10 @@ open class FailEveryOperation : VardaReadClient {
         throw NotImplementedError()
     }
 
+    override fun getLapset(): List<VardaReadClient.LapsiResponse> {
+        throw NotImplementedError()
+    }
+
     override fun getLapsi(url: URI): VardaReadClient.LapsiResponse {
         throw NotImplementedError()
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -35,6 +35,7 @@ import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.varda.VardaChildCalculatedServiceNeedChanges
+import java.net.URI
 import java.time.Duration
 import java.time.LocalDate
 import java.util.UUID
@@ -277,13 +278,27 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
-    data class UpdateVardaChild(
-        val serviceNeedDiffByChild: VardaChildCalculatedServiceNeedChanges
+    data class VardaUpdateChild(val childId: ChildId, val dryRun: Boolean = false) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class VardaPlanEndExistingChildData(val endDate: LocalDate, val dryRun: Boolean) :
+        AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class VardaEndExistingChildData(
+        val lapsiUrl: URI,
+        val endDate: LocalDate,
+        val dryRun: Boolean
     ) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
 
-    data class VardaUpdateChild(val childId: ChildId, val dryRun: Boolean = false) : AsyncJob {
+    // Old Varda jobs
+    data class UpdateVardaChild(
+        val serviceNeedDiffByChild: VardaChildCalculatedServiceNeedChanges
+    ) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
 
@@ -302,6 +317,7 @@ sealed interface AsyncJob : AsyncJobPayload {
     data class DeleteVardaChild(val vardaChildId: Long) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
+    // End of Old Varda jobs
 
     data class SendOutdatedIncomeNotificationEmail(
         val guardianId: PersonId,
@@ -399,6 +415,8 @@ sealed interface AsyncJob : AsyncJobPayload {
                 AsyncJobPool.Config(concurrency = 1),
                 setOf(
                     VardaUpdateChild::class,
+                    VardaPlanEndExistingChildData::class,
+                    VardaEndExistingChildData::class,
                     UpdateVardaChild::class,
                     ResetVardaChild::class,
                     DeleteVardaChild::class,

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
@@ -8,25 +8,18 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.github.kittinunf.fuel.core.FuelError
-import com.github.kittinunf.fuel.core.FuelManager
-import com.github.kittinunf.fuel.core.Headers
-import com.github.kittinunf.fuel.core.Method
-import com.github.kittinunf.fuel.core.Request
-import com.github.kittinunf.fuel.core.ResponseResultOf
-import com.github.kittinunf.fuel.core.extensions.authentication
-import com.github.kittinunf.fuel.core.extensions.jsonBody
-import com.github.kittinunf.result.Result
-import fi.espoo.evaka.shared.utils.responseStringWithRetries
-import fi.espoo.evaka.shared.utils.token
 import fi.espoo.evaka.varda.VardaUnitClient
 import fi.espoo.evaka.varda.VardaUnitRequest
 import fi.espoo.evaka.varda.VardaUnitResponse
 import fi.espoo.evaka.varda.integration.VardaTokenProvider
-import fi.espoo.voltti.logging.loggers.error
 import java.net.URI
 import java.time.LocalDate
 import mu.KotlinLogging
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
 
 private val logger = KotlinLogging.logger {}
 
@@ -243,7 +236,7 @@ interface VardaEntity {
 
 class VardaClient(
     private val tokenProvider: VardaTokenProvider,
-    private val fuel: FuelManager,
+    private val httpClient: OkHttpClient,
     private val jsonMapper: JsonMapper,
     vardaBaseUrl: URI
 ) : VardaReadClient, VardaWriteClient, VardaUnitClient {
@@ -297,7 +290,7 @@ class VardaClient(
     override fun updateUnit(id: Long, unit: VardaUnitRequest): VardaUnitResponse =
         put(baseUrl.resolve("v1/toimipaikat/$id/"), unit)
 
-    private inline fun <reified R> get(url: URI): R = request(Method.GET, url)
+    private inline fun <reified R> get(url: URI): R = request("GET", url)
 
     private data class PaginatedResponse<T>(
         val count: Int,
@@ -317,39 +310,41 @@ class VardaClient(
         return acc.toList()
     }
 
-    private inline fun <T, reified R> post(url: URI, body: T): R = request(Method.POST, url, body)
+    private inline fun <T, reified R> post(url: URI, body: T): R = request("POST", url, body)
 
-    private inline fun <T, reified R> put(url: URI, body: T): R = request(Method.PUT, url, body)
+    private inline fun <T, reified R> put(url: URI, body: T): R = request("PUT", url, body)
 
-    override fun <T : VardaEntity> delete(data: T) = request<Unit>(Method.DELETE, data.url)
+    override fun <T : VardaEntity> delete(data: T) = request<Unit>("DELETE", data.url)
 
-    private inline fun <reified R> request(method: Method, url: URI, body: Any? = null): R {
+    private inline fun <reified R> request(method: String, url: URI, body: Any? = null): R {
         logger.info("requesting $method $url" + if (body == null) "" else " with body $body")
 
-        val (request, _, result) =
-            fuel
-                .request(method, validateUrl(url))
-                .let { if (body != null) it.jsonBody(jsonMapper.writeValueAsString(body)) else it }
-                .authenticatedResponseStringWithRetries()
-
-        return when (result) {
-            is Result.Success -> {
-                logger.info("successfully requested $method $url")
-                if (Unit is R) {
-                    Unit
-                } else {
-                    jsonMapper.readValue(result.get())
-                }
-            }
-            is Result.Failure -> {
-                if (null !is R || result.error.response.statusCode != 404) {
-                    vardaError(request, result.error) { err ->
-                        "failed to request $method $url: ${err.toString().trim()}"
+        val req =
+            Request.Builder()
+                .method(
+                    method,
+                    body?.let {
+                        jsonMapper
+                            .writeValueAsString(it)
+                            .toRequestBody("application/json".toMediaType())
                     }
-                } else {
-                    logger.info("successfully requested $method $url: not found")
-                    null as R
-                }
+                )
+                .url(validateUrl(url))
+                .build()
+
+        return httpClient.executeAuthenticated(req) { response ->
+            if (!response.isSuccessful) {
+                val message =
+                    "request failed $method $url: status=${response.code} body=${response.body?.string()}"
+                logger.error { message }
+                error(message)
+            }
+
+            logger.info { "successfully requested $method $url" }
+            if (Unit is R) {
+                Unit
+            } else {
+                jsonMapper.readValue(response.body?.string()!!)
             }
         }
     }
@@ -362,79 +357,6 @@ class VardaClient(
         return result
     }
 
-    private data class VardaRequestError(
-        val method: String,
-        val url: String,
-        val body: String,
-        val errorMessage: String,
-        val errorCode: String?,
-        val errorDescription: String?,
-        val statusCode: String
-    ) {
-        fun asMap() =
-            mapOf(
-                "method" to method,
-                "url" to url,
-                "body" to body,
-                "errorMessage" to errorMessage,
-                "errorCode" to errorCode,
-                "errorDescription" to errorDescription,
-                "statusCode" to statusCode
-            )
-    }
-
-    private fun parseVardaErrorBody(errorString: String): Pair<List<String>, List<String>> {
-        val codes =
-            Regex("\"error_code\":\"(\\w+)\"")
-                .findAll(errorString)
-                .map { it.groupValues[1] }
-                .toList()
-        val descriptions =
-            Regex("\"description\":\"([^\"]+)\"")
-                .findAll(errorString)
-                .map { it.groupValues[1] }
-                .toList()
-        return Pair(codes, descriptions)
-    }
-
-    private fun parseVardaError(request: Request, error: FuelError): VardaRequestError {
-        return try {
-            val errorString = error.errorData.decodeToString()
-            val (errorCodes, descriptions) = parseVardaErrorBody(errorString)
-            VardaRequestError(
-                method = request.method.toString(),
-                url = request.url.toString(),
-                body = request.body.asString("application/json"),
-                errorMessage = errorString,
-                errorCode = errorCodes.first(),
-                errorDescription = descriptions.first(),
-                statusCode = error.response.statusCode.toString()
-            )
-        } catch (e: Exception) {
-            VardaRequestError(
-                method = request.method.toString(),
-                url = request.url.toString(),
-                body = request.body.asString("application/json"),
-                errorMessage = error.errorData.decodeToString(),
-                errorCode = null,
-                errorDescription = null,
-                statusCode = error.response.statusCode.toString()
-            )
-        }
-    }
-
-    private fun vardaError(
-        request: Request,
-        error: FuelError,
-        message: (meta: VardaRequestError) -> String
-    ): Nothing {
-        val meta = parseVardaError(request, error)
-        logger.error(request, meta.asMap()) {
-            "request failed ${meta.method} ${meta.url}, status ${meta.statusCode}, reason ${meta.errorCode}: ${meta.errorDescription}"
-        }
-        error(message(meta))
-    }
-
     /**
      * Wrapper for Fuel Request.responseString() that handles API token refreshes and retries when
      * throttled.
@@ -444,35 +366,29 @@ class VardaClient(
      * TODO: Make API token usage thread-safe. Now nothing prevents another thread from invalidating
      *   the token about to be used by another thread.
      */
-    private fun Request.authenticatedResponseStringWithRetries(
-        maxTries: Int = 3
-    ): ResponseResultOf<String> =
+    private fun <T> OkHttpClient.executeAuthenticated(
+        request: Request,
+        fn: (response: Response) -> T
+    ): T =
         tokenProvider.withToken { token, refreshToken ->
-            this.authentication()
-                .token(token)
-                .header(Headers.ACCEPT, "application/json")
-                .responseStringWithRetries(maxTries, 300L) { r, remainingTries ->
-                    when (r.second.statusCode) {
-                        403 ->
-                            when {
-                                jsonMapper.readTree(r.third.error.errorData).get("errors")?.any {
-                                    it.get("error_code").asText() == "PE007"
-                                } ?: false -> {
-                                    logger.info(
-                                        "Varda API token invalid. Refreshing token and retrying original request."
-                                    )
-                                    val newToken = refreshToken()
-                                    // API token refresh should only be attempted once -> don't pass
-                                    // an error handler to let
-                                    // any subsequent errors fall through.
-                                    this.authentication()
-                                        .token(newToken)
-                                        .responseStringWithRetries(remainingTries, 300L)
-                                }
-                                else -> r
-                            }
-                        else -> r
+            executeWithToken(request, token).use { response ->
+                if (response.code == 403) {
+                    val errorBody = response.body?.string() ?: ""
+                    if (errorBody.contains("PE007")) {
+                        logger.info {
+                            "Varda API token invalid. Refreshing token and retrying original request."
+                        }
+                        val newToken = refreshToken()
+                        executeWithToken(request, newToken).use { fn(it) }
+                    } else {
+                        fn(response)
                     }
+                } else {
+                    fn(response)
                 }
+            }
         }
+
+    private fun OkHttpClient.executeWithToken(request: Request, token: String): Response =
+        this.newCall(request.newBuilder().header("Authorization", "Token $token").build()).execute()
 }


### PR DESCRIPTION
Uusi async job `VardaPlanEndExistingChildData` ottaa parametrinaan loppupäivän (`endDate`) ja hakee Vardasta kaikki lapsi-tietueet. Jokaiselle löydetylle lapselle planataan async job `VardaEndExistingChildData`, joka hakee lapsen maksutiedot, varhaiskasvatussuhteet ja varhaiskasvatuspaatokset. Mikäli jokin kyseisistä tietueista on merkitty alkavaksi loppupäivän jälkeen, se poistetaan. Mikäli jokin tietue on merkitty päättyväksi loppupäivän jälkeen tai ei ollenkaan, se merkitään päättyväksi loppupäivänä.

Loppupäivän lisäksi kumpikin jobi ottaa parametrin `dryRun`. Jos se asetetaan arvoon `true`, ei jobi tee mitään muutoksia, vaan ainoastaan lokittaa muutokset, jotka tultaisiin tekemään.

Käytetään lisäämällä async job suoraan tietokantaan, esim:
```
-- Kaikki lapset
insert into async_job (type, run_at, retry_count, retry_interval, payload) values (
    'VardaPlanEndExistingChildData', current_timestamp, 1, '5 minutes',
    json_build_object('endDate', '2024-03-31', 'dryRun', true)
);

-- Yksi lapsi (vaatii Vardan lapsitietueen URL:n)
insert into async_job (type, run_at, retry_count, retry_interval, payload) values (
    'VardaEndExistingChildData', current_timestamp, 1, '5 minutes',
    json_build_object('lapsiUrl', 'https://...', 'endDate', '2024-03-31', 'dryRun', true)
);
```