### PR TITLE
Päätetään palvelusetelikertoimia automaattisesti sijoituksen päättyessä/muuttuessa

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedVoucerCoefficientEndOutdatedTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/AssistanceNeedVoucerCoefficientEndOutdatedTest.kt
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.assistanceneed
+
+import fi.espoo.evaka.PureJdbiTest
+import fi.espoo.evaka.assistanceneed.vouchercoefficient.endOutdatedAssistanceNeedVoucherCoefficients
+import fi.espoo.evaka.shared.dev.DevAssistanceNeedVoucherCoefficient
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPersonType
+import fi.espoo.evaka.shared.dev.DevPlacement
+import fi.espoo.evaka.shared.dev.insert
+import fi.espoo.evaka.shared.domain.FiniteDateRange
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class AssistanceNeedVoucerCoefficientEndOutdatedTest : PureJdbiTest(resetDbBeforeEach = true) {
+    private val jan1 = LocalDate.of(2024, 1, 1)
+    private val dec31 = LocalDate.of(2024, 12, 31)
+
+    private val today = LocalDate.of(2024, 8, 1)
+    private val yesterday = today.minusDays(1)
+
+    @Test
+    fun `coefficient is not ended if placement continues`() {
+        db.transaction { tx ->
+            val area = DevCareArea()
+            val unit = DevDaycare(areaId = area.id)
+            val child = DevPerson()
+
+            tx.insert(area)
+            tx.insert(unit)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = unit.id,
+                    startDate = jan1,
+                    endDate = today,
+                )
+            )
+            tx.insert(
+                DevAssistanceNeedVoucherCoefficient(
+                    childId = child.id,
+                    validityPeriod = FiniteDateRange(jan1, dec31),
+                )
+            )
+        }
+        assertEquals(listOf(FiniteDateRange(jan1, dec31)), getCoefficientRanges())
+
+        db.transaction { tx -> tx.endOutdatedAssistanceNeedVoucherCoefficients(today) }
+
+        assertEquals(listOf(FiniteDateRange(jan1, dec31)), getCoefficientRanges())
+    }
+
+    @Test
+    fun `coefficient is not ended if placement changed to same unit`() {
+        db.transaction { tx ->
+            val area = DevCareArea()
+            val unit = DevDaycare(areaId = area.id)
+            val child = DevPerson()
+
+            tx.insert(area)
+            tx.insert(unit)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = unit.id,
+                    startDate = jan1,
+                    endDate = yesterday,
+                )
+            )
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = unit.id,
+                    startDate = today,
+                    endDate = dec31,
+                )
+            )
+            tx.insert(
+                DevAssistanceNeedVoucherCoefficient(
+                    childId = child.id,
+                    validityPeriod = FiniteDateRange(jan1, dec31),
+                )
+            )
+        }
+        assertEquals(listOf(FiniteDateRange(jan1, dec31)), getCoefficientRanges())
+
+        db.transaction { tx -> tx.endOutdatedAssistanceNeedVoucherCoefficients(today) }
+
+        assertEquals(listOf(FiniteDateRange(jan1, dec31)), getCoefficientRanges())
+    }
+
+    @Test
+    fun `coefficient is ended if placement has ended`() {
+        db.transaction { tx ->
+            val area = DevCareArea()
+            val unit = DevDaycare(areaId = area.id)
+            val child = DevPerson()
+
+            tx.insert(area)
+            tx.insert(unit)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = unit.id,
+                    startDate = jan1,
+                    endDate = yesterday,
+                )
+            )
+            tx.insert(
+                DevAssistanceNeedVoucherCoefficient(
+                    childId = child.id,
+                    validityPeriod = FiniteDateRange(jan1, dec31),
+                )
+            )
+        }
+        assertEquals(listOf(FiniteDateRange(jan1, dec31)), getCoefficientRanges())
+
+        db.transaction { tx -> tx.endOutdatedAssistanceNeedVoucherCoefficients(today) }
+
+        assertEquals(listOf(FiniteDateRange(jan1, yesterday)), getCoefficientRanges())
+    }
+
+    @Test
+    fun `coefficient is ended if placement has changed to a different unit`() {
+        db.transaction { tx ->
+            val area = DevCareArea()
+            val unit = DevDaycare(areaId = area.id)
+            val unit2 = DevDaycare(areaId = area.id)
+            val child = DevPerson()
+
+            tx.insert(area)
+            tx.insert(unit)
+            tx.insert(unit2)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = unit.id,
+                    startDate = jan1,
+                    endDate = yesterday,
+                )
+            )
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = unit2.id,
+                    startDate = today,
+                    endDate = dec31,
+                )
+            )
+            tx.insert(
+                DevAssistanceNeedVoucherCoefficient(
+                    childId = child.id,
+                    validityPeriod = FiniteDateRange(jan1, dec31),
+                )
+            )
+        }
+        assertEquals(listOf(FiniteDateRange(jan1, dec31)), getCoefficientRanges())
+
+        db.transaction { tx -> tx.endOutdatedAssistanceNeedVoucherCoefficients(today) }
+
+        assertEquals(listOf(FiniteDateRange(jan1, yesterday)), getCoefficientRanges())
+    }
+
+    @Test
+    fun `past data is not affected`() {
+        db.transaction { tx ->
+            val area = DevCareArea()
+            val unit = DevDaycare(areaId = area.id)
+            val child = DevPerson()
+
+            tx.insert(area)
+            tx.insert(unit)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = unit.id,
+                    startDate = jan1,
+                    // Placement already ended 2 days ago
+                    endDate = today.minusDays(2),
+                )
+            )
+            tx.insert(
+                DevAssistanceNeedVoucherCoefficient(
+                    childId = child.id,
+                    validityPeriod = FiniteDateRange(jan1, dec31),
+                )
+            )
+        }
+        assertEquals(listOf(FiniteDateRange(jan1, dec31)), getCoefficientRanges())
+
+        db.transaction { tx -> tx.endOutdatedAssistanceNeedVoucherCoefficients(today) }
+
+        assertEquals(listOf(FiniteDateRange(jan1, dec31)), getCoefficientRanges())
+    }
+
+    private fun getCoefficientRanges() =
+        db.read {
+            it.createQuery {
+                    sql(
+                        "SELECT validity_period FROM assistance_need_voucher_coefficient ORDER BY validity_period"
+                    )
+                }
+                .toList<FiniteDateRange>()
+        }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientQueries.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.NotFound
+import java.time.LocalDate
 
 fun Database.Transaction.insertAssistanceNeedVoucherCoefficient(
     childId: ChildId,
@@ -99,3 +100,31 @@ WHERE child_id = ${bind(childId)}
             )
         }
         .toList()
