### PR TITLE
Tuen päätösten raportille lisätty päätösnumero ja onko kyseessä varhaiskasvatus vai esiopetus

### DIFF
--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReport.tsx
@@ -157,6 +157,7 @@ export default React.memo(function AssistanceNeedDecisionsReport() {
           <Table>
             <Thead>
               <Tr>
+                <Th>{i18n.reports.assistanceNeedDecisions.decisionNumber}</Th>
                 <SortableTh
                   sorted={
                     sortColumn === 'sentForDecision' ? sortDirection : undefined
@@ -209,6 +210,12 @@ export default React.memo(function AssistanceNeedDecisionsReport() {
                   }
                   data-qa="assistance-need-decision-row"
                 >
+                  <Td data-qa="decision-number">
+                    {(row.preschool
+                      ? i18n.reports.assistanceNeedDecisions.preschoolPrefix
+                      : i18n.reports.assistanceNeedDecisions
+                          .childhoodEducationPrefix) + row.decisionNumber}
+                  </Td>
                   <Td data-qa="sent-for-decision">
                     {row.isOpened === false && (
                       <Highlight data-qa="unopened-indicator" />

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -46,6 +46,7 @@ export interface AssistanceNeedDecisionsReportRow {
   careAreaName: string
   childName: string
   decisionMade: LocalDate | null
+  decisionNumber: number
   id: UUID
   isOpened: boolean | null
   preschool: boolean

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3518,6 +3518,9 @@ export const fi = {
     assistanceNeedDecisions: {
       title: 'Tuen päätökset',
       description: 'Päätöksen tekijälle lähetetyt tuen päätökset.',
+      decisionNumber: 'Päätösnumero',
+      childhoodEducationPrefix: 'VK ',
+      preschoolPrefix: 'EO ',
       sentToDecisionMaker: 'Lähetetty päätöksen tekijälle',
       decisionMade: 'Päätös tehty',
       status: 'Tila',

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedDecisionsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedDecisionsReport.kt
@@ -96,7 +96,7 @@ private fun Database.Read.getDecisionRows(
                 """
 WITH decisions AS (
     SELECT 
-        id, false as preschool, status, sent_for_decision, decision_made, 
+        id, decision_number, false as preschool, status, sent_for_decision, decision_made,
         child_id, selected_unit, decision_maker_employee_id, decision_maker_has_opened
     FROM assistance_need_decision ad
     WHERE sent_for_decision IS NOT NULL
@@ -105,13 +105,13 @@ WITH decisions AS (
     UNION ALL
     
     SELECT 
-        id, true as preschool, status, sent_for_decision, decision_made, 
+        id, decision_number, true as preschool, status, sent_for_decision, decision_made,
         child_id, selected_unit, decision_maker_employee_id, decision_maker_has_opened
     FROM assistance_need_preschool_decision apd
     WHERE sent_for_decision IS NOT NULL
     AND (${predicate(idFilterPreschool.forTable("apd"))})
 )
-SELECT ad.id, ad.preschool, sent_for_decision, concat(child.last_name, ' ', child.first_name) child_name,
+SELECT ad.id, ad.decision_number, ad.preschool, sent_for_decision, concat(child.last_name, ' ', child.first_name) child_name,
     care_area.name care_area_name, daycare.name unit_name, decision_made, status,
     (CASE WHEN decision_maker_employee_id = ${bind(userId)} THEN decision_maker_has_opened END) is_opened
 FROM decisions ad
@@ -126,6 +126,7 @@ JOIN care_area ON care_area.id = daycare.care_area_id
 
 data class AssistanceNeedDecisionsReportRow(
     val id: UUID,
+    val decisionNumber: Long,
     val preschool: Boolean,
     val sentForDecision: LocalDate,
     val childName: String,


### PR DESCRIPTION
Tuen päätösten raportille on lisätty sarake, jossa näkyy päätösnumero sekä etuliite VK tai EO joka kertoo onko kyseessä varhaiskasvatuksen vai esiopetuksen tuen päätös. Etuliite on tarvittaessa kustomoitavissa (mukaanlukien tyhjäksi stringiksi, jos joku ei jostain syystä halua sitä lainkaan näkyviin).