### PR TITLE
Korjataan koko päivän poissaolon näyttäminen kuntalaiselle

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -868,12 +868,13 @@ const Reservations = React.memo(function Reservations({
         holidayPeriodEffect.period,
         holidayPeriodEffect.reservationsOpenOn
       )}
+      data-qa="not-yet-reservable"
     >
       {i18n.calendar.notYetReservable}
     </ExpandingInfo>
   ) : withoutTimes.length > 0 ? (
     // In theory, we could have reservations with and without times, but this shouldn't happen in practice
-    <ReservationStatus data-qa="reservations-no-times">
+    <ReservationStatus data-qa="reservation-no-times">
       {i18n.calendar.present}
     </ReservationStatus>
   ) : withTimes.length > 0 ? (

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -204,7 +204,6 @@ function View({
     />
   ) : undefined
 
-  const isPast = modalData.response.date.isBefore(LocalDate.todayInSystemTz())
   return (
     <DayModal
       date={modalData.response.date}
@@ -216,10 +215,7 @@ function View({
     >
       {(childIndex) => {
         const child = modalData.response.children[childIndex]
-        return (!featureFlags.automaticFixedScheduleAbsences ||
-          isPast ||
-          child.reservations.length === 0) &&
-          child.absence !== null ? (
+        return child.absence !== null ? (
           <Absence absence={child.absence} />
         ) : (
           <Reservations

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -15,7 +15,6 @@ import {
   ReservationResponseDay,
   ReservationResponseDayChild
 } from 'lib-common/generated/api-types/reservations'
-import LocalDate from 'lib-common/local-date'
 import {
   reservationHasTimes,
   reservationsAndAttendancesDiffer
@@ -57,10 +56,9 @@ export const Reservations = React.memo(function Reservations({
     () =>
       groupChildren({
         children: data.children,
-        isPast: data.date.isBefore(LocalDate.todayInHelsinkiTz()),
         i18n
       }),
-    [data.children, data.date, i18n]
+    [data.children, i18n]
   )
 
   return data.children.length === 0 && data.holiday && !isReservable ? (
@@ -171,11 +169,9 @@ const absenceElementType = (absence: AbsenceInfo) =>
 
 const groupChildren = ({
   children,
-  isPast,
   i18n
 }: {
   children: ReservationResponseDayChild[]
-  isPast: boolean
   i18n: Translations
 }): GroupedDailyChildren[] =>
   Object.entries(
@@ -199,10 +195,7 @@ const groupChildren = ({
           }
         }
 
-        if (
-          (isPast || !featureFlags.automaticFixedScheduleAbsences) &&
-          child.absence
-        ) {
+        if (child.absence) {
           const elementType = absenceElementType(child.absence)
           return {
             childId: child.childId,
@@ -234,15 +227,6 @@ const groupChildren = ({
                 formatReservation(reservation, child.reservableTimeRange, i18n)
               )
               .join(', ')
-          }
-        }
-
-        if (child.absence) {
-          const elementType = absenceElementType(child.absence)
-          return {
-            childId: child.childId,
-            type: elementType,
-            text: i18n.calendar[elementType]
           }
         }
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -72,11 +72,6 @@ export default class CitizenCalendarPage {
   monthlySummaryInfoButton = (year: number, month: number) =>
     this.page.findByDataQa(`monthly-summary-info-button-${month}-${year}`)
 
-  async openDayModal(date: LocalDate) {
-    await this.dayCell(date).click()
-    return new DayModal(this.page)
-  }
-
   async waitUntilLoaded() {
     await this.page
       .find('[data-qa="calendar-page"][data-isloading="false"]')
@@ -670,6 +665,7 @@ class DayView extends Element {
 
   #editButton = this.findByDataQa('edit')
   #createAbsenceButton = this.findByDataQa('create-absence')
+  childNames = this.findAllByDataQa('child-name')
 
   #childSection(childId: UUID) {
     return this.findByDataQa(`child-${childId}`)
@@ -853,15 +849,5 @@ class HolidayModal extends Element {
     await this.#childSection(child.id)
       .findByDataQa('not-eligible')
       .waitUntilVisible()
-  }
-}
-
-class DayModal {
-  childName: ElementCollection
-  closeModal: Element
-
-  constructor(readonly page: Page) {
-    this.childName = page.findAllByDataQa('child-name')
-    this.closeModal = page.findByDataQa('day-view-close-button')
   }
 }

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -683,6 +683,30 @@ class DayView extends Element {
     await reservationsElement.assertTextEquals(reservations)
   }
 
+  async assertReservationNoTimes(childId: UUID) {
+    await this.#childSection(childId)
+      .findByDataQa('reservation-no-times')
+      .waitUntilVisible()
+  }
+
+  async assertReservationNotRequired(childId: UUID) {
+    await this.#childSection(childId)
+      .findByDataQa('reservation-not-required')
+      .waitUntilVisible()
+  }
+
+  async assertNotYetReservable(childId: UUID) {
+    await this.#childSection(childId)
+      .findByDataQa('not-yet-reservable')
+      .waitUntilVisible()
+  }
+
+  async assertAttendances(childId: UUID, attendances: string[]) {
+    await this.#childSection(childId)
+      .findByDataQa('attendances')
+      .assertTextEquals(attendances.join('\n'))
+  }
+
   getServiceUsageWarning(childId: UUID) {
     return this.#childSection(childId).findByDataQa('service-usage-warning')
   }

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -677,18 +677,10 @@ class DayView extends Element {
       .waitUntilVisible()
   }
 
-  async assertReservations(
-    childId: UUID,
-    reservations: FormatterReservation[],
-    formatter: (res: FormatterReservation) => string = (
-      r: FormatterReservation
-    ) => `${r.startTime}–${r.endTime}`
-  ) {
+  async assertReservations(childId: UUID, reservations: string) {
     const reservationsElement =
       this.#childSection(childId).findByDataQa('reservations')
-    await reservationsElement.assertTextEquals(
-      reservations.map(formatter).join(', ')
-    )
+    await reservationsElement.assertTextEquals(reservations)
   }
 
   getServiceUsageWarning(childId: UUID) {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -1220,9 +1220,9 @@ describe('Citizen calendar child visibility', () => {
     const calendarPage = await openCalendarPage('desktop')
     await calendarPage.assertChildCountOnDay(firstReservationDay, 1)
 
-    const holidayDayModal = await calendarPage.openDayModal(firstReservationDay)
-    await holidayDayModal.childName.assertCount(1)
-    await holidayDayModal.closeModal.click()
+    const holidayDayModal = await calendarPage.openDayView(firstReservationDay)
+    await holidayDayModal.childNames.assertCount(1)
+    await holidayDayModal.close()
 
     const reservationsModal = await calendarPage.openReservationModal()
     await reservationsModal.createIrregularReservation(

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -673,6 +673,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
     await init()
     const calendarPage = await openCalendarPage(env)
     await calendarPage.assertDay(today.subDays(1), [])
+
+    const day = await calendarPage.openDayView(today.subDays(1))
+    await day.assertNoActivePlacementsMsgVisible()
   })
 
   it('Holiday', async () => {
@@ -682,6 +685,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
     const calendarPage = await openCalendarPage(env)
     await calendarPage.assertHoliday(today)
     await calendarPage.assertDay(today, [])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertNoActivePlacementsMsgVisible()
   })
 
   it('Missing reservation', async () => {
@@ -690,6 +696,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
     await calendarPage.assertDay(today, [
       { childIds: [testChild2.id], text: 'Ilmoitus puuttuu' }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertNoReservation(testChild2.id)
   })
 
   it('Reservation', async () => {
@@ -709,6 +718,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: '08:00–16:00'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertReservations(testChild2.id, '08:00–16:00')
   })
 
   it('Two reservations', async () => {
@@ -731,6 +743,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: '08:00–12:00, 18:00–23:59'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertReservations(testChild2.id, '08:00–12:00, 18:00–23:59')
   })
 
   it('Holiday period highlight', async () => {
@@ -743,6 +758,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
 
     const calendarPage = await openCalendarPage(env)
     await calendarPage.assertDayHighlight(today, 'holidayPeriod')
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertNoReservation(testChild2.id)
   })
 
   it('Holiday period not yet open', async () => {
@@ -760,6 +778,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: `Ilmoittautuminen avataan ${today.addDays(1).format()}`
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertNotYetReservable(testChild2.id)
   })
 
   it('Reservation without times', async () => {
@@ -780,6 +801,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
     await calendarPage.assertDay(today, [
       { childIds: [testChild2.id], text: 'Läsnä' }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertReservationNoTimes(testChild2.id)
   })
 
   it('Fixed schedule', async () => {
@@ -789,6 +813,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
     await calendarPage.assertDay(today, [
       { childIds: [testChild2.id], text: 'Läsnä' }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertReservationNotRequired(testChild2.id)
   })
 
   it('Ongoing attendance', async () => {
@@ -809,6 +836,10 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: '08:00–'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertNoReservation(testChild2.id)
+    await day.assertAttendances(testChild2.id, ['08:00–'])
   })
 
   it('Attendance', async () => {
@@ -829,6 +860,10 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: '08:00–15:30'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertNoReservation(testChild2.id)
+    await day.assertAttendances(testChild2.id, ['08:00–15:30'])
   })
 
   it('Three attendances', async () => {
@@ -856,6 +891,14 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: '08:00–12:00, 14:00–18:00, 20:00–23:00'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertNoReservation(testChild2.id)
+    await day.assertAttendances(testChild2.id, [
+      '08:00–12:00',
+      '14:00–18:00',
+      '20:00–23:00'
+    ])
   })
 
   it('Absent', async () => {
@@ -875,6 +918,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: 'Poissa'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertAbsence(testChild2.id, 'Poissa')
   })
 
   it('Absent (marked by staff)', async () => {
@@ -894,6 +940,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: 'Poissa'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertAbsence(testChild2.id, 'Henkilökunnan merkitsemä poissaolo')
   })
 
   it('Free absence', async () => {
@@ -914,6 +963,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: 'Maksuton poissaolo'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertAbsence(testChild2.id, 'Henkilökunnan merkitsemä poissaolo')
   })
 
   it('Planned absence', async () => {
@@ -937,6 +989,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: 'Vuorotyöpoissaolo'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertAbsence(testChild2.id, 'Vuorotyöpoissaolo')
   })
 
   it('Reservation + full day absence (daycare)', async () => {
@@ -962,6 +1017,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: 'Poissa'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertAbsence(testChild2.id, 'Sairauspoissaolo')
   })
 
   it('Reservation + full day absence (preschool + daycare)', async () => {
@@ -993,6 +1051,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: 'Poissa'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertAbsence(testChild2.id, 'Poissa')
   })
 
   it('Reservation + part-day planned absence', async () => {
@@ -1019,6 +1080,9 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: '09:00–13:00'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertReservations(testChild2.id, '09:00–13:00')
   })
 
   it('Reservation + part-day planned absence (in the past)', async () => {
@@ -1047,6 +1111,41 @@ describe.each(e)('Calendar day content (%s)', (env) => {
         text: 'Poissa'
       }
     ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertAbsence(testChild2.id, 'Poissa')
+  })
+
+  it('Reservation + part-day planned absence (in the past) with citizenAttendanceSummary feature flag', async () => {
+    await init({ placementType: 'PRESCHOOL_DAYCARE' })
+
+    await Fixture.attendanceReservationRaw({
+      childId: testChild2.id,
+      date: today,
+      range: new TimeRange(LocalTime.of(9, 0), LocalTime.of(13, 0))
+    }).save()
+
+    await Fixture.absence({
+      childId: testChild2.id,
+      date: today,
+      modifiedBy: testAdult.id,
+      absenceCategory: 'BILLABLE',
+      absenceType: 'PLANNED_ABSENCE'
+    }).save()
+
+    const calendarPage = await openCalendarPage(env, {
+      mockedTime: today.addDays(1).toHelsinkiDateTime(LocalTime.of(12, 0)),
+      featureFlags: { citizenAttendanceSummary: true }
+    })
+    await calendarPage.assertDay(today, [
+      {
+        childIds: [testChild2.id],
+        text: 'Vuorotyöpoissaolo'
+      }
+    ])
+
+    const day = await calendarPage.openDayView(today)
+    await day.assertAbsence(testChild2.id, 'Vuorotyöpoissaolo')
   })
 })
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -307,7 +307,7 @@ describe.each(e)('Citizen attendance reservations (%s)', (env) => {
     await editor.saveButton.click()
 
     await dayView.assertNoReservation(children[0].id)
-    await dayView.assertReservations(children[1].id, [reservation1])
+    await dayView.assertReservations(children[1].id, '08:00–16:00')
     await dayView.assertNoReservation(children[2].id)
   })
 
@@ -340,7 +340,7 @@ describe.each(e)('Citizen attendance reservations (%s)', (env) => {
     await editor.saveButton.click()
 
     await dayView.assertNoReservation(children[0].id)
-    await dayView.assertReservations(children[1].id, [reservation1])
+    await dayView.assertReservations(children[1].id, '09:00–13:00')
     await dayView.assertNoReservation(children[2].id)
 
     // There's no way for the citizen to see that an absence was created, so use DevApi for that
@@ -601,9 +601,7 @@ describe.each(e)('Citizen attendance reservations (%s)', (env) => {
     await childSection.reservationEnd.fill('16:00')
     await editor.saveButton.click()
 
-    await dayView.assertReservations(testChild.id, [
-      { startTime: '08:00', endTime: '16:00' }
-    ])
+    await dayView.assertReservations(testChild.id, '08:00–16:00')
   })
 
   test('Citizen creates a weekly reservation that spans a holiday', async () => {
@@ -1386,7 +1384,7 @@ describe.each(e)('Citizen calendar shift care reservations', (env) => {
     await child.reservationEnd.fill(reservation1.endTime)
     await editor.saveButton.click()
 
-    await dayView.assertReservations(testChild2.id, [reservation1])
+    await dayView.assertReservations(testChild2.id, '08:00–16:00')
 
     editor = await dayView.edit()
     child = editor.childSection(testChild2.id)
@@ -1395,10 +1393,7 @@ describe.each(e)('Citizen calendar shift care reservations', (env) => {
     await child.reservation2End.fill(reservation2.endTime)
     await editor.saveButton.click()
 
-    await dayView.assertReservations(testChild2.id, [
-      reservation1,
-      reservation2
-    ])
+    await dayView.assertReservations(testChild2.id, '08:00–16:00, 17:00–19:00')
   })
 
   test(`Citizen creates 2 reservations from reservation modal: ${env}`, async () => {
@@ -1434,9 +1429,6 @@ describe.each(e)('Citizen calendar shift care reservations', (env) => {
 
     const dayView = await calendarPage.openDayView(reservationDay)
 
-    await dayView.assertReservations(testChild2.id, [
-      reservation1,
-      reservation2
-    ])
+    await dayView.assertReservations(testChild2.id, '10:00–16:00, 17:00–18:00')
   })
 })

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-start-after-holiday-deadline.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-start-after-holiday-deadline.spec.ts
@@ -115,7 +115,7 @@ describe('Placement start after deadline end', () => {
     await childView.reservationEnd.fill(reservation.endTime)
     await editor.saveButton.click()
 
-    await dayView.assertReservations(child.id, [reservation])
+    await dayView.assertReservations(child.id, '08:00–16:00')
     await dayView.close()
 
     await calendar.assertDay(startDate, [

--- a/frontend/src/e2e-test/specs/0_citizen/feature-flag-citizen-reservations-intermittent-shif-care.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/feature-flag-citizen-reservations-intermittent-shif-care.spec.ts
@@ -12,7 +12,6 @@ import { Fixture, testChild, testAdult } from '../../dev-api/fixtures'
 import { resetServiceState } from '../../generated/api-clients'
 import { DevPerson } from '../../generated/api-types'
 import CitizenCalendarPage, {
-  FormatterReservation,
   TwoPartReservation
 } from '../../pages/citizen/citizen-calendar'
 import CitizenHeader, { EnvType } from '../../pages/citizen/citizen-header'
@@ -184,8 +183,7 @@ describe.each(e)(
 
       await dayView.assertReservations(
         child.id,
-        [reservation1, reservation2],
-        getFormatterReservationOutput
+        '05:00–10:00 Ilta-/vuorohoito, 10:00–16:00'
       )
     })
   }
@@ -273,11 +271,6 @@ const addTestData = async (date: LocalDate) => {
 
   return { parent, child }
 }
-
-const getFormatterReservationOutput = (res: FormatterReservation) =>
-  res.isOverdraft
-    ? `${res.startTime}–${res.endTime} Ilta-/vuorohoito`
-    : `${res.startTime}–${res.endTime}`
 
 const getTwoPartReservationOutput = (reservations: TwoPartReservation) =>
   reservations

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -197,7 +197,12 @@ class ReservationControllerCitizen(
                                                                 placementDay.scheduleType,
                                                             shiftCare = placementDay.shiftCare,
                                                             absence =
-                                                                selectSingleAbsence(childAbsences),
+                                                                relevantAbsence(
+                                                                    today,
+                                                                    placementDay.placementType,
+                                                                    childReservations.isNotEmpty(),
+                                                                    childAbsences
+                                                                ),
                                                             reservations =
                                                                 childReservations.sorted(),
                                                             attendances =
@@ -467,13 +472,26 @@ private fun placementDay(
     }
 }
 
-/**
- * Show at most one absence per child per day. Take billable one if available, as it affects
- * invoicing and is more important in that sense.
- */
-private fun selectSingleAbsence(absences: List<Absence>): AbsenceInfo? =
-    (absences.firstOrNull { it.category == AbsenceCategory.BILLABLE } ?: absences.firstOrNull())
-        ?.let { AbsenceInfo(it.absenceType, it.editableByCitizen()) }
+private fun relevantAbsence(
+    today: LocalDate,
+    placementType: PlacementType,
+    hasReservation: Boolean,
+    absences: List<Absence>
+): AbsenceInfo? {
+    // Take billable absence if available, as it affects invoicing and is more important in that
+    // sense
+    val absence =
+        (absences.firstOrNull { it.category == AbsenceCategory.BILLABLE } ?: absences.firstOrNull())
+            ?: return null
+
+    return if (absence.date.isBefore(today) || !hasReservation) {
+        // Absence should be shown in citizen's calendar (although attendances still take precedence)
+        AbsenceInfo(absence.absenceType, absence.editableByCitizen())
+    } else {
+        // Absence is not relevant for citizen's calendar
+        null
+    }
+}
 
 data class ReservationsResponse(
     val children: List<ReservationChild>,

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -483,9 +483,11 @@ private fun relevantAbsence(
     val absence =
         (absences.firstOrNull { it.category == AbsenceCategory.BILLABLE } ?: absences.firstOrNull())
             ?: return null
+    val fullDayAbsence = absences.size == placementType.absenceCategories().size
 
-    return if (absence.date.isBefore(today) || !hasReservation) {
-        // Absence should be shown in citizen's calendar (although attendances still take precedence)
+    return if (absence.date.isBefore(today) || fullDayAbsence || !hasReservation) {
+        // Absence should be shown in citizen's calendar (although attendances still take
+        // precedence)
         AbsenceInfo(absence.absenceType, absence.editableByCitizen())
     } else {
         // Absence is not relevant for citizen's calendar


### PR DESCRIPTION
Jos lapsen sijoitustyyppi sisältää maksullisen ja maksuttoman osuuden, kuluvan päivän ja tulevaisuuden kokopäivän poissaoloja ei näytetty oikein kuntalaiselle, vaan ensisijaisesti näytettiin varaus.