### PR TITLE
Varaudutaan rikkinäisiin henkilöviitteisiin vasu-migraatiossa

### DIFF
--- a/frontend/src/lib-common/generated/api-types/vasu.ts
+++ b/frontend/src/lib-common/generated/api-types/vasu.ts
@@ -140,6 +140,7 @@ export interface VasuContent {
 */
 export interface VasuDocument {
   basics: VasuBasics
+  childId: UUID
   content: VasuContent
   created: HelsinkiDateTime
   documentState: VasuDocumentState

--- a/service/src/main/kotlin/fi/espoo/evaka/vasu/Vasu.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vasu/Vasu.kt
@@ -97,6 +97,7 @@ data class VasuDocumentSummary(
 
 data class VasuDocument(
     val id: VasuDocumentId,
+    val childId: ChildId,
     val created: HelsinkiDateTime,
     val modifiedAt: HelsinkiDateTime,
     val templateId: VasuTemplateId,


### PR DESCRIPTION
child_document json:ssa olevat child/guardian id:t eivät välttämättä löydy person taulusta jos hetuttomia on yhdistelty