### PR TITLE
Tulevien esikoululaisten raportin bugikorjaus

### DIFF
--- a/frontend/src/employee-frontend/components/reports/FuturePreschoolersReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/FuturePreschoolersReport.tsx
@@ -78,7 +78,7 @@ export default React.memo(function FuturePreschoolersReport() {
                   { label: 'Lahiosoite', key: 'address' },
                   { label: 'Postinumero', key: 'postalCode' },
                   { label: 'Postitoimipaikka', key: 'postOffice' },
-                  { label: 'Paikkojen_lkm', key: 'groupSize' },
+                  { label: 'Paikkojen_lkm', key: 'unitSize' },
                   { label: 'ominaisuudet', key: 'options' }
                 ]}
                 filename="Esiopetusyksikot.csv"

--- a/frontend/src/employee-frontend/components/reports/queries.ts
+++ b/frontend/src/employee-frontend/components/reports/queries.ts
@@ -11,6 +11,7 @@ import {
   getExceededServiceNeedReportUnits,
   getFamilyContactsReport,
   getFuturePreschoolersReport,
+  getFuturePreschoolersSourceUnitsReport,
   getFuturePreschoolersUnitsReport,
   getMealReportByUnit,
   getMissingHeadOfFamilyReport,
@@ -156,7 +157,7 @@ export const preschoolUnitsQuery = query({
 })
 
 export const preschoolSourceUnitsQuery = query({
-  api: getFuturePreschoolersUnitsReport,
+  api: getFuturePreschoolersSourceUnitsReport,
   queryKey: queryKeys.futurePreschoolersUnits
 })
 

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -622,12 +622,12 @@ export interface PlacementSketchingReportRow {
 */
 export interface PreschoolUnitsReportRow {
   address: string
-  groupSize: number
   id: UUID
   options: string[]
   postOffice: string
   postalCode: string
   unitName: string
+  unitSize: number
 }
 
 /**

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/FuturePreschoolersReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/FuturePreschoolersReportTest.kt
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test
 
 class FuturePreschoolersReportTest : PureJdbiTest(resetDbBeforeEach = true) {
 
-
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/FuturePreschoolersReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/FuturePreschoolersReportTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test
 
 class FuturePreschoolersReportTest : PureJdbiTest(resetDbBeforeEach = true) {
 
+
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
@@ -36,9 +37,9 @@ class FuturePreschoolersReportTest : PureJdbiTest(resetDbBeforeEach = true) {
             testDecisionMaker_2.let {
                 tx.insert(DevEmployee(id = it.id, firstName = it.firstName, lastName = it.lastName))
             }
-            tx.insert(testDaycare)
-            tx.insert(testVoucherDaycare)
-            tx.insert(testRoundTheClockDaycare)
+            tx.insert(testDaycare.copy(openingDate = LocalDate.of(2000, 1, 1)))
+            tx.insert(testVoucherDaycare.copy(openingDate = LocalDate.of(2000, 1, 1)))
+            tx.insert(testRoundTheClockDaycare.copy(openingDate = LocalDate.of(2000, 1, 1)))
             tx.insert(
                 DevDaycareGroup(
                     id = GroupId(UUID.randomUUID()),
@@ -136,6 +137,6 @@ class FuturePreschoolersReportTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     private fun getSourceUnitReport(): List<SourceUnitsReportRow> {
-        return db.read { it.geSourceUnitsRows(LocalDate.of(2023, 1, 1)) }
+        return db.read { it.getSourceUnitsRows(LocalDate.of(2023, 1, 1)) }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FuturePreschoolersReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FuturePreschoolersReport.kt
@@ -78,7 +78,7 @@ class FuturePreschoolersReport(private val accessControl: AccessControl) {
                         Action.Global.READ_FUTURE_PRESCHOOLERS
                     )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
-                    it.geSourceUnitsRows(clock.today())
+                    it.getSourceUnitsRows(clock.today())
                 }
             }
             .also { Audit.FuturePreschoolers.log(meta = mapOf("count" to it.size)) }
@@ -157,7 +157,7 @@ d.opening_date <= :today AND (d.closing_date IS NULL OR d.closing_date >= :today
         .bind("today", today)
         .toList<PreschoolUnitsReportRow>()
 
-fun Database.Read.geSourceUnitsRows(today: LocalDate): List<SourceUnitsReportRow> =
+fun Database.Read.getSourceUnitsRows(today: LocalDate): List<SourceUnitsReportRow> =
     createQuery {
             sql(
                 """

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/FuturePreschoolersReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/FuturePreschoolersReport.kt
@@ -140,7 +140,7 @@ SELECT d.id,
             FROM daycare_group 
             WHERE daycare_id = d.id
         ) AND start_date < :today AND end_date >= :today
-    ) * 7 AS group_size,
+    ) * 7 AS unit_size,
     array_remove(ARRAY[
         CASE WHEN d.provider_type != 'MUNICIPAL' THEN 'PRIVATE' END,
         CASE WHEN d.with_school THEN 'WITH_SCHOOL' END,
@@ -193,7 +193,7 @@ data class PreschoolUnitsReportRow(
     val address: String,
     val postalCode: String,
     val postOffice: String,
-    val groupSize: Int,
+    val unitSize: Int,
     val options: List<String>
 )
 


### PR DESCRIPTION
Yksiköt monistuivat raportilla, koska tietokantakyselyyn oli jäänyt vanha ryhmäkohtainen paikkojen lukumäärän laskenta. Nyt ryhmien paikat lasketaan yhteen.

Lasten nykyisten yksiköiden raporttiin käytettiin väärää kyselyä. Käli korjattu käyttämään oikeaa dataa.
<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
