### PR TITLE
Automaattinen poissaolojen luonti varausten luonnin yhteydessä

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -201,6 +201,7 @@ function View({
     />
   ) : undefined
 
+  const isPast = modalData.response.date.isBefore(LocalDate.todayInSystemTz())
   return (
     <DayModal
       date={modalData.response.date}
@@ -212,27 +213,18 @@ function View({
     >
       {(childIndex) => {
         const child = modalData.response.children[childIndex]
-        if (!featureFlags.automaticFixedScheduleAbsences) {
-          return child.absence !== null ? (
-            <Absence absence={child.absence} />
-          ) : (
-            <Reservations
-              reservations={child.reservations}
-              scheduleType={child.scheduleType}
-              reservableTimeRange={child.reservableTimeRange}
-            />
-          )
-        } else {
-          return child.reservations.length === 0 && child.absence !== null ? (
-            <Absence absence={child.absence} />
-          ) : (
-            <Reservations
-              reservations={child.reservations}
-              scheduleType={child.scheduleType}
-              reservableTimeRange={child.reservableTimeRange}
-            />
-          )
-        }
+        return (!featureFlags.automaticFixedScheduleAbsences ||
+          isPast ||
+          child.reservations.length === 0) &&
+          child.absence !== null ? (
+          <Absence absence={child.absence} />
+        ) : (
+          <Reservations
+            reservations={child.reservations}
+            scheduleType={child.scheduleType}
+            reservableTimeRange={child.reservableTimeRange}
+          />
+        )
       }}
     </DayModal>
   )

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -212,15 +212,27 @@ function View({
     >
       {(childIndex) => {
         const child = modalData.response.children[childIndex]
-        return child.absence !== null ? (
-          <Absence absence={child.absence} />
-        ) : (
-          <Reservations
-            reservations={child.reservations}
-            scheduleType={child.scheduleType}
-            reservableTimeRange={child.reservableTimeRange}
-          />
-        )
+        if (!featureFlags.automaticFixedScheduleAbsences) {
+          return child.absence !== null ? (
+            <Absence absence={child.absence} />
+          ) : (
+            <Reservations
+              reservations={child.reservations}
+              scheduleType={child.scheduleType}
+              reservableTimeRange={child.reservableTimeRange}
+            />
+          )
+        } else {
+          return child.reservations.length === 0 && child.absence !== null ? (
+            <Absence absence={child.absence} />
+          ) : (
+            <Reservations
+              reservations={child.reservations}
+              scheduleType={child.scheduleType}
+              reservableTimeRange={child.reservableTimeRange}
+            />
+          )
+        }
       }}
     </DayModal>
   )

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -9,11 +9,13 @@ import styled, { css } from 'styled-components'
 
 import { mapScheduleType } from 'lib-common/api-types/placement'
 import {
+  AbsenceInfo,
   ReservableTimeRange,
   Reservation,
   ReservationResponseDay,
   ReservationResponseDayChild
 } from 'lib-common/generated/api-types/reservations'
+import LocalDate from 'lib-common/local-date'
 import {
   reservationHasTimes,
   reservationsAndAttendancesDiffer
@@ -52,8 +54,13 @@ export const Reservations = React.memo(function Reservations({
   )
 
   const groupedChildren = useMemo(
-    () => groupChildren(data.children, i18n),
-    [data.children, i18n]
+    () =>
+      groupChildren({
+        children: data.children,
+        isPast: data.date.isBefore(LocalDate.todayInHelsinkiTz()),
+        i18n
+      }),
+    [data.children, data.date, i18n]
   )
 
   return data.children.length === 0 && data.holiday && !isReservable ? (
@@ -154,13 +161,28 @@ interface GroupedDailyChildren {
   key: string
 }
 
-const groupChildren = (
-  relevantChildren: ReservationResponseDayChild[],
+const absenceElementType = (
+  absence: AbsenceInfo
+): DailyChildGroupElementType =>
+  absence.type === 'FREE_ABSENCE'
+    ? 'absent-free'
+    : featureFlags.citizenAttendanceSummary &&
+        absence.type === 'PLANNED_ABSENCE'
+      ? 'absent-planned'
+      : 'absent'
+
+const groupChildren = ({
+  children,
+  isPast,
+  i18n
+}: {
+  children: ReservationResponseDayChild[]
+  isPast: boolean
   i18n: Translations
-) =>
+}): GroupedDailyChildren[] =>
   Object.entries(
     groupBy(
-      relevantChildren.map((child): DailyChildGroupElement => {
+      children.map((child): DailyChildGroupElement => {
         if (child.attendances.length > 0) {
           return {
             childId: child.childId,
@@ -169,18 +191,13 @@ const groupChildren = (
           }
         }
 
-        // This block of code also appears later in this function. When the feature flag is removed,
-        // also remove this block.
-        if (!featureFlags.automaticFixedScheduleAbsences && child.absence) {
+        if (
+          (isPast || !featureFlags.automaticFixedScheduleAbsences) &&
+          child.absence
+        ) {
           return {
             childId: child.childId,
-            type:
-              child.absence.type === 'FREE_ABSENCE'
-                ? 'absent-free'
-                : featureFlags.citizenAttendanceSummary &&
-                    child.absence.type === 'PLANNED_ABSENCE'
-                  ? 'absent-planned'
-                  : 'absent'
+            type: absenceElementType(child.absence)
           }
         }
 
@@ -212,13 +229,7 @@ const groupChildren = (
         if (child.absence) {
           return {
             childId: child.childId,
-            type:
-              child.absence.type === 'FREE_ABSENCE'
-                ? 'absent-free'
-                : featureFlags.citizenAttendanceSummary &&
-                    child.absence.type === 'PLANNED_ABSENCE'
-                  ? 'absent-planned'
-                  : 'absent'
+            type: absenceElementType(child.absence)
           }
         }
 

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -169,7 +169,9 @@ const groupChildren = (
           }
         }
 
-        if (child.absence) {
+        // This block of code also appears later in this function. When the feature flag is removed,
+        // also remove this block.
+        if (!featureFlags.automaticFixedScheduleAbsences && child.absence) {
           return {
             childId: child.childId,
             type:
@@ -204,6 +206,19 @@ const groupChildren = (
                 formatReservation(reservation, child.reservableTimeRange, i18n)
               )
               .join(', ')
+          }
+        }
+
+        if (child.absence) {
+          return {
+            childId: child.childId,
+            type:
+              child.absence.type === 'FREE_ABSENCE'
+                ? 'absent-free'
+                : featureFlags.citizenAttendanceSummary &&
+                    child.absence.type === 'PLANNED_ABSENCE'
+                  ? 'absent-planned'
+                  : 'absent'
           }
         }
 

--- a/frontend/src/citizen-frontend/calendar/queries.ts
+++ b/frontend/src/citizen-frontend/calendar/queries.ts
@@ -6,6 +6,8 @@ import sortBy from 'lodash/sortBy'
 
 import LocalDate from 'lib-common/local-date'
 import { mutation, query } from 'lib-common/query'
+import { Arg0 } from 'lib-common/types'
+import { featureFlags } from 'lib-customizations/citizen'
 
 import { getCitizenCalendarEvents } from '../generated/api-clients/calendarevent'
 import { getDailyServiceTimeNotifications } from '../generated/api-clients/dailyservicetimes'
@@ -56,7 +58,12 @@ export const dailyServiceTimeNotificationsQuery = query({
 })
 
 export const postReservationsMutation = mutation({
-  api: postReservations,
+  api: (arg: Pick<Arg0<typeof postReservations>, 'body'>) =>
+    postReservations({
+      ...arg,
+      automaticFixedScheduleAbsencesEnabled:
+        featureFlags.automaticFixedScheduleAbsences
+    }),
   invalidateQueryKeys: () => [queryKeys.allReservations()]
 })
 

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.spec.ts
@@ -2551,6 +2551,104 @@ describe('resetTimes', () => {
       })
     })
 
+    it('Reservation + absence', () => {
+      const range = new FiniteDateRange(monday, monday)
+
+      const calendarDays: ReservationResponseDay[] = [
+        {
+          date: monday,
+          holiday: false,
+          children: [
+            {
+              ...emptyChild,
+              childId: 'child-1',
+              reservations: [
+                {
+                  type: 'TIMES',
+                  range: new TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0)),
+                  staffCreated: false
+                }
+              ],
+              absence: { type: 'OTHER_ABSENCE', editable: true }
+            }
+          ]
+        }
+      ]
+
+      const dayProperties = new DayProperties(calendarDays, reservableRange, [])
+
+      expect(
+        resetTimes(dayProperties, undefined, {
+          repetition: 'IRREGULAR',
+          selectedRange: range,
+          selectedChildren: ['child-1']
+        })
+      ).toEqual({
+        branch: 'irregularTimes',
+        state: [
+          {
+            date: monday,
+            day: {
+              branch: 'reservation',
+              state: {
+                validTimeRange: defaultReservableTimeRange,
+                reservation: {
+                  branch: 'timeRanges',
+                  state: [timeInputState('08:00', '16:00')]
+                }
+              }
+            }
+          }
+        ]
+      })
+    })
+
+    it('Reservation + absence marked by employee', () => {
+      const range = new FiniteDateRange(monday, monday)
+
+      const calendarDays: ReservationResponseDay[] = [
+        {
+          date: monday,
+          holiday: false,
+          children: [
+            {
+              ...emptyChild,
+              childId: 'child-1',
+              reservations: [
+                {
+                  type: 'TIMES',
+                  range: new TimeRange(LocalTime.of(8, 0), LocalTime.of(16, 0)),
+                  staffCreated: false
+                }
+              ],
+              absence: { type: 'OTHER_ABSENCE', editable: false }
+            }
+          ]
+        }
+      ]
+
+      const dayProperties = new DayProperties(calendarDays, reservableRange, [])
+
+      expect(
+        resetTimes(dayProperties, undefined, {
+          repetition: 'IRREGULAR',
+          selectedRange: range,
+          selectedChildren: ['child-1']
+        })
+      ).toEqual({
+        branch: 'irregularTimes',
+        state: [
+          {
+            date: monday,
+            day: {
+              branch: 'readOnly',
+              state: 'absentNotEditable'
+            }
+          }
+        ]
+      })
+    })
+
     it('Holidays', () => {
       // MO TU WE
       //    s  s

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -579,8 +579,8 @@ const hasReservationsForEveryChild = (
         (child) =>
           child.childId === childId &&
           (child.reservations.length > 0 ||
-            child.scheduleType !== 'RESERVATION_REQUIRED') &&
-          child.absence === null
+            (child.scheduleType !== 'RESERVATION_REQUIRED' &&
+              child.absence === null))
       )
     )
   )
@@ -620,7 +620,10 @@ const allChildrenAreAbsent = (
   calendarDays.every((day) =>
     selectedChildren.every((childId) =>
       day.children.some(
-        (child) => child.childId === childId && child.absence !== null
+        (child) =>
+          child.childId === childId &&
+          child.reservations.length === 0 &&
+          child.absence !== null
       )
     )
   )

--- a/frontend/src/citizen-frontend/generated/api-clients/reservations.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/reservations.ts
@@ -60,12 +60,17 @@ export async function postAbsences(
 */
 export async function postReservations(
   request: {
+    automaticFixedScheduleAbsencesEnabled?: boolean | null,
     body: DailyReservationRequest[]
   }
 ): Promise<void> {
+  const params = createUrlSearchParams(
+    ['automaticFixedScheduleAbsencesEnabled', request.automaticFixedScheduleAbsencesEnabled?.toString()]
+  )
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/reservations`.toString(),
     method: 'POST',
+    params,
     data: request.body satisfies JsonCompatible<DailyReservationRequest[]>
   })
   return json

--- a/frontend/src/e2e-test/generated/api-clients.ts
+++ b/frontend/src/e2e-test/generated/api-clients.ts
@@ -4,6 +4,8 @@
 
 // GENERATED FILE: no manual modifications
 
+import LocalDate from 'lib-common/local-date'
+import { Absence } from 'lib-common/generated/api-types/absence'
 import { ApplicationDetails } from 'lib-common/generated/api-types/application'
 import { Autocomplete } from './api-types'
 import { Caretaker } from './api-types'
@@ -96,6 +98,7 @@ import { StaffMemberAttendance } from 'lib-common/generated/api-types/attendance
 import { UUID } from 'lib-common/types'
 import { VoucherValueDecision } from './api-types'
 import { createUrlSearchParams } from 'lib-common/api'
+import { deserializeJsonAbsence } from 'lib-common/generated/api-types/absence'
 import { deserializeJsonApplicationDetails } from 'lib-common/generated/api-types/application'
 import { deserializeJsonDecision } from 'lib-common/generated/api-types/decision'
 import { deserializeJsonEmployee } from 'lib-common/generated/api-types/pis'
@@ -1582,6 +1585,32 @@ export async function forceFullVtjRefresh(
       method: 'POST'
     })
     return json
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}
+
+
+/**
+* Generated from fi.espoo.evaka.shared.dev.DevApi.getAbsences
+*/
+export async function getAbsences(
+  request: {
+    childId: UUID,
+    date: LocalDate
+  }
+): Promise<Absence[]> {
+  try {
+    const params = createUrlSearchParams(
+      ['childId', request.childId],
+      ['date', request.date.formatIso()]
+    )
+    const { data: json } = await devClient.request<JsonOf<Absence[]>>({
+      url: uri`/absences`.toString(),
+      method: 'GET',
+      params
+    })
+    return json.map(e => deserializeJsonAbsence(e))
   } catch (e) {
     throw new DevApiError(e)
   }

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import uniq from 'lodash/uniq'
+
 import FiniteDateRange from 'lib-common/finite-date-range'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
@@ -190,15 +192,17 @@ export default class CitizenCalendarPage {
     }
     await rows.assertCount(groups.length)
 
-    for (const [i, { childIds, text }] of groups.entries()) {
+    for (const [i, group] of groups.entries()) {
       const row = rows.nth(i)
+      const childIds = uniq(group.childIds)
 
+      await row.findAllByDataQa('child-image').assertCount(childIds.length)
       for (const childId of childIds) {
         await row
           .find(`[data-qa="child-image"][data-qa-child-id="${childId}"]`)
           .waitUntilVisible()
       }
-      await row.findByDataQa('reservation-text').assertTextEquals(text)
+      await row.findByDataQa('reservation-text').assertTextEquals(group.text)
     }
   }
 

--- a/frontend/src/employee-frontend/components/unit/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/queries.ts
@@ -5,6 +5,7 @@
 import LocalDate from 'lib-common/local-date'
 import { mutation, query } from 'lib-common/query'
 import { Arg0, UUID } from 'lib-common/types'
+import { featureFlags } from 'lib-customizations/employee'
 
 import {
   acceptPlacementProposal,
@@ -185,7 +186,12 @@ export const unitGroupDetailsQuery = query({
 })
 
 export const postReservationsMutation = mutation({
-  api: postReservations,
+  api: (arg: Pick<Arg0<typeof postReservations>, 'body'>) =>
+    postReservations({
+      ...arg,
+      automaticFixedScheduleAbsencesEnabled:
+        featureFlags.automaticFixedScheduleAbsences
+    }),
   invalidateQueryKeys: () => [queryKeys.unitAttendanceReservations()]
 })
 

--- a/frontend/src/employee-frontend/generated/api-clients/reservations.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reservations.ts
@@ -84,12 +84,17 @@ export async function postChildDatePresence(
 */
 export async function postReservations(
   request: {
+    automaticFixedScheduleAbsencesEnabled?: boolean | null,
     body: DailyReservationRequest[]
   }
 ): Promise<void> {
+  const params = createUrlSearchParams(
+    ['automaticFixedScheduleAbsencesEnabled', request.automaticFixedScheduleAbsencesEnabled?.toString()]
+  )
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/attendance-reservations`.toString(),
     method: 'POST',
+    params,
     data: request.body satisfies JsonCompatible<DailyReservationRequest[]>
   })
   return json

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -41,7 +41,8 @@ const features: Features = {
     noAbsenceType: false,
     discussionReservations: true,
     jamixIntegration: true,
-    forceUnpublishDocumentTemplate: true
+    forceUnpublishDocumentTemplate: true,
+    automaticFixedScheduleAbsences: true
   },
   staging: {
     citizenShiftCareAbsence: true,
@@ -71,7 +72,8 @@ const features: Features = {
     noAbsenceType: false,
     discussionReservations: true,
     jamixIntegration: true,
-    forceUnpublishDocumentTemplate: true
+    forceUnpublishDocumentTemplate: true,
+    automaticFixedScheduleAbsences: true
   },
   prod: {
     citizenShiftCareAbsence: true,

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import 'react'
 import type { LatLngExpression } from 'leaflet'
+import React from 'react'
 
 import { AbsenceType } from 'lib-common/generated/api-types/absence'
 import { ApplicationType } from 'lib-common/generated/api-types/application'
@@ -243,6 +243,12 @@ interface BaseFeatureFlags {
    * Note the corresponding backend environment variable feature flag.
    */
   forceUnpublishDocumentTemplate?: boolean
+
+  /**
+   * Create absences for preschool/preparatory/5-year-old children automatically
+   * when adding reservations.
+   */
+  automaticFixedScheduleAbsences?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -216,7 +216,8 @@ class AttendanceReservationController(
         db: Database,
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,
-        @RequestBody body: List<DailyReservationRequest>
+        @RequestBody body: List<DailyReservationRequest>,
+        @RequestParam automaticFixedScheduleAbsencesEnabled: Boolean = false
     ) {
         val children = body.map { it.childId }.toSet()
 
@@ -236,7 +237,8 @@ class AttendanceReservationController(
                         user,
                         body,
                         featureConfig.citizenReservationThresholdHours,
-                        env.plannedAbsenceEnabledForHourBasedServiceNeeds
+                        env.plannedAbsenceEnabledForHourBasedServiceNeeds,
+                        automaticFixedScheduleAbsencesEnabled
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.reservations
 
 import fi.espoo.evaka.absence.AbsenceCategory
 import fi.espoo.evaka.absence.AbsenceType
+import fi.espoo.evaka.daycare.domain.Language
 import fi.espoo.evaka.occupancy.familyUnitPlacementCoefficient
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ShiftCareType
@@ -304,6 +305,7 @@ data class ReservationPlacement(
     val childId: ChildId,
     val range: FiniteDateRange,
     val type: PlacementType,
+    val unitLanguage: Language,
     val operationTimes: List<TimeRange?>,
     val shiftCareOperationTimes: List<TimeRange?>?,
     val shiftCareOpenOnHolidays: Boolean,
@@ -323,6 +325,7 @@ data class ReservationPlacementRow(
     val placementId: PlacementId,
     val range: FiniteDateRange,
     val type: PlacementType,
+    val unitLanguage: Language,
     val operationTimes: List<TimeRange?>,
     val shiftCareOperationTimes: List<TimeRange?>?,
     val shiftCareOpenOnHolidays: Boolean,
@@ -345,6 +348,7 @@ SELECT
     pl.id AS placement_id,
     daterange(pl.start_date, pl.end_date, '[]') AS range,
     pl.type,
+    u.language AS unit_language,
     u.operation_times,
     u.shift_care_operation_times,
     u.shift_care_open_on_holidays,
@@ -371,6 +375,7 @@ WHERE
                 childId = rows[0].childId,
                 range = rows[0].range,
                 type = rows[0].type,
+                unitLanguage = rows[0].unitLanguage,
                 operationTimes = rows[0].operationTimes,
                 shiftCareOperationTimes = rows[0].shiftCareOperationTimes,
                 shiftCareOpenOnHolidays = rows[0].shiftCareOpenOnHolidays,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.BucketEnv
 import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.absence.AbsenceCategory
 import fi.espoo.evaka.absence.AbsenceType
+import fi.espoo.evaka.absence.getAbsencesOfChildByDate
 import fi.espoo.evaka.application.ApplicationDetails
 import fi.espoo.evaka.application.ApplicationForm
 import fi.espoo.evaka.application.ApplicationOrigin
@@ -995,7 +996,8 @@ UPDATE placement SET end_date = ${bind(req.endDate)}, termination_requested_date
                     fakeAdmin,
                     body,
                     featureConfig.citizenReservationThresholdHours,
-                    true
+                    plannedAbsenceEnabledForHourBasedServiceNeeds = true,
+                    automaticFixedScheduleAbsencesEnabled = false
                 )
             }
         }
@@ -1487,6 +1489,10 @@ VALUES (${bind(body.id)}, ${bind(body.guardianId)}, ${bind(body.dailyServiceTime
     @PostMapping("/absence")
     fun addAbsence(db: Database, @RequestBody body: DevAbsence) =
         db.connect { dbc -> dbc.transaction { it.insert(body) } }
+
+    @GetMapping("/absences")
+    fun getAbsences(db: Database, @RequestParam childId: ChildId, @RequestParam date: LocalDate) =
+        db.connect { dbc -> dbc.transaction { it.getAbsencesOfChildByDate(childId, date) } }
 
     @PostMapping("/club-term")
     fun createClubTerm(db: Database, @RequestBody body: DevClubTerm) {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Time.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/domain/Time.kt
@@ -179,6 +179,12 @@ data class FiniteDateRange(override val start: LocalDate, override val end: Loca
             val to = date.with(lastDayOfMonth())
             return FiniteDateRange(from, to)
         }
+
+        fun ofYear(year: Int): FiniteDateRange {
+            val from = LocalDate.of(year, 1, 1)
+            val to = LocalDate.of(year, 12, 31)
+            return FiniteDateRange(from, to)
+        }
     }
 }
 


### PR DESCRIPTION
Luodaan automaattisesti poissaoloja seuraavissa tapauksissa:
- Kuntalainen tekee toistuvia varauksia tai varauksen yksittäiselle päivälle
- Henkilökunta tekee toistuvia varauksia 

Poissaolojen luonnin säännöt on [dokumentoitu wikissä](https://github.com/espoon-voltti/evaka/wiki/L%C3%A4sn%C3%A4%E2%80%90-ja-poissaolot#poissaolojen-syntyminen-p%C3%A4iv%C3%A4n-l%C3%A4sn%C3%A4oloajasta).

Kuntalaisen kalenteri myös näyttää nyt ensisijaisesti varauksen, kun se ennen näytti ensisijaisesti poissaolon. Poissaolo näytetään vain jos varauksia ei ole lainkaan.

Feature flagin `automaticFixedScheduleAbsences` takana.

