### PR TITLE
Parannuksia sähköpostien lähetykseen

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailClient.kt
@@ -76,4 +76,5 @@ private fun Database.Read.getEmailAddressAndEnabledTypes(
             sql("""SELECT email, enabled_email_types FROM person WHERE id = ${bind(personId)}""")
         }
         .exactlyOne<EmailAndEnabledEmailTypes>()
+        .let { it.copy(email = it.email?.trim()) }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -288,10 +288,6 @@ RETURNING id
         .executeAndReturnGeneratedKeys()
         .toList<MessageId>()
 
-fun Database.Read.getMessageAuthor(content: MessageContentId): MessageAccountId? =
-    createQuery { sql("SELECT author_id FROM message_content WHERE id = ${bind(content)}") }
-        .exactlyOneOrNull<MessageAccountId>()
-
 fun Database.Transaction.insertThreadsWithMessages(
     count: Int,
     now: HelsinkiDateTime,


### PR DESCRIPTION
- Lähetetään notifikaatio kunnallisista tiedotteista heti (SES:n quotan puitteissa). Aiemmin kunnallisten tiedotteiden notifikaatioiden lähettäminen jaettiin tasaisesti 12 tunnin ajalle.
- Sähköpostin lähetys ei enää epäonnistu vaikka vastaanottajan osoitteen alussa tai lopussa olisi tyhjää