### PR TITLE
Varda-yksikköpäivitys perustuu nyt OID:hen

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/VardaPlacementsIntegrationTest.kt
@@ -18,8 +18,8 @@ internal fun insertVardaUnit(
         it.execute {
             sql(
                 """
-INSERT INTO varda_unit (evaka_daycare_id, varda_unit_id, created_at, last_success_at)
-VALUES (${bind(unitId)}, 1, ${bind(HelsinkiDateTime.now())}, ${bind(HelsinkiDateTime.now())})
+INSERT INTO varda_unit (evaka_daycare_id, created_at, last_success_at)
+VALUES (${bind(unitId)}, ${bind(HelsinkiDateTime.now())}, ${bind(HelsinkiDateTime.now())})
 """
             )
         }

--- a/service/src/main/resources/db/migration/V417__varda_unit_remove_id.sql
+++ b/service/src/main/resources/db/migration/V417__varda_unit_remove_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE varda_unit DROP COLUMN varda_unit_id;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -413,3 +413,4 @@ V413__invoiced_fee_decision.sql
 V414__varda_unit_state.sql
 V415__meal_texture.sql
 V416__shift_care_operation_times_improvements.sql
+V417__varda_unit_remove_id.sql

--- a/service/src/test/kotlin/fi/espoo/evaka/varda/VardaUnitModelTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/varda/VardaUnitModelTest.kt
@@ -50,6 +50,7 @@ class VardaUnitModelTest {
 val testUnit =
     VardaUnit(
         evakaDaycareId = DaycareId(UUID.randomUUID()),
+        ophUnitOid = "1.2.3.4.5",
         name = "Testipäiväkoti",
         streetAddress = "Testiosoite 6",
         postalCode = "00200",


### PR DESCRIPTION
eVakassa oleva yksikkö kohdistuu oikeaan Varda-yksikköön OID:n perusteella. Tämä korjaa Varda-päivityksen yksiköille, jotka on luotu eVakan ulkopuolella, kunhan niiden OID on tiedossa. Jos yksikölle ei ole asetettu OID:ta, luodaan Vardaan uusi yksikkö ja tallennetaan saatu OID. Tämä logiikka on lähempänä sitä, miten lapsen päivitys toimii.