### PR TITLE
Korjauksia sähköpostien lähetykseen

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationQueriesTest.kt
@@ -7,7 +7,6 @@ import fi.espoo.evaka.calendarevent.CalendarEventType
 import fi.espoo.evaka.calendarevent.ParentWithEvents
 import fi.espoo.evaka.calendarevent.getParentsWithNewEventsAfter
 import fi.espoo.evaka.daycare.domain.Language
-import fi.espoo.evaka.emailclient.CalendarEventNotificationData
 import fi.espoo.evaka.shared.CalendarEventId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
@@ -137,16 +136,11 @@ class CalendarEventNotificationQueriesTest : PureJdbiTest(resetDbBeforeEach = tr
     @Test
     fun `Unit-wide event`() {
         insertTestData()
-        createCalendarEvent(
-            title = "Unit-wide event",
-            period = FiniteDateRange(today, today),
-            unitId = testDaycare.id,
-        )
-
-        val expectedEvent =
-            CalendarEventNotificationData(
+        val eventId =
+            createCalendarEvent(
                 title = "Unit-wide event",
                 period = FiniteDateRange(today, today),
+                unitId = testDaycare.id,
             )
 
         assertEquals(
@@ -154,17 +148,17 @@ class CalendarEventNotificationQueriesTest : PureJdbiTest(resetDbBeforeEach = tr
                     ParentWithEvents(
                         parentId = testAdult_1.id,
                         language = Language.fi,
-                        events = listOf(expectedEvent),
+                        events = listOf(eventId),
                     ),
                     ParentWithEvents(
                         parentId = testAdult_2.id,
                         language = Language.fi,
-                        events = listOf(expectedEvent),
+                        events = listOf(eventId),
                     ),
                     ParentWithEvents(
                         parentId = testAdult_3.id,
                         language = Language.sv,
-                        events = listOf(expectedEvent),
+                        events = listOf(eventId),
                     ),
                 )
                 .sortedBy { it.parentId },
@@ -176,17 +170,12 @@ class CalendarEventNotificationQueriesTest : PureJdbiTest(resetDbBeforeEach = tr
     @Test
     fun `Group event`() {
         insertTestData()
-        createCalendarEvent(
-            title = "Group event",
-            period = FiniteDateRange(today, today),
-            unitId = testDaycare.id,
-            groupIds = listOf(testDaycareGroup.id),
-        )
-
-        val expectedEvent =
-            CalendarEventNotificationData(
+        val eventId =
+            createCalendarEvent(
                 title = "Group event",
                 period = FiniteDateRange(today, today),
+                unitId = testDaycare.id,
+                groupIds = listOf(testDaycareGroup.id),
             )
 
         assertEquals(
@@ -194,7 +183,7 @@ class CalendarEventNotificationQueriesTest : PureJdbiTest(resetDbBeforeEach = tr
                 ParentWithEvents(
                     parentId = testAdult_2.id,
                     language = Language.fi,
-                    events = listOf(expectedEvent),
+                    events = listOf(eventId),
                 )
             ),
             db.read { tx -> tx.getParentsWithNewEventsAfter(today, now.minusHours(24)) },
@@ -235,16 +224,11 @@ class CalendarEventNotificationQueriesTest : PureJdbiTest(resetDbBeforeEach = tr
                 )
             )
         }
-        createCalendarEvent(
-            title = "Backup care",
-            period = FiniteDateRange(today, today.plusDays(1)),
-            unitId = testDaycare.id,
-        )
-
-        val expectedEvent =
-            CalendarEventNotificationData(
+        val eventId =
+            createCalendarEvent(
                 title = "Backup care",
                 period = FiniteDateRange(today, today.plusDays(1)),
+                unitId = testDaycare.id,
             )
 
         assertEquals(
@@ -252,12 +236,12 @@ class CalendarEventNotificationQueriesTest : PureJdbiTest(resetDbBeforeEach = tr
                     ParentWithEvents(
                         parentId = testAdult_2.id,
                         language = Language.fi,
-                        events = listOf(expectedEvent),
+                        events = listOf(eventId),
                     ),
                     ParentWithEvents(
                         parentId = testAdult_3.id,
                         language = Language.sv,
-                        events = listOf(expectedEvent),
+                        events = listOf(eventId),
                     ),
                 )
                 .sortedBy { it.parentId },
@@ -281,21 +265,16 @@ class CalendarEventNotificationQueriesTest : PureJdbiTest(resetDbBeforeEach = tr
                 )
             )
         }
-        createCalendarEvent(
-            title = "Child event",
-            period = FiniteDateRange(today, today),
-            unitId = testDaycare.id,
-            groupChildIds =
-                listOf(
-                    testDaycareGroup.id to testChild_2.id,
-                    testDaycareGroup2.id to testChild_3.id,
-                ),
-        )
-
-        val expectedEvent =
-            CalendarEventNotificationData(
+        val eventId =
+            createCalendarEvent(
                 title = "Child event",
                 period = FiniteDateRange(today, today),
+                unitId = testDaycare.id,
+                groupChildIds =
+                    listOf(
+                        testDaycareGroup.id to testChild_2.id,
+                        testDaycareGroup2.id to testChild_3.id,
+                    ),
             )
 
         assertEquals(
@@ -303,12 +282,12 @@ class CalendarEventNotificationQueriesTest : PureJdbiTest(resetDbBeforeEach = tr
                     ParentWithEvents(
                         parentId = testAdult_2.id,
                         language = Language.fi,
-                        events = listOf(expectedEvent),
+                        events = listOf(eventId),
                     ),
                     ParentWithEvents(
                         parentId = testAdult_3.id,
                         language = Language.sv,
-                        events = listOf(expectedEvent),
+                        events = listOf(eventId),
                     ),
                 )
                 .sortedBy { it.parentId },

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventServiceIntegrationTest.kt
@@ -1728,7 +1728,8 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             )
         calendarEventController.createCalendarEvent(dbInstance(), admin, clock, form)
 
-        calendarEventNotificationService.sendCalendarEventDigests(db, now)
+        calendarEventNotificationService.scheduleCalendarEventDigestEmails(db, now)
+        asyncJobRunner.runPendingJobsSync(clock)
 
         assertEquals(1, MockEmailClient.emails.size)
         MockEmailClient.emails.first().let { email ->

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
@@ -15,6 +15,7 @@ import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.db.Predicate
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
@@ -25,18 +26,11 @@ fun Database.Read.getCalendarEventsByUnit(
     unitId: DaycareId,
     range: FiniteDateRange,
 ): List<CalendarEvent> =
-    getCalendarEventsQuery(unitId = unitId, range = range).toList<CalendarEvent>()
+    getCalendarEventsQuery(unit(unitId).and(range(range))).toList<CalendarEvent>()
 
-private fun Database.Read.getCalendarEventsQuery(
-    calendarEventId: CalendarEventId? = null,
-    unitId: DaycareId? = null,
-    range: FiniteDateRange? = null,
-    groupId: GroupId? = null,
-    eventTypes: List<CalendarEventType>? = null,
-) =
-    createQuery {
-            sql(
-                """
+private fun Database.Read.getCalendarEventsQuery(where: Predicate) = createQuery {
+    sql(
+        """
 SELECT
     ce.id, cea.unit_id, ce.title, ce.description, ce.period, ce.content_modified_at, ce.event_type,
     (
@@ -67,11 +61,7 @@ JOIN calendar_event ce ON cea.calendar_event_id = ce.id
 LEFT JOIN daycare_group dg ON dg.id = cea.group_id
 LEFT JOIN person p ON p.id = cea.child_id
 LEFT JOIN calendar_event_time cet ON cet.calendar_event_id = ce.id
-WHERE (:calendarEventId IS NULL OR ce.id = :calendarEventId) 
-AND (:unitId IS NULL OR cea.unit_id = :unitId) 
-AND (:groupId IS NULL OR cea.group_id = :groupId)
-AND (:range IS NULL OR ce.period && :range)
-AND (:eventTypes::calendar_event_type[] IS NULL OR ce.event_type = ANY(:eventTypes::calendar_event_type[]))
+WHERE ${predicate(where.forTable(""))}
 AND (cea.child_id IS NULL OR EXISTS(
     -- filter out attendees that haven't been placed in the specified unit/group,
     -- for example due to changes in placements after the event creation or a new backup care
@@ -82,14 +72,21 @@ AND (cea.child_id IS NULL OR EXISTS(
       AND rp.unit_id = cea.unit_id
 ))
 GROUP BY ce.id, cea.unit_id
-        """
-            )
-        }
-        .bind("calendarEventId", calendarEventId)
-        .bind("unitId", unitId)
-        .bind("groupId", groupId)
-        .bind("range", range)
-        .bind("eventTypes", eventTypes.takeIf { !it.isNullOrEmpty() })
+"""
+    )
+}
+
+private fun unit(unitId: DaycareId) = Predicate { where("cea.unit_id = ${bind(unitId)}") }
+
+private fun range(range: FiniteDateRange) = Predicate { where("ce.period && ${bind(range)}") }
+
+private fun event(eventId: CalendarEventId) = Predicate { where("ce.id = ${bind(eventId)}") }
+
+private fun group(groupId: GroupId) = Predicate { where("cea.group_id = ${bind(groupId)}") }
+
+private fun eventType(eventTypes: List<CalendarEventType>) = Predicate {
+    where("ce.event_type = ANY(${bind(eventTypes)})")
+}
 
 fun Database.Transaction.createCalendarEvent(
     event: CalendarEventForm,
@@ -186,15 +183,15 @@ fun Database.Transaction.deleteCalendarEventTime(id: CalendarEventTimeId) =
         .updateExactlyOne()
 
 fun Database.Read.getCalendarEventById(id: CalendarEventId) =
-    getCalendarEventsQuery(calendarEventId = id).exactlyOneOrNull<CalendarEvent>()
+    getCalendarEventsQuery(event(id)).exactlyOneOrNull<CalendarEvent>()
 
 fun Database.Read.getCalendarEventsByGroupAndType(
     groupId: GroupId,
     eventTypes: List<CalendarEventType>,
-) = getCalendarEventsQuery(groupId = groupId, eventTypes = eventTypes).toList<CalendarEvent>()
+) = getCalendarEventsQuery(group(groupId).and(eventType(eventTypes))).toList<CalendarEvent>()
 
 fun Database.Read.getCalendarEventsByUnitWithRange(unitId: DaycareId, range: FiniteDateRange) =
-    getCalendarEventsQuery(unitId = unitId, range = range).toList<CalendarEvent>()
+    getCalendarEventsQuery(unit(unitId).and(range(range))).toList<CalendarEvent>()
 
 fun Database.Transaction.deleteCalendarEvent(eventId: CalendarEventId) =
     this.createUpdate { sql("DELETE FROM calendar_event WHERE id = ${bind(eventId)}") }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
@@ -369,26 +369,20 @@ class FeeDecisionService(
 
         logger.info { "Sending fee decision emails for (decisionId: $feeDecisionId)" }
 
-        val recipients = listOfNotNull(decision.headOfFamily)
+        // simplified to get rid of superfluous language requirement
+        val fromAddress = emailEnv.sender(Language.fi)
+        val content =
+            emailMessageProvider.financeDecisionNotification(FinanceDecisionType.FEE_DECISION)
+        Email.create(
+                db,
+                decision.headOfFamily.id,
+                EmailMessageType.DECISION_NOTIFICATION,
+                fromAddress,
+                content,
+                "$feeDecisionId - ${decision.headOfFamily.id}",
+            )
+            ?.also { emailClient.send(it) }
 
-        recipients.forEach { recipient ->
-            // simplified to get rid of superfluous language requirement
-            val fromAddress = emailEnv.sender(Language.fi)
-            val content =
-                emailMessageProvider.financeDecisionNotification(FinanceDecisionType.FEE_DECISION)
-            Email.create(
-                    db,
-                    recipient.id,
-                    EmailMessageType.DECISION_NOTIFICATION,
-                    fromAddress,
-                    content,
-                    "$feeDecisionId - ${recipient.id}",
-                )
-                ?.also { emailClient.send(it) }
-        }
-
-        logger.info {
-            "Successfully sent fee decision emails (${recipients.size}) (id: $feeDecisionId)."
-        }
+        logger.info { "Successfully sent fee decision email (id: $feeDecisionId)." }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
@@ -254,28 +254,24 @@ class VoucherValueDecisionService(
             "Sending voucher value decision emails for (decisionId: $voucherValueDecisionId)"
         }
 
-        val recipients = listOfNotNull(decision.headOfFamily)
-
-        recipients.forEach { recipient ->
-            // simplified to get rid of superfluous language requirement
-            val fromAddress = emailEnv.sender(Language.fi)
-            val content =
-                emailMessageProvider.financeDecisionNotification(
-                    FinanceDecisionType.VOUCHER_VALUE_DECISION
-                )
-            Email.create(
-                    db,
-                    recipient.id,
-                    EmailMessageType.DECISION_NOTIFICATION,
-                    fromAddress,
-                    content,
-                    "$voucherValueDecisionId - ${recipient.id}",
-                )
-                ?.also { emailClient.send(it) }
-        }
+        // simplified to get rid of superfluous language requirement
+        val fromAddress = emailEnv.sender(Language.fi)
+        val content =
+            emailMessageProvider.financeDecisionNotification(
+                FinanceDecisionType.VOUCHER_VALUE_DECISION
+            )
+        Email.create(
+                db,
+                decision.headOfFamily.id,
+                EmailMessageType.DECISION_NOTIFICATION,
+                fromAddress,
+                content,
+                "$voucherValueDecisionId - ${decision.headOfFamily.id}",
+            )
+            ?.also { emailClient.send(it) }
 
         logger.info {
-            "Successfully sent voucher value decision emails (${recipients.size}) (id: $voucherValueDecisionId)."
+            "Successfully sent voucher value decision email (id: $voucherValueDecisionId)."
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -231,7 +231,8 @@ sealed interface AsyncJob : AsyncJobPayload {
     }
 
     data class SendAssistanceNeedPreschoolDecisionEmail(
-        val decisionId: AssistanceNeedPreschoolDecisionId
+        val decisionId: AssistanceNeedPreschoolDecisionId,
+        val guardianId: PersonId,
     ) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -237,6 +237,14 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class SendCalendarEventDigestEmail(
+        val parentId: PersonId,
+        val language: Language,
+        val events: List<CalendarEventId>,
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     data class CreateAssistanceNeedPreschoolDecisionPdf(
         val decisionId: AssistanceNeedPreschoolDecisionId
     ) : AsyncJob {
@@ -425,6 +433,7 @@ sealed interface AsyncJob : AsyncJobPayload {
                     SendApplicationEmail::class,
                     SendAssistanceNeedDecisionEmail::class,
                     SendAssistanceNeedPreschoolDecisionEmail::class,
+                    SendCalendarEventDigestEmail::class,
                     SendChildDocumentNotificationEmail::class,
                     SendMessageNotificationEmail::class,
                     SendMissingReservationsReminder::class,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -205,8 +205,10 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
-    data class SendAssistanceNeedDecisionEmail(val decisionId: AssistanceNeedDecisionId) :
-        AsyncJob {
+    data class SendAssistanceNeedDecisionEmail(
+        val decisionId: AssistanceNeedDecisionId,
+        val guardianId: PersonId,
+    ) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -437,7 +437,7 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun sendCalendarEventDigests(db: Database.Connection, clock: EvakaClock) {
-        calendarEventNotificationService.sendCalendarEventDigests(db, clock.now())
+        calendarEventNotificationService.scheduleCalendarEventDigestEmails(db, clock.now())
     }
 
     fun scheduleDiscussionSurveyDigests(db: Database.Connection, clock: EvakaClock) {


### PR DESCRIPTION
Sähköposteja tulee lähettää yksi per async job, jotta sähköposteja ei lähetetä liian nopeasti eikä virhetilanteissa montaa kertaa per vastaanottaja. Suurin osa sähköpostia lähettävistä jobeista toimi jo näin, ja tämä PR korjaa loput.