### PR TITLE
Korjauksia palse-arvoeditoriin

### DIFF
--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4551,6 +4551,9 @@ export const fi = {
       errors: {
         'date-overlap':
           'Voimassaolo ei voi alkaa ennen toisen palveluseteliarvon alkamispäivää',
+        'end-date-overlap':
+          'Voimassaolo ei voi alkaa ennen edellisen palvelusetelin päättymispäivää seuraavaa päivää',
+        'date-gap': 'Voimassaolojen välissä ei voi olla aukkoja',
         shouldNotHappen: 'Odottamaton virhe'
       },
       modals: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueIntegrationTest.kt
@@ -177,6 +177,29 @@ class VoucherValueIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
         addVoucherValue(testVoucherValue)
     }
 
+    @Test
+    fun `should throw if trying to add a new voucher value such that it would leave a gap after the end of the previous one`() {
+        val voucherValuesBefore =
+            getVoucherValues()[snDefaultDaycare.id]!!.sortedBy { it.voucherValues.range.start }
+
+        val endedVoucherValue =
+            voucherValuesBefore[1]
+                .voucherValues
+                .copy(
+                    range =
+                        DateRange(
+                            voucherValuesBefore[1].voucherValues.range.start,
+                            LocalDate.of(2024, 5, 31)
+                        )
+                )
+        updateVoucherValue(voucherValuesBefore[1].id, endedVoucherValue)
+
+        val newVoucherValue =
+            testVoucherValue.copy(range = DateRange(LocalDate.of(2024, 6, 3), null))
+        assertThrows<BadRequest> { addVoucherValue(newVoucherValue) }
+    }
+
+    @Test
     fun `should update an existing voucher value`() {
         val voucherValuesBefore =
             getVoucherValues()[snDefaultDaycare.id]!!.sortedBy { it.voucherValues.range.start }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FinanceBasicsController.kt
@@ -185,6 +185,14 @@ class FinanceBasicsController(
                                     "New voucher value range must start after existing ones"
                                 )
 
+                            if (
+                                latest.voucherValues.range.end != null &&
+                                    body.range.start != latest.voucherValues.range.start.plusDays(1)
+                            )
+                                throw BadRequest(
+                                    "New voucher value can't leave a gap in validities"
+                                )
+
                             if (latest.voucherValues.range.overlaps(body.range)) {
                                 tx.updateVoucherValueEndDate(
                                     latest.id,


### PR DESCRIPTION
- UI validoi nyt ettei palse-arvojen voimassaolojen väleihin saa jäädä aukkoja
- Back end siirtää lisätyn arvon alkamispäivää aiemmaksi, jos sen ja edellisen väliin jäisi aukko
- Korjattu ongelma jossa viimeisin palse-arvo ei ollut editoitavissa tai poistettavissa jos sille oli asetettu päättymispäivä
- Uuden arvon alkamispäivä asetetaan nyt automaattisesti edellisen arvon päättymispäivää seuraavaan päivään, jos edellisen arvon päättymispäivä oli asetettu