### PR TITLE
Jamix diet sync

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/child-information.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information.spec.ts
@@ -143,18 +143,16 @@ describe('Child Information - edit additional information', () => {
       body: [
         {
           id: 79,
-          name: 'Laktoositon',
           abbreviation: 'L'
         },
         {
           id: 80,
-          name: 'Gluteeniton Laktoositon',
           abbreviation: 'L G'
         }
       ]
     })
-    const dietCaption = 'L (Laktoositon) - 79'
-    const dietSearchTerm = 'laktoosi'
+    const dietCaption = 'L - 79'
+    const dietSearchTerm = 'L - 79'
     const dietId = 79
 
     await page.goto(

--- a/frontend/src/employee-frontend/components/child-information/person-details/AdditionalInformation.tsx
+++ b/frontend/src/employee-frontend/components/child-information/person-details/AdditionalInformation.tsx
@@ -70,7 +70,7 @@ interface Props {
 }
 
 function getDietCaption(diet: SpecialDiet) {
-  return `${diet.abbreviation}${diet.name ? ` (${diet.name})` : ''} - ${diet.id}`
+  return `${diet.abbreviation} - ${diet.id}`
 }
 
 export default React.memo(function AdditionalInformation({ childId }: Props) {

--- a/frontend/src/employee-frontend/components/reports/MealReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/MealReport.tsx
@@ -87,7 +87,6 @@ const MealReportData = ({
       mealId: i18n.reports.meals.headings.mealId,
       mealCount: i18n.reports.meals.headings.mealCount,
       dietId: i18n.reports.meals.headings.dietId,
-      dietName: i18n.reports.meals.headings.dietName,
       dietAbbreviation: i18n.reports.meals.headings.dietAbbreviation,
       additionalInfo: i18n.reports.meals.headings.additionalInfo
     }

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -461,7 +461,6 @@ export interface MealReportRow {
   additionalInfo: string | null
   dietAbbreviation: string | null
   dietId: number | null
-  dietName: string | null
   mealCount: number
   mealId: number
   mealType: MealType

--- a/frontend/src/lib-common/generated/api-types/specialdiet.ts
+++ b/frontend/src/lib-common/generated/api-types/specialdiet.ts
@@ -26,5 +26,4 @@ export interface JamixSpecialDietFields {
 export interface SpecialDiet {
   abbreviation: string
   id: number | null
-  name: string
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/jamix/JamixIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/jamix/JamixIntegrationTest.kt
@@ -178,7 +178,7 @@ class JamixIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
                 )
                 .forEach { tx.insert(it) }
 
-            tx.setSpecialDiets(listOf(SpecialDiet(1, "diet name", "diet abbreviation")))
+            tx.setSpecialDiets(listOf(SpecialDiet(1, "diet abbreviation")))
 
             tx.insert(childWithSpecialDiet, DevPersonType.RAW_ROW)
             tx.insert(DevChild(id = childWithSpecialDiet.id, dietId = 1))
@@ -303,10 +303,7 @@ class JamixIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         fetchAndUpdateJamixDiets(client, db)
         db.transaction { tx ->
             val diets = tx.getSpecialDiets().toSet()
-            assertEquals(
-                setOf(SpecialDiet(1, "Foobar", "Foo"), SpecialDiet(2, "Hello World", "Hello")),
-                diets
-            )
+            assertEquals(setOf(SpecialDiet(1, "Foo"), SpecialDiet(2, "Hello")), diets)
         }
     }
 
@@ -314,7 +311,7 @@ class JamixIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     fun `diet sync nullifies removed diets from child`() {
         val childWithSpecialDiet = DevPerson(firstName = "Diet", lastName = "Johnson")
         db.transaction { tx ->
-            tx.setSpecialDiets(listOf(SpecialDiet(555, "diet name", "diet abbreviation")))
+            tx.setSpecialDiets(listOf(SpecialDiet(555, "diet abbreviation")))
             tx.insert(childWithSpecialDiet, DevPersonType.RAW_ROW)
             tx.insert(DevChild(id = childWithSpecialDiet.id, dietId = 555))
         }
@@ -340,9 +337,7 @@ class JamixIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     fun `diet sync keeps diet selection when diet abbreviation changes`() {
         val childWithSpecialDiet = DevPerson(firstName = "Diet", lastName = "Johnson")
         db.transaction { tx ->
-            tx.setSpecialDiets(
-                listOf(SpecialDiet(1, "diet name with a typo", "diet abbreviation with a typo"))
-            )
+            tx.setSpecialDiets(listOf(SpecialDiet(1, "diet abbreviation with a typo")))
             tx.insert(childWithSpecialDiet, DevPersonType.RAW_ROW)
             tx.insert(DevChild(id = childWithSpecialDiet.id, dietId = 1))
         }
@@ -361,7 +356,7 @@ class JamixIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             val childAfterSync = tx.getChild(childWithSpecialDiet.id)
             assertNotNull(childAfterSync)
             assertEquals(
-                SpecialDiet(1, "diet name fixed", "diet abbreviation fixed"),
+                SpecialDiet(1, "diet abbreviation fixed"),
                 childAfterSync.additionalInformation.specialDiet
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/ChildQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/ChildQueries.kt
@@ -12,7 +12,7 @@ fun Database.Read.getChild(id: ChildId): Child? {
     // language=SQL
     val sql =
         """
-SELECT child.*, person.preferred_name, special_diet.id as special_diet_id, special_diet.name as special_diet_name, special_diet.abbreviation as special_diet_abbreviation
+SELECT child.*, person.preferred_name, special_diet.id as special_diet_id, special_diet.abbreviation as special_diet_abbreviation
 FROM child JOIN person ON child.id = person.id LEFT JOIN special_diet on child.diet_id = special_diet.id
 WHERE child.id = :id
 """

--- a/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
@@ -294,14 +294,9 @@ private fun LocalDate.weekSpan(): FiniteDateRange {
 }
 
 fun cleanupJamixDietList(specialDietList: List<JamixSpecialDiet>): List<SpecialDiet> {
-    return specialDietList
-        .map {
-            SpecialDiet(
-                it.modelId,
-                cleanupJamixString(it.fields.dietName),
-                cleanupJamixString(it.fields.dietAbbreviation)
-            )
-        }
+    return specialDietList.map {
+        SpecialDiet(it.modelId, cleanupJamixString(it.fields.dietAbbreviation))
+    }
 }
 
 fun cleanupJamixString(s: String): String {

--- a/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
@@ -298,21 +298,12 @@ fun cleanupJamixDietList(specialDietList: List<JamixSpecialDiet>): List<SpecialD
         .map {
             SpecialDiet(
                 it.modelId,
-                cleanupJamixDietNameString(it.fields.dietName),
-                cleanupJamixDietAbbreviationString(it.fields.dietAbbreviation)
+                cleanupJamixString(it.fields.dietName),
+                cleanupJamixString(it.fields.dietAbbreviation)
             )
         }
-        .filterNot { it.name.contains("POISTA") }
-        .filterNot { it.name.isEmpty() && it.abbreviation.isEmpty() }
 }
 
-fun cleanupJamixDietNameString(s: String): String {
-    return s.replace("tsekattava", "", true)
-        .replace("tsek", "", true)
-        .replace(Regex("\\s+"), " ")
-        .trim()
-}
-
-fun cleanupJamixDietAbbreviationString(s: String): String {
-    return s.replace("ätarkasta", "", true).replace(Regex("\\s+"), " ").trim()
+fun cleanupJamixString(s: String): String {
+    return s.replace(Regex("\\s+"), " ").trim()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MealReportUtil.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MealReportUtil.kt
@@ -29,7 +29,6 @@ data class MealReportRow(
     val mealId: Int,
     val mealCount: Int,
     val dietId: Int? = null,
-    val dietName: String? = null,
     val dietAbbreviation: String? = null,
     val additionalInfo: String? = null
 )
@@ -136,7 +135,6 @@ fun mealReportData(
                                     childInfo.lastName + " " + childInfo.firstName
                                 } else null,
                             dietId = childInfo.dietInfo?.id,
-                            dietName = childInfo.dietInfo?.name,
                             dietAbbreviation = childInfo.dietInfo?.abbreviation
                         )
                     }
@@ -150,7 +148,6 @@ fun mealReportData(
             mealTypeMapper.toMealId(it.key.mealType, it.key.dietId != null),
             it.value,
             it.key.dietId,
-            it.key.dietName,
             it.key.dietAbbreviation,
             it.key.additionalInfo
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -143,7 +143,7 @@ class AsyncJobRunner<T : AsyncJobPayload>(
 
     fun startBackgroundPolling(
         clock: EvakaClock = RealEvakaClock(),
-        pollingInterval: Duration = Duration.ofSeconds(2)
+        pollingInterval: Duration = Duration.ofMinutes(1)
     ) {
         val newTimer =
             fixedRateTimer("$name.timer", period = pollingInterval.toMillis()) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -143,7 +143,7 @@ class AsyncJobRunner<T : AsyncJobPayload>(
 
     fun startBackgroundPolling(
         clock: EvakaClock = RealEvakaClock(),
-        pollingInterval: Duration = Duration.ofMinutes(1)
+        pollingInterval: Duration = Duration.ofSeconds(2)
     ) {
         val newTimer =
             fixedRateTimer("$name.timer", period = pollingInterval.toMillis()) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -191,6 +191,7 @@ import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.shared.security.actionrule.AccessControlFilter
 import fi.espoo.evaka.shared.security.upsertEmployeeUser
 import fi.espoo.evaka.specialdiet.SpecialDiet
+import fi.espoo.evaka.specialdiet.resetSpecialDietsNotContainedWithin
 import fi.espoo.evaka.specialdiet.setSpecialDiets
 import fi.espoo.evaka.vasu.CurriculumType
 import fi.espoo.evaka.vasu.getDefaultTemplateContent
@@ -1623,7 +1624,12 @@ $form
 
     @PutMapping("/diets")
     fun putDiets(db: Database, @RequestBody diets: List<SpecialDiet>) {
-        db.connect { dbc -> dbc.transaction { tx -> tx.setSpecialDiets((diets)) } }
+        db.connect { dbc ->
+            dbc.transaction { tx ->
+                tx.resetSpecialDietsNotContainedWithin(diets)
+                tx.setSpecialDiets(diets)
+            }
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -122,6 +122,10 @@ enum class ScheduledJob(
             schedule = JobSchedule.cron("0 25 2 * * 2") // tue @ 2:25
         )
     ),
+    SyncJamixDiets(
+        ScheduledJobs::syncJamixDiets,
+        ScheduledJobSettings(enabled = false, schedule = JobSchedule.cron("0 */10 * * * *"))
+    ),
     SendPendingDecisionReminderEmails(
         ScheduledJobs::sendPendingDecisionReminderEmails,
         ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(7, 0)))
@@ -337,6 +341,10 @@ WHERE id IN (SELECT id FROM attendances_to_end)
 
     fun sendJamixOrders(db: Database.Connection, clock: EvakaClock) {
         jamixService.planOrders(db, clock)
+    }
+
+    fun syncJamixDiets(db: Database.Connection, clock: EvakaClock) {
+        jamixService.syncDiets(db, clock)
     }
 
     fun sendPendingDecisionReminderEmails(db: Database.Connection, clock: EvakaClock) {

--- a/service/src/main/kotlin/fi/espoo/evaka/specialdiet/SpecialDietQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/specialdiet/SpecialDietQueries.kt
@@ -7,7 +7,7 @@ package fi.espoo.evaka.specialdiet
 import fi.espoo.evaka.shared.db.Database
 import org.jdbi.v3.core.mapper.PropagateNull
 
-data class SpecialDiet(@PropagateNull val id: Int?, val name: String, val abbreviation: String)
+data class SpecialDiet(@PropagateNull val id: Int?, val abbreviation: String)
 
 /**
  * Sets child's special diets to null if there are some children whose special diet is not contained
@@ -31,14 +31,12 @@ fun Database.Transaction.setSpecialDiets(specialDietList: List<SpecialDiet>): In
     executeBatch(specialDietList) {
         sql(
             """
-INSERT INTO special_diet (id, name, abbreviation)
+INSERT INTO special_diet (id, abbreviation)
 VALUES (
     ${bind{it.id}},
-    ${bind{it.name}},
     ${bind{it.abbreviation}}
 )
 ON CONFLICT (id) DO UPDATE SET
-  name = excluded.name,
   abbreviation = excluded.abbreviation
 """
         )
@@ -47,6 +45,5 @@ ON CONFLICT (id) DO UPDATE SET
 }
 
 fun Database.Transaction.getSpecialDiets(): List<SpecialDiet> {
-    return createQuery { sql("SELECT id, name, abbreviation FROM special_diet") }
-        .toList<SpecialDiet>()
+    return createQuery { sql("SELECT id, abbreviation FROM special_diet") }.toList<SpecialDiet>()
 }

--- a/service/src/main/resources/db/migration/V412__special_diet_foreing_key.sql
+++ b/service/src/main/resources/db/migration/V412__special_diet_foreing_key.sql
@@ -1,0 +1,8 @@
+alter table child
+    drop constraint fk$diet_id_special_diet_id;
+
+alter table child
+    add constraint fk$diet_id_special_diet_id
+        foreign key (diet_id) references special_diet
+            deferrable;
+

--- a/service/src/main/resources/db/migration/V412__special_diet_foreing_key.sql
+++ b/service/src/main/resources/db/migration/V412__special_diet_foreing_key.sql
@@ -1,8 +1,3 @@
-alter table child
-    drop constraint fk$diet_id_special_diet_id;
-
-alter table child
-    add constraint fk$diet_id_special_diet_id
-        foreign key (diet_id) references special_diet
-            deferrable;
+alter table special_diet
+    drop column name;
 

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -408,3 +408,4 @@ V408__varda_unit_error.sql
 V409__jamix_customer_number.sql
 V410__parentship_meta_data.sql
 V411__daycare_shiftcare_operation_times.sql
+V412__special_diet_foreing_key.sql

--- a/service/src/test/kotlin/fi/espoo/evaka/jamix/JamixServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/jamix/JamixServiceTest.kt
@@ -15,16 +15,19 @@ class JamixServiceTest {
     fun `cleanupJamixDietList retains normal entries`() {
         val testData = listOf(JamixSpecialDiet(1, JamixSpecialDietFields("Foobar", "Foo")))
         val result = cleanupJamixDietList(testData)
-        assertEquals(setOf(SpecialDiet(1, "Foobar", "Foo")), result.toSet())
+        assertEquals(setOf(SpecialDiet(1, "Foo")), result.toSet())
     }
 
     @Test
     fun `cleanupJamixDietList strips whitespace from entries`() {
         val testData =
             listOf(
-                JamixSpecialDiet(1, JamixSpecialDietFields("tsekattava   \nFoobar  ", "ätarkastaFoo"))
+                JamixSpecialDiet(
+                    1,
+                    JamixSpecialDietFields("tsekattava   \nFoobar  ", "ätarkasta   \nFoo")
+                )
             )
         val result = cleanupJamixDietList(testData)
-        assertEquals(setOf(SpecialDiet(1, "tsekattava Foobar", "ätarkastaFoo")), result.toSet())
+        assertEquals(setOf(SpecialDiet(1, "ätarkasta Foo")), result.toSet())
     }
 }

--- a/service/src/test/kotlin/fi/espoo/evaka/jamix/JamixServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/jamix/JamixServiceTest.kt
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.jamix
+
+import fi.espoo.evaka.specialdiet.JamixSpecialDiet
+import fi.espoo.evaka.specialdiet.JamixSpecialDietFields
+import fi.espoo.evaka.specialdiet.SpecialDiet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JamixServiceTest {
+    @Test
+    fun `cleanupJamixDietList retains normal entries`() {
+        val testData = listOf(JamixSpecialDiet(1, JamixSpecialDietFields("Foobar", "Foo")))
+        val result = cleanupJamixDietList(testData)
+        assertEquals(setOf(SpecialDiet(1, "Foobar", "Foo")), result.toSet())
+    }
+
+    @Test
+    fun `cleanupJamixDietList removes POISTA entries`() {
+        val testData =
+            listOf(
+                JamixSpecialDiet(1, JamixSpecialDietFields("Foobar", "Foo")),
+                JamixSpecialDiet(1, JamixSpecialDietFields("POISTA", "Foo"))
+            )
+        val result = cleanupJamixDietList(testData)
+        assertEquals(setOf(SpecialDiet(1, "Foobar", "Foo")), result.toSet())
+    }
+
+    @Test
+    fun `cleanupJamixDietList strips ätarkasta, tsekattava and whitespace from entries`() {
+        val testData =
+            listOf(
+                JamixSpecialDiet(1, JamixSpecialDietFields("tsekattava\nFoobar  ", "ätarkastaFoo"))
+            )
+        val result = cleanupJamixDietList(testData)
+        assertEquals(setOf(SpecialDiet(1, "Foobar", "Foo")), result.toSet())
+    }
+}

--- a/service/src/test/kotlin/fi/espoo/evaka/jamix/JamixServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/jamix/JamixServiceTest.kt
@@ -19,23 +19,12 @@ class JamixServiceTest {
     }
 
     @Test
-    fun `cleanupJamixDietList removes POISTA entries`() {
+    fun `cleanupJamixDietList strips whitespace from entries`() {
         val testData =
             listOf(
-                JamixSpecialDiet(1, JamixSpecialDietFields("Foobar", "Foo")),
-                JamixSpecialDiet(1, JamixSpecialDietFields("POISTA", "Foo"))
+                JamixSpecialDiet(1, JamixSpecialDietFields("tsekattava   \nFoobar  ", "ätarkastaFoo"))
             )
         val result = cleanupJamixDietList(testData)
-        assertEquals(setOf(SpecialDiet(1, "Foobar", "Foo")), result.toSet())
-    }
-
-    @Test
-    fun `cleanupJamixDietList strips ätarkasta, tsekattava and whitespace from entries`() {
-        val testData =
-            listOf(
-                JamixSpecialDiet(1, JamixSpecialDietFields("tsekattava\nFoobar  ", "ätarkastaFoo"))
-            )
-        val result = cleanupJamixDietList(testData)
-        assertEquals(setOf(SpecialDiet(1, "Foobar", "Foo")), result.toSet())
+        assertEquals(setOf(SpecialDiet(1, "tsekattava Foobar", "ätarkastaFoo")), result.toSet())
     }
 }

--- a/service/src/test/kotlin/fi/espoo/evaka/reports/MealReportTests.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/reports/MealReportTests.kt
@@ -170,8 +170,8 @@ class MealReportTests {
     @Test
     fun `mealReportData should provide individual rows for meals when child has special diet`() {
         val testDate = LocalDate.of(2023, 5, 10)
-        val glutenFreeDiet = SpecialDiet(id = 101, name = "Gluten-Free", abbreviation = "G")
-        val lactoseFreeDiet = SpecialDiet(id = 42, name = "Lactose-Free", abbreviation = "L")
+        val glutenFreeDiet = SpecialDiet(id = 101, abbreviation = "G")
+        val lactoseFreeDiet = SpecialDiet(id = 42, abbreviation = "L")
         val childInfo =
             listOf(
                 MealReportChildInfo( // child with glutenFreeDiet
@@ -246,7 +246,6 @@ class MealReportTests {
                     143,
                     1,
                     glutenFreeDiet.id,
-                    glutenFreeDiet.name,
                     glutenFreeDiet.abbreviation,
                     "Brown Ella"
                 ),
@@ -255,7 +254,6 @@ class MealReportTests {
                     145,
                     1,
                     glutenFreeDiet.id,
-                    glutenFreeDiet.name,
                     glutenFreeDiet.abbreviation,
                     "Brown Ella"
                 ),
@@ -264,7 +262,6 @@ class MealReportTests {
                     160,
                     1,
                     glutenFreeDiet.id,
-                    glutenFreeDiet.name,
                     glutenFreeDiet.abbreviation,
                     "Brown Ella"
                 )
@@ -284,7 +281,6 @@ class MealReportTests {
                     145,
                     1,
                     glutenFreeDiet.id,
-                    glutenFreeDiet.name,
                     glutenFreeDiet.abbreviation,
                     "Brown Mike"
                 ),
@@ -304,7 +300,6 @@ class MealReportTests {
                     145,
                     1,
                     lactoseFreeDiet.id,
-                    lactoseFreeDiet.name,
                     lactoseFreeDiet.abbreviation,
                     "Mallikas Mikko"
                 ),


### PR DESCRIPTION
Tämä muutos lisää 10 minuutin välein ajettavan erityisruokavaliosynkronoinnin Jamix API -> eVaka.

Tämä muutos poistaa Jamix -> eVaka erityisruokavalio synkronoinnista listan siivouksen: Aikaisemmin kaikki POISTA-sanan sisältävät tiedot jätettiin tuomatta eVakaan ja sanat "ätarkasta", "tsek" ja "tsekattava" poistettiin näkyvistä.

Tämä muutos poistaa `special_diets` tietokantataulusta `name` sarakkeen koska Jamix:in nimi tietueet voivat sisältää arkaluontoista tietoa jota emme halua eVakaan.

Käyttöönotto:
Aseta Spring property:
```
evaka.job.sync_jamix_diets.enabled = true
```