### PR TITLE
Datadog seurannan lisäys Keycloak:iin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,3 +112,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: maven
+    directory: "/keycloak/dd-fetch"
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -10,7 +10,7 @@
 # ===============
 #
 # If you need to target a local service instead you can use
-# a pseudo address docker.for.mac.localhost when running on OXS.
+# a pseudo address docker.for.mac.localhost when running on macOS.
 # E.g. to target local application service set APPLICATION_API_URL: http://docker.for.mac.localhost:8080
 version: '3.5'
 

--- a/keycloak/.dockerignore
+++ b/keycloak/.dockerignore
@@ -16,3 +16,5 @@ evaka-review-profile/target
 !theme/scripts
 !evaka-logging
 evaka-logging/target
+!dd-fetch
+dd-fetch/target

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -52,6 +52,13 @@ ADD ./evaka-logging/ /project/
 RUN mvn --batch-mode clean install
 
 
+FROM maven-builder AS builder-dd
+
+ADD ./dd-fetch/pom.xml /project/pom.xml
+
+RUN mvn --batch-mode clean package
+
+
 FROM node:20 AS builder-theme
 
 WORKDIR /work
@@ -70,6 +77,8 @@ ENV KC_HEALTH_ENABLED=true
 ENV KC_METRICS_ENABLED=true
 ENV KC_DB=postgres
 ENV KC_HTTP_RELATIVE_PATH=/auth
+ENV JAVA_OPTS_APPEND=-javaagent:/opt/keycloak/dd-java-agent.jar
+ENV DD_SERVICE_NAME=keycloak
 
 ADD --chmod=0644 \
     --checksum=sha256:424a3e03a17df0a2bc2b3ca749d81b04e79d59cb7aeec8876a5a3f308d0caf51 \
@@ -81,14 +90,9 @@ COPY --from=builder-authenticator /project/target/evaka-review-profile.jar \
           /opt/keycloak/providers/
 COPY --from=builder-logger /project/target/evaka-logging.jar \
           /opt/keycloak/providers/
+COPY --from=builder-dd /project/target/libs/dd-java-agent.jar \
+          /opt/keycloak/
 
-## Datadog ##
-
-ADD --chmod=0644 \
-    'https://dtdg.co/latest-java-tracer' /opt/keycloak/dd-java-agent.jar
-
-ENV JAVA_OPTS_APPEND=-javaagent:/opt/keycloak/dd-java-agent.jar
-ENV DD_SERVICE_NAME=keycloak
 
 RUN /opt/keycloak/bin/kc.sh build
 

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -82,6 +82,14 @@ COPY --from=builder-authenticator /project/target/evaka-review-profile.jar \
 COPY --from=builder-logger /project/target/evaka-logging.jar \
           /opt/keycloak/providers/
 
+## Datadog ##
+
+ADD --chmod=0644 \
+    'https://dtdg.co/latest-java-tracer' /opt/keycloak/dd-java-agent.jar
+
+ENV JAVA_OPTS_APPEND=-javaagent:/opt/keycloak/dd-java-agent.jar
+ENV DD_SERVICE_NAME=keycloak
+
 RUN /opt/keycloak/bin/kc.sh build
 
 USER 1000

--- a/keycloak/dd-fetch/pom.xml
+++ b/keycloak/dd-fetch/pom.xml
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2017-2024 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/keycloak/dd-fetch/pom.xml
+++ b/keycloak/dd-fetch/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.espoo.keycloak</groupId>
+    <artifactId>datadog-agent-downloader</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <datadog.version>1.38.0</datadog.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+        <!-- This dependency is here so that Dependabot is able to see the
+        dd-java-agent version we use and notify about updates. The actual
+        fetching is done with copy-dependencies -->
+            <groupId>com.datadoghq</groupId>
+            <artifactId>dd-java-agent</artifactId>
+            <version>${datadog.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.datadoghq</groupId>
+                                    <artifactId>dd-java-agent</artifactId>
+                                    <version>${datadog.version}</version>
+                                    <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                                    <destFileName>dd-java-agent.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
## Ennen tätä muutosta
Keycloak:issa ei ollut Datadog instrumentointia. Eikä meillä ollut tapaa yhdistää Keycloakin logituksia proxyn request logituksiin.
## Tämän muutoksen jälkeen
Keycloak:in logituksiin tulee Datadogin `trace_id` ja `span_id` metadatat näkyviin. Tämän lisäksi requestit trackataan Datadogiin, kunhan Datadog agent asetukset asetetaan infran puolelta ympäristömuuttujilla kohdilleen.