### PR TITLE
Migratoidaan myös lasten OPH OID:t vanhasta Varda-integraatiosta uuteen

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaQueries.kt
@@ -237,6 +237,12 @@ fun Database.Transaction.addNewChildrenForVardaUpdate(migrationSpeed: Int = 0): 
                         NOT EXISTS (SELECT FROM varda_state WHERE child_id = evaka_child_id)
                     LIMIT ${bind(migrationSpeed)}
                     RETURNING child_id
+                ), _ AS (
+                    UPDATE person p SET oph_person_oid = voc.varda_person_oid
+                    FROM varda_organizer_child voc
+                    WHERE
+                        p.id IN (SELECT child_id from inserted_children) AND
+                        voc.evaka_person_id = p.id
                 )
                 DELETE FROM varda_reset_child
                 WHERE evaka_child_id IN (SELECT child_id FROM inserted_children)


### PR DESCRIPTION
Jos lapsella ei ole OPH OID:tä, tehdään `/v1/hae-henkilo`-apikutsu henkilötunnuksen perusteella. Varda kuitenkin näyttää rajoittavan (ainakin) henkilötunnuksellisia hakuja 500 kappaleeseen per vuorokausi, jolloin migraationopeus ei voi käytännössä olla kuin ~400, jotta jäisi varaa myös kokonaan uusien lapsten viennille.

Vanhan integraation `varda_organizer_child`-taulu sisältää lasten OPH OID:t, joten kopioidaan migratoiduille lapsille OID sieltä.