### PR TITLE
es2022 readiness 

### DIFF
--- a/frontend/src/e2e-test/pages/admin/application-details-page.ts
+++ b/frontend/src/e2e-test/pages/admin/application-details-page.ts
@@ -2,26 +2,27 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page, TextInput } from '../../utils/page'
+import { Page, TextInput, Element, ElementCollection } from '../../utils/page'
 
 export default class ApplicationDetailsPage {
-  constructor(private page: Page) {}
-
-  #guardianName = this.page.findByDataQa('guardian-name')
-
-  #vtjGuardianName = this.page.findByDataQa('vtj-guardian-name')
-
-  #otherGuardianAgreementStatus = this.page.findByDataQa('agreement-status')
-
-  #otherGuardianSameAddress = this.page.findByDataQa(
-    'other-vtj-guardian-lives-in-same-address'
-  )
-
-  #noOtherVtjGuardianText = this.page.findByDataQa('no-other-vtj-guardian')
-
-  #applicationStatus = this.page.findByDataQa('application-status')
-
-  #notes = this.page.findAllByDataQa('note-container')
+  #guardianName: Element
+  #vtjGuardianName: Element
+  #otherGuardianAgreementStatus: Element
+  #otherGuardianSameAddress: Element
+  #noOtherVtjGuardianText: Element
+  #applicationStatus: Element
+  #notes: ElementCollection
+  constructor(private page: Page) {
+    this.#guardianName = page.findByDataQa('guardian-name')
+    this.#vtjGuardianName = page.findByDataQa('vtj-guardian-name')
+    this.#otherGuardianAgreementStatus = page.findByDataQa('agreement-status')
+    this.#otherGuardianSameAddress = page.findByDataQa(
+      'other-vtj-guardian-lives-in-same-address'
+    )
+    this.#noOtherVtjGuardianText = page.findByDataQa('no-other-vtj-guardian')
+    this.#applicationStatus = page.findByDataQa('application-status')
+    this.#notes = page.findAllByDataQa('note-container')
+  }
 
   async assertGuardianName(expectedName: string) {
     await this.#guardianName.findText(expectedName).waitUntilVisible()

--- a/frontend/src/e2e-test/pages/admin/application-details-page.ts
+++ b/frontend/src/e2e-test/pages/admin/application-details-page.ts
@@ -7,19 +7,19 @@ import { Page, TextInput } from '../../utils/page'
 export default class ApplicationDetailsPage {
   constructor(private page: Page) {}
 
-  #guardianName = this.page.find('[data-qa="guardian-name"]')
+  #guardianName = this.page.findByDataQa('guardian-name')
 
-  #vtjGuardianName = this.page.find('[data-qa="vtj-guardian-name"]')
+  #vtjGuardianName = this.page.findByDataQa('vtj-guardian-name')
 
-  #otherGuardianAgreementStatus = this.page.find('[data-qa="agreement-status"]')
+  #otherGuardianAgreementStatus = this.page.findByDataQa('agreement-status')
 
-  #otherGuardianSameAddress = this.page.find(
-    '[data-qa="other-vtj-guardian-lives-in-same-address"]'
+  #otherGuardianSameAddress = this.page.findByDataQa(
+    'other-vtj-guardian-lives-in-same-address'
   )
 
-  #noOtherVtjGuardianText = this.page.find('[data-qa="no-other-vtj-guardian"]')
+  #noOtherVtjGuardianText = this.page.findByDataQa('no-other-vtj-guardian')
 
-  #applicationStatus = this.page.find('[data-qa="application-status"]')
+  #applicationStatus = this.page.findByDataQa('application-status')
 
   #notes = this.page.findAllByDataQa('note-container')
 

--- a/frontend/src/e2e-test/pages/admin/application-workbench-page.ts
+++ b/frontend/src/e2e-test/pages/admin/application-workbench-page.ts
@@ -8,16 +8,17 @@ import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
 import { waitUntilTrue } from '../../utils'
-import { Checkbox, Combobox, Page } from '../../utils/page'
+import { Checkbox, Combobox, Page, Element } from '../../utils/page'
 import ApplicationListView from '../employee/applications/application-list-view'
 import { PlacementDraftPage } from '../employee/placement-draft-page'
 
 import ApplicationDetailsPage from './application-details-page'
 
 export class SearchFilter {
-  constructor(private page: Page) {}
-
-  #statusRadioAll = this.page.findByDataQa('application-status-filter-ALL')
+  #statusRadioAll: Element
+  constructor(private page: Page) {
+    this.#statusRadioAll = page.findByDataQa('application-status-filter-ALL')
+  }
 
   async filterByTransferOnly() {
     await this.page.findByDataQa('filter-transfer-only').click()
@@ -60,37 +61,48 @@ export class DecisionEditorPage {
 }
 
 export class ApplicationWorkbenchPage {
-  constructor(private page: Page) {}
+  #applicationPlacementProposalStatusIndicator: Element
+  #applicationPlacementProposalStatusTooltip: Element
+  applicationsSent: Element
+  #applicationsWaitingPlacement: Element
+  #applicationsWaitingDecision: Element
+  #applicationsWaitingUnitConfirmation: Element
+  applicationsAll: Element
+  #applicationList: Element
+  #btnCloseApplication: Element
+  #agreementStatus: Element
+  #otherGuardianTel: Element
+  #otherGuardianEmail: Element
+  #withdrawPlacementProposalsButton: Element
+  constructor(private page: Page) {
+    this.#applicationPlacementProposalStatusIndicator = page.findByDataQa(
+      'placement-proposal-status'
+    )
+    this.#applicationPlacementProposalStatusTooltip = page.findByDataQa(
+      'placement-proposal-status-tooltip'
+    )
+    this.applicationsSent = page.findByDataQa('application-status-filter-SENT')
+    this.#applicationsWaitingPlacement = page.findByDataQa(
+      'application-status-filter-WAITING_PLACEMENT'
+    )
+    this.#applicationsWaitingDecision = page.findByDataQa(
+      'application-status-filter-WAITING_DECISION'
+    )
+    this.#applicationsWaitingUnitConfirmation = page.findByDataQa(
+      'application-status-filter-WAITING_UNIT_CONFIRMATION'
+    )
+    this.applicationsAll = page.findByDataQa('application-status-filter-ALL')
+    this.#applicationList = page.findByDataQa('applications-list')
+    this.#btnCloseApplication = page.findByDataQa('close-application')
+    this.#agreementStatus = page.findByDataQa('agreement-status')
+    this.#otherGuardianTel = page.findByDataQa('second-guardian-phone')
+    this.#otherGuardianEmail = page.findByDataQa('second-guardian-email')
+    this.#withdrawPlacementProposalsButton = page.findByDataQa(
+      'action-bar-withdrawPlacementProposal'
+    )
+  }
 
   searchFilter = new SearchFilter(this.page)
-
-  #applicationPlacementProposalStatusIndicator = this.page.findByDataQa(
-    'placement-proposal-status'
-  )
-  #applicationPlacementProposalStatusTooltip = this.page.findByDataQa(
-    'placement-proposal-status-tooltip'
-  )
-  applicationsSent = this.page.findByDataQa('application-status-filter-SENT')
-  #applicationsWaitingPlacement = this.page.findByDataQa(
-    'application-status-filter-WAITING_PLACEMENT'
-  )
-  #applicationsWaitingDecision = this.page.findByDataQa(
-    'application-status-filter-WAITING_DECISION'
-  )
-  #applicationsWaitingUnitConfirmation = this.page.findByDataQa(
-    'application-status-filter-WAITING_UNIT_CONFIRMATION'
-  )
-  applicationsAll = this.page.findByDataQa('application-status-filter-ALL')
-  // only matches when applications have been loaded
-  #applicationList = this.page.findByDataQa('applications-list')
-  #btnCloseApplication = this.page.findByDataQa('close-application')
-  #agreementStatus = this.page.findByDataQa('agreement-status')
-  #otherGuardianTel = this.page.findByDataQa('second-guardian-phone')
-  #otherGuardianEmail = this.page.findByDataQa('second-guardian-email')
-
-  #withdrawPlacementProposalsButton = this.page.findByDataQa(
-    'action-bar-withdrawPlacementProposal'
-  )
 
   getApplicationListItem(applicationId: string) {
     return this.#applicationList.find(

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -8,23 +8,35 @@ import { UUID } from 'lib-common/types'
 
 import { waitUntilDefined, waitUntilEqual } from '../../utils'
 import { FormInput, Section, sections } from '../../utils/application-forms'
-import { Checkbox, FileInput, Page, Radio, TextInput } from '../../utils/page'
+import {
+  Checkbox,
+  FileInput,
+  Page,
+  Radio,
+  TextInput,
+  Element
+} from '../../utils/page'
 
 export default class CitizenApplicationsPage {
-  constructor(private readonly page: Page) {}
+  #createNewApplicationButton: Element
+  #transferApplicationNotification: Element
+  #duplicateApplicationNotification: Element
+  #applicationTitle: Element
+  constructor(private readonly page: Page) {
+    this.#createNewApplicationButton = page.findByDataQa('submit')
+    this.#transferApplicationNotification = page.findByDataQa(
+      'transfer-application-notification'
+    )
+    this.#duplicateApplicationNotification = page.findByDataQa(
+      'duplicate-application-notification'
+    )
+    this.#applicationTitle = page.findByDataQa('application-type-title')
+  }
 
   #newApplicationButton = (childId: string) =>
     this.page.findByDataQa(`new-application-${childId}`)
   #applicationTypeRadio = (type: 'DAYCARE' | 'PRESCHOOL' | 'CLUB') =>
     new Radio(this.page.findByDataQa(`type-radio-${type}`))
-  #createNewApplicationButton = this.page.findByDataQa('submit')
-  #transferApplicationNotification = this.page.findByDataQa(
-    'transfer-application-notification'
-  )
-  #duplicateApplicationNotification = this.page.findByDataQa(
-    'duplicate-application-notification'
-  )
-  #applicationTitle = this.page.findByDataQa('application-type-title')
   #openApplicationButton = (id: string) =>
     this.page.findByDataQa(`button-open-application-${id}`)
   #cancelApplicationButton = (id: string) =>
@@ -122,48 +134,63 @@ export default class CitizenApplicationsPage {
 }
 
 class CitizenApplicationReadView {
-  constructor(private readonly page: Page) {}
-
-  contactInfoSection = this.page.findByDataQa('contact-info-section')
-  unitPreferenceSection = this.page.findByDataQa('unit-preference-section')
-  assistanceNeedDescription = new TextInput(
-    this.page.findByDataQa('assistance-need-description')
-  )
+  contactInfoSection: Element
+  unitPreferenceSection: Element
+  assistanceNeedDescription: TextInput
+  constructor(private readonly page: Page) {
+    this.contactInfoSection = page.findByDataQa('contact-info-section')
+    this.unitPreferenceSection = page.findByDataQa('unit-preference-section')
+    this.assistanceNeedDescription = new TextInput(
+      page.findByDataQa('assistance-need-description')
+    )
+  }
 }
 
 class CitizenApplicationEditor {
-  constructor(private readonly page: Page) {}
+  #verifyButton: Element
+  #verifyCheckbox: Checkbox
+  #allowOtherGuardianAccess: Checkbox
+  #sendButton: Element
+  #applicationSentModal: Element
+  #errorsTitle: Element
+  #preferredStartDateInput: TextInput
+  #preferredStartDateWarning: Element
+  #preferredStartDateInfo: Element
+  saveAsDraftButton: Element
+  modalOkBtn: Element
+  guardianPhoneInput: TextInput
+  constructor(private readonly page: Page) {
+    this.#verifyButton = page.findByDataQa('verify-btn')
+    this.#verifyCheckbox = new Checkbox(page.findByDataQa('verify-checkbox'))
+    this.#allowOtherGuardianAccess = new Checkbox(
+      page.findByDataQa('allow-other-guardian-access')
+    )
+    this.#sendButton = page.findByDataQa('send-btn')
+    this.#applicationSentModal = page.findByDataQa(
+      'info-message-application-sent'
+    )
+    this.#errorsTitle = page.findByDataQa('application-has-errors-title')
+    this.#preferredStartDateInput = new TextInput(
+      page.findByDataQa('preferredStartDate-input')
+    )
+    this.#preferredStartDateWarning = page.findByDataQa(
+      'daycare-processing-time-warning'
+    )
+    this.#preferredStartDateInfo = page.findByDataQa(
+      'preferredStartDate-input-info'
+    )
+    this.saveAsDraftButton = page.findByDataQa('save-as-draft-btn')
+    this.modalOkBtn = page.findByDataQa('modal-okBtn')
+    this.guardianPhoneInput = new TextInput(
+      page.findByDataQa('guardianPhone-input')
+    )
+  }
 
-  #verifyButton = this.page.findByDataQa('verify-btn')
-  #verifyCheckbox = new Checkbox(this.page.findByDataQa('verify-checkbox'))
-  #allowOtherGuardianAccess = new Checkbox(
-    this.page.findByDataQa('allow-other-guardian-access')
-  )
-  #sendButton = this.page.findByDataQa('send-btn')
-  #applicationSentModal = this.page.findByDataQa(
-    'info-message-application-sent'
-  )
-  #errorsTitle = this.page.findByDataQa('application-has-errors-title')
   #section = (name: string) => this.page.findByDataQa(`${name}-section`)
   #sectionHeader = (name: string) =>
     this.page.findByDataQa(`${name}-section-header`)
   #preferredUnitsInput = new TextInput(
     this.page.find('[data-qa="preferredUnits-input"] input')
-  )
-  #preferredStartDateInput = new TextInput(
-    this.page.findByDataQa('preferredStartDate-input')
-  )
-  #preferredStartDateWarning = this.page.findByDataQa(
-    'daycare-processing-time-warning'
-  )
-  #preferredStartDateInfo = this.page.findByDataQa(
-    'preferredStartDate-input-info'
-  )
-
-  saveAsDraftButton = this.page.findByDataQa('save-as-draft-btn')
-  modalOkBtn = this.page.findByDataQa('modal-okBtn')
-  guardianPhoneInput = new TextInput(
-    this.page.findByDataQa('guardianPhone-input')
   )
 
   async writeAssistanceNeedDescription(description: string) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -14,29 +14,29 @@ export default class CitizenApplicationsPage {
   constructor(private readonly page: Page) {}
 
   #newApplicationButton = (childId: string) =>
-    this.page.find(`[data-qa="new-application-${childId}"]`)
+    this.page.findByDataQa(`new-application-${childId}`)
   #applicationTypeRadio = (type: 'DAYCARE' | 'PRESCHOOL' | 'CLUB') =>
-    new Radio(this.page.find(`[data-qa="type-radio-${type}"]`))
-  #createNewApplicationButton = this.page.find('[data-qa="submit"]')
-  #transferApplicationNotification = this.page.find(
-    '[data-qa="transfer-application-notification"]'
+    new Radio(this.page.findByDataQa(`type-radio-${type}`))
+  #createNewApplicationButton = this.page.findByDataQa('submit')
+  #transferApplicationNotification = this.page.findByDataQa(
+    'transfer-application-notification'
   )
-  #duplicateApplicationNotification = this.page.find(
-    '[data-qa="duplicate-application-notification"]'
+  #duplicateApplicationNotification = this.page.findByDataQa(
+    'duplicate-application-notification'
   )
-  #applicationTitle = this.page.find('[data-qa="application-type-title"]')
+  #applicationTitle = this.page.findByDataQa('application-type-title')
   #openApplicationButton = (id: string) =>
-    this.page.find(`[data-qa="button-open-application-${id}"]`)
+    this.page.findByDataQa(`button-open-application-${id}`)
   #cancelApplicationButton = (id: string) =>
-    this.page.find(`[data-qa="button-remove-application-${id}"]`)
+    this.page.findByDataQa(`button-remove-application-${id}`)
   #childTitle = (childId: string) =>
-    this.page.find(`[data-qa="title-applications-child-name-${childId}"]`)
+    this.page.findByDataQa(`title-applications-child-name-${childId}`)
   #applicationType = (id: string) =>
-    this.page.find(`[data-qa="title-application-type-${id}"]`)
+    this.page.findByDataQa(`title-application-type-${id}`)
   #applicationPreferredStartDate = (id: string) =>
-    this.page.find(`[data-qa="application-period-${id}"]`)
+    this.page.findByDataQa(`application-period-${id}`)
   #applicationStatus = (id: string) =>
-    this.page.find(`[data-qa="application-status-${id}"]`)
+    this.page.findByDataQa(`application-status-${id}`)
 
   async createApplication(
     childId: string,
@@ -109,7 +109,7 @@ export default class CitizenApplicationsPage {
 
   async cancelApplication(id: string) {
     await this.#cancelApplicationButton(id).click()
-    await this.page.find('[data-qa="modal-okBtn"]').click()
+    await this.page.findByDataQa('modal-okBtn').click()
   }
 
   async assertApplicationDoesNotExist(id: string) {
@@ -134,30 +134,30 @@ class CitizenApplicationReadView {
 class CitizenApplicationEditor {
   constructor(private readonly page: Page) {}
 
-  #verifyButton = this.page.find('[data-qa="verify-btn"]')
-  #verifyCheckbox = new Checkbox(this.page.find('[data-qa="verify-checkbox"]'))
+  #verifyButton = this.page.findByDataQa('verify-btn')
+  #verifyCheckbox = new Checkbox(this.page.findByDataQa('verify-checkbox'))
   #allowOtherGuardianAccess = new Checkbox(
     this.page.findByDataQa('allow-other-guardian-access')
   )
-  #sendButton = this.page.find('[data-qa="send-btn"]')
-  #applicationSentModal = this.page.find(
-    '[data-qa="info-message-application-sent"]'
+  #sendButton = this.page.findByDataQa('send-btn')
+  #applicationSentModal = this.page.findByDataQa(
+    'info-message-application-sent'
   )
-  #errorsTitle = this.page.find('[data-qa="application-has-errors-title"]')
-  #section = (name: string) => this.page.find(`[data-qa="${name}-section"]`)
+  #errorsTitle = this.page.findByDataQa('application-has-errors-title')
+  #section = (name: string) => this.page.findByDataQa(`${name}-section`)
   #sectionHeader = (name: string) =>
-    this.page.find(`[data-qa="${name}-section-header"]`)
+    this.page.findByDataQa(`${name}-section-header`)
   #preferredUnitsInput = new TextInput(
     this.page.find('[data-qa="preferredUnits-input"] input')
   )
   #preferredStartDateInput = new TextInput(
-    this.page.find('[data-qa="preferredStartDate-input"]')
+    this.page.findByDataQa('preferredStartDate-input')
   )
-  #preferredStartDateWarning = this.page.find(
-    '[data-qa="daycare-processing-time-warning"]'
+  #preferredStartDateWarning = this.page.findByDataQa(
+    'daycare-processing-time-warning'
   )
-  #preferredStartDateInfo = this.page.find(
-    '[data-qa="preferredStartDate-input-info"]'
+  #preferredStartDateInfo = this.page.findByDataQa(
+    'preferredStartDate-input-info'
   )
 
   saveAsDraftButton = this.page.findByDataQa('save-as-draft-btn')