+
+/**
+ * End a voucher coefficient if 1) placement has ended yesterday, or 2) there is a new placement,
+ * but it's to a different unit.
+ */
+fun Database.Transaction.endOutdatedAssistanceNeedVoucherCoefficients(today: LocalDate) {
+    val yesterday = today.minusDays(1)
+    execute {
+        sql(
+            """
+UPDATE assistance_need_voucher_coefficient a
+SET validity_period = daterange(lower(validity_period), ${bind(yesterday)}, '[]')
+FROM placement pl
+WHERE
+    a.validity_period && daterange(${bind(yesterday)}, ${bind(today)}, '[]') AND
+    daterange(pl.start_date, pl.end_date, '[]') @> ${bind(yesterday)} AND
+    pl.child_id = a.child_id AND
+    NOT EXISTS (
+        SELECT FROM placement pl_new
+        WHERE
+            daterange(pl_new.start_date, pl_new.end_date, '[]') @> ${bind(today)} AND
+            pl_new.child_id = a.child_id AND
+            pl_new.unit_id = pl.unit_id
+    )
+"""
+        )
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.application.removeOldDrafts
 import fi.espoo.evaka.assistance.endAssistanceFactorsWhichBelongToPastPlacements
 import fi.espoo.evaka.assistanceneed.decision.endActiveDaycareAssistanceDecisions
 import fi.espoo.evaka.assistanceneed.preschooldecision.endActivePreschoolAssistanceDecisions
+import fi.espoo.evaka.assistanceneed.vouchercoefficient.endOutdatedAssistanceNeedVoucherCoefficients
 import fi.espoo.evaka.attachment.AttachmentService
 import fi.espoo.evaka.attendance.addMissingStaffAttendanceDepartures
 import fi.espoo.evaka.calendarevent.CalendarEventNotificationService
@@ -63,6 +64,10 @@ enum class ScheduledJob(
     EndAssistanceFactorsWhichBelongToPastPlacements(
         ScheduledJobs::endAssistanceFactorsWhichBelongToPastPlacements,
         ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(1, 0))),
+    ),
+    EndOutdatedAssistanceNeedVoucherValueCoefficients(
+        ScheduledJobs::endOutdatedAssistanceNeedVoucherValueCoefficients,
+        ScheduledJobSettings(enabled = true, schedule = JobSchedule.daily(LocalTime.of(1, 0))),
     ),
     EndActiveDaycareAssistanceDecisions(
         ScheduledJobs::endActiveDaycareAssistanceDecisions,
@@ -227,6 +232,13 @@ class ScheduledJobs(
         clock: EvakaClock,
     ) {
         db.transaction { tx -> tx.endAssistanceFactorsWhichBelongToPastPlacements(clock.today()) }
+    }
+
+    fun endOutdatedAssistanceNeedVoucherValueCoefficients(
+        db: Database.Connection,
+        clock: EvakaClock,
+    ) {
+        db.transaction { tx -> tx.endOutdatedAssistanceNeedVoucherCoefficients(clock.today()) }
     }
 
     fun endActiveDaycareAssistanceDecisions(db: Database.Connection, clock: EvakaClock) {


### PR DESCRIPTION
Palvelusetelikerroin päätetään automaattisesti yöllisessä ajossa jos
a) sijoitus on päättynyt eilen, tai
b) sijoitus on vaihtunut toiseen yksikköön tästä päivästä alkaen.