### PR TITLE
Piilotetaan laskunäkymästä tili ja laskulaji niiltä kunnilta jossa niitä ei käytetä

### DIFF
--- a/frontend/src/employee-frontend/components/invoice/InvoiceDetailsSection.tsx
+++ b/frontend/src/employee-frontend/components/invoice/InvoiceDetailsSection.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom'
 
 import { InvoiceDetailed } from 'lib-common/generated/api-types/invoicing'
 import CollapsibleSection from 'lib-components/molecules/CollapsibleSection'
+import { featureFlags } from 'lib-customizations/employee'
 import { faMoneyCheck } from 'lib-icons'
 
 import LabelValueList from '../../components/common/LabelValueList'
@@ -46,14 +47,22 @@ const InvoiceDetailsSection = React.memo(function InvoiceDetailsSection({
             label: i18n.invoice.form.details.dueDate,
             value: invoice.dueDate.format()
           },
-          {
-            label: i18n.invoice.form.details.account,
-            value: invoice.account
-          },
-          {
-            label: i18n.invoice.form.details.agreementType,
-            value: invoice.agreementType
-          },
+          ...(featureFlags.invoiceDisplayAccountNumber
+            ? [
+                {
+                  label: i18n.invoice.form.details.account,
+                  value: invoice.account
+                }
+              ]
+            : []),
+          ...(invoice.agreementType !== null
+            ? [
+                {
+                  label: i18n.invoice.form.details.agreementType,
+                  value: invoice.agreementType
+                }
+              ]
+            : []),
           {
             label: i18n.invoice.form.details.relatedFeeDecisions,
             value: (

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -42,7 +42,8 @@ const features: Features = {
     discussionReservations: true,
     jamixIntegration: true,
     forceUnpublishDocumentTemplate: true,
-    automaticFixedScheduleAbsences: true
+    automaticFixedScheduleAbsences: true,
+    invoiceDisplayAccountNumber: true
   },
   staging: {
     citizenShiftCareAbsence: true,
@@ -73,7 +74,8 @@ const features: Features = {
     discussionReservations: true,
     jamixIntegration: true,
     forceUnpublishDocumentTemplate: true,
-    automaticFixedScheduleAbsences: true
+    automaticFixedScheduleAbsences: true,
+    invoiceDisplayAccountNumber: true
   },
   prod: {
     citizenShiftCareAbsence: true,
@@ -102,7 +104,8 @@ const features: Features = {
     intermittentShiftCare: false,
     noAbsenceType: false,
     discussionReservations: false,
-    forceUnpublishDocumentTemplate: false
+    forceUnpublishDocumentTemplate: false,
+    invoiceDisplayAccountNumber: true
   }
 }
 

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -249,6 +249,11 @@ interface BaseFeatureFlags {
    * when adding reservations.
    */
   automaticFixedScheduleAbsences?: boolean
+
+  /**
+   * Display account number on invoice details view.
+   */
+  invoiceDisplayAccountNumber?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>


### PR DESCRIPTION
Uusi optional frontend feature flag invoiceDisplayAccountNumber - voi laittaa falseksi tai jättää asettamatta muualla kuin Espoossa.