### PR TITLE
Kuntalaisen kalenterin päivämodaalin saavutettavuusparannuksia

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -531,7 +531,7 @@ const Day = React.memo(function Day({
         <DayCellDate
           inactive={!dayIsReservable(day.date)}
           holiday={day.holiday}
-          aria-label={day.date.formatExotic('EEEE do MMMM', lang)}
+          aria-label={day.date.formatExotic('cccc do MMMM', lang)}
         >
           {day.date.format('d.M.')}
         </DayCellDate>

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -396,7 +396,11 @@ const DayModal = React.memo(function DayModal({
                       disabled={!dateActions?.navigateToPreviousDate}
                       aria-label={i18n.calendar.previousDay}
                     />
-                    <ModalHeader headingComponent={DayOfWeek}>
+                    <ModalHeader
+                      headingComponent={DayOfWeek}
+                      aria-live="polite"
+                      aria-label={date.formatExotic('cccc do MMMM', lang)}
+                    >
                       {date.format('EEEEEE d.M.yyyy', lang)}
                     </ModalHeader>
                     <IconOnlyButton


### PR DESCRIPTION
### Ennen tätä muutosta
Ruudunlukijan käyttäjälle ei ollut selvää, että mikä päivä on auki kun siirrytään seuraavaan / edelliseen päivään
### Tämän muutoksen jälkeen
Ruudunlukija lausuu valitun päivän kun päivää vaihdetaan. Tämä muutos korjaa myös väärin muotoillun päivän nimen kalenteritaulukon päiväväsoluissa.