### PR TITLE
Ruokatilausintegraatio: lounaan ateriatyyppi esiopetuksessa

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MealReportUtil.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MealReportUtil.kt
@@ -64,7 +64,11 @@ private fun childMeals(
         if (fixedScheduleRange != null) listOf(fixedScheduleRange) else reservations
     // if we don't have data about when child will be present, default to breakfast + lunch + snack
     if (presentTimeRanges.isEmpty()) {
-        return setOf(MealType.BREAKFAST, MealType.LUNCH, MealType.SNACK)
+        return setOf(
+            MealType.BREAKFAST,
+            if (usePreschoolMealTypes) MealType.LUNCH_PRESCHOOL else MealType.LUNCH,
+            MealType.SNACK
+        )
     }
     // otherwise check unit meal times against the present time ranges
     val meals = mutableSetOf<MealType>()

--- a/service/src/test/kotlin/fi/espoo/evaka/reports/MealReportTests.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/reports/MealReportTests.kt
@@ -110,6 +110,50 @@ class MealReportTests {
     }
 
     @Test
+    fun `mealReportData should default to breakfast, preschool lunch, and snack when no reservations for PRESCHOOL_DAYCARE`() {
+        val testDate = LocalDate.of(2023, 5, 10)
+        val childInfo =
+            listOf(
+                MealReportChildInfo(
+                    placementType = PlacementType.PRESCHOOL_DAYCARE,
+                    firstName = "Jane",
+                    lastName = "Smith",
+                    reservations = emptyList(), // No reservations
+                    absences = null, // No absences
+                    dietInfo = null,
+                    dailyPreschoolTime = null,
+                    dailyPreparatoryTime = null,
+                    mealTimes =
+                        DaycareMealtimes(
+                            breakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                            lunch = TimeRange(LocalTime.of(12, 0), LocalTime.of(12, 20)),
+                            snack = TimeRange(LocalTime.of(15, 30), LocalTime.of(15, 50)),
+                            supper = null,
+                            eveningSnack = null
+                        )
+                )
+            )
+        val preschoolTerms = emptyList<PreschoolTerm>()
+
+        val report =
+            mealReportData(
+                children = childInfo,
+                date = testDate,
+                preschoolTerms = preschoolTerms,
+                DefaultMealTypeMapper
+            )
+
+        val expectedMeals = setOf(MealType.BREAKFAST, MealType.LUNCH_PRESCHOOL, MealType.SNACK)
+        val actualMeals = report.map { it.mealType }.toSet()
+
+        assertEquals(
+            expectedMeals,
+            actualMeals,
+            "Expected default meals (breakfast, lunch, snack) when there are no reservations"
+        )
+    }
+
+    @Test
     fun `mealReportData should provide meals during preschool times for preschool type placements`() {
         val testDate = LocalDate.of(2023, 5, 10)
         val childInfo =


### PR DESCRIPTION
## Ennen tätä muutosta
Esiopetuksen lounastilaukset menivät väärällä ateriakoodilla jos lapsella ei ollut varauksia.
## Tämän muutoksen jälkeen
Esiopetuksen lounastilauksessa käytetään oikeaa ateriakoodia myös silloin kun tilataan ns. vakiotilaus, eli aamupala, lounas ja välipala.