### PR TITLE
Jamix-integraatio: Käsitellään asiakasnumeroita

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1231,7 +1231,7 @@ export const daycareGroupFixture: DevDaycareGroup = {
   name: 'Kosmiset vakiot',
   startDate: LocalDate.of(2000, 1, 1),
   endDate: null,
-  jamixCustomerId: null
+  jamixCustomerNumber: null
 }
 
 export function createDaycarePlacementFixture(
@@ -1323,7 +1323,7 @@ export class Fixture {
       name: `daycareGroup_${id}`,
       startDate: LocalDate.of(2020, 1, 1),
       endDate: null,
-      jamixCustomerId: null
+      jamixCustomerNumber: null
     })
   }
 

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -487,7 +487,7 @@ export interface DevDaycareGroup {
   daycareId: UUID
   endDate: LocalDate | null
   id: UUID
-  jamixCustomerId: number | null
+  jamixCustomerNumber: number | null
   name: string
   startDate: LocalDate
 }

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -106,7 +106,7 @@ beforeEach(async () => {
         name: 'Varayksikön ryhmä',
         startDate: LocalDate.of(2000, 1, 1),
         endDate: null,
-        jamixCustomerId: null
+        jamixCustomerNumber: null
       }
     ]
   })

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupUpdateModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupUpdateModal.tsx
@@ -34,12 +34,12 @@ export default React.memo(function GroupUpdateModal({ group }: Props) {
     name: string
     startDate: LocalDate
     endDate: LocalDate | null
-    jamixCustomerId: number | null
+    jamixCustomerNumber: number | null
   }>({
     name: group.name,
     startDate: group.startDate,
     endDate: group.endDate,
-    jamixCustomerId: group.jamixCustomerId
+    jamixCustomerNumber: group.jamixCustomerNumber
   })
 
   return (
@@ -99,13 +99,15 @@ export default React.memo(function GroupUpdateModal({ group }: Props) {
                 {i18n.unit.groups.updateModal.jamixTitle}
               </div>
               <InputField
-                value={data.jamixCustomerId?.toString() ?? ''}
+                value={data.jamixCustomerNumber?.toString() ?? ''}
                 onChange={(value) => {
                   if (value.match(/^\d*$/)) {
                     const parsedNumber = parseInt(value)
                     setData((state) => ({
                       ...state,
-                      jamixCustomerId: isNaN(parsedNumber) ? null : parsedNumber
+                      jamixCustomerNumber: isNaN(parsedNumber)
+                        ? null
+                        : parsedNumber
                     }))
                   }
                 }}

--- a/frontend/src/lib-common/generated/api-types/daycare.ts
+++ b/frontend/src/lib-common/generated/api-types/daycare.ts
@@ -284,7 +284,7 @@ export interface DaycareGroup {
   deletable: boolean
   endDate: LocalDate | null
   id: UUID
-  jamixCustomerId: number | null
+  jamixCustomerNumber: number | null
   name: string
   startDate: LocalDate
 }
@@ -360,7 +360,7 @@ export interface GroupStaffAttendance {
 */
 export interface GroupUpdateRequest {
   endDate: LocalDate | null
-  jamixCustomerId: number | null
+  jamixCustomerNumber: number | null
   name: string
   startDate: LocalDate
 }

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2422,8 +2422,8 @@ export const fi = {
         startDate: 'Perustettu',
         endDate: 'Lakkautettu',
         info: 'Ryhmän aikaisempia tietoja ei säilytetä',
-        jamixPlaceholder: 'Jamix customerID',
-        jamixTitle: 'Ruokatilausten asiakastunniste'
+        jamixPlaceholder: 'Jamix customerNumber',
+        jamixTitle: 'Ruokatilausten asiakasnumero'
       },
       startDate: 'Perustettu',
       endDate: 'Lakkautettu',

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareGroupQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareGroupQueries.kt
@@ -21,7 +21,7 @@ private fun Database.Read.createDaycareGroupQuery(
             // language=SQL
             """
 SELECT
-  id, daycare_id, name, start_date, end_date, jamix_customer_id,
+  id, daycare_id, name, start_date, end_date, jamix_customer_number,
   (NOT exists(SELECT 1 FROM backup_care WHERE group_id = daycare_group.id) AND
   NOT exists(SELECT 1 FROM daycare_group_placement WHERE daycare_group_id = daycare_group.id)) AS deletable
 FROM daycare_group
@@ -45,7 +45,7 @@ fun Database.Transaction.createDaycareGroup(
             """
 INSERT INTO daycare_group (daycare_id, name, start_date, end_date)
 VALUES (:daycareId, :name, :startDate, NULL)
-RETURNING id, daycare_id, name, start_date, end_date, true AS deletable, jamix_customer_id
+RETURNING id, daycare_id, name, start_date, end_date, true AS deletable, jamix_customer_number
 """
         )
         .bind("daycareId", daycareId)
@@ -59,13 +59,13 @@ fun Database.Transaction.updateGroup(
     name: String,
     startDate: LocalDate,
     endDate: LocalDate?,
-    jamixCustomerId: Int?
+    jamixCustomerNumber: Int?
 ) {
     createUpdate {
             sql(
                 """
 UPDATE daycare_group
-SET name = ${bind(name)}, start_date = ${bind(startDate)}, end_date = ${bind(endDate)}, jamix_customer_id = ${bind(jamixCustomerId)}
+SET name = ${bind(name)}, start_date = ${bind(startDate)}, end_date = ${bind(endDate)}, jamix_customer_number = ${bind(jamixCustomerNumber)}
 WHERE id = ${bind(groupId)}
         """
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -242,7 +242,7 @@ class DaycareController(
         val name: String,
         val startDate: LocalDate,
         val endDate: LocalDate?,
-        val jamixCustomerId: Int?
+        val jamixCustomerNumber: Int?
     )
 
     @PutMapping("/{daycareId}/groups/{groupId}")
@@ -262,7 +262,7 @@ class DaycareController(
                     body.name,
                     body.startDate,
                     body.endDate,
-                    body.jamixCustomerId
+                    body.jamixCustomerNumber
                 )
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -76,7 +76,7 @@ data class DaycareGroup(
     val startDate: LocalDate,
     val endDate: LocalDate?,
     val deletable: Boolean,
-    val jamixCustomerId: Int?
+    val jamixCustomerNumber: Int?
 )
 
 data class Caretakers(val minimum: Double, val maximum: Double)

--- a/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixQueries.kt
@@ -23,15 +23,18 @@ data class JamixChildData(
     val absences: Set<AbsenceCategory>
 )
 
-fun Database.Read.getJamixCustomerIds(): Set<Int> =
+fun Database.Read.getJamixCustomerNumbers(): Set<Int> =
     createQuery {
             sql(
-                "SELECT DISTINCT jamix_customer_id FROM daycare_group WHERE jamix_customer_id IS NOT NULL"
+                "SELECT DISTINCT jamix_customer_number FROM daycare_group WHERE jamix_customer_number IS NOT NULL"
             )
         }
         .toSet()
 
-fun Database.Read.getJamixChildData(jamixCustomerId: Int, date: LocalDate): List<JamixChildData> =
+fun Database.Read.getJamixChildData(
+    jamixCustomerNumber: Int,
+    date: LocalDate
+): List<JamixChildData> =
     createQuery {
             sql(
                 """
@@ -59,7 +62,7 @@ SELECT
 FROM realized_placement_one(${bind(date)}) rp
 JOIN daycare_group dg ON dg.id = rp.group_id
 JOIN person p ON p.id = rp.child_id
-WHERE dg.jamix_customer_id = ${bind(jamixCustomerId)}
+WHERE dg.jamix_customer_number = ${bind(jamixCustomerNumber)}
                     """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -322,7 +322,8 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
-    data class SendJamixOrder(val customerId: Int, val date: LocalDate) : AsyncJob {
+    data class SendJamixOrder(val customerNumber: Int, val customerId: Int, val date: LocalDate) :
+        AsyncJob {
         override val user: AuthenticatedUser? = null
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -712,8 +712,8 @@ fun Database.Transaction.insert(row: DevDaycareGroup): GroupId =
     createUpdate {
             sql(
                 """
-INSERT INTO daycare_group (id, daycare_id, name, start_date, end_date, jamix_customer_id)
-VALUES (${bind(row.id)}, ${bind(row.daycareId)}, ${bind(row.name)}, ${bind(row.startDate)}, ${bind(row.endDate)}, ${bind(row.jamixCustomerId)})
+INSERT INTO daycare_group (id, daycare_id, name, start_date, end_date, jamix_customer_number)
+VALUES (${bind(row.id)}, ${bind(row.daycareId)}, ${bind(row.name)}, ${bind(row.startDate)}, ${bind(row.endDate)}, ${bind(row.jamixCustomerNumber)})
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1864,7 +1864,7 @@ data class DevDaycareGroup(
     val name: String = "Testiläiset",
     val startDate: LocalDate = LocalDate.of(2019, 1, 1),
     val endDate: LocalDate? = null,
-    val jamixCustomerId: Int? = null
+    val jamixCustomerNumber: Int? = null
 )
 
 data class DevDaycareGroupPlacement(

--- a/service/src/main/resources/db/migration/V409__jamix_customer_number.sql
+++ b/service/src/main/resources/db/migration/V409__jamix_customer_number.sql
@@ -1,0 +1,1 @@
+ALTER TABLE daycare_group RENAME COLUMN jamix_customer_id TO jamix_customer_number;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -405,3 +405,4 @@ V405__employee_pin_locked_not_null.sql
 V406__varda_state_error.sql
 V407__official_language.sql
 V408__varda_unit_error.sql
+V409__jamix_customer_number.sql


### PR DESCRIPTION
Jamix-tilausten luonti tarvitsee asiakas-ID:n, mutta Jamixin käyttöliittymä tarjoaa vain asiakasnumeron. Tästä eteenpäin ryhmän tietoihin kirjataan asiakasnumero, jonka eVaka osaa muuntaa asiakas-ID:ksi ennen kuin tilauksia aletaan luoda.