@@ -223,12 +223,12 @@ class CitizenApplicationEditor {
 
   async selectBooleanRadio(field: string, value: boolean) {
     await new Radio(
-      this.page.find(`[data-qa="${field}-input-${String(value)}"]`)
+      this.page.findByDataQa(`${field}-input-${String(value)}`)
     ).click()
   }
 
   async setCheckbox(field: string, value: boolean) {
-    const element = new Checkbox(this.page.find(`[data-qa="${field}-input"]`))
+    const element = new Checkbox(this.page.findByDataQa(`${field}-input`))
 
     if ((await element.checked) !== value) {
       await element.click()
@@ -241,7 +241,7 @@ class CitizenApplicationEditor {
     clearFirst = true,
     pressEnterAfter = false
   ) {
-    const element = new TextInput(this.page.find(`[data-qa="${field}-input"]`))
+    const element = new TextInput(this.page.findByDataQa(`${field}-input`))
     if (clearFirst) {
       await element.clear()
     }
@@ -278,13 +278,11 @@ class CitizenApplicationEditor {
           } else if (field === 'siblingBasis') {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             await this.setCheckbox(field, value)
-            await new Checkbox(
-              this.page.find('[data-qa="other-sibling"]')
-            ).click()
+            await new Checkbox(this.page.findByDataQa('other-sibling')).click()
           } else if (field === 'otherGuardianAgreementStatus' && value) {
             await new Radio(
-              this.page.find(
-                `[data-qa="otherGuardianAgreementStatus-${String(value)}"]`
+              this.page.findByDataQa(
+                `otherGuardianAgreementStatus-${String(value)}`
               )
             ).click()
           } else if (
@@ -293,7 +291,7 @@ class CitizenApplicationEditor {
           ) {
             for (let i = 0; i < data.contactInfo?.otherChildren?.length; i++) {
               if (i > 0) {
-                await this.page.find('[data-qa="add-other-child"]').click()
+                await this.page.findByDataQa('add-other-child').click()
               }
               await this.fillInput(
                 `otherChildren[${i}].firstName`,

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -137,7 +137,7 @@ class CitizenApplicationReadView {
   contactInfoSection: Element
   unitPreferenceSection: Element
   assistanceNeedDescription: TextInput
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.contactInfoSection = page.findByDataQa('contact-info-section')
     this.unitPreferenceSection = page.findByDataQa('unit-preference-section')
     this.assistanceNeedDescription = new TextInput(

--- a/frontend/src/e2e-test/pages/citizen/citizen-assistance-need-decision.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-assistance-need-decision.ts
@@ -2,10 +2,19 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export default class AssistanceNeedDecisionPage {
-  constructor(private readonly page: Page) {}
+  structuralMotivationDescription: Element
+  otherRepresentativeDetails: Element
+  constructor(private readonly page: Page) {
+    this.structuralMotivationDescription = page.findByDataQa(
+      'structural-motivation-description'
+    )
+    this.otherRepresentativeDetails = page.findByDataQa(
+      'other-representative-details'
+    )
+  }
 
   private getLabelledValue(label: string) {
     return this.page.findByDataQa(`labelled-value-${label}`).text
@@ -19,9 +28,6 @@ export default class AssistanceNeedDecisionPage {
       .findByDataQa('structural-motivation-section')
       .findByDataQa(`list-option-${opt}`)
       .waitUntilVisible()
-  readonly structuralMotivationDescription = this.page.findByDataQa(
-    'structural-motivation-description'
-  )
   readonly careMotivation = this.getLabelledValue('care-motivation')
   readonly assertServiceOption = (opt: string) =>
     this.page
@@ -29,9 +35,6 @@ export default class AssistanceNeedDecisionPage {
       .findByDataQa(`list-option-${opt}`)
       .waitUntilVisible()
   readonly guardiansHeardOn = this.getLabelledValue('guardians-heard-at')
-  readonly otherRepresentativeDetails = this.page.findByDataQa(
-    'other-representative-details'
-  )
   readonly viewOfGuardians = this.getLabelledValue('view-of-the-guardians')
   readonly futureLevelOfAssistance = this.getLabelledValue(
     'future-level-of-assistance'

--- a/frontend/src/e2e-test/pages/citizen/citizen-assistance-need-preschool-decision.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-assistance-need-preschool-decision.ts
@@ -2,28 +2,41 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export default class AssistanceNeedPreschoolDecisionPage {
-  constructor(private readonly page: Page) {}
-
-  readonly status = this.page.findByDataQa('status')
-  readonly type = this.page.findByDataQa('type')
-  readonly validFrom = this.page.findByDataQa('valid-from')
-  readonly extendedCompulsoryEducation = this.page.findByDataQa(
-    'extended-compulsory-education'
-  )
-  readonly grantedServices = this.page.findByDataQa('granted-services')
-  readonly grantedServicesBasis = this.page.findByDataQa(
-    'granted-services-basis'
-  )
-  readonly selectedUnit = this.page.findByDataQa('unit')
-  readonly primaryGroup = this.page.findByDataQa('primary-group')
-  readonly decisionBasis = this.page.findByDataQa('decision-basis')
-  readonly documentBasis = this.page.findByDataQa('document-basis')
-  readonly basisDocumentsInfo = this.page.findByDataQa('basis-documents-info')
-  readonly guardiansHeardOn = this.page.findByDataQa('guardians-heard-on')
-  readonly viewOfGuardians = this.page.findByDataQa('view-of-guardians')
-  readonly preparer1 = this.page.findByDataQa('preparer-1')
-  readonly decisionMaker = this.page.findByDataQa('decision-maker')
+  status: Element
+  type: Element
+  validFrom: Element
+  extendedCompulsoryEducation: Element
+  grantedServices: Element
+  grantedServicesBasis: Element
+  selectedUnit: Element
+  primaryGroup: Element
+  decisionBasis: Element
+  documentBasis: Element
+  basisDocumentsInfo: Element
+  guardiansHeardOn: Element
+  viewOfGuardians: Element
+  preparer1: Element
+  decisionMaker: Element
+  constructor(private readonly page: Page) {
+    this.status = page.findByDataQa('status')
+    this.type = page.findByDataQa('type')
+    this.validFrom = page.findByDataQa('valid-from')
+    this.extendedCompulsoryEducation = page.findByDataQa(
+      'extended-compulsory-education'
+    )
+    this.grantedServices = page.findByDataQa('granted-services')
+    this.grantedServicesBasis = page.findByDataQa('granted-services-basis')
+    this.selectedUnit = page.findByDataQa('unit')
+    this.primaryGroup = page.findByDataQa('primary-group')
+    this.decisionBasis = page.findByDataQa('decision-basis')
+    this.documentBasis = page.findByDataQa('document-basis')
+    this.basisDocumentsInfo = page.findByDataQa('basis-documents-info')
+    this.guardiansHeardOn = page.findByDataQa('guardians-heard-on')
+    this.viewOfGuardians = page.findByDataQa('view-of-guardians')
+    this.preparer1 = page.findByDataQa('preparer-1')
+    this.decisionMaker = page.findByDataQa('decision-maker')
+  }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-assistance-need-preschool-decision.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-assistance-need-preschool-decision.ts
@@ -20,7 +20,7 @@ export default class AssistanceNeedPreschoolDecisionPage {
   viewOfGuardians: Element
   preparer1: Element
   decisionMaker: Element
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.status = page.findByDataQa('status')
     this.type = page.findByDataQa('type')
     this.validFrom = page.findByDataQa('valid-from')

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -744,7 +744,7 @@ class HolidayModal extends Element {
 class DayModal {
   childName: ElementCollection
   closeModal: Element
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.childName = page.findAllByDataQa('child-name')
     this.closeModal = page.findByDataQa('day-view-close-button')
   }

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -260,42 +260,40 @@ export default class CitizenCalendarPage {
 class ReservationsModal {
   constructor(private readonly page: Page) {}
 
-  #startDateInput = new TextInput(this.page.find('[data-qa="start-date"]'))
-  #endDateInput = new TextInput(this.page.find('[data-qa="end-date"]'))
-  #repetitionSelect = new Select(this.page.find('[data-qa="repetition"]'))
+  #startDateInput = new TextInput(this.page.findByDataQa('start-date'))
+  #endDateInput = new TextInput(this.page.findByDataQa('end-date'))
+  #repetitionSelect = new Select(this.page.findByDataQa('repetition'))
   #dailyStartTimeInput = new TextInput(
-    this.page.find('[data-qa="daily-time-0-start"]')
+    this.page.findByDataQa('daily-time-0-start')
   )
-  #dailyEndTimeInput = new TextInput(
-    this.page.find('[data-qa="daily-time-0-end"]')
-  )
+  #dailyEndTimeInput = new TextInput(this.page.findByDataQa('daily-time-0-end'))
 
   #weeklyStartTimeInputs = [0, 1, 2, 3, 4, 5, 6].map(
     (index) =>
-      new TextInput(this.page.find(`[data-qa="weekly-${index}-time-0-start"]`))
+      new TextInput(this.page.findByDataQa(`weekly-${index}-time-0-start`))
   )
   #weeklyEndTimeInputs = [0, 1, 2, 3, 4, 5, 6].map(
     (index) =>
-      new TextInput(this.page.find(`[data-qa="weekly-${index}-time-0-end"]`))
+      new TextInput(this.page.findByDataQa(`weekly-${index}-time-0-end`))
   )
   #weeklyAbsentButtons = [0, 1, 2, 3, 4, 5, 6].map(
     (index) =>
-      new TextInput(this.page.find(`[data-qa="weekly-${index}-absent-button"]`))
+      new TextInput(this.page.findByDataQa(`weekly-${index}-absent-button`))
   )
-  #modalSendButton = this.page.find('[data-qa="modal-okBtn"]')
+  #modalSendButton = this.page.findByDataQa('modal-okBtn')
 
   irregularStartTimeInput = (date: LocalDate) =>
     new TextInput(
-      this.page.find(`[data-qa="irregular-${date.formatIso()}-time-0-start"]`)
+      this.page.findByDataQa(`irregular-${date.formatIso()}-time-0-start`)
     )
 
   irregularEndTimeInput = (date: LocalDate) =>
     new TextInput(
-      this.page.find(`[data-qa="irregular-${date.formatIso()}-time-0-end"]`)
+      this.page.findByDataQa(`irregular-${date.formatIso()}-time-0-end`)
     )
 
   #childCheckbox = (childId: string) =>
-    new Checkbox(this.page.find(`[data-qa="child-${childId}"]`))
+    new Checkbox(this.page.findByDataQa(`child-${childId}`))
 
   async save() {
     await this.#modalSendButton.click()
@@ -490,13 +488,13 @@ class AbsencesModal {
   #childCheckbox = (childId: string) =>
     new Checkbox(this.page.findByDataQa(`child-${childId}`))
 
-  startDateInput = new TextInput(this.page.find('[data-qa="start-date"]'))
-  endDateInput = new TextInput(this.page.find('[data-qa="end-date"]'))
+  startDateInput = new TextInput(this.page.findByDataQa('start-date'))
+  endDateInput = new TextInput(this.page.findByDataQa('end-date'))
   #absenceChip = (type: string) =>
-    new Checkbox(this.page.find(`[data-qa="absence-${type}"]`))
-  #modalSendButton = this.page.find('[data-qa="modal-okBtn"]')
-  absenceTypeRequiredError = this.page.find(
-    '[data-qa="modal-absence-type-required-error"]'
+    new Checkbox(this.page.findByDataQa(`absence-${type}`))
+  #modalSendButton = this.page.findByDataQa('modal-okBtn')
+  absenceTypeRequiredError = this.page.findByDataQa(
+    'modal-absence-type-required-error'
   )
 
   async assertChildrenSelectable(childIds: string[]) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -7,7 +7,14 @@ import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
 import { waitUntilEqual, waitUntilTrue } from '../../utils'
-import { Checkbox, Element, Page, Select, TextInput } from '../../utils/page'
+import {
+  Checkbox,
+  Element,
+  Page,
+  Select,
+  TextInput,
+  ElementCollection
+} from '../../utils/page'
 
 export type FormatterReservation = {
   startTime: string
@@ -17,19 +24,34 @@ export type FormatterReservation = {
 export type TwoPartReservation = [FormatterReservation, FormatterReservation]
 
 export default class CitizenCalendarPage {
+  #openCalendarActionsModal: Element
+  reservationModal: Element
+  #holidayCtas: ElementCollection
+  #expiringIncomeCta: Element
+  #dailyServiceTimeNotifications: ElementCollection
+  #dailyServiceTimeNotificationModal: Element
   constructor(
     private readonly page: Page,
     private readonly type: 'desktop' | 'mobile'
-  ) {}
+  ) {
+    this.#openCalendarActionsModal = page.findByDataQa(
+      'open-calendar-actions-modal'
+    )
+    this.reservationModal = page.findByDataQa('reservation-modal')
+    this.#holidayCtas = page.findAllByDataQa('holiday-period-cta')
+    this.#expiringIncomeCta = page.findByDataQa('expiring-income-cta')
+    this.#dailyServiceTimeNotifications = page.findAllByDataQa(
+      'daily-service-time-notification'
+    )
+    this.#dailyServiceTimeNotificationModal = page.findByDataQa(
+      'daily-service-time-notification-modal'
+    )
+  }
 
-  #openCalendarActionsModal = this.page.findByDataQa(
-    'open-calendar-actions-modal'
-  )
   dayCell = (date: LocalDate) =>
     this.page.findByDataQa(`${this.type}-calendar-day-${date.formatIso()}`)
   monthlySummaryInfoButton = (year: number, month: number) =>
     this.page.findByDataQa(`monthly-summary-info-button-${month}-${year}`)
-  reservationModal = this.page.findByDataQa('reservation-modal')
 
   async openDayModal(date: LocalDate) {
     await this.dayCell(date).click()
@@ -202,9 +224,6 @@ export default class CitizenCalendarPage {
       .assertTextEquals(formatter(twoPartReservation))
   }
 
-  #holidayCtas = this.page.findAllByDataQa('holiday-period-cta')
-  #expiringIncomeCta = this.page.findByDataQa('expiring-income-cta')
-
   async getHolidayCtaContent(): Promise<string> {
     return this.#holidayCtas.nth(0).text
   }
@@ -235,17 +254,9 @@ export default class CitizenCalendarPage {
     await this.#expiringIncomeCta.waitUntilHidden()
   }
 
-  #dailyServiceTimeNotifications = this.page.findAllByDataQa(
-    'daily-service-time-notification'
-  )
-
   async getDailyServiceTimeNotificationContent(nth: number): Promise<string> {
     return this.#dailyServiceTimeNotifications.nth(nth).text
   }
-
-  #dailyServiceTimeNotificationModal = this.page.findByDataQa(
-    'daily-service-time-notification-modal'
-  )
 
   async getDailyServiceTimeNotificationModalContent(): Promise<string> {
     return this.#dailyServiceTimeNotificationModal.findByDataQa('text').text
@@ -258,15 +269,24 @@ export default class CitizenCalendarPage {
 }
 
 class ReservationsModal {
-  constructor(private readonly page: Page) {}
-
-  #startDateInput = new TextInput(this.page.findByDataQa('start-date'))
-  #endDateInput = new TextInput(this.page.findByDataQa('end-date'))
-  #repetitionSelect = new Select(this.page.findByDataQa('repetition'))
-  #dailyStartTimeInput = new TextInput(
-    this.page.findByDataQa('daily-time-0-start')
-  )
-  #dailyEndTimeInput = new TextInput(this.page.findByDataQa('daily-time-0-end'))
+  #startDateInput: TextInput
+  #endDateInput: TextInput
+  #repetitionSelect: Select
+  #dailyStartTimeInput: TextInput
+  #dailyEndTimeInput: TextInput
+  #modalSendButton: Element
+  constructor(private readonly page: Page) {
+    this.#startDateInput = new TextInput(page.findByDataQa('start-date'))
+    this.#endDateInput = new TextInput(page.findByDataQa('end-date'))
+    this.#repetitionSelect = new Select(page.findByDataQa('repetition'))
+    this.#dailyStartTimeInput = new TextInput(
+      page.findByDataQa('daily-time-0-start')
+    )
+    this.#dailyEndTimeInput = new TextInput(
+      page.findByDataQa('daily-time-0-end')
+    )
+    this.#modalSendButton = page.findByDataQa('modal-okBtn')
+  }
 
   #weeklyStartTimeInputs = [0, 1, 2, 3, 4, 5, 6].map(
     (index) =>
@@ -280,7 +300,6 @@ class ReservationsModal {
     (index) =>
       new TextInput(this.page.findByDataQa(`weekly-${index}-absent-button`))
   )
-  #modalSendButton = this.page.findByDataQa('modal-okBtn')
 
   irregularStartTimeInput = (date: LocalDate) =>
     new TextInput(
@@ -483,19 +502,24 @@ class ReservationsModal {
 }
 
 class AbsencesModal {
-  constructor(private readonly page: Page) {}
+  startDateInput: TextInput
+  endDateInput: TextInput
+  #modalSendButton: Element
+  absenceTypeRequiredError: Element
+  constructor(private readonly page: Page) {
+    this.startDateInput = new TextInput(page.findByDataQa('start-date'))
+    this.endDateInput = new TextInput(page.findByDataQa('end-date'))
+    this.#modalSendButton = page.findByDataQa('modal-okBtn')
+    this.absenceTypeRequiredError = page.findByDataQa(
+      'modal-absence-type-required-error'
+    )
+  }
 
   #childCheckbox = (childId: string) =>
     new Checkbox(this.page.findByDataQa(`child-${childId}`))
 
-  startDateInput = new TextInput(this.page.findByDataQa('start-date'))
-  endDateInput = new TextInput(this.page.findByDataQa('end-date'))
   #absenceChip = (type: string) =>
     new Checkbox(this.page.findByDataQa(`absence-${type}`))
-  #modalSendButton = this.page.findByDataQa('modal-okBtn')
-  absenceTypeRequiredError = this.page.findByDataQa(
-    'modal-absence-type-required-error'
-  )
 
   async assertChildrenSelectable(childIds: string[]) {
     for (const childId of childIds) {
@@ -718,8 +742,10 @@ class HolidayModal extends Element {
 }
 
 class DayModal {
-  constructor(private readonly page: Page) {}
-
-  childName = this.page.findAllByDataQa('child-name')
-  closeModal = this.page.findByDataQa('day-view-close-button')
+  childName: ElementCollection
+  closeModal: Element
+  constructor(private readonly page: Page) {
+    this.childName = page.findAllByDataQa('child-name')
+    this.closeModal = page.findByDataQa('day-view-close-button')
+  }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
@@ -3,13 +3,15 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { waitUntilEqual, waitUntilTrue } from '../../utils'
-import { Checkbox, FileInput, Page, TextInput } from '../../utils/page'
+import { Checkbox, FileInput, Page, TextInput, Element } from '../../utils/page'
 
 export class CitizenChildIncomeStatementViewPage {
-  constructor(private readonly page: Page) {}
-
-  private startDate = this.page.findByDataQa('start-date')
-  private otherInfo = this.page.findByDataQa('other-info')
+  startDate: Element
+  otherInfo: Element
+  constructor(private readonly page: Page) {
+    this.startDate = page.findByDataQa('start-date')
+    this.otherInfo = page.findByDataQa('other-info')
+  }
 
   async waitUntilReady() {
     await this.startDate.waitUntilVisible()
@@ -37,13 +39,16 @@ export class CitizenChildIncomeStatementViewPage {
 }
 
 export class CitizenChildIncomeStatementEditPage {
-  constructor(private readonly page: Page) {}
-
-  startDateInput = new TextInput(this.page.findByDataQa('start-date'))
-
-  private otherInfoInput = new TextInput(this.page.findByDataQa('other-info'))
-  private assure = new Checkbox(this.page.findByDataQa('assure-checkbox'))
-  private saveButton = this.page.findByDataQa('save-btn')
+  startDateInput: TextInput
+  otherInfoInput: TextInput
+  assure: Checkbox
+  saveButton: Element
+  constructor(private readonly page: Page) {
+    this.startDateInput = new TextInput(page.findByDataQa('start-date'))
+    this.otherInfoInput = new TextInput(page.findByDataQa('other-info'))
+    this.assure = new Checkbox(page.findByDataQa('assure-checkbox'))
+    this.saveButton = page.findByDataQa('save-btn')
+  }
 
   async waitUntilReady() {
     await this.startDateInput.waitUntilVisible()

--- a/frontend/src/e2e-test/pages/citizen/citizen-children.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-children.ts
@@ -6,18 +6,25 @@ import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
 import { waitUntilEqual } from '../../utils'
-import { AsyncButton, Page, TextInput } from '../../utils/page'
+import {
+  AsyncButton,
+  Page,
+  TextInput,
+  ElementCollection
+} from '../../utils/page'
 
 import { EnvType } from './citizen-header'
 
 export class CitizenChildPage {
+  #placements: ElementCollection
+  #terminatedPlacements: ElementCollection
   constructor(
     private readonly page: Page,
     private readonly env: EnvType = 'desktop'
-  ) {}
-
-  #placements = this.page.findAllByDataQa('placement')
-  #terminatedPlacements = this.page.findAllByDataQa('terminated-placement')
+  ) {
+    this.#placements = page.findAllByDataQa('placement')
+    this.#terminatedPlacements = page.findAllByDataQa('terminated-placement')
+  }
 
   async assertChildNameIsShown(name: string) {
     await this.page.find(`h1:has-text("${name}")`).waitUntilVisible()

--- a/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
@@ -204,7 +204,7 @@ class CitizenDecisionResponsePage {
 
   #title = this.page.find('h1')
   #decisionBlock = (decisionId: string) =>
-    this.page.find(`[data-qa="decision-${decisionId}"]`)
+    this.page.findByDataQa(`decision-${decisionId}`)
   #acceptRadioButton = (decisionId: string) =>
     this.#decisionBlock(decisionId).find('[data-qa="radio-accept"]')
   #rejectRadioButton = (decisionId: string) =>
@@ -269,7 +269,7 @@ class CitizenDecisionResponsePage {
 }
 
 async function assertUnresolvedDecisionsCount(page: Page, count: number) {
-  const element = page.find('[data-qa="alert-box-unconfirmed-decisions-count"]')
+  const element = page.findByDataQa('alert-box-unconfirmed-decisions-count')
 
   if (count === 0) {
     return element.waitUntilHidden()

--- a/frontend/src/e2e-test/pages/citizen/citizen-header.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-header.ts
@@ -5,23 +5,28 @@
 import { Lang } from 'lib-customizations/citizen'
 
 import { waitUntilFalse } from '../../utils'
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export type EnvType = 'desktop' | 'mobile'
 
 export default class CitizenHeader {
+  #languageMenuToggle: Element
+  #languageOptionList: Element
+  #childrenNav: Element
+  #unreadChildrenCount: Element
+  #subNavMenu: Element
   constructor(
     private readonly page: Page,
     private readonly type: EnvType = 'desktop'
-  ) {}
-
-  #languageMenuToggle = this.page.findByDataQa('button-select-language')
-  #languageOptionList = this.page.findByDataQa('select-lang')
-  #childrenNav = this.page.findByDataQa(`nav-children-${this.type}`)
-  #unreadChildrenCount = this.page.findByDataQa(
-    `nav-children-${this.type}-notification-count`
-  )
-  #subNavMenu = this.page.findByDataQa(`sub-nav-menu-${this.type}`)
+  ) {
+    this.#languageMenuToggle = page.findByDataQa('button-select-language')
+    this.#languageOptionList = page.findByDataQa('select-lang')
+    this.#childrenNav = page.findByDataQa(`nav-children-${this.type}`)
+    this.#unreadChildrenCount = page.findByDataQa(
+      `nav-children-${this.type}-notification-count`
+    )
+    this.#subNavMenu = page.findByDataQa(`sub-nav-menu-${this.type}`)
+  }
 
   #languageOption(lang: Lang) {
     return this.#languageOptionList.find(`[data-qa="lang-${lang}"]`)

--- a/frontend/src/e2e-test/pages/citizen/citizen-header.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-header.ts
@@ -15,8 +15,8 @@ export default class CitizenHeader {
     private readonly type: EnvType = 'desktop'
   ) {}
 
-  #languageMenuToggle = this.page.find('[data-qa="button-select-language"]')
-  #languageOptionList = this.page.find('[data-qa="select-lang"]')
+  #languageMenuToggle = this.page.findByDataQa('button-select-language')
+  #languageOptionList = this.page.findByDataQa('select-lang')
   #childrenNav = this.page.findByDataQa(`nav-children-${this.type}`)
   #unreadChildrenCount = this.page.findByDataQa(
     `nav-children-${this.type}-notification-count`

--- a/frontend/src/e2e-test/pages/citizen/citizen-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-income.ts
@@ -8,17 +8,17 @@ export default class CitizenIncomePage {
   constructor(private readonly page: Page) {}
 
   rows = this.page.findAll('tbody tr')
-  requiredAttachments = this.page.find('[data-qa="required-attachments"]')
-  assureCheckBox = new Checkbox(this.page.find('[data-qa="assure-checkbox"]'))
+  requiredAttachments = this.page.findByDataQa('required-attachments')
+  assureCheckBox = new Checkbox(this.page.findByDataQa('assure-checkbox'))
 
   async createNewIncomeStatement() {
-    await this.page.find('[data-qa="new-income-statement-btn"]').click()
+    await this.page.findByDataQa('new-income-statement-btn').click()
   }
 
   async selectIncomeStatementType(
     type: 'highest-fee' | 'gross-income' | 'entrepreneur-income'
   ) {
-    await this.page.find(`[data-qa="${type}-checkbox"]`).click()
+    await this.page.findByDataQa(`${type}-checkbox`).click()
   }
 
   #startDate = new TextInput(this.page.find('#start-date'))
@@ -43,11 +43,11 @@ export default class CitizenIncomePage {
   }
 
   async selectEntrepreneurType(value: 'full-time' | 'part-time') {
-    await this.page.find(`[data-qa="entrepreneur-${value}-option"]`).click()
+    await this.page.findByDataQa(`entrepreneur-${value}-option`).click()
   }
 
   #entrepreneurDate = new TextInput(
-    this.page.find('[data-qa="entrepreneur-start-date"]')
+    this.page.findByDataQa('entrepreneur-start-date')
   )
 
   async setEntrepreneurStartDate(date: string) {
@@ -75,7 +75,7 @@ export default class CitizenIncomePage {
       | 'self-employed-estimated-income',
     check: boolean
   ) {
-    const elem = new Checkbox(this.page.find(`[data-qa="${checkbox}"]`))
+    const elem = new Checkbox(this.page.findByDataQa(`${checkbox}`))
     check ? await elem.check() : await elem.uncheck()
   }
 
@@ -92,7 +92,7 @@ export default class CitizenIncomePage {
   }
 
   async toggleLlcType(value: 'attachments' | 'incomes-register') {
-    await this.page.find(`[data-qa="llc-${value}"]`).click()
+    await this.page.findByDataQa(`llc-${value}`).click()
   }
 
   async toggleLightEntrepreneur(check: boolean) {
@@ -124,20 +124,20 @@ export default class CitizenIncomePage {
   }
 
   async fillAccountant() {
-    await new TextInput(this.page.find('[data-qa="accountant-name"]')).fill(
+    await new TextInput(this.page.findByDataQa('accountant-name')).fill(
       'Kirjanpitäjä'
     )
-    await new TextInput(this.page.find('[data-qa="accountant-email"]')).fill(
+    await new TextInput(this.page.findByDataQa('accountant-email')).fill(
       'foo@example.com'
     )
-    await new TextInput(this.page.find('[data-qa="accountant-phone"]')).fill(
+    await new TextInput(this.page.findByDataQa('accountant-phone')).fill(
       '0400123456'
     )
   }
 
   async setGrossIncomeEstimate(income: number) {
     await new TextInput(
-      this.page.find('[data-qa="gross-monthly-income-estimate"]')
+      this.page.findByDataQa('gross-monthly-income-estimate')
     ).fill(String(income))
   }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-income.ts
@@ -2,14 +2,21 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Checkbox, Page, Radio, TextInput } from '../../utils/page'
+import { Checkbox, Page, Radio, TextInput, Element } from '../../utils/page'
 
 export default class CitizenIncomePage {
-  constructor(private readonly page: Page) {}
+  requiredAttachments: Element
+  assureCheckBox: Checkbox
+  #entrepreneurDate: TextInput
+  constructor(private readonly page: Page) {
+    this.requiredAttachments = page.findByDataQa('required-attachments')
+    this.assureCheckBox = new Checkbox(page.findByDataQa('assure-checkbox'))
+    this.#entrepreneurDate = new TextInput(
+      page.findByDataQa('entrepreneur-start-date')
+    )
+  }
 
   rows = this.page.findAll('tbody tr')
-  requiredAttachments = this.page.findByDataQa('required-attachments')
-  assureCheckBox = new Checkbox(this.page.findByDataQa('assure-checkbox'))
 
   async createNewIncomeStatement() {
     await this.page.findByDataQa('new-income-statement-btn').click()
@@ -45,10 +52,6 @@ export default class CitizenIncomePage {
   async selectEntrepreneurType(value: 'full-time' | 'part-time') {
     await this.page.findByDataQa(`entrepreneur-${value}-option`).click()
   }
-
-  #entrepreneurDate = new TextInput(
-    this.page.findByDataQa('entrepreneur-start-date')
-  )
 
   async setEntrepreneurStartDate(date: string) {
     await this.#entrepreneurDate.fill(date)

--- a/frontend/src/e2e-test/pages/citizen/citizen-map.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-map.ts
@@ -13,24 +13,23 @@ import {
 } from '../../utils/page'
 
 export default class CitizenMapPage {
-  constructor(private readonly page: Page) {}
+  daycareFilter: Radio
+  preschoolFilter: Radio
+  clubFilter: Radio
+  unitDetailsPanel: UnitDetailsPanel
+  map: Map
+  searchInput: MapSearchInput
+  constructor(private readonly page: Page) {
+    this.daycareFilter = new Radio(page.findByDataQa('map-filter-DAYCARE'))
+    this.preschoolFilter = new Radio(page.findByDataQa('map-filter-PRESCHOOL'))
+    this.clubFilter = new Radio(page.findByDataQa('map-filter-CLUB'))
+    this.unitDetailsPanel = new UnitDetailsPanel(
+      page.findByDataQa('map-unit-details')
+    )
+    this.map = new Map(page.findByDataQa('map-view'))
+    this.searchInput = new MapSearchInput(page.findByDataQa('map-search-input'))
+  }
 
-  readonly daycareFilter = new Radio(
-    this.page.findByDataQa('map-filter-DAYCARE')
-  )
-  readonly preschoolFilter = new Radio(
-    this.page.findByDataQa('map-filter-PRESCHOOL')
-  )
-  readonly clubFilter = new Radio(this.page.findByDataQa('map-filter-CLUB'))
-
-  readonly unitDetailsPanel = new UnitDetailsPanel(
-    this.page.findByDataQa('map-unit-details')
-  )
-
-  readonly map = new Map(this.page.findByDataQa('map-view'))
-  readonly searchInput = new MapSearchInput(
-    this.page.findByDataQa('map-search-input')
-  )
   readonly languageChips = {
     fi: new SelectionChip(this.page.findByDataQa('map-filter-fi')),
     sv: new SelectionChip(this.page.findByDataQa('map-filter-sv'))

--- a/frontend/src/e2e-test/pages/citizen/citizen-map.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-map.ts
@@ -16,24 +16,24 @@ export default class CitizenMapPage {
   constructor(private readonly page: Page) {}
 
   readonly daycareFilter = new Radio(
-    this.page.find('[data-qa="map-filter-DAYCARE"]')
+    this.page.findByDataQa('map-filter-DAYCARE')
   )
   readonly preschoolFilter = new Radio(
-    this.page.find('[data-qa="map-filter-PRESCHOOL"]')
+    this.page.findByDataQa('map-filter-PRESCHOOL')
   )
-  readonly clubFilter = new Radio(this.page.find('[data-qa="map-filter-CLUB"]'))
+  readonly clubFilter = new Radio(this.page.findByDataQa('map-filter-CLUB'))
 
   readonly unitDetailsPanel = new UnitDetailsPanel(
-    this.page.find('[data-qa="map-unit-details"]')
+    this.page.findByDataQa('map-unit-details')
   )
 
-  readonly map = new Map(this.page.find('[data-qa="map-view"]'))
+  readonly map = new Map(this.page.findByDataQa('map-view'))
   readonly searchInput = new MapSearchInput(
-    this.page.find('[data-qa="map-search-input"]')
+    this.page.findByDataQa('map-search-input')
   )
   readonly languageChips = {
-    fi: new SelectionChip(this.page.find('[data-qa="map-filter-fi"]')),
-    sv: new SelectionChip(this.page.find('[data-qa="map-filter-sv"]'))
+    fi: new SelectionChip(this.page.findByDataQa('map-filter-fi')),
+    sv: new SelectionChip(this.page.findByDataQa('map-filter-sv'))
   }
 
   async setLanguageFilter(language: 'fi' | 'sv', selected: boolean) {
@@ -44,7 +44,7 @@ export default class CitizenMapPage {
   }
 
   listItemFor(daycare: DevDaycare) {
-    return this.page.find(`[data-qa="map-unit-list-${daycare.id}"]`)
+    return this.page.findByDataQa(`map-unit-list-${daycare.id}`)
   }
 
   async testMapPopup(daycare: DevDaycare) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -16,26 +16,37 @@ export class MockStrongAuthPage {
   }
 }
 export default class CitizenMessagesPage {
-  constructor(private readonly page: Page) {}
+  #messageReplyContent: TextInput
+  #threadListItem: Element
+  #threadTitle: Element
+  #redactedThreadTitle: Element
+  #strongAuthLink: Element
+  #openReplyEditorButton: Element
+  #sendReplyButton: Element
+  #messageEditor: Element
+  discardMessageButton: Element
+  constructor(private readonly page: Page) {
+    this.#messageReplyContent = new TextInput(
+      page.findByDataQa('message-reply-content')
+    )
+    this.#threadListItem = page.findByDataQa('thread-list-item')
+    this.#threadTitle = page.findByDataQa('thread-reader-title')
+    this.#redactedThreadTitle = page.findByDataQa(
+      'redacted-thread-reader-title'
+    )
+    this.#strongAuthLink = page.findByDataQa('strong-auth-link')
+    this.#openReplyEditorButton = page.findByDataQa(`${this.replyButtonTag}`)
+    this.#sendReplyButton = page.findByDataQa('message-send-btn')
+    this.#messageEditor = page.findByDataQa('message-editor')
+    this.discardMessageButton = page.findByDataQa('message-discard-btn')
+  }
 
   replyButtonTag = 'message-reply-editor-btn'
 
-  #messageReplyContent = new TextInput(
-    this.page.findByDataQa('message-reply-content')
-  )
-  #threadListItem = this.page.findByDataQa('thread-list-item')
-  #threadTitle = this.page.findByDataQa('thread-reader-title')
-  #redactedThreadTitle = this.page.findByDataQa('redacted-thread-reader-title')
-  #strongAuthLink = this.page.findByDataQa('strong-auth-link')
   #inboxEmpty = this.page.find('[data-qa="inbox-empty"][data-loading="false"]')
   #threadContent = this.page.findAll('[data-qa="thread-reader-content"]')
   #threadUrgent = this.page.findByDataQa('thread-reader').findByDataQa('urgent')
-  #openReplyEditorButton = this.page.findByDataQa(`${this.replyButtonTag}`)
-  #sendReplyButton = this.page.findByDataQa('message-send-btn')
   newMessageButton = this.page.findAllByDataQa('new-message-btn').first()
-  #messageEditor = this.page.findByDataQa('message-editor')
-
-  discardMessageButton = this.page.findByDataQa('message-discard-btn')
 
   async createNewMessage(): Promise<CitizenMessageEditor> {
     await this.newMessageButton.click()

--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -21,23 +21,21 @@ export default class CitizenMessagesPage {
   replyButtonTag = 'message-reply-editor-btn'
 
   #messageReplyContent = new TextInput(
-    this.page.find('[data-qa="message-reply-content"]')
+    this.page.findByDataQa('message-reply-content')
   )
-  #threadListItem = this.page.find('[data-qa="thread-list-item"]')
-  #threadTitle = this.page.find('[data-qa="thread-reader-title"]')
-  #redactedThreadTitle = this.page.find(
-    '[data-qa="redacted-thread-reader-title"]'
-  )
-  #strongAuthLink = this.page.find('[data-qa="strong-auth-link"]')
+  #threadListItem = this.page.findByDataQa('thread-list-item')
+  #threadTitle = this.page.findByDataQa('thread-reader-title')
+  #redactedThreadTitle = this.page.findByDataQa('redacted-thread-reader-title')
+  #strongAuthLink = this.page.findByDataQa('strong-auth-link')
   #inboxEmpty = this.page.find('[data-qa="inbox-empty"][data-loading="false"]')
   #threadContent = this.page.findAll('[data-qa="thread-reader-content"]')
   #threadUrgent = this.page.findByDataQa('thread-reader').findByDataQa('urgent')
-  #openReplyEditorButton = this.page.find(`[data-qa="${this.replyButtonTag}"]`)
-  #sendReplyButton = this.page.find('[data-qa="message-send-btn"]')
+  #openReplyEditorButton = this.page.findByDataQa(`${this.replyButtonTag}`)
+  #sendReplyButton = this.page.findByDataQa('message-send-btn')
   newMessageButton = this.page.findAllByDataQa('new-message-btn').first()
   #messageEditor = this.page.findByDataQa('message-editor')
 
-  discardMessageButton = this.page.find('[data-qa="message-discard-btn"]')
+  discardMessageButton = this.page.findByDataQa('message-discard-btn')
 
   async createNewMessage(): Promise<CitizenMessageEditor> {
     await this.newMessageButton.click()

--- a/frontend/src/e2e-test/pages/citizen/citizen-pedagogical-documents.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-pedagogical-documents.ts
@@ -8,13 +8,13 @@ export default class CitizenPedagogicalDocumentsPage {
   constructor(private readonly page: Page) {}
 
   readonly #date = (id: string) =>
-    this.page.find(`[data-qa="pedagogical-document-date-${id}"]`)
+    this.page.findByDataQa(`pedagogical-document-date-${id}`)
   readonly #childName = (id: string) =>
-    this.page.find(`[data-qa="pedagogical-document-child-name-${id}"]`)
+    this.page.findByDataQa(`pedagogical-document-child-name-${id}`)
   readonly #description = (id: string) =>
-    this.page.find(`[data-qa="pedagogical-document-description-${id}"]`)
+    this.page.findByDataQa(`pedagogical-document-description-${id}`)
   readonly #downloadAttachment = (id: string) =>
-    this.page.find(`[data-qa="attachment-${id}-download"]`)
+    this.page.findByDataQa(`attachment-${id}-download`)
 
   async assertPedagogicalDocumentExists(
     id: string,

--- a/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
@@ -9,7 +9,7 @@ export default class CitizenPersonalDetails {
   personalDetailsSection: CitizenPersonalDetailsSection
   loginDetailsSection: LoginDetailsSection
   notificationSettingsSectiong: CitizenNotificationSettingsSection
-  constructor(private readonly page: Page) {
+  constructor(page: Page) {
     this.personalDetailsSection = new CitizenPersonalDetailsSection(
       page.findByDataQa('personal-details-section')
     )

--- a/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
@@ -6,17 +6,20 @@ import { waitUntilFalse, waitUntilTrue } from '../../utils'
 import { Checkbox, Element, Page, Select, TextInput } from '../../utils/page'
 
 export default class CitizenPersonalDetails {
-  constructor(private readonly page: Page) {}
-
-  personalDetailsSection = new CitizenPersonalDetailsSection(
-    this.page.findByDataQa('personal-details-section')
-  )
-  loginDetailsSection = new LoginDetailsSection(
-    this.page.findByDataQa('login-details-section')
-  )
-  notificationSettingsSectiong = new CitizenNotificationSettingsSection(
-    this.page.findByDataQa('notification-settings-section')
-  )
+  personalDetailsSection: CitizenPersonalDetailsSection
+  loginDetailsSection: LoginDetailsSection
+  notificationSettingsSectiong: CitizenNotificationSettingsSection
+  constructor(private readonly page: Page) {
+    this.personalDetailsSection = new CitizenPersonalDetailsSection(
+      page.findByDataQa('personal-details-section')
+    )
+    this.loginDetailsSection = new LoginDetailsSection(
+      page.findByDataQa('login-details-section')
+    )
+    this.notificationSettingsSectiong = new CitizenNotificationSettingsSection(
+      page.findByDataQa('notification-settings-section')
+    )
+  }
 }
 
 export class CitizenPersonalDetailsSection extends Element {

--- a/frontend/src/e2e-test/pages/employee/IncomeStatementPage.ts
+++ b/frontend/src/e2e-test/pages/employee/IncomeStatementPage.ts
@@ -8,15 +8,17 @@ export class IncomeStatementPage {
   #form: Element
   #childOtherInfo: Element
   #noAttachments: Element
+  #handledCheckbox: Checkbox
+  #noteInput: TextInput
+  #submitBtn: Element
   constructor(private readonly page: Page) {
     this.#form = page.findByDataQa(`handler-notes-form`)
     this.#childOtherInfo = page.findByDataQa('other-info')
     this.#noAttachments = page.findByDataQa('no-attachments')
+    this.#handledCheckbox = new Checkbox(this.#form.findByDataQa('set-handled'))
+    this.#noteInput = new TextInput(this.#form.find('input[type="text"]'))
+    this.#submitBtn = this.#form.find('button')
   }
-
-  #handledCheckbox = new Checkbox(this.#form.find('[data-qa="set-handled"]'))
-  #noteInput = new TextInput(this.#form.find('input[type="text"]'))
-  #submitBtn = this.#form.find('button')
 
   #attachments = this.page.findAll('[data-qa="attachments"]')
 

--- a/frontend/src/e2e-test/pages/employee/IncomeStatementPage.ts
+++ b/frontend/src/e2e-test/pages/employee/IncomeStatementPage.ts
@@ -2,20 +2,23 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Checkbox, Page, TextInput } from '../../utils/page'
+import { Checkbox, Page, TextInput, Element } from '../../utils/page'
 
 export class IncomeStatementPage {
-  constructor(private readonly page: Page) {}
-
-  #form = this.page.findByDataQa(`handler-notes-form`)
+  #form: Element
+  #childOtherInfo: Element
+  #noAttachments: Element
+  constructor(private readonly page: Page) {
+    this.#form = page.findByDataQa(`handler-notes-form`)
+    this.#childOtherInfo = page.findByDataQa('other-info')
+    this.#noAttachments = page.findByDataQa('no-attachments')
+  }
 
   #handledCheckbox = new Checkbox(this.#form.find('[data-qa="set-handled"]'))
   #noteInput = new TextInput(this.#form.find('input[type="text"]'))
   #submitBtn = this.#form.find('button')
 
-  #childOtherInfo = this.page.findByDataQa('other-info')
   #attachments = this.page.findAll('[data-qa="attachments"]')
-  #noAttachments = this.page.findByDataQa('no-attachments')
 
   async assertChildIncomeStatement(
     expectedOtherInfo: string,

--- a/frontend/src/e2e-test/pages/employee/IncomeStatementPage.ts
+++ b/frontend/src/e2e-test/pages/employee/IncomeStatementPage.ts
@@ -7,15 +7,15 @@ import { Checkbox, Page, TextInput } from '../../utils/page'
 export class IncomeStatementPage {
   constructor(private readonly page: Page) {}
 
-  #form = this.page.find(`[data-qa="handler-notes-form"]`)
+  #form = this.page.findByDataQa(`handler-notes-form`)
 
   #handledCheckbox = new Checkbox(this.#form.find('[data-qa="set-handled"]'))
   #noteInput = new TextInput(this.#form.find('input[type="text"]'))
   #submitBtn = this.#form.find('button')
 
-  #childOtherInfo = this.page.find('[data-qa="other-info"]')
+  #childOtherInfo = this.page.findByDataQa('other-info')
   #attachments = this.page.findAll('[data-qa="attachments"]')
-  #noAttachments = this.page.find('[data-qa="no-attachments"]')
+  #noAttachments = this.page.findByDataQa('no-attachments')
 
   async assertChildIncomeStatement(
     expectedOtherInfo: string,

--- a/frontend/src/e2e-test/pages/employee/SystemNotificationsPage.ts
+++ b/frontend/src/e2e-test/pages/employee/SystemNotificationsPage.ts
@@ -7,14 +7,19 @@ import { SystemNotificationTargetGroup } from 'lib-common/generated/api-types/sy
 import { DatePicker, Page, TextInput, AsyncButton } from '../../utils/page'
 
 export class SystemNotificationsPage {
-  constructor(private readonly page: Page) {}
+  saveButton: AsyncButton
+  textInput: TextInput
+  dateInput: DatePicker
+  timeInput: TextInput
+  constructor(private readonly page: Page) {
+    this.saveButton = new AsyncButton(page.findByDataQa('save-btn'))
+    this.textInput = new TextInput(page.findByDataQa('text-input'))
+    this.dateInput = new DatePicker(page.findByDataQa('date-input'))
+    this.timeInput = new TextInput(page.findByDataQa('time-input'))
+  }
 
   notificationSection = (target: SystemNotificationTargetGroup) =>
     this.page.findByDataQa(`notification-${target}`)
   createButton = (target: SystemNotificationTargetGroup) =>
     this.notificationSection(target).findByDataQa('create-btn')
-  saveButton = new AsyncButton(this.page.findByDataQa('save-btn'))
-  textInput = new TextInput(this.page.findByDataQa('text-input'))
-  dateInput = new DatePicker(this.page.findByDataQa('date-input'))
-  timeInput = new TextInput(this.page.findByDataQa('time-input'))
 }

--- a/frontend/src/e2e-test/pages/employee/applications.ts
+++ b/frontend/src/e2e-test/pages/employee/applications.ts
@@ -10,7 +10,7 @@ export default class ApplicationsPage {
   constructor(private readonly page: Page) {}
 
   applicationStatusFilter(status: 'ALL') {
-    return this.page.find(`[data-qa="application-status-filter-${status}"]`)
+    return this.page.findByDataQa(`application-status-filter-${status}`)
   }
 
   async toggleApplicationStatusFilter(status: 'ALL') {
@@ -23,7 +23,7 @@ export default class ApplicationsPage {
   }
 
   readonly details = {
-    applicantDeadIndicator: this.page.find('[data-qa="applicant-dead"]')
+    applicantDeadIndicator: this.page.findByDataQa('applicant-dead')
   }
 }
 

--- a/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
@@ -22,37 +22,35 @@ import ApplicationReadView from './application-read-view'
 export default class ApplicationEditView {
   constructor(private readonly page: Page) {}
 
-  #saveButton = this.page.find('[data-qa="save-application"]')
-  #urgentCheckbox = new Checkbox(this.page.find('[data-qa="checkbox-urgent"]'))
-  #urgentAttachmentFileUpload = this.page.find('[data-qa="file-upload-urgent"]')
+  #saveButton = this.page.findByDataQa('save-application')
+  #urgentCheckbox = new Checkbox(this.page.findByDataQa('checkbox-urgent'))
+  #urgentAttachmentFileUpload = this.page.findByDataQa('file-upload-urgent')
   #preferredStartDate = new DatePickerDeprecated(
-    this.page.find('[data-qa="datepicker-start-date"]')
+    this.page.findByDataQa('datepicker-start-date')
   )
-  #startTime = new TextInput(this.page.find('[data-qa="start-time"]'))
-  #endTime = new TextInput(this.page.find('[data-qa="end-time"]'))
+  #startTime = new TextInput(this.page.findByDataQa('start-time'))
+  #endTime = new TextInput(this.page.findByDataQa('end-time'))
   #connectedDaycare = new Checkbox(
-    this.page.find('[data-qa="checkbox-service-need-connected"]')
+    this.page.findByDataQa('checkbox-service-need-connected')
   )
   #connectedDaycarePreferredStartDate = new DatePickerDeprecated(
-    this.page.find(
-      '[data-qa="datepicker-connected-daycare-preferred-start-date"]'
-    )
+    this.page.findByDataQa('datepicker-connected-daycare-preferred-start-date')
   )
-  #connectedDaycarePreferredStartDateInputWarning = this.page.find(
-    '[data-qa="input-warning-connected-daycare-preferred-start-date"]'
+  #connectedDaycarePreferredStartDateInputWarning = this.page.findByDataQa(
+    'input-warning-connected-daycare-preferred-start-date'
   )
-  #preferredUnit = new Combobox(this.page.find('[data-qa="preferred-unit"]'))
+  #preferredUnit = new Combobox(this.page.findByDataQa('preferred-unit'))
   #applicantPhone = new TextInput(
-    this.page.find('[data-qa="application-person-phone"]')
+    this.page.findByDataQa('application-person-phone')
   )
   #applicantEmail = new TextInput(
-    this.page.find('[data-qa="application-person-email"]')
+    this.page.findByDataQa('application-person-email')
   )
   #shiftCareCheckbox = new Checkbox(
-    this.page.find('[data-qa="checkbox-service-need-shift-care"]')
+    this.page.findByDataQa('checkbox-service-need-shift-care')
   )
-  #shiftCareAttachmentFileUpload = this.page.find(
-    '[data-qa="file-upload-shift-care"]'
+  #shiftCareAttachmentFileUpload = this.page.findByDataQa(
+    'file-upload-shift-care'
   )
 
   async saveApplication() {
@@ -126,9 +124,7 @@ export default class ApplicationEditView {
   }
 
   async assertUrgencyAttachmentReceivedAtVisible(fileName: string) {
-    const attachment = this.page.find(
-      `[data-qa="urgent-attachment-${fileName}"]`
-    )
+    const attachment = this.page.findByDataQa(`urgent-attachment-${fileName}`)
     await attachment.waitUntilVisible()
     await attachment
       .find('[data-qa="attachment-received-at"]')
@@ -169,9 +165,9 @@ export default class ApplicationEditView {
     )
   }
 
-  #guardianName = this.page.find('[data-qa="guardian-name"]')
-  #guardianSsn = this.page.find('[data-qa="guardian-ssn"]')
-  #guardianAddress = this.page.find('[data-qa="guardian-address"]')
+  #guardianName = this.page.findByDataQa('guardian-name')
+  #guardianSsn = this.page.findByDataQa('guardian-ssn')
+  #guardianAddress = this.page.findByDataQa('guardian-address')
 
   async assertGuardian(
     expectedName: string,
@@ -184,19 +180,19 @@ export default class ApplicationEditView {
   }
 
   #secondGuardianToggle = new Checkbox(
-    this.page.find('[data-qa="application-second-guardian-toggle"]')
+    this.page.findByDataQa('application-second-guardian-toggle')
   )
   #secondGuardianPhone = new TextInput(
-    this.page.find('[data-qa="application-second-guardian-phone"]')
+    this.page.findByDataQa('application-second-guardian-phone')
   )
   #secondGuardianEmail = new TextInput(
-    this.page.find('[data-qa="application-second-guardian-email"]')
+    this.page.findByDataQa('application-second-guardian-email')
   )
 
   #guardianAgreementStatus = (status: OtherGuardianAgreementStatus) =>
     new Radio(
-      this.page.find(
-        `[data-qa="radio-other-guardian-agreement-status-${status ?? 'null'}"]`
+      this.page.findByDataQa(
+        `radio-other-guardian-agreement-status-${status ?? 'null'}`
       )
     )
 

--- a/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-edit-view.ts
@@ -14,44 +14,77 @@ import {
   FileInput,
   Page,
   Radio,
-  TextInput
+  TextInput,
+  Element
 } from '../../../utils/page'
 
 import ApplicationReadView from './application-read-view'
 
 export default class ApplicationEditView {
-  constructor(private readonly page: Page) {}
-
-  #saveButton = this.page.findByDataQa('save-application')
-  #urgentCheckbox = new Checkbox(this.page.findByDataQa('checkbox-urgent'))
-  #urgentAttachmentFileUpload = this.page.findByDataQa('file-upload-urgent')
-  #preferredStartDate = new DatePickerDeprecated(
-    this.page.findByDataQa('datepicker-start-date')
-  )
-  #startTime = new TextInput(this.page.findByDataQa('start-time'))
-  #endTime = new TextInput(this.page.findByDataQa('end-time'))
-  #connectedDaycare = new Checkbox(
-    this.page.findByDataQa('checkbox-service-need-connected')
-  )
-  #connectedDaycarePreferredStartDate = new DatePickerDeprecated(
-    this.page.findByDataQa('datepicker-connected-daycare-preferred-start-date')
-  )
-  #connectedDaycarePreferredStartDateInputWarning = this.page.findByDataQa(
-    'input-warning-connected-daycare-preferred-start-date'
-  )
-  #preferredUnit = new Combobox(this.page.findByDataQa('preferred-unit'))
-  #applicantPhone = new TextInput(
-    this.page.findByDataQa('application-person-phone')
-  )
-  #applicantEmail = new TextInput(
-    this.page.findByDataQa('application-person-email')
-  )
-  #shiftCareCheckbox = new Checkbox(
-    this.page.findByDataQa('checkbox-service-need-shift-care')
-  )
-  #shiftCareAttachmentFileUpload = this.page.findByDataQa(
-    'file-upload-shift-care'
-  )
+  #saveButton: Element
+  #urgentCheckbox: Checkbox
+  #urgentAttachmentFileUpload: Element
+  #preferredStartDate: DatePickerDeprecated
+  #startTime: TextInput
+  #endTime: TextInput
+  #connectedDaycare: Checkbox
+  #connectedDaycarePreferredStartDate: DatePickerDeprecated
+  #connectedDaycarePreferredStartDateInputWarning: Element
+  #preferredUnit: Combobox
+  #applicantPhone: TextInput
+  #applicantEmail: TextInput
+  #shiftCareCheckbox: Checkbox
+  #shiftCareAttachmentFileUpload: Element
+  #guardianName: Element
+  #guardianSsn: Element
+  #guardianAddress: Element
+  #secondGuardianToggle: Checkbox
+  #secondGuardianPhone: TextInput
+  #secondGuardianEmail: TextInput
+  constructor(private readonly page: Page) {
+    this.#saveButton = page.findByDataQa('save-application')
+    this.#urgentCheckbox = new Checkbox(page.findByDataQa('checkbox-urgent'))
+    this.#urgentAttachmentFileUpload = page.findByDataQa('file-upload-urgent')
+    this.#preferredStartDate = new DatePickerDeprecated(
+      page.findByDataQa('datepicker-start-date')
+    )
+    this.#startTime = new TextInput(page.findByDataQa('start-time'))
+    this.#endTime = new TextInput(page.findByDataQa('end-time'))
+    this.#connectedDaycare = new Checkbox(
+      page.findByDataQa('checkbox-service-need-connected')
+    )
+    this.#connectedDaycarePreferredStartDate = new DatePickerDeprecated(
+      page.findByDataQa('datepicker-connected-daycare-preferred-start-date')
+    )
+    this.#connectedDaycarePreferredStartDateInputWarning = page.findByDataQa(
+      'input-warning-connected-daycare-preferred-start-date'
+    )
+    this.#preferredUnit = new Combobox(page.findByDataQa('preferred-unit'))
+    this.#applicantPhone = new TextInput(
+      page.findByDataQa('application-person-phone')
+    )
+    this.#applicantEmail = new TextInput(
+      page.findByDataQa('application-person-email')
+    )
+    this.#shiftCareCheckbox = new Checkbox(
+      page.findByDataQa('checkbox-service-need-shift-care')
+    )
+    this.#shiftCareAttachmentFileUpload = page.findByDataQa(
+      'file-upload-shift-care'
+    )
+    this.#guardianName = page.findByDataQa('guardian-name')
+    this.#guardianSsn = page.findByDataQa('guardian-ssn')
+    this.#guardianAddress = page.findByDataQa('guardian-address')
+    this.#secondGuardianToggle = new Checkbox(
+      page.findByDataQa('application-second-guardian-toggle')
+    )
+    this.#secondGuardianPhone = new TextInput(
+      page.findByDataQa('application-second-guardian-phone')
+    )
+    this.#secondGuardianEmail = new TextInput(
+      page.findByDataQa('application-second-guardian-email')
+    )
+  }
 
   async saveApplication() {
     await this.#saveButton.click()
@@ -165,10 +198,6 @@ export default class ApplicationEditView {
     )
   }
 
-  #guardianName = this.page.findByDataQa('guardian-name')
-  #guardianSsn = this.page.findByDataQa('guardian-ssn')
-  #guardianAddress = this.page.findByDataQa('guardian-address')
-
   async assertGuardian(
     expectedName: string,
     expectedSsn: string,
@@ -178,16 +207,6 @@ export default class ApplicationEditView {
     await this.#guardianSsn.findText(expectedSsn).waitUntilVisible()
     await this.#guardianAddress.findText(expectedAddress).waitUntilVisible()
   }
-
-  #secondGuardianToggle = new Checkbox(
-    this.page.findByDataQa('application-second-guardian-toggle')
-  )
-  #secondGuardianPhone = new TextInput(
-    this.page.findByDataQa('application-second-guardian-phone')
-  )
-  #secondGuardianEmail = new TextInput(
-    this.page.findByDataQa('application-second-guardian-email')
-  )
 
   #guardianAgreementStatus = (status: OtherGuardianAgreementStatus) =>
     new Radio(

--- a/frontend/src/e2e-test/pages/employee/applications/application-list-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-list-view.ts
@@ -6,20 +6,26 @@ import { ApplicationTypeToggle } from 'lib-common/generated/api-types/applicatio
 
 import config from '../../../config'
 import { waitUntilEqual } from '../../../utils'
-import { MultiSelect, Page } from '../../../utils/page'
+import { MultiSelect, Page, Element } from '../../../utils/page'
 
 export default class ApplicationListView {
-  constructor(private page: Page) {}
+  applicationStatus: Element
+  allApplications: Element
+  #areaFilter: MultiSelect
+  #unitFilter: MultiSelect
+  constructor(private page: Page) {
+    this.applicationStatus = page.findByDataQa('application-status')
+    this.allApplications = page.findByDataQa('application-status-filter-ALL')
+    this.#areaFilter = new MultiSelect(page.findByDataQa('area-filter'))
+    this.#unitFilter = new MultiSelect(page.findByDataQa('unit-selector'))
+  }
 
   static url = `${config.employeeUrl}/applications`
-  applicationStatus = this.page.findByDataQa('application-status')
 
   actionsMenu = (applicationId: string) =>
     this.page
       .find(`[data-application-id="${applicationId}"]`)
       .find('[data-qa="application-actions-menu"]')
-
-  allApplications = this.page.findByDataQa('application-status-filter-ALL')
 
   #actionsMenuItemSelector = (id: string) =>
     this.page.findByDataQa(`action-item-${id}`)
@@ -34,8 +40,6 @@ export default class ApplicationListView {
     )
   }
 
-  #areaFilter = new MultiSelect(this.page.findByDataQa('area-filter'))
-
   async toggleArea(areaName: string) {
     await this.#areaFilter.fillAndSelectFirst(areaName)
   }
@@ -43,8 +47,6 @@ export default class ApplicationListView {
   specialFilterItems = {
     duplicate: this.page.findByDataQa('application-basis-DUPLICATE_APPLICATION')
   }
-
-  #unitFilter = new MultiSelect(this.page.findByDataQa('unit-selector'))
 
   toggleUnit = async (unitName: string) => {
     await this.#unitFilter.fillAndSelectFirst(unitName)

--- a/frontend/src/e2e-test/pages/employee/applications/application-list-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-list-view.ts
@@ -12,17 +12,17 @@ export default class ApplicationListView {
   constructor(private page: Page) {}
 
   static url = `${config.employeeUrl}/applications`
-  applicationStatus = this.page.find('[data-qa="application-status"]')
+  applicationStatus = this.page.findByDataQa('application-status')
 
   actionsMenu = (applicationId: string) =>
     this.page
       .find(`[data-application-id="${applicationId}"]`)
       .find('[data-qa="application-actions-menu"]')
 
-  allApplications = this.page.find('[data-qa="application-status-filter-ALL"]')
+  allApplications = this.page.findByDataQa('application-status-filter-ALL')
 
   #actionsMenuItemSelector = (id: string) =>
-    this.page.find(`[data-qa="action-item-${id}"]`)
+    this.page.findByDataQa(`action-item-${id}`)
 
   actionsMenuItems = {
     verify: this.#actionsMenuItemSelector('verify'),
@@ -34,7 +34,7 @@ export default class ApplicationListView {
     )
   }
 
-  #areaFilter = new MultiSelect(this.page.find('[data-qa="area-filter"]'))
+  #areaFilter = new MultiSelect(this.page.findByDataQa('area-filter'))
 
   async toggleArea(areaName: string) {
     await this.#areaFilter.fillAndSelectFirst(areaName)
@@ -44,7 +44,7 @@ export default class ApplicationListView {
     duplicate: this.page.findByDataQa('application-basis-DUPLICATE_APPLICATION')
   }
 
-  #unitFilter = new MultiSelect(this.page.find('[data-qa="unit-selector"]'))
+  #unitFilter = new MultiSelect(this.page.findByDataQa('unit-selector'))
 
   toggleUnit = async (unitName: string) => {
     await this.#unitFilter.fillAndSelectFirst(unitName)
@@ -65,13 +65,13 @@ export default class ApplicationListView {
   }
 
   voucherUnitFilter = {
-    firstChoice: this.page.find('[data-qa="filter-voucher-first-choice"]'),
-    voucherOnly: this.page.find('[data-qa="filter-voucher-all"]'),
-    voucherHide: this.page.find('[data-qa="filter-voucher-hide"]'),
-    noFilter: this.page.find('[data-qa="filter-voucher-no-filter"]')
+    firstChoice: this.page.findByDataQa('filter-voucher-first-choice'),
+    voucherOnly: this.page.findByDataQa('filter-voucher-all'),
+    voucherHide: this.page.findByDataQa('filter-voucher-hide'),
+    noFilter: this.page.findByDataQa('filter-voucher-no-filter')
   }
 
   async filterByApplicationType(type: ApplicationTypeToggle) {
-    await this.page.find(`[data-qa="application-type-filter-${type}"]`).click()
+    await this.page.findByDataQa(`application-type-filter-${type}`).click()
   }
 }

--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -8,7 +8,13 @@ import { UUID } from 'lib-common/types'
 
 import config from '../../../config'
 import { waitUntilTrue } from '../../../utils'
-import { DatePickerDeprecated, Page, Radio, Element } from '../../../utils/page'
+import {
+  DatePickerDeprecated,
+  Page,
+  Radio,
+  Element,
+  ElementCollection
+} from '../../../utils/page'
 import MessagesPage from '../messages/messages-page'
 
 import ApplicationEditView from './application-edit-view'
@@ -23,6 +29,8 @@ export default class ApplicationReadView {
   #applicationStatus: Element
   #sendMessageButton: Element
   notesList: Element
+  #title: Element
+  private notes: ElementCollection
   constructor(private page: Page) {
     this.#editButton = page.findByDataQa('edit-application')
     this.#vtjGuardianName = page.findByDataQa('vtj-guardian-name')
@@ -33,10 +41,9 @@ export default class ApplicationReadView {
     this.#applicationStatus = page.findByDataQa('application-status')
     this.#sendMessageButton = page.findByDataQa('send-message-button')
     this.notesList = page.findByDataQa('application-notes-list')
+    this.#title = this.page.findByDataQa('application-title').find('h1')
+    this.notes = this.notesList.findAllByDataQa('note-container')
   }
-
-  #title = this.page.findByDataQa('application-title').find('h1')
-  notes = this.notesList.findAllByDataQa('note-container')
 
   async waitUntilLoaded() {
     await this.page.findByDataQa('application-read-view').waitUntilVisible()

--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -16,20 +16,20 @@ import ApplicationEditView from './application-edit-view'
 export default class ApplicationReadView {
   constructor(private page: Page) {}
 
-  #title = this.page.find('[data-qa="application-title"]').find('h1')
-  #editButton = this.page.find('[data-qa="edit-application"]')
-  #vtjGuardianName = this.page.find('[data-qa="vtj-guardian-name"]')
-  #vtjGuardianPhone = this.page.find('[data-qa="vtj-guardian-phone"]')
-  #vtjGuardianEmail = this.page.find('[data-qa="vtj-guardian-email"]')
-  #givenOtherGuardianPhone = this.page.find('[data-qa="second-guardian-phone"]')
-  #giveOtherGuardianEmail = this.page.find('[data-qa="second-guardian-email"]')
-  #applicationStatus = this.page.find('[data-qa="application-status"]')
+  #title = this.page.findByDataQa('application-title').find('h1')
+  #editButton = this.page.findByDataQa('edit-application')
+  #vtjGuardianName = this.page.findByDataQa('vtj-guardian-name')
+  #vtjGuardianPhone = this.page.findByDataQa('vtj-guardian-phone')
+  #vtjGuardianEmail = this.page.findByDataQa('vtj-guardian-email')
+  #givenOtherGuardianPhone = this.page.findByDataQa('second-guardian-phone')
+  #giveOtherGuardianEmail = this.page.findByDataQa('second-guardian-email')
+  #applicationStatus = this.page.findByDataQa('application-status')
   #sendMessageButton = this.page.findByDataQa('send-message-button')
   notesList = this.page.findByDataQa('application-notes-list')
   notes = this.notesList.findAllByDataQa('note-container')
 
   async waitUntilLoaded() {
-    await this.page.find('[data-qa="application-read-view"]').waitUntilVisible()
+    await this.page.findByDataQa('application-read-view').waitUntilVisible()
     await this.page
       .find('[data-qa="vtj-guardian-section"][data-isloading="false"]')
       .waitUntilVisible()
@@ -89,7 +89,7 @@ export default class ApplicationReadView {
   }
 
   async acceptDecision(type: DecisionType) {
-    const decision = this.page.find(`[data-qa="application-decision-${type}"]`)
+    const decision = this.page.findByDataQa(`application-decision-${type}`)
 
     const acceptRadio = new Radio(
       decision.find('[data-qa="decision-radio-accept"]')
@@ -120,9 +120,7 @@ export default class ApplicationReadView {
     fileName: string,
     byPaper = true
   ) {
-    const attachment = this.page.find(
-      `[data-qa="urgent-attachment-${fileName}"]`
-    )
+    const attachment = this.page.findByDataQa(`urgent-attachment-${fileName}`)
     await attachment.waitUntilVisible()
 
     const text = attachment.find(`[data-qa="attachment-received-at"]`)
@@ -154,7 +152,7 @@ export default class ApplicationReadView {
   }
 
   async assertApplicantIsDead() {
-    await this.page.find('[data-qa="applicant-dead"]').waitUntilVisible()
+    await this.page.findByDataQa('applicant-dead').waitUntilVisible()
   }
 
   async assertDueDate(dueDate: LocalDate) {

--- a/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
+++ b/frontend/src/e2e-test/pages/employee/applications/application-read-view.ts
@@ -8,24 +8,34 @@ import { UUID } from 'lib-common/types'
 
 import config from '../../../config'
 import { waitUntilTrue } from '../../../utils'
-import { DatePickerDeprecated, Page, Radio } from '../../../utils/page'
+import { DatePickerDeprecated, Page, Radio, Element } from '../../../utils/page'
 import MessagesPage from '../messages/messages-page'
 
 import ApplicationEditView from './application-edit-view'
 
 export default class ApplicationReadView {
-  constructor(private page: Page) {}
+  #editButton: Element
+  #vtjGuardianName: Element
+  #vtjGuardianPhone: Element
+  #vtjGuardianEmail: Element
+  #givenOtherGuardianPhone: Element
+  #giveOtherGuardianEmail: Element
+  #applicationStatus: Element
+  #sendMessageButton: Element
+  notesList: Element
+  constructor(private page: Page) {
+    this.#editButton = page.findByDataQa('edit-application')
+    this.#vtjGuardianName = page.findByDataQa('vtj-guardian-name')
+    this.#vtjGuardianPhone = page.findByDataQa('vtj-guardian-phone')
+    this.#vtjGuardianEmail = page.findByDataQa('vtj-guardian-email')
+    this.#givenOtherGuardianPhone = page.findByDataQa('second-guardian-phone')
+    this.#giveOtherGuardianEmail = page.findByDataQa('second-guardian-email')
+    this.#applicationStatus = page.findByDataQa('application-status')
+    this.#sendMessageButton = page.findByDataQa('send-message-button')
+    this.notesList = page.findByDataQa('application-notes-list')
+  }
 
   #title = this.page.findByDataQa('application-title').find('h1')
-  #editButton = this.page.findByDataQa('edit-application')
-  #vtjGuardianName = this.page.findByDataQa('vtj-guardian-name')
-  #vtjGuardianPhone = this.page.findByDataQa('vtj-guardian-phone')
-  #vtjGuardianEmail = this.page.findByDataQa('vtj-guardian-email')
-  #givenOtherGuardianPhone = this.page.findByDataQa('second-guardian-phone')
-  #giveOtherGuardianEmail = this.page.findByDataQa('second-guardian-email')
-  #applicationStatus = this.page.findByDataQa('application-status')
-  #sendMessageButton = this.page.findByDataQa('send-message-button')
-  notesList = this.page.findByDataQa('application-notes-list')
   notes = this.notesList.findAllByDataQa('note-container')
 
   async waitUntilLoaded() {

--- a/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-edit-page.ts
+++ b/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-edit-page.ts
@@ -3,21 +3,21 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { waitUntilEqual } from '../../../utils'
-import { Page, TextInput, Combobox } from '../../../utils/page'
+import { Page, TextInput, Combobox, Element } from '../../../utils/page'
 
 export default class AssistanceNeedDecisionEditPage {
-  constructor(private readonly page: Page) {}
-
-  readonly #decisionMakerSelect = this.page.findByDataQa(
-    'decision-maker-select'
-  )
-
-  pedagogicalMotivationInput = new TextInput(
-    this.page.findByDataQa('pedagogical-motivation-field')
-  )
-  guardiansHeardOnInput = new TextInput(
-    this.page.findByDataQa('guardians-heard-on')
-  )
+  #decisionMakerSelect: Element
+  pedagogicalMotivationInput: TextInput
+  guardiansHeardOnInput: TextInput
+  constructor(private readonly page: Page) {
+    this.#decisionMakerSelect = page.findByDataQa('decision-maker-select')
+    this.pedagogicalMotivationInput = new TextInput(
+      page.findByDataQa('pedagogical-motivation-field')
+    )
+    this.guardiansHeardOnInput = new TextInput(
+      page.findByDataQa('guardians-heard-on')
+    )
+  }
 
   async assertDeciderSelectVisible() {
     await this.#decisionMakerSelect.waitUntilVisible()

--- a/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-preview-page.ts
+++ b/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-decision-preview-page.ts
@@ -2,10 +2,15 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from '../../../utils/page'
+import { Page, Element } from '../../../utils/page'
 
 export default class AssistanceNeedDecisionPreviewPage {
-  constructor(private readonly page: Page) {}
+  sendDecisionButton: Element
+  revertToUnsent: Element
+  constructor(private readonly page: Page) {
+    this.sendDecisionButton = page.findByDataQa('send-decision')
+    this.revertToUnsent = page.findByDataQa('revert-to-unsent')
+  }
 
   private getLabelledValue(label: string) {
     return this.page.findByDataQa(`labelled-value-${label}`).text
@@ -79,8 +84,6 @@ export default class AssistanceNeedDecisionPreviewPage {
     return this.getLabelledValue('decision-maker')
   }
 
-  readonly sendDecisionButton = this.page.findByDataQa('send-decision')
-  readonly revertToUnsent = this.page.findByDataQa('revert-to-unsent')
   get decisionSentAt() {
     return this.page.findByDataQa('decision-sent-at')
   }

--- a/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-preschool-decision-page.ts
+++ b/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-preschool-decision-page.ts
@@ -2,49 +2,68 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Checkbox, Combobox, Page, TextInput } from '../../../utils/page'
+import {
+  Checkbox,
+  Combobox,
+  Page,
+  TextInput,
+  Element
+} from '../../../utils/page'
 
 export default class AssistanceNeedPreschoolDecisionPage {
-  constructor(private readonly page: Page) {}
+  autoSaveIndicator: Element
+  status: Element
+  decisionNumber: Element
+  typeRadioNew: Element
+  validFromInput: TextInput
+  unitSelect: Combobox
+  primaryGroupInput: TextInput
+  decisionBasisInput: TextInput
+  basisPedagogicalReportCheckbox: Checkbox
+  guardiansHeardInput: TextInput
+  viewOfGuardiansInput: TextInput
+  decisionMakerSelect: Combobox
+  decisionMakerTitleInput: TextInput
+  preparer1Select: Combobox
+  preparer1TitleInput: TextInput
+  previewButton: Element
+  editButton: Element
+  sendDecisionButton: Element
+  constructor(private readonly page: Page) {
+    this.autoSaveIndicator = page.findByDataQa('autosave-indicator')
+    this.status = page.findByDataQa('status')
+    this.decisionNumber = page.findByDataQa('decision-number')
+    this.typeRadioNew = page.findByDataQa('type-radio-NEW')
+    this.validFromInput = new TextInput(page.findByDataQa('valid-from'))
+    this.unitSelect = new Combobox(page.findByDataQa('unit-select'))
+    this.primaryGroupInput = new TextInput(page.findByDataQa('primary-group'))
+    this.decisionBasisInput = new TextInput(page.findByDataQa('decision-basis'))
+    this.basisPedagogicalReportCheckbox = new Checkbox(
+      page.findByDataQa('basis-pedagogical-report')
+    )
+    this.guardiansHeardInput = new TextInput(
+      page.findByDataQa('guardians-heard')
+    )
+    this.viewOfGuardiansInput = new TextInput(
+      page.findByDataQa('view-of-guardians')
+    )
+    this.decisionMakerSelect = new Combobox(
+      page.findByDataQa('decision-maker-select')
+    )
+    this.decisionMakerTitleInput = new TextInput(
+      page.findByDataQa('decision-maker-title')
+    )
+    this.preparer1Select = new Combobox(page.findByDataQa('preparer-1-select'))
+    this.preparer1TitleInput = new TextInput(
+      page.findByDataQa('preparer-1-title')
+    )
+    this.previewButton = page.findByDataQa('preview-button')
+    this.editButton = page.findByDataQa('edit-button')
+    this.sendDecisionButton = page.findByDataQa('send-decision')
+  }
 
-  readonly autoSaveIndicator = this.page.findByDataQa('autosave-indicator')
-  readonly status = this.page.findByDataQa('status')
-  readonly decisionNumber = this.page.findByDataQa('decision-number')
-  readonly typeRadioNew = this.page.findByDataQa('type-radio-NEW')
-  readonly validFromInput = new TextInput(this.page.findByDataQa('valid-from'))
-  readonly unitSelect = new Combobox(this.page.findByDataQa('unit-select'))
-  readonly primaryGroupInput = new TextInput(
-    this.page.findByDataQa('primary-group')
-  )
-  readonly decisionBasisInput = new TextInput(
-    this.page.findByDataQa('decision-basis')
-  )
-  readonly basisPedagogicalReportCheckbox = new Checkbox(
-    this.page.findByDataQa('basis-pedagogical-report')
-  )
-  readonly guardiansHeardInput = new TextInput(
-    this.page.findByDataQa('guardians-heard')
-  )
   readonly guardianHeardCheckbox = (n: number) =>
     new Checkbox(this.page.findAllByDataQa('guardian-heard').nth(n))
   readonly guardianDetailsInput = (n: number) =>
     new TextInput(this.page.findAllByDataQa('guardian-details').nth(n))
-  readonly viewOfGuardiansInput = new TextInput(
-    this.page.findByDataQa('view-of-guardians')
-  )
-  readonly decisionMakerSelect = new Combobox(
-    this.page.findByDataQa('decision-maker-select')
-  )
-  readonly decisionMakerTitleInput = new TextInput(
-    this.page.findByDataQa('decision-maker-title')
-  )
-  readonly preparer1Select = new Combobox(
-    this.page.findByDataQa('preparer-1-select')
-  )
-  readonly preparer1TitleInput = new TextInput(
-    this.page.findByDataQa('preparer-1-title')
-  )
-  readonly previewButton = this.page.findByDataQa('preview-button')
-  readonly editButton = this.page.findByDataQa('edit-button')
-  readonly sendDecisionButton = this.page.findByDataQa('send-decision')
 }

--- a/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-preschool-decision-preview-page.ts
+++ b/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-preschool-decision-preview-page.ts
@@ -11,7 +11,7 @@ export default class AssistanceNeedPreschoolDecisionPreviewPage {
   preparedBy1: Element
   decisionMaker: Element
   sendDecisionButton: Element
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.guardiansHeardOn = page.findByDataQa(`guardians-heard-on`)
     this.validFrom = page.findByDataQa('valid-from')
     this.selectedUnit = page.findByDataQa('unit')

--- a/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-preschool-decision-preview-page.ts
+++ b/frontend/src/e2e-test/pages/employee/assistance-need-decision/assistance-need-preschool-decision-preview-page.ts
@@ -2,15 +2,21 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from '../../../utils/page'
+import { Page, Element } from '../../../utils/page'
 
 export default class AssistanceNeedPreschoolDecisionPreviewPage {
-  constructor(private readonly page: Page) {}
-  guardiansHeardOn = this.page.findByDataQa(`guardians-heard-on`)
-  validFrom = this.page.findByDataQa('valid-from')
-  selectedUnit = this.page.findByDataQa('unit')
-  preparedBy1 = this.page.findByDataQa('preparer-1')
-  decisionMaker = this.page.findByDataQa('decision-maker')
-
-  readonly sendDecisionButton = this.page.findByDataQa('send-decision')
+  guardiansHeardOn: Element
+  validFrom: Element
+  selectedUnit: Element
+  preparedBy1: Element
+  decisionMaker: Element
+  sendDecisionButton: Element
+  constructor(private readonly page: Page) {
+    this.guardiansHeardOn = page.findByDataQa(`guardians-heard-on`)
+    this.validFrom = page.findByDataQa('valid-from')
+    this.selectedUnit = page.findByDataQa('unit')
+    this.preparedBy1 = page.findByDataQa('preparer-1')
+    this.decisionMaker = page.findByDataQa('decision-maker')
+    this.sendDecisionButton = page.findByDataQa('send-decision')
+  }
 }

--- a/frontend/src/e2e-test/pages/employee/child-information.ts
+++ b/frontend/src/e2e-test/pages/employee/child-information.ts
@@ -35,17 +35,15 @@ import { VasuPage } from './vasu/vasu'
 export default class ChildInformationPage {
   constructor(private readonly page: Page) {}
 
-  readonly #deceased = this.page.find('[data-qa="deceased-label"]')
+  readonly #deceased = this.page.findByDataQa('deceased-label')
   readonly #ophPersonOidInput = new TextInput(
-    this.page.find('[data-qa="person-oph-person-oid"]')
+    this.page.findByDataQa('person-oph-person-oid')
   )
 
-  readonly #editButton = this.page.find(
-    '[data-qa="edit-person-settings-button"]'
-  )
+  readonly #editButton = this.page.findByDataQa('edit-person-settings-button')
 
-  readonly confirmButton = this.page.find(
-    '[data-qa="confirm-edited-person-button"]'
+  readonly confirmButton = this.page.findByDataQa(
+    'confirm-edited-person-button'
   )
 
   async navigateToChild(id: UUID) {
@@ -115,7 +113,7 @@ export default class ChildInformationPage {
   additionalInformationSection() {
     return new AdditionalInformationSection(
       this.page,
-      this.page.find('[data-qa="additional-information-section"]')
+      this.page.findByDataQa('additional-information-section')
     )
   }
 }
@@ -374,7 +372,7 @@ export class PedagogicalDocumentsSection extends Section {
     testfileName: string,
     testfilePath: string
   ) {
-    await new FileInput(page.find('[data-qa="btn-upload-file"]')).setInputFiles(
+    await new FileInput(page.findByDataQa('btn-upload-file')).setInputFiles(
       testfilePath
     )
     await waitUntilTrue(async () =>
@@ -861,7 +859,7 @@ export class PlacementsSection extends Section {
   }) {
     await this.find('[data-qa="create-new-placement-button"]').click()
 
-    const modal = new Modal(this.page.find('[data-qa="modal"]'))
+    const modal = new Modal(this.page.findByDataQa('modal'))
     const unitSelect = new Combobox(modal.find('[data-qa="unit-select"]'))
     await unitSelect.fillAndSelectFirst(unitName)
 

--- a/frontend/src/e2e-test/pages/employee/child-information.ts
+++ b/frontend/src/e2e-test/pages/employee/child-information.ts
@@ -33,18 +33,18 @@ import { IncomeSection } from './guardian-information'
 import { VasuPage } from './vasu/vasu'
 
 export default class ChildInformationPage {
-  constructor(private readonly page: Page) {}
-
-  readonly #deceased = this.page.findByDataQa('deceased-label')
-  readonly #ophPersonOidInput = new TextInput(
-    this.page.findByDataQa('person-oph-person-oid')
-  )
-
-  readonly #editButton = this.page.findByDataQa('edit-person-settings-button')
-
-  readonly confirmButton = this.page.findByDataQa(
-    'confirm-edited-person-button'
-  )
+  #deceased: Element
+  #ophPersonOidInput: TextInput
+  #editButton: Element
+  confirmButton: Element
+  constructor(private readonly page: Page) {
+    this.#deceased = page.findByDataQa('deceased-label')
+    this.#ophPersonOidInput = new TextInput(
+      page.findByDataQa('person-oph-person-oid')
+    )
+    this.#editButton = page.findByDataQa('edit-person-settings-button')
+    this.confirmButton = page.findByDataQa('confirm-edited-person-button')
+  }
 
   async navigateToChild(id: UUID) {
     await this.page.goto(config.employeeUrl + '/child-information/' + id)
@@ -128,26 +128,32 @@ class Section extends Element {
 }
 
 export class AdditionalInformationSection extends Section {
+  languageAtHome: Element
+  languageAtHomeCombobox: Combobox
+  languageAtHomeDetails: Element
+  languageAtHomeDetailsInput: TextInput
+  specialDietCombobox: Combobox
+
+  constructor(page: Page, root: Element) {
+    super(page, root)
+    this.languageAtHome = page.findByDataQa('person-language-at-home')
+    this.languageAtHomeCombobox = new Combobox(
+      page.findByDataQa('input-language-at-home')
+    )
+    this.languageAtHomeDetails = page.findByDataQa(
+      'person-language-at-home-details'
+    )
+    this.languageAtHomeDetailsInput = new TextInput(
+      page.findByDataQa('input-language-at-home-details')
+    )
+    this.specialDietCombobox = new Combobox(page.findByDataQa('diet-input'))
+  }
+
   medication = this.find('[data-qa="medication"]')
   editBtn = this.find('[data-qa="edit-child-settings-button"]')
   medicationInput = new TextInput(this.find('[data-qa="medication-input"]'))
   confirmBtn = this.find('[data-qa="confirm-edited-child-button"]')
 
-  readonly languageAtHome = this.page.findByDataQa('person-language-at-home')
-  readonly languageAtHomeCombobox = new Combobox(
-    this.page.findByDataQa('input-language-at-home')
-  )
-
-  readonly languageAtHomeDetails = this.page.findByDataQa(
-    'person-language-at-home-details'
-  )
-  readonly languageAtHomeDetailsInput = new TextInput(
-    this.page.findByDataQa('input-language-at-home-details')
-  )
-
-  readonly specialDietCombobox = new Combobox(
-    this.page.findByDataQa('diet-input')
-  )
   readonly specialDiet = this.page.findByDataQa('diet-value-display')
 }
 
@@ -384,6 +390,19 @@ export class PedagogicalDocumentsSection extends Section {
 }
 
 export class ChildDocumentsSection extends Section {
+  createDocumentButton: Element
+  createModalTemplateSelect: Select
+  modalOk: Element
+
+  constructor(page: Page, root: Element) {
+    super(page, root)
+    this.createDocumentButton = page.findByDataQa('create-document')
+    this.createModalTemplateSelect = new Select(
+      page.findByDataQa('template-select')
+    )
+    this.modalOk = page.findByDataQa('modal-okBtn')
+  }
+
   readonly #addNewVasu = this.find('[data-qa="add-new-vasu-button"]')
 
   async addNewVasu() {
@@ -407,12 +426,6 @@ export class ChildDocumentsSection extends Section {
     await this.page.findByDataQa(`curriculum-document-${id}`).click()
     return new VasuPage(this.page)
   }
-
-  readonly createDocumentButton = this.page.findByDataQa('create-document')
-  readonly createModalTemplateSelect = new Select(
-    this.page.findByDataQa('template-select')
-  )
-  readonly modalOk = this.page.findByDataQa('modal-okBtn')
 
   async assertChildDocuments(expectedRows: { id: UUID }[]) {
     const rows = this.page
@@ -894,6 +907,23 @@ export class PlacementsSection extends Section {
 }
 
 export class AssistanceSection extends Section {
+  createAssistanceNeedVoucherCoefficientBtn: Element
+  createAssistanceNeedVoucherCoefficientForm: Element
+  editAssistanceNeedVoucherCoefficientForm: Element
+
+  constructor(page: Page, root: Element) {
+    super(page, root)
+    this.createAssistanceNeedVoucherCoefficientBtn = page.findByDataQa(
+      'assistance-need-voucher-coefficient-create-btn'
+    )
+    this.createAssistanceNeedVoucherCoefficientForm = page.findByDataQa(
+      'create-new-assistance-need-voucher-coefficient'
+    )
+    this.editAssistanceNeedVoucherCoefficientForm = page.findByDataQa(
+      'table-assistance-need-voucher-coefficient-editor'
+    )
+  }
+
   createAssistanceFactorButton = this.findByDataQa(
     'assistance-factor-create-btn'
   )
@@ -1050,16 +1080,6 @@ export class AssistanceSection extends Section {
     }
   }
 
-  readonly createAssistanceNeedVoucherCoefficientBtn = this.page.findByDataQa(
-    'assistance-need-voucher-coefficient-create-btn'
-  )
-  readonly createAssistanceNeedVoucherCoefficientForm = this.page.findByDataQa(
-    'create-new-assistance-need-voucher-coefficient'
-  )
-  readonly editAssistanceNeedVoucherCoefficientForm = this.page.findByDataQa(
-    'table-assistance-need-voucher-coefficient-editor'
-  )
-
   readonly modalOkBtn = this.page.findByDataQa('modal-okBtn')
 }
 
@@ -1137,21 +1157,22 @@ class MessageBlocklistSection extends Section {
 }
 
 class FeeAlterationEditorPage {
-  constructor(private readonly page: Page) {}
-
-  readonly startDateInput = new DatePickerDeprecated(
-    this.page.findByDataQa('date-range-input-start-date')
-  )
-  readonly endDateInput = new DatePickerDeprecated(
-    this.page.findByDataQa('date-range-input-end-date')
-  )
-
-  readonly alterationValueInput = new TextInput(
-    this.page.findByDataQa('fee-alteration-amount-input')
-  )
-  readonly saveButton = this.page.findByDataQa(
-    'fee-alteration-editor-save-button'
-  )
+  startDateInput: DatePickerDeprecated
+  endDateInput: DatePickerDeprecated
+  alterationValueInput: TextInput
+  saveButton: Element
+  constructor(private readonly page: Page) {
+    this.startDateInput = new DatePickerDeprecated(
+      page.findByDataQa('date-range-input-start-date')
+    )
+    this.endDateInput = new DatePickerDeprecated(
+      page.findByDataQa('date-range-input-end-date')
+    )
+    this.alterationValueInput = new TextInput(
+      page.findByDataQa('fee-alteration-amount-input')
+    )
+    this.saveButton = page.findByDataQa('fee-alteration-editor-save-button')
+  }
 
   async uploadedCount() {
     return this.page.findAllByDataQa('file-download-button').count()

--- a/frontend/src/e2e-test/pages/employee/documents/child-document.ts
+++ b/frontend/src/e2e-test/pages/employee/documents/child-document.ts
@@ -2,16 +2,21 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page, TextInput } from '../../../utils/page'
+import { Page, TextInput, Element } from '../../../utils/page'
 
 export class ChildDocumentPage {
-  constructor(private readonly page: Page) {}
-
-  readonly status = this.page.findByDataQa('document-state-chip')
-  readonly savingIndicator = this.page.findByDataQa('saving-spinner')
-  readonly previewButton = this.page.findByDataQa('preview-button')
-  readonly editButton = this.page.findByDataQa('edit-button')
-  readonly returnButton = this.page.findByDataQa('return-button')
+  status: Element
+  savingIndicator: Element
+  previewButton: Element
+  editButton: Element
+  returnButton: Element
+  constructor(private readonly page: Page) {
+    this.status = page.findByDataQa('document-state-chip')
+    this.savingIndicator = page.findByDataQa('saving-spinner')
+    this.previewButton = page.findByDataQa('preview-button')
+    this.editButton = page.findByDataQa('edit-button')
+    this.returnButton = page.findByDataQa('return-button')
+  }
 
   getTextQuestion(sectionName: string, questionName: string) {
     const section = this.page.find('[data-qa="document-section"]', {

--- a/frontend/src/e2e-test/pages/employee/documents/document-templates.ts
+++ b/frontend/src/e2e-test/pages/employee/documents/document-templates.ts
@@ -14,10 +14,13 @@ import {
 } from '../../../utils/page'
 
 export class DocumentTemplatesListPage {
-  constructor(private readonly page: Page) {}
+  createNewButton: Element
+  importTemplate: Element
+  constructor(private readonly page: Page) {
+    this.createNewButton = page.findByDataQa('create-template-button')
+    this.importTemplate = page.findByDataQa('import-template')
+  }
 
-  readonly createNewButton = this.page.findByDataQa('create-template-button')
-  readonly importTemplate = this.page.findByDataQa('import-template')
   readonly templateImportModal = new TemplateImportModal(
     this.page.findByDataQa('template-import-modal').locator
   )
@@ -95,31 +98,32 @@ export class TemplateImportModal extends Element {
 }
 
 export class DocumentTemplateEditorPage {
-  constructor(private readonly page: Page) {}
-
-  readonly createNewSectionButton = this.page.findByDataQa(
-    'create-section-button'
-  )
-  readonly sectionNameInput = new TextInput(
-    this.page.findByDataQa('name-input')
-  )
-  readonly confirmCreateSectionButton = this.page.findByDataQa('modal-okBtn')
+  createNewSectionButton: Element
+  sectionNameInput: TextInput
+  confirmCreateSectionButton: Element
+  questionLabelInput: TextInput
+  confirmCreateQuestionButton: Element
+  publishCheckbox: Checkbox
+  saveButton: Element
+  constructor(private readonly page: Page) {
+    this.createNewSectionButton = page.findByDataQa('create-section-button')
+    this.sectionNameInput = new TextInput(page.findByDataQa('name-input'))
+    this.confirmCreateSectionButton = page.findByDataQa('modal-okBtn')
+    this.questionLabelInput = new TextInput(
+      page.findByDataQa('question-label-input')
+    )
+    this.confirmCreateQuestionButton = page.findByDataQa('modal-okBtn')
+    this.publishCheckbox = new Checkbox(
+      page.findByDataQa('ready-to-publish-checkbox')
+    )
+    this.saveButton = page.findByDataQa('save-template')
+  }
 
   getSection(name: string) {
     return new Section(
       this.page.find('[data-qa="template-section"]', { hasText: name })
     )
   }
-
-  readonly questionLabelInput = new TextInput(
-    this.page.findByDataQa('question-label-input')
-  )
-  readonly confirmCreateQuestionButton = this.page.findByDataQa('modal-okBtn')
-
-  readonly publishCheckbox = new Checkbox(
-    this.page.findByDataQa('ready-to-publish-checkbox')
-  )
-  readonly saveButton = this.page.findByDataQa('save-template')
 }
 
 class Section {

--- a/frontend/src/e2e-test/pages/employee/employee-nav.ts
+++ b/frontend/src/e2e-test/pages/employee/employee-nav.ts
@@ -3,19 +3,25 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { waitUntilEqual } from '../../utils'
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export default class EmployeeNav {
-  constructor(private readonly page: Page) {}
-
-  readonly #userNameBtn = this.page.findByDataQa('username')
-
-  readonly applicationsTab = this.page.findByDataQa('applications-nav')
-  readonly unitsTab = this.page.findByDataQa('units-nav')
-  readonly searchTab = this.page.findByDataQa('search-nav')
-  readonly financeTab = this.page.findByDataQa('finance-nav')
-  readonly reportsTab = this.page.findByDataQa('reports-nav')
-  readonly messagesTab = this.page.findByDataQa('messages-nav')
+  #userNameBtn: Element
+  applicationsTab: Element
+  unitsTab: Element
+  searchTab: Element
+  financeTab: Element
+  reportsTab: Element
+  messagesTab: Element
+  constructor(private readonly page: Page) {
+    this.#userNameBtn = page.findByDataQa('username')
+    this.applicationsTab = page.findByDataQa('applications-nav')
+    this.unitsTab = page.findByDataQa('units-nav')
+    this.searchTab = page.findByDataQa('search-nav')
+    this.financeTab = page.findByDataQa('finance-nav')
+    this.reportsTab = page.findByDataQa('reports-nav')
+    this.messagesTab = page.findByDataQa('messages-nav')
+  }
 
   async openAndClickDropdownMenuItem(
     item:

--- a/frontend/src/e2e-test/pages/employee/employee-pin.ts
+++ b/frontend/src/e2e-test/pages/employee/employee-pin.ts
@@ -1,14 +1,17 @@
 // SPDX-FileCopyrightText: 2017-2022 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
-import { Page, TextInput } from '../../utils/page'
+import { Page, TextInput, Element } from '../../utils/page'
 
 export class EmployeePinPage {
-  constructor(private readonly page: Page) {}
-
-  readonly pinInput = new TextInput(this.page.findByDataQa('pin-code-input'))
-  readonly inputInfo = this.page.findByDataQa('pin-code-input-info')
-  readonly pinLockedAlertBox = this.page.findByDataQa('pin-locked-alert-box')
-
-  readonly pinSendButton = this.page.findByDataQa('send-pin-button')
+  pinInput: TextInput
+  inputInfo: Element
+  pinLockedAlertBox: Element
+  pinSendButton: Element
+  constructor(private readonly page: Page) {
+    this.pinInput = new TextInput(page.findByDataQa('pin-code-input'))
+    this.inputInfo = page.findByDataQa('pin-code-input-info')
+    this.pinLockedAlertBox = page.findByDataQa('pin-locked-alert-box')
+    this.pinSendButton = page.findByDataQa('send-pin-button')
+  }
 }

--- a/frontend/src/e2e-test/pages/employee/employee-pin.ts
+++ b/frontend/src/e2e-test/pages/employee/employee-pin.ts
@@ -6,13 +6,9 @@ import { Page, TextInput } from '../../utils/page'
 export class EmployeePinPage {
   constructor(private readonly page: Page) {}
 
-  readonly pinInput = new TextInput(
-    this.page.find('[data-qa="pin-code-input"]')
-  )
-  readonly inputInfo = this.page.find('[data-qa="pin-code-input-info"]')
-  readonly pinLockedAlertBox = this.page.find(
-    '[data-qa="pin-locked-alert-box"]'
-  )
+  readonly pinInput = new TextInput(this.page.findByDataQa('pin-code-input'))
+  readonly inputInfo = this.page.findByDataQa('pin-code-input-info')
+  readonly pinLockedAlertBox = this.page.findByDataQa('pin-locked-alert-box')
 
-  readonly pinSendButton = this.page.find('[data-qa="send-pin-button"]')
+  readonly pinSendButton = this.page.findByDataQa('send-pin-button')
 }

--- a/frontend/src/e2e-test/pages/employee/employee-pin.ts
+++ b/frontend/src/e2e-test/pages/employee/employee-pin.ts
@@ -8,7 +8,7 @@ export class EmployeePinPage {
   inputInfo: Element
   pinLockedAlertBox: Element
   pinSendButton: Element
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.pinInput = new TextInput(page.findByDataQa('pin-code-input'))
     this.inputInfo = page.findByDataQa('pin-code-input-info')
     this.pinLockedAlertBox = page.findByDataQa('pin-locked-alert-box')

--- a/frontend/src/e2e-test/pages/employee/employee-preferred-first-name.ts
+++ b/frontend/src/e2e-test/pages/employee/employee-preferred-first-name.ts
@@ -10,7 +10,7 @@ import { AsyncButton, Page, Select } from '../../utils/page'
 export class EmployeePreferredFirstNamePage {
   preferredFirstNameSelect: Select
   confirmButton: AsyncButton
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.preferredFirstNameSelect = new Select(
       page.findByDataQa('select-preferred-first-name')
     )

--- a/frontend/src/e2e-test/pages/employee/employee-preferred-first-name.ts
+++ b/frontend/src/e2e-test/pages/employee/employee-preferred-first-name.ts
@@ -8,15 +8,14 @@ import { waitUntilEqual } from '../../utils'
 import { AsyncButton, Page, Select } from '../../utils/page'
 
 export class EmployeePreferredFirstNamePage {
-  constructor(private readonly page: Page) {}
-
-  readonly preferredFirstNameSelect = new Select(
-    this.page.findByDataQa('select-preferred-first-name')
-  )
-
-  readonly confirmButton = new AsyncButton(
-    this.page.findByDataQa('confirm-button')
-  )
+  preferredFirstNameSelect: Select
+  confirmButton: AsyncButton
+  constructor(private readonly page: Page) {
+    this.preferredFirstNameSelect = new Select(
+      page.findByDataQa('select-preferred-first-name')
+    )
+    this.confirmButton = new AsyncButton(page.findByDataQa('confirm-button'))
+  }
 
   async assertSelectedPreferredFirstName(expectedPreferredFirstName: string) {
     await waitUntilEqual(

--- a/frontend/src/e2e-test/pages/employee/employees.ts
+++ b/frontend/src/e2e-test/pages/employee/employees.ts
@@ -5,11 +5,10 @@
 import { Page, TextInput } from '../../utils/page'
 
 export class EmployeesPage {
-  constructor(private readonly page: Page) {}
-
-  readonly nameInput = new TextInput(
-    this.page.findByDataQa('employee-name-filter')
-  )
+  nameInput: TextInput
+  constructor(private readonly page: Page) {
+    this.nameInput = new TextInput(page.findByDataQa('employee-name-filter'))
+  }
 
   get visibleUsers(): Promise<string[]> {
     return this.page.findAllByDataQa('employee-name').allTexts()

--- a/frontend/src/e2e-test/pages/employee/error-modal.ts
+++ b/frontend/src/e2e-test/pages/employee/error-modal.ts
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export default class ErrorModal {
-  constructor(private page: Page) {}
+  #modal: Element
+  constructor(private page: Page) {
+    this.#modal = page.findByDataQa('app-error-modal')
+  }
 
-  #modal = this.page.findByDataQa('app-error-modal')
   #title = this.#modal.find('[data-qa="title"]')
   #text = this.#modal.find('[data-qa="text"]')
 

--- a/frontend/src/e2e-test/pages/employee/error-modal.ts
+++ b/frontend/src/e2e-test/pages/employee/error-modal.ts
@@ -6,12 +6,13 @@ import { Page, Element } from '../../utils/page'
 
 export default class ErrorModal {
   #modal: Element
-  constructor(private page: Page) {
+  #title: Element
+  #text: Element
+  constructor(page: Page) {
     this.#modal = page.findByDataQa('app-error-modal')
+    this.#title = this.#modal.find('[data-qa="title"]')
+    this.#text = this.#modal.find('[data-qa="text"]')
   }
-
-  #title = this.#modal.find('[data-qa="title"]')
-  #text = this.#modal.find('[data-qa="text"]')
 
   async ensureTitle(title: string) {
     await this.#title.findText(title).waitUntilVisible()

--- a/frontend/src/e2e-test/pages/employee/error-modal.ts
+++ b/frontend/src/e2e-test/pages/employee/error-modal.ts
@@ -7,7 +7,7 @@ import { Page } from '../../utils/page'
 export default class ErrorModal {
   constructor(private page: Page) {}
 
-  #modal = this.page.find('[data-qa="app-error-modal"]')
+  #modal = this.page.findByDataQa('app-error-modal')
   #title = this.#modal.find('[data-qa="title"]')
   #text = this.#modal.find('[data-qa="text"]')
 

--- a/frontend/src/e2e-test/pages/employee/finance-basics.ts
+++ b/frontend/src/e2e-test/pages/employee/finance-basics.ts
@@ -11,15 +11,15 @@ export default class FinanceBasicsPage {
   constructor(private readonly page: Page) {}
 
   readonly feesSection = {
-    root: this.page.find('[data-qa="fees-section"]'),
+    root: this.page.findByDataQa('fees-section'),
     rootLoaded: this.page.find(
       '[data-qa="fees-section"][data-isloading="false"]'
     ),
-    createFeeThresholdsButton: this.page.find(
-      '[data-qa="create-new-fee-thresholds"]'
+    createFeeThresholdsButton: this.page.findByDataQa(
+      'create-new-fee-thresholds'
     ),
     item: (index: number) => {
-      const element = this.page.find(`[data-qa="fee-thresholds-item-${index}"]`)
+      const element = this.page.findByDataQa(`fee-thresholds-item-${index}`)
 
       return {
         element,
@@ -28,7 +28,7 @@ export default class FinanceBasicsPage {
         },
         edit: async () => {
           await element.find('[data-qa="edit"]').click()
-          await this.page.find('[data-qa="modal-okBtn"]').click()
+          await this.page.findByDataQa('modal-okBtn').click()
         },
         assertItemContains: async (thresholds: FeeThresholds) => {
           const expectValueToBe = async (
@@ -78,46 +78,44 @@ export default class FinanceBasicsPage {
       }
     },
     editor: {
-      validFromInput: new TextInput(this.page.find('[data-qa="valid-from"]')),
-      validToInput: new TextInput(this.page.find('[data-qa="valid-to"]')),
-      maxFeeInput: new TextInput(this.page.find('[data-qa="max-fee"]')),
-      minFeeInput: new TextInput(this.page.find('[data-qa="min-fee"]')),
+      validFromInput: new TextInput(this.page.findByDataQa('valid-from')),
+      validToInput: new TextInput(this.page.findByDataQa('valid-to')),
+      maxFeeInput: new TextInput(this.page.findByDataQa('max-fee')),
+      minFeeInput: new TextInput(this.page.findByDataQa('min-fee')),
       minIncomeThreshold: (familySize: number) =>
         new TextInput(
-          this.page.find(`[data-qa="min-income-threshold-${familySize}"]`)
+          this.page.findByDataQa(`min-income-threshold-${familySize}`)
         ),
       maxIncomeThreshold: (familySize: number) =>
         new TextInput(
-          this.page.find(`[data-qa="max-income-threshold-${familySize}"]`)
+          this.page.findByDataQa(`max-income-threshold-${familySize}`)
         ),
       incomeMultiplier: (familySize: number) =>
         new TextInput(
-          this.page.find(`[data-qa="income-multiplier-${familySize}"]`)
+          this.page.findByDataQa(`income-multiplier-${familySize}`)
         ),
       maxFeeError: (familySize: number) =>
-        new TextInput(
-          this.page.find(`[data-qa="max-fee-error-${familySize}"]`)
-        ),
+        new TextInput(this.page.findByDataQa(`max-fee-error-${familySize}`)),
       incomeThresholdIncrease6Plus: new TextInput(
-        this.page.find('[data-qa="income-threshold-increase"]')
+        this.page.findByDataQa('income-threshold-increase')
       ),
       siblingDiscount2: new TextInput(
-        this.page.find('[data-qa="sibling-discount-2"]')
+        this.page.findByDataQa('sibling-discount-2')
       ),
       siblingDiscount2Plus: new TextInput(
-        this.page.find('[data-qa="sibling-discount-2-plus"]')
+        this.page.findByDataQa('sibling-discount-2-plus')
       ),
-      temporaryFee: new TextInput(this.page.find('[data-qa="temporary-fee"]')),
+      temporaryFee: new TextInput(this.page.findByDataQa('temporary-fee')),
       temporaryFeePartDay: new TextInput(
-        this.page.find('[data-qa="temporary-fee-part-day"]')
+        this.page.findByDataQa('temporary-fee-part-day')
       ),
       temporaryFeeSibling: new TextInput(
-        this.page.find('[data-qa="temporary-fee-sibling"]')
+        this.page.findByDataQa('temporary-fee-sibling')
       ),
       temporaryFeeSiblingPartDay: new TextInput(
-        this.page.find('[data-qa="temporary-fee-sibling-part-day"]')
+        this.page.findByDataQa('temporary-fee-sibling-part-day')
       ),
-      saveButton: new AsyncButton(this.page.find('[data-qa="save"]')),
+      saveButton: new AsyncButton(this.page.findByDataQa('save')),
       fillInThresholds: async (feeThresholds: FeeThresholds) => {
         await this.feesSection.editor.validFromInput.fill(
           feeThresholds.validDuring.start.format()
@@ -172,7 +170,7 @@ export default class FinanceBasicsPage {
         await this.feesSection.editor.saveButton.click()
 
         if (retroactive) {
-          await this.page.find('[data-qa="modal-okBtn"]').click()
+          await this.page.findByDataQa('modal-okBtn').click()
         }
 
         await this.feesSection.editor.saveButton.waitUntilHidden()

--- a/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
@@ -319,7 +319,7 @@ export class FinanceDecisionHandlerSelectModal {
   #decisionHandlerSelect: Select
   #decisionHandlerSelectModalResolveBtn: AsyncButton
   #decisionHandlerSelectModalRejectBtn: AsyncButton
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.#decisionHandlerSelect = new Select(
       page.findByDataQa('finance-decision-handler-select')
     )

--- a/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
@@ -22,7 +22,8 @@ import {
   Page,
   Radio,
   Select,
-  TextInput
+  TextInput,
+  Element
 } from '../../../utils/page'
 import ChildInformationPage from '../child-information'
 import GuardianInformationPage from '../guardian-information'
@@ -58,24 +59,30 @@ export class FinancePage {
 }
 
 export class FeeDecisionsPage {
-  constructor(private readonly page: Page) {}
+  #feeDecisionListPage: Element
+  #navigateBackButton: Element
+  #allFeeDecisionsToggle: Checkbox
+  #sendFeeDecisionsButton: AsyncButton
+  #openDecisionHandlerSelectModalButton: AsyncButton
+  constructor(private readonly page: Page) {
+    this.#feeDecisionListPage = page.findByDataQa('fee-decisions-page')
+    this.#navigateBackButton = page.findByDataQa('navigate-back')
+    this.#allFeeDecisionsToggle = new Checkbox(
+      page.findByDataQa('toggle-all-decisions')
+    )
+    this.#sendFeeDecisionsButton = new AsyncButton(
+      page.findByDataQa('confirm-decisions')
+    )
+    this.#openDecisionHandlerSelectModalButton = new AsyncButton(
+      page.findByDataQa('open-decision-handler-select-modal')
+    )
+  }
 
-  #feeDecisionListPage = this.page.findByDataQa('fee-decisions-page')
   #firstFeeDecisionRow = this.page
     .findAll('[data-qa="table-fee-decision-row"]')
     .first()
-  #navigateBackButton = this.page.findByDataQa('navigate-back')
   #statusFilter = (status: FeeDecisionStatus) =>
     new Checkbox(this.page.findByDataQa(`fee-decision-status-filter-${status}`))
-  #allFeeDecisionsToggle = new Checkbox(
-    this.page.findByDataQa('toggle-all-decisions')
-  )
-  #sendFeeDecisionsButton = new AsyncButton(
-    this.page.findByDataQa('confirm-decisions')
-  )
-  #openDecisionHandlerSelectModalButton = new AsyncButton(
-    this.page.findByDataQa('open-decision-handler-select-modal')
-  )
 
   async getFeeDecisionCount() {
     return this.page.findAll('[data-qa="table-fee-decision-row"]').count()
@@ -124,15 +131,20 @@ export class FeeDecisionsPage {
 }
 
 export class FeeDecisionDetailsPage {
-  constructor(private readonly page: Page) {}
+  #partnerName: Element
+  #headOfFamily: Element
+  #decisionHandler: Element
+  #openDecisionHandlerSelectModalButton: AsyncButton
+  constructor(private readonly page: Page) {
+    this.#partnerName = page.findByDataQa('partner')
+    this.#headOfFamily = page.findByDataQa('head-of-family')
+    this.#decisionHandler = page.findByDataQa('decision-handler')
+    this.#openDecisionHandlerSelectModalButton = new AsyncButton(
+      page.findByDataQa('open-decision-handler-select-modal')
+    )
+  }
 
-  #partnerName = this.page.findByDataQa('partner')
-  #headOfFamily = this.page.findByDataQa('head-of-family')
-  #decisionHandler = this.page.findByDataQa('decision-handler')
   #childIncome = this.page.findAll('[data-qa="child-income"]')
-  #openDecisionHandlerSelectModalButton = new AsyncButton(
-    this.page.findByDataQa('open-decision-handler-select-modal')
-  )
 
   async assertPartnerName(expectedName: string) {
     await this.#partnerName.assertTextEquals(expectedName)
@@ -166,26 +178,33 @@ export class FeeDecisionDetailsPage {
 }
 
 export class ValueDecisionsPage {
-  constructor(private readonly page: Page) {}
+  #fromDateInput: DatePickerDeprecated
+  #toDateInput: DatePickerDeprecated
+  #dateCheckbox: Checkbox
+  #allValueDecisionsToggle: Checkbox
+  #sendValueDecisionsButton: AsyncButton
+  #openDecisionHandlerSelectModalButton: AsyncButton
+  constructor(private readonly page: Page) {
+    this.#fromDateInput = new DatePickerDeprecated(
+      page.findByDataQa('value-decisions-start-date')
+    )
+    this.#toDateInput = new DatePickerDeprecated(
+      page.findByDataQa('value-decisions-end-date')
+    )
+    this.#dateCheckbox = new Checkbox(
+      page.findByDataQa('value-decision-search-by-start-date')
+    )
+    this.#allValueDecisionsToggle = new Checkbox(
+      page.findByDataQa('toggle-all-decisions')
+    )
+    this.#sendValueDecisionsButton = new AsyncButton(
+      page.findByDataQa('send-decisions')
+    )
+    this.#openDecisionHandlerSelectModalButton = new AsyncButton(
+      page.findByDataQa('open-decision-handler-select-modal')
+    )
+  }
 
-  readonly #fromDateInput = new DatePickerDeprecated(
-    this.page.findByDataQa('value-decisions-start-date')
-  )
-  readonly #toDateInput = new DatePickerDeprecated(
-    this.page.findByDataQa('value-decisions-end-date')
-  )
-  readonly #dateCheckbox = new Checkbox(
-    this.page.findByDataQa('value-decision-search-by-start-date')
-  )
-  #allValueDecisionsToggle = new Checkbox(
-    this.page.findByDataQa('toggle-all-decisions')
-  )
-  #sendValueDecisionsButton = new AsyncButton(
-    this.page.findByDataQa('send-decisions')
-  )
-  #openDecisionHandlerSelectModalButton = new AsyncButton(
-    this.page.findByDataQa('open-decision-handler-select-modal')
-  )
   #firstValueDecisionRow = this.page
     .findAll('[data-qa="table-value-decision-row"]')
     .first()
@@ -243,16 +262,21 @@ export class ValueDecisionsPage {
 }
 
 export class ValueDecisionDetailsPage {
-  constructor(private readonly page: Page) {}
+  #partnerName: Element
+  #headOfFamily: Element
+  #decisionHandler: Element
+  #sendDecisionButton: Element
+  #openDecisionHandlerSelectModalButton: AsyncButton
+  constructor(private readonly page: Page) {
+    this.#partnerName = page.findByDataQa('partner')
+    this.#headOfFamily = page.findByDataQa('head-of-family')
+    this.#decisionHandler = page.findByDataQa('decision-handler')
+    this.#sendDecisionButton = page.findByDataQa('button-send-decision')
+    this.#openDecisionHandlerSelectModalButton = new AsyncButton(
+      page.findByDataQa('open-decision-handler-select-modal')
+    )
+  }
 
-  #partnerName = this.page.findByDataQa('partner')
-  #headOfFamily = this.page.findByDataQa('head-of-family')
-  #decisionHandler = this.page.findByDataQa('decision-handler')
-
-  #sendDecisionButton = this.page.findByDataQa('button-send-decision')
-  #openDecisionHandlerSelectModalButton = new AsyncButton(
-    this.page.findByDataQa('open-decision-handler-select-modal')
-  )
   #childIncome = this.page.findAll('[data-qa="child-income"]')
 
   async sendValueDecision() {
@@ -292,17 +316,20 @@ export class ValueDecisionDetailsPage {
 }
 
 export class FinanceDecisionHandlerSelectModal {
-  constructor(private readonly page: Page) {}
-
-  #decisionHandlerSelect = new Select(
-    this.page.findByDataQa('finance-decision-handler-select')
-  )
-  #decisionHandlerSelectModalResolveBtn = new AsyncButton(
-    this.page.findByDataQa('modal-okBtn')
-  )
-  #decisionHandlerSelectModalRejectBtn = new AsyncButton(
-    this.page.findByDataQa('modal-cancelBtn')
-  )
+  #decisionHandlerSelect: Select
+  #decisionHandlerSelectModalResolveBtn: AsyncButton
+  #decisionHandlerSelectModalRejectBtn: AsyncButton
+  constructor(private readonly page: Page) {
+    this.#decisionHandlerSelect = new Select(
+      page.findByDataQa('finance-decision-handler-select')
+    )
+    this.#decisionHandlerSelectModalResolveBtn = new AsyncButton(
+      page.findByDataQa('modal-okBtn')
+    )
+    this.#decisionHandlerSelectModalRejectBtn = new AsyncButton(
+      page.findByDataQa('modal-cancelBtn')
+    )
+  }
 
   async selectDecisionHandler(value: string) {
     await this.#decisionHandlerSelect.selectOption({ value })
@@ -322,28 +349,47 @@ export class FinanceDecisionHandlerSelectModal {
 }
 
 export class InvoicesPage {
-  constructor(private readonly page: Page) {}
+  #invoicesPage: Element
+  #invoiceDetailsPage: Element
+  #createInvoicesButton: Element
+  #invoiceInList: Element
+  #allInvoicesToggle: Checkbox
+  #openSendInvoicesDialogButton: Element
+  #sendInvoicesDialog: Element
+  #navigateBack: Element
+  #invoiceDetailsHeadOfFamily: Element
+  #addInvoiceRowButton: Element
+  #saveChangesButton: AsyncButton
+  #markInvoiceSentButton: AsyncButton
+  constructor(private readonly page: Page) {
+    this.#invoicesPage = page.findByDataQa('invoices-page')
+    this.#invoiceDetailsPage = page.findByDataQa('invoice-details-page')
+    this.#createInvoicesButton = page.findByDataQa('create-invoices')
+    this.#invoiceInList = page.findByDataQa('table-invoice-row')
+    this.#allInvoicesToggle = new Checkbox(
+      page.findByDataQa('toggle-all-invoices')
+    )
+    this.#openSendInvoicesDialogButton = page.findByDataQa(
+      'open-send-invoices-dialog'
+    )
+    this.#sendInvoicesDialog = page.findByDataQa('send-invoices-dialog')
+    this.#navigateBack = page.findByDataQa('navigate-back')
+    this.#invoiceDetailsHeadOfFamily = page.findByDataQa(
+      'invoice-details-head-of-family'
+    )
+    this.#addInvoiceRowButton = page.findByDataQa('invoice-button-add-row')
+    this.#saveChangesButton = new AsyncButton(
+      page.findByDataQa('invoice-actions-save-changes')
+    )
+    this.#markInvoiceSentButton = new AsyncButton(
+      page.findByDataQa('invoice-actions-mark-sent')
+    )
+  }
 
-  #invoicesPage = this.page.findByDataQa('invoices-page')
-  #invoiceDetailsPage = this.page.findByDataQa('invoice-details-page')
   #invoices = this.page.find('.invoices')
-  #createInvoicesButton = this.page.findByDataQa('create-invoices')
-  #invoiceInList = this.page.findByDataQa('table-invoice-row')
-  #allInvoicesToggle = new Checkbox(
-    this.page.findByDataQa('toggle-all-invoices')
-  )
-  #openSendInvoicesDialogButton = this.page.findByDataQa(
-    'open-send-invoices-dialog'
-  )
-  #sendInvoicesDialog = this.page.findByDataQa('send-invoices-dialog')
   #sendInvoicesButton = new AsyncButton(
     this.page.find('[data-qa="send-invoices-dialog"] [data-qa="modal-okBtn"]')
   )
-  #navigateBack = this.page.findByDataQa('navigate-back')
-  #invoiceDetailsHeadOfFamily = this.page.findByDataQa(
-    'invoice-details-head-of-family'
-  )
-  #addInvoiceRowButton = this.page.findByDataQa('invoice-button-add-row')
   #invoiceRow = (index: number) => {
     const row = this.page.find(
       `[data-qa="invoice-details-invoice-row"]:nth-child(${index + 1})`
@@ -358,12 +404,6 @@ export class InvoicesPage {
       )
     }
   }
-  #saveChangesButton = new AsyncButton(
-    this.page.findByDataQa('invoice-actions-save-changes')
-  )
-  #markInvoiceSentButton = new AsyncButton(
-    this.page.findByDataQa('invoice-actions-mark-sent')
-  )
 
   async assertLoaded() {
     await this.#invoicesPage.waitUntilVisible()

--- a/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
@@ -31,28 +31,28 @@ export class FinancePage {
   constructor(private readonly page: Page) {}
 
   async selectFeeDecisionsTab() {
-    await this.page.find(`[data-qa="fee-decisions-tab"]`).click()
+    await this.page.findByDataQa(`fee-decisions-tab`).click()
     return new FeeDecisionsPage(this.page)
   }
 
   async selectValueDecisionsTab() {
-    await this.page.find(`[data-qa="value-decisions-tab"]`).click()
+    await this.page.findByDataQa(`value-decisions-tab`).click()
     return new ValueDecisionsPage(this.page)
   }
 
   async selectInvoicesTab() {
-    await this.page.find(`[data-qa="invoices-tab"]`).click()
+    await this.page.findByDataQa(`invoices-tab`).click()
     const page = new InvoicesPage(this.page)
     await page.assertLoaded()
     return page
   }
 
   async selectIncomeStatementsTab() {
-    await this.page.find(`[data-qa="income-statements-tab"]`).click()
+    await this.page.findByDataQa(`income-statements-tab`).click()
   }
 
   async selectPaymentsTab() {
-    await this.page.find(`[data-qa="payments-tab"]`).click()
+    await this.page.findByDataQa(`payments-tab`).click()
     return new PaymentsPage(this.page)
   }
 }
@@ -60,21 +60,21 @@ export class FinancePage {
 export class FeeDecisionsPage {
   constructor(private readonly page: Page) {}
 
-  #feeDecisionListPage = this.page.find('[data-qa="fee-decisions-page"]')
+  #feeDecisionListPage = this.page.findByDataQa('fee-decisions-page')
   #firstFeeDecisionRow = this.page
     .findAll('[data-qa="table-fee-decision-row"]')
     .first()
-  #navigateBackButton = this.page.find('[data-qa="navigate-back"]')
+  #navigateBackButton = this.page.findByDataQa('navigate-back')
   #statusFilter = (status: FeeDecisionStatus) =>
     new Checkbox(this.page.findByDataQa(`fee-decision-status-filter-${status}`))
   #allFeeDecisionsToggle = new Checkbox(
-    this.page.find('[data-qa="toggle-all-decisions"]')
+    this.page.findByDataQa('toggle-all-decisions')
   )
   #sendFeeDecisionsButton = new AsyncButton(
-    this.page.find('[data-qa="confirm-decisions"]')
+    this.page.findByDataQa('confirm-decisions')
   )
   #openDecisionHandlerSelectModalButton = new AsyncButton(
-    this.page.find('[data-qa="open-decision-handler-select-modal"]')
+    this.page.findByDataQa('open-decision-handler-select-modal')
   )
 
   async getFeeDecisionCount() {
@@ -126,12 +126,12 @@ export class FeeDecisionsPage {
 export class FeeDecisionDetailsPage {
   constructor(private readonly page: Page) {}
 
-  #partnerName = this.page.find('[data-qa="partner"]')
-  #headOfFamily = this.page.find('[data-qa="head-of-family"]')
-  #decisionHandler = this.page.find('[data-qa="decision-handler"]')
+  #partnerName = this.page.findByDataQa('partner')
+  #headOfFamily = this.page.findByDataQa('head-of-family')
+  #decisionHandler = this.page.findByDataQa('decision-handler')
   #childIncome = this.page.findAll('[data-qa="child-income"]')
   #openDecisionHandlerSelectModalButton = new AsyncButton(
-    this.page.find('[data-qa="open-decision-handler-select-modal"]')
+    this.page.findByDataQa('open-decision-handler-select-modal')
   )
 
   async assertPartnerName(expectedName: string) {
@@ -169,22 +169,22 @@ export class ValueDecisionsPage {
   constructor(private readonly page: Page) {}
 
   readonly #fromDateInput = new DatePickerDeprecated(
-    this.page.find('[data-qa="value-decisions-start-date"]')
+    this.page.findByDataQa('value-decisions-start-date')
   )
   readonly #toDateInput = new DatePickerDeprecated(
-    this.page.find('[data-qa="value-decisions-end-date"]')
+    this.page.findByDataQa('value-decisions-end-date')
   )
   readonly #dateCheckbox = new Checkbox(
-    this.page.find('[data-qa="value-decision-search-by-start-date"]')
+    this.page.findByDataQa('value-decision-search-by-start-date')
   )
   #allValueDecisionsToggle = new Checkbox(
-    this.page.find('[data-qa="toggle-all-decisions"]')
+    this.page.findByDataQa('toggle-all-decisions')
   )
   #sendValueDecisionsButton = new AsyncButton(
-    this.page.find('[data-qa="send-decisions"]')
+    this.page.findByDataQa('send-decisions')
   )
   #openDecisionHandlerSelectModalButton = new AsyncButton(
-    this.page.find('[data-qa="open-decision-handler-select-modal"]')
+    this.page.findByDataQa('open-decision-handler-select-modal')
   )
   #firstValueDecisionRow = this.page
     .findAll('[data-qa="table-value-decision-row"]')
@@ -245,13 +245,13 @@ export class ValueDecisionsPage {
 export class ValueDecisionDetailsPage {
   constructor(private readonly page: Page) {}
 
-  #partnerName = this.page.find('[data-qa="partner"]')
-  #headOfFamily = this.page.find('[data-qa="head-of-family"]')
-  #decisionHandler = this.page.find('[data-qa="decision-handler"]')
+  #partnerName = this.page.findByDataQa('partner')
+  #headOfFamily = this.page.findByDataQa('head-of-family')
+  #decisionHandler = this.page.findByDataQa('decision-handler')
 
-  #sendDecisionButton = this.page.find('[data-qa="button-send-decision"]')
+  #sendDecisionButton = this.page.findByDataQa('button-send-decision')
   #openDecisionHandlerSelectModalButton = new AsyncButton(
-    this.page.find('[data-qa="open-decision-handler-select-modal"]')
+    this.page.findByDataQa('open-decision-handler-select-modal')
   )
   #childIncome = this.page.findAll('[data-qa="child-income"]')
 
@@ -295,13 +295,13 @@ export class FinanceDecisionHandlerSelectModal {
   constructor(private readonly page: Page) {}
 
   #decisionHandlerSelect = new Select(
-    this.page.find('[data-qa="finance-decision-handler-select"]')
+    this.page.findByDataQa('finance-decision-handler-select')
   )
   #decisionHandlerSelectModalResolveBtn = new AsyncButton(
-    this.page.find('[data-qa="modal-okBtn"]')
+    this.page.findByDataQa('modal-okBtn')
   )
   #decisionHandlerSelectModalRejectBtn = new AsyncButton(
-    this.page.find('[data-qa="modal-cancelBtn"]')
+    this.page.findByDataQa('modal-cancelBtn')
   )
 
   async selectDecisionHandler(value: string) {
@@ -324,26 +324,26 @@ export class FinanceDecisionHandlerSelectModal {
 export class InvoicesPage {
   constructor(private readonly page: Page) {}
 
-  #invoicesPage = this.page.find('[data-qa="invoices-page"]')
-  #invoiceDetailsPage = this.page.find('[data-qa="invoice-details-page"]')
+  #invoicesPage = this.page.findByDataQa('invoices-page')
+  #invoiceDetailsPage = this.page.findByDataQa('invoice-details-page')
   #invoices = this.page.find('.invoices')
-  #createInvoicesButton = this.page.find('[data-qa="create-invoices"]')
-  #invoiceInList = this.page.find('[data-qa="table-invoice-row"]')
+  #createInvoicesButton = this.page.findByDataQa('create-invoices')
+  #invoiceInList = this.page.findByDataQa('table-invoice-row')
   #allInvoicesToggle = new Checkbox(
-    this.page.find('[data-qa="toggle-all-invoices"]')
+    this.page.findByDataQa('toggle-all-invoices')
   )
-  #openSendInvoicesDialogButton = this.page.find(
-    '[data-qa="open-send-invoices-dialog"]'
+  #openSendInvoicesDialogButton = this.page.findByDataQa(
+    'open-send-invoices-dialog'
   )
-  #sendInvoicesDialog = this.page.find('[data-qa="send-invoices-dialog"]')
+  #sendInvoicesDialog = this.page.findByDataQa('send-invoices-dialog')
   #sendInvoicesButton = new AsyncButton(
     this.page.find('[data-qa="send-invoices-dialog"] [data-qa="modal-okBtn"]')
   )
-  #navigateBack = this.page.find('[data-qa="navigate-back"]')
-  #invoiceDetailsHeadOfFamily = this.page.find(
-    '[data-qa="invoice-details-head-of-family"]'
+  #navigateBack = this.page.findByDataQa('navigate-back')
+  #invoiceDetailsHeadOfFamily = this.page.findByDataQa(
+    'invoice-details-head-of-family'
   )
-  #addInvoiceRowButton = this.page.find('[data-qa="invoice-button-add-row"]')
+  #addInvoiceRowButton = this.page.findByDataQa('invoice-button-add-row')
   #invoiceRow = (index: number) => {
     const row = this.page.find(
       `[data-qa="invoice-details-invoice-row"]:nth-child(${index + 1})`
@@ -359,10 +359,10 @@ export class InvoicesPage {
     }
   }
   #saveChangesButton = new AsyncButton(
-    this.page.find('[data-qa="invoice-actions-save-changes"]')
+    this.page.findByDataQa('invoice-actions-save-changes')
   )
   #markInvoiceSentButton = new AsyncButton(
-    this.page.find('[data-qa="invoice-actions-mark-sent"]')
+    this.page.findByDataQa('invoice-actions-mark-sent')
   )
 
   async assertLoaded() {
@@ -397,7 +397,7 @@ export class InvoicesPage {
   }
 
   async showSentInvoices() {
-    await this.page.find('[data-qa="invoice-status-filter-SENT"]').click()
+    await this.page.findByDataQa('invoice-status-filter-SENT').click()
   }
 
   async showWaitingForSendingInvoices() {
@@ -460,9 +460,9 @@ export class InvoicesPage {
   }
 
   async freeTextFilter(text: string) {
-    await new TextInput(
-      this.page.find('[data-qa="free-text-search-input"]')
-    ).type(text)
+    await new TextInput(this.page.findByDataQa('free-text-search-input')).type(
+      text
+    )
   }
 
   async markInvoiceSent() {
@@ -480,7 +480,7 @@ export class IncomeStatementsPage {
 
   incomeStatementRows = this.page.findAll(`[data-qa="income-statement-row"]`)
   #providerTypeFilter = (type: ProviderType) =>
-    new Checkable(this.page.find(`[data-qa="provider-type-filter-${type}"]`))
+    new Checkable(this.page.findByDataQa(`provider-type-filter-${type}`))
 
   async waitUntilLoaded() {
     await this.page

--- a/frontend/src/e2e-test/pages/employee/guardian-information.ts
+++ b/frontend/src/e2e-test/pages/employee/guardian-information.ts
@@ -317,6 +317,8 @@ export class IncomeSection extends Section {
   #incomeSum: Element
   #expensesSum: Element
   #editIncomeItemButton: Element
+  #incomeStartDateInput: DatePicker
+  #incomeEndDateInput: DatePicker
 
   constructor(page: Page, root: Element) {
     super(page, root)
@@ -328,6 +330,13 @@ export class IncomeSection extends Section {
     this.#incomeSum = page.findByDataQa('income-sum-income')
     this.#expensesSum = page.findByDataQa('income-sum-expenses')
     this.#editIncomeItemButton = page.findByDataQa('edit-income-item')
+
+    this.#incomeStartDateInput = new DatePicker(
+      this.#incomeDateRange.findByDataQa('start-date')
+    )
+    this.#incomeEndDateInput = new DatePicker(
+      this.#incomeDateRange.findByDataQa('end-date')
+    )
   }
 
   // Income statements
@@ -367,13 +376,6 @@ export class IncomeSection extends Section {
   async openNewIncomeForm() {
     await this.#newIncomeButton.click()
   }
-
-  #incomeStartDateInput = new DatePicker(
-    this.#incomeDateRange.find('[data-qa="start-date"]')
-  )
-  #incomeEndDateInput = new DatePicker(
-    this.#incomeDateRange.find('[data-qa="end-date"]')
-  )
 
   async fillIncomeStartDate(value: string) {
     await this.#incomeStartDateInput.fill(value)

--- a/frontend/src/e2e-test/pages/employee/guardian-information.ts
+++ b/frontend/src/e2e-test/pages/employee/guardian-information.ts
@@ -41,13 +41,11 @@ export default class GuardianInformationPage {
       .waitUntilVisible()
   }
 
-  #restrictedDetailsEnabledLabel = this.page.find(
-    '[data-qa="restriction-details-enabled-label"]'
+  #restrictedDetailsEnabledLabel = this.page.findByDataQa(
+    'restriction-details-enabled-label'
   )
-  #personStreetAddress = this.page.find(
-    '[data-qa="person-details-street-address"]'
-  )
-  #timelineButton = this.page.find('[data-qa="timeline-button"]')
+  #personStreetAddress = this.page.findByDataQa('person-details-street-address')
+  #timelineButton = this.page.findByDataQa('timeline-button')
 
   async assertRestrictedDetails(enabled: boolean) {
     switch (enabled) {
@@ -144,7 +142,7 @@ class PartnersSection extends Section {
 
   async addPartner(partnerName: string, startDate: string) {
     await this.#addPartnerButton.click()
-    const modal = new Modal(this.page.find('[data-qa="fridge-partner-modal"]'))
+    const modal = new Modal(this.page.findByDataQa('fridge-partner-modal'))
 
     const combobox = new Combobox(
       modal.find('[data-qa="fridge-partner-person-search"]')
@@ -165,7 +163,7 @@ class ChildrenSection extends Section {
 
   async addChild(childName: string, startDate: string) {
     await this.#addChildButton.click()
-    const modal = new Modal(this.page.find('[data-qa="fridge-child-modal"]'))
+    const modal = new Modal(this.page.findByDataQa('fridge-child-modal'))
 
     const combobox = new Combobox(
       modal.find('[data-qa="fridge-child-person-search"]')
@@ -341,13 +339,13 @@ export class IncomeSection extends Section {
   }
 
   // Incomes
-  #newIncomeButton = this.page.find('[data-qa="add-income-button"]')
+  #newIncomeButton = this.page.findByDataQa('add-income-button')
 
   async openNewIncomeForm() {
     await this.#newIncomeButton.click()
   }
 
-  #incomeDateRange = this.page.find('[data-qa="income-date-range"]')
+  #incomeDateRange = this.page.findByDataQa('income-date-range')
   #incomeStartDateInput = new DatePicker(
     this.#incomeDateRange.find('[data-qa="start-date"]')
   )
@@ -364,28 +362,28 @@ export class IncomeSection extends Section {
   }
 
   #incomeInput = (type: string) =>
-    new TextInput(this.page.find(`[data-qa="income-input-${type}"]`))
+    new TextInput(this.page.findByDataQa(`income-input-${type}`))
 
   async fillIncome(type: string, value: string) {
     await this.#incomeInput(type).fill(value)
   }
 
   #incomeEffect = (effect: string) =>
-    this.page.find(`[data-qa="income-effect-${effect}"]`)
+    this.page.findByDataQa(`income-effect-${effect}`)
 
   async chooseIncomeEffect(effect: string) {
     await this.#incomeEffect(effect).click()
   }
 
   #coefficientSelect = (type: string) =>
-    new Select(this.page.find(`[data-qa="income-coefficient-select-${type}"]`))
+    new Select(this.page.findByDataQa(`income-coefficient-select-${type}`))
 
   async chooseCoefficient(type: string, coefficient: string) {
     await this.#coefficientSelect(type).selectOption({ value: coefficient })
   }
 
-  #saveIncomeButton = this.page.find('[data-qa="save-income"]')
-  #cancelIncomeButton = this.page.find('[data-qa="cancel-income-edit"]')
+  #saveIncomeButton = this.page.findByDataQa('save-income')
+  #cancelIncomeButton = this.page.findByDataQa('cancel-income-edit')
 
   async save() {
     await this.#saveIncomeButton.click()
@@ -418,25 +416,25 @@ export class IncomeSection extends Section {
     await this.find('[data-qa="modal-okBtn"]').click()
   }
 
-  #toggleIncomeItemButton = this.page.find('[data-qa="toggle-income-item"]')
+  #toggleIncomeItemButton = this.page.findByDataQa('toggle-income-item')
 
   async toggleIncome() {
     await this.#toggleIncomeItemButton.click()
   }
 
-  #incomeSum = this.page.find('[data-qa="income-sum-income"]')
+  #incomeSum = this.page.findByDataQa('income-sum-income')
 
   async getIncomeSum() {
     return await this.#incomeSum.text
   }
 
-  #expensesSum = this.page.find('[data-qa="income-sum-expenses"]')
+  #expensesSum = this.page.findByDataQa('income-sum-expenses')
 
   async getExpensesSum() {
     return await this.#expensesSum.text
   }
 
-  #editIncomeItemButton = this.page.find('[data-qa="edit-income-item"]')
+  #editIncomeItemButton = this.page.findByDataQa('edit-income-item')
 
   async edit() {
     await this.#editIncomeItemButton.click()
@@ -502,7 +500,7 @@ class FeeDecisionsSection extends Section {
     await this.find(
       '[data-qa="create-retroactive-fee-decision-button"]'
     ).click()
-    const modal = new Modal(this.page.find('[data-qa="modal"]'))
+    const modal = new Modal(this.page.findByDataQa('modal'))
 
     const startDate = new DatePicker(
       modal.find('[data-qa="retroactive-fee-decision-start-date"]')

--- a/frontend/src/e2e-test/pages/employee/guardian-information.ts
+++ b/frontend/src/e2e-test/pages/employee/guardian-information.ts
@@ -25,7 +25,18 @@ import { IncomeStatementPage } from './IncomeStatementPage'
 import { TimelinePage } from './timeline/timeline-page'
 
 export default class GuardianInformationPage {
-  constructor(private readonly page: Page) {}
+  #restrictedDetailsEnabledLabel: Element
+  #personStreetAddress: Element
+  #timelineButton: Element
+  constructor(private readonly page: Page) {
+    this.#restrictedDetailsEnabledLabel = page.findByDataQa(
+      'restriction-details-enabled-label'
+    )
+    this.#personStreetAddress = page.findByDataQa(
+      'person-details-street-address'
+    )
+    this.#timelineButton = page.findByDataQa('timeline-button')
+  }
 
   async navigateToGuardian(personId: UUID) {
     await this.page.goto(config.employeeUrl + '/profile/' + personId)
@@ -40,12 +51,6 @@ export default class GuardianInformationPage {
       .find('[data-qa="family-overview-section"][data-isloading="false"]')
       .waitUntilVisible()
   }
-
-  #restrictedDetailsEnabledLabel = this.page.findByDataQa(
-    'restriction-details-enabled-label'
-  )
-  #personStreetAddress = this.page.findByDataQa('person-details-street-address')
-  #timelineButton = this.page.findByDataQa('timeline-button')
 
   async assertRestrictedDetails(enabled: boolean) {
     switch (enabled) {
@@ -304,6 +309,27 @@ class DecisionsSection extends Section {
 }
 
 export class IncomeSection extends Section {
+  #newIncomeButton: Element
+  #incomeDateRange: Element
+  #saveIncomeButton: Element
+  #cancelIncomeButton: Element
+  #toggleIncomeItemButton: Element
+  #incomeSum: Element
+  #expensesSum: Element
+  #editIncomeItemButton: Element
+
+  constructor(page: Page, root: Element) {
+    super(page, root)
+    this.#newIncomeButton = page.findByDataQa('add-income-button')
+    this.#incomeDateRange = page.findByDataQa('income-date-range')
+    this.#saveIncomeButton = page.findByDataQa('save-income')
+    this.#cancelIncomeButton = page.findByDataQa('cancel-income-edit')
+    this.#toggleIncomeItemButton = page.findByDataQa('toggle-income-item')
+    this.#incomeSum = page.findByDataQa('income-sum-income')
+    this.#expensesSum = page.findByDataQa('income-sum-expenses')
+    this.#editIncomeItemButton = page.findByDataQa('edit-income-item')
+  }
+
   // Income statements
 
   #incomeStatementRows = this.findAll(`[data-qa="income-statement-row"]`)
@@ -338,14 +364,10 @@ export class IncomeSection extends Section {
     return this.#incomeStatementRows.nth(nth).text
   }
 
-  // Incomes
-  #newIncomeButton = this.page.findByDataQa('add-income-button')
-
   async openNewIncomeForm() {
     await this.#newIncomeButton.click()
   }
 
-  #incomeDateRange = this.page.findByDataQa('income-date-range')
   #incomeStartDateInput = new DatePicker(
     this.#incomeDateRange.find('[data-qa="start-date"]')
   )
@@ -382,9 +404,6 @@ export class IncomeSection extends Section {
     await this.#coefficientSelect(type).selectOption({ value: coefficient })
   }
 
-  #saveIncomeButton = this.page.findByDataQa('save-income')
-  #cancelIncomeButton = this.page.findByDataQa('cancel-income-edit')
-
   async save() {
     await this.#saveIncomeButton.click()
     await this.#saveIncomeButton.waitUntilHidden()
@@ -416,25 +435,17 @@ export class IncomeSection extends Section {
     await this.find('[data-qa="modal-okBtn"]').click()
   }
 
-  #toggleIncomeItemButton = this.page.findByDataQa('toggle-income-item')
-
   async toggleIncome() {
     await this.#toggleIncomeItemButton.click()
   }
-
-  #incomeSum = this.page.findByDataQa('income-sum-income')
 
   async getIncomeSum() {
     return await this.#incomeSum.text
   }
 
-  #expensesSum = this.page.findByDataQa('income-sum-expenses')
-
   async getExpensesSum() {
     return await this.#expensesSum.text
   }
-
-  #editIncomeItemButton = this.page.findByDataQa('edit-income-item')
 
   async edit() {
     await this.#editIncomeItemButton.click()

--- a/frontend/src/e2e-test/pages/employee/holiday-term-periods.ts
+++ b/frontend/src/e2e-test/pages/employee/holiday-term-periods.ts
@@ -5,10 +5,33 @@
 import FiniteDateRange from 'lib-common/finite-date-range'
 import LocalDate from 'lib-common/local-date'
 
-import { Checkbox, DatePicker, Page, Radio, TextInput } from '../../utils/page'
+import {
+  Checkbox,
+  DatePicker,
+  Page,
+  Radio,
+  TextInput,
+  ElementCollection,
+  Element
+} from '../../utils/page'
 
 export class HolidayAndTermPeriodsPage {
-  constructor(private readonly page: Page) {}
+  #periodRows: ElementCollection
+  #questionnaireRows: ElementCollection
+  #preschoolTermRows: ElementCollection
+  #clubTermRows: ElementCollection
+  confirmCheckbox: Checkbox
+  #addTermBreakButton: Element
+  #termBreakRows: ElementCollection
+  constructor(private readonly page: Page) {
+    this.#periodRows = page.findAllByDataQa('holiday-period-row')
+    this.#questionnaireRows = page.findAllByDataQa('questionnaire-row')
+    this.#preschoolTermRows = page.findAllByDataQa('preschool-term-row')
+    this.#clubTermRows = page.findAllByDataQa('club-term-row')
+    this.confirmCheckbox = new Checkbox(page.findByDataQa('confirm-checkbox'))
+    this.#addTermBreakButton = page.findByDataQa('add-term-break-button')
+    this.#termBreakRows = page.findAllByDataQa('term-break')
+  }
 
   get visiblePeriods(): Promise<string[]> {
     return this.page.findAllByDataQa('holiday-period').allTexts()
@@ -35,12 +58,6 @@ export class HolidayAndTermPeriodsPage {
       .findAllByDataQa(`term-break-${date.formatIso()}`)
       .allTexts()
   }
-
-  #periodRows = this.page.findAllByDataQa('holiday-period-row')
-  #questionnaireRows = this.page.findAllByDataQa('questionnaire-row')
-
-  #preschoolTermRows = this.page.findAllByDataQa('preschool-term-row')
-  #clubTermRows = this.page.findAllByDataQa('club-term-row')
 
   get visibleQuestionnaires(): Promise<string[]> {
     return this.#questionnaireRows.allTexts()
@@ -92,8 +109,6 @@ export class HolidayAndTermPeriodsPage {
       }
     }
   }
-
-  confirmCheckbox = new Checkbox(this.page.findByDataQa('confirm-checkbox'))
 
   #questionnaireInputs = {
     activeStart: new DatePicker(this.page.findByDataQa('input-start')),
@@ -187,9 +202,6 @@ export class HolidayAndTermPeriodsPage {
       }
     }
   }
-
-  #addTermBreakButton = this.page.findByDataQa('add-term-break-button')
-  #termBreakRows = this.page.findAllByDataQa('term-break')
 
   #preschoolTermInputs = {
     finnishPreschoolStart: new DatePicker(

--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -26,6 +26,8 @@ export default class MessagesPage {
   #messageReplyContent: TextInput
   #emptyInboxText: Element
   #unitAccount: Element
+  #draftMessagesBoxRow: TextInput
+  unitReceived: Element
   constructor(private readonly page: Page) {
     this.newMessageButton = page.findByDataQa('new-message-btn')
     this.#personalAccount = page.findByDataQa('personal-account')
@@ -40,6 +42,12 @@ export default class MessagesPage {
     )
     this.#emptyInboxText = page.findByDataQa('empty-inbox-text')
     this.#unitAccount = page.findByDataQa('unit-accounts')
+    this.#draftMessagesBoxRow = new TextInput(
+      this.#personalAccount.findByDataQa('message-box-row-drafts')
+    )
+    this.unitReceived = this.#unitAccount.findByDataQa(
+      'message-box-row-received'
+    )
   }
 
   async openSentMessages(nth = 0) {
@@ -47,13 +55,8 @@ export default class MessagesPage {
     return new SentMessagesPage(this.page)
   }
 
-  #draftMessagesBoxRow = new TextInput(
-    this.#personalAccount.find('[data-qa="message-box-row-drafts"]')
-  )
   #messageContent = (index = 0) =>
     this.page.findByDataQa(`message-content"][data-index="${index}`)
-
-  unitReceived = this.#unitAccount.find('[data-qa="message-box-row-received"]')
 
   async getReceivedMessageCount() {
     return await this.page.findAll('[data-qa="received-message-row"]').count()

--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -10,36 +10,49 @@ import {
   Checkbox,
   Combobox,
   TreeDropdown,
-  Element
+  Element,
+  ElementCollection
 } from '../../../utils/page'
 
 export default class MessagesPage {
-  constructor(private readonly page: Page) {}
+  newMessageButton: Element
+  #personalAccount: Element
+  #messageCopiesInbox: Element
+  receivedMessage: Element
+  #draftMessage: Element
+  #openReplyEditorButton: Element
+  sendReplyButton: Element
+  discardMessageButton: Element
+  #messageReplyContent: TextInput
+  #emptyInboxText: Element
+  #unitAccount: Element
+  constructor(private readonly page: Page) {
+    this.newMessageButton = page.findByDataQa('new-message-btn')
+    this.#personalAccount = page.findByDataQa('personal-account')
+    this.#messageCopiesInbox = page.findByDataQa('message-box-row-copies')
+    this.receivedMessage = page.findByDataQa('received-message-row')
+    this.#draftMessage = page.findByDataQa('draft-message-row')
+    this.#openReplyEditorButton = page.findByDataQa(`message-reply-editor-btn`)
+    this.sendReplyButton = page.findByDataQa('message-send-btn')
+    this.discardMessageButton = page.findByDataQa('message-discard-btn')
+    this.#messageReplyContent = new TextInput(
+      page.findByDataQa('message-reply-content')
+    )
+    this.#emptyInboxText = page.findByDataQa('empty-inbox-text')
+    this.#unitAccount = page.findByDataQa('unit-accounts')
+  }
 
   async openSentMessages(nth = 0) {
     await this.page.findAllByDataQa('message-box-row-sent').nth(nth).click()
     return new SentMessagesPage(this.page)
   }
 
-  newMessageButton = this.page.findByDataQa('new-message-btn')
-  #personalAccount = this.page.findByDataQa('personal-account')
   #draftMessagesBoxRow = new TextInput(
     this.#personalAccount.find('[data-qa="message-box-row-drafts"]')
   )
-  #messageCopiesInbox = this.page.findByDataQa('message-box-row-copies')
-  receivedMessage = this.page.findByDataQa('received-message-row')
-  #draftMessage = this.page.findByDataQa('draft-message-row')
   #messageContent = (index = 0) =>
     this.page.findByDataQa(`message-content"][data-index="${index}`)
 
-  #openReplyEditorButton = this.page.findByDataQa(`message-reply-editor-btn`)
-  sendReplyButton = this.page.findByDataQa('message-send-btn')
-  discardMessageButton = this.page.findByDataQa('message-discard-btn')
-  #messageReplyContent = new TextInput(
-    this.page.findByDataQa('message-reply-content')
-  )
-  #emptyInboxText = this.page.findByDataQa('empty-inbox-text')
-  #unitAccount = this.page.findByDataQa('unit-accounts')
   unitReceived = this.#unitAccount.find('[data-qa="message-box-row-received"]')
 
   async getReceivedMessageCount() {
@@ -133,9 +146,10 @@ export default class MessagesPage {
 }
 
 export class SentMessagesPage {
-  constructor(private readonly page: Page) {}
-
-  sentMessages = this.page.findAllByDataQa('sent-message-row')
+  sentMessages: ElementCollection
+  constructor(private readonly page: Page) {
+    this.sentMessages = page.findAllByDataQa('sent-message-row')
+  }
 
   async assertMessageParticipants(nth: number, participants: string) {
     await this.sentMessages

--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -21,27 +21,25 @@ export default class MessagesPage {
     return new SentMessagesPage(this.page)
   }
 
-  newMessageButton = this.page.find('[data-qa="new-message-btn"]')
-  #personalAccount = this.page.find('[data-qa="personal-account"]')
+  newMessageButton = this.page.findByDataQa('new-message-btn')
+  #personalAccount = this.page.findByDataQa('personal-account')
   #draftMessagesBoxRow = new TextInput(
     this.#personalAccount.find('[data-qa="message-box-row-drafts"]')
   )
   #messageCopiesInbox = this.page.findByDataQa('message-box-row-copies')
-  receivedMessage = this.page.find('[data-qa="received-message-row"]')
-  #draftMessage = this.page.find('[data-qa="draft-message-row"]')
+  receivedMessage = this.page.findByDataQa('received-message-row')
+  #draftMessage = this.page.findByDataQa('draft-message-row')
   #messageContent = (index = 0) =>
-    this.page.find(`[data-qa="message-content"][data-index="${index}"]`)
+    this.page.findByDataQa(`message-content"][data-index="${index}`)
 
-  #openReplyEditorButton = this.page.find(
-    `[data-qa="message-reply-editor-btn"]`
-  )
-  sendReplyButton = this.page.find('[data-qa="message-send-btn"]')
-  discardMessageButton = this.page.find('[data-qa="message-discard-btn"]')
+  #openReplyEditorButton = this.page.findByDataQa(`message-reply-editor-btn`)
+  sendReplyButton = this.page.findByDataQa('message-send-btn')
+  discardMessageButton = this.page.findByDataQa('message-discard-btn')
   #messageReplyContent = new TextInput(
-    this.page.find('[data-qa="message-reply-content"]')
+    this.page.findByDataQa('message-reply-content')
   )
   #emptyInboxText = this.page.findByDataQa('empty-inbox-text')
-  #unitAccount = this.page.find('[data-qa="unit-accounts"]')
+  #unitAccount = this.page.findByDataQa('unit-accounts')
   unitReceived = this.#unitAccount.find('[data-qa="message-box-row-received"]')
 
   async getReceivedMessageCount() {

--- a/frontend/src/e2e-test/pages/employee/mobile/pairing-flow.ts
+++ b/frontend/src/e2e-test/pages/employee/mobile/pairing-flow.ts
@@ -2,21 +2,33 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page, TextInput } from '../../../utils/page'
+import { Page, TextInput, Element } from '../../../utils/page'
 
 export class PairingFlow {
-  constructor(private readonly page: Page) {}
-
-  #mobileStartPairingBtn = this.page.findByDataQa('start-pairing-btn')
-  #mobilePairingTitle1 = this.page.findByDataQa('mobile-pairing-wizard-title-1')
-  #mobilePairingTitle3 = this.page.findByDataQa('mobile-pairing-wizard-title-3')
-  #challengeKeyInput = new TextInput(
-    this.page.findByDataQa('challenge-key-input')
-  )
-  #submitChallengeKeyBtn = this.page.findByDataQa('submit-challenge-key-btn')
-  #responseKey = this.page.findByDataQa('response-key')
-  #startCtaLink = this.page.findByDataQa('start-cta-link')
-  #topBarTitle = this.page.findByDataQa('top-bar-title')
+  #mobileStartPairingBtn: Element
+  #mobilePairingTitle1: Element
+  #mobilePairingTitle3: Element
+  #challengeKeyInput: TextInput
+  #submitChallengeKeyBtn: Element
+  #responseKey: Element
+  #startCtaLink: Element
+  #topBarTitle: Element
+  constructor(private readonly page: Page) {
+    this.#mobileStartPairingBtn = page.findByDataQa('start-pairing-btn')
+    this.#mobilePairingTitle1 = page.findByDataQa(
+      'mobile-pairing-wizard-title-1'
+    )
+    this.#mobilePairingTitle3 = page.findByDataQa(
+      'mobile-pairing-wizard-title-3'
+    )
+    this.#challengeKeyInput = new TextInput(
+      page.findByDataQa('challenge-key-input')
+    )
+    this.#submitChallengeKeyBtn = page.findByDataQa('submit-challenge-key-btn')
+    this.#responseKey = page.findByDataQa('response-key')
+    this.#startCtaLink = page.findByDataQa('start-cta-link')
+    this.#topBarTitle = page.findByDataQa('top-bar-title')
+  }
 
   async startPairing() {
     await this.#mobileStartPairingBtn.click()

--- a/frontend/src/e2e-test/pages/employee/mobile/pairing-flow.ts
+++ b/frontend/src/e2e-test/pages/employee/mobile/pairing-flow.ts
@@ -13,7 +13,7 @@ export class PairingFlow {
   #responseKey: Element
   #startCtaLink: Element
   #topBarTitle: Element
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.#mobileStartPairingBtn = page.findByDataQa('start-pairing-btn')
     this.#mobilePairingTitle1 = page.findByDataQa(
       'mobile-pairing-wizard-title-1'

--- a/frontend/src/e2e-test/pages/employee/mobile/pairing-flow.ts
+++ b/frontend/src/e2e-test/pages/employee/mobile/pairing-flow.ts
@@ -7,22 +7,16 @@ import { Page, TextInput } from '../../../utils/page'
 export class PairingFlow {
   constructor(private readonly page: Page) {}
 
-  #mobileStartPairingBtn = this.page.find('[data-qa="start-pairing-btn"]')
-  #mobilePairingTitle1 = this.page.find(
-    '[data-qa="mobile-pairing-wizard-title-1"]'
-  )
-  #mobilePairingTitle3 = this.page.find(
-    '[data-qa="mobile-pairing-wizard-title-3"]'
-  )
+  #mobileStartPairingBtn = this.page.findByDataQa('start-pairing-btn')
+  #mobilePairingTitle1 = this.page.findByDataQa('mobile-pairing-wizard-title-1')
+  #mobilePairingTitle3 = this.page.findByDataQa('mobile-pairing-wizard-title-3')
   #challengeKeyInput = new TextInput(
-    this.page.find('[data-qa="challenge-key-input"]')
+    this.page.findByDataQa('challenge-key-input')
   )
-  #submitChallengeKeyBtn = this.page.find(
-    '[data-qa="submit-challenge-key-btn"]'
-  )
-  #responseKey = this.page.find('[data-qa="response-key"]')
-  #startCtaLink = this.page.find('[data-qa="start-cta-link"]')
-  #topBarTitle = this.page.find('[data-qa="top-bar-title"]')
+  #submitChallengeKeyBtn = this.page.findByDataQa('submit-challenge-key-btn')
+  #responseKey = this.page.findByDataQa('response-key')
+  #startCtaLink = this.page.findByDataQa('start-cta-link')
+  #topBarTitle = this.page.findByDataQa('top-bar-title')
 
   async startPairing() {
     await this.#mobileStartPairingBtn.click()

--- a/frontend/src/e2e-test/pages/employee/person-search.ts
+++ b/frontend/src/e2e-test/pages/employee/person-search.ts
@@ -4,15 +4,37 @@
 
 import LocalDate from 'lib-common/local-date'
 
-import { Checkbox, Page, TextInput } from '../../utils/page'
+import {
+  Checkbox,
+  Page,
+  TextInput,
+  ElementCollection,
+  Element
+} from '../../utils/page'
 
 export default class PersonSearchPage {
-  constructor(private readonly page: Page) {}
+  searchInput: TextInput
+  searchResults: ElementCollection
+  #createPersonButton: Element
+  #addSsnButton: Element
+  #noSsnText: Element
+  #disableSsnAddingCheckbox: Checkbox
+  #ssnInput: TextInput
+  #modalConfirm: Element
+  constructor(private readonly page: Page) {
+    this.searchInput = new TextInput(page.findByDataQa('search-input'))
+    this.searchResults = page.findAllByDataQa('person-row')
+    this.#createPersonButton = page.findByDataQa('create-person-button')
+    this.#addSsnButton = page.findByDataQa('add-ssn-button')
+    this.#noSsnText = page.findByDataQa('no-ssn')
+    this.#disableSsnAddingCheckbox = new Checkbox(
+      page.findByDataQa('disable-ssn-adding')
+    )
+    this.#ssnInput = new TextInput(page.findByDataQa('ssn-input'))
+    this.#modalConfirm = page.findByDataQa('modal-okBtn')
+  }
 
-  searchInput = new TextInput(this.page.findByDataQa('search-input'))
-  searchResults = this.page.findAllByDataQa('person-row')
   #personLink = this.page.find('[data-qa="person-row"] a')
-  #createPersonButton = this.page.findByDataQa('create-person-button')
   #createPersonModal = {
     modal: this.page.findByDataQa('modal'),
     firstNameInput: new TextInput(this.page.findByDataQa('first-name-input')),
@@ -33,13 +55,6 @@ export default class PersonSearchPage {
     address: this.page.findByDataQa('person-address'),
     ssn: this.page.findByDataQa('person-ssn')
   }
-  #addSsnButton = this.page.findByDataQa('add-ssn-button')
-  #noSsnText = this.page.findByDataQa('no-ssn')
-  #disableSsnAddingCheckbox = new Checkbox(
-    this.page.findByDataQa('disable-ssn-adding')
-  )
-  #ssnInput = new TextInput(this.page.findByDataQa('ssn-input'))
-  #modalConfirm = this.page.findByDataQa('modal-okBtn')
 
   async createPerson(personData: {
     firstName: string

--- a/frontend/src/e2e-test/pages/employee/person-search.ts
+++ b/frontend/src/e2e-test/pages/employee/person-search.ts
@@ -9,43 +9,37 @@ import { Checkbox, Page, TextInput } from '../../utils/page'
 export default class PersonSearchPage {
   constructor(private readonly page: Page) {}
 
-  searchInput = new TextInput(this.page.find('[data-qa="search-input"]'))
+  searchInput = new TextInput(this.page.findByDataQa('search-input'))
   searchResults = this.page.findAllByDataQa('person-row')
   #personLink = this.page.find('[data-qa="person-row"] a')
-  #createPersonButton = this.page.find('[data-qa="create-person-button"]')
+  #createPersonButton = this.page.findByDataQa('create-person-button')
   #createPersonModal = {
     modal: this.page.findByDataQa('modal'),
-    firstNameInput: new TextInput(
-      this.page.find('[data-qa="first-name-input"]')
-    ),
-    lastNameInput: new TextInput(this.page.find('[data-qa="last-name-input"]')),
+    firstNameInput: new TextInput(this.page.findByDataQa('first-name-input')),
+    lastNameInput: new TextInput(this.page.findByDataQa('last-name-input')),
     dateOfBirthInput: new TextInput(
-      this.page.find('[data-qa="date-of-birth-input"]')
+      this.page.findByDataQa('date-of-birth-input')
     ),
     streetAddressInput: new TextInput(
-      this.page.find('[data-qa="street-address-input"]')
+      this.page.findByDataQa('street-address-input')
     ),
-    postalCodeInput: new TextInput(
-      this.page.find('[data-qa="postal-code-input"]')
-    ),
-    postOfficeInput: new TextInput(
-      this.page.find('[data-qa="post-office-input"]')
-    )
+    postalCodeInput: new TextInput(this.page.findByDataQa('postal-code-input')),
+    postOfficeInput: new TextInput(this.page.findByDataQa('post-office-input'))
   }
   #personData = {
-    firstName: this.page.find('[data-qa="person-first-names"]'),
-    lastName: this.page.find('[data-qa="person-last-name"]'),
-    dateOfBirth: this.page.find('[data-qa="person-birthday"]'),
-    address: this.page.find('[data-qa="person-address"]'),
-    ssn: this.page.find('[data-qa="person-ssn"]')
+    firstName: this.page.findByDataQa('person-first-names'),
+    lastName: this.page.findByDataQa('person-last-name'),
+    dateOfBirth: this.page.findByDataQa('person-birthday'),
+    address: this.page.findByDataQa('person-address'),
+    ssn: this.page.findByDataQa('person-ssn')
   }
-  #addSsnButton = this.page.find('[data-qa="add-ssn-button"]')
-  #noSsnText = this.page.find('[data-qa="no-ssn"]')
+  #addSsnButton = this.page.findByDataQa('add-ssn-button')
+  #noSsnText = this.page.findByDataQa('no-ssn')
   #disableSsnAddingCheckbox = new Checkbox(
-    this.page.find('[data-qa="disable-ssn-adding"]')
+    this.page.findByDataQa('disable-ssn-adding')
   )
-  #ssnInput = new TextInput(this.page.find('[data-qa="ssn-input"]'))
-  #modalConfirm = this.page.find('[data-qa="modal-okBtn"]')
+  #ssnInput = new TextInput(this.page.findByDataQa('ssn-input'))
+  #modalConfirm = this.page.findByDataQa('modal-okBtn')
 
   async createPerson(personData: {
     firstName: string

--- a/frontend/src/e2e-test/pages/employee/placement-draft-page.ts
+++ b/frontend/src/e2e-test/pages/employee/placement-draft-page.ts
@@ -4,25 +4,26 @@
 
 import { UUID } from 'lib-common/types'
 
-import { Combobox, DatePickerDeprecated, Page } from '../../utils/page'
+import { Combobox, DatePickerDeprecated, Page, Element } from '../../utils/page'
 
 export class PlacementDraftPage {
-  constructor(private page: Page) {}
-
-  #restrictedDetailsWarning = this.page.findByDataQa(
-    'restricted-details-warning'
-  )
-
-  readonly startDate = new DatePickerDeprecated(
-    this.page.findByDataQa('start-date')
-  )
+  #restrictedDetailsWarning: Element
+  startDate: DatePickerDeprecated
+  #addOtherUnitCombobox: Combobox
+  constructor(private page: Page) {
+    this.#restrictedDetailsWarning = page.findByDataQa(
+      'restricted-details-warning'
+    )
+    this.startDate = new DatePickerDeprecated(page.findByDataQa('start-date'))
+    this.#addOtherUnitCombobox = new Combobox(
+      page.findByDataQa('add-other-unit')
+    )
+  }
 
   #unitCard = (unitId: UUID) =>
     this.page
       .find('[data-qa="placement-list"]')
       .find(`[data-qa="placement-item-${unitId}"]`)
-
-  #addOtherUnitCombobox = new Combobox(this.page.findByDataQa('add-other-unit'))
 
   async waitUntilLoaded() {
     await this.page

--- a/frontend/src/e2e-test/pages/employee/placement-draft-page.ts
+++ b/frontend/src/e2e-test/pages/employee/placement-draft-page.ts
@@ -9,8 +9,8 @@ import { Combobox, DatePickerDeprecated, Page } from '../../utils/page'
 export class PlacementDraftPage {
   constructor(private page: Page) {}
 
-  #restrictedDetailsWarning = this.page.find(
-    '[data-qa="restricted-details-warning"]'
+  #restrictedDetailsWarning = this.page.findByDataQa(
+    'restricted-details-warning'
   )
 
   readonly startDate = new DatePickerDeprecated(
@@ -22,9 +22,7 @@ export class PlacementDraftPage {
       .find('[data-qa="placement-list"]')
       .find(`[data-qa="placement-item-${unitId}"]`)
 
-  #addOtherUnitCombobox = new Combobox(
-    this.page.find('[data-qa="add-other-unit"]')
-  )
+  #addOtherUnitCombobox = new Combobox(this.page.findByDataQa('add-other-unit'))
 
   async waitUntilLoaded() {
     await this.page
@@ -71,7 +69,7 @@ export class PlacementDraftPage {
   }
 
   async submit() {
-    await this.page.find('[data-qa="send-placement-button"]').click()
+    await this.page.findByDataQa('send-placement-button').click()
   }
 }
 

--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -23,47 +23,47 @@ export default class ReportsPage {
   constructor(private readonly page: Page) {}
 
   async openMissingHeadOfFamilyReport() {
-    await this.page.find('[data-qa="report-missing-head-of-family"]').click()
+    await this.page.findByDataQa('report-missing-head-of-family').click()
     return new MissingHeadOfFamilyReport(this.page)
   }
 
   async openApplicationsReport() {
-    await this.page.find('[data-qa="report-applications"]').click()
+    await this.page.findByDataQa('report-applications').click()
     return new ApplicationsReport(this.page)
   }
 
   async openNonSsnChildrenReport() {
-    await this.page.find('[data-qa="report-non-ssn-children"]').click()
+    await this.page.findByDataQa('report-non-ssn-children').click()
     return new NonSsnChildrenReport(this.page)
   }
 
   async openPlacementGuaranteeReport() {
-    await this.page.find('[data-qa="report-placement-guarantee"]').click()
+    await this.page.findByDataQa('report-placement-guarantee').click()
     return new PlacementGuaranteeReport(this.page)
   }
 
   async openPlacementSketchingReport() {
-    await this.page.find('[data-qa="report-placement-sketching"]').click()
+    await this.page.findByDataQa('report-placement-sketching').click()
     return new PlacementSketchingReport(this.page)
   }
 
   async openVoucherServiceProvidersReport() {
-    await this.page.find('[data-qa="report-voucher-service-providers"]').click()
+    await this.page.findByDataQa('report-voucher-service-providers').click()
     return new VoucherServiceProvidersReport(this.page)
   }
 
   async openManualDuplicationReport() {
-    await this.page.find('[data-qa="report-manual-duplication"]').click()
+    await this.page.findByDataQa('report-manual-duplication').click()
     return new ManualDuplicationReport(this.page)
   }
 
   async openPreschoolAbsenceReport() {
-    await this.page.find('[data-qa="report-preschool-absence"]').click()
+    await this.page.findByDataQa('report-preschool-absence').click()
     return new PreschoolAbsenceReport(this.page)
   }
 
   async openVardaErrorsReport() {
-    await this.page.find('[data-qa="report-varda-child-errors"]').click()
+    await this.page.findByDataQa('report-varda-child-errors').click()
     return new VardaErrorsReport(this.page)
   }
 }
@@ -98,7 +98,7 @@ export class MissingHeadOfFamilyReport {
 export class NonSsnChildrenReport {
   constructor(private page: Page) {}
 
-  #nameHeader = this.page.find(`[data-qa="child-name-header"]`)
+  #nameHeader = this.page.findByDataQa(`child-name-header`)
 
   async changeSortOrder() {
     await this.#nameHeader.click()
@@ -127,8 +127,8 @@ export class NonSsnChildrenReport {
 export class ApplicationsReport {
   constructor(private page: Page) {}
 
-  #table = this.page.find(`[data-qa="report-application-table"]`)
-  #areaSelector = new Combobox(this.page.find('[data-qa="select-area"]'))
+  #table = this.page.findByDataQa(`report-application-table`)
+  #areaSelector = new Combobox(this.page.findByDataQa('select-area'))
 
   private async areaWithNameExists(area: string, exists = true) {
     await this.#table.waitUntilVisible()
@@ -169,10 +169,10 @@ export class ApplicationsReport {
 
   async selectDateRangePickerDates(from: LocalDate, to: LocalDate) {
     const fromInput = new DatePickerDeprecated(
-      this.page.find('[data-qa="datepicker-from"]')
+      this.page.findByDataQa('datepicker-from')
     )
     const toInput = new DatePickerDeprecated(
-      this.page.find('[data-qa="datepicker-to"]')
+      this.page.findByDataQa('datepicker-to')
     )
     await fromInput.fill(from.format())
     await toInput.fill(to.format())
@@ -220,7 +220,7 @@ export class PlacementSketchingReport {
   constructor(private page: Page) {}
 
   #applicationStatus = new MultiSelect(
-    this.page.find('[data-qa="select-application-status"]')
+    this.page.findByDataQa('select-application-status')
   )
 
   async assertRow(
@@ -229,7 +229,7 @@ export class PlacementSketchingReport {
     childName: string,
     currentUnitName: string | null = null
   ) {
-    const element = this.page.find(`[data-qa="${applicationId}"]`)
+    const element = this.page.findByDataQa(`${applicationId}`)
     await element.waitUntilVisible()
 
     await element
@@ -244,7 +244,7 @@ export class PlacementSketchingReport {
   }
 
   async assertNotRow(applicationId: string) {
-    const element = this.page.find(`[data-qa="${applicationId}"]`)
+    const element = this.page.findByDataQa(`${applicationId}`)
     await element.waitUntilHidden()
   }
 
@@ -258,9 +258,9 @@ export class PlacementSketchingReport {
 export class VoucherServiceProvidersReport {
   constructor(private page: Page) {}
 
-  #month = new Select(this.page.find('[data-qa="select-month"]'))
-  #year = new Select(this.page.find('[data-qa="select-year"]'))
-  #area = new Select(this.page.find('[data-qa="select-area"]'))
+  #month = new Select(this.page.findByDataQa('select-month'))
+  #year = new Select(this.page.findByDataQa('select-year'))
+  #area = new Select(this.page.findByDataQa('select-area'))
 
   #downloadCsvLink = this.page.find('[data-qa="download-csv"] a')
 
@@ -288,7 +288,7 @@ export class VoucherServiceProvidersReport {
     expectedChildCount: string,
     expectedMonthlySum: string
   ) {
-    const row = this.page.find(`[data-qa="${unitId}"]`)
+    const row = this.page.findByDataQa(`${unitId}`)
     await row.waitUntilVisible()
     expect(await row.find(`[data-qa="child-count"]`).text).toStrictEqual(
       expectedChildCount
@@ -380,11 +380,11 @@ export class ManualDuplicationReport {
 export class VardaErrorsReport {
   constructor(private page: Page) {}
 
-  #errorsTable = this.page.find('[data-qa="varda-errors-table"]')
+  #errorsTable = this.page.findByDataQa('varda-errors-table')
   #errorRows = this.page.findAll('[data-qa="varda-error-row"]')
-  #errors = (childId: string) => this.page.find(`[data-qa="errors-${childId}"]`)
+  #errors = (childId: string) => this.page.findByDataQa(`errors-${childId}`)
   #resetChild = (childId: string) =>
-    this.page.find(`[data-qa="reset-button-${childId}"]`)
+    this.page.findByDataQa(`reset-button-${childId}`)
 
   async assertErrorsContains(childId: string, expected: string) {
     await waitUntilTrue(async () =>

--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -16,7 +16,9 @@ import {
   Page,
   Select,
   StaticChip,
-  TextInput
+  TextInput,
+  Element,
+  ElementCollection
 } from '../../utils/page'
 
 export default class ReportsPage {
@@ -96,9 +98,10 @@ export class MissingHeadOfFamilyReport {
 }
 
 export class NonSsnChildrenReport {
-  constructor(private page: Page) {}
-
-  #nameHeader = this.page.findByDataQa(`child-name-header`)
+  #nameHeader: Element
+  constructor(private page: Page) {
+    this.#nameHeader = page.findByDataQa(`child-name-header`)
+  }
 
   async changeSortOrder() {
     await this.#nameHeader.click()
@@ -125,10 +128,12 @@ export class NonSsnChildrenReport {
 }
 
 export class ApplicationsReport {
-  constructor(private page: Page) {}
-
-  #table = this.page.findByDataQa(`report-application-table`)
-  #areaSelector = new Combobox(this.page.findByDataQa('select-area'))
+  #table: Element
+  #areaSelector: Combobox
+  constructor(private page: Page) {
+    this.#table = page.findByDataQa(`report-application-table`)
+    this.#areaSelector = new Combobox(page.findByDataQa('select-area'))
+  }
 
   private async areaWithNameExists(area: string, exists = true) {
     await this.#table.waitUntilVisible()
@@ -217,11 +222,12 @@ export class PlacementGuaranteeReport {
 }
 
 export class PlacementSketchingReport {
-  constructor(private page: Page) {}
-
-  #applicationStatus = new MultiSelect(
-    this.page.findByDataQa('select-application-status')
-  )
+  #applicationStatus: MultiSelect
+  constructor(private page: Page) {
+    this.#applicationStatus = new MultiSelect(
+      page.findByDataQa('select-application-status')
+    )
+  }
 
   async assertRow(
     applicationId: string,
@@ -256,11 +262,14 @@ export class PlacementSketchingReport {
 }
 
 export class VoucherServiceProvidersReport {
-  constructor(private page: Page) {}
-
-  #month = new Select(this.page.findByDataQa('select-month'))
-  #year = new Select(this.page.findByDataQa('select-year'))
-  #area = new Select(this.page.findByDataQa('select-area'))
+  #month: Select
+  #year: Select
+  #area: Select
+  constructor(private page: Page) {
+    this.#month = new Select(page.findByDataQa('select-month'))
+    this.#year = new Select(page.findByDataQa('select-year'))
+    this.#area = new Select(page.findByDataQa('select-area'))
+  }
 
   #downloadCsvLink = this.page.find('[data-qa="download-csv"] a')
 
@@ -312,9 +321,10 @@ export class VoucherServiceProvidersReport {
 }
 
 export class ServiceVoucherUnitReport {
-  constructor(private page: Page) {}
-
-  #childRows = this.page.findAllByDataQa('child-row')
+  #childRows: ElementCollection
+  constructor(private page: Page) {
+    this.#childRows = page.findAllByDataQa('child-row')
+  }
 
   async assertChildRowCount(expected: number) {
     await waitUntilEqual(() => this.#childRows.count(), expected)
@@ -378,9 +388,11 @@ export class ManualDuplicationReport {
 }
 
 export class VardaErrorsReport {
-  constructor(private page: Page) {}
+  #errorsTable: Element
+  constructor(private page: Page) {
+    this.#errorsTable = page.findByDataQa('varda-errors-table')
+  }
 
-  #errorsTable = this.page.findByDataQa('varda-errors-table')
   #errorRows = this.page.findAll('[data-qa="varda-error-row"]')
   #errors = (childId: string) => this.page.findByDataQa(`errors-${childId}`)
   #resetChild = (childId: string) =>
@@ -403,9 +415,10 @@ export class VardaErrorsReport {
 }
 
 export class AssistanceNeedDecisionsReport {
-  constructor(private page: Page) {}
-
-  rows = this.page.findAllByDataQa('assistance-need-decision-row')
+  rows: ElementCollection
+  constructor(private page: Page) {
+    this.rows = page.findAllByDataQa('assistance-need-decision-row')
+  }
 
   async row(nth: number) {
     const row = this.rows.nth(nth)
@@ -427,26 +440,36 @@ export class AssistanceNeedDecisionsReport {
 }
 
 export class AssistanceNeedDecisionsReportDecision {
-  constructor(private page: Page) {}
-
-  decisionMaker = this.page.findByDataQa('labelled-value-decision-maker')
-  decisionStatus = new StaticChip(this.page.findByDataQa('decision-status'))
-  annulmentReason = this.page.findByDataQa('labelled-value-annulment-reason')
-  returnForEditBtn = this.page.findByDataQa('return-for-edit')
+  decisionMaker: Element
+  decisionStatus: StaticChip
+  annulmentReason: Element
+  returnForEditBtn: Element
+  approveBtn: Element
+  rejectBtn: Element
+  annulBtn: Element
+  annulReasonInput: TextInput
+  modalOkBtn: Element
+  mismatchModalLink: Element
+  constructor(private page: Page) {
+    this.decisionMaker = page.findByDataQa('labelled-value-decision-maker')
+    this.decisionStatus = new StaticChip(page.findByDataQa('decision-status'))
+    this.annulmentReason = page.findByDataQa('labelled-value-annulment-reason')
+    this.returnForEditBtn = page.findByDataQa('return-for-edit')
+    this.approveBtn = page.findByDataQa('approve-button')
+    this.rejectBtn = page.findByDataQa('reject-button')
+    this.annulBtn = page.findByDataQa('annul-button')
+    this.annulReasonInput = new TextInput(
+      page.findByDataQa('annul-reason-input')
+    )
+    this.modalOkBtn = page.findByDataQa('modal-okBtn')
+    this.mismatchModalLink = page.findByDataQa('mismatch-modal-link')
+  }
 
   get returnForEditModal() {
     return {
       okBtn: this.page.findByDataQa('modal-okBtn')
     }
   }
-
-  approveBtn = this.page.findByDataQa('approve-button')
-  rejectBtn = this.page.findByDataQa('reject-button')
-  annulBtn = this.page.findByDataQa('annul-button')
-  annulReasonInput = new TextInput(this.page.findByDataQa('annul-reason-input'))
-  modalOkBtn = this.page.findByDataQa('modal-okBtn')
-
-  mismatchModalLink = this.page.findByDataQa('mismatch-modal-link')
 
   get mismatchModal() {
     return {
@@ -457,28 +480,39 @@ export class AssistanceNeedDecisionsReportDecision {
 }
 
 export class AssistanceNeedPreschoolDecisionsReportDecision {
-  constructor(private page: Page) {}
-
-  returnForEditBtn = this.page.findByDataQa('return-for-edit-button')
-  approveBtn = this.page.findByDataQa('approve-button')
-  rejectBtn = this.page.findByDataQa('reject-button')
-  annulBtn = this.page.findByDataQa('annul-button')
-  annulReasonInput = new TextInput(this.page.findByDataQa('annul-reason-input'))
-  modalOkBtn = this.page.findByDataQa('modal-okBtn')
-
-  status = this.page.findByDataQa('status')
-  annulmentReason = this.page.findByDataQa('annulment-reason')
+  returnForEditBtn: Element
+  approveBtn: Element
+  rejectBtn: Element
+  annulBtn: Element
+  annulReasonInput: TextInput
+  modalOkBtn: Element
+  status: Element
+  annulmentReason: Element
+  constructor(private page: Page) {
+    this.returnForEditBtn = page.findByDataQa('return-for-edit-button')
+    this.approveBtn = page.findByDataQa('approve-button')
+    this.rejectBtn = page.findByDataQa('reject-button')
+    this.annulBtn = page.findByDataQa('annul-button')
+    this.annulReasonInput = new TextInput(
+      page.findByDataQa('annul-reason-input')
+    )
+    this.modalOkBtn = page.findByDataQa('modal-okBtn')
+    this.status = page.findByDataQa('status')
+    this.annulmentReason = page.findByDataQa('annulment-reason')
+  }
 }
 
 export class AssistanceNeedsAndActionsReport {
-  constructor(private page: Page) {}
-  needsAndActionsRows = this.page.findAllByDataQa(
-    'assistance-needs-and-actions-row'
-  )
-
-  childRows = this.page.findAllByDataQa('child-row')
-
-  careAreaSelect = new Combobox(this.page.findByDataQa('care-area-filter'))
+  needsAndActionsRows: ElementCollection
+  childRows: ElementCollection
+  careAreaSelect: Combobox
+  constructor(private page: Page) {
+    this.needsAndActionsRows = page.findAllByDataQa(
+      'assistance-needs-and-actions-row'
+    )
+    this.childRows = page.findAllByDataQa('child-row')
+    this.careAreaSelect = new Combobox(page.findByDataQa('care-area-filter'))
+  }
 
   async selectCareAreaFilter(area: string) {
     await this.careAreaSelect.fillAndSelectFirst(area)

--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -416,7 +416,7 @@ export class VardaErrorsReport {
 
 export class AssistanceNeedDecisionsReport {
   rows: ElementCollection
-  constructor(private page: Page) {
+  constructor(page: Page) {
     this.rows = page.findAllByDataQa('assistance-need-decision-row')
   }
 
@@ -488,7 +488,7 @@ export class AssistanceNeedPreschoolDecisionsReportDecision {
   modalOkBtn: Element
   status: Element
   annulmentReason: Element
-  constructor(private page: Page) {
+  constructor(page: Page) {
     this.returnForEditBtn = page.findByDataQa('return-for-edit-button')
     this.approveBtn = page.findByDataQa('approve-button')
     this.rejectBtn = page.findByDataQa('reject-button')

--- a/frontend/src/e2e-test/pages/employee/units/unit-calendar-page-base.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-calendar-page-base.ts
@@ -6,24 +6,28 @@ import FiniteDateRange from 'lib-common/finite-date-range'
 import LocalDate from 'lib-common/local-date'
 
 import { waitUntilEqual } from '../../../utils'
-import { Page } from '../../../utils/page'
+import { Page, Element } from '../../../utils/page'
 
 import { UnitCalendarEventsSection } from './unit'
 
 /** Common elements and actions for both month and week calendar pages */
 export class UnitCalendarPageBase {
-  constructor(protected readonly page: Page) {}
+  monthModeButton: Element
+  weekModeButton: Element
+  nextWeekButton: Element
+  previousWeekButton: Element
+  constructor(protected readonly page: Page) {
+    this.monthModeButton = page.findByDataQa('choose-calendar-mode-month')
+    this.weekModeButton = page.findByDataQa('choose-calendar-mode-week')
+    this.nextWeekButton = page.findByDataQa('next-week')
+    this.previousWeekButton = page.findByDataQa('previous-week')
+  }
 
   async waitUntilLoaded() {
     await this.page
       .find('[data-qa="unit-attendances"][data-isloading="false"]')
       .waitUntilVisible()
   }
-
-  monthModeButton = this.page.findByDataQa('choose-calendar-mode-month')
-  weekModeButton = this.page.findByDataQa('choose-calendar-mode-week')
-  nextWeekButton = this.page.findByDataQa('next-week')
-  previousWeekButton = this.page.findByDataQa('previous-week')
 
   calendarEventsSection = new UnitCalendarEventsSection(this.page)
 

--- a/frontend/src/e2e-test/pages/employee/units/unit-discussion-survey-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-discussion-survey-page.ts
@@ -25,16 +25,20 @@ export interface TestEventTime {
 }
 
 export class DiscussionSurveyListPage {
-  constructor(protected readonly page: Page) {}
+  createSurveyButton: Element
+  surveyList: Element
+  constructor(protected readonly page: Page) {
+    this.createSurveyButton = page.findByDataQa(
+      'create-discussion-survey-button'
+    )
+    this.surveyList = page.findByDataQa('discussion-survey-list')
+  }
 
   async waitUntilLoaded() {
     await this.page
       .find('[data-qa="discussion-survey-ist"][data-isloading="false"]')
       .waitUntilVisible()
   }
-
-  createSurveyButton = this.page.findByDataQa('create-discussion-survey-button')
-  surveyList = this.page.findByDataQa('discussion-survey-list')
 
   async openDiscussionSurvey(surveyId: string) {
     const surveyItem = this.surveyList.findByDataQa(`survey-${surveyId}`)
@@ -63,17 +67,22 @@ export class DiscussionSurveyListPage {
 }
 
 export class CreateDiscussionSurveyEditor {
-  constructor(protected readonly page: Page) {}
-
-  submitSurveyButton = this.page.findByDataQa('survey-editor-submit-button')
-  titleInput = new TextInput(this.page.findByDataQa('survey-title-input'))
-  descriptionInput = new TextInput(
-    this.page.findByDataQa('survey-description-input')
-  )
-  attendeeSelect = new TreeDropdown(
-    this.page.findByDataQa('survey-attendees-select')
-  )
-  newTimesCalendar = this.page.findByDataQa('survey-times-calendar')
+  submitSurveyButton: Element
+  titleInput: TextInput
+  descriptionInput: TextInput
+  attendeeSelect: TreeDropdown
+  newTimesCalendar: Element
+  constructor(protected readonly page: Page) {
+    this.submitSurveyButton = page.findByDataQa('survey-editor-submit-button')
+    this.titleInput = new TextInput(page.findByDataQa('survey-title-input'))
+    this.descriptionInput = new TextInput(
+      page.findByDataQa('survey-description-input')
+    )
+    this.attendeeSelect = new TreeDropdown(
+      page.findByDataQa('survey-attendees-select')
+    )
+    this.newTimesCalendar = page.findByDataQa('survey-times-calendar')
+  }
 
   async waitUntilLoaded() {
     await this.submitSurveyButton.waitUntilVisible()
@@ -100,17 +109,20 @@ export class CreateDiscussionSurveyEditor {
 }
 
 export class DiscussionSurveyReadView {
-  constructor(protected readonly page: Page) {}
+  editSurveyButton: Element
+  deleteSurveyButton: Element
+  surveyTimesCalendar: Element
+  constructor(protected readonly page: Page) {
+    this.editSurveyButton = page.findByDataQa('survey-edit-button')
+    this.deleteSurveyButton = page.findByDataQa('survey-delete-button')
+    this.surveyTimesCalendar = page.findByDataQa('reservation-calendar')
+  }
 
   async waitUntilLoaded() {
     await this.page
       .findByDataQa('survey-reservation-calendar-title')
       .waitUntilVisible()
   }
-
-  editSurveyButton = this.page.findByDataQa('survey-edit-button')
-  deleteSurveyButton = this.page.findByDataQa('survey-delete-button')
-  surveyTimesCalendar = this.page.findByDataQa('reservation-calendar')
 
   async addEventTimeForDay(date: LocalDate, eventTime: TestEventTime) {
     const calendarDay = this.surveyTimesCalendar.findByDataQa(
@@ -211,16 +223,20 @@ export class DiscussionSurveyReadView {
 }
 
 export class DiscussionSurveyEditor {
-  constructor(protected readonly page: Page) {}
-
-  titleInput = new TextInput(this.page.findByDataQa('survey-title-input'))
-  descriptionInput = new TextInput(
-    this.page.findByDataQa('survey-description-input')
-  )
-  attendeeInput = new TreeDropdown(
-    this.page.findByDataQa('survey-attendees-select')
-  )
-  submitButton = this.page.findByDataQa('survey-editor-submit-button')
+  titleInput: TextInput
+  descriptionInput: TextInput
+  attendeeInput: TreeDropdown
+  submitButton: Element
+  constructor(protected readonly page: Page) {
+    this.titleInput = new TextInput(page.findByDataQa('survey-title-input'))
+    this.descriptionInput = new TextInput(
+      page.findByDataQa('survey-description-input')
+    )
+    this.attendeeInput = new TreeDropdown(
+      page.findByDataQa('survey-attendees-select')
+    )
+    this.submitButton = page.findByDataQa('survey-editor-submit-button')
+  }
 
   async waitUntilLoaded() {
     await this.submitButton.waitUntilVisible()

--- a/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
@@ -15,7 +15,12 @@ import {
 import { UnitMonthCalendarPage } from './unit-month-calendar-page'
 
 export class UnitGroupsPage {
-  constructor(private readonly page: Page) {}
+  childCapacityFactorColumnHeading: Element
+  constructor(private readonly page: Page) {
+    this.childCapacityFactorColumnHeading = page.findByDataQa(
+      `child-capacity-factor-heading`
+    )
+  }
 
   async waitUntilLoaded() {
     await this.page
@@ -58,10 +63,6 @@ export class UnitGroupsPage {
       .find(`[data-qa="child-capacity-factor-${childId}"]`)
       .assertTextEquals(factor)
   }
-
-  readonly childCapacityFactorColumnHeading = this.page.findByDataQa(
-    `child-capacity-factor-heading`
-  )
 
   readonly childCapacityFactorColumnData = this.page.findAll(
     `[data-qa="child-capacity-factor-column"]`

--- a/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
@@ -27,7 +27,7 @@ export class UnitGroupsPage {
     `[data-qa^="daycare-group-collapsible-"]`
   )
   #groupCollapsible = (groupId: string) =>
-    this.page.find(`[data-qa="daycare-group-collapsible-${groupId}"]`)
+    this.page.findByDataQa(`daycare-group-collapsible-${groupId}`)
 
   async selectPeriod(period: '1 day' | '3 months' | '6 months' | '1 year') {
     await this.page
@@ -37,20 +37,20 @@ export class UnitGroupsPage {
   }
 
   async setFilterStartDate(date: string) {
-    await new DatePicker(
-      this.page.find('[data-qa="unit-filter-start-date"]')
-    ).fill(date)
+    await new DatePicker(this.page.findByDataQa('unit-filter-start-date')).fill(
+      date
+    )
     await this.waitUntilLoaded()
   }
 
   terminatedPlacementsSection = new TerminatedPlacementsSection(
     this.page,
-    this.page.find('[data-qa="terminated-placements-section"]')
+    this.page.findByDataQa('terminated-placements-section')
   )
 
   missingPlacementsSection = new MissingPlacementsSection(
     this.page,
-    this.page.find('[data-qa="missing-placements-section"]')
+    this.page.findByDataQa('missing-placements-section')
   )
 
   async assertChildCapacityFactor(childId: string, factor: string) {
@@ -59,8 +59,8 @@ export class UnitGroupsPage {
       .assertTextEquals(factor)
   }
 
-  readonly childCapacityFactorColumnHeading = this.page.find(
-    `[data-qa="child-capacity-factor-heading"]`
+  readonly childCapacityFactorColumnHeading = this.page.findByDataQa(
+    `child-capacity-factor-heading`
   )
 
   readonly childCapacityFactorColumnData = this.page.findAll(
@@ -87,7 +87,7 @@ export class UnitGroupsPage {
   }
 
   async waitUntilVisible() {
-    await this.page.find('[data-qa="groups-title-bar"]').waitUntilVisible()
+    await this.page.findByDataQa('groups-title-bar').waitUntilVisible()
   }
 
   async assertChildOccupancyFactorColumnNotVisible() {
@@ -198,7 +198,7 @@ export class MissingPlacementRow extends Element {
   async addToGroup() {
     await this.#addToGroup.click()
     return new CreateGroupPlacementModal(
-      this.page.find('[data-qa="group-placement-modal"]')
+      this.page.findByDataQa('group-placement-modal')
     )
   }
 }

--- a/frontend/src/e2e-test/pages/employee/units/unit-month-calendar-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-month-calendar-page.ts
@@ -16,22 +16,36 @@ import {
   Modal,
   Radio,
   Select,
-  TextInput
+  TextInput,
+  Page
 } from '../../../utils/page'
 
 import { UnitCalendarPageBase } from './unit-calendar-page-base'
 import { UnitWeekCalendarPage } from './unit-week-calendar-page'
 
 export class UnitMonthCalendarPage extends UnitCalendarPageBase {
+  #unitName: Element
+  #groupSelector: Select
+  previousWeekButton: Element
+  nextWeekButton: Element
+  #addAbsencesButton: Element
+
+  constructor(page: Page) {
+    super(page)
+    this.#unitName = page.findByDataQa('attendances-unit-name')
+    this.#groupSelector = new Select(
+      page.findByDataQa('attendances-group-select')
+    )
+    this.previousWeekButton = page.findByDataQa('previous-week')
+    this.nextWeekButton = page.findByDataQa('next-week')
+    this.#addAbsencesButton = page.findByDataQa('add-absences-button')
+  }
+
   async openWeekCalendar(): Promise<UnitWeekCalendarPage> {
     await this.weekModeButton.click()
     return new UnitWeekCalendarPage(this.page)
   }
 
-  #unitName = this.page.findByDataQa('attendances-unit-name')
-  #groupSelector = new Select(
-    this.page.findByDataQa('attendances-group-select')
-  )
   childRow = (childId: UUID) =>
     this.page.findByDataQa(`absence-child-row-${childId}`)
 
@@ -40,11 +54,7 @@ export class UnitMonthCalendarPage extends UnitCalendarPageBase {
       this.childRow(childId).findByDataQa(`absence-cell-${date.formatIso()}`)
     )
 
-  previousWeekButton = this.page.findByDataQa('previous-week')
-  nextWeekButton = this.page.findByDataQa('next-week')
-
   #staffAttendanceCells = this.page.findAll('[data-qa="staff-attendance-cell"]')
-  #addAbsencesButton = this.page.findByDataQa('add-absences-button')
 
   async assertUnitName(expectedName: string) {
     await this.#unitName.assertTextEquals(expectedName)

--- a/frontend/src/e2e-test/pages/employee/units/unit-month-calendar-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-month-calendar-page.ts
@@ -28,9 +28,9 @@ export class UnitMonthCalendarPage extends UnitCalendarPageBase {
     return new UnitWeekCalendarPage(this.page)
   }
 
-  #unitName = this.page.find('[data-qa="attendances-unit-name"]')
+  #unitName = this.page.findByDataQa('attendances-unit-name')
   #groupSelector = new Select(
-    this.page.find('[data-qa="attendances-group-select"]')
+    this.page.findByDataQa('attendances-group-select')
   )
   childRow = (childId: UUID) =>
     this.page.findByDataQa(`absence-child-row-${childId}`)
@@ -44,7 +44,7 @@ export class UnitMonthCalendarPage extends UnitCalendarPageBase {
   nextWeekButton = this.page.findByDataQa('next-week')
 
   #staffAttendanceCells = this.page.findAll('[data-qa="staff-attendance-cell"]')
-  #addAbsencesButton = this.page.find('[data-qa="add-absences-button"]')
+  #addAbsencesButton = this.page.findByDataQa('add-absences-button')
 
   async assertUnitName(expectedName: string) {
     await this.#unitName.assertTextEquals(expectedName)
@@ -63,7 +63,7 @@ export class UnitMonthCalendarPage extends UnitCalendarPageBase {
     await this.absenceCell(childId, date).select()
     await this.#addAbsencesButton.click()
 
-    const modal = new AbsenceModal(this.page.find('[data-qa="absence-modal"]'))
+    const modal = new AbsenceModal(this.page.findByDataQa('absence-modal'))
     await modal.selectAbsenceType(type)
     for (const category of categories) {
       await modal.selectAbsenceCategory(category)

--- a/frontend/src/e2e-test/pages/employee/units/unit-week-calendar-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-week-calendar-page.ts
@@ -22,14 +22,20 @@ import { UnitCalendarPageBase } from './unit-calendar-page-base'
 import { UnitMonthCalendarPage } from './unit-month-calendar-page'
 
 export class UnitWeekCalendarPage extends UnitCalendarPageBase {
+  occupancies: UnitOccupanciesSection
+
+  constructor(page: Page) {
+    super(page)
+    this.occupancies = new UnitOccupanciesSection(
+      page.findByDataQa('occupancies')
+    )
+  }
+
   async openMonthCalendar(): Promise<UnitMonthCalendarPage> {
     await this.monthModeButton.click()
     return new UnitMonthCalendarPage(this.page)
   }
 
-  occupancies = new UnitOccupanciesSection(
-    this.page.findByDataQa('occupancies')
-  )
   staffAttendances = new UnitStaffAttendancesTable(
     this.page,
     this.page.findByDataQa('staff-attendances-table')

--- a/frontend/src/e2e-test/pages/employee/units/unit-week-calendar-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-week-calendar-page.ts
@@ -28,7 +28,7 @@ export class UnitWeekCalendarPage extends UnitCalendarPageBase {
   }
 
   occupancies = new UnitOccupanciesSection(
-    this.page.find('[data-qa="occupancies"]')
+    this.page.findByDataQa('occupancies')
   )
   staffAttendances = new UnitStaffAttendancesTable(
     this.page,
@@ -40,9 +40,9 @@ export class UnitWeekCalendarPage extends UnitCalendarPageBase {
   )
 
   async setFilterStartDate(date: LocalDate) {
-    await new DatePicker(
-      this.page.find('[data-qa="unit-filter-start-date"]')
-    ).fill(date.format())
+    await new DatePicker(this.page.findByDataQa('unit-filter-start-date')).fill(
+      date.format()
+    )
     await this.waitUntilLoaded()
   }
 

--- a/frontend/src/e2e-test/pages/employee/units/unit.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit.ts
@@ -46,10 +46,10 @@ export type MealTimes = {
 export class UnitPage {
   constructor(private readonly page: Page) {}
 
-  #unitInfoTab = this.page.find('[data-qa="unit-info-tab"]')
-  #groupsTab = this.page.find('[data-qa="groups-tab"]')
-  #calendarTab = this.page.find('[data-qa="calendar-tab"]')
-  #applicationProcessTab = this.page.find('[data-qa="application-process-tab"]')
+  #unitInfoTab = this.page.findByDataQa('unit-info-tab')
+  #groupsTab = this.page.findByDataQa('groups-tab')
+  #calendarTab = this.page.findByDataQa('calendar-tab')
+  #applicationProcessTab = this.page.findByDataQa('application-process-tab')
 
   static async openUnit(page: Page, id: string): Promise<UnitPage> {
     await page.goto(`${config.employeeUrl}/units/${id}`)
@@ -114,8 +114,8 @@ export class UnitCalendarPage extends UnitCalendarPageBase {
 export class UnitInfoPage {
   constructor(private readonly page: Page) {}
 
-  #unitName = this.page.find('[data-qa="unit-name"]')
-  #visitingAddress = this.page.find('[data-qa="unit-visiting-address"]')
+  #unitName = this.page.findByDataQa('unit-name')
+  #visitingAddress = this.page.findByDataQa('unit-visiting-address')
 
   async waitUntilLoaded() {
     await this.page
@@ -133,26 +133,26 @@ export class UnitInfoPage {
 
   supervisorAcl = new AclSection(
     this.page,
-    this.page.find('[data-qa="daycare-acl-supervisors"]')
+    this.page.findByDataQa('daycare-acl-supervisors')
   )
   specialEducationTeacherAcl = new AclSection(
     this.page,
-    this.page.find('[data-qa="daycare-acl-set"]')
+    this.page.findByDataQa('daycare-acl-set')
   )
   earlyChildhoodEducationSecretary = new AclSection(
     this.page,
-    this.page.find('[data-qa="daycare-acl-eces"]')
+    this.page.findByDataQa('daycare-acl-eces')
   )
   staffAcl = new AclSection(
     this.page,
-    this.page.find('[data-qa="daycare-acl-staff"]')
+    this.page.findByDataQa('daycare-acl-staff')
   )
   mobileAcl = new MobileDevicesSection(
     this.page,
-    this.page.find('[data-qa="daycare-mobile-devices"]')
+    this.page.findByDataQa('daycare-mobile-devices')
   )
 
-  #unitDetailsLink = this.page.find('[data-qa="unit-details-link"]')
+  #unitDetailsLink = this.page.findByDataQa('unit-details-link')
 
   async openUnitDetails(): Promise<UnitDetailsPage> {
     await this.#unitDetailsLink.click()
@@ -165,7 +165,7 @@ export class UnitInfoPage {
 export class UnitDetailsPage {
   constructor(private readonly page: Page) {}
 
-  readonly #editUnitButton = this.page.find('[data-qa="enable-edit-button"]')
+  readonly #editUnitButton = this.page.findByDataQa('enable-edit-button')
   readonly #unitName = this.page
     .find('[data-qa="unit-editor-container"]')
     .find('h1')
@@ -184,9 +184,9 @@ export class UnitDetailsPage {
       .assertTextEquals(expectedTime)
   }
 
-  readonly #unitManagerName = this.page.find('[data-qa="unit-manager-name"]')
-  readonly #unitManagerPhone = this.page.find('[data-qa="unit-manager-phone"]')
-  readonly #unitManagerEmail = this.page.find('[data-qa="unit-manager-email"]')
+  readonly #unitManagerName = this.page.findByDataQa('unit-manager-name')
+  readonly #unitManagerPhone = this.page.findByDataQa('unit-manager-phone')
+  readonly #unitManagerEmail = this.page.findByDataQa('unit-manager-email')
 
   async assertManagerData(name: string, phone: string, email: string) {
     await this.#unitManagerName.assertTextEquals(name)
@@ -218,33 +218,31 @@ export class UnitEditor {
   constructor(private readonly page: Page) {}
 
   readonly #unitNameInput = new TextInput(
-    this.page.find('[data-qa="unit-name-input"]')
+    this.page.findByDataQa('unit-name-input')
   )
-  readonly #areaSelect = new Combobox(this.page.find('[data-qa="area-select"]'))
+  readonly #areaSelect = new Combobox(this.page.findByDataQa('area-select'))
 
   readonly providesShiftCare: Checkbox = new Checkbox(
     this.page.findByDataQa('provides-shift-care')
   )
 
   #timeInput(dayNumber: number, startEnd: 'start' | 'end') {
-    return new TextInput(this.page.find(`[data-qa="${dayNumber}-${startEnd}"]`))
+    return new TextInput(this.page.findByDataQa(`${dayNumber}-${startEnd}`))
   }
 
   #shiftCareTimeInput(dayNumber: number, startEnd: 'start' | 'end') {
     return new TextInput(
-      this.page.find(`[data-qa="shift-care-${dayNumber}-${startEnd}"]`)
+      this.page.findByDataQa(`shift-care-${dayNumber}-${startEnd}`)
     )
   }
 
   #timeCheckBox(dayNumber: number) {
-    return new Checkbox(
-      this.page.find(`[data-qa="operation-day-${dayNumber}"]`)
-    )
+    return new Checkbox(this.page.findByDataQa(`operation-day-${dayNumber}`))
   }
 
   #shiftCareTimeCheckBox(dayNumber: number) {
     return new Checkbox(
-      this.page.find(`[data-qa="shift-care-operation-day-${dayNumber}"]`)
+      this.page.findByDataQa(`shift-care-operation-day-${dayNumber}`)
     )
   }
 
@@ -284,43 +282,37 @@ export class UnitEditor {
   }
 
   #careTypeCheckbox(type: CareType) {
-    return new Checkbox(
-      this.page.find(`[data-qa="care-type-checkbox-${type}"]`)
-    )
+    return new Checkbox(this.page.findByDataQa(`care-type-checkbox-${type}`))
   }
 
   #applicationTypeCheckbox(type: ApplicationType) {
     return new Checkbox(
-      this.page.find(`[data-qa="application-type-checkbox-${type}"]`)
+      this.page.findByDataQa(`application-type-checkbox-${type}`)
     )
   }
 
   #streetInput(type: 'visiting-address' | 'mailing-address') {
-    return new TextInput(this.page.find(`[data-qa="${type}-street-input"]`))
+    return new TextInput(this.page.findByDataQa(`${type}-street-input`))
   }
 
   #postalCodeInput(type: 'visiting-address' | 'mailing-address') {
-    return new TextInput(
-      this.page.find(`[data-qa="${type}-postal-code-input"]`)
-    )
+    return new TextInput(this.page.findByDataQa(`${type}-postal-code-input`))
   }
 
   #postOfficeInput(type: 'visiting-address' | 'mailing-address') {
-    return new TextInput(
-      this.page.find(`[data-qa="${type}-post-office-input"]`)
-    )
+    return new TextInput(this.page.findByDataQa(`${type}-post-office-input`))
   }
 
   readonly #managerNameInput = new TextInput(
-    this.page.find('[data-qa="manager-name-input"]')
+    this.page.findByDataQa('manager-name-input')
   )
 
   readonly #managerPhoneInputField = new TextInput(
-    this.page.find('[data-qa="qa-unit-manager-phone-input-field"]')
+    this.page.findByDataQa('qa-unit-manager-phone-input-field')
   )
 
   readonly #managerEmailInputField = new TextInput(
-    this.page.find('[data-qa="qa-unit-manager-email-input-field"]')
+    this.page.findByDataQa('qa-unit-manager-email-input-field')
   )
 
   readonly #closingDateInput = this.page.find(
@@ -334,28 +326,28 @@ export class UnitEditor {
   )
 
   readonly #providerTypeRadio = (providerType: UnitProviderType) =>
-    this.page.find(`[data-qa="provider-type-${providerType}"]`)
+    this.page.findByDataQa(`provider-type-${providerType}`)
 
   readonly #unitHandlerAddressInput = new TextInput(
     this.page.find('#unit-handler-address')
   )
 
-  readonly #checkInvoicedByMunicipality = this.page.find(
-    '[data-qa="check-invoice-by-municipality"]'
+  readonly #checkInvoicedByMunicipality = this.page.findByDataQa(
+    'check-invoice-by-municipality'
   )
   readonly #unitCostCenterInput = new TextInput(
     this.page.find('#unit-cost-center')
   )
 
   readonly #invoiceByMunicipality = new Checkbox(
-    this.page.find('[data-qa="check-invoice-by-municipality"]')
+    this.page.findByDataQa('check-invoice-by-municipality')
   )
 
   saveButton = this.page.findByDataQa('save-button')
 
   static async openById(page: Page, unitId: UUID) {
     await page.goto(`${config.employeeUrl}/units/${unitId}/details`)
-    await page.find('[data-qa="enable-edit-button"]').click()
+    await page.findByDataQa('enable-edit-button').click()
 
     return new UnitEditor(page)
   }
@@ -401,11 +393,11 @@ export class UnitEditor {
   }
 
   async assertWarningIsVisible(dataQa: string) {
-    await this.page.find(`[data-qa="${dataQa}"]`).waitUntilVisible()
+    await this.page.findByDataQa(`${dataQa}`).waitUntilVisible()
   }
 
   async assertWarningIsNotVisible(dataQa: string) {
-    await this.page.find(`[data-qa="${dataQa}"]`).waitUntilHidden()
+    await this.page.findByDataQa(`${dataQa}`).waitUntilHidden()
   }
 
   async selectSomeClosingDate() {
@@ -458,12 +450,10 @@ export class UnitEditor {
   async fillMealTimes(mealTimes: MealTimes) {
     for (const [key, value] of Object.entries(mealTimes)) {
       const inputStart = new TextInput(
-        this.page.find(`[data-qa="${key}-input-start"]`)
+        this.page.findByDataQa(`${key}-input-start`)
       )
       await inputStart.fill(value.start)
-      const inputEnd = new TextInput(
-        this.page.find(`[data-qa="${key}-input-end"]`)
-      )
+      const inputEnd = new TextInput(this.page.findByDataQa(`${key}-input-end`))
       await inputEnd.fill(value.end)
     }
   }
@@ -606,7 +596,7 @@ class AclSection extends Element {
   async assertTemporaryEmployeeHidden() {
     await this.#addButton.click()
     const addModal = new DaycareAclAdditionModal(
-      this.page.find('[data-qa="add-daycare-acl-modal"]')
+      this.page.findByDataQa('add-daycare-acl-modal')
     )
     await addModal.temporarySelect.waitUntilHidden()
   }
@@ -614,7 +604,7 @@ class AclSection extends Element {
   async assertTemporaryEmployeeVisible() {
     await this.#addButton.click()
     const addModal = new DaycareAclAdditionModal(
-      this.page.find('[data-qa="add-daycare-acl-modal"]')
+      this.page.findByDataQa('add-daycare-acl-modal')
     )
     await addModal.temporarySelect.waitUntilVisible()
   }
@@ -622,7 +612,7 @@ class AclSection extends Element {
   async addAcl(email: string, groupIds: UUID[], occupancyCoefficient: boolean) {
     await this.#addButton.click()
     const addModal = new DaycareAclAdditionModal(
-      this.page.find('[data-qa="add-daycare-acl-modal"]')
+      this.page.findByDataQa('add-daycare-acl-modal')
     )
     await addModal.personCombobox.fillAndSelectFirst(email)
     if (groupIds.length > 0) {
@@ -643,7 +633,7 @@ class AclSection extends Element {
   ) {
     await this.#addButton.click()
     const addModal = new DaycareAclAdditionModal(
-      this.page.find('[data-qa="add-daycare-acl-modal"]')
+      this.page.findByDataQa('add-daycare-acl-modal')
     )
     await addModal.temporarySelect.check()
     await addModal.employeeFirstName.fill(firstName)
@@ -658,16 +648,12 @@ class AclSection extends Element {
 
   async deleteAcl(id: UUID) {
     await this.#tableRow(id).find('[data-qa="delete"]').click()
-    await new Modal(
-      this.page.find('[data-qa="remove-daycare-acl-modal"]')
-    ).submit()
+    await new Modal(this.page.findByDataQa('remove-daycare-acl-modal')).submit()
   }
 
   async deleteAclByIndex(index: number) {
     await this.#tableRows.nth(index).find('[data-qa="delete"]').click()
-    await new Modal(
-      this.page.find('[data-qa="remove-daycare-acl-modal"]')
-    ).submit()
+    await new Modal(this.page.findByDataQa('remove-daycare-acl-modal')).submit()
   }
 
   async deleteTemporaryEmployeeByIndex(index: number) {
@@ -676,7 +662,7 @@ class AclSection extends Element {
       .find('[data-qa="delete"]')
       .click()
     await new Modal(
-      this.page.find('[data-qa="remove-temporary-employee-modal"]')
+      this.page.findByDataQa('remove-temporary-employee-modal')
     ).submit()
   }
 
@@ -784,7 +770,7 @@ class MobileDevicesSection extends Element {
     await this.#startPairingButton.click()
 
     const phase1 = new Modal(
-      this.page.find('[data-qa="mobile-pairing-modal-phase-1"]')
+      this.page.findByDataQa('mobile-pairing-modal-phase-1')
     )
 
     const challengeKey = await phase1.find('[data-qa="challenge-key"]').text
@@ -798,14 +784,14 @@ class MobileDevicesSection extends Element {
     }
 
     const phase2 = new Modal(
-      this.page.find('[data-qa="mobile-pairing-modal-phase-2"]')
+      this.page.findByDataQa('mobile-pairing-modal-phase-2')
     )
     await new TextInput(phase2.find('[data-qa="response-key-input"]')).fill(
       responseKey
     )
 
     const phase3 = new Modal(
-      this.page.find('[data-qa="mobile-pairing-modal-phase-3"]')
+      this.page.findByDataQa('mobile-pairing-modal-phase-3')
     )
     await new TextInput(
       phase3.find('[data-qa="mobile-device-name-input"]')
@@ -832,7 +818,7 @@ export class ApplicationProcessPage {
   }
 
   waitingConfirmation = new WaitingConfirmationSection(
-    this.page.find('[data-qa="waiting-confirmation-section"]')
+    this.page.findByDataQa('waiting-confirmation-section')
   )
   placementProposals = new PlacementProposalsSection(this.page)
 
@@ -871,16 +857,12 @@ class PlacementProposalsSection {
   constructor(private readonly page: Page) {}
 
   #applicationRow(applicationId: string) {
-    return this.page.find(`[data-qa="placement-proposal-row-${applicationId}"]`)
+    return this.page.findByDataQa(`placement-proposal-row-${applicationId}`)
   }
 
-  #placementProposalTable = this.page.find(
-    '[data-qa="placement-proposal-table"]'
-  )
+  #placementProposalTable = this.page.findByDataQa('placement-proposal-table')
 
-  #acceptButton = this.page.find(
-    '[data-qa="placement-proposals-accept-button"]'
-  )
+  #acceptButton = this.page.findByDataQa('placement-proposals-accept-button')
 
   async assertAcceptButtonDisabled() {
     await waitUntilTrue(() => this.#acceptButton.disabled)
@@ -912,7 +894,7 @@ class PlacementProposalsSection {
   }
 
   async submitProposalRejectionReason() {
-    await this.page.find('[data-qa="modal-okBtn"]').click()
+    await this.page.findByDataQa('modal-okBtn').click()
     await this.page.findByDataQa('modal-okBtn').waitUntilHidden()
   }
 

--- a/frontend/src/e2e-test/pages/employee/units/unit.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit.ts
@@ -44,12 +44,16 @@ export type MealTimes = {
 }
 
 export class UnitPage {
-  constructor(private readonly page: Page) {}
-
-  #unitInfoTab = this.page.findByDataQa('unit-info-tab')
-  #groupsTab = this.page.findByDataQa('groups-tab')
-  #calendarTab = this.page.findByDataQa('calendar-tab')
-  #applicationProcessTab = this.page.findByDataQa('application-process-tab')
+  #unitInfoTab: Element
+  #groupsTab: Element
+  #calendarTab: Element
+  #applicationProcessTab: Element
+  constructor(private readonly page: Page) {
+    this.#unitInfoTab = page.findByDataQa('unit-info-tab')
+    this.#groupsTab = page.findByDataQa('groups-tab')
+    this.#calendarTab = page.findByDataQa('calendar-tab')
+    this.#applicationProcessTab = page.findByDataQa('application-process-tab')
+  }
 
   static async openUnit(page: Page, id: string): Promise<UnitPage> {
     await page.goto(`${config.employeeUrl}/units/${id}`)
@@ -112,10 +116,14 @@ export class UnitCalendarPage extends UnitCalendarPageBase {
 }
 
 export class UnitInfoPage {
-  constructor(private readonly page: Page) {}
-
-  #unitName = this.page.findByDataQa('unit-name')
-  #visitingAddress = this.page.findByDataQa('unit-visiting-address')
+  #unitName: Element
+  #visitingAddress: Element
+  #unitDetailsLink: Element
+  constructor(private readonly page: Page) {
+    this.#unitName = page.findByDataQa('unit-name')
+    this.#visitingAddress = page.findByDataQa('unit-visiting-address')
+    this.#unitDetailsLink = page.findByDataQa('unit-details-link')
+  }
 
   async waitUntilLoaded() {
     await this.page
@@ -152,8 +160,6 @@ export class UnitInfoPage {
     this.page.findByDataQa('daycare-mobile-devices')
   )
 
-  #unitDetailsLink = this.page.findByDataQa('unit-details-link')
-
   async openUnitDetails(): Promise<UnitDetailsPage> {
     await this.#unitDetailsLink.click()
     const unitDetails = new UnitDetailsPage(this.page)
@@ -163,9 +169,17 @@ export class UnitInfoPage {
 }
 
 export class UnitDetailsPage {
-  constructor(private readonly page: Page) {}
+  #editUnitButton: Element
+  #unitManagerName: Element
+  #unitManagerPhone: Element
+  #unitManagerEmail: Element
+  constructor(private readonly page: Page) {
+    this.#editUnitButton = page.findByDataQa('enable-edit-button')
+    this.#unitManagerName = page.findByDataQa('unit-manager-name')
+    this.#unitManagerPhone = page.findByDataQa('unit-manager-phone')
+    this.#unitManagerEmail = page.findByDataQa('unit-manager-email')
+  }
 
-  readonly #editUnitButton = this.page.findByDataQa('enable-edit-button')
   readonly #unitName = this.page
     .find('[data-qa="unit-editor-container"]')
     .find('h1')
@@ -183,10 +197,6 @@ export class UnitDetailsPage {
       .find(`[data-qa="unit-timerange-detail-${dayNumber}"]`)
       .assertTextEquals(expectedTime)
   }
-
-  readonly #unitManagerName = this.page.findByDataQa('unit-manager-name')
-  readonly #unitManagerPhone = this.page.findByDataQa('unit-manager-phone')
-  readonly #unitManagerEmail = this.page.findByDataQa('unit-manager-email')
 
   async assertManagerData(name: string, phone: string, email: string) {
     await this.#unitManagerName.assertTextEquals(name)
@@ -215,16 +225,38 @@ export class UnitDetailsPage {
 }
 
 export class UnitEditor {
-  constructor(private readonly page: Page) {}
-
-  readonly #unitNameInput = new TextInput(
-    this.page.findByDataQa('unit-name-input')
-  )
-  readonly #areaSelect = new Combobox(this.page.findByDataQa('area-select'))
-
-  readonly providesShiftCare: Checkbox = new Checkbox(
-    this.page.findByDataQa('provides-shift-care')
-  )
+  #unitNameInput: TextInput
+  #areaSelect: Combobox
+  providesShiftCare: Checkbox
+  #managerNameInput: TextInput
+  #managerPhoneInputField: TextInput
+  #managerEmailInputField: TextInput
+  #checkInvoicedByMunicipality: Element
+  #invoiceByMunicipality: Checkbox
+  saveButton: Element
+  constructor(private readonly page: Page) {
+    this.#unitNameInput = new TextInput(page.findByDataQa('unit-name-input'))
+    this.#areaSelect = new Combobox(page.findByDataQa('area-select'))
+    this.providesShiftCare = new Checkbox(
+      page.findByDataQa('provides-shift-care')
+    )
+    this.#managerNameInput = new TextInput(
+      page.findByDataQa('manager-name-input')
+    )
+    this.#managerPhoneInputField = new TextInput(
+      page.findByDataQa('qa-unit-manager-phone-input-field')
+    )
+    this.#managerEmailInputField = new TextInput(
+      page.findByDataQa('qa-unit-manager-email-input-field')
+    )
+    this.#checkInvoicedByMunicipality = page.findByDataQa(
+      'check-invoice-by-municipality'
+    )
+    this.#invoiceByMunicipality = new Checkbox(
+      page.findByDataQa('check-invoice-by-municipality')
+    )
+    this.saveButton = page.findByDataQa('save-button')
+  }
 
   #timeInput(dayNumber: number, startEnd: 'start' | 'end') {
     return new TextInput(this.page.findByDataQa(`${dayNumber}-${startEnd}`))
@@ -303,18 +335,6 @@ export class UnitEditor {
     return new TextInput(this.page.findByDataQa(`${type}-post-office-input`))
   }
 
-  readonly #managerNameInput = new TextInput(
-    this.page.findByDataQa('manager-name-input')
-  )
-
-  readonly #managerPhoneInputField = new TextInput(
-    this.page.findByDataQa('qa-unit-manager-phone-input-field')
-  )
-
-  readonly #managerEmailInputField = new TextInput(
-    this.page.findByDataQa('qa-unit-manager-email-input-field')
-  )
-
   readonly #closingDateInput = this.page.find(
     '[data-qa="closing-date-input"] input'
   )
@@ -332,18 +352,9 @@ export class UnitEditor {
     this.page.find('#unit-handler-address')
   )
 
-  readonly #checkInvoicedByMunicipality = this.page.findByDataQa(
-    'check-invoice-by-municipality'
-  )
   readonly #unitCostCenterInput = new TextInput(
     this.page.find('#unit-cost-center')
   )
-
-  readonly #invoiceByMunicipality = new Checkbox(
-    this.page.findByDataQa('check-invoice-by-municipality')
-  )
-
-  saveButton = this.page.findByDataQa('save-button')
 
   static async openById(page: Page, unitId: UUID) {
     await page.goto(`${config.employeeUrl}/units/${unitId}/details`)
@@ -809,7 +820,12 @@ class AclRow extends Element {
 }
 
 export class ApplicationProcessPage {
-  constructor(private readonly page: Page) {}
+  waitingConfirmation: WaitingConfirmationSection
+  constructor(private readonly page: Page) {
+    this.waitingConfirmation = new WaitingConfirmationSection(
+      page.findByDataQa('waiting-confirmation-section')
+    )
+  }
 
   async waitUntilLoaded() {
     await this.page
@@ -817,9 +833,6 @@ export class ApplicationProcessPage {
       .waitUntilVisible()
   }
 
-  waitingConfirmation = new WaitingConfirmationSection(
-    this.page.findByDataQa('waiting-confirmation-section')
-  )
   placementProposals = new PlacementProposalsSection(this.page)
 
   async waitUntilVisible() {
@@ -854,15 +867,16 @@ class WaitingConfirmationSection extends Element {
 }
 
 class PlacementProposalsSection {
-  constructor(private readonly page: Page) {}
+  #placementProposalTable: Element
+  #acceptButton: Element
+  constructor(private readonly page: Page) {
+    this.#placementProposalTable = page.findByDataQa('placement-proposal-table')
+    this.#acceptButton = page.findByDataQa('placement-proposals-accept-button')
+  }
 
   #applicationRow(applicationId: string) {
     return this.page.findByDataQa(`placement-proposal-row-${applicationId}`)
   }
-
-  #placementProposalTable = this.page.findByDataQa('placement-proposal-table')
-
-  #acceptButton = this.page.findByDataQa('placement-proposals-accept-button')
 
   async assertAcceptButtonDisabled() {
     await waitUntilTrue(() => this.#acceptButton.disabled)

--- a/frontend/src/e2e-test/pages/employee/units/units.ts
+++ b/frontend/src/e2e-test/pages/employee/units/units.ts
@@ -9,6 +9,7 @@ import { waitUntilEqual } from '../../../utils'
 import {
   Checkbox,
   Element,
+  ElementCollection,
   MultiSelect,
   Page,
   TextInput
@@ -23,6 +24,7 @@ export default class UnitsPage {
   careTypesSelect: MultiSelect
   #showClosedUnits: Checkbox
   #table: Element
+  #rows: ElementCollection
   constructor(private readonly page: Page) {
     this.#createNewUnitButton = page.findByDataQa('create-new-unit')
     this.#unitNameFilter = new TextInput(page.findByDataQa('unit-name-filter'))
@@ -34,6 +36,7 @@ export default class UnitsPage {
     )
     this.#showClosedUnits = new Checkbox(page.findByDataQa('include-closed'))
     this.#table = page.findByDataQa('table-of-units')
+    this.#rows = this.#table.findAllByDataQa('unit-row')
   }
 
   static async open(page: Page) {
@@ -52,8 +55,6 @@ export default class UnitsPage {
       await this.#showClosedUnits.uncheck()
     }
   }
-
-  #rows = this.#table.findAll('[data-qa="unit-row"]')
 
   async assertRowCount(expectedCount: number) {
     await waitUntilEqual(() => this.#rows.count(), expectedCount)

--- a/frontend/src/e2e-test/pages/employee/units/units.ts
+++ b/frontend/src/e2e-test/pages/employee/units/units.ts
@@ -19,16 +19,14 @@ import { UnitEditor, UnitPage } from './unit'
 export default class UnitsPage {
   constructor(private readonly page: Page) {}
 
-  #createNewUnitButton = this.page.find('[data-qa="create-new-unit"]')
+  #createNewUnitButton = this.page.findByDataQa('create-new-unit')
 
   static async open(page: Page) {
     await page.goto(config.employeeUrl + '/units')
     return new UnitsPage(page)
   }
 
-  #unitNameFilter = new TextInput(
-    this.page.find('[data-qa="unit-name-filter"]')
-  )
+  #unitNameFilter = new TextInput(this.page.findByDataQa('unit-name-filter'))
 
   providerTypesSelect = new MultiSelect(
     this.page.findByDataQa('provider-types-select')
@@ -36,7 +34,7 @@ export default class UnitsPage {
 
   careTypesSelect = new MultiSelect(this.page.findByDataQa('care-types-select'))
 
-  #showClosedUnits = new Checkbox(this.page.find('[data-qa="include-closed"]'))
+  #showClosedUnits = new Checkbox(this.page.findByDataQa('include-closed'))
 
   async filterByName(text: string) {
     await this.#unitNameFilter.fill(text)
@@ -50,7 +48,7 @@ export default class UnitsPage {
     }
   }
 
-  #table = this.page.find('[data-qa="table-of-units"]')
+  #table = this.page.findByDataQa('table-of-units')
   #rows = this.#table.findAll('[data-qa="unit-row"]')
 
   async assertRowCount(expectedCount: number) {
@@ -60,7 +58,7 @@ export default class UnitsPage {
   unitRow(id: UUID) {
     return new UnitRow(
       this.page,
-      this.page.find(`[data-qa="unit-row"][data-id="${id}"]`)
+      this.page.findByDataQa(`unit-row"][data-id="${id}`)
     )
   }
 

--- a/frontend/src/e2e-test/pages/employee/units/units.ts
+++ b/frontend/src/e2e-test/pages/employee/units/units.ts
@@ -17,24 +17,29 @@ import {
 import { UnitEditor, UnitPage } from './unit'
 
 export default class UnitsPage {
-  constructor(private readonly page: Page) {}
-
-  #createNewUnitButton = this.page.findByDataQa('create-new-unit')
+  #createNewUnitButton: Element
+  #unitNameFilter: TextInput
+  providerTypesSelect: MultiSelect
+  careTypesSelect: MultiSelect
+  #showClosedUnits: Checkbox
+  #table: Element
+  constructor(private readonly page: Page) {
+    this.#createNewUnitButton = page.findByDataQa('create-new-unit')
+    this.#unitNameFilter = new TextInput(page.findByDataQa('unit-name-filter'))
+    this.providerTypesSelect = new MultiSelect(
+      page.findByDataQa('provider-types-select')
+    )
+    this.careTypesSelect = new MultiSelect(
+      page.findByDataQa('care-types-select')
+    )
+    this.#showClosedUnits = new Checkbox(page.findByDataQa('include-closed'))
+    this.#table = page.findByDataQa('table-of-units')
+  }
 
   static async open(page: Page) {
     await page.goto(config.employeeUrl + '/units')
     return new UnitsPage(page)
   }
-
-  #unitNameFilter = new TextInput(this.page.findByDataQa('unit-name-filter'))
-
-  providerTypesSelect = new MultiSelect(
-    this.page.findByDataQa('provider-types-select')
-  )
-
-  careTypesSelect = new MultiSelect(this.page.findByDataQa('care-types-select'))
-
-  #showClosedUnits = new Checkbox(this.page.findByDataQa('include-closed'))
 
   async filterByName(text: string) {
     await this.#unitNameFilter.fill(text)
@@ -48,7 +53,6 @@ export default class UnitsPage {
     }
   }
 
-  #table = this.page.findByDataQa('table-of-units')
   #rows = this.#table.findAll('[data-qa="unit-row"]')
 
   async assertRowCount(expectedCount: number) {

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu-template-edit.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu-template-edit.ts
@@ -7,5 +7,5 @@ import { Page } from '../../../utils/page'
 export class VasuTemplateEditPage {
   constructor(readonly page: Page) {}
 
-  saveButton = this.page.find('[data-qa="save-template"]')
+  saveButton = this.page.findByDataQa('save-template')
 }

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu-template-edit.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu-template-edit.ts
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from '../../../utils/page'
+import { Page, Element } from '../../../utils/page'
 
 export class VasuTemplateEditPage {
-  constructor(readonly page: Page) {}
-
-  saveButton = this.page.findByDataQa('save-template')
+  saveButton: Element
+  constructor(readonly page: Page) {
+    this.saveButton = page.findByDataQa('save-template')
+  }
 }

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu-templates-list.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu-templates-list.ts
@@ -8,12 +8,12 @@ import { Page, Select, TextInput } from '../../../utils/page'
 export class VasuTemplatesListPage {
   constructor(readonly page: Page) {}
 
-  addTemplateButton = this.page.find('[data-qa="add-button"]')
-  nameInput = new TextInput(this.page.find('[data-qa="template-name"]'))
-  selectType = new Select(this.page.find('[data-qa="select-type"]'))
-  okButton = this.page.find('[data-qa="modal-okBtn"]')
+  addTemplateButton = this.page.findByDataQa('add-button')
+  nameInput = new TextInput(this.page.findByDataQa('template-name'))
+  selectType = new Select(this.page.findByDataQa('select-type'))
+  okButton = this.page.findByDataQa('modal-okBtn')
   templateRows = this.page.findAll('[data-qa="template-row"]')
-  templateTable = this.page.find('[data-qa="template-table"]')
+  templateTable = this.page.findByDataQa('template-table')
 
   async assertTemplateRowCount(expected: number) {
     await this.templateTable.waitUntilVisible()

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu-templates-list.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu-templates-list.ts
@@ -3,17 +3,23 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { waitUntilEqual } from '../../../utils'
-import { Page, Select, TextInput } from '../../../utils/page'
+import { Page, Select, TextInput, Element } from '../../../utils/page'
 
 export class VasuTemplatesListPage {
-  constructor(readonly page: Page) {}
+  addTemplateButton: Element
+  nameInput: TextInput
+  selectType: Select
+  okButton: Element
+  templateTable: Element
+  constructor(readonly page: Page) {
+    this.addTemplateButton = page.findByDataQa('add-button')
+    this.nameInput = new TextInput(page.findByDataQa('template-name'))
+    this.selectType = new Select(page.findByDataQa('select-type'))
+    this.okButton = page.findByDataQa('modal-okBtn')
+    this.templateTable = page.findByDataQa('template-table')
+  }
 
-  addTemplateButton = this.page.findByDataQa('add-button')
-  nameInput = new TextInput(this.page.findByDataQa('template-name'))
-  selectType = new Select(this.page.findByDataQa('select-type'))
-  okButton = this.page.findByDataQa('modal-okBtn')
   templateRows = this.page.findAll('[data-qa="template-row"]')
-  templateTable = this.page.findByDataQa('template-table')
 
   async assertTemplateRowCount(expected: number) {
     await this.templateTable.waitUntilVisible()

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
@@ -83,7 +83,16 @@ class VasuPageCommon {
 }
 
 export class VasuEditPage extends VasuPageCommon {
-  readonly modalOkButton = this.page.findByDataQa('modal-okBtn')
+  modalOkButton: Element
+  #vasuPreviewBtn: Element
+  #vasuContainer: Element
+
+  constructor(page: Page) {
+    super(page)
+    this.modalOkButton = page.findByDataQa('modal-okBtn')
+    this.#vasuPreviewBtn = page.findByDataQa('vasu-preview-btn')
+    this.#vasuContainer = page.findByDataQa('vasu-container')
+  }
 
   #followup(nth: number) {
     const question = this.page
@@ -101,9 +110,6 @@ export class VasuEditPage extends VasuPageCommon {
   #followupAddBtn = this.page
     .findByDataQa('vasu-followup-question')
     .findByDataQa('followup-add-btn')
-
-  readonly #vasuPreviewBtn = this.page.findByDataQa('vasu-preview-btn')
-  readonly #vasuContainer = this.page.findByDataQa('vasu-container')
 
   readonly #multiSelectQuestionOption = (text: string) =>
     this.page.findByDataQa(`multi-select-question-option-${text}`)
@@ -161,16 +167,29 @@ export class VasuEditPage extends VasuPageCommon {
 }
 
 export class VasuPage extends VasuPageCommon {
-  readonly finalizeButton = this.page.findByDataQa(
-    'transition-button-MOVED_TO_READY'
-  )
-  readonly markReviewedButton = this.page.findByDataQa(
-    'transition-button-MOVED_TO_REVIEWED'
-  )
-  readonly markClosedButton = this.page.findByDataQa(
-    'transition-button-MOVED_TO_CLOSED'
-  )
-  readonly modalOkButton = this.page.findByDataQa('modal-okBtn')
+  finalizeButton: Element
+  markReviewedButton: Element
+  markClosedButton: Element
+  modalOkButton: Element
+  #templateName: Element
+  #backButton: Element
+  #editButton: Element
+
+  constructor(page: Page) {
+    super(page)
+    this.finalizeButton = page.findByDataQa('transition-button-MOVED_TO_READY')
+    this.markReviewedButton = page.findByDataQa(
+      'transition-button-MOVED_TO_REVIEWED'
+    )
+    this.markClosedButton = page.findByDataQa(
+      'transition-button-MOVED_TO_CLOSED'
+    )
+    this.modalOkButton = page.findByDataQa('modal-okBtn')
+    this.#templateName = page.findByDataQa('template-name')
+    this.#backButton = page.findByDataQa('back-button')
+    this.#editButton = page.findByDataQa('edit-button')
+  }
+
   readonly #vasuEventListLabels = this.page.findAll(
     '[data-qa="vasu-event-list"] label'
   )
@@ -180,10 +199,6 @@ export class VasuPage extends VasuPageCommon {
   readonly documentState = this.page.find(
     '[data-qa="vasu-event-list"] [data-qa="vasu-state-chip"]'
   )
-
-  readonly #templateName = this.page.findByDataQa('template-name')
-  readonly #backButton = this.page.findByDataQa('back-button')
-  readonly #editButton = this.page.findByDataQa('edit-button')
 
   // The (first) label for the state chip has no corresponding span, so the index is off by one.
   #valueForLabel = (label: string): Promise<string> =>
@@ -232,14 +247,19 @@ export class VasuPage extends VasuPageCommon {
 }
 
 export class VasuPreviewPage extends VasuPageCommon {
+  #titleChildName: Element
+  #confirmCheckBox: Checkbox
+  #confirmButton: Element
+
+  constructor(page: Page) {
+    super(page)
+    this.#titleChildName = page.findByDataQa('title-child-name')
+    this.#confirmCheckBox = new Checkbox(page.findByDataQa('confirm-checkbox'))
+    this.#confirmButton = page.findByDataQa('confirm-button')
+  }
+
   readonly #multiselectAnswer = (questionNumber: string) =>
     this.page.findByDataQa(`value-or-no-record-${questionNumber}`)
-
-  readonly #titleChildName = this.page.findByDataQa('title-child-name')
-  readonly #confirmCheckBox = new Checkbox(
-    this.page.findByDataQa('confirm-checkbox')
-  )
-  readonly #confirmButton = this.page.findByDataQa('confirm-button')
 
   async assertTitleChildName(expectedName: string) {
     await this.#titleChildName.assertTextEquals(expectedName)

--- a/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
+++ b/frontend/src/e2e-test/pages/employee/vasu/vasu.ts
@@ -83,7 +83,7 @@ class VasuPageCommon {
 }
 
 export class VasuEditPage extends VasuPageCommon {
-  readonly modalOkButton = this.page.find('[data-qa="modal-okBtn"]')
+  readonly modalOkButton = this.page.findByDataQa('modal-okBtn')
 
   #followup(nth: number) {
     const question = this.page
@@ -102,16 +102,14 @@ export class VasuEditPage extends VasuPageCommon {
     .findByDataQa('vasu-followup-question')
     .findByDataQa('followup-add-btn')
 
-  readonly #vasuPreviewBtn = this.page.find('[data-qa="vasu-preview-btn"]')
-  readonly #vasuContainer = this.page.find('[data-qa="vasu-container"]')
+  readonly #vasuPreviewBtn = this.page.findByDataQa('vasu-preview-btn')
+  readonly #vasuContainer = this.page.findByDataQa('vasu-container')
 
   readonly #multiSelectQuestionOption = (text: string) =>
-    this.page.find(`[data-qa="multi-select-question-option-${text}"]`)
+    this.page.findByDataQa(`multi-select-question-option-${text}`)
   readonly #multiSelectQuestionOptionTextInput = (text: string) =>
     new TextInput(
-      this.page.find(
-        `[data-qa="multi-select-question-option-text-input-${text}"]`
-      )
+      this.page.findByDataQa(`multi-select-question-option-text-input-${text}`)
     )
 
   async clickMultiSelectQuestionOption(key: string) {
@@ -163,16 +161,16 @@ export class VasuEditPage extends VasuPageCommon {
 }
 
 export class VasuPage extends VasuPageCommon {
-  readonly finalizeButton = this.page.find(
-    '[data-qa="transition-button-MOVED_TO_READY"]'
+  readonly finalizeButton = this.page.findByDataQa(
+    'transition-button-MOVED_TO_READY'
   )
-  readonly markReviewedButton = this.page.find(
-    '[data-qa="transition-button-MOVED_TO_REVIEWED"]'
+  readonly markReviewedButton = this.page.findByDataQa(
+    'transition-button-MOVED_TO_REVIEWED'
   )
-  readonly markClosedButton = this.page.find(
-    '[data-qa="transition-button-MOVED_TO_CLOSED"]'
+  readonly markClosedButton = this.page.findByDataQa(
+    'transition-button-MOVED_TO_CLOSED'
   )
-  readonly modalOkButton = this.page.find('[data-qa="modal-okBtn"]')
+  readonly modalOkButton = this.page.findByDataQa('modal-okBtn')
   readonly #vasuEventListLabels = this.page.findAll(
     '[data-qa="vasu-event-list"] label'
   )
@@ -183,9 +181,9 @@ export class VasuPage extends VasuPageCommon {
     '[data-qa="vasu-event-list"] [data-qa="vasu-state-chip"]'
   )
 
-  readonly #templateName = this.page.find('[data-qa="template-name"]')
+  readonly #templateName = this.page.findByDataQa('template-name')
   readonly #backButton = this.page.findByDataQa('back-button')
-  readonly #editButton = this.page.find('[data-qa="edit-button"]')
+  readonly #editButton = this.page.findByDataQa('edit-button')
 
   // The (first) label for the state chip has no corresponding span, so the index is off by one.
   #valueForLabel = (label: string): Promise<string> =>
@@ -235,7 +233,7 @@ export class VasuPage extends VasuPageCommon {
 
 export class VasuPreviewPage extends VasuPageCommon {
   readonly #multiselectAnswer = (questionNumber: string) =>
-    this.page.find(`[data-qa="value-or-no-record-${questionNumber}"]`)
+    this.page.findByDataQa(`value-or-no-record-${questionNumber}`)
 
   readonly #titleChildName = this.page.findByDataQa('title-child-name')
   readonly #confirmCheckBox = new Checkbox(

--- a/frontend/src/e2e-test/pages/mobile/absences-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/absences-page.ts
@@ -5,16 +5,19 @@
 import { AbsenceType } from 'lib-common/generated/api-types/absence'
 import LocalDate from 'lib-common/local-date'
 
-import { Page, TextInput } from '../../utils/page'
+import { Page, TextInput, Element } from '../../utils/page'
 
 export default class MobileAbsencesPage {
-  constructor(private readonly page: Page) {}
+  #markAbsentBtn: Element
+  #confirmDeleteBtn: Element
+  constructor(private readonly page: Page) {
+    this.#markAbsentBtn = page.findByDataQa('mark-absent-btn')
+    this.#confirmDeleteBtn = page.findByDataQa('modal-okBtn')
+  }
 
-  #markAbsentBtn = this.page.findByDataQa('mark-absent-btn')
   #firstDeleteAbsencePeriodBtn = this.page
     .findAll('[data-qa="delete-absence-period"]')
     .first()
-  #confirmDeleteBtn = this.page.findByDataQa('modal-okBtn')
 
   async markAbsent() {
     return this.#markAbsentBtn.click()

--- a/frontend/src/e2e-test/pages/mobile/absences-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/absences-page.ts
@@ -10,11 +10,11 @@ import { Page, TextInput } from '../../utils/page'
 export default class MobileAbsencesPage {
   constructor(private readonly page: Page) {}
 
-  #markAbsentBtn = this.page.find('[data-qa="mark-absent-btn"]')
+  #markAbsentBtn = this.page.findByDataQa('mark-absent-btn')
   #firstDeleteAbsencePeriodBtn = this.page
     .findAll('[data-qa="delete-absence-period"]')
     .first()
-  #confirmDeleteBtn = this.page.find('[data-qa="modal-okBtn"]')
+  #confirmDeleteBtn = this.page.findByDataQa('modal-okBtn')
 
   async markAbsent() {
     return this.#markAbsentBtn.click()
@@ -25,7 +25,7 @@ export default class MobileAbsencesPage {
   }
 
   absenceChip(absenceType: AbsenceType) {
-    return this.page.find(`[data-qa="mark-absent-${absenceType}"]`)
+    return this.page.findByDataQa(`mark-absent-${absenceType}`)
   }
 
   async markNewAbsencePeriod(
@@ -33,10 +33,10 @@ export default class MobileAbsencesPage {
     to: LocalDate,
     absenceType: AbsenceType
   ) {
-    await new TextInput(this.page.find('[data-qa="start-date-input"]')).fill(
+    await new TextInput(this.page.findByDataQa('start-date-input')).fill(
       from.formatIso()
     )
-    await new TextInput(this.page.find('[data-qa="end-date-input"]')).fill(
+    await new TextInput(this.page.findByDataQa('end-date-input')).fill(
       to.formatIso()
     )
     await this.absenceChip(absenceType).click()

--- a/frontend/src/e2e-test/pages/mobile/child-attendance-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/child-attendance-page.ts
@@ -13,23 +13,23 @@ import { Page, TextInput } from '../../utils/page'
 export default class ChildAttendancePage {
   constructor(private readonly page: Page) {}
 
-  #presentTab = this.page.find('[data-qa="present-tab"]')
-  #markPresentButton = this.page.find('[data-qa="mark-present-btn"]')
+  #presentTab = this.page.findByDataQa('present-tab')
+  #markPresentButton = this.page.findByDataQa('mark-present-btn')
   #childLink = (n: number) => this.page.findAll('[data-qa="child-name"]').nth(n)
-  #markDepartedLink = this.page.find('[data-qa="mark-departed-link"]')
-  markDepartedButton = this.page.find('[data-qa="mark-departed-btn"]')
-  #markAbsentButton = this.page.find('[data-qa="mark-absent-btn"]')
+  #markDepartedLink = this.page.findByDataQa('mark-departed-link')
+  markDepartedButton = this.page.findByDataQa('mark-departed-btn')
+  #markAbsentButton = this.page.findByDataQa('mark-absent-btn')
   #noChildrenIndicator = this.page
     .findAll('[data-qa="no-children-indicator"]')
     .first()
-  #childStatusLabel = this.page.find('[data-qa="child-status"]')
-  #setTimeInput = new TextInput(this.page.find('[data-qa="set-time"]'))
+  #childStatusLabel = this.page.findByDataQa('child-status')
+  #setTimeInput = new TextInput(this.page.findByDataQa('set-time'))
   groupNote = this.page.findAllByDataQa('group-note')
 
   setTimeInfo = this.page.findByDataQa('set-time-info')
 
   #markAbsentByTypeButton = (type: AbsenceType) =>
-    this.page.find(`[data-qa="mark-absent-${type}"]`)
+    this.page.findByDataQa(`mark-absent-${type}`)
 
   markAbsentByCategoryAndTypeButton = (
     category: AbsenceCategory,

--- a/frontend/src/e2e-test/pages/mobile/child-attendance-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/child-attendance-page.ts
@@ -8,25 +8,34 @@ import {
 } from 'lib-common/generated/api-types/absence'
 
 import { waitUntilEqual, waitUntilTrue } from '../../utils'
-import { Page, TextInput } from '../../utils/page'
+import { Page, TextInput, Element, ElementCollection } from '../../utils/page'
 
 export default class ChildAttendancePage {
-  constructor(private readonly page: Page) {}
+  #presentTab: Element
+  #markPresentButton: Element
+  #markDepartedLink: Element
+  markDepartedButton: Element
+  #markAbsentButton: Element
+  #childStatusLabel: Element
+  #setTimeInput: TextInput
+  groupNote: ElementCollection
+  setTimeInfo: Element
+  constructor(private readonly page: Page) {
+    this.#presentTab = page.findByDataQa('present-tab')
+    this.#markPresentButton = page.findByDataQa('mark-present-btn')
+    this.#markDepartedLink = page.findByDataQa('mark-departed-link')
+    this.markDepartedButton = page.findByDataQa('mark-departed-btn')
+    this.#markAbsentButton = page.findByDataQa('mark-absent-btn')
+    this.#childStatusLabel = page.findByDataQa('child-status')
+    this.#setTimeInput = new TextInput(page.findByDataQa('set-time'))
+    this.groupNote = page.findAllByDataQa('group-note')
+    this.setTimeInfo = page.findByDataQa('set-time-info')
+  }
 
-  #presentTab = this.page.findByDataQa('present-tab')
-  #markPresentButton = this.page.findByDataQa('mark-present-btn')
   #childLink = (n: number) => this.page.findAll('[data-qa="child-name"]').nth(n)
-  #markDepartedLink = this.page.findByDataQa('mark-departed-link')
-  markDepartedButton = this.page.findByDataQa('mark-departed-btn')
-  #markAbsentButton = this.page.findByDataQa('mark-absent-btn')
   #noChildrenIndicator = this.page
     .findAll('[data-qa="no-children-indicator"]')
     .first()
-  #childStatusLabel = this.page.findByDataQa('child-status')
-  #setTimeInput = new TextInput(this.page.findByDataQa('set-time'))
-  groupNote = this.page.findAllByDataQa('group-note')
-
-  setTimeInfo = this.page.findByDataQa('set-time-info')
 
   #markAbsentByTypeButton = (type: AbsenceType) =>
     this.page.findByDataQa(`mark-absent-${type}`)

--- a/frontend/src/e2e-test/pages/mobile/child-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/child-page.ts
@@ -4,36 +4,47 @@
 
 import { DevChild } from '../../generated/api-types'
 import { waitUntilEqual } from '../../utils'
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export default class MobileChildPage {
-  constructor(private readonly page: Page) {}
-
-  childName = this.page.findByDataQa('child-name')
-  reservation = this.page.findByDataQa('reservation')
-  termBreak = this.page.findByDataQa('term-break')
-  markPresentLink = this.page.findByDataQa('mark-present-link')
-  markDepartedLink = this.page.findByDataQa('mark-departed-link')
-  markAbsentLink = this.page.findByDataQa('mark-absent-link')
-  cancelArrivalButton = this.page.findByDataQa('cancel-arrival-button')
-  returnToPresentButton = this.page.findByDataQa('return-to-present-btn')
-
-  modalOkButton = this.page.findByDataQa('modal-okBtn')
-
-  markReservationsLink = this.page.findByDataQa('mark-reservations')
-  markAbsentBeforehandLink = this.page.findByDataQa('mark-absent-beforehand')
-  sensitiveInfoLink = this.page.findByDataQa('link-child-sensitive-info')
-
-  messageEditorLink = this.page.findByDataQa('link-new-message')
-
-  notesLink = this.page.findByDataQa('link-child-daycare-daily-note')
-
-  notesExistsBubble = this.page.findByDataQa('daily-note-icon-bubble')
-
-  saveNoteButton = this.page.findByDataQa('create-daily-note-btn')
-
-  goBack = this.page.findByDataQa('back-btn')
-  goBackFromSensitivePage = this.page.findByDataQa('go-back')
+  childName: Element
+  reservation: Element
+  termBreak: Element
+  markPresentLink: Element
+  markDepartedLink: Element
+  markAbsentLink: Element
+  cancelArrivalButton: Element
+  returnToPresentButton: Element
+  modalOkButton: Element
+  markReservationsLink: Element
+  markAbsentBeforehandLink: Element
+  sensitiveInfoLink: Element
+  messageEditorLink: Element
+  notesLink: Element
+  notesExistsBubble: Element
+  saveNoteButton: Element
+  goBack: Element
+  goBackFromSensitivePage: Element
+  constructor(private readonly page: Page) {
+    this.childName = page.findByDataQa('child-name')
+    this.reservation = page.findByDataQa('reservation')
+    this.termBreak = page.findByDataQa('term-break')
+    this.markPresentLink = page.findByDataQa('mark-present-link')
+    this.markDepartedLink = page.findByDataQa('mark-departed-link')
+    this.markAbsentLink = page.findByDataQa('mark-absent-link')
+    this.cancelArrivalButton = page.findByDataQa('cancel-arrival-button')
+    this.returnToPresentButton = page.findByDataQa('return-to-present-btn')
+    this.modalOkButton = page.findByDataQa('modal-okBtn')
+    this.markReservationsLink = page.findByDataQa('mark-reservations')
+    this.markAbsentBeforehandLink = page.findByDataQa('mark-absent-beforehand')
+    this.sensitiveInfoLink = page.findByDataQa('link-child-sensitive-info')
+    this.messageEditorLink = page.findByDataQa('link-new-message')
+    this.notesLink = page.findByDataQa('link-child-daycare-daily-note')
+    this.notesExistsBubble = page.findByDataQa('daily-note-icon-bubble')
+    this.saveNoteButton = page.findByDataQa('create-daily-note-btn')
+    this.goBack = page.findByDataQa('back-btn')
+    this.goBackFromSensitivePage = page.findByDataQa('go-back')
+  }
 
   sensitiveInfo = {
     name: this.page.findByDataQa('child-info-name'),

--- a/frontend/src/e2e-test/pages/mobile/list-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/list-page.ts
@@ -4,19 +4,27 @@
 
 import { UUID } from 'lib-common/types'
 
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export default class MobileListPage {
-  constructor(private readonly page: Page) {}
-
-  unreadMessagesIndicator = this.page.findByDataQa('unread-messages-indicator')
-
-  confirmedDaysTab = this.page.findByDataQa('confirmed-days-tab')
-
-  comingChildrenTab = this.page.findByDataQa('coming-tab')
-  presentChildrenTab = this.page.findByDataQa('present-tab')
-  departedChildrenTab = this.page.findByDataQa('departed-tab')
-  absentChildrenTab = this.page.findByDataQa('absent-tab')
+  unreadMessagesIndicator: Element
+  confirmedDaysTab: Element
+  comingChildrenTab: Element
+  presentChildrenTab: Element
+  departedChildrenTab: Element
+  absentChildrenTab: Element
+  groupSelectorButton: Element
+  constructor(private readonly page: Page) {
+    this.unreadMessagesIndicator = page.findByDataQa(
+      'unread-messages-indicator'
+    )
+    this.confirmedDaysTab = page.findByDataQa('confirmed-days-tab')
+    this.comingChildrenTab = page.findByDataQa('coming-tab')
+    this.presentChildrenTab = page.findByDataQa('present-tab')
+    this.departedChildrenTab = page.findByDataQa('departed-tab')
+    this.absentChildrenTab = page.findByDataQa('absent-tab')
+    this.groupSelectorButton = page.findByDataQa('group-selector-button')
+  }
 
   childRow = (childId: UUID) => this.page.findByDataQa(`child-${childId}`)
 
@@ -60,8 +68,6 @@ export default class MobileListPage {
 
     return Object.fromEntries(await Promise.all([...counts, total]))
   }
-
-  groupSelectorButton = this.page.findByDataQa('group-selector-button')
 
   selectedGroupElement = (id: string) =>
     this.page.findByDataQa(`selected-group--${id}`)

--- a/frontend/src/e2e-test/pages/mobile/message-editor-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/message-editor-page.ts
@@ -6,7 +6,7 @@ import { Page, Element } from '../../utils/page'
 
 export default class MessageEditorPage {
   noReceiversInfo: Element
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.noReceiversInfo = page.findByDataQa('info-no-receivers')
   }
 }

--- a/frontend/src/e2e-test/pages/mobile/message-editor-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/message-editor-page.ts
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export default class MessageEditorPage {
-  constructor(private readonly page: Page) {}
-
-  noReceiversInfo = this.page.findByDataQa('info-no-receivers')
+  noReceiversInfo: Element
+  constructor(private readonly page: Page) {
+    this.noReceiversInfo = page.findByDataQa('info-no-receivers')
+  }
 }

--- a/frontend/src/e2e-test/pages/mobile/messages.ts
+++ b/frontend/src/e2e-test/pages/mobile/messages.ts
@@ -3,23 +3,29 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { waitUntilTrue } from '../../utils'
-import { Element, Page } from '../../utils/page'
+import { Element, Page, ElementCollection } from '../../utils/page'
 
 import MobileMessageEditor from './message-editor'
 
 export default class MobileMessagesPage {
-  constructor(private readonly page: Page) {}
-
-  messagesContainer = this.page.findByDataQa('messages-page-content-area')
-  noAccountInfo = this.page.findByDataQa('info-no-account-access')
-
-  receivedTab = this.page.findByDataQa('received-tab')
-  sentTab = this.page.findByDataQa('sent-tab')
-  draftsTab = this.page.findByDataQa('drafts-tab')
-
-  threads = this.page.findAllByDataQa('message-preview')
-  titles = this.page.findAllByDataQa('message-preview-title')
-  newMessage = this.page.findByDataQa('new-message-btn')
+  messagesContainer: Element
+  noAccountInfo: Element
+  receivedTab: Element
+  sentTab: Element
+  draftsTab: Element
+  threads: ElementCollection
+  titles: ElementCollection
+  newMessage: Element
+  constructor(private readonly page: Page) {
+    this.messagesContainer = page.findByDataQa('messages-page-content-area')
+    this.noAccountInfo = page.findByDataQa('info-no-account-access')
+    this.receivedTab = page.findByDataQa('received-tab')
+    this.sentTab = page.findByDataQa('sent-tab')
+    this.draftsTab = page.findByDataQa('drafts-tab')
+    this.threads = page.findAllByDataQa('message-preview')
+    this.titles = page.findAllByDataQa('message-preview-title')
+    this.newMessage = page.findByDataQa('new-message-btn')
+  }
 
   async getThreadTitle(index: number) {
     return this.titles.nth(index).text
@@ -49,9 +55,10 @@ export class ReceivedThreadPreview extends Element {
 }
 
 export class SentTab {
-  constructor(private readonly page: Page) {}
-
-  messages = this.page.findAllByDataQa('sent-message-preview')
+  messages: ElementCollection
+  constructor(private readonly page: Page) {
+    this.messages = page.findAllByDataQa('sent-message-preview')
+  }
 
   message(nth: number) {
     return new SentMessagePreview(this.page, this.messages.nth(nth))
@@ -75,16 +82,20 @@ export class SentMessagePreview extends Element {
 }
 
 export class SentMessage {
-  constructor(private readonly page: Page) {}
-
-  topBarTitle = this.page.findByDataQa('top-bar-title')
-  content = this.page.findByDataQa('single-message-content')
+  topBarTitle: Element
+  content: Element
+  constructor(private readonly page: Page) {
+    this.topBarTitle = page.findByDataQa('top-bar-title')
+    this.content = page.findByDataQa('single-message-content')
+  }
 }
 
 export class DraftsTab {
-  constructor(private readonly page: Page) {}
+  list: Element
+  constructor(private readonly page: Page) {
+    this.list = page.findByDataQa('draft-list')
+  }
 
-  list = this.page.findByDataQa('draft-list')
   messages = this.list.findAllByDataQa('draft-message-preview')
 
   message(nth: number) {

--- a/frontend/src/e2e-test/pages/mobile/messages.ts
+++ b/frontend/src/e2e-test/pages/mobile/messages.ts
@@ -84,7 +84,7 @@ export class SentMessagePreview extends Element {
 export class SentMessage {
   topBarTitle: Element
   content: Element
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.topBarTitle = page.findByDataQa('top-bar-title')
     this.content = page.findByDataQa('single-message-content')
   }
@@ -92,11 +92,11 @@ export class SentMessage {
 
 export class DraftsTab {
   list: Element
+  private messages: ElementCollection
   constructor(private readonly page: Page) {
     this.list = page.findByDataQa('draft-list')
+    this.messages = this.list.findAllByDataQa('draft-message-preview')
   }
-
-  messages = this.list.findAllByDataQa('draft-message-preview')
 
   message(nth: number) {
     return new DraftMessagePreview(this.page, this.messages.nth(nth))

--- a/frontend/src/e2e-test/pages/mobile/mobile-nav.ts
+++ b/frontend/src/e2e-test/pages/mobile/mobile-nav.ts
@@ -9,18 +9,18 @@ import { Page } from '../../utils/page'
 export default class MobileNav {
   constructor(private readonly page: Page) {}
 
-  readonly #groupSelectorButton = this.page.find(
-    '[data-qa="group-selector-button"]'
+  readonly #groupSelectorButton = this.page.findByDataQa(
+    'group-selector-button'
   )
 
   private groupWithId(id: UUID) {
-    return this.page.find(`[data-qa="group--${id}"]`)
+    return this.page.findByDataQa(`group--${id}`)
   }
 
-  children = this.page.find('[data-qa="bottomnav-children"]')
-  staff = this.page.find('[data-qa="bottomnav-staff"]')
-  messages = this.page.find('[data-qa="bottomnav-messages"]')
-  settings = this.page.find('[data-qa="bottomnav-settings"]')
+  children = this.page.findByDataQa('bottomnav-children')
+  staff = this.page.findByDataQa('bottomnav-staff')
+  messages = this.page.findByDataQa('bottomnav-messages')
+  settings = this.page.findByDataQa('bottomnav-settings')
 
   get selectedGroupName() {
     return this.#groupSelectorButton.text

--- a/frontend/src/e2e-test/pages/mobile/mobile-nav.ts
+++ b/frontend/src/e2e-test/pages/mobile/mobile-nav.ts
@@ -4,23 +4,25 @@
 
 import { UUID } from 'lib-common/types'
 
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export default class MobileNav {
-  constructor(private readonly page: Page) {}
-
-  readonly #groupSelectorButton = this.page.findByDataQa(
-    'group-selector-button'
-  )
+  #groupSelectorButton: Element
+  children: Element
+  staff: Element
+  messages: Element
+  settings: Element
+  constructor(private readonly page: Page) {
+    this.#groupSelectorButton = page.findByDataQa('group-selector-button')
+    this.children = page.findByDataQa('bottomnav-children')
+    this.staff = page.findByDataQa('bottomnav-staff')
+    this.messages = page.findByDataQa('bottomnav-messages')
+    this.settings = page.findByDataQa('bottomnav-settings')
+  }
 
   private groupWithId(id: UUID) {
     return this.page.findByDataQa(`group--${id}`)
   }
-
-  children = this.page.findByDataQa('bottomnav-children')
-  staff = this.page.findByDataQa('bottomnav-staff')
-  messages = this.page.findByDataQa('bottomnav-messages')
-  settings = this.page.findByDataQa('bottomnav-settings')
 
   get selectedGroupName() {
     return this.#groupSelectorButton.text

--- a/frontend/src/e2e-test/pages/mobile/note-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/note-page.ts
@@ -17,38 +17,34 @@ export default class MobileNotePage {
 
   #stickyNote = {
     note: this.page.findAll('[data-qa="sticky-note"]'),
-    newNoteBtn: this.page.find('[data-qa="sticky-note-new"]'),
+    newNoteBtn: this.page.findByDataQa('sticky-note-new'),
     editBtn: this.page.findAll('[data-qa="sticky-note-edit"]'),
     removeBtn: this.page.findAll('[data-qa="sticky-note-remove"]'),
-    saveBtn: this.page.find('[data-qa="sticky-note-save"]'),
-    input: new TextInput(this.page.find('[data-qa="sticky-note-input"]'))
+    saveBtn: this.page.findByDataQa('sticky-note-save'),
+    input: new TextInput(this.page.findByDataQa('sticky-note-input'))
   }
 
-  #createNoteButton = this.page.find('[data-qa="create-daily-note-btn"]')
-  #deleteNoteButton = this.page.find('[data-qa="open-delete-dialog-btn"]')
+  #createNoteButton = this.page.findByDataQa('create-daily-note-btn')
+  #deleteNoteButton = this.page.findByDataQa('open-delete-dialog-btn')
   #note = {
-    dailyNote: new TextInput(
-      this.page.find('[data-qa="daily-note-note-input"]')
-    ),
+    dailyNote: new TextInput(this.page.findByDataQa('daily-note-note-input')),
     sleepingTimeHours: new TextInput(
-      this.page.find('[data-qa="sleeping-time-hours-input"]')
+      this.page.findByDataQa('sleeping-time-hours-input')
     ),
     sleepingTimeMinutes: new TextInput(
-      this.page.find('[data-qa="sleeping-time-minutes-input"]')
+      this.page.findByDataQa('sleeping-time-minutes-input')
     ),
-    reminderNote: new TextInput(
-      this.page.find('[data-qa="reminder-note-input"]')
-    ),
+    reminderNote: new TextInput(this.page.findByDataQa('reminder-note-input')),
     feedingNote: (level: ChildDailyNoteLevel) =>
-      this.page.find(`[data-qa="feeding-note-${level}"]`),
+      this.page.findByDataQa(`feeding-note-${level}`),
     sleepingNote: (level: ChildDailyNoteLevel) =>
-      this.page.find(`[data-qa="sleeping-note-${level}"]`),
+      this.page.findByDataQa(`sleeping-note-${level}`),
     reminders: (reminder: ChildDailyNoteReminder) =>
-      this.page.find(`[data-qa="reminders-${reminder}"]`)
+      this.page.findByDataQa(`reminders-${reminder}`)
   }
 
   async selectTab(tab: 'note' | 'group' | 'sticky') {
-    await this.page.find(`[data-qa="tab-${tab.toUpperCase()}"]`).click()
+    await this.page.findByDataQa(`tab-${tab.toUpperCase()}`).click()
   }
 
   async initNewStickyNote() {
@@ -110,7 +106,7 @@ export default class MobileNotePage {
 
   async deleteChildDailyNote() {
     await this.#deleteNoteButton.click()
-    await new Modal(this.page.find('[data-qa="modal"]')).submit()
+    await new Modal(this.page.findByDataQa('modal')).submit()
   }
 
   async assertNote(expected: ChildDailyNoteBody) {

--- a/frontend/src/e2e-test/pages/mobile/note-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/note-page.ts
@@ -10,10 +10,15 @@ import {
 import LocalDate from 'lib-common/local-date'
 
 import { waitUntilEqual, waitUntilTrue } from '../../utils'
-import { Modal, Page, TextInput } from '../../utils/page'
+import { Modal, Page, TextInput, Element } from '../../utils/page'
 
 export default class MobileNotePage {
-  constructor(private readonly page: Page) {}
+  #createNoteButton: Element
+  #deleteNoteButton: Element
+  constructor(private readonly page: Page) {
+    this.#createNoteButton = page.findByDataQa('create-daily-note-btn')
+    this.#deleteNoteButton = page.findByDataQa('open-delete-dialog-btn')
+  }
 
   #stickyNote = {
     note: this.page.findAll('[data-qa="sticky-note"]'),
@@ -24,8 +29,6 @@ export default class MobileNotePage {
     input: new TextInput(this.page.findByDataQa('sticky-note-input'))
   }
 
-  #createNoteButton = this.page.findByDataQa('create-daily-note-btn')
-  #deleteNoteButton = this.page.findByDataQa('open-delete-dialog-btn')
   #note = {
     dailyNote: new TextInput(this.page.findByDataQa('daily-note-note-input')),
     sleepingTimeHours: new TextInput(

--- a/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
@@ -9,7 +9,7 @@ export default class PinLoginPage {
   #pinInput: TextInput
   #pinSubmit: TextInput
   #pinInfo: Element
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.#staffSelect = new Select(page.findByDataQa('select-staff'))
     this.#pinInput = new TextInput(page.findByDataQa('pin-input'))
     this.#pinSubmit = new TextInput(page.findByDataQa('pin-submit'))

--- a/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
@@ -7,10 +7,10 @@ import { Page, Select, TextInput } from '../../utils/page'
 export default class PinLoginPage {
   constructor(private readonly page: Page) {}
 
-  #staffSelect = new Select(this.page.find('[data-qa="select-staff"]'))
-  #pinInput = new TextInput(this.page.find('[data-qa="pin-input"]'))
-  #pinSubmit = new TextInput(this.page.find('[data-qa="pin-submit"]'))
-  #pinInfo = this.page.find('[data-qa="pin-input-info"]')
+  #staffSelect = new Select(this.page.findByDataQa('select-staff'))
+  #pinInput = new TextInput(this.page.findByDataQa('pin-input'))
+  #pinSubmit = new TextInput(this.page.findByDataQa('pin-submit'))
+  #pinInfo = this.page.findByDataQa('pin-input-info')
 
   async submitPin(pin: string) {
     await this.#pinInput.fill(pin)

--- a/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/pin-login-page.ts
@@ -2,15 +2,19 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page, Select, TextInput } from '../../utils/page'
+import { Page, Select, TextInput, Element } from '../../utils/page'
 
 export default class PinLoginPage {
-  constructor(private readonly page: Page) {}
-
-  #staffSelect = new Select(this.page.findByDataQa('select-staff'))
-  #pinInput = new TextInput(this.page.findByDataQa('pin-input'))
-  #pinSubmit = new TextInput(this.page.findByDataQa('pin-submit'))
-  #pinInfo = this.page.findByDataQa('pin-input-info')
+  #staffSelect: Select
+  #pinInput: TextInput
+  #pinSubmit: TextInput
+  #pinInfo: Element
+  constructor(private readonly page: Page) {
+    this.#staffSelect = new Select(page.findByDataQa('select-staff'))
+    this.#pinInput = new TextInput(page.findByDataQa('pin-input'))
+    this.#pinSubmit = new TextInput(page.findByDataQa('pin-submit'))
+    this.#pinInfo = page.findByDataQa('pin-input-info')
+  }
 
   async submitPin(pin: string) {
     await this.#pinInput.fill(pin)

--- a/frontend/src/e2e-test/pages/mobile/staff-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/staff-page.ts
@@ -21,12 +21,12 @@ import {
 export default class StaffPage {
   constructor(private readonly page: Page) {}
 
-  #staffCount = this.page.find('[data-qa="staff-count"]')
-  #staffOtherCount = this.page.find('[data-qa="staff-other-count"]')
-  #cancelButton = this.page.find('[data-qa="cancel-button"]')
-  #confirmButton = this.page.find('[data-qa="confirm-button"]')
-  #occupancyRealized = this.page.find('[data-qa="realized-occupancy"]')
-  #updated = this.page.find('[data-qa="updated"]')
+  #staffCount = this.page.findByDataQa('staff-count')
+  #staffOtherCount = this.page.findByDataQa('staff-other-count')
+  #cancelButton = this.page.findByDataQa('cancel-button')
+  #confirmButton = this.page.findByDataQa('confirm-button')
+  #occupancyRealized = this.page.findByDataQa('realized-occupancy')
+  #updated = this.page.findByDataQa('updated')
 
   private countButton(parent: Element, which: 'plus' | 'minus') {
     return parent.find(`[data-qa="${which}-button"]`)

--- a/frontend/src/e2e-test/pages/mobile/staff-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/staff-page.ts
@@ -19,14 +19,20 @@ import {
 } from '../../utils/page'
 
 export default class StaffPage {
-  constructor(private readonly page: Page) {}
-
-  #staffCount = this.page.findByDataQa('staff-count')
-  #staffOtherCount = this.page.findByDataQa('staff-other-count')
-  #cancelButton = this.page.findByDataQa('cancel-button')
-  #confirmButton = this.page.findByDataQa('confirm-button')
-  #occupancyRealized = this.page.findByDataQa('realized-occupancy')
-  #updated = this.page.findByDataQa('updated')
+  #staffCount: Element
+  #staffOtherCount: Element
+  #cancelButton: Element
+  #confirmButton: Element
+  #occupancyRealized: Element
+  #updated: Element
+  constructor(private readonly page: Page) {
+    this.#staffCount = page.findByDataQa('staff-count')
+    this.#staffOtherCount = page.findByDataQa('staff-other-count')
+    this.#cancelButton = page.findByDataQa('cancel-button')
+    this.#confirmButton = page.findByDataQa('confirm-button')
+    this.#occupancyRealized = page.findByDataQa('realized-occupancy')
+    this.#updated = page.findByDataQa('updated')
+  }
 
   private countButton(parent: Element, which: 'plus' | 'minus') {
     return parent.find(`[data-qa="${which}-button"]`)
@@ -102,21 +108,23 @@ export class StaffAttendancePage {
   arrivalTime: Element
   departureTime: Element
 
+  #addNewExternalMemberButton: Element
+  pinInput: Element
+
   constructor(private readonly page: Page) {
     this.editButton = this.page.findByDataQa('edit')
     this.arrivalTime = this.page.findByDataQa('arrival-time')
     this.departureTime = this.page.findByDataQa('departure-time')
+    this.#addNewExternalMemberButton = page.findByDataQa(
+      'add-external-member-btn'
+    )
+    this.pinInput = page.findByDataQa('pin-input')
   }
 
   #tabs = {
     present: this.page.findByDataQa('present-tab'),
     absent: this.page.findByDataQa('absent-tab')
   }
-
-  #addNewExternalMemberButton = this.page.findByDataQa(
-    'add-external-member-btn'
-  )
-  pinInput = this.page.findByDataQa('pin-input')
 
   anyArrivalPage = {
     arrivedInput: new TextInput(this.page.findByDataQa('input-arrived')),

--- a/frontend/src/e2e-test/pages/mobile/staff-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/staff-page.ts
@@ -25,7 +25,7 @@ export default class StaffPage {
   #confirmButton: Element
   #occupancyRealized: Element
   #updated: Element
-  constructor(private readonly page: Page) {
+  constructor(readonly page: Page) {
     this.#staffCount = page.findByDataQa('staff-count')
     this.#staffOtherCount = page.findByDataQa('staff-other-count')
     this.#cancelButton = page.findByDataQa('cancel-button')

--- a/frontend/src/e2e-test/pages/mobile/thread-view.ts
+++ b/frontend/src/e2e-test/pages/mobile/thread-view.ts
@@ -2,16 +2,23 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page, TextInput } from '../../utils/page'
+import { Page, TextInput, Element } from '../../utils/page'
 
 export default class ThreadViewPage {
-  constructor(private readonly page: Page) {}
-
-  goBack = this.page.findByDataQa('go-back')
-  replyButton = this.page.findByDataQa('message-reply-editor-btn')
-  replyContent = new TextInput(this.page.findByDataQa('message-reply-content'))
-  sendReplyButton = this.page.findByDataQa('message-send-btn')
-  discardReplyButton = this.page.findByDataQa('message-discard-btn')
+  goBack: Element
+  replyButton: Element
+  replyContent: TextInput
+  sendReplyButton: Element
+  discardReplyButton: Element
+  constructor(private readonly page: Page) {
+    this.goBack = page.findByDataQa('go-back')
+    this.replyButton = page.findByDataQa('message-reply-editor-btn')
+    this.replyContent = new TextInput(
+      page.findByDataQa('message-reply-content')
+    )
+    this.sendReplyButton = page.findByDataQa('message-send-btn')
+    this.discardReplyButton = page.findByDataQa('message-discard-btn')
+  }
 
   singleMessageContents = this.page.findAll(
     '[data-qa="single-message-content"]'

--- a/frontend/src/e2e-test/pages/mobile/top-nav.ts
+++ b/frontend/src/e2e-test/pages/mobile/top-nav.ts
@@ -8,16 +8,16 @@ export default class TopNav {
   #userMenu: Element
   systemNotificationBtn: Element
   systemNotificationModal: Element
-  constructor(private readonly page: Page) {
+  systemNotificationModalClose: Element
+  constructor(readonly page: Page) {
     this.#userMenu = page.findByDataQa('top-bar-user')
     this.systemNotificationBtn = page.findByDataQa('system-notification-btn')
     this.systemNotificationModal = page.findByDataQa(
       'system-notification-modal'
     )
+    this.systemNotificationModalClose =
+      this.systemNotificationModal.findByDataQa('modal-okBtn')
   }
-
-  systemNotificationModalClose =
-    this.systemNotificationModal.findByDataQa('modal-okBtn')
 
   async openUserMenu() {
     await this.#userMenu.click()

--- a/frontend/src/e2e-test/pages/mobile/top-nav.ts
+++ b/frontend/src/e2e-test/pages/mobile/top-nav.ts
@@ -2,15 +2,20 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export default class TopNav {
-  constructor(private readonly page: Page) {}
+  #userMenu: Element
+  systemNotificationBtn: Element
+  systemNotificationModal: Element
+  constructor(private readonly page: Page) {
+    this.#userMenu = page.findByDataQa('top-bar-user')
+    this.systemNotificationBtn = page.findByDataQa('system-notification-btn')
+    this.systemNotificationModal = page.findByDataQa(
+      'system-notification-modal'
+    )
+  }
 
-  #userMenu = this.page.findByDataQa('top-bar-user')
-
-  systemNotificationBtn = this.page.findByDataQa('system-notification-btn')
-  systemNotificationModal = this.page.findByDataQa('system-notification-modal')
   systemNotificationModalClose =
     this.systemNotificationModal.findByDataQa('modal-okBtn')
 

--- a/frontend/src/e2e-test/pages/mobile/top-nav.ts
+++ b/frontend/src/e2e-test/pages/mobile/top-nav.ts
@@ -7,7 +7,7 @@ import { Page } from '../../utils/page'
 export default class TopNav {
   constructor(private readonly page: Page) {}
 
-  #userMenu = this.page.find('[data-qa="top-bar-user"]')
+  #userMenu = this.page.findByDataQa('top-bar-user')
 
   systemNotificationBtn = this.page.findByDataQa('system-notification-btn')
   systemNotificationModal = this.page.findByDataQa('system-notification-modal')

--- a/frontend/src/e2e-test/pages/mobile/unread-message-counts.ts
+++ b/frontend/src/e2e-test/pages/mobile/unread-message-counts.ts
@@ -2,12 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page } from '../../utils/page'
+import { Page, Element } from '../../utils/page'
 
 export default class UnreadMobileMessagesPage {
-  constructor(private readonly page: Page) {}
-
-  pinLoginButton = this.page.findByDataQa(`pin-login-button`)
+  pinLoginButton: Element
+  constructor(private readonly page: Page) {
+    this.pinLoginButton = page.findByDataQa(`pin-login-button`)
+  }
 
   linkToGroup(groupId: string) {
     return this.page.findByDataQa(`link-to-group-messages-${groupId}`)

--- a/frontend/src/e2e-test/pages/mobile/unread-message-counts.ts
+++ b/frontend/src/e2e-test/pages/mobile/unread-message-counts.ts
@@ -7,10 +7,10 @@ import { Page } from '../../utils/page'
 export default class UnreadMobileMessagesPage {
   constructor(private readonly page: Page) {}
 
-  pinLoginButton = this.page.find(`[data-qa="pin-login-button"]`)
+  pinLoginButton = this.page.findByDataQa(`pin-login-button`)
 
   linkToGroup(groupId: string) {
-    return this.page.find(`[data-qa="link-to-group-messages-${groupId}"]`)
+    return this.page.findByDataQa(`link-to-group-messages-${groupId}`)
   }
 
   async groupLinksExist() {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -1077,7 +1077,7 @@ describe('Citizen calendar visibility', () => {
     })
     await enduserLogin(page)
 
-    await page.find('[data-qa="nav-calendar-desktop"]').waitUntilVisible()
+    await page.findByDataQa('nav-calendar-desktop').waitUntilVisible()
   })
 
   test('Child is not visible when placement starts later than 2 weeks', async () => {
@@ -1100,8 +1100,8 @@ describe('Citizen calendar visibility', () => {
     await enduserLogin(page)
 
     // Ensure page has loaded
-    await page.find('[data-qa="nav-children-desktop"]').waitUntilVisible()
-    await page.find('[data-qa="nav-calendar-desktop"]').waitUntilHidden()
+    await page.findByDataQa('nav-children-desktop').waitUntilVisible()
+    await page.findByDataQa('nav-calendar-desktop').waitUntilHidden()
   })
 
   test('Child is not visible when placement is in the past', async () => {
@@ -1124,8 +1124,8 @@ describe('Citizen calendar visibility', () => {
     await enduserLogin(page)
 
     // Ensure page has loaded
-    await page.find('[data-qa="applications-list"]').waitUntilVisible()
-    await page.find('[data-qa="nav-children-desktop"]').waitUntilHidden()
+    await page.findByDataQa('applications-list').waitUntilVisible()
+    await page.findByDataQa('nav-children-desktop').waitUntilHidden()
   })
 })
 

--- a/frontend/src/e2e-test/specs/5_employee/unit-acl.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-acl.spec.ts
@@ -142,7 +142,7 @@ describe('Employee - unit ACL', () => {
       const row = unitInfoPage.staffAcl.getRow(pete.id)
       await row.edit()
       const editModal = new EmployeeRowEditModal(
-        page.find('[data-qa="employee-row-edit-person-modal"]')
+        page.findByDataQa('employee-row-edit-person-modal')
       )
       await editModal.toggleGroups(groups)
       await editModal.saveButton.click()
@@ -180,7 +180,7 @@ describe('Employee - unit ACL', () => {
       const row = unitInfoPage.staffAcl.getRow(pete.id)
       await row.edit()
       const editModal = new EmployeeRowEditModal(
-        page.find('[data-qa="employee-row-edit-person-modal"]')
+        page.findByDataQa('employee-row-edit-person-modal')
       )
       await editModal.setCoefficient(coefficientValue)
       await editModal.saveButton.click()
@@ -256,7 +256,7 @@ describe('Employee - unit ACL - temporary employee', () => {
     const row = unitInfoPage.staffAcl.getRowByIndex(index)
     await row.edit()
     return new EmployeeRowEditModal(
-      page.find('[data-qa="employee-row-edit-person-modal"]')
+      page.findByDataQa('employee-row-edit-person-modal')
     )
   }
 


### PR DESCRIPTION
Tämä muutos tekee e2e testien page object koodista paremmin es2022 yhteensopivaa. Suurin osa muutoksista on tehty [jscodeshift muunnoksella](https://gist.github.com/Wnt/86a21158e6f4818a95095901a2d96206) joka siirtää fieldien initialisoinnin konstruktoriin.

## Ennen tätä muutosta
Frontendin TypeScript käännös jossa `target` asetettu -> `es2022` tuotti 614 virheitä
## Tämän muutoksen jälkeen
TypeScript käännös tuottaa vain 157 virhettä