### PR TITLE
Korjaus käyttöoikeuksiin

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionCitizenController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionCitizenController.kt
@@ -144,7 +144,7 @@ class AssistanceNeedPreschoolDecisionCitizenController(
                         tx,
                         user,
                         clock,
-                        Action.Citizen.Person.READ_UNREAD_ASSISTANCE_NEED_DECISION_COUNT,
+                        Action.Citizen.Person.READ_UNREAD_ASSISTANCE_NEED_PRESCHOOL_DECISION_COUNT,
                         user.id
                     )
                     tx.getAssistanceNeedPreschoolDecisionsUnreadCountsForCitizen(


### PR DESCRIPTION
Endpoint käytti READ_UNREAD_ASSISTANCE_NEED_DECISION_COUNT actionia kun piti käyttää READ_UNREAD_ASSISTANCE_NEED_PRESCHOOL_DECISION_COUNT. Kyseinen endpoint ei kuitenkaan ole tietoturvakriittinen ja molemmissa on ainakin oletuksena samat oikeudet.