### PR TITLE
Korjauksia esiopetuksen poissaoloraporttiin

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/preschool-absence-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/preschool-absence-report.spec.ts
@@ -51,6 +51,7 @@ beforeEach(async () => {
 
   await Fixture.absence({
     absenceType: 'SICKLEAVE',
+    absenceCategory: 'NONBILLABLE',
     date: mockedToday,
     childId: child.id
   }).save()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
@@ -449,6 +449,19 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
                 )
             )
 
+            // billable absence shouldn't show up
+            tx.insert(
+                DevAbsence(
+                    id = AbsenceId(UUID.randomUUID()),
+                    testChildCecil.id,
+                    monday,
+                    AbsenceType.UNKNOWN_ABSENCE,
+                    HelsinkiDateTime.atStartOfDay(monday),
+                    EvakaUserId(admin.id.raw),
+                    AbsenceCategory.BILLABLE
+                )
+            )
+
             // Tuesday
 
             tx.insertTestChildAttendance(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
@@ -247,6 +247,8 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
         val wednesday = monday.plusDays(2)
         val thursday = monday.plusDays(3)
         val friday = monday.plusDays(4)
+        val saturday = monday.plusDays(5)
+        val previousSunday = monday.minusDays(1)
 
         return db.transaction { tx ->
             tx.insert(admin)
@@ -514,6 +516,21 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
                 HelsinkiDateTime.of(friday, LocalTime.of(11, 0))
             )
 
+            // Saturday
+
+            // absence outside unit operation days shouldn't show up
+            tx.insert(
+                DevAbsence(
+                    id = AbsenceId(UUID.randomUUID()),
+                    testChildCecil.id,
+                    saturday,
+                    AbsenceType.UNKNOWN_ABSENCE,
+                    HelsinkiDateTime.atStartOfDay(saturday),
+                    EvakaUserId(admin.id.raw),
+                    AbsenceCategory.NONBILLABLE
+                )
+            )
+
             // next monday
             // unfinished attendance shouldn't show up
             tx.insertTestChildAttendance(
@@ -521,6 +538,20 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
                 preschoolAId,
                 HelsinkiDateTime.of(monday.plusWeeks(1), LocalTime.of(11, 0)),
                 null
+            )
+
+            // previous sunday
+            // absence outside unit operation days shouldn't show up
+            tx.insert(
+                DevAbsence(
+                    id = AbsenceId(UUID.randomUUID()),
+                    testChildCecil.id,
+                    previousSunday,
+                    AbsenceType.UNKNOWN_ABSENCE,
+                    HelsinkiDateTime.atStartOfDay(previousSunday),
+                    EvakaUserId(admin.id.raw),
+                    AbsenceCategory.NONBILLABLE
+                )
             )
 
             PreschoolAbsenceReportTestData(

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReport.kt
@@ -194,7 +194,9 @@ fun getPreschoolAbsenceReportRowsForUnit(
                      (select child.id,
                              child.first_name,
                              child.last_name,
-                             daterange(p.start_date, p.end_date, '[]') * ${bind(preschoolTerm)} as examination_range
+                             daterange(p.start_date, p.end_date, '[]') * ${bind(preschoolTerm)} as examination_range,
+                             d.shift_care_operation_days,
+                             d.operation_days
                       from placement p
                                join person child on p.child_id = child.id
                                join daycare d
@@ -214,7 +216,8 @@ fun getPreschoolAbsenceReportRowsForUnit(
                      left join unnest(${bind(absenceTypes)}::absence_type[]) as types (absence_type) on true
                      left join absence ab on ppc.examination_range @> ab.date and
                                              ppc.id = ab.child_id and
-                                             ab.absence_type = types.absence_type
+                                             ab.absence_type = types.absence_type and
+                                             extract(isodow from ab.date) = ANY(coalesce(ppc.shift_care_operation_days, ppc.operation_days))
             group by ppc.id, ppc.first_name, ppc.last_name, types.absence_type;
         """
                     .trimIndent()
@@ -237,7 +240,9 @@ fun getPreschoolAbsenceReportRowsForGroup(
          (select child.id,
                  child.first_name,
                  child.last_name,
-                 daterange(dgp.start_date, dgp.end_date, '[]') * ${bind(preschoolTerm)} as examination_range
+                 daterange(dgp.start_date, dgp.end_date, '[]') * ${bind(preschoolTerm)} as examination_range,
+                 d.shift_care_operation_days,
+                 d.operation_days
           from placement p
                    join person child on p.child_id = child.id
                    join daycare d
@@ -262,7 +267,8 @@ from preschool_group_placement_children pgpc
          left join unnest(${bind(absenceTypes)}::absence_type[]) as types (absence_type) on true
          left join absence ab on pgpc.examination_range @> ab.date and
                                  pgpc.id = ab.child_id and
-                                 ab.absence_type = types.absence_type
+                                 ab.absence_type = types.absence_type and
+                                 extract(isodow from ab.date) = ANY(coalesce(pgpc.shift_care_operation_days, pgpc.operation_days))
 group by pgpc.id, pgpc.first_name, pgpc.last_name, types.absence_type;
         """
                     .trimIndent()

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReport.kt
@@ -217,6 +217,7 @@ fun getPreschoolAbsenceReportRowsForUnit(
                      left join absence ab on ppc.examination_range @> ab.date and
                                              ppc.id = ab.child_id and
                                              ab.absence_type = types.absence_type and
+                                             ab.category = 'NONBILLABLE' and
                                              extract(isodow from ab.date) = ANY(coalesce(ppc.shift_care_operation_days, ppc.operation_days))
             group by ppc.id, ppc.first_name, ppc.last_name, types.absence_type;
         """
@@ -268,6 +269,7 @@ from preschool_group_placement_children pgpc
          left join absence ab on pgpc.examination_range @> ab.date and
                                  pgpc.id = ab.child_id and
                                  ab.absence_type = types.absence_type and
+                                 ab.category = 'NONBILLABLE' and
                                  extract(isodow from ab.date) = ANY(coalesce(pgpc.shift_care_operation_days, pgpc.operation_days))
 group by pgpc.id, pgpc.first_name, pgpc.last_name, types.absence_type;
         """


### PR DESCRIPTION
1. Raportti laski poissaolot yksikön aukiolopäivien ulkopuolelta
2. Raportti laski liittyvän/täydentävän varhaiskasvatuksen poissaolot