### PR TITLE
Tulotietojen päättymispäivä pakolliseksi jos muu kuin suostumus korkeimpaan

### DIFF
--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
@@ -56,7 +56,11 @@ function useInitialEditorState(
       startDates,
       formData:
         incomeStatement === null
-          ? { ...emptyIncomeStatementForm, childIncome: true }
+          ? {
+              ...emptyIncomeStatementForm,
+              childIncome: true,
+              highestFee: false
+            }
           : Form.fromIncomeStatement(incomeStatement)
     })
   )

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
@@ -179,6 +179,7 @@ const ChildIncomeTimeRangeSelection = React.memo(
                 isValidStartDate(d) ? null : t.validationErrors.unselectableDate
               }
               data-qa="start-date"
+              required={true}
             />
           </div>
           <div>

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -327,6 +327,11 @@ const IncomeTypeSelection = React.memo(
       [formData.startDate, t]
     )
 
+    const isEndDateRequired = useMemo(
+      () => formData.grossSelected || formData.entrepreneurSelected,
+      [formData.grossSelected, formData.entrepreneurSelected]
+    )
+
     const validateEndDate = useCallback(
       (endDate: LocalDate | null) => {
         if (!formData.startDate) return undefined
@@ -335,7 +340,7 @@ const IncomeTypeSelection = React.memo(
 
         if (formData.highestFeeSelected) return undefined
 
-        if (formData.grossSelected || formData.entrepreneurSelected) {
+        if (isEndDateRequired) {
           if (!endDate) return 'required'
 
           if (endDate > formData.startDate.addYears(1)) return 'dateTooLate'
@@ -343,12 +348,7 @@ const IncomeTypeSelection = React.memo(
 
         return undefined
       },
-      [
-        formData.entrepreneurSelected,
-        formData.grossSelected,
-        formData.highestFeeSelected,
-        formData.startDate
-      ]
+      [formData.highestFeeSelected, formData.startDate, isEndDateRequired]
     )
 
     const endDateInputInfo = useMemo(
@@ -384,6 +384,7 @@ const IncomeTypeSelection = React.memo(
                 info={startDateInputInfo}
                 hideErrorsBeforeTouched={!showFormErrors}
                 locale={lang}
+                required={true}
                 isInvalidDate={(d) =>
                   isValidStartDate(d)
                     ? null
@@ -392,7 +393,7 @@ const IncomeTypeSelection = React.memo(
               />
             </div>
             <div>
-              <Label htmlFor="end-date">{t.income.incomeType.endDate}</Label>
+              <Label htmlFor="end-date">{`${t.income.incomeType.endDate}${isEndDateRequired ? ' *' : ''}`}</Label>
               <Gap size="xs" />
               <DatePicker
                 id="end-date"
@@ -407,6 +408,7 @@ const IncomeTypeSelection = React.memo(
                   errorToInputInfo(validateEndDate(d), t.validationErrors)
                     ?.text || null
                 }
+                required={isEndDateRequired}
               />
             </div>
           </FixedSpaceRow>

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -322,6 +322,22 @@ const IncomeTypeSelection = React.memo(
       [formData.startDate, t]
     )
 
+    const endDateInputInfo = useMemo(
+      () =>
+        errorToInputInfo(
+          formData.highestFeeSelected
+            ? undefined
+            : formData.endDate
+              ? undefined
+              : 'required',
+          t.validationErrors
+        ),
+      [formData.highestFeeSelected, formData.endDate, t]
+    )
+
+    const isValidEndDate = (date: LocalDate) =>
+      formData.highestFeeSelected || !!date
+
     return (
       <ContentArea opaque paddingVertical="L" ref={ref}>
         <FixedSpaceColumn spacing="zero">
@@ -363,8 +379,12 @@ const IncomeTypeSelection = React.memo(
                 date={formData.endDate}
                 onChange={useFieldDispatch(onChange, 'endDate')}
                 minDate={formData.startDate ?? undefined}
-                hideErrorsBeforeTouched
+                hideErrorsBeforeTouched={false}
                 locale={lang}
+                info={endDateInputInfo}
+                isInvalidDate={(d) =>
+                  isValidEndDate(d) ? null : t.validationErrors.unselectableDate
+                }
               />
             </div>
           </FixedSpaceRow>

--- a/frontend/src/citizen-frontend/income-statements/types/body.ts
+++ b/frontend/src/citizen-frontend/income-statements/types/body.ts
@@ -50,7 +50,7 @@ export function fromBody(
     }
     return { type: 'HIGHEST_FEE', startDate, endDate: formData.endDate }
   } else {
-    if (!formData.endDate) return null
+    if (personType === 'adult' && !formData.endDate) return null
   }
 
   if (formData.childIncome) {

--- a/frontend/src/citizen-frontend/income-statements/types/body.ts
+++ b/frontend/src/citizen-frontend/income-statements/types/body.ts
@@ -49,6 +49,8 @@ export function fromBody(
       return null
     }
     return { type: 'HIGHEST_FEE', startDate, endDate: formData.endDate }
+  } else {
+    if (!formData.endDate) return null
   }
 
   if (formData.childIncome) {

--- a/frontend/src/citizen-frontend/income-statements/types/form.ts
+++ b/frontend/src/citizen-frontend/income-statements/types/form.ts
@@ -70,7 +70,7 @@ export interface Accountant {
 export const emptyIncomeStatementForm: IncomeStatementForm = {
   startDate: null,
   endDate: null,
-  highestFee: false,
+  highestFee: true,
   childIncome: false,
   gross: {
     selected: false,

--- a/frontend/src/e2e-test/pages/citizen/citizen-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-income.ts
@@ -34,7 +34,8 @@ export default class CitizenIncomePage {
   async selectIncomeStatementType(
     type: 'highest-fee' | 'gross-income' | 'entrepreneur-income'
   ) {
-    await this.page.findByDataQa(`${type}-checkbox`).click()
+    await new Checkbox(this.page.findByDataQa(`highest-fee-checkbox`)).uncheck()
+    await new Checkbox(this.page.findByDataQa(`${type}-checkbox`)).check()
   }
 
   async setValidFromDate(date: string) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-income.ts
@@ -16,7 +16,9 @@ export default class CitizenIncomePage {
   rows: ElementCollection
   assureCheckBox: Checkbox
   #entrepreneurDate: TextInput
-  #startDate: TextInput
+  validFromDate: TextInput
+  validToDate: TextInput
+  incomeEndDateInfo: Element
   constructor(private readonly page: Page) {
     this.requiredAttachments = page.findByDataQa('required-attachments')
     this.rows = page.findAll('tbody tr')
@@ -24,7 +26,9 @@ export default class CitizenIncomePage {
     this.#entrepreneurDate = new TextInput(
       page.findByDataQa('entrepreneur-start-date')
     )
-    this.#startDate = new TextInput(page.find('#start-date'))
+    this.validFromDate = new TextInput(page.findByDataQa('income-start-date'))
+    this.validToDate = new TextInput(page.findByDataQa('income-end-date'))
+    this.incomeEndDateInfo = page.findByDataQa('income-end-date-info')
   }
 
   async createNewIncomeStatement() {
@@ -39,8 +43,13 @@ export default class CitizenIncomePage {
   }
 
   async setValidFromDate(date: string) {
-    await this.#startDate.fill(date)
-    await this.#startDate.press('Enter')
+    await this.validFromDate.fill(date)
+    await this.validFromDate.press('Enter')
+  }
+
+  async setValidToDate(date: string) {
+    await this.validToDate.fill(date)
+    await this.validToDate.press('Enter')
   }
 
   async submit() {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
@@ -48,6 +48,7 @@ const assertRequiredAttachment = async (attachment: string, present = true) =>
 
 describe('Income statements', () => {
   const startDate = '24.12.2044'
+  const endDate = '24.12.2044'
 
   describe('With the bare minimum selected', () => {
     test('Highest fee', async () => {
@@ -65,12 +66,21 @@ describe('Income statements', () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
       await incomeStatementsPage.setValidFromDate(startDate)
+      await incomeStatementsPage.incomeEndDateInfo.waitUntilHidden()
       await incomeStatementsPage.selectIncomeStatementType('gross-income')
+      await incomeStatementsPage.incomeEndDateInfo.waitUntilVisible()
+
       await incomeStatementsPage.checkIncomesRegisterConsent()
       await incomeStatementsPage.checkAssured()
       await incomeStatementsPage.setGrossIncomeEstimate(1500)
-      await incomeStatementsPage.submit()
+      // End date can be max 1y from start date so a warning is shown
+      await incomeStatementsPage.setValidToDate('25.12.2045')
+      await incomeStatementsPage.incomeEndDateInfo.waitUntilVisible()
 
+      await incomeStatementsPage.setValidToDate(endDate)
+      await incomeStatementsPage.incomeEndDateInfo.waitUntilHidden()
+
+      await incomeStatementsPage.submit()
       await assertIncomeStatementCreated(startDate)
     })
   })
@@ -80,6 +90,7 @@ describe('Income statements', () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
       await incomeStatementsPage.setValidFromDate(startDate)
+      await incomeStatementsPage.setValidToDate(endDate)
       await incomeStatementsPage.selectIncomeStatementType(
         'entrepreneur-income'
       )
@@ -118,6 +129,7 @@ describe('Income statements', () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
       await incomeStatementsPage.setValidFromDate(startDate)
+      await incomeStatementsPage.setValidToDate(endDate)
       await incomeStatementsPage.selectIncomeStatementType(
         'entrepreneur-income'
       )
@@ -155,6 +167,7 @@ describe('Income statements', () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
       await incomeStatementsPage.setValidFromDate(startDate)
+      await incomeStatementsPage.setValidToDate(endDate)
       await incomeStatementsPage.selectIncomeStatementType(
         'entrepreneur-income'
       )
@@ -188,6 +201,7 @@ describe('Income statements', () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
       await incomeStatementsPage.setValidFromDate(startDate)
+      await incomeStatementsPage.setValidToDate(endDate)
       await incomeStatementsPage.selectIncomeStatementType(
         'entrepreneur-income'
       )

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
@@ -79,7 +79,6 @@ describe('Income statements', () => {
 
       await incomeStatementsPage.setValidToDate(endDate)
       await incomeStatementsPage.incomeEndDateInfo.waitUntilHidden()
-
       await incomeStatementsPage.submit()
       await assertIncomeStatementCreated(startDate)
     })

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerCitizenIntegrationTest.kt
@@ -374,7 +374,7 @@ class IncomeStatementControllerCitizenIntegrationTest :
         createIncomeStatement(
             IncomeStatementBody.Income(
                 startDate = LocalDate.of(2021, 4, 3),
-                endDate = null,
+                endDate = LocalDate.of(2022, 4, 1),
                 gross =
                     Gross(
                         incomeSource = IncomeSource.ATTACHMENTS,
@@ -399,7 +399,7 @@ class IncomeStatementControllerCitizenIntegrationTest :
                     firstName = testAdult_1.firstName,
                     lastName = testAdult_1.lastName,
                     startDate = LocalDate.of(2021, 4, 3),
-                    endDate = null,
+                    endDate = LocalDate.of(2022, 4, 1),
                     gross =
                         Gross(
                             incomeSource = IncomeSource.ATTACHMENTS,
@@ -570,7 +570,7 @@ class IncomeStatementControllerCitizenIntegrationTest :
             incomeStatement.id,
             IncomeStatementBody.Income(
                 startDate = LocalDate.of(2021, 6, 11),
-                endDate = null,
+                endDate = LocalDate.of(2022, 6, 1),
                 gross = null,
                 entrepreneur =
                     Entrepreneur(
@@ -607,7 +607,7 @@ class IncomeStatementControllerCitizenIntegrationTest :
                 firstName = testAdult_1.firstName,
                 lastName = testAdult_1.lastName,
                 startDate = LocalDate.of(2021, 6, 11),
-                endDate = null,
+                endDate = LocalDate.of(2022, 6, 1),
                 gross = null,
                 entrepreneur =
                     Entrepreneur(

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatement.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatement.kt
@@ -123,6 +123,8 @@ fun validateIncomeStatementBody(body: IncomeStatementBody): Boolean {
         is IncomeStatementBody.Income ->
             if (body.gross == null && body.entrepreneur == null) {
                 false
+            } else if (body.endDate == null) {
+                false
             } else {
                 body.entrepreneur.let { entrepreneur ->
                     entrepreneur == null ||


### PR DESCRIPTION
- Jos kuntalaisen tulotiedoissa valitaan muu kuin suostumus korkeimpaan maksuun, on päättymispäivä pakollinen ja maksimissaan 1v alkupäivästä päivästä
- Valitaan suostumus korkeimpaan oletusarvoisesti
- Lapsen tulotietojen loppupäivä pysyy valinnaisena