### PR TITLE
Korjauksia esiopetuksen poissaoloraporttiin

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
@@ -29,6 +29,7 @@ import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.DevDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.DevHoliday
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.DevPlacement
@@ -243,18 +244,23 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
     }
 
     private fun initTestData(monday: LocalDate): PreschoolAbsenceReportTestData {
+        val previousFriday = monday.minusDays(3)
+        val previousSunday = monday.minusDays(1)
         val tuesday = monday.plusDays(1)
         val wednesday = monday.plusDays(2)
         val thursday = monday.plusDays(3)
         val friday = monday.plusDays(4)
         val saturday = monday.plusDays(5)
-        val previousSunday = monday.minusDays(1)
+        val nextTuesday = tuesday.plusWeeks(1)
 
         return db.transaction { tx ->
             tx.insert(admin)
 
             val testTerm = FiniteDateRange(monday.minusMonths(6), monday.plusMonths(6))
             tx.insertPreschoolTerm(testTerm, testTerm, testTerm, testTerm, DateSet.empty())
+
+            tx.insert(DevHoliday(date = previousFriday))
+            tx.insert(DevHoliday(date = nextTuesday))
 
             val areaAId = tx.insert(DevCareArea(name = "Area A", shortName = "Area A"))
             val areaBId = tx.insert(DevCareArea(name = "Area B", shortName = "Area B"))
@@ -551,6 +557,34 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
                 preschoolAId,
                 HelsinkiDateTime.of(monday.plusWeeks(1), LocalTime.of(11, 0)),
                 null
+            )
+
+            // next tuesday
+            // absence on holiday shouldn't show up
+            tx.insert(
+                DevAbsence(
+                    id = AbsenceId(UUID.randomUUID()),
+                    testChildCecil.id,
+                    nextTuesday,
+                    AbsenceType.OTHER_ABSENCE,
+                    HelsinkiDateTime.atStartOfDay(nextTuesday),
+                    EvakaUserId(admin.id.raw),
+                    AbsenceCategory.NONBILLABLE
+                )
+            )
+
+            // previous friday
+            // absence on holiday shouldn't show up
+            tx.insert(
+                DevAbsence(
+                    id = AbsenceId(UUID.randomUUID()),
+                    testChildCecil.id,
+                    previousFriday,
+                    AbsenceType.OTHER_ABSENCE,
+                    HelsinkiDateTime.atStartOfDay(previousFriday),
+                    EvakaUserId(admin.id.raw),
+                    AbsenceCategory.NONBILLABLE
+                )
             )
 
             // previous sunday

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
@@ -531,7 +531,7 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
 
             // Saturday
 
-            // absence outside unit operation days shouldn't show up
+            // absence on the weekend shouldn't show up
             tx.insert(
                 DevAbsence(
                     id = AbsenceId(UUID.randomUUID()),
@@ -554,7 +554,7 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
             )
 
             // previous sunday
-            // absence outside unit operation days shouldn't show up
+            // absence on the weekend shouldn't show up
             tx.insert(
                 DevAbsence(
                     id = AbsenceId(UUID.randomUUID()),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
@@ -424,7 +424,7 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
                     id = AbsenceId(UUID.randomUUID()),
                     testChildAapo.id,
                     monday,
-                    AbsenceType.OTHER_ABSENCE,
+                    AbsenceType.PLANNED_ABSENCE,
                     HelsinkiDateTime.atStartOfDay(monday),
                     EvakaUserId(admin.id.raw),
                     AbsenceCategory.NONBILLABLE

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReport.kt
@@ -216,7 +216,8 @@ fun getPreschoolAbsenceReportRowsForUnit(
                                              ppc.id = ab.child_id and
                                              ab.absence_type = types.absence_type and
                                              ab.category = 'NONBILLABLE' and
-                                             extract(isodow from ab.date) BETWEEN 1 AND 5
+                                             extract(isodow from ab.date) BETWEEN 1 AND 5 and
+                                             not exists (SELECT FROM holiday h WHERE h.date = ab.date)
             group by ppc.id, ppc.first_name, ppc.last_name, types.absence_type;
         """
                     .trimIndent()
@@ -266,7 +267,8 @@ from preschool_group_placement_children pgpc
                                  pgpc.id = ab.child_id and
                                  ab.absence_type = types.absence_type and
                                  ab.category = 'NONBILLABLE' and
-                                 extract(isodow from ab.date) BETWEEN 1 AND 5
+                                 extract(isodow from ab.date) BETWEEN 1 AND 5 and
+                                 not exists (SELECT FROM holiday h WHERE h.date = ab.date)
 group by pgpc.id, pgpc.first_name, pgpc.last_name, types.absence_type;
         """
                     .trimIndent()

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReport.kt
@@ -194,9 +194,7 @@ fun getPreschoolAbsenceReportRowsForUnit(
                      (select child.id,
                              child.first_name,
                              child.last_name,
-                             daterange(p.start_date, p.end_date, '[]') * ${bind(preschoolTerm)} as examination_range,
-                             d.shift_care_operation_days,
-                             d.operation_days
+                             daterange(p.start_date, p.end_date, '[]') * ${bind(preschoolTerm)} as examination_range
                       from placement p
                                join person child on p.child_id = child.id
                                join daycare d
@@ -218,7 +216,7 @@ fun getPreschoolAbsenceReportRowsForUnit(
                                              ppc.id = ab.child_id and
                                              ab.absence_type = types.absence_type and
                                              ab.category = 'NONBILLABLE' and
-                                             extract(isodow from ab.date) = ANY(coalesce(ppc.shift_care_operation_days, ppc.operation_days))
+                                             extract(isodow from ab.date) BETWEEN 1 AND 5
             group by ppc.id, ppc.first_name, ppc.last_name, types.absence_type;
         """
                     .trimIndent()
@@ -241,9 +239,7 @@ fun getPreschoolAbsenceReportRowsForGroup(
          (select child.id,
                  child.first_name,
                  child.last_name,
-                 daterange(dgp.start_date, dgp.end_date, '[]') * ${bind(preschoolTerm)} as examination_range,
-                 d.shift_care_operation_days,
-                 d.operation_days
+                 daterange(dgp.start_date, dgp.end_date, '[]') * ${bind(preschoolTerm)} as examination_range
           from placement p
                    join person child on p.child_id = child.id
                    join daycare d
@@ -270,7 +266,7 @@ from preschool_group_placement_children pgpc
                                  pgpc.id = ab.child_id and
                                  ab.absence_type = types.absence_type and
                                  ab.category = 'NONBILLABLE' and
-                                 extract(isodow from ab.date) = ANY(coalesce(pgpc.shift_care_operation_days, pgpc.operation_days))
+                                 extract(isodow from ab.date) BETWEEN 1 AND 5
 group by pgpc.id, pgpc.first_name, pgpc.last_name, types.absence_type;
         """
                     .trimIndent()


### PR DESCRIPTION
https://github.com/espoon-voltti/evaka/pull/5522 osa 2:
1. esiopetuksen toimintapäivät ovat aina ma-pe
2. pyhäpäivät eivät kerrytä poissaoloja
3. suunniteltu poissaolo pitäisi tulkita muuna poissaolona.

Viimeinen on ehkä bugi poissaolojen tallennuksessa: kun huoltaja ilmoittaa sopimuspäiväläiselle poissaoloja, pitäisi esiopetuksen poissaoloksi ehkä tulla "muu poissaolo". Nyt tulee "suunniteltu / sopimuksen mukainen poissaolo", joka ei oikein käy järkeen esiopetuksen osalta (sopimuspäivät tarkoittavat liittyvän / täydentävän varhaiskasvatuksen sopimusta, ei esiopetuksen).