### PR TITLE
Lisätään tulotiedon päättymispäivä tuloselvitykset-listaan

### DIFF
--- a/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
+++ b/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
@@ -7,13 +7,13 @@ import React, { useContext, useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { isLoading, Success, wrapResult } from 'lib-common/api'
+import { isLoading } from 'lib-common/api'
 import {
   IncomeStatementAwaitingHandler,
   IncomeStatementSortParam
 } from 'lib-common/generated/api-types/incomestatement'
 import { SortDirection } from 'lib-common/generated/api-types/invoicing'
-import { useApiState } from 'lib-common/utils/useRestApi'
+import { queryOrDefault, useQueryResult } from 'lib-common/query'
 import Pagination from 'lib-components/Pagination'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { Container, ContentArea } from 'lib-components/layout/Container'
@@ -32,16 +32,12 @@ import { Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faCommentAlt, fasCommentAltLines, fasFile } from 'lib-icons'
 
-import { getIncomeStatementsAwaitingHandler } from '../../generated/api-clients/incomestatement'
 import { useTranslation } from '../../state/i18n'
 import { InvoicingUiContext } from '../../state/invoicing-ui'
 import { renderResult } from '../async-rendering'
 
 import IncomeStatementFilters from './IncomeStatementFilters'
-
-const getIncomeStatementsAwaitingHandlerResult = wrapResult(
-  getIncomeStatementsAwaitingHandler
-)
+import { incomeStatementsAwaitingHandlerQuery } from './queries'
 
 const pageSize = 50
 
@@ -156,29 +152,34 @@ export default React.memo(function IncomeStatementsPage() {
     incomeStatements: { searchFilters }
   } = useContext(InvoicingUiContext)
 
-  const [incomeStatements] = useApiState(() => {
-    const { sentStartDate, sentEndDate } = searchFilters
-    if (sentStartDate && sentEndDate && sentStartDate.isAfter(sentEndDate)) {
-      return Promise.resolve(Success.of({ data: [], pages: 0, total: 0 }))
-    }
-
-    return getIncomeStatementsAwaitingHandlerResult({
-      body: {
-        page,
-        pageSize,
-        sortBy,
-        sortDirection,
-        areas: searchFilters.area.length > 0 ? searchFilters.area : null,
-        providerTypes:
-          searchFilters.providerTypes.length > 0
-            ? searchFilters.providerTypes
-            : null,
-        sentStartDate: searchFilters.sentStartDate ?? null,
-        sentEndDate: searchFilters.sentEndDate ?? null,
-        placementValidDate: searchFilters.placementValidDate ?? null
-      }
-    })
-  }, [page, sortBy, sortDirection, searchFilters])
+  const incomeStatements = useQueryResult(
+    queryOrDefault(incomeStatementsAwaitingHandlerQuery, {
+      data: [],
+      pages: 0,
+      total: 0
+    })(
+      searchFilters.sentStartDate == null ||
+        searchFilters.sentEndDate == null ||
+        searchFilters.sentStartDate.isEqualOrBefore(searchFilters.sentEndDate)
+        ? {
+            body: {
+              page,
+              pageSize,
+              sortBy,
+              sortDirection,
+              areas: searchFilters.area.length > 0 ? searchFilters.area : null,
+              providerTypes:
+                searchFilters.providerTypes.length > 0
+                  ? searchFilters.providerTypes
+                  : null,
+              sentStartDate: searchFilters.sentStartDate ?? null,
+              sentEndDate: searchFilters.sentEndDate ?? null,
+              placementValidDate: searchFilters.placementValidDate ?? null
+            }
+          }
+        : undefined
+    )
+  )
 
   return (
     <Container

--- a/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
+++ b/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
@@ -87,6 +87,12 @@ function IncomeStatementsList({
             {i18n.incomeStatement.table.startDate}
           </SortableTh>
           <Th>{i18n.incomeStatement.table.type}</Th>
+          <SortableTh
+            sorted={isSorted('INCOME_END_DATE')}
+            onClick={toggleSort('INCOME_END_DATE')}
+          >
+            {i18n.incomeStatement.table.incomeEndDate}
+          </SortableTh>
           <Th minimalWidth={true}>{i18n.incomeStatement.table.link}</Th>
           <Th minimalWidth={true}>{i18n.incomeStatement.table.note}</Th>
         </Tr>
@@ -112,6 +118,7 @@ function IncomeStatementsList({
             <Td data-qa="income-statement-type">
               {i18n.incomeStatement.statementTypes[row.type].toLowerCase()}
             </Td>
+            <Td>{row.incomeEndDate?.format() ?? '-'}</Td>
             <Td>
               <Link
                 to={`/profile/${encodeURIComponent(

--- a/frontend/src/employee-frontend/components/income-statements/queries.ts
+++ b/frontend/src/employee-frontend/components/income-statements/queries.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { getIncomeStatementsAwaitingHandler } from 'employee-frontend/generated/api-clients/incomestatement'
+import { createQueryKeys } from 'employee-frontend/query'
+import { SearchIncomeStatementsRequest } from 'lib-common/generated/api-types/incomestatement'
+import { query } from 'lib-common/query'
+
+const queryKeys = createQueryKeys('incomeStatements', {
+  incomeStatementsAwaitingHandler: (params: SearchIncomeStatementsRequest) => [
+    'incomeStatementsAwaitingHandler',
+    params
+  ]
+})
+
+export const incomeStatementsAwaitingHandlerQuery = query({
+  api: getIncomeStatementsAwaitingHandler,
+  queryKey: (params) => queryKeys.incomeStatementsAwaitingHandler(params.body)
+})

--- a/frontend/src/employee-frontend/query.ts
+++ b/frontend/src/employee-frontend/query.ts
@@ -14,6 +14,7 @@ export type QueryKeyPrefix =
   | 'employees'
   | 'financeBasics'
   | 'holidayPeriods'
+  | 'incomeStatements'
   | 'reports'
   | 'timeline'
   | 'unit'

--- a/frontend/src/lib-common/generated/api-types/incomestatement.ts
+++ b/frontend/src/lib-common/generated/api-types/incomestatement.ts
@@ -157,6 +157,7 @@ export interface IncomeStatementAwaitingHandler {
   created: HelsinkiDateTime
   handlerNote: string
   id: UUID
+  incomeEndDate: LocalDate | null
   personId: UUID
   personName: string
   primaryCareArea: string | null
@@ -214,6 +215,7 @@ export type IncomeStatementBody = IncomeStatementBody.ChildIncome | IncomeStatem
 export type IncomeStatementSortParam =
   | 'CREATED'
   | 'START_DATE'
+  | 'INCOME_END_DATE'
 
 /**
 * Generated from fi.espoo.evaka.incomestatement.IncomeStatementType
@@ -375,6 +377,7 @@ export function deserializeJsonIncomeStatementAwaitingHandler(json: JsonOf<Incom
   return {
     ...json,
     created: HelsinkiDateTime.parseIso(json.created),
+    incomeEndDate: (json.incomeEndDate != null) ? LocalDate.parseIso(json.incomeEndDate) : null,
     startDate: LocalDate.parseIso(json.startDate)
   }
 }

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2088,7 +2088,8 @@ export const fi = {
       customer: 'Asiakas',
       area: 'Alue',
       created: 'Luotu',
-      startDate: 'Voimassa',
+      startDate: 'Voimassa alkaen',
+      incomeEndDate: 'Tulotieto päättyy',
       type: 'Tyyppi',
       link: 'Selvitys',
       note: 'Muistiinpano'

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementControllerIntegrationTest.kt
@@ -30,7 +30,6 @@ import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.MockEvakaClock
-import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.testAdult_1
 import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testAdult_3
@@ -65,6 +64,8 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
     private val employeeId = EmployeeId(UUID.randomUUID())
     private val citizenId = testAdult_1.id
     private val employee = AuthenticatedUser.Employee(employeeId, setOf(UserRole.FINANCE_ADMIN))
+
+    private val now = HelsinkiDateTime.of(LocalDate.of(2024, 8, 30), LocalTime.of(12, 0))
 
     @BeforeEach
     fun beforeEach() {
@@ -986,7 +987,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
         return incomeStatementController.getIncomeStatement(
             dbInstance(),
             employee,
-            RealEvakaClock(),
+            MockEvakaClock(now),
             citizenId,
             id,
         )
@@ -996,7 +997,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
         return incomeStatementController.getIncomeStatements(
             dbInstance(),
             employee,
-            RealEvakaClock(),
+            MockEvakaClock(now),
             personId,
             page = 1,
             pageSize = 10,
@@ -1010,7 +1011,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
         incomeStatementController.setIncomeStatementHandled(
             dbInstance(),
             employee,
-            RealEvakaClock(),
+            MockEvakaClock(now),
             id,
             body,
         )
@@ -1019,7 +1020,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
     private fun getIncomeStatementsAwaitingHandler(
         body: SearchIncomeStatementsRequest =
             SearchIncomeStatementsRequest(1, 50, null, null, emptyList(), emptyList(), null, null),
-        clock: EvakaClock = RealEvakaClock(),
+        clock: EvakaClock = MockEvakaClock(now),
     ): PagedIncomeStatementsAwaitingHandler {
         return incomeStatementController.getIncomeStatementsAwaitingHandler(
             dbInstance(),
@@ -1033,7 +1034,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
         return attachmentsController.uploadIncomeStatementAttachmentEmployee(
             dbInstance(),
             employee,
-            RealEvakaClock(),
+            MockEvakaClock(now),
             id,
             MockMultipartFile("file", "evaka-logo.png", "image/png", pngFile.readBytes()),
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
@@ -196,4 +196,5 @@ data class SearchIncomeStatementsRequest(
 enum class IncomeStatementSortParam {
     CREATED,
     START_DATE,
+    INCOME_END_DATE,
 }


### PR DESCRIPTION
Lisätään tuloselvitykset-listaan uusi sarake "Tulotieto päättyy", jossa on henkilön viimeisimmän tulotiedon päättymispäivä. Jos tulotietoa ei ole tai päättymispäivä on tyhjä, näytetään "-".

<img width="1140" alt="Screenshot 2024-09-03 at 7 56 12" src="https://github.com/user-attachments/assets/28569359-3c17-4c73-acb4-1a242c938878">
