### PR TITLE
isPermittedForSomeTarget-käyttöoikeustarkastus ei ole enää liian salliva

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/IsCitizenTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/security/IsCitizenTest.kt
@@ -4,27 +4,39 @@
 
 package fi.espoo.evaka.shared.security
 
-import fi.espoo.evaka.shared.EmployeeId
-import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
+import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.DevGuardian
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPersonType
+import fi.espoo.evaka.shared.dev.insert
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.security.actionrule.IsCitizen
 import java.time.LocalDateTime
-import java.util.UUID
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class IsCitizenTest : AccessControlTest() {
-    private val strongCitizen =
-        AuthenticatedUser.Citizen(PersonId(UUID.randomUUID()), CitizenAuthLevel.STRONG)
-    private val weakCitizen =
-        AuthenticatedUser.Citizen(PersonId(UUID.randomUUID()), CitizenAuthLevel.WEAK)
-    private val employee = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), emptySet())
+    private val strongPerson = DevPerson()
+    private val strongCitizen = strongPerson.user(CitizenAuthLevel.STRONG)
+    private val weakPerson = DevPerson()
+    private val weakCitizen = weakPerson.user(CitizenAuthLevel.WEAK)
+    private val employee = DevEmployee()
 
     private val clock = MockEvakaClock(HelsinkiDateTime.of(LocalDateTime.of(2022, 1, 1, 12, 0)))
+
+    @BeforeEach
+    fun beforeEach() {
+        db.transaction { tx ->
+            tx.insert(strongPerson, DevPersonType.ADULT)
+            tx.insert(weakPerson, DevPersonType.ADULT)
+            tx.insert(employee)
+        }
+    }
 
     @Test
     fun `permits only strongly authenticated citizen if allowWeakLogin = false`() {
@@ -33,7 +45,7 @@ class IsCitizenTest : AccessControlTest() {
         db.read { tx ->
             assertTrue(accessControl.hasPermissionFor(tx, strongCitizen, clock, action))
             assertFalse(accessControl.hasPermissionFor(tx, weakCitizen, clock, action))
-            assertFalse(accessControl.hasPermissionFor(tx, employee, clock, action))
+            assertFalse(accessControl.hasPermissionFor(tx, employee.user, clock, action))
         }
     }
 
@@ -44,7 +56,7 @@ class IsCitizenTest : AccessControlTest() {
         db.read { tx ->
             assertTrue(accessControl.hasPermissionFor(tx, strongCitizen, clock, action))
             assertTrue(accessControl.hasPermissionFor(tx, weakCitizen, clock, action))
-            assertFalse(accessControl.hasPermissionFor(tx, employee, clock, action))
+            assertFalse(accessControl.hasPermissionFor(tx, employee.user, clock, action))
         }
     }
 
@@ -63,5 +75,27 @@ class IsCitizenTest : AccessControlTest() {
                 accessControl.hasPermissionFor(tx, weakCitizen, clock, action, weakCitizen.id)
             )
         }
