### PR TITLE
Tuki keskustelukyselyjen tietojen näyttämiselle kasvattajan kalenterissa

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit.ts
@@ -949,6 +949,10 @@ export class UnitCalendarEventsSection {
     return new EventEditModal(this.page.findByDataQa('modal'))
   }
 
+  get surveySummaryModal() {
+    return new SurveySummaryModal(this.page.findByDataQa('modal'))
+  }
+
   get eventDeleteModal() {
     return new EventDeleteModal(
       this.page.findByDataQa('deletion-modal').findByDataQa('modal')
@@ -974,6 +978,24 @@ export class EventEditModal extends Modal {
 
   async delete() {
     await this.findByDataQa('delete').click()
+  }
+}
+
+export class SurveySummaryModal extends Modal {
+  async close() {
+    await this.findByDataQa('close-button').click()
+  }
+
+  async assertDescription(description: string) {
+    await this.findByDataQa('survey-description').assertTextEquals(description)
+  }
+
+  async assertEventTime(id: string, timeString: string) {
+    await this.findByDataQa(`times-${id}`).assertTextEquals(timeString)
+  }
+
+  async assertReservee(id: string, reservee: string) {
+    await this.findByDataQa(`reservee-${id}`).assertTextEquals(reservee)
   }
 }
 

--- a/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
@@ -220,6 +220,26 @@ describe('Calendar events', () => {
 })
 
 describe('Discussion surveys', () => {
+  test('Employee can see existing discussion survey in week calendar and summary modal', async () => {
+    await calendarPage.selectGroup(groupId)
+    await calendarPage.weekModeButton.click()
+
+    await calendarPage.calendarEventsSection
+      .getEventOfDay(mockedToday, 0)
+      .click()
+    await calendarPage.calendarEventsSection.surveySummaryModal.assertDescription(
+      'Survey description'
+    )
+    await calendarPage.calendarEventsSection.surveySummaryModal.assertEventTime(
+      eventTimeId,
+      '08:00 - 08:30'
+    )
+    await calendarPage.calendarEventsSection.surveySummaryModal.assertReservee(
+      eventTimeId,
+      'Vapaa'
+    )
+  })
+
   test('Employee can see existing discussion survey in survey list', async () => {
     await calendarPage.selectGroup(groupId)
     await calendarPage.weekModeButton.click()

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
@@ -1003,14 +1003,14 @@ const SurveySummaryModal = React.memo(function SurveySummaryModal({
     >
       <Label>{tr.surveySummaryCalendarLabel}</Label>
       <p data-qa="survey-description">{event.description}</p>
-
       <p>
-        {`${tr.calendarSurveySummaryInstruction} `}
-        <Link
-          to={`/units/${unitId}/groups/${groupId}/discussion-reservation-surveys/${event.id}`}
-        >
-          {tr.calendarSurveySummaryLinkText}
-        </Link>
+        {tr.calendarSurveySummary((linkText) => (
+          <Link
+            to={`/units/${unitId}/groups/${groupId}/discussion-reservation-surveys/${event.id}`}
+          >
+            {linkText}
+          </Link>
+        ))}
       </p>
       {times.length > 0 && (
         <>

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
@@ -59,7 +59,6 @@ import { useTranslation } from '../../../state/i18n'
 import { UnitContext } from '../../../state/unit'
 import { DayOfWeek } from '../../../types'
 import { renderResult } from '../../async-rendering'
-import { FlexRow } from '../../common/styled/containers'
 import { unitGroupDetailsQuery } from '../queries'
 
 const createCalendarEventResult = wrapResult(createCalendarEvent)
@@ -281,26 +280,27 @@ export default React.memo(function CalendarEventsSection({
           groupId={groupId}
         />
       )}
-
-      <FlexRow justifyContent={groupId ? 'space-between' : 'flex-end'}>
-        {featureFlags.discussionReservations && !!groupId && (
-          <DiscussionLink
-            data-qa="discussion-survey-page-button"
-            to={`/units/${unitId}/groups/${groupId}/discussion-reservation-surveys`}
-          >
-            {
-              i18n.unit.calendar.events.discussionReservation
-                .discussionPageTitle
-            }
-          </DiscussionLink>
-        )}
-        <AddButton
-          flipped
-          text={i18n.unit.calendar.events.createEvent}
-          onClick={() => setCreateEventModalVisible(true)}
-          data-qa="create-new-event-btn"
-        />
-      </FlexRow>
+      <EventButtonRow>
+        <EventButtonColumn>
+          {featureFlags.discussionReservations && !!groupId && (
+            <DiscussionLink
+              data-qa="discussion-survey-page-button"
+              to={`/units/${unitId}/groups/${groupId}/discussion-reservation-surveys`}
+            >
+              {
+                i18n.unit.calendar.events.discussionReservation
+                  .discussionPageTitle
+              }
+            </DiscussionLink>
+          )}
+          <AddButton
+            text={i18n.unit.calendar.events.createEvent}
+            onClick={() => setCreateEventModalVisible(true)}
+            data-qa="create-new-event-btn"
+          />
+        </EventButtonColumn>
+        <div />
+      </EventButtonRow>
       <Gap size="s" />
       {renderResult(events, (events) => (
         <div>
@@ -357,7 +357,11 @@ export default React.memo(function CalendarEventsSection({
                         key={event.id}
                       >
                         <Link
-                          to={`/units/${unitId}/calendar/events/${event.id}`}
+                          to={
+                            event.eventType === 'DAYCARE_EVENT'
+                              ? `/units/${unitId}/calendar/events/${event.id}`
+                              : `/units/${unitId}/groups/${groupId}/discussion-reservation-surveys/${event.id}`
+                          }
                           data-qa="event"
                         >
                           <Bold>{specifier.text}:</Bold> {event.title}
@@ -888,3 +892,18 @@ const EditEventModal = React.memo(function EditEventModal({
     </>
   )
 })
+
+const EventButtonColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: 16px;
+`
+
+const EventButtonRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  width: 100%;
+`

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyView.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyView.tsx
@@ -341,12 +341,7 @@ export default React.memo(function DiscussionReservationSurveyView({
         />
       )}
       <Container>
-        <ReturnButton
-          label={i18n.common.goBack}
-          onClick={() => {
-            navigate('..', { relative: 'path' })
-          }}
-        />
+        <ReturnButton label={i18n.common.goBack} />
         <ContentArea opaque>
           <FixedSpaceRow alignItems="center" justifyContent="space-between">
             <H2 data-qa="survey-title">{eventData.title}</H2>

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/survey-editor/DiscussionSurveyForm.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/survey-editor/DiscussionSurveyForm.tsx
@@ -185,7 +185,8 @@ export default React.memo(function DiscussionSurveyForm({
             disabled={!isBasicInfoValid}
             onSuccess={() =>
               navigate(
-                `/units/${unitId}/groups/${groupId}/discussion-reservation-surveys/${eventData.id}`
+                `/units/${unitId}/groups/${groupId}/discussion-reservation-surveys/${eventData.id}`,
+                { replace: true }
               )
             }
             onClick={() =>

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2356,6 +2356,7 @@ export const fi = {
           surveySubject: 'Keskustelun aihe',
           surveyInvitees: 'Keskustelujen osallistujat',
           surveySummary: 'Lisätietoja huoltajalle',
+          surveySummaryCalendarLabel: 'Lisätietoja',
           surveySummaryInfo:
             'Tämä teksti näytetään huoltajalle kyselyn yhteydessä. Voit kertoa siinä lisätietoja keskusteluista, esimerkiksi saapumisohjeet tai keskusteluun varattavan ajan.',
           surveySubjectPlaceholder: 'Enintään 30 merkkiä',
@@ -2381,6 +2382,9 @@ export const fi = {
           reservedTitle: 'Varanneet',
           reserveButton: 'Varaa',
           unreservedTitle: 'Varaamatta',
+          calendarSurveySummaryInstruction: 'Tarkempia tietoja varten',
+          calendarSurveySummaryLinkText:
+            'siirry keskustelukyselyn tarkastelunäkymään',
           reservationModal: {
             reservationStatus: 'Varaustilanne',
             reserved: 'Varattu',
@@ -2405,7 +2409,9 @@ export const fi = {
             addError: 'Keskusteluajan lisääminen epäonnistui',
             deleteError: 'Keskusteluajan poistaminen epäonnistui'
           }
-        }
+        },
+        reservedTimesLabel: 'varattua',
+        freeTimesLabel: 'vapaata'
       }
     },
     groups: {

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2319,7 +2319,7 @@ export const fi = {
       previousWeek: 'Edellinen viikko',
       events: {
         title: 'Tapahtumat',
-        createEvent: 'Uusi tapahtuma',
+        createEvent: 'Luo muu tapahtuma',
         edit: {
           title: 'Tapahtuma',
           saveChanges: 'Tallenna muutokset',
@@ -2347,7 +2347,7 @@ export const fi = {
             otherEventSingular: 'muu tapahtuma',
             otherEventPlural: 'muuta tapahtumaa'
           },
-          discussionPageTitle: 'Keskustelut',
+          discussionPageTitle: 'Keskusteluaikojen hallinta',
           discussionPageDescription:
             'Tällä sivulla voit luoda ja seurata kyselyjä, joilla kysytään huoltajille sopivia keskusteluaikoja.',
           surveyCreate: 'Uusi keskustelukysely',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2382,9 +2382,14 @@ export const fi = {
           reservedTitle: 'Varanneet',
           reserveButton: 'Varaa',
           unreservedTitle: 'Varaamatta',
-          calendarSurveySummaryInstruction: 'Tarkempia tietoja varten',
-          calendarSurveySummaryLinkText:
-            'siirry keskustelukyselyn tarkastelunäkymään',
+          calendarSurveySummary: (
+            link: (text: string) => React.ReactNode
+          ): React.ReactNode => (
+            <>
+              Tarkempia tietoja varten{' '}
+              {link('siirry keskustelukyselyn tarkastelunäkymään')}
+            </>
+          ),
           reservationModal: {
             reservationStatus: 'Varaustilanne',
             reserved: 'Varattu',


### PR DESCRIPTION
Tuki keskustelukyselyjen otsikon, lisätietojen ja varaustilanteen näyttämiselle tiivistetysti kasvattajan viikko/kuukausi -kalenterissa ja siitä avautuvassa lisätietomodaalissa.

![summary_modal_2](https://github.com/user-attachments/assets/06cd29ec-c64e-4e05-8a96-548874906ef5)
