### PR TITLE
Korjaus null pointer exceptioniin palse-arvojen luonnissa

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueIntegrationTest.kt
@@ -156,6 +156,15 @@ class VoucherValueIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
     }
 
     @Test
+    fun `should throw when adding a voucher value that starts before the existing latest one`() {
+        assertThrows<BadRequest> {
+            addVoucherValue(
+                testVoucherValue.copy(range = DateRange(LocalDate.of(2024, 1, 1), null))
+            )
+        }
+    }
+
+    @Test
     fun `should work when service need option has no prior voucher values`() {
         db.transaction { tx -> tx.deleteTestVoucherValues() }
         addVoucherValue(testVoucherValue)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueIntegrationTest.kt
@@ -14,6 +14,7 @@ import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.ServiceNeedOptionVoucherValueId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.MockEvakaClock
@@ -154,6 +155,12 @@ class VoucherValueIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
         }
     }
 
+    @Test
+    fun `should work when service need option has no prior voucher values`() {
+        db.transaction { tx -> tx.deleteTestVoucherValues() }
+        addVoucherValue(testVoucherValue)
+    }
+
     fun deleteVoucherValue(id: ServiceNeedOptionVoucherValueId) {
         financeBasicsController.deleteVoucherValue(dbInstance(), financeUser, mockClock, id)
     }
@@ -170,4 +177,16 @@ class VoucherValueIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
     fun getVoucherValues():
         Map<ServiceNeedOptionId, List<ServiceNeedOptionVoucherValueRangeWithId>> =
         dbInstance().connect { dbc -> dbc.read { tx -> tx.getVoucherValuesByServiceNeedOption() } }
+
+    fun Database.Transaction.deleteTestVoucherValues() {
+        execute {
+            sql(
+                """
+                DELETE FROM service_need_option_voucher_value
+                WHERE service_need_option_id = ${bind(snDefaultDaycare.id)}
+            """
+                    .trimIndent()
+            )
+        }
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
@@ -177,13 +177,17 @@ class FinanceBasicsController(
                     if (serviceNeedOption == null)
                         throw BadRequest("Invalid service need option ID")
 
-                    val currentVoucherValues =
-                        tx.getVoucherValuesByServiceNeedOption()[body.serviceNeedOptionId]!!
+                    val currentVoucherValues = tx.getVoucherValuesByServiceNeedOption()
 
-                    val latest = currentVoucherValues.maxByOrNull { it.voucherValues.range.start }
+                    if (currentVoucherValues.containsKey(body.serviceNeedOptionId)) {
+                        val latest =
+                            currentVoucherValues[body.serviceNeedOptionId]!!.maxBy {
+                                it.voucherValues.range.start
+                            }
 
-                    if (latest != null && latest.voucherValues.range.end == null)
-                        tx.updateVoucherValueEndDate(latest.id, body.range.start)
+                        if (latest.voucherValues.range.end == null)
+                            tx.updateVoucherValueEndDate(latest.id, body.range.start)
+                    }
 
                     tx.insertNewVoucherValue(body)
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
@@ -14,8 +14,6 @@ import fi.espoo.evaka.serviceneed.getServiceNeedOptions
 import fi.espoo.evaka.shared.FeeThresholdsId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.ServiceNeedOptionVoucherValueId
-import fi.espoo.evaka.shared.async.AsyncJob
-import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.psqlCause
@@ -47,7 +45,6 @@ import org.springframework.web.bind.annotation.RestController
 )
 class FinanceBasicsController(
     private val accessControl: AccessControl,
-    private val asyncJobRunner: AsyncJobRunner<AsyncJob>
 ) {
     @GetMapping("/fee-thresholds")
     fun getFeeThresholds(
@@ -179,15 +176,22 @@ class FinanceBasicsController(
 
                     val currentVoucherValues = tx.getVoucherValuesByServiceNeedOption()
 
-                    if (currentVoucherValues.containsKey(body.serviceNeedOptionId)) {
-                        val latest =
-                            currentVoucherValues[body.serviceNeedOptionId]!!.maxBy {
-                                it.voucherValues.range.start
-                            }
+                    currentVoucherValues
+                        .getOrDefault(body.serviceNeedOptionId, emptyList())
+                        .maxByOrNull { it.voucherValues.range.start }
+                        ?.let { latest ->
+                            if (!body.range.start.isAfter(latest.voucherValues.range.start))
+                                throw BadRequest(
+                                    "New voucher value range must start after existing ones"
+                                )
 
-                        if (latest.voucherValues.range.end == null)
-                            tx.updateVoucherValueEndDate(latest.id, body.range.start)
-                    }
+                            if (latest.voucherValues.range.overlaps(body.range)) {
+                                tx.updateVoucherValueEndDate(
+                                    latest.id,
+                                    body.range.start.minusDays(1)
+                                )
+                            }
+                        }
 
                     tx.insertNewVoucherValue(body)
                 }
@@ -504,7 +508,7 @@ fun Database.Transaction.updateVoucherValueEndDate(
             sql(
                 """
                 UPDATE service_need_option_voucher_value
-                SET validity = daterange(lower(validity), ${bind(endDate)})
+                SET validity = daterange(lower(validity), ${bind(endDate)}, '[]')
                 WHERE id = ${bind(id)}
             """
             )


### PR DESCRIPTION
Palse-arvon lisääminen palvelutarpeelle jolla ei ollut ennestään yhtään palse-arvoa epäonnistui, koska servicellä tuli null pointer exception

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
