### PR TITLE
Vaka- tuen päätöksiin automaattinen päättymispäivä jos tulevaisuudessa on jo toinen päätös

### DIFF
--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReportDecision.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReportDecision.tsx
@@ -337,7 +337,7 @@ const DecisionModal = React.memo(function DecisionModal({
               status: decisionStatus
             }
           })
-          if (result.isFailure && result.statusCode === 409) {
+          if (result.isFailure) {
             onFailed()
           } else {
             onClose(true)
@@ -361,7 +361,6 @@ const ApproveFailedModal = React.memo(function ApproveFailedModal({
     <InfoModal
       type="danger"
       title={t.title}
-      text={t.text}
       icon={faTimes}
       reject={{
         action: onClose,

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3526,8 +3526,7 @@ export const fi = {
       },
       approveFailedModal: {
         title: 'Päätöksen hyväksyminen epäonnistui',
-        okBtn: 'Sulje',
-        text: 'Päätöksen hyväksyminen epäonnistui, koska toinen hyväksytty päätös on tehty alkaen samasta tai myöhemmästä päivästä. Mitätöi toinen päätös ensin.'
+        okBtn: 'Sulje'
       },
       annulModal: {
         title: 'Mitätöidäänkö päätös?',

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
@@ -382,8 +382,7 @@ UPDATE assistance_need_decision
 SET validity_period = daterange(lower(validity_period), ${bind(endDate)}, '[]')
 WHERE
     id <> ${bind(excludingId)} AND
-    lower(validity_period) <= ${bind(endDate)} AND 
-    (upper(validity_period) IS NULL OR upper(validity_period) > ${bind(endDate)}) AND
+    validity_period @> ${bind(endDate)} AND
     child_id = ${bind(childId)} AND
     status = 'ACCEPTED'
 """

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
@@ -351,7 +351,8 @@ fun Database.Transaction.decideAssistanceNeedDecision(
     id: AssistanceNeedDecisionId,
     status: AssistanceNeedDecisionStatus,
     decisionMade: LocalDate?,
-    unreadGuardianIds: List<PersonId>?
+    unreadGuardianIds: List<PersonId>?,
+    validTo: LocalDate?
 ) {
     createUpdate {
             sql(
@@ -360,7 +361,8 @@ UPDATE assistance_need_decision
 SET 
     status = ${bind(status)},
     decision_made = ${bind(decisionMade)},
-    unread_guardian_ids = ${bind(unreadGuardianIds)}
+    unread_guardian_ids = ${bind(unreadGuardianIds)},
+    validity_period = daterange(lower(validity_period), ${bind(validTo)}, '[]')
 WHERE id = ${bind(id)} AND status IN ('DRAFT', 'NEEDS_WORK')
 """
             )
@@ -377,10 +379,11 @@ fun Database.Transaction.endActiveAssistanceNeedDecisions(
         sql(
             """
 UPDATE assistance_need_decision
-SET validity_period = daterange(lower(validity_period), ${bind(endDate.minusDays(1))}, '[]')
+SET validity_period = daterange(lower(validity_period), ${bind(endDate)}, '[]')
 WHERE
     id <> ${bind(excludingId)} AND
-    (upper(validity_period) IS NULL OR upper(validity_period) > ${bind(endDate.minusDays(1))}) AND
+    lower(validity_period) <= ${bind(endDate)} AND 
+    (upper(validity_period) IS NULL OR upper(validity_period) > ${bind(endDate)}) AND
     child_id = ${bind(childId)} AND
     status = 'ACCEPTED'
 """
@@ -419,24 +422,23 @@ WHERE daycare_assistance_decision_with_new_end_date.id = assistance_need_decisio
     )
 }
 
-fun Database.Read.hasLaterAssistanceNeedDecisions(
+fun Database.Read.getNextAssistanceNeedDecisionValidFrom(
     childId: ChildId,
     startDate: LocalDate,
-): Boolean =
+) =
     createQuery {
             sql(
                 """
-SELECT EXISTS (
-    SELECT 1
-    FROM assistance_need_decision
-    WHERE child_id = ${bind(childId)}
-      AND ${bind(startDate)} <= lower(validity_period)
-      AND status = 'ACCEPTED'
-)
+SELECT min(lower(validity_period))
+FROM assistance_need_decision
+WHERE child_id = ${bind(childId)}
+  AND lower(validity_period) >= ${bind(startDate)}
+  AND status = 'ACCEPTED'
 """
             )
         }
-        .exactlyOne()
+        .mapTo<LocalDate>()
+        .exactlyOneOrNull()
 
 fun Database.Transaction.annulAssistanceNeedDecision(
     id: AssistanceNeedDecisionId,


### PR DESCRIPTION
Muutetaan vaka- tuen päätösten logiikka samanlaiseksi kuin esiopetuksessa eli jos nyt hyväksyttävää päätöstä myöhempänä on toinen hyväksytty päätös, niin asetetaan päätös päättymään sitä edellisenä päivänä.