### PR TITLE
Poistetaan `timeUsageInfo` feature flag

### DIFF
--- a/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
+++ b/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
@@ -11,7 +11,6 @@ import {
 import { reservationsAndAttendancesDiffer } from 'lib-common/reservations'
 import TimeInterval from 'lib-common/time-interval'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
-import { featureFlags } from 'lib-customizations/citizen'
 
 import { useTranslation } from '../localization'
 
@@ -170,7 +169,7 @@ export default React.memo(function AttendanceInfo({
   reservations,
   usedService
 }: AttendanceInfoProps) {
-  return featureFlags.timeUsageInfo && usedService ? (
+  return usedService ? (
     <AttendanceInfoWithServiceUsage
       attendances={attendances}
       reservations={reservations}

--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -30,7 +30,6 @@ import {
 } from 'lib-components/molecules/ExpandingInfo'
 import { fontWeights, H2 } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
-import { featureFlags } from 'lib-customizations/citizen'
 import colors from 'lib-customizations/common'
 import { faCalendar, faCalendarPlus, faTreePalm, faUserMinus } from 'lib-icons'
 
@@ -288,14 +287,13 @@ const Month = React.memo(function Month({
 }) {
   const i18n = useTranslation()
 
-  const displaySummary = featureFlags.timeUsageInfo && childSummaries.length > 0
   const { summaryInfoOpen, toggleSummaryInfo, displayAlert } =
     useSummaryInfo(childSummaries)
   return (
     <ContentArea opaque={false} key={`${month}${year}`}>
       <MonthTitle>
         {`${i18n.common.datetime.months[month - 1]} ${year}`}
-        {displaySummary && (
+        {childSummaries.length > 0 && (
           <InlineInfoButton
             onClick={toggleSummaryInfo}
             aria-label={i18n.common.openExpandingInfo}

--- a/frontend/src/citizen-frontend/calendar/MonthElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthElem.tsx
@@ -20,7 +20,6 @@ import {
 } from 'lib-components/molecules/ExpandingInfo'
 import { fontWeights, H2, H3 } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
-import { featureFlags } from 'lib-customizations/citizen'
 import colors from 'lib-customizations/common'
 
 import { useTranslation } from '../localization'
@@ -74,8 +73,6 @@ export default React.memo(function MonthElem({
 }: MonthProps) {
   const i18n = useTranslation()
 
-  const displaySummary = featureFlags.timeUsageInfo && childSummaries.length > 0
-
   const { summaryInfoOpen, toggleSummaryInfo, displayAlert } =
     useSummaryInfo(childSummaries)
   return (
@@ -83,7 +80,7 @@ export default React.memo(function MonthElem({
       <MonthSummaryContainer>
         <MonthTitle>
           {i18n.common.datetime.months[calendarMonth.monthNumber - 1]}
-          {displaySummary && (
+          {childSummaries.length > 0 && (
             <InlineInfoButton
               onClick={toggleSummaryInfo}
               aria-label={i18n.common.openExpandingInfo}
@@ -156,6 +153,7 @@ export function groupByMonth(days: ReservationResponseDay[]): CalendarMonth[] {
   })
   return months
 }
+
 const titleStyles = css`
   margin: 0;
   display: flex;

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -46,8 +46,7 @@ export const Reservations = React.memo(function Reservations({
   const i18n = useTranslation()
   const showAttendanceWarning = data.children.some(
     ({ reservations, attendances, usedService }) =>
-      (featureFlags.timeUsageInfo &&
-        usedService != null &&
+      (usedService != null &&
         usedService.usedServiceMinutes > usedService.reservedMinutes) ||
       reservationsAndAttendancesDiffer(reservations, attendances)
   )

--- a/frontend/src/citizen-frontend/calendar/hooks.ts
+++ b/frontend/src/citizen-frontend/calendar/hooks.ts
@@ -4,27 +4,20 @@
 
 import { useCallback, useState, useEffect } from 'react'
 
-import { featureFlags } from 'lib-customizations/citizen'
-
 import { MonthlyTimeSummary } from './MonthlyHoursSummary'
 
 export function useSummaryInfo(childSummaries: MonthlyTimeSummary[]) {
-  const displayAlert = !!(
-    featureFlags.timeUsageInfo &&
-    childSummaries.some(
-      ({ reservedMinutes, usedServiceMinutes, serviceNeedMinutes }) =>
-        reservedMinutes > serviceNeedMinutes ||
-        usedServiceMinutes > serviceNeedMinutes
-    )
+  const displayAlert = childSummaries.some(
+    ({ reservedMinutes, usedServiceMinutes, serviceNeedMinutes }) =>
+      reservedMinutes > serviceNeedMinutes ||
+      usedServiceMinutes > serviceNeedMinutes
   )
   const [summaryExplicitlyClosed, setSummaryExplicitlyClosed] = useState(false)
-  const [summaryInfoOpen, setSummaryInfoOpen] = useState(
-    () =>
-      featureFlags.timeUsageInfo &&
-      childSummaries.some(
-        ({ reservedMinutes, serviceNeedMinutes }) =>
-          reservedMinutes > serviceNeedMinutes
-      )
+  const [summaryInfoOpen, setSummaryInfoOpen] = useState(() =>
+    childSummaries.some(
+      ({ reservedMinutes, serviceNeedMinutes }) =>
+        reservedMinutes > serviceNeedMinutes
+    )
   )
 
   const toggleSummaryInfo = useCallback(() => {
@@ -39,7 +32,6 @@ export function useSummaryInfo(childSummaries: MonthlyTimeSummary[]) {
 
   useEffect(() => {
     if (
-      featureFlags.timeUsageInfo &&
       !summaryExplicitlyClosed &&
       childSummaries.some(
         ({ reservedMinutes, serviceNeedMinutes }) =>

--- a/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
@@ -49,8 +49,7 @@ beforeEach(async () => {
   ).save()
 
   page = await Page.open({
-    mockedTime: today.toHelsinkiDateTime(LocalTime.of(8, 0)),
-    employeeCustomizations: { featureFlags: { timeUsageInfo: true } }
+    mockedTime: today.toHelsinkiDateTime(LocalTime.of(8, 0))
   })
   await employeeLogin(page, unitSupervisor.data)
   unitPage = new UnitPage(page)

--- a/frontend/src/employee-frontend/components/absences/MonthCalendarTable.tsx
+++ b/frontend/src/employee-frontend/components/absences/MonthCalendarTable.tsx
@@ -175,7 +175,7 @@ function getHourInfo(child: GroupMonthCalendarChild): {
   showUsedHoursWarning: boolean
 } {
   const { usedService, reservationTotalHours, attendanceTotalHours } = child
-  if (featureFlags.timeUsageInfo && usedService) {
+  if (usedService) {
     return {
       reservedHours: usedService.reservedHours,
       showReservedHoursWarning:

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -39,7 +39,6 @@ const features: Features = {
     citizenAttendanceSummary: false,
     intermittentShiftCare: false,
     noAbsenceType: false,
-    timeUsageInfo: true,
     discussionReservations: false,
     jamixIntegration: true
   },
@@ -69,7 +68,6 @@ const features: Features = {
     voucherUnitPayments: false,
     intermittentShiftCare: false,
     noAbsenceType: false,
-    timeUsageInfo: true,
     discussionReservations: false,
     jamixIntegration: true
   },
@@ -99,7 +97,6 @@ const features: Features = {
     voucherUnitPayments: false,
     intermittentShiftCare: false,
     noAbsenceType: false,
-    timeUsageInfo: false,
     discussionReservations: false
   }
 }

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -223,11 +223,6 @@ interface BaseFeatureFlags {
    */
 
   /**
-   * Display time usage info in citizen calendar views
-   */
-  timeUsageInfo?: boolean
-
-  /**
    * Hide option to create a club application in citizen UI
    */
   hideClubApplication?: boolean


### PR DESCRIPTION
Lippu on päällä kaikissa tuntipohjaisia palveluntarpeita käyttävissä kunnissa, joten sitä ei enää tarvita.