### PR TITLE
Pääkäyttäjä voi testiympäristössä peruuttaa lomakepohjan julkaisun

### DIFF
--- a/frontend/src/employee-frontend/components/document-templates/queries.ts
+++ b/frontend/src/employee-frontend/components/document-templates/queries.ts
@@ -9,6 +9,7 @@ import {
   createTemplate,
   deleteDraftTemplate,
   duplicateTemplate,
+  forceUnpublishTemplate,
   getActiveTemplates,
   getTemplate,
   getTemplates,
@@ -85,6 +86,14 @@ export const updateDocumentTemplateValidityMutation = mutation({
 
 export const publishDocumentTemplateMutation = mutation({
   api: publishTemplate,
+  invalidateQueryKeys: (arg) => [
+    queryKeys.documentTemplateSummaries(),
+    queryKeys.documentTemplate(arg.templateId)
+  ]
+})
+
+export const forceUnpublishDocumentTemplateMutation = mutation({
+  api: forceUnpublishTemplate,
   invalidateQueryKeys: (arg) => [
     queryKeys.documentTemplateSummaries(),
     queryKeys.documentTemplate(arg.templateId)

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateContentEditor.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateContentEditor.tsx
@@ -35,14 +35,17 @@ import {
   FixedSpaceColumn,
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
+import { ConfirmedMutation } from 'lib-components/molecules/ConfirmedMutation'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 import { DateRangePickerF } from 'lib-components/molecules/date-picker/DateRangePicker'
 import { H1, H2, Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
+import { featureFlags } from 'lib-customizations/employee'
 
 import { useTranslation } from '../../../state/i18n'
 import LabelValueList from '../../common/LabelValueList'
 import {
+  forceUnpublishDocumentTemplateMutation,
   publishDocumentTemplateMutation,
   updateDocumentTemplateBasicsMutation,
   updateDocumentTemplateContentMutation
@@ -147,6 +150,26 @@ export default React.memo(function TemplateContentEditor({
             text={i18n.common.goBack}
             onClick={() => navigate('/document-templates')}
           />
+
+          {featureFlags.forceUnpublishDocumentTemplate &&
+            template.published && (
+              <ConfirmedMutation
+                buttonStyle="BUTTON"
+                buttonText={
+                  i18n.documentTemplates.templateEditor.forceUnpublish.button
+                }
+                confirmationTitle={
+                  i18n.documentTemplates.templateEditor.forceUnpublish
+                    .confirmationTitle
+                }
+                confirmationText={
+                  i18n.documentTemplates.templateEditor.forceUnpublish
+                    .confirmationText
+                }
+                mutation={forceUnpublishDocumentTemplateMutation}
+                onClick={() => ({ templateId: template.id })}
+              />
+            )}
 
           {!readOnly && (
             <FixedSpaceRow alignItems="center">

--- a/frontend/src/employee-frontend/generated/api-clients/document.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/document.ts
@@ -98,6 +98,22 @@ export async function exportTemplate(
 
 
 /**
+* Generated from fi.espoo.evaka.document.DocumentTemplateController.forceUnpublishTemplate
+*/
+export async function forceUnpublishTemplate(
+  request: {
+    templateId: UUID
+  }
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/document-templates/${request.templateId}/force-unpublish`.toString(),
+    method: 'PUT'
+  })
+  return json
+}
+
+
+/**
 * Generated from fi.espoo.evaka.document.DocumentTemplateController.getActiveTemplates
 */
 export async function getActiveTemplates(

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4597,7 +4597,13 @@ export const fi = {
       titleEditQuestion: 'Muokkaa kysymystä',
       moveUp: 'Siirrä ylös',
       moveDown: 'Siirrä alas',
-      readyToPublish: 'Valmis julkaistavaksi'
+      readyToPublish: 'Valmis julkaistavaksi',
+      forceUnpublish: {
+        button: 'Peruuta julkaisu',
+        confirmationTitle: 'Haluatko varmasti perua julkaisun?',
+        confirmationText:
+          'Kaikki tätä lomakepohjaa käyttävät asiakirjat poistetaan.'
+      }
     },
     questionTypes: {
       TEXT: 'Tekstikenttä',

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -40,7 +40,8 @@ const features: Features = {
     intermittentShiftCare: false,
     noAbsenceType: false,
     discussionReservations: true,
-    jamixIntegration: true
+    jamixIntegration: true,
+    forceUnpublishDocumentTemplate: true
   },
   staging: {
     citizenShiftCareAbsence: true,
@@ -69,7 +70,8 @@ const features: Features = {
     intermittentShiftCare: false,
     noAbsenceType: false,
     discussionReservations: true,
-    jamixIntegration: true
+    jamixIntegration: true,
+    forceUnpublishDocumentTemplate: true
   },
   prod: {
     citizenShiftCareAbsence: true,
@@ -97,7 +99,8 @@ const features: Features = {
     voucherUnitPayments: false,
     intermittentShiftCare: false,
     noAbsenceType: false,
-    discussionReservations: false
+    discussionReservations: false,
+    forceUnpublishDocumentTemplate: false
   }
 }
 

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -231,10 +231,18 @@ interface BaseFeatureFlags {
    * EXPERIMENTAL: Enable discussion reservation surveys
    */
   discussionReservations?: boolean
+
   /**
    * Display Jamix food ordering service related functions
    */
   jamixIntegration?: boolean
+
+  /**
+   * Allow admin to force unpublish document templates.
+   * Do not set in production.
+   * Note the corresponding backend environment variable feature flag.
+   */
+  forceUnpublishDocumentTemplate?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -158,6 +158,7 @@ private val plannedEndpoints =
         "/employee/document-templates/{templateId}/content",
         "/employee/document-templates/{templateId}/duplicate",
         "/employee/document-templates/{templateId}/export",
+        "/employee/document-templates/{templateId}/force-unpublish",
         "/employee/document-templates/{templateId}/publish",
         "/employee/document-templates/{templateId}/validity",
         "/employee/employees",

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Controllers.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Controllers.kt
@@ -389,6 +389,7 @@ private val knownLegacyPaths =
         "/document-templates/{templateId}/content",
         "/document-templates/{templateId}/duplicate",
         "/document-templates/{templateId}/export",
+        "/document-templates/{templateId}/force-unpublish",
         "/document-templates/{templateId}/publish",
         "/document-templates/{templateId}/validity",
         "/employee",

--- a/service/src/integrationTest/resources/application-integration-test.yaml
+++ b/service/src/integrationTest/resources/application-integration-test.yaml
@@ -82,6 +82,8 @@ evaka:
           location: classpath:xroad/trustStore.jks
           password: password
           type: JKS
+  not_for_prod:
+    force_unpublish_document_template_enabled: true
   jwt:
     public_keys_url: classpath:evaka-integration-test/jwks.json
   max_attachments_per_user: 3

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -226,6 +226,7 @@ enum class Audit(
     DocumentTemplateCopy,
     DocumentTemplateCreate,
     DocumentTemplateDelete,
+    DocumentTemplateForceUnpublish,
     DocumentTemplatePublish,
     DocumentTemplateRead,
     DocumentTemplateUpdateBasics,

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -28,6 +28,7 @@ data class EvakaEnv(
     val vtjEnabled: Boolean,
     val webPushEnabled: Boolean,
     val jamixEnabled: Boolean,
+    val forceUnpublishDocumentTemplateEnabled: Boolean,
     val awsRegion: Region,
     val asyncJobRunnerDisabled: Boolean,
     val frontendBaseUrlFi: String,
@@ -56,6 +57,9 @@ data class EvakaEnv(
                         ?: false,
                 webPushEnabled = env.lookup("evaka.web_push.enabled") ?: false,
                 jamixEnabled = env.lookup("evaka.integration.jamix.enabled") ?: false,
+                forceUnpublishDocumentTemplateEnabled =
+                    env.lookup("evaka.not_for_prod.force_unpublish_document_template_enabled")
+                        ?: false,
                 awsRegion = Region.of(env.lookup("evaka.aws.region", "aws.region")),
                 asyncJobRunnerDisabled =
                     env.lookup("evaka.async_job_runner.disable_runner") ?: false,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -1408,7 +1408,8 @@ sealed interface Action {
         READ(HasGlobalRole(ADMIN)),
         COPY(HasGlobalRole(ADMIN)),
         UPDATE(HasGlobalRole(ADMIN)),
-        DELETE(HasGlobalRole(ADMIN));
+        DELETE(HasGlobalRole(ADMIN)),
+        FORCE_UNPUBLISH(HasGlobalRole(ADMIN));
 
         override fun toString(): String = "${javaClass.name}.$name"
     }

--- a/service/src/main/resources/application-local.yaml
+++ b/service/src/main/resources/application-local.yaml
@@ -65,6 +65,8 @@ evaka:
         trust_store:
           password: password
           type: JKS
+  not_for_prod:
+    force_unpublish_document_template_enabled: true
   jwt:
     public_keys_url: classpath:local-development/jwks.json
   web_push:


### PR DESCRIPTION
Samalla poistetaan kaikki lomakepohjaa käyttävät lomakkeet ja niiden asianhallintaprosessit. Julkaisun perumisen jälkeen lomakepohjan voi myös poistaa.

Toiminnallisuus vaatii sekä frontend että backend feature flagin, joita ei kuulu laittaa päälle tuotantoympäristössä:
frontend: `forceUnpublishDocumentTemplate: true`
service env: `EVAKA_NOT_FOR_PROD_FORCE_UNPUBLISH_DOCUMENT_TEMPLATE_ENABLED`