### PR TITLE
Päätetään edellisen vaka-järjestelmän Varda-tiedot normaalin Varda-päivityksen yhteydessä

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
@@ -25,7 +25,8 @@ private val logger = KotlinLogging.logger {}
 private fun maskHenkilotunnus(henkilotunnus: String?): String? =
     henkilotunnus?.let { "${it.slice(0..4)}******" }
 
-private fun maskName(name: String): String = name.take(2) + "*".repeat(name.length - 2)
+private fun maskName(name: String): String =
+    if (name.length > 2) name.take(2) + "*".repeat(name.length - 2) else "**"
 
 interface VardaReadClient {
     @JsonInclude(JsonInclude.Include.NON_NULL)


### PR DESCRIPTION
Mikäli jokin toinen lähdejärjestelmä on syöttänyt dataa Vardaan, ja se menee päällekkäin eVakassa olevan datan kanssa, poistetaan vanha data tai asetetaan se päättymään eVakan Varda-datan alkupäivää edeltävään päivään.

Mikäli `evaka.integration.varda.start_date` on asetettu, mikään eVakan Varda-data ei ulotu tätä kauemmas menneisyyteen joten olemassaolevat data katkaistaan päättymään tätä päivää edeltävänä päivänä.