### PR TITLE
Tarkastettu-tila palvelusetelien maksuaineistojen maksatukselle eVakasta

### DIFF
--- a/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
@@ -563,4 +563,12 @@ export class PaymentsPage {
   async deletePayments() {
     await this.page.findByDataQa('delete-payments').click()
   }
+
+  async confirmPayments() {
+    await this.page.findByDataQa('confirm-payments').click()
+  }
+
+  async revertPayments() {
+    await this.page.findByDataQa('revert-payments').click()
+  }
 }

--- a/frontend/src/e2e-test/specs/4_finance/payments.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/payments.spec.ts
@@ -46,8 +46,17 @@ describe('Payments', () => {
   test('are toggled and sent', async () => {
     await paymentsPage.togglePayments(true)
     await paymentsPage.assertPaymentCount(1)
+
+    await paymentsPage.confirmPayments()
+    await paymentsPage.assertPaymentCount(0)
+
+    await paymentsPage.setStatusFilter('CONFIRMED')
+    await paymentsPage.assertPaymentCount(1)
+
+    await paymentsPage.togglePayments(true)
     await paymentsPage.sendPayments()
     await paymentsPage.assertPaymentCount(0)
+
     await paymentsPage.setStatusFilter('SENT')
     await paymentsPage.assertPaymentCount(1)
   })
@@ -57,5 +66,23 @@ describe('Payments', () => {
     await paymentsPage.assertPaymentCount(1)
     await paymentsPage.deletePayments()
     await paymentsPage.assertPaymentCount(0)
+  })
+
+  test('are reverted', async () => {
+    await paymentsPage.togglePayments(true)
+    await paymentsPage.assertPaymentCount(1)
+
+    await paymentsPage.confirmPayments()
+    await paymentsPage.assertPaymentCount(0)
+
+    await paymentsPage.setStatusFilter('CONFIRMED')
+    await paymentsPage.assertPaymentCount(1)
+
+    await paymentsPage.togglePayments(true)
+    await paymentsPage.revertPayments()
+    await paymentsPage.assertPaymentCount(0)
+
+    await paymentsPage.setStatusFilter('DRAFT')
+    await paymentsPage.assertPaymentCount(1)
   })
 })

--- a/frontend/src/employee-frontend/components/payments/Actions.tsx
+++ b/frontend/src/employee-frontend/components/payments/Actions.tsx
@@ -15,7 +15,8 @@ import colors from 'lib-customizations/common'
 
 import {
   confirmDraftPayments,
-  deleteDraftPayments
+  deleteDraftPayments,
+  revertPaymentsToDrafts
 } from '../../generated/api-clients/invoicing'
 import { useTranslation } from '../../state/i18n'
 import StickyActionBar from '../common/StickyActionBar'
@@ -25,6 +26,7 @@ import { PaymentsActions } from './payments-state'
 
 const deleteDraftPaymentsResult = wrapResult(deleteDraftPayments)
 const confirmDraftPaymentsResult = wrapResult(confirmDraftPayments)
