### PR TITLE
Näytetään testiympäristöissä ympäristön nimi jotta erottuu selkeämmin tuotannosta

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -12,10 +12,12 @@ import {
   Notifications,
   NotificationsContextProvider
 } from 'lib-components/Notifications'
+import { EnvironmentLabel } from 'lib-components/atoms/EnvironmentLabel'
 import SkipToContent from 'lib-components/atoms/buttons/SkipToContent'
 import ErrorPage from 'lib-components/molecules/ErrorPage'
 import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
 import { theme } from 'lib-customizations/common'
+import { featureFlags } from 'lib-customizations/employee'
 
 import AccessibilityStatement from './AccessibilityStatement'
 import RequireAuth from './RequireAuth'
@@ -115,6 +117,9 @@ const Content = React.memo(function Content() {
         <Outlet />
       </MainContainer>
       <MobileNav />
+      {!!featureFlags.environmentLabel && (
+        <EnvironmentLabel>{featureFlags.environmentLabel}</EnvironmentLabel>
+      )}
     </FullPageContainer>
   )
 })

--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -9,6 +9,7 @@ import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom'
 import { StyleSheetManager, ThemeProvider } from 'styled-components'
 
 import { Notifications } from 'lib-components/Notifications'
+import { EnvironmentLabel } from 'lib-components/atoms/EnvironmentLabel'
 import ErrorPage from 'lib-components/molecules/ErrorPage'
 import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
 import { theme } from 'lib-customizations/common'
@@ -164,6 +165,9 @@ const Content = React.memo(function Content() {
       <Outlet />
 
       <Footer />
+      {!!featureFlags.environmentLabel && (
+        <EnvironmentLabel>{featureFlags.environmentLabel}</EnvironmentLabel>
+      )}
       <ErrorMessage />
       <LoginErrorModal />
       <PairingModal />

--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -22,8 +22,10 @@ import {
   Notifications,
   NotificationsContextProvider
 } from 'lib-components/Notifications'
+import { EnvironmentLabel } from 'lib-components/atoms/EnvironmentLabel'
 import ErrorPage from 'lib-components/molecules/ErrorPage'
 import { theme } from 'lib-customizations/common'
+import { featureFlags } from 'lib-customizations/employee'
 
 import RequireAuth from './RequireAuth'
 import { RequirePinAuth } from './RequirePinAuth'
@@ -114,6 +116,11 @@ export default function App() {
                             element={<Navigate replace to="/landing" />}
                           />
                         </Routes>
+                        {!!featureFlags.environmentLabel && (
+                          <EnvironmentLabel>
+                            {featureFlags.environmentLabel}
+                          </EnvironmentLabel>
+                        )}
                       </Router>
                     </RememberContextProvider>
                   </NotificationsContextProvider>

--- a/frontend/src/lib-components/atoms/EnvironmentLabel.tsx
+++ b/frontend/src/lib-components/atoms/EnvironmentLabel.tsx
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import styled from 'styled-components'
+
+import { tabletMin } from '../breakpoints'
+
+export const EnvironmentLabel = styled.div`
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 100;
+  background-color: ${(p) => p.theme.colors.status.success};
+  color: ${(p) => p.theme.colors.grayscale.g0};
+  padding: 4px 12px;
+  border-radius: 0 0 12px 0;
+
+  @media (max-width: ${tabletMin}) {
+    font-size: 12px;
+    padding: 2px 8px;
+    border-radius: 0 0 8px 0;
+  }
+`

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -14,6 +14,7 @@ type Features = {
 
 const features: Features = {
   default: {
+    environmentLabel: 'Lokaali',
     citizenShiftCareAbsence: true,
     assistanceActionOther: true,
     daycareApplication: {
@@ -45,6 +46,7 @@ const features: Features = {
     automaticFixedScheduleAbsences: true
   },
   staging: {
+    environmentLabel: 'Staging',
     citizenShiftCareAbsence: true,
     assistanceActionOther: true,
     daycareApplication: {
@@ -76,6 +78,7 @@ const features: Features = {
     automaticFixedScheduleAbsences: true
   },
   prod: {
+    environmentLabel: null,
     citizenShiftCareAbsence: true,
     assistanceActionOther: true,
     daycareApplication: {

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -103,6 +103,12 @@ interface MapConfig {
  */
 interface BaseFeatureFlags {
   /**
+   * Name of the environment to be displayed on the upper left corner.
+   * Use null for prod environment to not display it.
+   */
+  environmentLabel: string | null
+
+  /**
    * Whether to show PLANNED_ABSENCE as a third absence option for shift care children in
    * citizen's absence modal
    */


### PR DESCRIPTION
Uusi frontend feature flag `environmentLabel`. Arvon tulisi olla esim `'Staging'` ja tuotannossa `null`.

<img width="1165" alt="Screenshot 2024-08-01 at 15 13 28" src="https://github.com/user-attachments/assets/ccbf5ec5-d81c-433b-8e03-38153ef2c1bd">

<img width="377" alt="Screenshot 2024-08-01 at 15 13 56" src="https://github.com/user-attachments/assets/e92dd273-890a-4ae4-929d-9aa69a6061db">
