### PR TITLE
Otetaan vuorohoito huomioon päivittäisten vaka-aikojen poissaolojen luonnissa

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareQueries.kt
@@ -26,7 +26,6 @@ import fi.espoo.evaka.shared.domain.TimeRange
 import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.shared.security.actionrule.AccessControlFilter
 import fi.espoo.evaka.shared.security.actionrule.toPredicate
-import java.time.DayOfWeek
 import java.time.LocalDate
 
 data class DaycareFields(
@@ -513,18 +512,3 @@ SELECT EXISTS(
             )
         }
         .exactlyOne<Boolean>()
-
-private data class UnitOperationDays(val id: DaycareId, val operationDays: List<Int>)
-
-fun Database.Read.getUnitOperationDays(): Map<DaycareId, Set<DayOfWeek>> =
-    createQuery { sql("""
-SELECT id, operation_days
-FROM daycare
-""") }
-        .mapTo<UnitOperationDays>()
-        .useIterable { rows ->
-            rows.fold(mutableMapOf()) { acc, row ->
-                acc[row.id] = row.operationDays.map { DayOfWeek.of(it) }.toSet()
-                acc
-            }
-        }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -94,34 +94,6 @@ AND daterange(p.start_date, p.end_date, '[]') @> ${bind(clock.today())}
         .exactlyOneOrNull<Placement>()
 }
 
-data class ChildPlacementType(
-    val childId: ChildId,
-    val unitId: DaycareId,
-    val period: FiniteDateRange,
-    val placementType: PlacementType
-)
-
-fun Database.Read.getChildPlacementTypesByRange(
-    childId: ChildId,
-    period: DateRange
-): List<ChildPlacementType> {
-    return createQuery {
-            sql(
-                """
-SELECT
-    child_id,
-    unit_id,
-    daterange(start_date, end_date, '[]') AS period,
-    type AS placement_type
-FROM placement
-WHERE child_id = ${bind(childId)}
-AND daterange(start_date, end_date, '[]') && ${bind(period)}
-"""
-            )
-        }
-        .toList<ChildPlacementType>()
-}
-
 fun Database.Transaction.insertPlacement(
     type: PlacementType,
     childId: ChildId,


### PR DESCRIPTION
Lapselle luodaan poissoloja automaattisesti päivittäisten vaka-aikojen perusteella. Poissolot luodaan vain niille päiville, joina yksikkö on auki. Ennen tätä muutosta kaikille lapsille käytettiin normaaleja aukioloaikoja, jolloin vuorohoitolapsille ei koskaan generoitu poissaoloja viikonlopuille. Tämän muutoksen jälkeen vuorohoitolapsille käytetään yksikön vuorohoitoaikoja aukiolopäivien päättelyyn, jolloin poissaolot generoituvat oikein myös viikonlopuille.