### PR TITLE
Korjaus Varda-tietueiden voimassaoloajan päättämiseen

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/new/VardaUpdaterIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/new/VardaUpdaterIntegrationTest.kt
@@ -2222,7 +2222,8 @@ class VardaUpdaterIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                                         varhaiskasvatuspaatos =
                                             VardaReadClient.VarhaiskasvatuspaatosResponse(
                                                 url = old.varhaiskasvatusPaatosToEndUrl,
-                                                lahdejarjestelma = old.sourceSystem,
+                                                lahdejarjestelma =
+                                                    null, // This will be set to new.sourceSystem
                                                 alkamis_pvm = old.beforeEvakaRange.start,
                                                 paattymis_pvm = old.beforeEvakaRange.end,
                                                 hakemus_pvm = old.applicationDate,
@@ -2239,7 +2240,8 @@ class VardaUpdaterIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                                                     url = old.varhaiskasvatusSuhdeToEndUrl,
                                                     varhaiskasvatuspaatos =
                                                         old.varhaiskasvatusPaatosToEndUrl,
-                                                    lahdejarjestelma = old.sourceSystem,
+                                                    lahdejarjestelma =
+                                                        old.sourceSystem, // This will be kept
                                                     alkamis_pvm = old.beforeEvakaRange.start,
                                                     paattymis_pvm = old.beforeEvakaRange.end,
                                                     toimipaikka_oid = old.unitOid
@@ -2348,13 +2350,13 @@ class VardaUpdaterIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             listOf(
                 "SetPaattymisPvm" to
                     (old.maksutietoToEndUrl to
-                        VardaWriteClient.SetPaattymisPvmRequest(dayBeforeEvaka)),
+                        VardaWriteClient.SetPaattymisPvmRequest(old.sourceSystem, dayBeforeEvaka)),
                 "SetPaattymisPvm" to
                     (old.varhaiskasvatusSuhdeToEndUrl to
-                        VardaWriteClient.SetPaattymisPvmRequest(dayBeforeEvaka)),
+                        VardaWriteClient.SetPaattymisPvmRequest(old.sourceSystem, dayBeforeEvaka)),
                 "SetPaattymisPvm" to
                     (old.varhaiskasvatusPaatosToEndUrl to
-                        VardaWriteClient.SetPaattymisPvmRequest(dayBeforeEvaka)),
+                        VardaWriteClient.SetPaattymisPvmRequest(new.sourceSystem, dayBeforeEvaka)),
                 "Delete" to old.varhaiskasvatusSuhdeToDeleteUrl,
                 "Delete" to old.varhaiskasvatusPaatosToDeleteUrl,
                 "Create" to

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
@@ -207,7 +207,7 @@ interface VardaWriteClient {
 
     fun <T : VardaEntity> delete(data: T)
 
-    data class SetPaattymisPvmRequest(val paattymis_pvm: LocalDate)
+    data class SetPaattymisPvmRequest(val lahdejarjestelma: String, val paattymis_pvm: LocalDate)
 
     fun setPaattymisPvm(url: URI, body: SetPaattymisPvmRequest)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -620,7 +620,13 @@ class VardaUpdater(
         } else {
             val paattymisPvm: LocalDate? = entity.paattymis_pvm
             if (paattymisPvm == null || paattymisPvm > endDate) {
-                this.setPaattymisPvm(entity.url, VardaWriteClient.SetPaattymisPvmRequest(endDate))
+                this.setPaattymisPvm(
+                    entity.url,
+                    VardaWriteClient.SetPaattymisPvmRequest(
+                        entity.lahdejarjestelma ?: lahdejarjestelma,
+                        endDate
+                    )
+                )
             }
         }
     }


### PR DESCRIPTION
Toisessa kunnassa päivähoidossa olleiden lasten auki jääneitä Varda-datoja pitää joskus merkitä päättyneeksi. Jostain syystä Vardassa on tietueita, joiden `lahdejarjestelma`-kenttää ei ole asetettu, ja Varda ei suostu päivittämään tällaisten tietueiden voimassaolopäivää, jolle `lahdejarjestelma`-kenttää aseteta samalla.

Tämän muutoksen myötä eVaka asettaa `lahdejarjestelma`-kentän mikäli siihen on tarvetta. Arvoksi asetetaan eVakaan konfiguroitu lähdejärjestelmäkoodi, joka on sinäänsä väärin, koska data ei ole alunperin eVakasta, mutta ei siihen oikein mitään muutakaan voi asettaa 🤷 