### PR TITLE
Pidetään enintään yksi Jamix-ruokavaliosynkki kerrallaan

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -333,6 +333,10 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    class SyncJamixDiets : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     companion object {
         val main =
             AsyncJobRunner.Pool(
@@ -357,6 +361,7 @@ sealed interface AsyncJob : AsyncJobPayload {
                     SendAssistanceNeedPreschoolDecisionSfiMessage::class,
                     SendDecision::class,
                     SendJamixOrder::class,
+                    SyncJamixDiets::class,
                     SendPatuReport::class,
                     UpdateFromVtj::class,
                     UploadToKoski::class,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -345,7 +345,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun syncJamixDiets(db: Database.Connection, clock: EvakaClock) {
-        jamixService.syncDiets(db, clock)
+        jamixService.planDietSync(db, clock)
     }
 
     fun sendPendingDecisionReminderEmails(db: Database.Connection, clock: EvakaClock) {


### PR DESCRIPTION
Jos async jobeja on paljon ajossa, aiemmin oli mahdollista että Jamix-ruokavaliosynkkejä jäi ajoon monta peräkkäin. Nyt ajamattomat jobit poistetaan ensin.