### PR TITLE
Varausten ja poissaolojen siivous sijoitusten muuttuessa

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizenIntegrationTest.kt
@@ -5,6 +5,8 @@
 package fi.espoo.evaka.placement
 
 import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.absence.AbsenceCategory
+import fi.espoo.evaka.absence.AbsenceType
 import fi.espoo.evaka.application.ApplicationStatus
 import fi.espoo.evaka.backupcare.getBackupCaresForChild
 import fi.espoo.evaka.daycare.addUnitFeatures
@@ -12,23 +14,27 @@ import fi.espoo.evaka.insertApplication
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.serviceneed.ShiftCareType
 import fi.espoo.evaka.serviceneed.insertServiceNeed
+import fi.espoo.evaka.shared.AbsenceId
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.ChildId
-import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.dev.DevAbsence
 import fi.espoo.evaka.shared.dev.DevBackupCare
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.DevDaycareGroupPlacement
+import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.DevPlacement
+import fi.espoo.evaka.shared.dev.DevReservation
 import fi.espoo.evaka.shared.dev.insert
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.Forbidden
-import fi.espoo.evaka.shared.domain.RealEvakaClock
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.snPreschoolDaycare45
 import fi.espoo.evaka.snPreschoolDaycarePartDay35
@@ -39,6 +45,7 @@ import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testDaycare
 import fi.espoo.evaka.testDaycare2
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -61,8 +68,7 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
     private val child = testChild_1
     private val parent = testAdult_1
     private val authenticatedParent = AuthenticatedUser.Citizen(parent.id, CitizenAuthLevel.STRONG)
-    private val admin =
-        AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
+    private val admin = DevEmployee(roles = setOf(UserRole.ADMIN))
 
     private val daycareId = testDaycare.id
     private val daycare2Id = testDaycare2.id
@@ -70,7 +76,8 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
     private val daycareGroup = DevDaycareGroup(daycareId = daycareId)
     private val daycareGroup2 = DevDaycareGroup(daycareId = daycare2Id)
 
-    private val today = LocalDate.now()
+    private val today = LocalDate.of(2024, 8, 5)
+    private val clock = MockEvakaClock(HelsinkiDateTime.Companion.of(today, LocalTime.of(15, 0)))
 
     private val placementStart = today.minusMonths(3)
     private val placementEnd = placementStart.plusMonths(6)
