### PR TITLE
Kielletään nullable API response-sisällöt koska Spring toimii oudosti niiden kanssa

### DIFF
--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -128,14 +128,22 @@ export async function employeeLogin(
 export async function getEmployeeDetails(
   req: express.Request,
   employeeId: string
-) {
-  const { data } = await client.get<EmployeeUserResponse | undefined>(
-    `/system/employee/${employeeId}`,
-    {
-      headers: createServiceRequestHeaders(req, machineUser)
+): Promise<EmployeeUserResponse | undefined> {
+  try {
+    const { data } = await client.get<EmployeeUserResponse>(
+      `/system/employee/${employeeId}`,
+      {
+        headers: createServiceRequestHeaders(req, machineUser)
+      }
+    )
+    return data
+  } catch (e: unknown) {
+    if (axios.isAxiosError(e) && e.response?.status === 404) {
+      return undefined
+    } else {
+      throw e
     }
-  )
-  return data
+  }
 }
 
 export async function citizenLogin(

--- a/frontend/src/employee-frontend/components/ApplicationPage.tsx
+++ b/frontend/src/employee-frontend/components/ApplicationPage.tsx
@@ -241,12 +241,12 @@ export default React.memo(function ApplicationPage() {
     (applicationData: ApplicationResponse) => {
       if (
         messageThread.isSuccess &&
-        messageThread.value !== null &&
-        messageThread.value.messages.length > 0
+        messageThread.value?.thread !== null &&
+        messageThread.value.thread.messages.length > 0
       ) {
         return `${getEmployeeUrlPrefix()}/employee/messages/?applicationId=${
           applicationData.application.id
-        }&messageBox=thread&threadId=${messageThread.value.id}&reply=true`
+        }&messageBox=thread&threadId=${messageThread.value.thread.id}&reply=true`
       }
       return `${getEmployeeUrlPrefix()}/employee/messages/send?recipient=${
         applicationData.application.guardianId

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -139,8 +139,8 @@ export default React.memo(function MessagesPage({
               view: 'sent',
               unitId: senderAccount.daycareGroup?.unitId ?? null
             })
-            if (res.value) {
-              setSelectedThread(res.value)
+            if (res.value.createdId) {
+              setSelectedThread(res.value.createdId)
             }
           }
           hideEditor()

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDateModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDateModal.tsx
@@ -421,50 +421,51 @@ export default React.memo(function ChildDateModal({
             otherAbsence={nonBillableAbsence.value()}
           />
         )}
-        {expectedAbsences.isSuccess && expectedAbsences.value !== null && (
-          <FixedSpaceColumn data-qa="absence-warnings">
-            {expectedAbsences.value.includes('NONBILLABLE') &&
-              nonBillableAbsence.value() === undefined && (
-                <AbsenceWarning
-                  data-qa="missing-nonbillable-absence"
-                  message={
-                    i18n.unit.attendanceReservations.childDateModal
-                      .missingNonbillableAbsence
-                  }
-                />
-              )}
-            {!expectedAbsences.value.includes('NONBILLABLE') &&
-              nonBillableAbsence.value() !== undefined && (
-                <AbsenceWarning
-                  data-qa="extra-nonbillable-absence"
-                  message={
-                    i18n.unit.attendanceReservations.childDateModal
-                      .extraNonbillableAbsence
-                  }
-                />
-              )}
-            {expectedAbsences.value.includes('BILLABLE') &&
-              billableAbsence.value() === undefined && (
-                <AbsenceWarning
-                  data-qa="missing-billable-absence"
-                  message={
-                    i18n.unit.attendanceReservations.childDateModal
-                      .missingBillableAbsence
-                  }
-                />
-              )}
-            {!expectedAbsences.value.includes('BILLABLE') &&
-              billableAbsence.value() !== undefined && (
-                <AbsenceWarning
-                  data-qa="extra-billable-absence"
-                  message={
-                    i18n.unit.attendanceReservations.childDateModal
-                      .extraBillableAbsence
-                  }
-                />
-              )}
-          </FixedSpaceColumn>
-        )}
+        {expectedAbsences.isSuccess &&
+          expectedAbsences.value?.categories !== null && (
+            <FixedSpaceColumn data-qa="absence-warnings">
+              {expectedAbsences.value?.categories.includes('NONBILLABLE') &&
+                nonBillableAbsence.value() === undefined && (
+                  <AbsenceWarning
+                    data-qa="missing-nonbillable-absence"
+                    message={
+                      i18n.unit.attendanceReservations.childDateModal
+                        .missingNonbillableAbsence
+                    }
+                  />
+                )}
+              {!expectedAbsences.value?.categories.includes('NONBILLABLE') &&
+                nonBillableAbsence.value() !== undefined && (
+                  <AbsenceWarning
+                    data-qa="extra-nonbillable-absence"
+                    message={
+                      i18n.unit.attendanceReservations.childDateModal
+                        .extraNonbillableAbsence
+                    }
+                  />
+                )}
+              {expectedAbsences.value?.categories.includes('BILLABLE') &&
+                billableAbsence.value() === undefined && (
+                  <AbsenceWarning
+                    data-qa="missing-billable-absence"
+                    message={
+                      i18n.unit.attendanceReservations.childDateModal
+                        .missingBillableAbsence
+                    }
+                  />
+                )}
+              {!expectedAbsences.value?.categories.includes('BILLABLE') &&
+                billableAbsence.value() !== undefined && (
+                  <AbsenceWarning
+                    data-qa="extra-billable-absence"
+                    message={
+                      i18n.unit.attendanceReservations.childDateModal
+                        .extraBillableAbsence
+                    }
+                  />
+                )}
+            </FixedSpaceColumn>
+          )}
       </FixedSpaceColumn>
       {!!mutationError && <AlertBox message={mutationError} />}
     </MutateFormModal>

--- a/frontend/src/employee-frontend/generated/api-clients/assistance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/assistance.ts
@@ -134,8 +134,8 @@ export async function deleteAssistanceFactor(
   request: {
     id: UUID
   }
-): Promise<UUID | null> {
-  const { data: json } = await client.request<JsonOf<UUID | null>>({
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/assistance-factors/${request.id}`.toString(),
     method: 'DELETE'
   })
@@ -150,8 +150,8 @@ export async function deleteDaycareAssistance(
   request: {
     id: UUID
   }
-): Promise<UUID | null> {
-  const { data: json } = await client.request<JsonOf<UUID | null>>({
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/daycare-assistances/${request.id}`.toString(),
     method: 'DELETE'
   })
@@ -166,8 +166,8 @@ export async function deleteOtherAssistanceMeasure(
   request: {
     id: UUID
   }
-): Promise<UUID | null> {
-  const { data: json } = await client.request<JsonOf<UUID | null>>({
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/other-assistance-measures/${request.id}`.toString(),
     method: 'DELETE'
   })
@@ -182,8 +182,8 @@ export async function deletePreschoolAssistance(
   request: {
     id: UUID
   }
-): Promise<UUID | null> {
-  const { data: json } = await client.request<JsonOf<UUID | null>>({
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/preschool-assistances/${request.id}`.toString(),
     method: 'DELETE'
   })

--- a/frontend/src/employee-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attendance.ts
@@ -5,13 +5,13 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
-import { AbsenceCategory } from 'lib-common/generated/api-types/absence'
 import { AbsenceRangeRequest } from 'lib-common/generated/api-types/attendance'
 import { ArrivalRequest } from 'lib-common/generated/api-types/attendance'
 import { AttendanceChild } from 'lib-common/generated/api-types/attendance'
 import { ChildAttendanceStatusResponse } from 'lib-common/generated/api-types/attendance'
 import { DepartureRequest } from 'lib-common/generated/api-types/attendance'
 import { ExpectedAbsencesOnDepartureRequest } from 'lib-common/generated/api-types/attendance'
+import { ExpectedAbsencesOnDepartureResponse } from 'lib-common/generated/api-types/attendance'
 import { ExternalAttendanceBody } from 'lib-common/generated/api-types/attendance'
 import { FullDayAbsenceRequest } from 'lib-common/generated/api-types/attendance'
 import { JsonCompatible } from 'lib-common/json'
@@ -95,8 +95,8 @@ export async function getChildExpectedAbsencesOnDeparture(
     childId: UUID,
     body: ExpectedAbsencesOnDepartureRequest
   }
-): Promise<AbsenceCategory[] | null> {
-  const { data: json } = await client.request<JsonOf<AbsenceCategory[] | null>>({
+): Promise<ExpectedAbsencesOnDepartureResponse> {
+  const { data: json } = await client.request<JsonOf<ExpectedAbsencesOnDepartureResponse>>({
     url: uri`/attendances/units/${request.unitId}/children/${request.childId}/departure/expected-absences`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<ExpectedAbsencesOnDepartureRequest>

--- a/frontend/src/employee-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/messaging.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import { AuthorizedMessageAccount } from 'lib-common/generated/api-types/messaging'
+import { CreateMessageResponse } from 'lib-common/generated/api-types/messaging'
 import { DraftContent } from 'lib-common/generated/api-types/messaging'
 import { EditRecipientRequest } from 'lib-common/generated/api-types/messaging'
 import { JsonCompatible } from 'lib-common/json'
@@ -19,6 +20,7 @@ import { PostMessagePreflightBody } from 'lib-common/generated/api-types/messagi
 import { PostMessagePreflightResponse } from 'lib-common/generated/api-types/messaging'
 import { Recipient } from 'lib-common/generated/api-types/messaging'
 import { ReplyToMessageBody } from 'lib-common/generated/api-types/messaging'
+import { ThreadByApplicationResponse } from 'lib-common/generated/api-types/messaging'
 import { ThreadReply } from 'lib-common/generated/api-types/messaging'
 import { UUID } from 'lib-common/types'
 import { UnreadCountByAccount } from 'lib-common/generated/api-types/messaging'
@@ -31,6 +33,7 @@ import { deserializeJsonMessageThread } from 'lib-common/generated/api-types/mes
 import { deserializeJsonPagedMessageCopies } from 'lib-common/generated/api-types/messaging'
 import { deserializeJsonPagedMessageThreads } from 'lib-common/generated/api-types/messaging'
 import { deserializeJsonPagedSentMessages } from 'lib-common/generated/api-types/messaging'
+import { deserializeJsonThreadByApplicationResponse } from 'lib-common/generated/api-types/messaging'
 import { deserializeJsonThreadReply } from 'lib-common/generated/api-types/messaging'
 import { uri } from 'lib-common/uri'
 
@@ -95,8 +98,8 @@ export async function createMessage(
     accountId: UUID,
     body: PostMessageBody
   }
-): Promise<UUID | null> {
-  const { data: json } = await client.request<JsonOf<UUID | null>>({
+): Promise<CreateMessageResponse> {
+  const { data: json } = await client.request<JsonOf<CreateMessageResponse>>({
     url: uri`/messages/${request.accountId}`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<PostMessageBody>
@@ -296,12 +299,12 @@ export async function getThreadByApplicationId(
   request: {
     applicationId: UUID
   }
-): Promise<MessageThread | null> {
-  const { data: json } = await client.request<JsonOf<MessageThread | null>>({
+): Promise<ThreadByApplicationResponse> {
+  const { data: json } = await client.request<JsonOf<ThreadByApplicationResponse>>({
     url: uri`/messages/application/${request.applicationId}`.toString(),
     method: 'GET'
   })
-  return (json != null) ? deserializeJsonMessageThread(json) : null
+  return deserializeJsonThreadByApplicationResponse(json)
 }
 
 

--- a/frontend/src/employee-frontend/generated/api-clients/reservations.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reservations.ts
@@ -5,10 +5,10 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
-import { AbsenceCategory } from 'lib-common/generated/api-types/absence'
 import { ChildDatePresence } from 'lib-common/generated/api-types/reservations'
 import { DailyReservationRequest } from 'lib-common/generated/api-types/reservations'
 import { ExpectedAbsencesRequest } from 'lib-common/generated/api-types/reservations'
+import { ExpectedAbsencesResponse } from 'lib-common/generated/api-types/reservations'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
@@ -52,8 +52,8 @@ export async function getExpectedAbsences(
   request: {
     body: ExpectedAbsencesRequest
   }
-): Promise<AbsenceCategory[] | null> {
-  const { data: json } = await client.request<JsonOf<AbsenceCategory[] | null>>({
+): Promise<ExpectedAbsencesResponse> {
+  const { data: json } = await client.request<JsonOf<ExpectedAbsencesResponse>>({
     url: uri`/attendance-reservations/child-date/expected-absences`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<ExpectedAbsencesRequest>

--- a/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkDeparted.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkDeparted.tsx
@@ -156,9 +156,9 @@ const MarkDepartedInner = React.memo(function MarkDepartedWithChild({
   const formIsValid =
     !timeError &&
     expectedAbsences.isSuccess &&
-    (expectedAbsences.value?.includes('NONBILLABLE') !== true ||
+    (expectedAbsences.value?.categories?.includes('NONBILLABLE') !== true ||
       selectedAbsenceTypeNonbillable !== undefined) &&
-    (expectedAbsences.value?.includes('BILLABLE') !== true ||
+    (expectedAbsences.value?.categories?.includes('BILLABLE') !== true ||
       selectedAbsenceTypeBillable !== undefined)
 
   const basicAbsenceTypes: AbsenceType[] = [
@@ -200,12 +200,13 @@ const MarkDepartedInner = React.memo(function MarkDepartedWithChild({
             <Gap size="xs" />
 
             {renderResult(expectedAbsences, (expectedAbsences) =>
-              expectedAbsences && expectedAbsences.length > 0 ? (
+              expectedAbsences?.categories &&
+              expectedAbsences.categories.length > 0 ? (
                 <FixedSpaceColumn>
                   <AbsenceTitle size={2}>
                     {i18n.attendances.absenceTitle}
                   </AbsenceTitle>
-                  {expectedAbsences.includes('NONBILLABLE') && (
+                  {expectedAbsences.categories.includes('NONBILLABLE') && (
                     <FixedSpaceColumn
                       spacing="xs"
                       data-qa="absence-NONBILLABLE"
@@ -238,7 +239,7 @@ const MarkDepartedInner = React.memo(function MarkDepartedWithChild({
                       />
                     </FixedSpaceColumn>
                   )}
-                  {expectedAbsences.includes('BILLABLE') && (
+                  {expectedAbsences.categories.includes('BILLABLE') && (
                     <FixedSpaceColumn spacing="xs" data-qa="absence-BILLABLE">
                       <div>
                         {formatCategory('BILLABLE', child.placementType, i18n)}
@@ -286,13 +287,15 @@ const MarkDepartedInner = React.memo(function MarkDepartedWithChild({
                       childId,
                       body: {
                         absenceTypeNonbillable:
-                          expectedAbsences.value?.includes('NONBILLABLE') &&
-                          selectedAbsenceTypeNonbillable !== 'NO_ABSENCE'
+                          expectedAbsences.value?.categories?.includes(
+                            'NONBILLABLE'
+                          ) && selectedAbsenceTypeNonbillable !== 'NO_ABSENCE'
                             ? selectedAbsenceTypeNonbillable ?? null
                             : null,
                         absenceTypeBillable:
-                          expectedAbsences.value?.includes('BILLABLE') &&
-                          selectedAbsenceTypeBillable !== 'NO_ABSENCE'
+                          expectedAbsences.value?.categories?.includes(
+                            'BILLABLE'
+                          ) && selectedAbsenceTypeBillable !== 'NO_ABSENCE'
                             ? selectedAbsenceTypeBillable ?? null
                             : null,
                         departed: LocalTime.parse(time)
@@ -301,7 +304,9 @@ const MarkDepartedInner = React.memo(function MarkDepartedWithChild({
                   }}
                   onSuccess={() => {
                     const absenceMarked = expectedAbsences
-                      .map((exp) => exp && exp.length > 0)
+                      .map(
+                        (exp) => exp?.categories && exp.categories.length > 0
+                      )
                       .getOrElse(false)
                     navigate(absenceMarked ? -1 : -2)
                   }}

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/attendance.ts
@@ -5,7 +5,6 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
-import { AbsenceCategory } from 'lib-common/generated/api-types/absence'
 import { AbsenceRangeRequest } from 'lib-common/generated/api-types/attendance'
 import { ArrivalRequest } from 'lib-common/generated/api-types/attendance'
 import { AttendanceChild } from 'lib-common/generated/api-types/attendance'
@@ -13,6 +12,7 @@ import { ChildAttendanceStatusResponse } from 'lib-common/generated/api-types/at
 import { CurrentDayStaffAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { DepartureRequest } from 'lib-common/generated/api-types/attendance'
 import { ExpectedAbsencesOnDepartureRequest } from 'lib-common/generated/api-types/attendance'
+import { ExpectedAbsencesOnDepartureResponse } from 'lib-common/generated/api-types/attendance'
 import { ExternalAttendanceBody } from 'lib-common/generated/api-types/attendance'
 import { ExternalStaffArrivalRequest } from 'lib-common/generated/api-types/attendance'
 import { ExternalStaffDepartureRequest } from 'lib-common/generated/api-types/attendance'
@@ -105,8 +105,8 @@ export async function getChildExpectedAbsencesOnDeparture(
     childId: UUID,
     body: ExpectedAbsencesOnDepartureRequest
   }
-): Promise<AbsenceCategory[] | null> {
-  const { data: json } = await client.request<JsonOf<AbsenceCategory[] | null>>({
+): Promise<ExpectedAbsencesOnDepartureResponse> {
+  const { data: json } = await client.request<JsonOf<ExpectedAbsencesOnDepartureResponse>>({
     url: uri`/attendances/units/${request.unitId}/children/${request.childId}/departure/expected-absences`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<ExpectedAbsencesOnDepartureRequest>

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/messaging.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import { AuthorizedMessageAccount } from 'lib-common/generated/api-types/messaging'
+import { CreateMessageResponse } from 'lib-common/generated/api-types/messaging'
 import { DraftContent } from 'lib-common/generated/api-types/messaging'
 import { EditRecipientRequest } from 'lib-common/generated/api-types/messaging'
 import { JsonCompatible } from 'lib-common/json'
@@ -19,6 +20,7 @@ import { PostMessagePreflightBody } from 'lib-common/generated/api-types/messagi
 import { PostMessagePreflightResponse } from 'lib-common/generated/api-types/messaging'
 import { Recipient } from 'lib-common/generated/api-types/messaging'
 import { ReplyToMessageBody } from 'lib-common/generated/api-types/messaging'
+import { ThreadByApplicationResponse } from 'lib-common/generated/api-types/messaging'
 import { ThreadReply } from 'lib-common/generated/api-types/messaging'
 import { UUID } from 'lib-common/types'
 import { UnreadCountByAccount } from 'lib-common/generated/api-types/messaging'
@@ -31,6 +33,7 @@ import { deserializeJsonMessageThread } from 'lib-common/generated/api-types/mes
 import { deserializeJsonPagedMessageCopies } from 'lib-common/generated/api-types/messaging'
 import { deserializeJsonPagedMessageThreads } from 'lib-common/generated/api-types/messaging'
 import { deserializeJsonPagedSentMessages } from 'lib-common/generated/api-types/messaging'
+import { deserializeJsonThreadByApplicationResponse } from 'lib-common/generated/api-types/messaging'
 import { deserializeJsonThreadReply } from 'lib-common/generated/api-types/messaging'
 import { uri } from 'lib-common/uri'
 
@@ -95,8 +98,8 @@ export async function createMessage(
     accountId: UUID,
     body: PostMessageBody
   }
-): Promise<UUID | null> {
-  const { data: json } = await client.request<JsonOf<UUID | null>>({
+): Promise<CreateMessageResponse> {
+  const { data: json } = await client.request<JsonOf<CreateMessageResponse>>({
     url: uri`/messages/${request.accountId}`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<PostMessageBody>
@@ -300,12 +303,12 @@ export async function getThreadByApplicationId(
   request: {
     applicationId: UUID
   }
-): Promise<MessageThread | null> {
-  const { data: json } = await client.request<JsonOf<MessageThread | null>>({
+): Promise<ThreadByApplicationResponse> {
+  const { data: json } = await client.request<JsonOf<ThreadByApplicationResponse>>({
     url: uri`/messages/application/${request.applicationId}`.toString(),
     method: 'GET'
   })
-  return (json != null) ? deserializeJsonMessageThread(json) : null
+  return deserializeJsonThreadByApplicationResponse(json)
 }
 
 

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -160,6 +160,13 @@ export interface ExpectedAbsencesOnDepartureRequest {
 }
 
 /**
+* Generated from fi.espoo.evaka.attendance.ChildAttendanceController.ExpectedAbsencesOnDepartureResponse
+*/
+export interface ExpectedAbsencesOnDepartureResponse {
+  categories: AbsenceCategory[] | null
+}
+
+/**
 * Generated from fi.espoo.evaka.attendance.ExternalAttendance
 */
 export interface ExternalAttendance {

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -75,6 +75,13 @@ export type CitizenMessageThread = CitizenMessageThread.Redacted | CitizenMessag
 
 
 /**
+* Generated from fi.espoo.evaka.messaging.MessageController.CreateMessageResponse
+*/
+export interface CreateMessageResponse {
+  createdId: UUID | null
+}
+
+/**
 * Generated from fi.espoo.evaka.messaging.DraftContent
 */
 export interface DraftContent {
@@ -331,6 +338,13 @@ export interface SentMessage {
 }
 
 /**
+* Generated from fi.espoo.evaka.messaging.MessageController.ThreadByApplicationResponse
+*/
+export interface ThreadByApplicationResponse {
+  thread: MessageThread | null
+}
+
+/**
 * Generated from fi.espoo.evaka.messaging.MessageService.ThreadReply
 */
 export interface ThreadReply {
@@ -464,6 +478,14 @@ export function deserializeJsonSentMessage(json: JsonOf<SentMessage>): SentMessa
   return {
     ...json,
     sentAt: HelsinkiDateTime.parseIso(json.sentAt)
+  }
+}
+
+
+export function deserializeJsonThreadByApplicationResponse(json: JsonOf<ThreadByApplicationResponse>): ThreadByApplicationResponse {
+  return {
+    ...json,
+    thread: (json.thread != null) ? deserializeJsonMessageThread(json.thread) : null
   }
 }
 

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -202,6 +202,13 @@ export interface ExpectedAbsencesRequest {
 }
 
 /**
+* Generated from fi.espoo.evaka.reservations.AttendanceReservationController.ExpectedAbsencesResponse
+*/
+export interface ExpectedAbsencesResponse {
+  categories: AbsenceCategory[] | null
+}
+
+/**
 * Generated from fi.espoo.evaka.reservations.AttendanceReservationController.GroupReservationStatisticResult
 */
 export interface GroupReservationStatisticResult {

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Controllers.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Controllers.kt
@@ -77,6 +77,10 @@ data class EndpointMetadata(
             }
         }
 
+        if (responseBodyType?.isMarkedNullable == true) {
+            fail("It must not have a nullable response body")
+        }
+
         when (httpMethod) {
             RequestMethod.GET,
             RequestMethod.HEAD,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/AttendanceTransitionsIntegrationTest.kt
@@ -535,14 +535,16 @@ class AttendanceTransitionsIntegrationTest : FullApplicationTest(resetDbBeforeEa
     }
 
     private fun getExpectedAbsencesOnDeparture(departed: LocalTime): Set<AbsenceCategory>? {
-        return childAttendanceController.getChildExpectedAbsencesOnDeparture(
-            dbInstance(),
-            mobileUser,
-            mockClock,
-            testDaycare.id,
-            testChild_1.id,
-            ChildAttendanceController.ExpectedAbsencesOnDepartureRequest(departed)
-        )
+        return childAttendanceController
+            .getChildExpectedAbsencesOnDeparture(
+                dbInstance(),
+                mobileUser,
+                mockClock,
+                testDaycare.id,
+                testChild_1.id,
+                ChildAttendanceController.ExpectedAbsencesOnDepartureRequest(departed)
+            )
+            .categories
     }
 
     private fun markDeparted(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/MockDvvModificationsService.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/dvv/MockDvvModificationsService.kt
@@ -21,13 +21,13 @@ private val logger = KotlinLogging.logger {}
 class MockDvvModificationsService {
 
     @GetMapping("/v1/kirjausavain/{date}")
-    fun getApiKey(@PathVariable date: String?): String {
+    fun getApiKey(@PathVariable date: String?): ByteArray {
         logger.info { "Mock dvv GET /kirjausavain/$date called" }
-        return "{\"viimeisinKirjausavain\":100000021}"
+        return "{\"viimeisinKirjausavain\":100000021}".toByteArray()
     }
 
     @PostMapping("/v1/muutokset")
-    fun getModifications(@RequestBody body: ModificationsRequest): String {
+    fun getModifications(@RequestBody body: ModificationsRequest): ByteArray {
         logger.info { "Mock dvv POST /muutokset called, body: $body" }
 
         val nextToken = body.viimeisinKirjausavain.toInt() + 1
@@ -38,6 +38,7 @@ class MockDvvModificationsService {
               "ajanTasalla": ${nextToken > 0}
             }
         """
+            .toByteArray()
     }
 }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -1375,25 +1375,27 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         filters: MessageController.PostMessageFilters? = null,
     ): MessageContentId? {
         val messageContentId =
-            messageController.createMessage(
-                dbInstance(),
-                user,
-                MockEvakaClock(now),
-                sender,
-                MessageController.PostMessageBody(
-                    title = title,
-                    content = message,
-                    type = messageType,
-                    recipients = recipients.toSet(),
-                    recipientNames = recipientNames,
-                    attachmentIds = attachmentIds,
-                    draftId = draftId,
-                    urgent = false,
-                    sensitive = sensitive,
-                    relatedApplicationId = relatedApplicationId,
-                    filters = filters
+            messageController
+                .createMessage(
+                    dbInstance(),
+                    user,
+                    MockEvakaClock(now),
+                    sender,
+                    MessageController.PostMessageBody(
+                        title = title,
+                        content = message,
+                        type = messageType,
+                        recipients = recipients.toSet(),
+                        recipientNames = recipientNames,
+                        attachmentIds = attachmentIds,
+                        draftId = draftId,
+                        urgent = false,
+                        sensitive = sensitive,
+                        relatedApplicationId = relatedApplicationId,
+                        filters = filters
+                    )
                 )
-            )
+                .createdId
         if (asyncJobRunningEnabled) {
             asyncJobRunner.runPendingJobsSync(MockEvakaClock(now.plusSeconds(30)))
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistance/AssistanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistance/AssistanceController.kt
@@ -381,8 +381,9 @@ class AssistanceController(
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,
         @PathVariable id: AssistanceFactorId,
-    ) =
-        db.connect { dbc ->
+    ) {
+        val deletedId =
+            db.connect { dbc ->
                 dbc.transaction { tx ->
                     accessControl
                         .checkPermissionFor(
@@ -413,9 +414,8 @@ class AssistanceController(
                         }
                 }
             }
-            .also { deletedId ->
-                deletedId?.let { Audit.AssistanceFactorDelete.log(targetId = AuditId(it)) }
-            }
+        deletedId?.let { Audit.AssistanceFactorDelete.log(targetId = AuditId(it)) }
+    }
 
     @PostMapping(
         "/children/{child}/daycare-assistances", // deprecated
@@ -478,8 +478,9 @@ class AssistanceController(
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,
         @PathVariable id: DaycareAssistanceId,
-    ) =
-        db.connect { dbc ->
+    ) {
+        val deletedId =
+            db.connect { dbc ->
                 dbc.transaction { tx ->
                     accessControl
                         .checkPermissionFor(
@@ -499,9 +500,8 @@ class AssistanceController(
                         }
                 }
             }
-            .also { deletedId ->
-                deletedId?.let { Audit.DaycareAssistanceDelete.log(targetId = AuditId(it)) }
-            }
+        deletedId?.let { Audit.DaycareAssistanceDelete.log(targetId = AuditId(it)) }
+    }
 
     @PostMapping(
         "/children/{child}/preschool-assistances", // deprecated
@@ -567,8 +567,9 @@ class AssistanceController(
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,
         @PathVariable id: PreschoolAssistanceId,
-    ) =
-        db.connect { dbc ->
+    ) {
+        val deletedId =
+            db.connect { dbc ->
                 dbc.transaction { tx ->
                     accessControl
                         .checkPermissionFor(
@@ -588,9 +589,8 @@ class AssistanceController(
                         }
                 }
             }
-            .also { deletedId ->
-                deletedId?.let { Audit.PreschoolAssistanceDelete.log(targetId = AuditId(it)) }
-            }
+        deletedId?.let { Audit.PreschoolAssistanceDelete.log(targetId = AuditId(it)) }
+    }
 
     @PostMapping(
         "/children/{child}/other-assistance-measures", // deprecated
@@ -656,7 +656,7 @@ class AssistanceController(
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,
         @PathVariable id: OtherAssistanceMeasureId,
-    ) =
+    ) {
         db.connect { dbc ->
                 dbc.transaction { tx ->
                     accessControl
@@ -680,4 +680,5 @@ class AssistanceController(
             .also { deletedId ->
                 deletedId?.let { Audit.OtherAssistanceMeasureDelete.log(targetId = AuditId(it)) }
             }
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
@@ -166,100 +166,82 @@ class SystemController(
         systemUser: AuthenticatedUser.SystemInternalUser,
         clock: EvakaClock,
         @PathVariable id: EmployeeId
-    ): EmployeeUserResponse? {
+    ): EmployeeUserResponse {
         return db.connect { dbc ->
                 dbc.read { tx ->
-                    tx.getEmployeeUser(id)?.let { employeeUser ->
-                        val user = AuthenticatedUser.Employee(employeeUser)
-                        val permittedGlobalActions =
-                            accessControl.getPermittedActions<Action.Global>(tx, user, clock)
-                        val accessibleFeatures =
-                            EmployeeFeatures(
-                                applications =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.APPLICATIONS_PAGE
-                                    ),
-                                employees =
-                                    permittedGlobalActions.contains(Action.Global.EMPLOYEES_PAGE),
-                                financeBasics =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.FINANCE_BASICS_PAGE
-                                    ),
-                                finance =
-                                    permittedGlobalActions.contains(Action.Global.FINANCE_PAGE),
-                                holidayAndTermPeriods =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.HOLIDAY_AND_TERM_PERIODS_PAGE
-                                    ),
-                                messages =
-                                    permittedGlobalActions.contains(Action.Global.MESSAGES_PAGE),
-                                personSearch =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.PERSON_SEARCH_PAGE
-                                    ),
-                                reports =
-                                    permittedGlobalActions.contains(Action.Global.REPORTS_PAGE),
-                                settings =
-                                    permittedGlobalActions.contains(Action.Global.SETTINGS_PAGE),
-                                systemNotifications =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.READ_SYSTEM_NOTIFICATIONS
-                                    ),
-                                unitFeatures =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.UNIT_FEATURES_PAGE
-                                    ),
-                                units = permittedGlobalActions.contains(Action.Global.UNITS_PAGE),
-                                createUnits =
-                                    permittedGlobalActions.contains(Action.Global.CREATE_UNIT),
-                                documentTemplates =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.DOCUMENT_TEMPLATES_PAGE
-                                    ),
-                                vasuTemplates =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.VASU_TEMPLATES_PAGE
-                                    ),
-                                personalMobileDevice =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.PERSONAL_MOBILE_DEVICE_PAGE
-                                    ),
-                                pinCode =
-                                    permittedGlobalActions.contains(Action.Global.PIN_CODE_PAGE),
-                                assistanceNeedDecisionsReport =
-                                    accessControl.isPermittedForSomeTarget(
-                                        tx,
-                                        user,
-                                        clock,
-                                        Action.AssistanceNeedDecision.READ_IN_REPORT
-                                    ),
-                                createDraftInvoices =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.CREATE_DRAFT_INVOICES
-                                    ),
-                                createPlacements =
-                                    accessControl.isPermittedForSomeTarget(
-                                        tx,
-                                        user,
-                                        clock,
-                                        Action.Unit.CREATE_PLACEMENT
-                                    ),
-                                submitPatuReport =
-                                    permittedGlobalActions.contains(
-                                        Action.Global.SUBMIT_PATU_REPORT
-                                    ),
-                            )
-
-                        EmployeeUserResponse(
-                            id = employeeUser.id,
-                            firstName = employeeUser.preferredFirstName ?: employeeUser.firstName,
-                            lastName = employeeUser.lastName,
-                            globalRoles = employeeUser.globalRoles,
-                            allScopedRoles = employeeUser.allScopedRoles,
-                            accessibleFeatures = accessibleFeatures,
-                            permittedGlobalActions = permittedGlobalActions
+                    val employeeUser = tx.getEmployeeUser(id) ?: throw NotFound()
+                    val user = AuthenticatedUser.Employee(employeeUser)
+                    val permittedGlobalActions =
+                        accessControl.getPermittedActions<Action.Global>(tx, user, clock)
+                    val accessibleFeatures =
+                        EmployeeFeatures(
+                            applications =
+                                permittedGlobalActions.contains(Action.Global.APPLICATIONS_PAGE),
+                            employees =
+                                permittedGlobalActions.contains(Action.Global.EMPLOYEES_PAGE),
+                            financeBasics =
+                                permittedGlobalActions.contains(Action.Global.FINANCE_BASICS_PAGE),
+                            finance = permittedGlobalActions.contains(Action.Global.FINANCE_PAGE),
+                            holidayAndTermPeriods =
+                                permittedGlobalActions.contains(
+                                    Action.Global.HOLIDAY_AND_TERM_PERIODS_PAGE
+                                ),
+                            messages = permittedGlobalActions.contains(Action.Global.MESSAGES_PAGE),
+                            personSearch =
+                                permittedGlobalActions.contains(Action.Global.PERSON_SEARCH_PAGE),
+                            reports = permittedGlobalActions.contains(Action.Global.REPORTS_PAGE),
+                            settings = permittedGlobalActions.contains(Action.Global.SETTINGS_PAGE),
+                            systemNotifications =
+                                permittedGlobalActions.contains(
+                                    Action.Global.READ_SYSTEM_NOTIFICATIONS
+                                ),
+                            unitFeatures =
+                                permittedGlobalActions.contains(Action.Global.UNIT_FEATURES_PAGE),
+                            units = permittedGlobalActions.contains(Action.Global.UNITS_PAGE),
+                            createUnits =
+                                permittedGlobalActions.contains(Action.Global.CREATE_UNIT),
+                            documentTemplates =
+                                permittedGlobalActions.contains(
+                                    Action.Global.DOCUMENT_TEMPLATES_PAGE
+                                ),
+                            vasuTemplates =
+                                permittedGlobalActions.contains(Action.Global.VASU_TEMPLATES_PAGE),
+                            personalMobileDevice =
+                                permittedGlobalActions.contains(
+                                    Action.Global.PERSONAL_MOBILE_DEVICE_PAGE
+                                ),
+                            pinCode = permittedGlobalActions.contains(Action.Global.PIN_CODE_PAGE),
+                            assistanceNeedDecisionsReport =
+                                accessControl.isPermittedForSomeTarget(
+                                    tx,
+                                    user,
+                                    clock,
+                                    Action.AssistanceNeedDecision.READ_IN_REPORT
+                                ),
+                            createDraftInvoices =
+                                permittedGlobalActions.contains(
+                                    Action.Global.CREATE_DRAFT_INVOICES
+                                ),
+                            createPlacements =
+                                accessControl.isPermittedForSomeTarget(
+                                    tx,
+                                    user,
+                                    clock,
+                                    Action.Unit.CREATE_PLACEMENT
+                                ),
+                            submitPatuReport =
+                                permittedGlobalActions.contains(Action.Global.SUBMIT_PATU_REPORT),
                         )
-                    }
+
+                    EmployeeUserResponse(
+                        id = employeeUser.id,
+                        firstName = employeeUser.preferredFirstName ?: employeeUser.firstName,
+                        lastName = employeeUser.lastName,
+                        globalRoles = employeeUser.globalRoles,
+                        allScopedRoles = employeeUser.allScopedRoles,
+                        accessibleFeatures = accessibleFeatures,
+                        permittedGlobalActions = permittedGlobalActions
+                    )
                 }
             }
             .also { Audit.EmployeeUserDetailsRead.log(targetId = AuditId(id)) }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -299,6 +299,8 @@ class AttendanceReservationController(
         val attendances: List<TimeRange>
     )
 
+    data class ExpectedAbsencesResponse(val categories: Set<AbsenceCategory>?)
+
     @PostMapping(
         "/attendance-reservations/child-date/expected-absences", // deprecated
         "/employee/attendance-reservations/child-date/expected-absences"
@@ -308,9 +310,9 @@ class AttendanceReservationController(
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,
         @RequestBody body: ExpectedAbsencesRequest
-    ): Set<AbsenceCategory>? {
+    ): ExpectedAbsencesResponse {
         if (!body.date.isBefore(clock.today())) {
-            return null
+            return ExpectedAbsencesResponse(categories = null)
         }
 
         return db.connect { dbc ->
@@ -323,11 +325,14 @@ class AttendanceReservationController(
                         body.childId
                     )
 
-                    getExpectedAbsenceCategories(
-                        tx = tx,
-                        date = body.date,
-                        childId = body.childId,
-                        attendanceTimes = body.attendances
+                    ExpectedAbsencesResponse(
+                        categories =
+                            getExpectedAbsenceCategories(
+                                tx = tx,
+                                date = body.date,
+                                childId = body.childId,
+                                attendanceTimes = body.attendances
+                            )
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/SpringMvcConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/SpringMvcConfig.kt
@@ -26,10 +26,14 @@ import org.jdbi.v3.core.Jdbi
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.MethodParameter
 import org.springframework.format.FormatterRegistry
+import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.converter.StringHttpMessageConverter
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.context.request.WebRequest.SCOPE_REQUEST
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import org.springframework.web.servlet.function.ServerRequest
 
@@ -69,6 +73,16 @@ class SpringMvcConfig(
     override fun addFormatters(registry: FormatterRegistry) {
         registry.addConverter(convertFrom<String, ExternalId> { ExternalId.parse(it) })
         registry.addConverter(convertFrom<String, Id<*>> { Id<DatabaseTable>(UUID.fromString(it)) })
+    }
+
+    override fun configureContentNegotiation(configurer: ContentNegotiationConfigurer) {
+        configurer.defaultContentType(MediaType.APPLICATION_JSON)
+    }
+
+    override fun configureMessageConverters(converters: MutableList<HttpMessageConverter<*>>) {
+        // If the response body is a string, we want it to be converted as JSON, not directly
+        // serialized as string
+        converters.removeIf { it is StringHttpMessageConverter }
     }
 
     private fun WebRequest.getDatabaseInstance(): Database =

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/integration/MockVardaIntegrationEndpoint.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/integration/MockVardaIntegrationEndpoint.kt
@@ -70,22 +70,22 @@ class MockVardaIntegrationEndpoint {
     }
 
     @GetMapping("/user/apikey/")
-    fun getApiKey(): String =
+    fun getApiKey(): ByteArray =
         lock.withLock {
             logger.info { "Mock varda integration endpoint GET /users/apiKey called" }
-            "{\"token\": \"49921df1b823e6fbaeb14dc23fd42325213187ad\"}"
+            "{\"token\": \"49921df1b823e6fbaeb14dc23fd42325213187ad\"}".toByteArray()
         }
 
     @PostMapping("/v1/toimipaikat/")
     fun createUnit(
         @RequestBody unit: VardaUnitRequest,
         @RequestHeader(name = "Authorization") auth: String
-    ): String =
+    ): ByteArray =
         lock.withLock {
             logger.info { "Mock varda integration endpoint POST /toimipaikat received body: $unit" }
             unitId = unitId.inc()
             units[unitId] = unit
-            getMockUnitResponse(unitId)
+            getMockUnitResponse(unitId).toByteArray()
         }
 
     @PutMapping("/v1/toimipaikat/{vardaId}/")
@@ -93,7 +93,7 @@ class MockVardaIntegrationEndpoint {
         @PathVariable vardaId: Long?,
         @RequestBody unit: VardaUnitRequest,
         @RequestHeader(name = "Authorization") auth: String
-    ): String =
+    ): ByteArray =
         lock.withLock {
             logger.info {
                 "Mock varda integration endpoint PUT /toimipaikat/$vardaId received body: $unit"
@@ -106,38 +106,38 @@ class MockVardaIntegrationEndpoint {
                     vardaId
                 }
             units.replace(id, unit)
-            getMockUnitResponse(id)
+            getMockUnitResponse(id).toByteArray()
         }
 
     @PostMapping("/v1/henkilot/")
     fun createPerson(
         @RequestBody body: VardaPersonRequest,
         @RequestHeader(name = "Authorization") auth: String
-    ): String =
+    ): ByteArray =
         lock.withLock {
             logger.info { "Mock varda integration endpoint POST /henkilot received body: $body" }
             personId = personId.inc()
             people[personId] = body
-            getMockPersonResponse(personId)
+            getMockPersonResponse(personId).toByteArray()
         }
 
     @PostMapping("/v1/lapset/")
     fun createChild(
         @RequestBody body: VardaChildRequest,
         @RequestHeader(name = "Authorization") auth: String
-    ): String =
+    ): ByteArray =
         lock.withLock {
             logger.info { "Mock varda integration endpoint POST /lapset received body: $body" }
             childId = childId.inc()
             this.children[childId] = body
-            getMockChildResponse(childId)
+            getMockChildResponse(childId).toByteArray()
         }
 
     @PostMapping("/v1/varhaiskasvatuspaatokset/")
     fun createDecision(
         @RequestBody body: VardaDecision,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> =
+    ): ResponseEntity<ByteArray> =
         lock.withLock {
             logger.info {
                 "Mock varda integration endpoint POST /varhaiskasvatuspaatokset received body: $body"
@@ -147,7 +147,7 @@ class MockVardaIntegrationEndpoint {
 
             decisionId = decisionId.inc()
             decisions[decisionId] = body
-            ResponseEntity.ok(getMockDecisionResponse(decisionId))
+            ResponseEntity.ok(getMockDecisionResponse(decisionId).toByteArray())
         }
 
     @PutMapping("/v1/varhaiskasvatuspaatokset/{vardaId}/")
@@ -155,7 +155,7 @@ class MockVardaIntegrationEndpoint {
         @PathVariable vardaId: Long,
         @RequestBody body: VardaDecision,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> =
+    ): ResponseEntity<ByteArray> =
         lock.withLock {
             logger.info {
                 "Mock varda integration endpoint PUT /varhaiskasvatuspaatokset/$vardaId/ received body: $body"
@@ -164,7 +164,7 @@ class MockVardaIntegrationEndpoint {
             if (shouldFailRequest(VardaCallType.DECISION)) return failRequest()
 
             decisions.replace(vardaId, body)
-            ResponseEntity.ok(getMockDecisionResponse(vardaId))
+            ResponseEntity.ok(getMockDecisionResponse(vardaId).toByteArray())
         }
 
     @DeleteMapping("/v1/varhaiskasvatuspaatokset/{vardaId}/")
@@ -183,14 +183,14 @@ class MockVardaIntegrationEndpoint {
     fun createPlacement(
         @RequestBody body: VardaPlacement,
         @RequestHeader(name = "Authorization") auth: String
-    ): String =
+    ): ByteArray =
         lock.withLock {
             logger.info {
                 "Mock varda integration endpoint POST /varhaiskasvatussuhteet received body: $body"
             }
             placementId = placementId.inc()
             placements[placementId] = body
-            getMockPlacementResponse(placementId)
+            getMockPlacementResponse(placementId).toByteArray()
         }
 
     @PutMapping("/v1/varhaiskasvatussuhteet/{vardaId}/")
@@ -198,13 +198,13 @@ class MockVardaIntegrationEndpoint {
         @PathVariable vardaId: Long,
         @RequestBody body: VardaPlacement,
         @RequestHeader(name = "Authorization") auth: String
-    ): String =
+    ): ByteArray =
         lock.withLock {
             logger.info {
                 "Mock varda integration endpoint PUT /varhaiskasvatussuhteet/$vardaId/ received body: $body"
             }
             placements.replace(vardaId, body)
-            getMockPlacementResponse(vardaId)
+            getMockPlacementResponse(vardaId).toByteArray()
         }
 
     @DeleteMapping("/v1/varhaiskasvatussuhteet/{vardaId}/")
@@ -223,7 +223,7 @@ class MockVardaIntegrationEndpoint {
     fun createFeeData(
         @RequestBody body: VardaFeeData,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> =
+    ): ResponseEntity<ByteArray> =
         lock.withLock {
             if (shouldFailRequest(VardaCallType.FEE_DATA)) return failRequest()
 
@@ -231,7 +231,7 @@ class MockVardaIntegrationEndpoint {
             this.feeData[feeDataId] = body
             this.feeDataCalls += 1
             logger.info { "Mock varda integration endpoint POST /maksutiedot received body: $body" }
-            ResponseEntity.ok(getMockFeeDataResponse(feeDataId, body))
+            ResponseEntity.ok(getMockFeeDataResponse(feeDataId, body).toByteArray())
         }
 
     @PutMapping("/v1/maksutiedot/{vardaId}")
@@ -239,7 +239,7 @@ class MockVardaIntegrationEndpoint {
         @PathVariable vardaId: Long,
         @RequestBody body: VardaFeeData,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> =
+    ): ResponseEntity<ByteArray> =
         lock.withLock {
             logger.info {
                 "Mock varda integration endpoint PUT /maksutiedot/$vardaId received body: $body"
@@ -248,14 +248,14 @@ class MockVardaIntegrationEndpoint {
             if (shouldFailRequest(VardaCallType.FEE_DATA)) return failRequest()
 
             this.feeData.replace(vardaId, body)
-            ResponseEntity.ok(getMockFeeDataResponse(vardaId, body))
+            ResponseEntity.ok(getMockFeeDataResponse(vardaId, body).toByteArray())
         }
 
     @DeleteMapping("/v1/maksutiedot/{vardaId}/")
     fun deleteFeeData(
         @PathVariable vardaId: Long,
         @RequestHeader(name = "Authorization") auth: String
-    ): ResponseEntity<String> =
+    ): ResponseEntity<ByteArray> =
         lock.withLock {
             logger.info {
                 "Mock varda integration endpoint DELETE /maksutiedot received id: $vardaId"
@@ -539,11 +539,11 @@ class MockVardaIntegrationEndpoint {
 
     private fun shouldFailRequest(type: VardaCallType) = type == failNextRequest
 
-    private fun failRequest(): ResponseEntity<String> {
+    private fun failRequest(): ResponseEntity<ByteArray> {
         logger.info(
             "MockVardaIntegrationEndpoint: failing $failNextRequest varda call as requested with $failResponseCode"
         )
         failNextRequest = null
-        return ResponseEntity.status(failResponseCode).body(failResponseMessage)
+        return ResponseEntity.status(failResponseCode).body(failResponseMessage.toByteArray())
     }
 }


### PR DESCRIPTION
Jos API:sta palauttaa ylätason nullin, Spring palauttaa aina väkisin tyhjän responsen (`Content-Length: 0` ja mahdollisesti `Content-Type: application/json`), eikä esim. `null` joka toimisi JSON-deserialisoinnissa oikein:

- axios tulkitsee sen tyhjänä merkkijonona ja frontissa arvoksi tulee `''`
- Fetch API heittää virheen jos yrittää kutsua `.json()`

Jotta vältytään yllätyksiltä varsinkin axioksen kanssa, kielletään ylätason nullit ja vaaditaan aina jonkinlainen wrapperi.

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
