### PR TITLE
Lisää lomakepohjien ohjeteksteihin monirivituen

### DIFF
--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateSectionModal.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateSectionModal.tsx
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { useForm, useFormFields } from 'lib-common/form/hooks'
 import { StateOf } from 'lib-common/form/types'
 import { InputFieldF } from 'lib-components/atoms/form/InputField'
+import { TextAreaF } from 'lib-components/atoms/form/TextArea'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
 import { Label } from 'lib-components/typography'
@@ -68,7 +69,7 @@ export default React.memo(function TemplateSectionModal({
         </FixedSpaceColumn>
         <FixedSpaceColumn>
           <Label>{i18n.documentTemplates.templateEditor.infoText}</Label>
-          <InputFieldF bind={infoText} hideErrorsBeforeTouched />
+          <TextAreaF bind={infoText} hideErrorsBeforeTouched />
         </FixedSpaceColumn>
       </FixedSpaceColumn>
     </AsyncFormModal>

--- a/frontend/src/lib-components/document-templates/question-descriptors/CheckboxGroupQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/CheckboxGroupQuestionDescriptor.tsx
@@ -34,6 +34,7 @@ import { Label } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import { faPlus, faTrash } from 'lib-icons'
 
+import { TextAreaF } from '../../atoms/form/TextArea'
 import { useTranslations } from '../../i18n'
 
 import { DocumentQuestionDescriptor, TemplateQuestionDescriptor } from './types'
@@ -258,7 +259,7 @@ const TemplateView = React.memo(function TemplateView({
       </FixedSpaceColumn>
       <FixedSpaceColumn>
         <Label>{i18n.documentTemplates.templateQuestions.infoText}</Label>
-        <InputFieldF bind={infoText} hideErrorsBeforeTouched />
+        <TextAreaF bind={infoText} hideErrorsBeforeTouched />
       </FixedSpaceColumn>
       <FixedSpaceColumn>
         <Label>{i18n.documentTemplates.templateQuestions.options}</Label>

--- a/frontend/src/lib-components/document-templates/question-descriptors/CheckboxQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/CheckboxQuestionDescriptor.tsx
@@ -21,6 +21,7 @@ import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 import { Label } from 'lib-components/typography'
 
+import { TextAreaF } from '../../atoms/form/TextArea'
 import { useTranslations } from '../../i18n'
 
 import { DocumentQuestionDescriptor, TemplateQuestionDescriptor } from './types'
@@ -131,7 +132,7 @@ const TemplateView = React.memo(function TemplateView({
       </FixedSpaceColumn>
       <FixedSpaceColumn>
         <Label>{i18n.documentTemplates.templateQuestions.infoText}</Label>
-        <InputFieldF bind={infoText} hideErrorsBeforeTouched />
+        <TextAreaF bind={infoText} hideErrorsBeforeTouched />
       </FixedSpaceColumn>
     </FixedSpaceColumn>
   )

--- a/frontend/src/lib-components/document-templates/question-descriptors/DateQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/DateQuestionDescriptor.tsx
@@ -21,6 +21,7 @@ import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 import { Label } from 'lib-components/typography'
 
+import { TextAreaF } from '../../atoms/form/TextArea'
 import { useTranslations } from '../../i18n'
 import { DatePickerF } from '../../molecules/date-picker/DatePicker'
 
@@ -139,7 +140,7 @@ const TemplateView = React.memo(function TemplateView({
       </FixedSpaceColumn>
       <FixedSpaceColumn>
         <Label>{i18n.documentTemplates.templateQuestions.infoText}</Label>
-        <InputFieldF bind={infoText} hideErrorsBeforeTouched />
+        <TextAreaF bind={infoText} hideErrorsBeforeTouched />
       </FixedSpaceColumn>
     </FixedSpaceColumn>
   )

--- a/frontend/src/lib-components/document-templates/question-descriptors/GroupedTextFieldsQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/GroupedTextFieldsQuestionDescriptor.tsx
@@ -33,6 +33,7 @@ import { Label } from 'lib-components/typography'
 import { faPlus, faTrash } from 'lib-icons'
 
 import { IconOnlyButton } from '../../atoms/buttons/IconOnlyButton'
+import { TextAreaF } from '../../atoms/form/TextArea'
 import { useTranslations } from '../../i18n'
 
 import { DocumentQuestionDescriptor, TemplateQuestionDescriptor } from './types'
@@ -291,7 +292,7 @@ const TemplateView = React.memo(function TemplateView({
       </FixedSpaceColumn>
       <FixedSpaceColumn>
         <Label>{i18n.documentTemplates.templateQuestions.infoText}</Label>
-        <InputFieldF bind={infoText} hideErrorsBeforeTouched />
+        <TextAreaF bind={infoText} hideErrorsBeforeTouched />
       </FixedSpaceColumn>
       <CheckboxF
         bind={allowMultipleRows}

--- a/frontend/src/lib-components/document-templates/question-descriptors/RadioButtonGroupQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/RadioButtonGroupQuestionDescriptor.tsx
@@ -33,6 +33,7 @@ import { Label } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import { faPlus, faTrash } from 'lib-icons'
 
+import { TextAreaF } from '../../atoms/form/TextArea'
 import { useTranslations } from '../../i18n'
 
 import { DocumentQuestionDescriptor, TemplateQuestionDescriptor } from './types'
@@ -197,7 +198,7 @@ const TemplateView = React.memo(function TemplateView({
       </FixedSpaceColumn>
       <FixedSpaceColumn>
         <Label>{i18n.documentTemplates.templateQuestions.infoText}</Label>
-        <InputFieldF bind={infoText} hideErrorsBeforeTouched />
+        <TextAreaF bind={infoText} hideErrorsBeforeTouched />
       </FixedSpaceColumn>
       <FixedSpaceColumn>
         <Label>{i18n.documentTemplates.templateQuestions.options}</Label>

--- a/frontend/src/lib-components/document-templates/question-descriptors/StaticTextDisplayQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/StaticTextDisplayQuestionDescriptor.tsx
@@ -171,7 +171,7 @@ const TemplateView = React.memo(function TemplateView({
       </FixedSpaceColumn>
       <FixedSpaceColumn>
         <Label>{i18n.documentTemplates.templateQuestions.infoText}</Label>
-        <InputFieldF bind={infoText} hideErrorsBeforeTouched />
+        <TextAreaF bind={infoText} hideErrorsBeforeTouched />
       </FixedSpaceColumn>
     </FixedSpaceColumn>
   )

--- a/frontend/src/lib-components/document-templates/question-descriptors/TextQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/TextQuestionDescriptor.tsx
@@ -156,7 +156,7 @@ const TemplateView = React.memo(function TemplateView({
       </FixedSpaceColumn>
       <FixedSpaceColumn>
         <Label>{i18n.documentTemplates.templateQuestions.infoText}</Label>
-        <InputFieldF bind={infoText} hideErrorsBeforeTouched />
+        <TextAreaF bind={infoText} hideErrorsBeforeTouched />
       </FixedSpaceColumn>
       <CheckboxF
         bind={multiline}


### PR DESCRIPTION
Ohjeet ovat välillä hyvinkin pitkiä ja rivinvaihdoilla saa luettavuutta parannettua.