+const revertPaymentsResult = wrapResult(revertPaymentsToDrafts)
 
 const CheckedRowsInfo = styled.div`
   color: ${colors.grayscale.g35};
@@ -58,38 +60,51 @@ const Actions = React.memo(function Actions({
           <Gap size="s" horizontal />
         </>
       ) : null}
-      {status === 'DRAFT' && (
-        <AsyncButton
-          text={i18n.payments.buttons.deletePayment(checkedIds.length)}
-          disabled={checkedIds.length === 0}
-          onClick={() => deleteDraftPaymentsResult({ body: checkedIds })}
-          onSuccess={() => {
-            actions.clearChecked()
-            reloadPayments()
-          }}
-          data-qa="delete-payments"
-        />
-      )}
-      <Gap size="s" horizontal />
       {status === 'DRAFT' ? (
-        <AsyncButton
-          text={i18n.payments.buttons.confirmPayments(checkedIds.length)}
-          disabled={checkedIds.length === 0}
-          onClick={() => confirmDraftPaymentsResult({ body: checkedIds })}
-          onSuccess={() => {
-            actions.clearChecked()
-            reloadPayments()
-          }}
-          data-qa="delete-payments"
-        />
+        <>
+          <AsyncButton
+            text={i18n.payments.buttons.deletePayment(checkedIds.length)}
+            disabled={checkedIds.length === 0}
+            onClick={() => deleteDraftPaymentsResult({ body: checkedIds })}
+            onSuccess={() => {
+              actions.clearChecked()
+              reloadPayments()
+            }}
+            data-qa="delete-payments"
+          />
+          <Gap size="s" horizontal />
+          <AsyncButton
+            text={i18n.payments.buttons.confirmPayments(checkedIds.length)}
+            disabled={checkedIds.length === 0}
+            onClick={() => confirmDraftPaymentsResult({ body: checkedIds })}
+            onSuccess={() => {
+              actions.clearChecked()
+              reloadPayments()
+            }}
+            data-qa="confirm-payments"
+          />
+        </>
       ) : status === 'CONFIRMED' ? (
-        <Button
-          primary
-          disabled={checkedIds.length === 0}
-          text={i18n.payments.buttons.sendPayments(checkedIds.length)}
-          onClick={actions.openModal}
-          data-qa="open-send-payments-dialog"
-        />
+        <>
+          <AsyncButton
+            text={i18n.payments.buttons.revertPayments(checkedIds.length)}
+            disabled={checkedIds.length === 0}
+            onClick={() => revertPaymentsResult({ body: checkedIds })}
+            onSuccess={() => {
+              actions.clearChecked()
+              reloadPayments()
+            }}
+            data-qa="revert-payments"
+          />
+          <Gap size="s" horizontal />
+          <Button
+            primary
+            disabled={checkedIds.length === 0}
+            text={i18n.payments.buttons.sendPayments(checkedIds.length)}
+            onClick={actions.openModal}
+            data-qa="open-send-payments-dialog"
+          />
+        </>
       ) : null}
     </StickyActionBar>
   ) : null

--- a/frontend/src/employee-frontend/components/payments/PaymentFilters.tsx
+++ b/frontend/src/employee-frontend/components/payments/PaymentFilters.tsx
@@ -184,7 +184,7 @@ export function PaymentStatusFilter({
 }: PaymentStatusFilterProps) {
   const { i18n } = useTranslation()
 
-  const statuses: PaymentStatus[] = ['DRAFT', 'SENT']
+  const statuses: PaymentStatus[] = ['DRAFT', 'CONFIRMED', 'SENT']
 
   return (
     <>

--- a/frontend/src/employee-frontend/components/payments/PaymentsPage.tsx
+++ b/frontend/src/employee-frontend/components/payments/PaymentsPage.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import { Result } from 'lib-common/api'
+import { PaymentStatus } from 'lib-common/generated/api-types/invoicing'
 import LocalDate from 'lib-common/local-date'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { DatePickerDeprecated } from 'lib-components/molecules/DatePickerDeprecated'
@@ -20,6 +21,8 @@ import Actions from './Actions'
 import PaymentFilters from './PaymentFilters'
 import Payments from './Payments'
 import { PaymentsActions, usePaymentsState } from './payments-state'
+
+export const selectablePaymentStatuses: PaymentStatus[] = ['DRAFT', 'CONFIRMED']
 
 export default React.memo(function PaymentsPage() {
   const {
@@ -57,7 +60,9 @@ export default React.memo(function PaymentsPage() {
           currentPage={page}
           sortBy={sortBy}
           sortDirection={sortDirection}
-          showCheckboxes={searchFilters.status === 'DRAFT'}
+          showCheckboxes={selectablePaymentStatuses.includes(
+            searchFilters.status
+          )}
           checked={checkedPayments}
         />
       </ContentArea>

--- a/frontend/src/employee-frontend/generated/api-clients/invoicing.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/invoicing.ts
@@ -831,6 +831,23 @@ export async function deleteDraftPayments(
 
 
 /**
+* Generated from fi.espoo.evaka.invoicing.controller.PaymentController.revertPaymentsToDrafts
+*/
+export async function revertPaymentsToDrafts(
+  request: {
+    body: UUID[]
+  }
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/employee/payments/revert-to-draft`.toString(),
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<UUID[]>
+  })
+  return json
+}
+
+
+/**
 * Generated from fi.espoo.evaka.invoicing.controller.PaymentController.searchPayments
 */
 export async function searchPayments(

--- a/frontend/src/employee-frontend/generated/api-clients/invoicing.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/invoicing.ts
@@ -785,6 +785,23 @@ export async function updateInvoiceCorrectionNote(
 
 
 /**
+* Generated from fi.espoo.evaka.invoicing.controller.PaymentController.confirmDraftPayments
+*/
+export async function confirmDraftPayments(
+  request: {
+    body: UUID[]
+  }
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/employee/payments/confirm`.toString(),
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<UUID[]>
+  })
+  return json
+}
+
+
+/**
 * Generated from fi.espoo.evaka.invoicing.controller.PaymentController.createPaymentDrafts
 */
 export async function createPaymentDrafts(): Promise<void> {

--- a/frontend/src/lib-common/generated/action.d.ts
+++ b/frontend/src/lib-common/generated/action.d.ts
@@ -337,6 +337,7 @@ export type Partnership =
 export type Payment =
   | 'CONFIRM'
   | 'DELETE'
+  | 'REVERT_TO_DRAFT'
   | 'SEND'
 
 export type Person =

--- a/frontend/src/lib-common/generated/action.d.ts
+++ b/frontend/src/lib-common/generated/action.d.ts
@@ -335,6 +335,7 @@ export type Partnership =
   | 'UPDATE'
 
 export type Payment =
+  | 'CONFIRM'
   | 'DELETE'
   | 'SEND'
 

--- a/frontend/src/lib-common/generated/api-types/invoicing.ts
+++ b/frontend/src/lib-common/generated/api-types/invoicing.ts
@@ -801,6 +801,7 @@ export type PaymentSortParam =
 */
 export type PaymentStatus =
   | 'DRAFT'
+  | 'CONFIRMED'
   | 'SENT'
 
 /**

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2934,6 +2934,8 @@ export const fi = {
       createPaymentDrafts: 'Luo maksatusaineisto',
       checked: (count: number) =>
         count === 1 ? `${count} rivi valittu` : `${count} riviä valittu`,
+      confirmPayments: (count: number) =>
+        count === 1 ? `Tarkasta ${count} maksu` : `Tarkasta ${count} maksua`,
       sendPayments: (count: number) =>
         count === 1 ? `Siirrä ${count} maksu` : `Siirrä ${count} maksua`,
       deletePayment: (count: number) =>
@@ -2941,6 +2943,7 @@ export const fi = {
     },
     status: {
       DRAFT: 'Luonnos',
+      CONFIRMED: 'Tarkastettu',
       SENT: 'Siirretty'
     },
     sendModal: {

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2935,7 +2935,13 @@ export const fi = {
       checked: (count: number) =>
         count === 1 ? `${count} rivi valittu` : `${count} riviä valittu`,
       confirmPayments: (count: number) =>
-        count === 1 ? `Tarkasta ${count} maksu` : `Tarkasta ${count} maksua`,
+        count === 1
+          ? `Merkitse ${count} maksu tarkastetuksi`
+          : `Merkitse ${count} maksua tarkastetuksi`,
+      revertPayments: (count: number) =>
+        count === 1
+          ? `Palauta ${count} maksu luonnokseksi`
+          : `Palauta ${count} maksua luonnoksiksi`,
       sendPayments: (count: number) =>
         count === 1 ? `Siirrä ${count} maksu` : `Siirrä ${count} maksua`,
       deletePayment: (count: number) =>

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/PaymentsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/PaymentsIntegrationTest.kt
@@ -207,6 +207,63 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     }
 
     @Test
+    fun `confirm payments`() {
+        createVoucherDecision(
+            janFirst,
+            // Doesn't have payment details
+            unitId = testDaycare.id,
+            headOfFamilyId = testAdult_2.id,
+            childId = testChild_2.id,
+            value = 134850,
+            coPayment = 28800
+        )
+        createVoucherDecision(
+            janFirst,
+            // Has payment details
+            unitId = testVoucherDaycare.id,
+            headOfFamilyId = testAdult_1.id,
+            childId = testChild_1.id,
+            value = 87000,
+            coPayment = 28800
+        )
+        db.transaction {
+            freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue, janFreeze)
+        }
+        val paymentDraftIds = createPaymentDrafts(janLast)
+
+        confirmPaymentDrafts(janLast, paymentDraftIds)
+
+        val payments = db.read { it.readPayments() }
+        assertEquals(2, payments.size)
+
+        // assert respective details
+        payments.first().let { payment ->
+            assertEquals(DateRange(janFirst, janLast), payment.period)
+            assertEquals(testDaycare.id, payment.unit.id)
+            assertEquals(testDaycare.name, payment.unit.name)
+            assertEquals(134850 - 28800, payment.amount)
+        }
+        payments.last().let { payment ->
+            assertEquals(testVoucherDaycare.id, payment.unit.id)
+            assertEquals(87000 - 28800, payment.amount)
+            assertEquals(testVoucherDaycare.name, payment.unit.name)
+        }
+
+        // assert that status is set and sending details remain unset
+        payments.forEach { payment ->
+            assertEquals(PaymentStatus.CONFIRMED, payment.status)
+            assertEquals(null, payment.paymentDate)
+            assertEquals(null, payment.dueDate)
+            assertEquals(null, payment.number)
+            assertEquals(null, payment.sentBy)
+            assertEquals(null, payment.sentAt)
+            assertEquals(null, payment.unit.businessId)
+            assertEquals(null, payment.unit.iban)
+            assertEquals(null, payment.unit.providerId)
+        }
+    }
+
+    @Test
     fun `send payments`() {
         createVoucherDecision(
             janFirst,
@@ -231,6 +288,7 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         }
         val paymentDraftIds = createPaymentDrafts(janLast)
 
+        confirmPaymentDrafts(janLast, paymentDraftIds)
         sendPayments(
             today = febFirst,
             paymentDate = febSecond,
@@ -241,7 +299,7 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         val payments = db.read { it.readPayments() }
         assertEquals(2, payments.size)
         payments.first().let { payment ->
-            assertEquals(PaymentStatus.DRAFT, payment.status)
+            assertEquals(PaymentStatus.CONFIRMED, payment.status)
             assertEquals(DateRange(janFirst, janLast), payment.period)
             assertEquals(testDaycare.id, payment.unit.id)
             assertEquals(134850 - 28800, payment.amount)
@@ -307,6 +365,8 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue, janFreeze)
         }
         val paymentDraftIds1 = createPaymentDrafts(janLast)
+
+        confirmPaymentDrafts(janLast, paymentDraftIds1)
 
         sendPayments(
             today = febFirst,
@@ -396,6 +456,15 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             tx.createQuery("""SELECT id FROM payment WHERE status = 'DRAFT' ORDER BY amount""")
                 .toList<PaymentId>()
         }
+    }
+
+    private fun confirmPaymentDrafts(today: LocalDate, ids: List<PaymentId>) {
+        paymentController.confirmDraftPayments(
+            dbInstance(),
+            financeUser,
+            MockEvakaClock(HelsinkiDateTime.of(today, LocalTime.of(10, 0))),
+            ids
+        )
     }
 
     private fun deletePaymentDrafts(today: LocalDate, paymentIds: List<PaymentId>) {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/PaymentsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/PaymentsIntegrationTest.kt
@@ -264,6 +264,65 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     }
 
     @Test
+    fun `revert confirmed payments to drafts`() {
+        createVoucherDecision(
+            janFirst,
+            // Doesn't have payment details
+            unitId = testDaycare.id,
+            headOfFamilyId = testAdult_2.id,
+            childId = testChild_2.id,
+            value = 134850,
+            coPayment = 28800
+        )
+        createVoucherDecision(
+            janFirst,
+            // Has payment details
+            unitId = testVoucherDaycare.id,
+            headOfFamilyId = testAdult_1.id,
+            childId = testChild_1.id,
+            value = 87000,
+            coPayment = 28800
+        )
+        db.transaction {
+            freezeVoucherValueReportRows(it, janFirst.year, janFirst.monthValue, janFreeze)
+        }
+        val paymentDraftIds = createPaymentDrafts(janLast)
+
+        confirmPaymentDrafts(janLast, paymentDraftIds)
+
+        revertPaymentsToDrafts(janLast, paymentDraftIds)
+
+        val payments = db.read { it.readPayments() }
+        assertEquals(2, payments.size)
+
+        // assert respective details
+        payments.first().let { payment ->
+            assertEquals(DateRange(janFirst, janLast), payment.period)
+            assertEquals(testDaycare.id, payment.unit.id)
+            assertEquals(testDaycare.name, payment.unit.name)
+            assertEquals(134850 - 28800, payment.amount)
+        }
+        payments.last().let { payment ->
+            assertEquals(testVoucherDaycare.id, payment.unit.id)
+            assertEquals(87000 - 28800, payment.amount)
+            assertEquals(testVoucherDaycare.name, payment.unit.name)
+        }
+
+        // assert that status is set and sending details remain unset
+        payments.forEach { payment ->
+            assertEquals(PaymentStatus.DRAFT, payment.status)
+            assertEquals(null, payment.paymentDate)
+            assertEquals(null, payment.dueDate)
+            assertEquals(null, payment.number)
+            assertEquals(null, payment.sentBy)
+            assertEquals(null, payment.sentAt)
+            assertEquals(null, payment.unit.businessId)
+            assertEquals(null, payment.unit.iban)
+            assertEquals(null, payment.unit.providerId)
+        }
+    }
+
+    @Test
     fun `send payments`() {
         createVoucherDecision(
             janFirst,
@@ -460,6 +519,15 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
 
     private fun confirmPaymentDrafts(today: LocalDate, ids: List<PaymentId>) {
         paymentController.confirmDraftPayments(
+            dbInstance(),
+            financeUser,
+            MockEvakaClock(HelsinkiDateTime.of(today, LocalTime.of(10, 0))),
+            ids
+        )
+    }
+
+    private fun revertPaymentsToDrafts(today: LocalDate, ids: List<PaymentId>) {
+        paymentController.revertPaymentsToDrafts(
             dbInstance(),
             financeUser,
             MockEvakaClock(HelsinkiDateTime.of(today, LocalTime.of(10, 0))),

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -383,6 +383,7 @@ enum class Audit(
     PartnerShipsUpdate,
     PartnersInDifferentAddressReportRead,
     PatuReportSend,
+    PaymentsConfirmDrafts,
     PaymentsCreate,
     PaymentsDeleteDrafts,
     PaymentsSend,

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -386,6 +386,7 @@ enum class Audit(
     PaymentsConfirmDrafts,
     PaymentsCreate,
     PaymentsDeleteDrafts,
+    PaymentsRevertToDrafts,
     PaymentsSend,
     PedagogicalDocumentCreate(securityEvent = true, securityLevel = "high"),
     PedagogicalDocumentCountUnread,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/PaymentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/PaymentController.kt
@@ -130,7 +130,7 @@ class PaymentController(
                 paymentService.confirmPayments(it, paymentIds)
             }
         }
-        Audit.PaymentsConfirmDrafts.log(targetId = paymentIds)
+        Audit.PaymentsConfirmDrafts.log(targetId = AuditId(paymentIds))
     }
 
     @PostMapping("/employee/payments/revert-to-draft")
@@ -152,7 +152,7 @@ class PaymentController(
                 paymentService.revertPaymentsToDrafts(it, paymentIds)
             }
         }
-        Audit.PaymentsRevertToDrafts.log(targetId = paymentIds)
+        Audit.PaymentsRevertToDrafts.log(targetId = AuditId(paymentIds))
     }
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/PaymentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/PaymentController.kt
@@ -20,19 +20,16 @@ import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import java.time.LocalDate
-import mu.KotlinLogging
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
-
-private val logger = KotlinLogging.logger {}
 
 @RestController
 class PaymentController(
     private val accessControl: AccessControl,
     private val paymentService: PaymentService
 ) {
-    @PostMapping("/payments/search")
+    @PostMapping(path = ["/payments/search", "/employee/payments/search"])
     fun searchPayments(
         db: Database,
         user: AuthenticatedUser.Employee,
@@ -41,7 +38,7 @@ class PaymentController(
         return db.connect { dbc -> dbc.read { tx -> tx.searchPayments(params) } }
     }
 
-    @PostMapping("/payments/create-drafts")
+    @PostMapping(path = ["/payments/create-drafts", "/employee/payments/create-drafts"])
     fun createPaymentDrafts(db: Database, user: AuthenticatedUser.Employee, clock: EvakaClock) {
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -63,7 +60,7 @@ class PaymentController(
         val paymentIds: List<PaymentId>
     )
 
-    @PostMapping("/payments/delete-drafts")
+    @PostMapping(path = ["/payments/delete-drafts", "/employee/payments/delete-drafts"])
     fun deleteDraftPayments(
         db: Database,
         user: AuthenticatedUser.Employee,
@@ -85,7 +82,7 @@ class PaymentController(
         Audit.PaymentsDeleteDrafts.log(targetId = AuditId(paymentIds))
     }
 
-    @PostMapping("/payments/send")
+    @PostMapping(path = ["/payments/send", "/employee/payments/send"])
     fun sendPayments(
         db: Database,
         user: AuthenticatedUser.Employee,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/PaymentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/PaymentController.kt
@@ -135,6 +135,28 @@ class PaymentController(
         }
         Audit.PaymentsConfirmDrafts.log(targetId = paymentIds)
     }
+
+    @PostMapping("/employee/payments/revert-to-draft")
+    fun revertPaymentsToDrafts(
+        db: Database,
+        user: AuthenticatedUser.Employee,
+        clock: EvakaClock,
+        @RequestBody paymentIds: List<PaymentId>
+    ) {
+        db.connect { dbc ->
+            dbc.transaction {
+                accessControl.requirePermissionFor(
+                    it,
+                    user,
+                    clock,
+                    Action.Payment.REVERT_TO_DRAFT,
+                    paymentIds
+                )
+                paymentService.revertPaymentsToDrafts(it, paymentIds)
+            }
+        }
+        Audit.PaymentsRevertToDrafts.log(targetId = paymentIds)
+    }
 }
 
 data class SearchPaymentsRequest(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/PaymentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/PaymentQueries.kt
@@ -167,29 +167,27 @@ WHERE id = ${bind { it.id }}
 fun Database.Transaction.confirmDraftPayments(draftIds: List<PaymentId>) {
     if (draftIds.isEmpty()) return
 
-    createUpdate {
-            sql(
-                """
-                UPDATE payment set status = ${bind(PaymentStatus.CONFIRMED)}::payment_status 
-                WHERE status = ${bind(PaymentStatus.DRAFT)}::payment_status
+    execute {
+        sql(
+            """
+                UPDATE payment set status = ${bind(PaymentStatus.CONFIRMED)} 
+                WHERE status = ${bind(PaymentStatus.DRAFT)}
                 AND id = ANY (${bind(draftIds)})
                 """
-            )
-        }
-        .execute()
+        )
+    }
 }
 
 fun Database.Transaction.revertPaymentsToDrafts(paymentIds: List<PaymentId>) {
     if (paymentIds.isEmpty()) return
 
-    createUpdate {
-            sql(
-                """
-                UPDATE payment set status = ${bind(PaymentStatus.DRAFT)}::payment_status 
-                WHERE status = ${bind(PaymentStatus.CONFIRMED)}::payment_status
+    execute {
+        sql(
+            """
+                UPDATE payment set status = ${bind(PaymentStatus.DRAFT)} 
+                WHERE status = ${bind(PaymentStatus.CONFIRMED)}
                 AND id = ANY (${bind(paymentIds)})
                 """
-            )
-        }
-        .execute()
+        )
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/PaymentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/PaymentQueries.kt
@@ -178,3 +178,18 @@ fun Database.Transaction.confirmDraftPayments(draftIds: List<PaymentId>) {
         }
         .execute()
 }
+
+fun Database.Transaction.revertPaymentsToDrafts(paymentIds: List<PaymentId>) {
+    if (paymentIds.isEmpty()) return
+
+    createUpdate {
+            sql(
+                """
+                UPDATE payment set status = ${bind(PaymentStatus.DRAFT)}::payment_status 
+                WHERE status = ${bind(PaymentStatus.CONFIRMED)}::payment_status
+                AND id = ANY (${bind(paymentIds)})
+                """
+            )
+        }
+        .execute()
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Payments.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Payments.kt
@@ -53,6 +53,7 @@ interface PaymentIntegrationClient {
 
 enum class PaymentStatus : DatabaseEnum {
     DRAFT,
+    CONFIRMED,
     SENT;
 
     override val sqlType = "payment_status"

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/PaymentService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/PaymentService.kt
@@ -4,9 +4,10 @@
 
 package fi.espoo.evaka.invoicing.service
 
+import fi.espoo.evaka.invoicing.data.confirmDraftPayments
 import fi.espoo.evaka.invoicing.data.getMaxPaymentNumber
 import fi.espoo.evaka.invoicing.data.readPaymentsByIdsWithFreshUnitData
-import fi.espoo.evaka.invoicing.data.updatePaymentDraftsAsSent
+import fi.espoo.evaka.invoicing.data.updateConfirmedPaymentsAsSent
 import fi.espoo.evaka.invoicing.domain.PaymentIntegrationClient
 import fi.espoo.evaka.invoicing.domain.PaymentStatus
 import fi.espoo.evaka.shared.FeatureConfig
@@ -39,9 +40,9 @@ class PaymentService(
                 ?: throw Error("paymentNumberSeriesStart not configured")
         val payments = tx.readPaymentsByIdsWithFreshUnitData(paymentIds)
 
-        val notDrafts = payments.filterNot { it.status == PaymentStatus.DRAFT }
-        if (notDrafts.isNotEmpty()) {
-            throw BadRequest("Some payments are not drafts")
+        val notConfirmed = payments.filterNot { it.status == PaymentStatus.CONFIRMED }
+        if (notConfirmed.isNotEmpty()) {
+            throw BadRequest("Some payments are not confirmed")
         }
 
         var nextPaymentNumber =
@@ -86,6 +87,20 @@ class PaymentService(
             sendResult.failed.map { it.id }.joinToString(", ")
             }"
         }
-        tx.updatePaymentDraftsAsSent(sendResult.succeeded, now)
+        tx.updateConfirmedPaymentsAsSent(sendResult.succeeded, now)
+    }
+
+    fun confirmPayments(
+        tx: Database.Transaction,
+        paymentIds: List<PaymentId>,
+    ) {
+        val payments = tx.readPaymentsByIdsWithFreshUnitData(paymentIds)
+
+        val notDrafts = payments.filterNot { it.status == PaymentStatus.DRAFT }
+        if (notDrafts.isNotEmpty()) {
+            throw BadRequest("Some payments are not drafts")
+        }
+
+        tx.confirmDraftPayments(paymentIds)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -1744,7 +1744,8 @@ sealed interface Action {
     enum class Payment(override vararg val defaultRules: ScopedActionRule<in PaymentId>) :
         ScopedAction<PaymentId> {
         SEND(HasGlobalRole(ADMIN, FINANCE_ADMIN)),
-        DELETE(HasGlobalRole(ADMIN, FINANCE_ADMIN));
+        DELETE(HasGlobalRole(ADMIN, FINANCE_ADMIN)),
+        CONFIRM(HasGlobalRole(ADMIN, FINANCE_ADMIN));
 
         override fun toString(): String = "${javaClass.name}.$name"
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -1745,7 +1745,8 @@ sealed interface Action {
         ScopedAction<PaymentId> {
         SEND(HasGlobalRole(ADMIN, FINANCE_ADMIN)),
         DELETE(HasGlobalRole(ADMIN, FINANCE_ADMIN)),
-        CONFIRM(HasGlobalRole(ADMIN, FINANCE_ADMIN));
+        CONFIRM(HasGlobalRole(ADMIN, FINANCE_ADMIN)),
+        REVERT_TO_DRAFT(HasGlobalRole(ADMIN, FINANCE_ADMIN));
 
         override fun toString(): String = "${javaClass.name}.$name"
     }

--- a/service/src/main/resources/db/migration/V419__payment_confirmed_state.sql
+++ b/service/src/main/resources/db/migration/V419__payment_confirmed_state.sql
@@ -1,0 +1,1 @@
+ALTER TYPE payment_status ADD VALUE 'CONFIRMED';

--- a/service/src/main/resources/db/migration/V420__payment_constraint_change.sql
+++ b/service/src/main/resources/db/migration/V420__payment_constraint_change.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.payment
+    DROP CONSTRAINT check$payment_state,
+    ADD CONSTRAINT check$payment_state
+        CHECK ((status = ANY('{DRAFT,CONFIRMED}'::payment_status[])) OR
+               ((unit_business_id IS NOT NULL) AND (unit_business_id <> ''::text) AND (unit_iban IS NOT NULL) AND
+                (unit_iban <> ''::text) AND (unit_provider_id IS NOT NULL) AND (unit_provider_id <> ''::text) AND
+                (number IS NOT NULL) AND (payment_date IS NOT NULL) AND (due_date IS NOT NULL) AND
+                (sent_at IS NOT NULL) AND (sent_by IS NOT NULL)));

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -415,3 +415,5 @@ V415__meal_texture.sql
 V416__shift_care_operation_times_improvements.sql
 V417__varda_unit_remove_id.sql
 V418__application_non_nullable_fields.sql
+V419__payment_confirmed_state.sql
+V420__payment_constraint_change.sql


### PR DESCRIPTION
Lisätty palvelusetelien maksatuksen käyttöliittymään `Tarkastettu`-tila manuaalisen tarkastamisen kirjanpitoa varten. Tilasiirtymä `Luonnos` -> `Tarkastettu` ei sisällä automaattisia tarkastuksia maksuaineiston laadusta. Lisätty filtteri tilan omaavien aineistojen näyttämiseen ja napit tilaan ja tilasta siirtymisiin. 

Käyttöoikeudet: pääkäyttäjä (ADMIN) ja talouden käyttäjä (FINANCE_ADMIN)

![tarkastettu](https://github.com/espoon-voltti/evaka/assets/19532529/634464f5-8992-47aa-945f-fa8d2e3403f1)
