### PR TITLE
Lisätään metadatan käsittely vasumigraatioon

### DIFF
--- a/frontend/src/employee-frontend/components/vasu/templates/MigrateTemplateModal.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/MigrateTemplateModal.tsx
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+
+import { wrapResult } from 'lib-common/api'
+import { string } from 'lib-common/form/fields'
+import { object, validated } from 'lib-common/form/form'
+import { useForm, useFormFields } from 'lib-common/form/hooks'
+import { nonBlank } from 'lib-common/form/validators'
+import { UUID } from 'lib-common/types'
+import { InputFieldF } from 'lib-components/atoms/form/InputField'
+import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
+import { Label } from 'lib-components/typography'
+
+import { migrateVasuDocuments } from '../../../generated/api-clients/vasu'
+import { useTranslation } from '../../../state/i18n'
+
+const migrateVasuDocumentsResult = wrapResult(migrateVasuDocuments)
+
+const form = object({
+  processDefinitionNumber: validated(string(), nonBlank)
+})
+
+export default React.memo(function MigrateTemplateModal({
+  templateId,
+  onClose
+}: {
+  templateId: UUID
+  onClose: () => void
+}) {
+  const { i18n } = useTranslation()
+
+  const boundForm = useForm(
+    form,
+    () => ({
+      processDefinitionNumber: ''
+    }),
+    i18n.validationErrors
+  )
+  const { processDefinitionNumber } = useFormFields(boundForm)
+
+  return (
+    <AsyncFormModal
+      title={i18n.vasuTemplates.migrateModal.title}
+      resolveAction={() =>
+        migrateVasuDocumentsResult({
+          id: templateId,
+          body: { processDefinitionNumber: processDefinitionNumber.value() }
+        })
+      }
+      resolveLabel={i18n.vasuTemplates.migrateModal.resolve}
+      resolveDisabled={!boundForm.isValid()}
+      onSuccess={onClose}
+      rejectAction={onClose}
+      rejectLabel={i18n.common.cancel}
+    >
+      <Label>{i18n.vasuTemplates.migrateModal.processDefinitionNumber}</Label>
+      <InputFieldF bind={processDefinitionNumber} />
+    </AsyncFormModal>
+  )
+})

--- a/frontend/src/employee-frontend/components/vasu/templates/VasuTemplatesPage.tsx
+++ b/frontend/src/employee-frontend/components/vasu/templates/VasuTemplatesPage.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -7,9 +7,9 @@ import { Link, useNavigate } from 'react-router-dom'
 
 import { Loading, Result, wrapResult } from 'lib-common/api'
 import { VasuTemplateSummary } from 'lib-common/generated/api-types/vasu'
+import { UUID } from 'lib-common/types'
 import { useRestApi } from 'lib-common/utils/useRestApi'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
-import { AsyncIconOnlyButton } from 'lib-components/atoms/buttons/AsyncIconOnlyButton'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import ErrorSegment from 'lib-components/atoms/state/ErrorSegment'
 import { SpinnerSegment } from 'lib-components/atoms/state/Spinner'
@@ -22,17 +22,16 @@ import { faPen, faTrash } from 'lib-icons'
 
 import {
   deleteTemplate,
-  getTemplates,
-  migrateVasuDocuments
+  getTemplates
 } from '../../../generated/api-clients/vasu'
 import { useTranslation } from '../../../state/i18n'
 
 import CopyTemplateModal from './CopyTemplateModal'
 import CreateTemplateModal from './CreateOrEditTemplateModal'
+import MigrateTemplateModal from './MigrateTemplateModal'
 
 const getTemplatesResult = wrapResult(getTemplates)
 const deleteTemplateResult = wrapResult(deleteTemplate)
