### PR TITLE
Ilmaisen heinäkuun saa jos aloitus oli elokuussa + ilmaisuuden sääntö konfiguroitavaksi

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
@@ -40,7 +40,7 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
     private val featureConfig: FeatureConfig = testFeatureConfig
     private val draftInvoiceGenerator: DraftInvoiceGenerator =
         DraftInvoiceGenerator(productProvider, featureConfig, DefaultInvoiceGenerationLogic)
-    private val generator: InvoiceGenerator = InvoiceGenerator(draftInvoiceGenerator)
+    private val generator: InvoiceGenerator = InvoiceGenerator(draftInvoiceGenerator, featureConfig)
     private val invoiceService =
         InvoiceService(
             InvoiceIntegrationClient.MockClient(defaultJsonMapperBuilder().build()),

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -193,6 +193,7 @@ class EspooConfig {
             applyPlacementUnitFromDecision = false,
             preferredStartRelativeApplicationDueDate = false,
             fiveYearsOldDaycareEnabled = true,
+            freeJulyStartOnSeptember = true,
             archiveMetadataOrganization = "Espoon kaupungin esiopetus ja varhaiskasvatus",
             archiveMetadataConfigs =
                 mapOf(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -143,7 +143,13 @@ data class FeatureConfig(
     val archiveMetadataOrganization: String,
 
     /** Configs for enabled archive metadata processes */
-    val archiveMetadataConfigs: Map<ArchiveProcessType, ArchiveProcessConfig>
+    val archiveMetadataConfigs: Map<ArchiveProcessType, ArchiveProcessConfig>,
+
+    /**
+     * Whether July is free of charge if daycare started latest on last year's September (normally
+     * August)
+     */
+    val freeJulyStartOnSeptember: Boolean = false
 )
 
 enum class ArchiveProcessType {


### PR DESCRIPTION
Ennen tätä muutosta eVaka antoi ilmaisen heinäkuun, jos sijoitus alkoi viimeistään edellisen vuoden syyskuussa.

Tämän muutoksen jälkeen oletuksena aloituksen pitää olla edellisen vuoden elokuussa, mutta sen voi konfiguroida syyskuuksi käyttämällä `FeatureConfig`:in kenttää `freeJulyStartOnSeptember`. Samalla konfiguroidaan Espoo käyttämään syyskuuta.