### PR TITLE
Kuntalaisen sähköposti-ilmoituksen lähettäminen uusista talouspäätöksistä

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -32,15 +32,16 @@ import fi.espoo.evaka.placement.insertPlacement
 import fi.espoo.evaka.sficlient.MockSfiMessagesClient
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.FeeDecisionId
+import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.dev.DevParentship
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.insert
-import fi.espoo.evaka.shared.dev.insertTestParentship
 import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
@@ -2076,11 +2077,15 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             )
         db.transaction {
             it.insert(optInAdult, DevPersonType.RAW_ROW)
-            it.insertTestParentship(
-                headOfChild = optInAdult.id,
-                childId = testChild_2.id,
-                startDate = testChild_2.dateOfBirth,
-                endDate = testChild_2.dateOfBirth.plusYears(18).minusDays(1)
+            it.insert(
+                DevParentship(
+                    ParentshipId(UUID.randomUUID()),
+                    testChild_2.id,
+                    optInAdult.id,
+                    testChild_2.dateOfBirth,
+                    testChild_2.dateOfBirth.plusYears(18).minusDays(1),
+                    HelsinkiDateTime.now()
+                )
             )
             it.insertTestPartnership(adult1 = optInAdult.id, adult2 = testAdult_7.id)
         }
@@ -2110,11 +2115,15 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
     fun `Email notification is sent to hof when decision in WAITING_FOR_MANUAL_SENDING is set to SENT`() {
         db.transaction {
             // testAdult_3 has an email address, but no mail address -> marked for manual sending
-            it.insertTestParentship(
-                headOfChild = testAdult_3.id,
-                childId = testChild_2.id,
-                startDate = testChild_2.dateOfBirth,
-                endDate = testChild_2.dateOfBirth.plusYears(18).minusDays(1)
+            it.insert(
+                DevParentship(
+                    ParentshipId(UUID.randomUUID()),
+                    testChild_2.id,
+                    testAdult_3.id,
+                    testChild_2.dateOfBirth,
+                    testChild_2.dateOfBirth.plusYears(18).minusDays(1),
+                    HelsinkiDateTime.now()
+                )
             )
             it.insertTestPartnership(adult1 = testAdult_3.id, adult2 = testAdult_4.id)
         }
@@ -2166,11 +2175,15 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             )
         db.transaction {
             it.insert(optOutAdult, DevPersonType.RAW_ROW)
-            it.insertTestParentship(
-                headOfChild = optOutAdult.id,
-                childId = testChild_2.id,
-                startDate = testChild_2.dateOfBirth,
-                endDate = testChild_2.dateOfBirth.plusYears(18).minusDays(1)
+            it.insert(
+                DevParentship(
+                    ParentshipId(UUID.randomUUID()),
+                    testChild_2.id,
+                    optOutAdult.id,
+                    testChild_2.dateOfBirth,
+                    testChild_2.dateOfBirth.plusYears(18).minusDays(1),
+                    HelsinkiDateTime.now()
+                )
             )
             it.insertTestPartnership(adult1 = optOutAdult.id, adult2 = testAdult_7.id)
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -6,7 +6,6 @@ package fi.espoo.evaka.invoicing
 
 import fi.espoo.evaka.EmailEnv
 import fi.espoo.evaka.FullApplicationTest
-import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.emailclient.Email
 import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.emailclient.MockEmailClient
@@ -2094,10 +2093,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         val emailContent =
-            emailMessageProvider.financeDecisionNotification(
-                Language.fi,
-                FinanceDecisionType.FEE_DECISION
-            )
+            emailMessageProvider.financeDecisionNotification(FinanceDecisionType.FEE_DECISION)
 
         // assert that only hof has mail
         assertEquals(
@@ -2145,10 +2141,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         asyncJobRunner.runPendingJobsSync(RealEvakaClock())
 
         val emailContent =
-            emailMessageProvider.financeDecisionNotification(
-                Language.fi,
-                FinanceDecisionType.FEE_DECISION
-            )
+            emailMessageProvider.financeDecisionNotification(FinanceDecisionType.FEE_DECISION)
 
         // assert that only hof has mail
         assertEquals(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -4,7 +4,12 @@
 
 package fi.espoo.evaka.invoicing
 
+import fi.espoo.evaka.EmailEnv
 import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.daycare.domain.Language
+import fi.espoo.evaka.emailclient.Email
+import fi.espoo.evaka.emailclient.IEmailMessageProvider
+import fi.espoo.evaka.emailclient.MockEmailClient
 import fi.espoo.evaka.insertGeneralTestFixtures
 import fi.espoo.evaka.invoicing.controller.DistinctiveParams
 import fi.espoo.evaka.invoicing.controller.FeeDecisionController
@@ -19,6 +24,8 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionDetailed
 import fi.espoo.evaka.invoicing.domain.FeeDecisionStatus
 import fi.espoo.evaka.invoicing.domain.FeeDecisionSummary
 import fi.espoo.evaka.invoicing.domain.FeeDecisionType
+import fi.espoo.evaka.invoicing.domain.FinanceDecisionType
+import fi.espoo.evaka.pis.EmailMessageType
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.insertPlacement
@@ -33,6 +40,8 @@ import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.insert
+import fi.espoo.evaka.shared.dev.insertTestParentship
+import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.EvakaClock
@@ -47,7 +56,9 @@ import fi.espoo.evaka.snDefaultDaycare
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testAdult_3
+import fi.espoo.evaka.testAdult_4
 import fi.espoo.evaka.testAdult_5
+import fi.espoo.evaka.testAdult_6
 import fi.espoo.evaka.testAdult_7
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
@@ -71,6 +82,8 @@ import org.springframework.beans.factory.annotation.Autowired
 class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     @Autowired private lateinit var feeDecisionController: FeeDecisionController
     @Autowired private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
+    @Autowired private lateinit var emailMessageProvider: IEmailMessageProvider
+    @Autowired private lateinit var emailEnv: EmailEnv
 
     private val user =
         AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.FINANCE_ADMIN))
@@ -299,6 +312,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
     @BeforeEach
     fun beforeEach() {
         MockSfiMessagesClient.clearMessages()
+        MockEmailClient.clear()
 
         db.transaction { tx -> tx.insertGeneralTestFixtures() }
     }
@@ -2049,6 +2063,125 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         assertEqualEnough(preschoolClubDecisions.map { toSummary(it) }, result.data)
     }
 
+    @Test
+    fun `Email notification is sent to hof when decision in WAITING_FOR_SENDING is set to SENT`() {
+        // optInAdult has an email address, and does not require manual sending of PDF decision
+        val optInAdult =
+            testAdult_6.copy(
+                id = PersonId(UUID.randomUUID()),
+                email = "optin@test.com",
+                forceManualFeeDecisions = false,
+                ssn = "291090-9986",
+                enabledEmailTypes = listOf(EmailMessageType.DECISION_NOTIFICATION)
+            )
+        db.transaction {
+            it.insert(optInAdult, DevPersonType.RAW_ROW)
+            it.insertTestParentship(
+                headOfChild = optInAdult.id,
+                childId = testChild_2.id,
+                startDate = testChild_2.dateOfBirth,
+                endDate = testChild_2.dateOfBirth.plusYears(18).minusDays(1)
+            )
+            it.insertTestPartnership(adult1 = optInAdult.id, adult2 = testAdult_7.id)
+        }
+        createAndConfirmFeeDecisionsForFamily(optInAdult, testAdult_7, listOf(testChild_2))
+
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+
+        val emailContent =
+            emailMessageProvider.financeDecisionNotification(
+                Language.fi,
+                FinanceDecisionType.FEE_DECISION
+            )
+
+        // assert that only hof has mail
+        assertEquals(
+            setOfNotNull(optInAdult.email),
+            MockEmailClient.emails.map { it.toAddress }.toSet()
+        )
+        assertEquals(emailContent.subject, getEmailFor(optInAdult).content.subject)
+        assertEquals(
+            "${emailEnv.senderNameFi} <${emailEnv.senderAddress}>",
+            getEmailFor(optInAdult).fromAddress
+        )
+    }
+
+    @Test
+    fun `Email notification is sent to hof when decision in WAITING_FOR_MANUAL_SENDING is set to SENT`() {
+        db.transaction {
+            // testAdult_3 has an email address, but no mail address -> marked for manual sending
+            it.insertTestParentship(
+                headOfChild = testAdult_3.id,
+                childId = testChild_2.id,
+                startDate = testChild_2.dateOfBirth,
+                endDate = testChild_2.dateOfBirth.plusYears(18).minusDays(1)
+            )
+            it.insertTestPartnership(adult1 = testAdult_3.id, adult2 = testAdult_4.id)
+        }
+        val feeDecision =
+            createAndConfirmFeeDecisionsForFamily(testAdult_3, testAdult_4, listOf(testChild_2))
+
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+
+        // assert that nothing sent yet
+        assertEquals(emptySet(), MockEmailClient.emails.map { it.toAddress }.toSet())
+
+        // mark waiting as sent
+        feeDecisionController.setFeeDecisionSent(
+            dbInstance(),
+            user,
+            RealEvakaClock(),
+            listOf(feeDecision.id)
+        )
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+
+        val emailContent =
+            emailMessageProvider.financeDecisionNotification(
+                Language.fi,
+                FinanceDecisionType.FEE_DECISION
+            )
+
+        // assert that only hof has mail
+        assertEquals(
+            setOfNotNull(testAdult_3.email),
+            MockEmailClient.emails.map { it.toAddress }.toSet()
+        )
+        assertEquals(emailContent.subject, getEmailFor(testAdult_3).content.subject)
+        assertEquals(
+            "${emailEnv.senderNameFi} <${emailEnv.senderAddress}>",
+            getEmailFor(testAdult_3).fromAddress
+        )
+    }
+
+    @Test
+    fun `Email notification is not sent to hof when opted out of decision emails`() {
+        // optOutAdult is eligible, but has elected to not receive decision emails
+        val optOutAdult =
+            testAdult_6.copy(
+                id = PersonId(UUID.randomUUID()),
+                ssn = "291090-9986",
+                email = "optout@test.com",
+                forceManualFeeDecisions = false,
+                enabledEmailTypes = listOf(),
+            )
+        db.transaction {
+            it.insert(optOutAdult, DevPersonType.RAW_ROW)
+            it.insertTestParentship(
+                headOfChild = optOutAdult.id,
+                childId = testChild_2.id,
+                startDate = testChild_2.dateOfBirth,
+                endDate = testChild_2.dateOfBirth.plusYears(18).minusDays(1)
+            )
+            it.insertTestPartnership(adult1 = optOutAdult.id, adult2 = testAdult_7.id)
+        }
+        createAndConfirmFeeDecisionsForFamily(optOutAdult, testAdult_7, listOf(testChild_2))
+
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+
+        // assert that no mail for anyone
+        assertEquals(emptySet(), MockEmailClient.emails.map { it.toAddress }.toSet())
+    }
+
     private fun getPdf(id: FeeDecisionId, user: AuthenticatedUser.Employee) {
         feeDecisionController.getFeeDecisionPdf(dbInstance(), user, RealEvakaClock(), id)
     }
@@ -2132,5 +2265,10 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
 
     private fun setDecisionType(id: FeeDecisionId, body: FeeDecisionTypeRequest) {
         feeDecisionController.setFeeDecisionType(dbInstance(), user, RealEvakaClock(), id, body)
+    }
+
+    private fun getEmailFor(person: DevPerson): Email {
+        val address = person.email ?: throw Error("$person has no email")
+        return MockEmailClient.getEmail(address) ?: throw Error("No emails sent to $address")
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -9,7 +9,6 @@ import com.github.kittinunf.fuel.jackson.objectBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.EmailEnv
 import fi.espoo.evaka.FullApplicationTest
-import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.emailclient.Email
 import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.emailclient.MockEmailClient
@@ -573,7 +572,6 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         val emailContent =
             emailMessageProvider.financeDecisionNotification(
-                Language.fi,
                 FinanceDecisionType.VOUCHER_VALUE_DECISION
             )
 
@@ -618,7 +616,6 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         val emailContent =
             emailMessageProvider.financeDecisionNotification(
-                Language.fi,
                 FinanceDecisionType.VOUCHER_VALUE_DECISION
             )
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -30,6 +30,7 @@ import fi.espoo.evaka.placement.PlacementUpdateRequestBody
 import fi.espoo.evaka.sficlient.MockSfiMessagesClient
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.ParentshipId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.VoucherValueDecisionId
@@ -552,11 +553,15 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
             )
         db.transaction {
             it.insert(optInAdult, DevPersonType.RAW_ROW)
-            it.insertTestParentship(
-                headOfChild = optInAdult.id,
-                childId = testChild_2.id,
-                startDate = testChild_2.dateOfBirth,
-                endDate = testChild_2.dateOfBirth.plusYears(18).minusDays(1)
+            it.insert(
+                DevParentship(
+                    ParentshipId(UUID.randomUUID()),
+                    testChild_2.id,
+                    optInAdult.id,
+                    testChild_2.dateOfBirth,
+                    testChild_2.dateOfBirth.plusYears(18).minusDays(1),
+                    HelsinkiDateTime.now()
+                )
             )
             it.insertTestPartnership(adult1 = optInAdult.id, adult2 = testAdult_7.id)
         }
@@ -587,11 +592,15 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
     fun `Email notification is sent to hof when decision in WAITING_FOR_MANUAL_SENDING is set to SENT`() {
         db.transaction {
             // testAdult_3 has an email address, but no mail address -> marked for manual sending
-            it.insertTestParentship(
-                headOfChild = testAdult_3.id,
-                childId = testChild_2.id,
-                startDate = testChild_2.dateOfBirth,
-                endDate = testChild_2.dateOfBirth.plusYears(18).minusDays(1)
+            it.insert(
+                DevParentship(
+                    ParentshipId(UUID.randomUUID()),
+                    testChild_2.id,
+                    testAdult_3.id,
+                    testChild_2.dateOfBirth,
+                    testChild_2.dateOfBirth.plusYears(18).minusDays(1),
+                    HelsinkiDateTime.now()
+                )
             )
             it.insertTestPartnership(adult1 = testAdult_3.id, adult2 = testAdult_4.id)
         }
@@ -639,11 +648,15 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
             it.insert(optOutAdult, DevPersonType.RAW_ROW)
 
             // optOutAdult has an email address, and does not require manual sending of PDF decision
-            it.insertTestParentship(
-                headOfChild = optOutAdult.id,
-                childId = testChild_2.id,
-                startDate = testChild_2.dateOfBirth,
-                endDate = testChild_2.dateOfBirth.plusYears(18).minusDays(1)
+            it.insert(
+                DevParentship(
+                    ParentshipId(UUID.randomUUID()),
+                    testChild_2.id,
+                    optOutAdult.id,
+                    testChild_2.dateOfBirth,
+                    testChild_2.dateOfBirth.plusYears(18).minusDays(1),
+                    HelsinkiDateTime.now()
+                )
             )
             it.insertTestPartnership(adult1 = optOutAdult.id, adult2 = testAdult_7.id)
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.emailclient
 
 import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.daycare.domain.Language
+import fi.espoo.evaka.invoicing.domain.FinanceDecisionType
 import fi.espoo.evaka.invoicing.service.IncomeNotificationType
 import fi.espoo.evaka.messaging.MessageThreadStub
 import fi.espoo.evaka.messaging.MessageType
@@ -570,4 +571,67 @@ $unsubscribeEn
 """
         )
     }
+
+    override fun financeDecisionNotification(
+        language: Language,
+        decisionType: FinanceDecisionType
+    ): EmailContent {
+        return EmailContent.fromHtml(
+            subject =
+                "${getFinanceDecisionSubjectText(Language.fi, decisionType)} / ${getFinanceDecisionSubjectText(Language.sv, decisionType)} / ${getFinanceDecisionSubjectText(Language.en, decisionType)}",
+            html =
+                """
+<p>Sinulle on saapunut uusi ${getFinanceDecisionTypeDescriptor(Language.fi, decisionType)} eVakaan.</p>
+$unsubscribeFi
+<hr>
+<p>Du har fått ett nytt ${getFinanceDecisionTypeDescriptor(Language.sv, decisionType)} i eVaka.</p>
+$unsubscribeSv
+<hr>
+<p>You have received a new ${getFinanceDecisionTypeDescriptor(Language.en, decisionType)} in eVaka.</p>
+$unsubscribeEn
+            """
+                    .trimIndent()
+        )
+    }
+
+    private fun getFinanceDecisionSubjectText(
+        language: Language,
+        decisionType: FinanceDecisionType
+    ): String {
+        val financeDecisionTypeDescriptor =
+            when (decisionType) {
+                FinanceDecisionType.FEE_DECISION ->
+                    when (language) {
+                        Language.sv -> "Ett nytt betalningsbeslut i eVaka"
+                        Language.fi -> "Uusi maksupäätös eVakassa"
+                        Language.en -> "New fee decision in eVaka"
+                    }
+                FinanceDecisionType.VOUCHER_VALUE_DECISION ->
+                    when (language) {
+                        Language.sv -> "Ett nytt beslut om värdet på servicesedlar i eVaka"
+                        Language.fi -> "Uusi arvosetelipäätös eVakassa"
+                        Language.en -> "New voucher value decision in eVaka"
+                    }
+            }
+        return financeDecisionTypeDescriptor
+    }
+
+    fun getFinanceDecisionTypeDescriptor(
+        language: Language,
+        decisionType: FinanceDecisionType
+    ): String =
+        when (decisionType) {
+            FinanceDecisionType.FEE_DECISION ->
+                when (language) {
+                    Language.sv -> "betalningsbeslut"
+                    Language.fi -> "maksupäätös"
+                    Language.en -> "fee decision"
+                }
+            FinanceDecisionType.VOUCHER_VALUE_DECISION ->
+                when (language) {
+                    Language.sv -> "beslut om värdet på servicesedlar"
+                    Language.fi -> "arvopäätös"
+                    Language.en -> "fee decision"
+                }
+        }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -578,45 +578,26 @@ $unsubscribeEn
     ): EmailContent {
         return EmailContent.fromHtml(
             subject =
-                "${getFinanceDecisionSubjectText(Language.fi, decisionType)} / ${getFinanceDecisionSubjectText(Language.sv, decisionType)} / ${getFinanceDecisionSubjectText(Language.en, decisionType)}",
+                "Uusi ${getFinanceDecisionTypeDescriptor(Language.fi, decisionType)} eVakassa / Ett nytt ${getFinanceDecisionTypeDescriptor(Language.sv, decisionType)} i eVaka / New ${getFinanceDecisionTypeDescriptor(Language.en, decisionType)} in eVaka",
             html =
                 """
 <p>Sinulle on saapunut uusi ${getFinanceDecisionTypeDescriptor(Language.fi, decisionType)} eVakaan.</p>
+<p>Päätös on nähtävissä eVakassa osoitteessa ${frontPageLink(Language.fi)}.</p>
 $unsubscribeFi
 <hr>
 <p>Du har fått ett nytt ${getFinanceDecisionTypeDescriptor(Language.sv, decisionType)} i eVaka.</p>
+<p>Beslutet finns att se i eVaka på ${frontPageLink(Language.sv)}.</p>
 $unsubscribeSv
 <hr>
 <p>You have received a new ${getFinanceDecisionTypeDescriptor(Language.en, decisionType)} in eVaka.</p>
+<p>The decision can be viewed on eVaka at ${frontPageLink(Language.en)}.</p>
 $unsubscribeEn
             """
                     .trimIndent()
         )
     }
 
-    private fun getFinanceDecisionSubjectText(
-        language: Language,
-        decisionType: FinanceDecisionType
-    ): String {
-        val financeDecisionTypeDescriptor =
-            when (decisionType) {
-                FinanceDecisionType.FEE_DECISION ->
-                    when (language) {
-                        Language.sv -> "Ett nytt betalningsbeslut i eVaka"
-                        Language.fi -> "Uusi maksupäätös eVakassa"
-                        Language.en -> "New fee decision in eVaka"
-                    }
-                FinanceDecisionType.VOUCHER_VALUE_DECISION ->
-                    when (language) {
-                        Language.sv -> "Ett nytt beslut om värdet på servicesedlar i eVaka"
-                        Language.fi -> "Uusi arvosetelipäätös eVakassa"
-                        Language.en -> "New voucher value decision in eVaka"
-                    }
-            }
-        return financeDecisionTypeDescriptor
-    }
-
-    fun getFinanceDecisionTypeDescriptor(
+    private fun getFinanceDecisionTypeDescriptor(
         language: Language,
         decisionType: FinanceDecisionType
     ): String =

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -579,11 +579,7 @@ $unsubscribeEn
         val (decisionTypeFi, decisionTypeSv, decisionTypeEn) =
             when (decisionType) {
                 FinanceDecisionType.VOUCHER_VALUE_DECISION ->
-                    Triple(
-                        "arvopäätös",
-                        "beslut om servicesedel",
-                        "voucher value decision"
-                    )
+                    Triple("arvopäätös", "beslut om servicesedel", "voucher value decision")
                 FinanceDecisionType.FEE_DECISION ->
                     Triple("maksupäätös", "betalningsbeslut", "fee decision")
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -576,43 +576,35 @@ $unsubscribeEn
         language: Language,
         decisionType: FinanceDecisionType
     ): EmailContent {
+        val (decisionTypeFi, decisionTypeSv, decisionTypeEn) =
+            when (decisionType) {
+                FinanceDecisionType.VOUCHER_VALUE_DECISION ->
+                    Triple(
+                        "arvopäätös",
+                        "beslut om värdet på servicesedlar",
+                        "voucher value decision"
+                    )
+                FinanceDecisionType.FEE_DECISION ->
+                    Triple("maksupäätös", "betalningsbeslut", "fee decision")
+            }
         return EmailContent.fromHtml(
             subject =
-                "Uusi ${getFinanceDecisionTypeDescriptor(Language.fi, decisionType)} eVakassa / Ett nytt ${getFinanceDecisionTypeDescriptor(Language.sv, decisionType)} i eVaka / New ${getFinanceDecisionTypeDescriptor(Language.en, decisionType)} in eVaka",
+                "Uusi $decisionTypeFi eVakassa / Ett nytt $decisionTypeSv i eVaka / New $decisionTypeEn in eVaka",
             html =
                 """
-<p>Sinulle on saapunut uusi ${getFinanceDecisionTypeDescriptor(Language.fi, decisionType)} eVakaan.</p>
+<p>Sinulle on saapunut uusi $decisionTypeFi eVakaan.</p>
 <p>Päätös on nähtävissä eVakassa osoitteessa ${frontPageLink(Language.fi)}.</p>
 $unsubscribeFi
 <hr>
-<p>Du har fått ett nytt ${getFinanceDecisionTypeDescriptor(Language.sv, decisionType)} i eVaka.</p>
+<p>Du har fått ett nytt $decisionTypeSv i eVaka.</p>
 <p>Beslutet finns att se i eVaka på ${frontPageLink(Language.sv)}.</p>
 $unsubscribeSv
 <hr>
-<p>You have received a new ${getFinanceDecisionTypeDescriptor(Language.en, decisionType)} in eVaka.</p>
+<p>You have received a new $decisionTypeEn in eVaka.</p>
 <p>The decision can be viewed on eVaka at ${frontPageLink(Language.en)}.</p>
 $unsubscribeEn
             """
                     .trimIndent()
         )
     }
-
-    private fun getFinanceDecisionTypeDescriptor(
-        language: Language,
-        decisionType: FinanceDecisionType
-    ): String =
-        when (decisionType) {
-            FinanceDecisionType.FEE_DECISION ->
-                when (language) {
-                    Language.sv -> "betalningsbeslut"
-                    Language.fi -> "maksupäätös"
-                    Language.en -> "fee decision"
-                }
-            FinanceDecisionType.VOUCHER_VALUE_DECISION ->
-                when (language) {
-                    Language.sv -> "beslut om värdet på servicesedlar"
-                    Language.fi -> "arvopäätös"
-                    Language.en -> "fee decision"
-                }
-        }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -581,7 +581,7 @@ $unsubscribeEn
                 FinanceDecisionType.VOUCHER_VALUE_DECISION ->
                     Triple(
                         "arvopäätös",
-                        "beslut om värdet på servicesedlar",
+                        "beslut om servicesedel",
                         "voucher value decision"
                     )
                 FinanceDecisionType.FEE_DECISION ->
@@ -589,7 +589,7 @@ $unsubscribeEn
             }
         return EmailContent.fromHtml(
             subject =
-                "Uusi $decisionTypeFi eVakassa / Ett nytt $decisionTypeSv i eVaka / New $decisionTypeEn in eVaka",
+                "Uusi $decisionTypeFi eVakassa / Nytt $decisionTypeSv i eVaka / New $decisionTypeEn in eVaka",
             html =
                 """
 <p>Sinulle on saapunut uusi $decisionTypeFi eVakaan.</p>

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -572,10 +572,7 @@ $unsubscribeEn
         )
     }
 
-    override fun financeDecisionNotification(
-        language: Language,
-        decisionType: FinanceDecisionType
-    ): EmailContent {
+    override fun financeDecisionNotification(decisionType: FinanceDecisionType): EmailContent {
         val (decisionTypeFi, decisionTypeSv, decisionTypeEn) =
             when (decisionType) {
                 FinanceDecisionType.VOUCHER_VALUE_DECISION ->

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.emailclient
 
 import fi.espoo.evaka.daycare.domain.Language
+import fi.espoo.evaka.invoicing.domain.FinanceDecisionType
 import fi.espoo.evaka.invoicing.service.IncomeNotificationType
 import fi.espoo.evaka.messaging.MessageThreadStub
 import fi.espoo.evaka.shared.ChildId
@@ -89,6 +90,11 @@ interface IEmailMessageProvider {
     fun calendarEventNotification(
         language: Language,
         events: List<CalendarEventNotificationData>
+    ): EmailContent
+
+    fun financeDecisionNotification(
+        language: Language,
+        decisionType: FinanceDecisionType
     ): EmailContent
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
@@ -92,10 +92,7 @@ interface IEmailMessageProvider {
         events: List<CalendarEventNotificationData>
     ): EmailContent
 
-    fun financeDecisionNotification(
-        language: Language,
-        decisionType: FinanceDecisionType
-    ): EmailContent
+    fun financeDecisionNotification(decisionType: FinanceDecisionType): EmailContent
 }
 
 data class CalendarEventNotificationData(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -228,6 +228,13 @@ class FeeDecisionController(
                     feeDecisionIds
                 )
                 service.setSent(it, clock, feeDecisionIds)
+                // emails should be sent only after decisions are actually visible to citizens in
+                // eVaka
+                asyncJobRunner.plan(
+                    it,
+                    feeDecisionIds.map { id -> AsyncJob.SendNewFeeDecisionEmail(decisionId = id) },
+                    runAt = clock.now()
+                )
             }
         }
         Audit.FeeDecisionMarkSent.log(targetId = feeDecisionIds)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/VoucherValueDecisionController.kt
@@ -212,6 +212,11 @@ class VoucherValueDecisionController(
                     throw BadRequest("Voucher value decision cannot be marked sent")
                 }
                 tx.markVoucherValueDecisionsSent(ids, clock.now())
+                asyncJobRunner.plan(
+                    tx,
+                    ids.map { AsyncJob.SendNewVoucherValueDecisionEmail(decisionId = it) },
+                    runAt = clock.now()
+                )
             }
         }
         Audit.VoucherValueDecisionMarkSent.log(targetId = ids)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
@@ -376,11 +376,8 @@ class FeeDecisionService(
         val recipients = listOfNotNull(decision.headOfFamily)
 
         recipients.forEach { recipient ->
-            val language =
-                if (!recipient.language.isNullOrEmpty())
-                    Language.tryValueOf(recipient.language) ?: Language.en
-                else Language.fi
-            val fromAddress = emailEnv.sender(language)
+            // simplified to get rid of superfluous language requirement
+            val fromAddress = emailEnv.sender(Language.fi)
             val content =
                 emailMessageProvider.financeDecisionNotification(FinanceDecisionType.FEE_DECISION)
             Email.create(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
@@ -382,10 +382,7 @@ class FeeDecisionService(
                 else Language.fi
             val fromAddress = emailEnv.sender(language)
             val content =
-                emailMessageProvider.financeDecisionNotification(
-                    language,
-                    FinanceDecisionType.FEE_DECISION
-                )
+                emailMessageProvider.financeDecisionNotification(FinanceDecisionType.FEE_DECISION)
             Email.create(
                     db,
                     recipient.id,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
@@ -264,7 +264,6 @@ class VoucherValueDecisionService(
             val fromAddress = emailEnv.sender(language)
             val content =
                 emailMessageProvider.financeDecisionNotification(
-                    language,
                     FinanceDecisionType.VOUCHER_VALUE_DECISION
                 )
             Email.create(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
@@ -257,11 +257,8 @@ class VoucherValueDecisionService(
         val recipients = listOfNotNull(decision.headOfFamily)
 
         recipients.forEach { recipient ->
-            val language =
-                if (!recipient.language.isNullOrEmpty())
-                    Language.tryValueOf(recipient.language) ?: Language.en
-                else Language.fi
-            val fromAddress = emailEnv.sender(language)
+            // simplified to get rid of superfluous language requirement
+            val fromAddress = emailEnv.sender(Language.fi)
             val content =
                 emailMessageProvider.financeDecisionNotification(
                     FinanceDecisionType.VOUCHER_VALUE_DECISION

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
@@ -5,7 +5,12 @@
 package fi.espoo.evaka.invoicing.service
 
 import fi.espoo.evaka.BucketEnv
+import fi.espoo.evaka.EmailEnv
+import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.decision.DecisionSendAddress
+import fi.espoo.evaka.emailclient.Email
+import fi.espoo.evaka.emailclient.EmailClient
+import fi.espoo.evaka.emailclient.IEmailMessageProvider
 import fi.espoo.evaka.invoicing.data.getValueDecisionsByIds
 import fi.espoo.evaka.invoicing.data.getVoucherValueDecision
 import fi.espoo.evaka.invoicing.data.getVoucherValueDecisionDocumentKey
@@ -16,10 +21,12 @@ import fi.espoo.evaka.invoicing.data.setVoucherValueDecisionToIgnored
 import fi.espoo.evaka.invoicing.data.setVoucherValueDecisionType
 import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionDocumentKey
 import fi.espoo.evaka.invoicing.data.updateVoucherValueDecisionStatus
+import fi.espoo.evaka.invoicing.domain.FinanceDecisionType
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionDetailed
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionType
 import fi.espoo.evaka.pdfgen.PdfGenerator
+import fi.espoo.evaka.pis.EmailMessageType
 import fi.espoo.evaka.s3.Document
 import fi.espoo.evaka.s3.DocumentService
 import fi.espoo.evaka.setting.SettingType
@@ -37,8 +44,11 @@ import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.domain.OfficialLanguage
 import fi.espoo.evaka.shared.message.IMessageProvider
 import java.time.LocalDate
+import mu.KotlinLogging
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {}
 
 @Component
 class VoucherValueDecisionService(
@@ -46,9 +56,16 @@ class VoucherValueDecisionService(
     private val documentClient: DocumentService,
     private val messageProvider: IMessageProvider,
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
-    env: BucketEnv
+    env: BucketEnv,
+    private val emailEnv: EmailEnv,
+    private val emailMessageProvider: IEmailMessageProvider,
+    private val emailClient: EmailClient,
 ) {
     private val bucket = env.voucherValueDecisions
+
+    init {
+        asyncJobRunner.registerHandler(::runSendNewVoucherValueDecisionEmail)
+    }
 
     fun createDecisionPdf(tx: Database.Transaction, decisionId: VoucherValueDecisionId) {
         val decision = getDecision(tx, decisionId)
@@ -134,7 +151,11 @@ class VoucherValueDecisionService(
         )
 
         tx.markVoucherValueDecisionsSent(listOf(decision.id), clock.now())
-
+        asyncJobRunner.plan(
+            tx,
+            listOf(AsyncJob.SendNewVoucherValueDecisionEmail(decisionId = decision.id)),
+            runAt = clock.now()
+        )
         return true
     }
 
@@ -217,6 +238,49 @@ class VoucherValueDecisionService(
         }
 
         tx.setVoucherValueDecisionType(decisionId, type)
+    }
+
+    fun runSendNewVoucherValueDecisionEmail(
+        db: Database.Connection,
+        clock: EvakaClock,
+        msg: AsyncJob.SendNewVoucherValueDecisionEmail
+    ) {
+        val voucherValueDecisionId = msg.decisionId
+        val decision =
+            db.read { tx -> tx.getVoucherValueDecision(voucherValueDecisionId) }
+                ?: throw NotFound("Decision not found")
+
+        logger.info {
+            "Sending voucher value decision emails for (decisionId: $voucherValueDecisionId)"
+        }
+
+        val recipients = listOfNotNull(decision.headOfFamily)
+
+        recipients.forEach { recipient ->
+            val language =
+                if (!recipient.language.isNullOrEmpty())
+                    Language.tryValueOf(recipient.language) ?: Language.en
+                else Language.fi
+            val fromAddress = emailEnv.sender(language)
+            val content =
+                emailMessageProvider.financeDecisionNotification(
+                    language,
+                    FinanceDecisionType.VOUCHER_VALUE_DECISION
+                )
+            Email.create(
+                    db,
+                    recipient.id,
+                    EmailMessageType.DECISION_NOTIFICATION,
+                    fromAddress,
+                    content,
+                    "$voucherValueDecisionId - ${recipient.id}",
+                )
+                ?.also { emailClient.send(it) }
+        }
+
+        logger.info {
+            "Successfully sent voucher value decision emails (${recipients.size}) (id: $voucherValueDecisionId)."
+        }
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalData.kt
@@ -33,7 +33,10 @@ enum class EmailMessageType {
     /** Notifications about new calendar events of daycare groups */
     CALENDAR_EVENT_NOTIFICATION,
 
-    /** Notifications about new decisions (e.g. daycare decision, assistance decision) */
+    /**
+     * Notifications about new decisions (e.g. daycare decision, assistance decision, finance
+     * decisions)
+     */
     DECISION_NOTIFICATION,
 
     /**

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -327,6 +327,16 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class SendNewFeeDecisionEmail(
+        val decisionId: FeeDecisionId,
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data class SendNewVoucherValueDecisionEmail(val decisionId: VoucherValueDecisionId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     companion object {
         val main =
             AsyncJobRunner.Pool(
@@ -375,6 +385,8 @@ sealed interface AsyncJob : AsyncJobPayload {
                     SendPendingDecisionEmail::class,
                     SendVasuNotificationEmail::class,
                     SendNewCustomerIncomeNotificationEmail::class,
+                    SendNewFeeDecisionEmail::class,
+                    SendNewVoucherValueDecisionEmail::class
                 )
             )
         val urgent =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -79,6 +79,7 @@ import fi.espoo.evaka.invoicing.domain.FeeDecisionDifference
 import fi.espoo.evaka.invoicing.domain.FeeDecisionStatus
 import fi.espoo.evaka.invoicing.domain.FeeDecisionType
 import fi.espoo.evaka.invoicing.domain.FeeThresholds
+import fi.espoo.evaka.invoicing.domain.FinanceDecisionType
 import fi.espoo.evaka.invoicing.domain.Invoice
 import fi.espoo.evaka.invoicing.domain.PaymentStatus
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecision
@@ -1530,6 +1531,7 @@ VALUES (${bind(body.id)}, ${bind(body.guardianId)}, ${bind(body.dailyServiceTime
         pedagogicalDocumentNotification,
         outdatedIncomeNotification,
         calendarEventNotification,
+        financeDecisionNotification
     }
 
     @GetMapping("/email-content")
@@ -1596,6 +1598,11 @@ VALUES (${bind(body.id)}, ${bind(body.guardianId)}, ${bind(body.dailyServiceTime
                                 )
                             ),
                         )
+                    )
+                EmailMessageType.financeDecisionNotification ->
+                    emailMessageProvider.financeDecisionNotification(
+                        Language.fi,
+                        FinanceDecisionType.FEE_DECISION
                     )
             }
         val content =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1601,7 +1601,6 @@ VALUES (${bind(body.id)}, ${bind(body.guardianId)}, ${bind(body.dailyServiceTime
                     )
                 EmailMessageType.financeDecisionNotification ->
                     emailMessageProvider.financeDecisionNotification(
-                        Language.fi,
                         FinanceDecisionType.FEE_DECISION
                     )
             }


### PR DESCRIPTION
Lisätty uusi tausta-ajo sähköposti-ilmoituksen lähettämisestä talouspäätöksen (maksupäätös, arvopäätös) päämiehelle, mikäli tämä ei ole estänyt päätösten lähettämisestä aiheutuvia sähköposti-ilmoituksia asetuksissaan.

Koska kuntalaisen käyttöliittymässä näytetään ainoastaan `Lähetetty` -tilassa olevat talouspäätökset, sähköposti-ilmoitukset on asetettu lähtemään sekä automaattisista, että manuaalisista talouspäätösten siirtymistä `Lähetetty` -tilaan.

HUOM! Vaatii kuntakohtaisen sähköpostikonfiguraation päivittämisen ja oman viestipohjan toteuttamisen.