-const migrateVasuDocumentsResult = wrapResult(migrateVasuDocuments)
 
 export default React.memo(function VasuTemplatesPage() {
   const { i18n } = useTranslation()
@@ -46,6 +45,7 @@ export default React.memo(function VasuTemplatesPage() {
   const [createModalOpen, setCreateModalOpen] = useState(false)
   const [templateToCopy, setTemplateToCopy] = useState<VasuTemplateSummary>()
   const [templateToEdit, setTemplateToEdit] = useState<VasuTemplateSummary>()
+  const [templateToMigrate, setTemplateToMigrate] = useState<UUID | null>(null)
 
   const loadTemplates = useRestApi(getTemplatesResult, setTemplates)
   useEffect(() => {
@@ -91,13 +91,10 @@ export default React.memo(function VasuTemplatesPage() {
                     <Td>{template.documentCount}</Td>
                     <Td>
                       <FixedSpaceRow spacing="s">
-                        <AsyncIconOnlyButton
+                        <IconOnlyButton
                           icon={faFileExport}
-                          aria-label="lol"
-                          onClick={() =>
-                            migrateVasuDocumentsResult({ id: template.id })
-                          }
-                          onSuccess={() => undefined}
+                          aria-label=""
+                          onClick={() => setTemplateToMigrate(template.id)}
                         />
                         <IconOnlyButton
                           icon={faPen}
@@ -146,6 +143,13 @@ export default React.memo(function VasuTemplatesPage() {
             template={templateToCopy}
             onSuccess={(id) => navigate(`/vasu-templates/${id}`)}
             onCancel={() => setTemplateToCopy(undefined)}
+          />
+        )}
+
+        {!!templateToMigrate && (
+          <MigrateTemplateModal
+            templateId={templateToMigrate}
+            onClose={() => setTemplateToMigrate(null)}
           />
         )}
       </ContentArea>

--- a/frontend/src/employee-frontend/generated/api-clients/vasu.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/vasu.ts
@@ -10,6 +10,7 @@ import { CreateDocumentRequest } from 'lib-common/generated/api-types/vasu'
 import { CreateTemplateRequest } from 'lib-common/generated/api-types/vasu'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { MigrateVasuRequest } from 'lib-common/generated/api-types/vasu'
 import { UUID } from 'lib-common/types'
 import { UpdateDocumentRequest } from 'lib-common/generated/api-types/vasu'
 import { VasuContent } from 'lib-common/generated/api-types/vasu'
@@ -222,12 +223,14 @@ export async function getTemplates(
 */
 export async function migrateVasuDocuments(
   request: {
-    id: UUID
+    id: UUID,
+    body: MigrateVasuRequest
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/vasu/templates/${request.id}/migrate`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    data: request.body satisfies JsonCompatible<MigrateVasuRequest>
   })
   return json
 }

--- a/frontend/src/lib-common/generated/api-types/vasu.ts
+++ b/frontend/src/lib-common/generated/api-types/vasu.ts
@@ -93,6 +93,13 @@ export const curriculumTypes = [
 export type CurriculumType = typeof curriculumTypes[number]
 
 /**
+* Generated from fi.espoo.evaka.vasu.VasuTemplateController.MigrateVasuRequest
+*/
+export interface MigrateVasuRequest {
+  processDefinitionNumber: string
+}
+
+/**
 * Generated from fi.espoo.evaka.vasu.VasuController.UpdateDocumentRequest
 */
 export interface UpdateDocumentRequest {
@@ -134,6 +141,7 @@ export interface VasuContent {
 export interface VasuDocument {
   basics: VasuBasics
   content: VasuContent
+  created: HelsinkiDateTime
   documentState: VasuDocumentState
   events: VasuDocumentEvent[]
   id: UUID
@@ -340,6 +348,7 @@ export function deserializeJsonVasuDocument(json: JsonOf<VasuDocument>): VasuDoc
     ...json,
     basics: deserializeJsonVasuBasics(json.basics),
     content: deserializeJsonVasuContent(json.content),
+    created: HelsinkiDateTime.parseIso(json.created),
     events: json.events.map(e => deserializeJsonVasuDocumentEvent(e)),
     modifiedAt: HelsinkiDateTime.parseIso(json.modifiedAt),
     publishedAt: (json.publishedAt != null) ? HelsinkiDateTime.parseIso(json.publishedAt) : null,

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4733,7 +4733,12 @@ export const fi = {
       TEMPLATE_NAME: 'Käytössä olevan pohjan nimeä ei voi vaihtaa'
     },
     moveUp: 'Siirrä ylemmäs',
-    moveDown: 'Siirrä alemmas'
+    moveDown: 'Siirrä alemmas',
+    migrateModal: {
+      title: 'Migratoi lomakepohjaksi ja asiakirjoiksi',
+      processDefinitionNumber: 'Tehtäväluokka (TOS)',
+      resolve: 'Käynnistä migraatio'
+    }
   },
   settings: {
     key: 'Asetus',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/DocumentMigratorTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/vasu/DocumentMigratorTest.kt
@@ -4,12 +4,14 @@
 
 package fi.espoo.evaka.vasu
 
-import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.document.childdocument.getChildDocuments
 import fi.espoo.evaka.document.getTemplateSummaries
 import fi.espoo.evaka.process.getArchiveProcessByChildDocumentId
 import fi.espoo.evaka.shared.ChildDocumentId
 import fi.espoo.evaka.shared.EvakaUserId
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.dev.DevChild
 import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.DevPerson
@@ -27,12 +29,13 @@ import java.time.LocalTime
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 
-class DocumentMigratorTest : PureJdbiTest(resetDbBeforeEach = true) {
+class DocumentMigratorTest : FullApplicationTest(resetDbBeforeEach = true) {
     private val mockToday: LocalDate = LocalDate.of(2023, 5, 22)
     private val clock = MockEvakaClock(HelsinkiDateTime.of(mockToday, LocalTime.of(12, 0)))
 
-    private lateinit var vasuTemplate: VasuTemplate
+    @Autowired lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     @Test
     fun `migration smoke test`() {
@@ -85,7 +88,8 @@ class DocumentMigratorTest : PureJdbiTest(resetDbBeforeEach = true) {
             val archiveMetadataOrganization = "Espoo"
             migrateVasu(
                 tx = tx,
-                today = mockToday,
+                asyncJobRunner = asyncJobRunner,
+                now = clock.now(),
                 id = vasuDocumentId,
                 processDefinitionNumber = processDefinitionNumber,
                 archiveMetadataOrganization = archiveMetadataOrganization

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -320,7 +320,10 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
-    data class MigrateVasuDocument(val documentId: VasuDocumentId) : AsyncJob {
+    data class MigrateVasuDocument(
+        val documentId: VasuDocumentId,
+        val processDefinitionNumber: String?
+    ) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/Vasu.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/Vasu.kt
@@ -97,6 +97,7 @@ data class VasuDocumentSummary(
 
 data class VasuDocument(
     val id: VasuDocumentId,
+    val created: HelsinkiDateTime,
     val modifiedAt: HelsinkiDateTime,
     val templateId: VasuTemplateId,
     val templateName: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuQueries.kt
@@ -93,6 +93,7 @@ fun Database.Read.getVasuDocumentMaster(today: LocalDate, id: VasuDocumentId): V
                 SELECT
                     cd.id,
                     cd.child_id,
+                    cd.created,
                     cd.modified_at,
                     cd.basics,
                     ct.id AS template_id,
@@ -141,6 +142,7 @@ fun Database.Read.getLatestPublishedVasuDocument(
                     cd.id,
                     cd.child_id,
                     cd.basics,
+                    cd.created,
                     cd.modified_at,
                     ct.id AS template_id,
                     ct.name AS template_name,

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuTemplateController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/VasuTemplateController.kt
@@ -206,6 +206,9 @@ class VasuTemplateController(
         Audit.VasuTemplateUpdate.log(targetId = AuditId(id))
     }
 
+    data class MigrateVasuRequest(
+        val processDefinitionNumber: String
+    )
     @PutMapping("/{id}/migrate")
     fun migrateVasuDocuments(
         db: Database,


### PR DESCRIPTION
Käynnistäessään opetussuunnitelmapohja-->lomakepohja migraation, pääkäyttäjä syöttää myös tehtäväluokan, jota käytetään asianhallintaprosessin migratoimiseen. 