### PR TITLE
Korjattu vuorohoidon näyttäminen yksikön johtajalle hakemuslistan tooltipissä

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -878,7 +878,7 @@ fun Database.Read.getApplicationUnitSummaries(unitId: DaycareId): List<Applicati
                     a.document -> 'serviceNeedOption' ->> 'nameSv' AS serviceNeedNameSv,
                     a.document -> 'serviceNeedOption' ->> 'nameEn' AS serviceNeedNameEn,
                     a.document -> 'serviceNeedOption' ->> 'validPlacementType' AS serviceNeedValidPlacementType,
-                    a.document ->> 'extendedCare' as extended_care,
+                    coalesce((a.document ->> 'extendedCare')::boolean, false) as extended_care,
                     a.document,
                     (a.document ->> 'preferredStartDate')::date as preferred_start_date,
                     (array_position((


### PR DESCRIPTION
Kantakyselyyn tehty muutos rikkoi kerhohakemusten hakemisen käyttöliittymään, koska niissä ei ole kannassa extendedCare- json-kenttää. Korjattu toimimaan oikein myös kerhohakemuksille ja mahdollisille muille tapauksille, joissa ko. kenttää ei löydy.