### PR TITLE
Muutos käytetyn palvelutarpeen laskentaan hyvityspäivien kohdalla

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/absence/AbsenceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/absence/AbsenceServiceIntegrationTest.kt
@@ -126,6 +126,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     today.year,
                     today.monthValue,
+                    false
                 )
             }
 
@@ -174,7 +175,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     placementStart,
                     testDaycareGroup.id,
                     placementStart.year,
-                    placementStart.monthValue
+                    placementStart.monthValue,
+                    false
                 )
             }
 
@@ -277,7 +279,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     firstOfMonth,
                     testDaycareGroup.id,
                     firstOfMonth.year,
-                    firstOfMonth.monthValue
+                    firstOfMonth.monthValue,
+                    false
                 )
             }
 
@@ -335,7 +338,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     placementDate,
                     roundTheClockGroupId,
                     placementDate.year,
-                    placementDate.monthValue
+                    placementDate.monthValue,
+                    false
                 )
             }
 
@@ -433,7 +437,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     placementStart,
                     testDaycareGroup.id,
                     placementStart.year,
-                    placementStart.monthValue
+                    placementStart.monthValue,
+                    false
                 )
             }
 
@@ -500,7 +505,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     placementStart,
                     testDaycareGroup.id,
                     placementStart.year,
-                    placementStart.monthValue
+                    placementStart.monthValue,
+                    false
                 )
             }
 
@@ -600,7 +606,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     placementStart,
                     testDaycareGroup.id,
                     placementStart.year,
-                    placementStart.monthValue
+                    placementStart.monthValue,
+                    false
                 )
             }
 
@@ -762,7 +769,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     placementStart,
                     testDaycareGroup.id,
                     placementStart.year,
-                    placementStart.monthValue
+                    placementStart.monthValue,
+                    false
                 )
             }
 
@@ -812,7 +820,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     placementStart,
                     testDaycareGroup.id,
                     placementStart.year,
-                    placementStart.monthValue
+                    placementStart.monthValue,
+                    false
                 )
             }
 
@@ -874,7 +883,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     placementStart,
                     testDaycareGroup.id,
                     placementStart.year,
-                    placementStart.monthValue
+                    placementStart.monthValue,
+                    false
                 )
             }
 
@@ -940,7 +950,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     absenceDate,
                     testDaycareGroup.id,
                     absenceDate.year,
-                    absenceDate.monthValue
+                    absenceDate.monthValue,
+                    false
                 )
             }
         val child =
@@ -991,7 +1002,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     absenceDate,
                     testDaycareGroup.id,
                     absenceDate.year,
-                    absenceDate.monthValue
+                    absenceDate.monthValue,
+                    false
                 )
             }
 
@@ -1026,7 +1038,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     absenceDate,
                     testDaycareGroup.id,
                     absenceDate.year,
-                    absenceDate.monthValue
+                    absenceDate.monthValue,
+                    false
                 )
             }
 
@@ -1054,7 +1067,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     absenceDate,
                     testDaycareGroup.id,
                     absenceDate.year,
-                    absenceDate.monthValue
+                    absenceDate.monthValue,
+                    false
                 )
             }
 
@@ -1179,7 +1193,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     firstOfJanuary2020,
                     testDaycareGroup.id,
                     firstOfJanuary2020.year,
-                    firstOfJanuary2020.monthValue
+                    firstOfJanuary2020.monthValue,
+                    false
                 )
             }
 
@@ -1203,7 +1218,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     firstOfJanuary2020,
                     testDaycareGroup.id,
                     firstOfJanuary2020.year,
-                    firstOfJanuary2020.monthValue
+                    firstOfJanuary2020.monthValue,
+                    false
                 )
             }
 
@@ -1226,7 +1242,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(40), result.children.map { it.reservationTotalHours })
     }
@@ -1253,7 +1276,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(60), result.children.map { it.reservationTotalHours })
     }
@@ -1272,7 +1302,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(12), result.children.map { it.reservationTotalHours })
     }
@@ -1291,7 +1328,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(12), result.children.map { it.reservationTotalHours })
     }
@@ -1313,7 +1357,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(12), result.children.map { it.reservationTotalHours })
     }
@@ -1335,7 +1386,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(12), result.children.map { it.reservationTotalHours })
     }
@@ -1358,7 +1416,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(40), result.children.map { it.reservationTotalHours })
     }
@@ -1380,7 +1445,9 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         insertBackupPlacement(testChild_1.id, backupUnit, backupGroup, backupPeriod)
 
         val result =
-            db.read { getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), backupGroup, 2019, 8) }
+            db.read {
+                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), backupGroup, 2019, 8, false)
+            }
         assertEquals(listOf(16), result.children.map { it.reservationTotalHours })
     }
 
