### PR TITLE
Ei lähetetä sähköpostia kalenteritapahtumista jos sijoitus on päättynyt

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationService.kt
@@ -124,7 +124,7 @@ class CalendarEventNotificationService(
     }
 
     fun sendCalendarEventDigests(dbc: Database.Connection, now: HelsinkiDateTime) {
-        dbc.read { tx -> tx.getParentsWithNewEventsAfter(now.minusHours(24)) }
+        dbc.read { tx -> tx.getParentsWithNewEventsAfter(now.toLocalDate(), now.minusHours(24)) }
             .also { parents ->
                 logger.info { "Sending calendar event notifications to ${parents.size} parents" }
             }


### PR DESCRIPTION
Normaalitilanteessa lapsella on sijoitus kalenteritapahtuman aikana, mutta jos tapahtuman ajankohdassa on virhe (esim. vuosiluku menneisyydessä) niin aiemmin sähköposti lähetettiin sijoituksen voimassaolosta riippumatta.