### PR TITLE
Korvataan opentracing opentelemetryllä evaka-proxyssä

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.6.0
+# syntax=docker/dockerfile:1.7-labs
 # SPDX-FileCopyrightText: 2017-2023 City of Espoo
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
@@ -21,7 +21,7 @@ COPY ./.yarn ./.yarn
 COPY ./package.json ./yarn.lock ./.yarnrc.yml ./
 RUN yarn install --immutable
 
-COPY . .
+COPY --exclude=proxy/ . .
 
 ARG EVAKA_CUSTOMIZATIONS=espoo
 COPY --from=customizations . src/lib-customizations/${EVAKA_CUSTOMIZATIONS}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-ARG NGINX_VERSION=1.26.0
+ARG NGINX_VERSION=1.26.2-otel
 
 FROM node:20.17.0-bookworm-slim AS builder
 ARG CACHE_BUST
@@ -71,23 +71,6 @@ RUN apt-get update \
  && chmod +x /bin/s3download \
  && echo "${S3_DOWNLOADER_SHA256}  /bin/s3download" | sha256sum -c - \
  && rm -rf /var/lib/apt/lists/*
-
-
-# https://docs.datadoghq.com/tracing/setup_overview/proxy_setup/?tab=nginx # update version using get_latest_release
-ARG OPENTRACING_NGINX_VERSION=v0.35.1
-ARG OPENTRACING_NGINX_SHA256="34e0fa9f110a6052a4f75451bc93e4de8d1a32229b523fb4748feee6bfb1d3ba"
-ARG DD_OPENTRACING_CPP_VERSION=v1.3.7
-ARG DD_OPENTRACING_CPP_SHA256="df9a8097c3d6f6e5a96f96db0f3919b5b7b35df3d10c5fcc530707a878e2dd00"
-
-RUN cd /tmp \
- && curl -sSfLO "https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz" \
- && echo "${OPENTRACING_NGINX_SHA256}  linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz" | sha256sum -c - \
- && tar zxf "linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz" -C /usr/lib/nginx/modules \
- && rm "linux-amd64-nginx-${NGINX_VERSION}-ngx_http_module.so.tgz" \
- && curl -sSfLO https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz \
- && echo "${DD_OPENTRACING_CPP_SHA256}  linux-amd64-libdd_opentracing_plugin.so.gz" | sha256sum -c - \
- && gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so \
- && rm linux-amd64-libdd_opentracing_plugin.so.gz
 
 COPY ./proxy/files/bin/ /bin/
 COPY ./proxy/files/internal/ /internal/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-ARG NGINX_VERSION=1.26.2-otel
-
 FROM node:20.17.0-bookworm-slim AS builder
 ARG CACHE_BUST
 
@@ -45,7 +43,7 @@ ENV APP_COMMIT="$commit"
 RUN export NODE_OPTIONS="--max-old-space-size=4096" \
  && yarn build
 
-FROM nginx:${NGINX_VERSION}
+FROM nginx:1.26.2-otel
 ARG CACHE_BUST
 
 LABEL maintainer="https://github.com/espoon-voltti/evaka"

--- a/frontend/proxy/files/bin/proxy-entrypoint.sh
+++ b/frontend/proxy/files/bin/proxy-entrypoint.sh
@@ -39,13 +39,13 @@ if [ "${DD_PROFILING_ENABLED}" = "true" ]; then
     echo "ERROR: DD_AGENT_HOST missing"
     exit 1
   fi
-  if test -z "${DD_AGENT_PORT:-}"; then
-    echo "ERROR: DD_AGENT_PORT missing"
+  if test -z "${DD_AGENT_OTEL_PORT:-}"; then
+    echo "ERROR: DD_AGENT_OTEL_PORT missing"
     exit 1
   fi
 else
   export DD_AGENT_HOST="localhost"
-  export DD_AGENT_PORT="8126"
+  export DD_AGENT_OTEL_PORT="4317"
 fi
 
 if [ "${DEPLOYMENT_BUCKET:-X}" != 'X' ]; then

--- a/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -141,10 +141,8 @@ log_format json_access escape=json
     '"traceId":"$request_id",'
     '"type":"app-requests-received",'
     '"userIdHash":"",'
-{{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
-    '"dd.trace_id":"$opentracing_context_x_datadog_trace_id",'
-    '"dd.span_id":"$opentracing_context_x_datadog_parent_id",'
-{{ end }}
+    '"dd.trace_id":"$otel_trace_id",'
+    '"dd.span_id":"$otel_span_id",'
     '"version":1'
   '}';
 
@@ -273,6 +271,9 @@ server {
   }
 
   location /api/application {
+{{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
+    otel_trace on;
+{{ end }}
     access_log /var/log/nginx/access.log json_access;
 
     include     proxy_params;
@@ -285,6 +286,9 @@ server {
   }
 
   location /api/internal {
+{{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
+    otel_trace on;
+{{ end }}
     access_log /var/log/nginx/access.log json_access;
 
     include     proxy_params;
@@ -303,6 +307,9 @@ server {
 
   # Direct all CPS reports to internal endpoint /api/csp/csp-report
   location /api/csp {
+{{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
+    otel_trace on;
+{{ end }}
     access_log /var/log/nginx/access.log json_access;
 
     include     proxy_params;
@@ -350,6 +357,9 @@ server {
     allow all;
   }
   location /auth/realms/ {
+{{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
+    otel_trace on;
+{{ end }}
     access_log /var/log/nginx/access.log json_access;
 
     include keycloak-proxy.conf;

--- a/frontend/proxy/files/etc/nginx/dd-config.json.gomplate.license
+++ b/frontend/proxy/files/etc/nginx/dd-config.json.gomplate.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2017-2021 City of Espoo
-
-SPDX-License-Identifier: LGPL-2.1-or-later

--- a/frontend/proxy/files/etc/nginx/dd-config.json.template
+++ b/frontend/proxy/files/etc/nginx/dd-config.json.template
@@ -1,8 +1,0 @@
-{
-  "environment": "{{ .Env.NGINX_ENV }}",
-  "service": "evaka-proxy",
-  "version": "{{ .Env.APP_COMMIT }}",
-  "operation_name_override": "nginx.handle",
-  "agent_host": "{{ .Env.DD_AGENT_HOST }}",
-  "agent_port": {{ .Env.DD_AGENT_PORT }}
-}

--- a/frontend/proxy/files/etc/nginx/dd-config.json.template.license
+++ b/frontend/proxy/files/etc/nginx/dd-config.json.template.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2017-2021 City of Espoo
-
-SPDX-License-Identifier: LGPL-2.1-or-later

--- a/frontend/proxy/files/etc/nginx/keycloak-proxy.conf.template
+++ b/frontend/proxy/files/etc/nginx/keycloak-proxy.conf.template
@@ -22,11 +22,6 @@ proxy_set_header X-Original-Forwarded-Proto "https";
 proxy_set_header X-Request-ID $request_id;
 proxy_set_header Host $http_host;
 
-{{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
-opentracing_operation_name "$request_method $uri";
-opentracing_propagate_context;
-{{ end }}
-
 # Actual caching headers should be set by downstream API Gateways;
 # this is just to prevent caching at the proxy level.
 proxy_no_cache 1;

--- a/frontend/proxy/files/etc/nginx/nginx.conf.template
+++ b/frontend/proxy/files/etc/nginx/nginx.conf.template
@@ -8,21 +8,24 @@ worker_processes  auto;
 error_log  /var/log/nginx/error.log notice;
 pid        /var/run/nginx.pid;
 
-{{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
-load_module modules/ngx_http_opentracing_module.so;
-{{ end }}
+load_module modules/ngx_otel_module.so;
 
 events {
     worker_connections  1024;
 }
 
 http {
-{{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
-    opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/nginx/dd-config.json;
+    otel_trace_context propagate;
+    otel_service_name "evaka-proxy";
+    otel_span_name "$request_method $uri";
+    otel_span_attr environment "{{ .Env.NGINX_ENV }}";
+    otel_span_attr version "{{ .Env.APP_COMMIT }}";
 
-    opentracing on;
-    opentracing_tag http_user_agent $http_user_agent; # Add a tag to each trace!
-    opentracing_trace_locations off; # Emit only one span per request.
+{{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
+    otel_trace off;
+    otel_exporter {
+        endpoint {{ .Env.DD_AGENT_HOST }}:{{ .Env.DD_AGENT_OTEL_PORT }};
+    }
 {{ end }}
 
     include       /etc/nginx/mime.types;
@@ -32,7 +35,7 @@ http {
     log_format with_trace_id '$remote_addr - $remote_user [$time_local] "$request" '
                              '$status $body_bytes_sent "$http_referer" '
                              '"$http_user_agent" "$http_x_forwarded_for"'
-                             '"$opentracing_context_x_datadog_trace_id" "$opentracing_context_x_datadog_parent_id"';
+                             '"$otel_trace_id" "$otel_span_id"';
     access_log /var/log/nginx/access.log with_trace_id;
 {{ else }}
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '

--- a/frontend/proxy/files/etc/nginx/proxy_params.template
+++ b/frontend/proxy/files/etc/nginx/proxy_params.template
@@ -16,8 +16,3 @@ proxy_set_header X-User "";
 # Actual caching headers should be set by downstream API Gateways;
 # this is just to prevent caching at the proxy level.
 proxy_no_cache 1;
-
-{{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
-opentracing_operation_name "$request_method $uri";
-opentracing_propagate_context;
-{{ end }}


### PR DESCRIPTION
Jos `DD_PROFILING_ENABLED=true`, pitää `DD_AGENT_OTEL_PORT` asettaa siksi portiksi, johon Datadog Agent vastaanottaa OTLP/gRPC-dataa.

Vaatii muutoksia infraan:
- Datadog Agent pitää konfiguroida vastaanottamaan OTLP/gRPC-dataa
- Application Load Balancer ilmeisesti tarvitsee muutoksia, jotta gRPC-protokolla toimii