+    }
+
+    @Test
+    fun `IsCitizen and isPermittedForSomeTarget check`() {
+        val action = Action.Child.READ
+        fun isPermittedForSomeTarget(user: AuthenticatedUser) =
+            db.read { accessControl.isPermittedForSomeTarget(it, user, clock, action) }
+
+        rules.add(action, IsCitizen(allowWeakLogin = false).guardianOfChild())
+
+        assertFalse(isPermittedForSomeTarget(weakCitizen))
+        assertFalse(isPermittedForSomeTarget(strongCitizen))
+
+        db.transaction { tx ->
+            val child = DevPerson()
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insert(DevGuardian(guardianId = weakCitizen.id, childId = child.id))
+            tx.insert(DevGuardian(guardianId = strongCitizen.id, childId = child.id))
+        }
+
+        assertFalse(isPermittedForSomeTarget(weakCitizen))
+        assertTrue(isPermittedForSomeTarget(strongCitizen))
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/ActionRule.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/ActionRule.kt
@@ -97,8 +97,6 @@ object DatabaseActionRule {
     }
 
     interface Params {
-        fun isPermittedForSomeTarget(ctx: QueryContext): Boolean
-
         override fun hashCode(): Int
 
         override fun equals(other: Any?): Boolean
@@ -122,6 +120,9 @@ object DatabaseActionRule {
 
             fun queryWithParams(ctx: QueryContext, params: P): QuerySql?
         }
+
+        fun queryWithParams(ctx: QueryContext): QuerySql? =
+            this.query.queryWithParams(ctx, this.params)
 
         data class Simple<T, P : Params>(override val params: P, override val query: Query<T, P>) :
             Scoped<T, P>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasGlobalRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasGlobalRole.kt
@@ -41,9 +41,6 @@ data class HasGlobalRole(val oneOf: EnumSet<UserRole>) :
             AccessControlDecision.None
         }
 
-    override fun isPermittedForSomeTarget(ctx: DatabaseActionRule.QueryContext): Boolean =
-        evaluate(ctx.user).isPermitted()
-
     private fun <T : Id<*>> rule(filter: Filter): DatabaseActionRule.Scoped<T, HasGlobalRole> =
         DatabaseActionRule.Scoped.Simple(this, Query(filter))
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsCitizen.kt
@@ -37,12 +37,6 @@ data class IsCitizen(val allowWeakLogin: Boolean) : DatabaseActionRule.Params {
     fun isPermittedAuthLevel(authLevel: CitizenAuthLevel) =
         authLevel == CitizenAuthLevel.STRONG || allowWeakLogin
 
-    override fun isPermittedForSomeTarget(ctx: DatabaseActionRule.QueryContext): Boolean =
-        when (ctx.user) {
-            is AuthenticatedUser.Citizen -> isPermittedAuthLevel(ctx.user.authLevel)
-            else -> false
-        }
-
     private fun <T : Id<*>> rule(filter: FilterByCitizen): DatabaseActionRule.Scoped<T, IsCitizen> =
         DatabaseActionRule.Scoped.Simple(this, Query(filter))
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsEmployee.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsEmployee.kt
@@ -22,12 +22,6 @@ private typealias FilterByEmployee =
     QuerySql.Builder.(user: AuthenticatedUser.Employee, now: HelsinkiDateTime) -> QuerySql
 
 data object IsEmployee : DatabaseActionRule.Params {
-    override fun isPermittedForSomeTarget(ctx: DatabaseActionRule.QueryContext): Boolean =
-        when (ctx.user) {
-            is AuthenticatedUser.Employee -> true
-            else -> false
-        }
-
     private fun <T : Id<*>> rule(
         filter: FilterByEmployee
     ): DatabaseActionRule.Scoped<T, IsEmployee> =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsMobile.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsMobile.kt
@@ -33,12 +33,6 @@ data class IsMobile(val requirePinLogin: Boolean) : DatabaseActionRule.Params {
             MobileAuthLevel.DEFAULT -> !requirePinLogin
         }
 
-    override fun isPermittedForSomeTarget(ctx: DatabaseActionRule.QueryContext): Boolean =
-        when (ctx.user) {
-            is AuthenticatedUser.MobileDevice -> isPermittedAuthLevel(ctx.user.authLevel)
-            else -> false
-        }
-
     private fun <T : Id<*>> rule(filter: FilterByMobile): DatabaseActionRule.Scoped<T, IsMobile> =
         DatabaseActionRule.Scoped.Simple(this, Query(filter))
 
@@ -148,13 +142,9 @@ JOIN (${subquery(aclQuery)}) acl USING (child_id)
     fun any() =
         object : StaticActionRule {
             override fun evaluate(user: AuthenticatedUser): AccessControlDecision =
-                if (
-                    user is AuthenticatedUser.MobileDevice && isPermittedAuthLevel(user.authLevel)
-                ) {
+                if (user is AuthenticatedUser.MobileDevice && isPermittedAuthLevel(user.authLevel))
                     AccessControlDecision.Permitted(this)
-                } else {
-                    AccessControlDecision.None
-                }
+                else AccessControlDecision.None
         }
 
     fun inPlacementUnitOfChild(cfg: ChildAclConfig = ChildAclConfig()) =


### PR DESCRIPTION
<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->

`isPermittedForSomeTarget` on vain toimintojen näkyvyyteen käytetty käyttöoikeustarkistus, joka oli aiemmin liian salliva, koska se ei yleensä käynyt tietokannassa ajamassa sääntöjen "jälkimmäistä puolta".

Esim. `IsCitizen(allowWeakAuth = false).guardianOfChild()` säännön kanssa tarkistus katsoi vain kirjautumisen tason `IsCitizen(allowWeakAuth)` (a.k.a "Params" toteutuksessa), eikä käynyt kannassa tarkistamassa huoltajuussuhteita `.guardianOfChild()` (a.k.a "Query" toteutuksessa).

Ongelma on korjattu kirjoittamalla toteutus osittain uudestaan ja siirtämällä tarkistusvastuu Params-tyypistä Query-tyyppiin. Koodin määrä vähenee hieman koska voidaan uudelleenkäyttää samaa `queryForParams`-funktiota joka on jo tehty `getAuthorizationFilter`-tarkistusta varten.