### PR TITLE
Lähetetään varoitus yksikönjohtajille ERV nollaantumisesta

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/children/ChildrenQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/children/ChildrenQueries.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.children
 
 import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.db.Database
 import java.time.LocalDate
@@ -64,3 +65,19 @@ SELECT child_id FROM foster_parent WHERE parent_id = ${bind(userId)} AND valid_d
             )
         }
         .toList()
+
+fun Database.Read.getActivePlacementUnitsForChildren(
+    today: LocalDate,
+    childIds: Set<ChildId>
+): Map<DaycareId, List<ChildId>> =
+    createQuery {
+            sql(
+                """
+SELECT unit_id, child_id
+FROM placement
+WHERE child_id = ANY (${bind(childIds)}) AND start_date <= ${bind(today)} AND end_date >= ${bind(today)}
+"""
+            )
+        }
+        .toList { column<DaycareId>("unit_id") to column<ChildId>("child_id") }
+        .groupBy({ it.first }, { it.second })

--- a/service/src/main/kotlin/fi/espoo/evaka/children/ChildrenQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/children/ChildrenQueries.kt
@@ -75,7 +75,7 @@ fun Database.Read.getActivePlacementUnitsForChildren(
                 """
 SELECT unit_id, child_id
 FROM placement
-WHERE child_id = ANY (${bind(childIds)}) AND start_date <= ${bind(today)} AND end_date >= ${bind(today)}
+WHERE child_id = ANY (${bind(childIds)}) AND daterange(start_date, end_date, '[]') @> ${bind(today)}
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EmailClient.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.emailclient
 
 import fi.espoo.evaka.pis.EmailMessageType
 import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.auth.DaycareAclRowEmployee
 import fi.espoo.evaka.shared.db.Database
 import mu.KotlinLogging
 
@@ -20,9 +21,6 @@ private constructor(
     val content: EmailContent,
     val traceId: String
 ) {
-    fun send(emailClient: EmailClient) {
-        emailClient.send(this)
-    }
 
     companion object {
         fun create(
@@ -56,6 +54,27 @@ private constructor(
             }
 
             return Email(toAddress, fromAddress, content, traceId)
+        }
+
+        fun createForEmployee(
+            employee: DaycareAclRowEmployee,
+            content: EmailContent,
+            traceId: String,
+            fromAddress: String
+        ): Email? {
+            if (employee.email == null) {
+                logger.warn("Will not send email due to missing email address: (traceId: $traceId)")
+                return null
+            }
+
+            if (!employee.email.matches(EMAIL_PATTERN)) {
+                logger.warn(
+                    "Will not send email due to invalid toAddress \"$employee.email\": (traceId: $traceId)"
+                )
+                return null
+            }
+
+            return Email(employee.email, fromAddress, content, traceId)
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
@@ -106,11 +106,15 @@ class JamixService(
         if (client == null) error("Cannot sync diet list: JamixEnv is not configured")
         val warningEmails =
             fetchAndUpdateJamixDiets(client, db, clock, emailEnv.sender(Language.fi))
-        fetchAndUpdateJamixTextures(client, db)
-        warningEmails.forEach { emailClient.send(it) }
+        try {
+            fetchAndUpdateJamixTextures(client, db)
+        } finally {
+            warningEmails.forEach { emailClient.send(it) }
+        }
     }
 }
 
+/** Throws an IllegalStateException if Jamix returns an empty diet list. */
 fun fetchAndUpdateJamixDiets(
     client: JamixClient,
     db: Database.Connection,
@@ -193,6 +197,7 @@ private fun createEmailBodyForUnit(
         emailBodyLines.joinToString("\n")
 }
 
+/** Throws an IllegalStateException if Jamix returns an empty texture list. */
 fun fetchAndUpdateJamixTextures(
     client: JamixClient,
     db: Database.Connection,

--- a/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
@@ -108,8 +108,16 @@ class JamixService(
             fetchAndUpdateJamixDiets(client, db, clock, emailEnv.sender(Language.fi))
         try {
             fetchAndUpdateJamixTextures(client, db)
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to sync meal textures from Jamix" }
         } finally {
-            warningEmails.forEach { emailClient.send(it) }
+            warningEmails.forEach { email ->
+                try {
+                    emailClient.send(email)
+                } catch (e: Exception) {
+                    logger.error(e) { "Failed to send warning email" }
+                }
+            }
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AclQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AclQueries.kt
@@ -28,7 +28,8 @@ data class DaycareAclRowEmployee(
 
 fun Database.Read.getDaycareAclRows(
     daycareId: DaycareId,
-    includeStaffOccupancy: Boolean
+    includeStaffOccupancy: Boolean,
+    role: UserRole? = null
 ): List<DaycareAclRow> =
     createQuery {
             sql(
@@ -52,7 +53,7 @@ FROM daycare_acl
                              JOIN daycare_group dg ON acl.daycare_group_id = dg.id
                     GROUP BY daycare_id, employee_id) groups USING (daycare_id, employee_id)
          LEFT JOIN staff_occupancy_coefficient soc USING (daycare_id, employee_id)
-WHERE daycare_id = ${bind(daycareId)}
+WHERE daycare_id = ${bind(daycareId)} ${if (role != null) "AND role = ${bind(role)}" else ""}
     """
             )
         }


### PR DESCRIPTION
## Ennen tätä muutosta
Kun Jamix erityisruokavalioiden synkronoiinti aiheutti jonkin eVakan lapsen erityisruokavalion asetuksen tyhjäksi, siitä jäi vain systeemin lokille viesti joka kertoi kuinka monen lapsen erityisruokavalio oli nollaantunut.

## Tämän muutoksen jälkeen
Kunkin yksikön johtajille lähetetään sähköpostilla varoitus jossa on eVaka lapsen tunniste ja aikaisemmin asetettu ruokavalio. Sähköpostit lähetetään vain sellaisista lapsista joilla on voimassaoleva sijoitus.