### PR TITLE
Näytetään henkilökunnan mobiilista luodut varaukset henkilökunnan luomina

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -1007,7 +1007,7 @@ SELECT
             'date', ar.date,
             'startTime', ar.start_time,
             'endTime', ar.end_time,
-            'staffCreated', eu.type = 'EMPLOYEE'
+            'staffCreated', eu.type <> 'CITIZEN'
         ) ORDER BY ar.date, ar.start_time)
         FROM attendance_reservation ar 
         JOIN evaka_user eu ON ar.created_by = eu.id
@@ -1027,7 +1027,7 @@ SELECT
             'category', a.category,
             'absenceTypeResponse', json_build_object(
                 'absenceType', a.absence_type,
-                'staffCreated', eu.type = 'EMPLOYEE'
+                'staffCreated', eu.type <> 'CITIZEN'
             )
         ) ORDER BY a.date)
         FROM absence a

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -503,7 +503,7 @@ SELECT pcd.child_id,
                'start', s.start_time,
                'end', s.end_time,
                'staffCreated', s.staff_created)), '[]'::jsonb)
-        FROM (select ar.start_time, ar.end_time, eu.type = 'EMPLOYEE' as staff_created
+        FROM (select ar.start_time, ar.end_time, eu.type <> 'CITIZEN' as staff_created
                 FROM attendance_reservation ar
                 JOIN evaka_user eu ON ar.created_by = eu.id
               WHERE ar.child_id = pcd.child_id


### PR DESCRIPTION
## Ennen tätä muutosta
Varaukset ja poissaolomerkinnät jotka henkilökunta oli tehnyt mobiilisovelluksen kautta näytettiin virheellisesti kuntalaisen tekeminä varauksina yksikön viikkokalenterissa.
## Tämän muutoksen jälkeen
Tällaiset varaukset näytetään henkilökunnan tekeminä.
<img width="597" alt="image" src="https://github.com/user-attachments/assets/e151332d-7763-4fad-a380-128e508acdd6">
