### PR TITLE
Säädettävä sijainti ja koko henkilön osoitesivun kirjekuori-ikkunalle

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pdfgen/PdfGeneratorTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pdfgen/PdfGeneratorTest.kt
@@ -41,7 +41,7 @@ import fi.espoo.evaka.shared.config.PDFConfig
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.OfficialLanguage
-import fi.espoo.evaka.shared.domain.RealEvakaClock
+import fi.espoo.evaka.shared.domain.Rectangle
 import fi.espoo.evaka.shared.message.EvakaMessageProvider
 import fi.espoo.evaka.shared.message.IMessageProvider
 import fi.espoo.evaka.shared.template.EvakaTemplateProvider
@@ -185,7 +185,13 @@ class PdfGeneratorTest {
 
     @Test
     fun createAddressPagePdfTest() {
-        val document = createAddressPagePdf(pdfGenerator, guardian, RealEvakaClock())
+        val document =
+            createAddressPagePdf(
+                pdfGenerator,
+                LocalDate.of(2024, 1, 1),
+                Rectangle.iPostWindowPosition,
+                guardian
+            )
 
         val file = File.createTempFile("address_page_", ".pdf")
         FileOutputStream(file).use { it.write(document.bytes) }

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka
 
 import fi.espoo.evaka.daycare.domain.Language
+import fi.espoo.evaka.shared.domain.Rectangle
 import fi.espoo.evaka.shared.job.JobSchedule
 import fi.espoo.evaka.shared.job.ScheduledJobSettings
 import java.net.URI
@@ -37,7 +38,8 @@ data class EvakaEnv(
     val mockClock: Boolean,
     val nrOfDaysFeeDecisionCanBeSentInAdvance: Long,
     val nrOfDaysVoucherValueDecisionCanBeSentInAdvance: Long,
-    val plannedAbsenceEnabledForHourBasedServiceNeeds: Boolean
+    val plannedAbsenceEnabledForHourBasedServiceNeeds: Boolean,
+    val personAddressEnvelopeWindowPosition: Rectangle,
 ) {
     companion object {
         fun fromEnvironment(env: Environment): EvakaEnv {
@@ -81,7 +83,11 @@ data class EvakaEnv(
                     env.lookup("evaka.voucher_value_decision.days_in_advance") ?: 0,
                 plannedAbsenceEnabledForHourBasedServiceNeeds =
                     env.lookup("evaka.planned_absence.enabled_for_hour_based_service_needs")
-                        ?: false
+                        ?: false,
+                personAddressEnvelopeWindowPosition =
+                    env.lookup<String?>("evaka.person_address_envelope_window_position")?.let {
+                        Rectangle.fromString(it)
+                    } ?: Rectangle.iPostWindowPosition
             )
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonController.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.pis.controllers
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.daycare.controllers.upsertAdditionalInformation
 import fi.espoo.evaka.daycare.getChild
 import fi.espoo.evaka.identity.ExternalIdentifier
@@ -67,7 +68,8 @@ class PersonController(
     private val mergeService: MergeService,
     private val accessControl: AccessControl,
     private val fridgeFamilyService: FridgeFamilyService,
-    private val pdfGenerator: PdfGenerator
+    private val pdfGenerator: PdfGenerator,
+    private val evakaEnv: EvakaEnv
 ) {
     @PostMapping
     fun createEmpty(
@@ -660,7 +662,13 @@ class PersonController(
                     )
                     val personData =
                         tx.getPersonById(guardianId) ?: throw NotFound("Person not found")
-                    val doc = createAddressPagePdf(pdfGenerator, personData, clock)
+                    val doc =
+                        createAddressPagePdf(
+                            pdfGenerator,
+                            clock.today(),
+                            evakaEnv.personAddressEnvelopeWindowPosition,
+                            personData
+                        )
                     val resource = ByteArrayResource(doc.bytes)
                     ResponseEntity.ok()
                         .contentLength(resource.contentLength())

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/service/PersonService.kt
@@ -32,9 +32,9 @@ import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.Conflict
-import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
+import fi.espoo.evaka.shared.domain.Rectangle
 import fi.espoo.evaka.vtjclient.dto.Nationality
 import fi.espoo.evaka.vtjclient.dto.NativeLanguage
 import fi.espoo.evaka.vtjclient.dto.VtjPersonDTO
@@ -736,10 +736,10 @@ private fun Database.Transaction.updateVtjGuardiansQueriedTimestamp(personId: Ch
 
 fun createAddressPagePdf(
     pdfGenerator: PdfGenerator,
-    guardian: PersonDTO,
-    clock: EvakaClock
+    today: LocalDate,
+    envelopeWindowPosition: Rectangle,
+    guardian: PersonDTO
 ): Document {
-
     // template path hardcoded to prevent need for customization
     val template = "address-page/address-page"
     val personDetails =
@@ -762,13 +762,14 @@ fun createAddressPagePdf(
         Page(
             Template(template),
             Context().apply {
+                setVariable("window", envelopeWindowPosition)
                 setVariable("guardian", personDetails)
                 setVariable("sendAddress", DecisionSendAddress.fromPerson(personDetails))
             }
         )
 
     return Document(
-        name = "osoitesivu_${guardian.lastName}_${clock.today()}.pdf",
+        name = "osoitesivu_${guardian.lastName}_$today.pdf",
         bytes = pdfGenerator.render(page),
         contentType = "application/pdf"
     )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Rectangle.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Rectangle.kt
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.domain
+
+data class Rectangle(val x: Int, val y: Int, val width: Int, val height: Int) {
+    companion object {
+        fun fromString(rectangle: String): Rectangle {
+            val parts = rectangle.split(",")
+            if (parts.size != 4) {
+                throw IllegalArgumentException("Rectangle must have 4 parts")
+            }
+            val intParts =
+                try {
+                    parts.map { it.toInt() }
+                } catch (e: NumberFormatException) {
+                    throw IllegalArgumentException("Rectangle parts must be integers")
+                }
+            val (x, y, width, height) = intParts
+            return Rectangle(x, y, width, height)
+        }
+
+        // Position of recipient's address in the iPost layout design instructions
+        val iPostWindowPosition = Rectangle(21, 55, 72, 30)
+    }
+}

--- a/service/src/main/resources/WEB-INF/templates/address-page/address-page.html
+++ b/service/src/main/resources/WEB-INF/templates/address-page/address-page.html
@@ -9,97 +9,30 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 <head>
     <meta charset="UTF-8"></meta>
     <style>
-        * {
-            line-height: 1.4;
-            font-family: 'Open Sans', sans-serif;
+        @page {
+            size: A4 portrait;
+            margin-left: [[${window.x}]]mm;
+            margin-top: [[${window.y}]]mm;
+            margin-right: 15mm;
+            margin-bottom: 15mm;
         }
 
         body {
             margin: 0;
         }
 
-        @page {
-            size: A4 portrait;
-            margin-top: 55mm; /* ipost first page requirement (20mm) + enough room for header */
-            margin-right: 13mm;
-            margin-bottom: 30mm; /* enough room for footer */
-            margin-left: 21mm; /* ipost first page requirement */
-            @top-left {
-                content: element(headerLeft);
-            }
-            @top-right {
-                content: element(headerRight);
-            }
-            @bottom-center {
-                content: element(footerLeft);
-            }
-        }
-
-        .page {
-            page-break-after: always;
-        }
-
-        .page p, .page div, .page td {
+        .address {
+            width: [[${window.width}]]mm;
+            height: [[${window.height}]]mm;
             font-family: 'Open Sans', sans-serif;
             font-weight: 400;
             font-size: 10pt;
-        }
-
-        .page h1 {
-            font-family: 'Montserrat Medium', sans-serif;
-            font-weight: 500;
-            font-size: 10pt;
-            text-transform: uppercase;
-            margin-bottom: 10mm;
-            padding-bottom: 2rem;
-            page-break-after: avoid;
-        }
-
-        .page h2 {
-            font-family: 'Open Sans SemiBold', sans-serif;
-            font-weight: 600;
-            font-size: 10pt;
-        }
-
-        .page strong.semi {
-            font-family: 'Open Sans SemiBold', sans-serif;
-            font-weight: 600;
-        }
-
-        .page a {
-            text-decoration: underline;
-            color: #0563C1;
-        }
-
-        .page.last-page {
-            page-break-after: avoid;
-        }
-
-        .page.first-page h1 {
-            margin-top: 30mm;
-        }
-
-        .row:after {
-            content: "";
-            display: table;
-            clear: both;
-        }
-
-        @media print {
-            a,
-            a:visited {
-                text-decoration: underline;
-            }
-
-            .page-break {
-                page-break-after: always;
-            }
+            line-height: 1.4;
         }
     </style>
 </head>
 <body>
-<div>
-    <div class="page">
+    <div class="address">
         <div th:if="${guardian} != null" th:text="|${guardian.lastName} ${guardian.firstName}|"></div>
         <th:block th:if="${sendAddress} != null">
             <div th:text="${sendAddress.row1}"></div>
@@ -107,6 +40,5 @@ SPDX-License-Identifier: LGPL-2.1-or-later
             <div th:if="${not #strings.isEmpty(sendAddress.row3)}" th:text="${sendAddress.row3}"></div>
         </th:block>
     </div>
-</div>
 </body>
 </html>

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/domain/RectangleTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/domain/RectangleTest.kt
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.domain
+
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class RectangleTest {
+    @Test
+    fun fromString() {
+        assertEquals(Rectangle(1, 2, 345, 6), Rectangle.fromString("1,2,345,6"))
+        assertThrows<IllegalArgumentException> { Rectangle.fromString("foobar") }
+        assertThrows<IllegalArgumentException> { Rectangle.fromString("1,2,3") }
+        assertThrows<IllegalArgumentException> { Rectangle.fromString("foo,bar,baz,quux") }
+    }
+}


### PR DESCRIPTION
Sijainti ja koko säädetään asettamalla seuraava Spring property:
```
evaka.person_address_envelope_window_position = x,y,w,h
```

- `x`: Ikkunan vasemman reunan etäisyys millimetreinä paperin vasemmasta reunasta
- `y`: Ikkunan yläreunan etäisyys millimetreinä paperin yläreunasta
- `w`: Ikkunan leveys millimetreinä
- `h`: Ikkunan korkeus millimetreinä

Jos arvoa ei ole annettu, käytetään arvona `21,55,72,30`, mikä vastaa iPost-ohjeistuksen vastaanottajan osoitteen paikkaa. iPostia käytetään esim. kirjeenä toimitettavissa Suomi.fi-viesteissä.

**HUOM:** Ikkunan reunoille kannattanee jättää hieman tilaa, jottei nimi ja osoite ala täsmälleen ikkunan reunasta vaan hieman sen sisäpuolelta.