@@ -1410,7 +1477,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
 
         // 1 operational day * 0 h + 1 operational day * 8 h
@@ -1442,7 +1516,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         // 22 operational days * 8h
         assertEquals(listOf(176), result.children.map { it.reservationTotalHours })
@@ -1469,7 +1550,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         // 8-16 + 8-14 (saturday is not included because the unit is not operational on saturdays)
         assertEquals(listOf(14), result.children.map { it.reservationTotalHours })
@@ -1497,7 +1585,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         // 21 operational days * 8h + 12h
         assertEquals(listOf(180), result.children.map { it.reservationTotalHours })
@@ -1522,7 +1617,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         // 21-9 + 9-15 (overlapping 2 hours are left out)
         assertEquals(listOf(18), result.children.map { it.reservationTotalHours })
@@ -1554,7 +1656,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         // the start and end of absence date overlaps with two reservations but only one reservation
         // is left out
@@ -1579,7 +1688,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(21 + 20 * 8), result.children.map { it.reservationTotalHours })
     }
@@ -1626,7 +1742,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(
             listOf(
@@ -1660,7 +1783,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(40), result.children.map { it.attendanceTotalHours })
     }
@@ -1687,7 +1817,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(60), result.children.map { it.attendanceTotalHours })
     }
@@ -1707,7 +1844,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(12), result.children.map { it.attendanceTotalHours })
     }
@@ -1727,7 +1871,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(12), result.children.map { it.attendanceTotalHours })
     }
@@ -1750,7 +1901,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(24), result.children.map { it.attendanceTotalHours })
     }
@@ -1773,7 +1931,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(40), result.children.map { it.attendanceTotalHours })
     }
@@ -1795,7 +1960,9 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         insertAttendances(testChild_1.id, backupUnit, attendances)
 
         val result =
-            db.read { getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), backupGroup, 2019, 8) }
+            db.read {
+                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), backupGroup, 2019, 8, false)
+            }
         assertEquals(listOf(16), result.children.map { it.attendanceTotalHours })
     }
 
@@ -1807,7 +1974,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(listOf(0), result.children.map { it.attendanceTotalHours })
     }
