### PR TITLE
Suurempi tekstikenttä kuntalaisen uusi viesti dialogiin

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -292,7 +292,7 @@ export default React.memo(function MessageEditor({
 
             <Gap size="s" />
 
-            <label>
+            <TextAreaLabel>
               <Bold>{required(i18n.messages.messageEditor.message)}</Bold>
               <Gap size="s" />
               <StyledTextArea
@@ -305,7 +305,7 @@ export default React.memo(function MessageEditor({
                 }
                 data-qa="input-content"
               />
-            </label>
+            </TextAreaLabel>
 
             <Gap size="s" />
             {displaySendError && (
@@ -389,6 +389,12 @@ const FormArea = styled.div`
   padding: ${defaultMargins.m};
   display: flex;
   flex-direction: column;
+`
+
+const TextAreaLabel = styled.label`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 `
 
 const StyledTextArea = styled.textarea`


### PR DESCRIPTION
<img width="1200" alt="Screenshot 2024-06-19 at 14 05 46" src="https://github.com/espoon-voltti/evaka/assets/1533854/b75457ca-7ac3-4153-8b61-e1cf05e783cb">
