### PR TITLE
Hakemuksia voi hakea myös toissijaisten toiveiden palvelualueiden perusteella

### DIFF
--- a/frontend/src/employee-frontend/components/applications/ApplicationsFilters.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsFilters.tsx
@@ -227,7 +227,10 @@ export default React.memo(function ApplicationFilters() {
           <ApplicationDistinctionsFilter
             toggle={toggleApplicationDistinctions}
             toggled={applicationSearchFilters.distinctions}
-            disableSecondary={applicationSearchFilters.units.length === 0}
+            disableSecondary={
+              applicationSearchFilters.area.length === 0 &&
+              applicationSearchFilters.units.length === 0
+            }
           />
           <Gap size="L" />
           <ApplicationTypeFilter


### PR DESCRIPTION
Hakemushaun valinta "Näytä myös, jos yksikköön on haettu 2. tai 3. toiveena" vaikuttaa nyt myös palvelualue-filtteriin.