@@ -78,6 +85,7 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
     @BeforeEach
     fun setUp() {
         db.transaction { tx ->
+            tx.insert(admin)
             tx.insert(testArea)
             tx.insert(testDaycare)
             tx.insert(testDaycare2)
@@ -128,26 +136,43 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
 
     @Test
     fun `citizen can terminate own child's placement starting from tomorrow`() {
-        db.transaction { tx ->
-            tx.insert(
-                DevPlacement(
-                    childId = child.id,
-                    unitId = daycareId,
-                    startDate = placementStart,
-                    endDate = placementEnd
-                )
+        val placement1 =
+            DevPlacement(
+                childId = child.id,
+                unitId = daycareId,
+                startDate = placementStart,
+                endDate = placementEnd
             )
-            tx.insert(
-                DevPlacement(
-                    childId = child.id,
-                    unitId = daycare2Id,
-                    startDate = placementEnd.plusDays(1),
-                    endDate = placementEnd.plusMonths(2)
-                )
+        val placement2 =
+            DevPlacement(
+                childId = child.id,
+                unitId = daycare2Id,
+                startDate = placementEnd.plusDays(1),
+                endDate = placementEnd.plusMonths(2)
             )
-        }
-
         val placementTerminationDate = today.plusDays(1)
+        val reservation =
+            DevReservation(
+                childId = child.id,
+                date = today.plusDays(3),
+                startTime = LocalTime.of(9, 0),
+                endTime = LocalTime.of(17, 0),
+                createdBy = admin.evakaUserId
+            )
+        val absence =
+            DevAbsence(
+                childId = child.id,
+                absenceCategory = AbsenceCategory.BILLABLE,
+                absenceType = AbsenceType.PLANNED_ABSENCE,
+                date = today.plusDays(3),
+                modifiedBy = admin.evakaUserId
+            )
+        db.transaction { tx ->
+            tx.insert(placement1)
+            tx.insert(placement2)
+            tx.insert(reservation)
+            tx.insert(absence)
+        }
 
         terminatePlacements(
             child.id,
@@ -175,6 +200,18 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
         assertEquals(
             listOf(null),
             childPlacements[1].placements.map { it.terminationRequestedDate }
+        )
+
+        assertEquals(
+            0,
+            db.read {
+                it.createQuery { sql("SELECT count(*) FROM attendance_reservation") }
+                    .exactlyOne<Int>()
+            }
+        )
+        assertEquals(
+            0,
+            db.read { it.createQuery { sql("SELECT count(*) FROM absence") }.exactlyOne<Int>() }
         )
     }
 
@@ -279,6 +316,30 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
 
         val startPreschool = today.minusWeeks(2)
         val endPreschool = startPreschool.plusMonths(1)
+        val reservation =
+            DevReservation(
+                childId = child.id,
+                date = placementTerminationDate.plusDays(1),
+                startTime = LocalTime.of(9, 0),
+                endTime = LocalTime.of(17, 0),
+                createdBy = admin.evakaUserId
+            )
+        val billableAbsence =
+            DevAbsence(
+                childId = child.id,
+                absenceCategory = AbsenceCategory.BILLABLE,
+                absenceType = AbsenceType.FORCE_MAJEURE,
+                date = placementTerminationDate.plusDays(2),
+                modifiedBy = admin.evakaUserId
+            )
+        val nonbillableAbsence =
+            DevAbsence(
+                childId = child.id,
+                absenceCategory = AbsenceCategory.NONBILLABLE,
+                absenceType = AbsenceType.PLANNED_ABSENCE,
+                date = placementTerminationDate.plusDays(3),
+                modifiedBy = admin.evakaUserId
+            )
         db.transaction {
             val id =
                 it.insert(
@@ -310,6 +371,9 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
                 null,
                 null
             )
+            it.insert(reservation)
+            it.insert(billableAbsence)
+            it.insert(nonbillableAbsence)
         }
 
         val placementsBefore = getChildPlacements(child.id)
@@ -357,6 +421,18 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
         assertEquals(PlacementType.PRESCHOOL, remainderOfPreschool.type)
         assertEquals(placementTerminationDate.plusDays(1), remainderOfPreschool.startDate)
         assertEquals(endPreschool, remainderOfPreschool.endDate)
+
+        assertEquals(
+            0,
+            db.read {
+                it.createQuery { sql("SELECT count(*) FROM attendance_reservation") }
+                    .exactlyOne<Int>()
+            }
+        )
+        assertEquals(
+            setOf(nonbillableAbsence.id),
+            db.read { it.createQuery { sql("SELECT id FROM absence") }.toSet<AbsenceId>() }
+        )
     }
 
     @Test
@@ -973,7 +1049,7 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
         placementControllerCitizen.postPlacementTermination(
             dbInstance(),
             authenticatedParent,
-            RealEvakaClock(),
+            clock,
             childId,
             termination
         )
@@ -981,13 +1057,13 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
 
     private fun getChildPlacements(childId: ChildId): List<TerminatablePlacementGroup> {
         return placementControllerCitizen
-            .getPlacements(dbInstance(), authenticatedParent, RealEvakaClock(), childId)
+            .getPlacements(dbInstance(), authenticatedParent, clock, childId)
             .placements
     }
 
     private fun getChildGroupPlacements(childId: ChildId): List<DaycareGroupPlacement> {
         return placementController
-            .getPlacements(dbInstance(), admin, RealEvakaClock(), childId = childId)
+            .getPlacements(dbInstance(), admin.user, clock, childId = childId)
             .placements
             .toList()
             .flatMap { it.groupPlacements }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementQueriesIntegrationTest.kt
@@ -32,8 +32,8 @@ class PlacementQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     private val daycare = DevDaycare(areaId = area.id)
 
     @Test
-    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for club placement`() {
-        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+    fun `deleteFutureReservationsAndAbsencesOutsideValidPlacements for club placement`() {
+        `deleteFutureReservationsAndAbsencesOutsideValidPlacements works`(
             placementType = PlacementType.CLUB,
             hasReservations = false,
             hasBillableAbsences = false,
@@ -42,8 +42,8 @@ class PlacementQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for daycare placement`() {
-        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+    fun `deleteFutureReservationsAndAbsencesOutsideValidPlacements for daycare placement`() {
+        `deleteFutureReservationsAndAbsencesOutsideValidPlacements works`(
             placementType = PlacementType.DAYCARE,
             hasReservations = true,
             hasBillableAbsences = true,
@@ -52,8 +52,8 @@ class PlacementQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for preschool placement`() {
-        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+    fun `deleteFutureReservationsAndAbsencesOutsideValidPlacements for preschool placement`() {
+        `deleteFutureReservationsAndAbsencesOutsideValidPlacements works`(
             placementType = PlacementType.PRESCHOOL,
             hasReservations = false,
             hasBillableAbsences = false,
@@ -62,8 +62,8 @@ class PlacementQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for preschool_daycare placement`() {
-        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+    fun `deleteFutureReservationsAndAbsencesOutsideValidPlacements for preschool_daycare placement`() {
+        `deleteFutureReservationsAndAbsencesOutsideValidPlacements works`(
             placementType = PlacementType.PRESCHOOL_DAYCARE,
             hasReservations = true,
             hasBillableAbsences = true,
@@ -72,8 +72,8 @@ class PlacementQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for preparatory placement`() {
-        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+    fun `deleteFutureReservationsAndAbsencesOutsideValidPlacements for preparatory placement`() {
+        `deleteFutureReservationsAndAbsencesOutsideValidPlacements works`(
             placementType = PlacementType.PREPARATORY,
             hasReservations = false,
             hasBillableAbsences = false,
@@ -82,8 +82,8 @@ class PlacementQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for preparatory_daycare placement`() {
-        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+    fun `deleteFutureReservationsAndAbsencesOutsideValidPlacements for preparatory_daycare placement`() {
+        `deleteFutureReservationsAndAbsencesOutsideValidPlacements works`(
             placementType = PlacementType.PREPARATORY_DAYCARE,
             hasReservations = true,
             hasBillableAbsences = true,
@@ -92,8 +92,8 @@ class PlacementQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for daycare_five_year_olds placement`() {
-        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+    fun `deleteFutureReservationsAndAbsencesOutsideValidPlacements for daycare_five_year_olds placement`() {
+        `deleteFutureReservationsAndAbsencesOutsideValidPlacements works`(
             placementType = PlacementType.DAYCARE_FIVE_YEAR_OLDS,
             hasReservations = true,
             hasBillableAbsences = true,
@@ -101,7 +101,7 @@ class PlacementQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
     }
 
-    private fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+    private fun `deleteFutureReservationsAndAbsencesOutsideValidPlacements works`(
         placementType: PlacementType,
         hasReservations: Boolean,
         hasBillableAbsences: Boolean,
@@ -204,7 +204,7 @@ class PlacementQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         }
 
         db.transaction { tx ->
-            tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(child.id, today)
+            tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(child.id, today)
         }
 
         val reservationIds =

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementQueriesIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementQueriesIntegrationTest.kt
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.placement
+
+import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.absence.AbsenceCategory
+import fi.espoo.evaka.absence.AbsenceType
+import fi.espoo.evaka.shared.AbsenceId
+import fi.espoo.evaka.shared.AttendanceReservationId
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.dev.DevAbsence
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPersonType
+import fi.espoo.evaka.shared.dev.DevPlacement
+import fi.espoo.evaka.shared.dev.DevReservation
+import fi.espoo.evaka.shared.dev.insert
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class PlacementQueriesIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
+    private val today = LocalDate.of(2024, 3, 4) // mon
+    private val area = DevCareArea()
+    private val daycare = DevDaycare(areaId = area.id)
+
+    @Test
+    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for club placement`() {
+        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+            placementType = PlacementType.CLUB,
+            hasReservations = false,
+            hasBillableAbsences = false,
+            hasNonbillableAbsences = true
+        )
+    }
+
+    @Test
+    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for daycare placement`() {
+        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+            placementType = PlacementType.DAYCARE,
+            hasReservations = true,
+            hasBillableAbsences = true,
+            hasNonbillableAbsences = false
+        )
+    }
+
+    @Test
+    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for preschool placement`() {
+        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+            placementType = PlacementType.PRESCHOOL,
+            hasReservations = false,
+            hasBillableAbsences = false,
+            hasNonbillableAbsences = true
+        )
+    }
+
+    @Test
+    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for preschool_daycare placement`() {
+        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+            placementType = PlacementType.PRESCHOOL_DAYCARE,
+            hasReservations = true,
+            hasBillableAbsences = true,
+            hasNonbillableAbsences = true
+        )
+    }
+
+    @Test
+    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for preparatory placement`() {
+        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+            placementType = PlacementType.PREPARATORY,
+            hasReservations = false,
+            hasBillableAbsences = false,
+            hasNonbillableAbsences = true
+        )
+    }
+
+    @Test
+    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for preparatory_daycare placement`() {
+        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+            placementType = PlacementType.PREPARATORY_DAYCARE,
+            hasReservations = true,
+            hasBillableAbsences = true,
+            hasNonbillableAbsences = true
+        )
+    }
+
+    @Test
+    fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements for daycare_five_year_olds placement`() {
+        `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+            placementType = PlacementType.DAYCARE_FIVE_YEAR_OLDS,
+            hasReservations = true,
+            hasBillableAbsences = true,
+            hasNonbillableAbsences = true
+        )
+    }
+
+    private fun `cleanupFutureReservationsAndAbsencesOutsideValidPlacements works`(
+        placementType: PlacementType,
+        hasReservations: Boolean,
+        hasBillableAbsences: Boolean,
+        hasNonbillableAbsences: Boolean,
+    ) {
+        val child = DevPerson()
+        val placementPeriod = FiniteDateRange(today.minusYears(1), today.plusDays(3))
+        val placement =
+            DevPlacement(
+                type = placementType,
+                unitId = daycare.id,
+                startDate = placementPeriod.start,
+                endDate = placementPeriod.end,
+                childId = child.id
+            )
+
+        val reservationYesterday =
+            DevReservation(
+                childId = child.id,
+                date = today.minusDays(1),
+                startTime = LocalTime.of(9, 0),
+                endTime = LocalTime.of(17, 0),
+                createdBy = AuthenticatedUser.SystemInternalUser.evakaUserId
+            )
+        val reservationDuringPlacement =
+            DevReservation(
+                childId = child.id,
+                date = today.plusDays(1),
+                startTime = LocalTime.of(9, 0),
+                endTime = LocalTime.of(17, 0),
+                createdBy = AuthenticatedUser.SystemInternalUser.evakaUserId
+            )
+        val reservationAfterPlacement =
+            DevReservation(
+                childId = child.id,
+                date = placementPeriod.end.plusDays(1),
+                startTime = LocalTime.of(9, 0),
+                endTime = LocalTime.of(17, 0),
+                createdBy = AuthenticatedUser.SystemInternalUser.evakaUserId
+            )
+
+        val billableAbsenceYesterday =
+            DevAbsence(
+                childId = child.id,
+                absenceType = AbsenceType.PLANNED_ABSENCE,
+                absenceCategory = AbsenceCategory.BILLABLE,
+                date = today.minusDays(1)
+            )
+        val billableAbsenceDuringPlacement =
+            DevAbsence(
+                childId = child.id,
+                absenceType = AbsenceType.PLANNED_ABSENCE,
+                absenceCategory = AbsenceCategory.BILLABLE,
+                date = today.plusDays(1)
+            )
+        val billableAbsenceAfterPlacement =
+            DevAbsence(
+                childId = child.id,
+                absenceType = AbsenceType.PLANNED_ABSENCE,
+                absenceCategory = AbsenceCategory.BILLABLE,
+                date = placementPeriod.end.plusDays(1)
+            )
+
+        val nonbillableAbsenceYesterday =
+            DevAbsence(
+                childId = child.id,
+                absenceType = AbsenceType.PLANNED_ABSENCE,
+                absenceCategory = AbsenceCategory.NONBILLABLE,
+                date = today.minusDays(1)
+            )
+        val nonbillableAbsenceDuringPlacement =
+            DevAbsence(
+                childId = child.id,
+                absenceType = AbsenceType.PLANNED_ABSENCE,
+                absenceCategory = AbsenceCategory.NONBILLABLE,
+                date = today.plusDays(1)
+            )
+        val nonbillableAbsenceAfterPlacement =
+            DevAbsence(
+                childId = child.id,
+                absenceType = AbsenceType.PLANNED_ABSENCE,
+                absenceCategory = AbsenceCategory.NONBILLABLE,
+                date = placementPeriod.end.plusDays(1)
+            )
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insert(placement)
+            tx.insert(reservationYesterday)
+            tx.insert(reservationDuringPlacement)
+            tx.insert(reservationAfterPlacement)
+            tx.insert(billableAbsenceYesterday)
+            tx.insert(billableAbsenceDuringPlacement)
+            tx.insert(billableAbsenceAfterPlacement)
+            tx.insert(nonbillableAbsenceYesterday)
+            tx.insert(nonbillableAbsenceDuringPlacement)
+            tx.insert(nonbillableAbsenceAfterPlacement)
+        }
+
+        db.transaction { tx ->
+            tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(child.id, today)
+        }
+
+        val reservationIds =
+            db.read {
+                it.createQuery { sql("SELECT id FROM attendance_reservation") }
+                    .toSet<AttendanceReservationId>()
+            }
+        assertTrue(reservationIds.contains(reservationYesterday.id))
+        assertEquals(hasReservations, reservationIds.contains(reservationDuringPlacement.id))
+        assertFalse(reservationIds.contains(reservationAfterPlacement.id))
+
+        val absenceIds =
+            db.read { it.createQuery { sql("SELECT id FROM absence") }.toSet<AbsenceId>() }
+        assertTrue(absenceIds.contains(billableAbsenceYesterday.id))
+        assertTrue(absenceIds.contains(nonbillableAbsenceYesterday.id))
+        assertEquals(hasBillableAbsences, absenceIds.contains(billableAbsenceDuringPlacement.id))
+        assertEquals(
+            hasNonbillableAbsences,
+            absenceIds.contains(nonbillableAbsenceDuringPlacement.id)
+        )
+        assertFalse(absenceIds.contains(billableAbsenceAfterPlacement.id))
+        assertFalse(absenceIds.contains(nonbillableAbsenceAfterPlacement.id))
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceQueries.kt
@@ -221,26 +221,6 @@ RETURNING id
         .executeAndReturnGeneratedKeys()
         .toList()
 
-fun Database.Transaction.deleteNonSystemGeneratedAbsencesByCategoryInRange(
-    childId: ChildId,
-    range: DateRange,
-    categories: Set<AbsenceCategory>
-): List<AbsenceId> =
-    createQuery {
-            sql(
-                """
-DELETE FROM absence
-WHERE
-    child_id = ${bind(childId)} AND
-    between_start_and_end(${bind(range)}, date) AND
-    category = ANY (${bind(categories)}::absence_category[]) AND
-    modified_by != ${bind(AuthenticatedUser.SystemInternalUser.evakaUserId)}
-RETURNING id
-"""
-            )
-        }
-        .toList()
-
 fun Database.Transaction.deleteOldGeneratedAbsencesInRange(
     now: HelsinkiDateTime,
     childId: ChildId,

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceService.kt
@@ -419,27 +419,6 @@ fun generateAbsencesFromIrregularDailyServiceTimes(
     tx.deleteOldGeneratedAbsencesInRange(now, childId, period)
 }
 
-fun deleteFutureNonGeneratedAbsencesByCategoryInRange(
-    tx: Database.Transaction,
-    clock: EvakaClock,
-    childId: ChildId,
-    range: DateRange,
-    categoriesToDelete: Set<AbsenceCategory>
-) {
-    if (range.start.isBefore(clock.now().toLocalDate().plusDays(1))) {
-        throw BadRequest("Could not delete future absences - Range has to be in future ")
-    }
-
-    val futureAbsences = getFutureAbsencesOfChild(tx, clock, childId)
-
-    val futureAbsencesToDelete =
-        futureAbsences.filter { absence -> categoriesToDelete.contains(absence.category) }
-
-    if (futureAbsencesToDelete.isNotEmpty()) {
-        tx.deleteNonSystemGeneratedAbsencesByCategoryInRange(childId, range, categoriesToDelete)
-    }
-}
-
 private fun supplementReservationsWithDailyServiceTimes(
     possibleAttendanceDates: List<LocalDate>,
     reservations: List<Pair<LocalDate, List<ChildReservation>>>,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -6,15 +6,12 @@ package fi.espoo.evaka.placement
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
-import fi.espoo.evaka.absence.AbsenceCategory
-import fi.espoo.evaka.absence.deleteFutureNonGeneratedAbsencesByCategoryInRange
 import fi.espoo.evaka.absence.generateAbsencesFromIrregularDailyServiceTimes
 import fi.espoo.evaka.daycare.controllers.AdditionalInformation
 import fi.espoo.evaka.daycare.controllers.Child
 import fi.espoo.evaka.daycare.createChild
 import fi.espoo.evaka.daycare.getChild
 import fi.espoo.evaka.daycare.getDaycares
-import fi.espoo.evaka.reservations.clearReservationsForRangeExceptInHolidayPeriod
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.FeatureConfig
@@ -224,40 +221,11 @@ class PlacementController(
                             placeGuarantee = body.placeGuarantee
                         )
                         .also {
+                            tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(
+                                body.childId,
+                                now.toLocalDate()
+                            )
                             generateAbsencesFromIrregularDailyServiceTimes(tx, now, body.childId)
-
-                            val future = DateRange(now.toLocalDate().plusDays(1), null)
-                            val range = DateRange(body.startDate, body.endDate).intersection(future)
-
-                            // Only proceed with future absence and reservation deletion if
-                            // placements range is in future
-                            if (range != null) {
-                                // Delete future absences if new absence category is specific
-                                if (
-                                    body.type.absenceCategories().size !=
-                                        AbsenceCategory.values().size
-                                ) {
-                                    deleteFutureNonGeneratedAbsencesByCategoryInRange(
-                                        tx,
-                                        clock,
-                                        body.childId,
-                                        range,
-                                        setOf(
-                                            when (body.type.absenceCategories().single()) {
-                                                AbsenceCategory.BILLABLE ->
-                                                    AbsenceCategory.NONBILLABLE
-                                                AbsenceCategory.NONBILLABLE ->
-                                                    AbsenceCategory.BILLABLE
-                                            }
-                                        )
-                                    )
-                                }
-                                tx.clearReservationsForRangeExceptInHolidayPeriod(
-                                    body.childId,
-                                    range
-                                )
-                            }
-
                             asyncJobRunner.plan(
                                 tx,
                                 listOf(
@@ -320,24 +288,12 @@ class PlacementController(
                         aclAuth,
                         useFiveYearsOldDaycare
                     )
+
+                tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(
+                    oldPlacement.childId,
+                    now.toLocalDate()
+                )
                 generateAbsencesFromIrregularDailyServiceTimes(tx, now, oldPlacement.childId)
-
-                // Clear absences and reservations that are not in range of updated placement period
-                if (
-                    body.endDate.isAfter(now.toLocalDate()) &&
-                        body.endDate.isBefore(oldPlacement.endDate)
-                ) {
-                    val range = DateRange(body.endDate, oldPlacement.endDate)
-                    deleteFutureNonGeneratedAbsencesByCategoryInRange(
-                        tx,
-                        clock,
-                        oldPlacement.childId,
-                        range,
-                        oldPlacement.type.absenceCategories()
-                    )
-                    tx.clearReservationsForRangeExceptInHolidayPeriod(oldPlacement.childId, range)
-                }
-
                 asyncJobRunner.plan(
                     tx,
                     listOf(
@@ -380,28 +336,11 @@ class PlacementController(
                         tx.getPlacement(placementId)
                             ?: throw NotFound("Placement $placementId not found")
                     tx.cancelPlacement(placementId).also {
+                        tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(
+                            it.childId,
+                            now.toLocalDate()
+                        )
                         generateAbsencesFromIrregularDailyServiceTimes(tx, now, it.childId)
-
-                        // Clear future absences and reservations that are in range of placement
-                        // period
-                        if (placement.endDate.isAfter(now.toLocalDate())) {
-                            val startDate =
-                                if (placement.startDate.isAfter(clock.today())) placement.startDate
-                                else clock.today().plusDays(1)
-                            val range = DateRange(startDate, placement.endDate)
-                            deleteFutureNonGeneratedAbsencesByCategoryInRange(
-                                tx,
-                                clock,
-                                placement.childId,
-                                range,
-                                placement.type.absenceCategories()
-                            )
-                            tx.clearReservationsForRangeExceptInHolidayPeriod(
-                                placement.childId,
-                                range
-                            )
-                        }
-
                         asyncJobRunner.plan(
                             tx,
                             listOf(

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -221,7 +221,7 @@ class PlacementController(
                             placeGuarantee = body.placeGuarantee
                         )
                         .also {
-                            tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(
+                            tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(
                                 body.childId,
                                 now.toLocalDate()
                             )
@@ -289,7 +289,7 @@ class PlacementController(
                         useFiveYearsOldDaycare
                     )
 
-                tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(
+                tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(
                     oldPlacement.childId,
                     now.toLocalDate()
                 )
@@ -336,7 +336,7 @@ class PlacementController(
                         tx.getPlacement(placementId)
                             ?: throw NotFound("Placement $placementId not found")
                     tx.cancelPlacement(placementId).also {
-                        tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(
+                        tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(
                             it.childId,
                             now.toLocalDate()
                         )

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
@@ -149,7 +149,7 @@ class PlacementControllerCitizen(
                         val cancelableTransferApplicationIds =
                             tx.cancelAllActiveTransferApplications(childId)
 
-                        tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(
+                        tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(
                             childId,
                             clock.today()
                         )

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
@@ -149,6 +149,10 @@ class PlacementControllerCitizen(
                         val cancelableTransferApplicationIds =
                             tx.cancelAllActiveTransferApplications(childId)
 
+                        tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(
+                            childId,
+                            clock.today()
+                        )
                         asyncJobRunner.plan(
                             tx,
                             listOf(

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -266,6 +266,9 @@ class PlacementPlanService(
             cancelPlacementsAfterClub = true,
             placeGuarantee = false
         )
+
+        tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(childId, clock.today())
+
         val timeline = DateSet.of(placementTypePeriods.map { it.first })
         asyncJobRunner.plan(
             tx,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -267,7 +267,7 @@ class PlacementPlanService(
             placeGuarantee = false
         )
 
-        tx.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(childId, clock.today())
+        tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(childId, clock.today())
 
         val timeline = DateSet.of(placementTypePeriods.map { it.first })
         asyncJobRunner.plan(

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -843,7 +843,7 @@ WHERE pl.child_id = ${bind(childId)} AND daterange(pl.start_date, pl.end_date, '
         }
         .exactlyOneOrNull<Language>()
 
-fun Database.Transaction.cleanupFutureReservationsAndAbsencesOutsideValidPlacements(
+fun Database.Transaction.deleteFutureReservationsAndAbsencesOutsideValidPlacements(
     childId: ChildId,
     today: LocalDate
 ) {

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementType.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementType.kt
@@ -182,6 +182,10 @@ enum class PlacementType : DatabaseEnum {
         val invoiced = entries.filter { it.isInvoiced() }.filterNot { temporary.contains(it) }
         val requiringAttendanceReservations =
             entries.filter { it != CLUB && it != PRESCHOOL && it != PREPARATORY }
+        val withBillableAbsences =
+            entries.filter { it.absenceCategories().contains(AbsenceCategory.BILLABLE) }
+        val withNonbillableAbsences =
+            entries.filter { it.absenceCategories().contains(AbsenceCategory.NONBILLABLE) }
     }
 }
 


### PR DESCRIPTION
Jos haluaa poistaa tietokannasta kertaluontoisesti kaikki kertyneet turhat varaukset ja poissaolot, voi ajaa seuraavat queryt:

```
DELETE FROM attendance_reservation ar
WHERE ar.date > now()::date AND NOT EXISTS(
    SELECT FROM placement pl
    WHERE pl.child_id = ar.child_id AND daterange(pl.start_date, pl.end_date, '[]') @> ar.date
        AND pl.type IN (
            'DAYCARE',
            'DAYCARE_PART_TIME',
            'DAYCARE_FIVE_YEAR_OLDS',
            'DAYCARE_PART_TIME_FIVE_YEAR_OLDS',
            'PRESCHOOL_DAYCARE',
            'PRESCHOOL_DAYCARE_ONLY',
            'PRESCHOOL_CLUB',
            'PREPARATORY_DAYCARE',
            'PREPARATORY_DAYCARE_ONLY',
            'TEMPORARY_DAYCARE',
            'TEMPORARY_DAYCARE_PART_DAY',
            'SCHOOL_SHIFT_CARE'
        )
);
```

```
DELETE FROM absence ab
WHERE ab.date > now()::date AND (
    (ab.category = 'BILLABLE' AND NOT EXISTS(
        SELECT FROM placement pl
        WHERE pl.child_id = ab.child_id AND daterange(pl.start_date, pl.end_date, '[]') @> ab.date
        AND pl.type IN (
            'DAYCARE',
            'DAYCARE_PART_TIME',
            'DAYCARE_FIVE_YEAR_OLDS',
            'DAYCARE_PART_TIME_FIVE_YEAR_OLDS',
            'PRESCHOOL_DAYCARE',
            'PRESCHOOL_DAYCARE_ONLY',
            'PRESCHOOL_CLUB',
            'PREPARATORY_DAYCARE',
            'PREPARATORY_DAYCARE_ONLY',
            'TEMPORARY_DAYCARE',
            'TEMPORARY_DAYCARE_PART_DAY'
        )
    )) OR (ab.category = 'NONBILLABLE' AND NOT EXISTS(
        SELECT FROM placement pl
        WHERE pl.child_id = ab.child_id AND daterange(pl.start_date, pl.end_date, '[]') @> ab.date
        AND pl.type IN (
            'CLUB',
            'DAYCARE_FIVE_YEAR_OLDS',
            'DAYCARE_PART_TIME_FIVE_YEAR_OLDS',
            'PRESCHOOL',
            'PRESCHOOL_DAYCARE',
            'PRESCHOOL_CLUB',
            'PREPARATORY',
            'PREPARATORY_DAYCARE',
            'SCHOOL_SHIFT_CARE'
        )
    )));
```