### PR TITLE
Tulotietomuistutuksen lähetyslogiikan muutos

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
@@ -81,8 +81,10 @@ FROM expiring_income_with_billable_placement_day_after_expiration expiring_incom
 WHERE NOT EXISTS (
     SELECT 1 FROM income_statement
     WHERE person_id = expiring_income.person_id
-        AND (created > ${bind(today)} - INTERVAL '1 month' OR (end_date IS NOT NULL AND ${bind(dayAfterExpiration)} <= end_date))
         AND handler_id IS NULL
+        AND created > ${bind(today)} - INTERVAL '12 months'
+        AND (end_date IS NULL OR ${bind(dayAfterExpiration)} <= end_date)
+    
 ) 
 ${if (checkForExistingRecentIncomeNotificationType != null) """AND NOT EXISTS (
     SELECT 1 FROM income_notification


### PR DESCRIPTION
If exists an unhandled income statement from the past year with an open ended end date or an end date that is after the expiration date of the income do not send a notification.

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