@@ -1840,7 +2014,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 31), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 31),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    false
+                )
             }
         assertEquals(1, result.children.size)
         assertEquals(
@@ -1896,7 +2077,8 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     placementDate,
                     testDaycareGroup.id,
                     placementDate.year,
-                    placementDate.monthValue
+                    placementDate.monthValue,
+                    false
                 )
             }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -40,6 +40,7 @@ data class EvakaEnv(
     val nrOfDaysVoucherValueDecisionCanBeSentInAdvance: Long,
     val plannedAbsenceEnabledForHourBasedServiceNeeds: Boolean,
     val personAddressEnvelopeWindowPosition: Rectangle,
+    val forceMajeureAbsenceDaysCalculatedAsUsedServiceNeed: Boolean
 ) {
     companion object {
         fun fromEnvironment(env: Environment): EvakaEnv {
@@ -87,7 +88,10 @@ data class EvakaEnv(
                 personAddressEnvelopeWindowPosition =
                     env.lookup<String?>("evaka.person_address_envelope_window_position")?.let {
                         Rectangle.fromString(it)
-                    } ?: Rectangle.iPostWindowPosition
+                    } ?: Rectangle.iPostWindowPosition,
+                forceMajeureAbsenceDaysCalculatedAsUsedServiceNeed =
+                    env.lookup("evaka.force_majeure_absence_days_calculated_as_used_service_need")
+                        ?: false
             )
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceController.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.absence
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
+import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.reservations.clearOldReservations
 import fi.espoo.evaka.reservations.deleteReservationsFromHolidayPeriodDates
 import fi.espoo.evaka.reservations.getReservableRange
@@ -33,7 +34,8 @@ import org.springframework.web.bind.annotation.RestController
 )
 class AbsenceController(
     private val accessControl: AccessControl,
-    private val featureConfig: FeatureConfig
+    private val featureConfig: FeatureConfig,
+    private val env: EvakaEnv
 ) {
     @GetMapping("/{groupId}")
     fun groupMonthCalendar(
@@ -53,7 +55,14 @@ class AbsenceController(
                         Action.Group.READ_ABSENCES,
                         groupId
                     )
-                    getGroupMonthCalendar(it, clock.today(), groupId, year, month)
+                    getGroupMonthCalendar(
+                        it,
+                        clock.today(),
+                        groupId,
+                        year,
+                        month,
+                        env.forceMajeureAbsenceDaysCalculatedAsUsedServiceNeed
+                    )
                 }
             }
             .also {

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceService.kt
@@ -45,7 +45,8 @@ fun getGroupMonthCalendar(
     today: LocalDate,
     groupId: GroupId,
     year: Int,
-    month: Int
+    month: Int,
+    forceMajeureAbsenceDaysCalculatedAsUsedServiceNeed: Boolean
 ): GroupMonthCalendar {
     val range = FiniteDateRange.ofMonth(year, Month.of(month))
 
@@ -140,7 +141,8 @@ fun getGroupMonthCalendar(
                                                     it.reservation.asTimeRange()
                                                 },
                                             attendances =
-                                                childAttendances.map { it.asTimeInterval() }
+                                                childAttendances.map { it.asTimeInterval() },
+                                            forceMajeureAbsenceDaysCalculatedAsUsedServiceNeed
                                         )
                                     usedServiceByChild.updateKey(child.id) {
                                         (it ?: UsedServiceData(daycareHoursPerMonth)).let { totals

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -181,7 +181,9 @@ class ReservationControllerCitizen(
                                                                             .mapNotNull {
                                                                                 it.asTimeRange()
                                                                             },
-                                                                        childAttendances
+                                                                        childAttendances,
+                                                                        env
+                                                                            .forceMajeureAbsenceDaysCalculatedAsUsedServiceNeed
                                                                     )
                                                                 }
                                                         ReservationResponseDayChild(

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -537,7 +537,8 @@ fun computeUsedService(
     shiftCareType: ShiftCareType,
     absences: List<Pair<AbsenceType, AbsenceCategory>>,
     reservations: List<TimeRange>,
-    attendances: List<TimeInterval>
+    attendances: List<TimeInterval>,
+    forceMajureAbsenceDaysCalculateAsUsedServiceNeed: Boolean
 ): UsedServiceResult {
     // Today's date is taken to be "in the future" if child has no attendances today or there's an
     // ongoing attendance
@@ -577,6 +578,16 @@ fun computeUsedService(
     if (isDateInFuture) {
         return UsedServiceResult(
             reservedMinutes = minutesOf(effectiveReservations),
+            usedServiceMinutes = 0,
+            usedServiceRanges = emptyList()
+        )
+    }
+    if (
+        !forceMajureAbsenceDaysCalculateAsUsedServiceNeed &&
+            absences.map { it.first }.toSet() == setOf(AbsenceType.FORCE_MAJEURE)
+    ) {
+        return UsedServiceResult(
+            reservedMinutes = 0,
             usedServiceMinutes = 0,
             usedServiceRanges = emptyList()
         )

--- a/service/src/test/kotlin/fi/espoo/evaka/reservations/UsedServiceTests.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/reservations/UsedServiceTests.kt
@@ -50,7 +50,8 @@ class UsedServiceTests {
             shiftCareType,
             absences,
             reservations,
-            attendances
+            attendances,
+            false
         )
 
     @Test
@@ -187,6 +188,18 @@ class UsedServiceTests {
             .also {
                 assertEquals(it.usedServiceMinutes, 480)
                 assertEquals(it.usedServiceRanges, listOf(range(8, 16)))
+            }
+    }
+
+    @Test
+    fun `force majeure absence days do not increase used service time`() {
+        compute(
+                attendances = listOf(interval(8, 16)),
+                absences = listOf(AbsenceType.FORCE_MAJEURE to AbsenceCategory.BILLABLE)
+            )
+            .also {
+                assertEquals(0, it.usedServiceMinutes)
+                assertEquals(emptyList(), it.usedServiceRanges)
             }
     }
 


### PR DESCRIPTION
## Ennen tätä muutosta
Päivät joilla on `FORCE_MAJEURE` tyyppinen poissaolomerkintä kasvattivat käytettyä palveluntarvetta. `FORCE_MAJEURE` näyttäytyy kunnasta riippuen henkilökunnan käyttöliittymässä "Maksuton päivä (rajoitettu käyttö)", "hyvityspäivä" tai "Päiväkohtainen alennus". Kuntalaisen käyttöliittymässä nämä näkyvät "Henkilökunnan merkitsemä poissaolo"
![image](https://github.com/espoon-voltti/evaka/assets/886091/60f65d98-6c7a-4841-b768-be7327667f4e)

## Tämän muutoksen jälkeen
Ympäristömuuttujalla `evaka.force_majeure_absence_days_calculated_as_used_service_need` voidaan määritellä kasvattavatko `FORCE_MAJEURE` poissaolot käytettyä palveluntarvetta vai ei. Oletuksena tämä on `false` jolloin käytettyä palvelutarvetta ei lasketa näiltä päiviltä.
![image](https://github.com/espoon-voltti/evaka/assets/886091/4fbb480b-c409-41f7-8b42-f06f8ed6664d)
