### PR TITLE
Korjaa tuen päätökset -raportin linkin esiopetuksen tuen päätöksille

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reports/ReportPermissions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/ReportPermissions.kt
@@ -74,7 +74,13 @@ class ReportPermissions(private val accessControl: AccessControl) {
                             user,
                             clock,
                             Action.AssistanceNeedDecision.READ_IN_REPORT
-                        )
+                        ) ||
+                            accessControl.isPermittedForSomeTarget(
+                                tx,
+                                user,
+                                clock,
+                                Action.AssistanceNeedPreschoolDecision.READ_IN_REPORT
+                            )
                     },
                     Report.ASSISTANCE_NEEDS_AND_ACTIONS.takeIf {
                         permittedActionsForSomeUnit.contains(


### PR DESCRIPTION
Tuen päätökset -raportti näyttää sekä varhaiskasvatuksen että esiopetuksen tuen päätöksiä, mutta raportin linkin näkyvyys valikoitiin vain varhaiskasvatuksen tuen päätöksien perusteella.

Kts. `/employee/reports/assistance-need-decisions`