### PR TITLE
Lisätty konfigurointimahdollisuus tilapäisen osa-aikaisen vakan laskukäsittelyyn

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
@@ -602,7 +602,12 @@ class DraftInvoiceGenerator(
                     unitId,
                     dailyFeeDivisor,
                     attendanceDates,
-                    absences
+                    if (
+                        invoiceRowStub.placement.type != PlacementType.TEMPORARY_DAYCARE_PART_DAY ||
+                            featureConfig.temporaryDaycarePartDayAbsenceGivesADailyRefund
+                    )
+                        absences
+                    else emptyList()
                 )
             else ->
                 toPermanentPlacementInvoiceRows(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -134,4 +134,7 @@ data class FeatureConfig(
 
     /** Enable use of special five-year-old daycare placement types */
     val fiveYearsOldDaycareEnabled: Boolean,
+
+    /** Controls whether absences give a daily refund for TEMPORARY_DAYCARE_PART_DAY */
+    val temporaryDaycarePartDayAbsenceGivesADailyRefund: Boolean = true,
 )


### PR DESCRIPTION
Normaalisti poissaolot vähentävät tilapäisen vakan päiviä, mutta Tampereen 2024 kesäkerhoja varten ei pitäisi vähentää. Tämä muutos voidaan todennäköisesti poistaa syksyllä.