### PR TITLE
Bugikorjaus käyttöastekyselyyn

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/CaretakerQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/CaretakerQueries.kt
@@ -64,7 +64,7 @@ SELECT
     daterange(dc.start_date, dc.end_date, '[]') * daterange(dg.start_date, dg.end_date, '[]') * ${bind(range)} AS range,
     dc.amount
 FROM daycare_group dg
-JOIN daycare_caretaker dc ON dg.id = dc.group_id
+JOIN daycare_caretaker dc ON dg.id = dc.group_id AND daterange(dg.start_date, dg.end_date, '[]') && daterange(dc.start_date, dc.end_date, '[]')
 WHERE ${predicate(byGroup.toRawPredicate().forTable("dg"))}
 AND daterange(dg.start_date, dg.end_date, '[]') && ${bind(range)}
 AND daterange(dc.start_date, dc.end_date, '[]') && ${bind(range)}


### PR DESCRIPTION
Kyselystä puuttuu overlap-tarkistus jonka takia intersektio (`*`-operaattori) voi palauttaa tyhjän daterangen, jota ei tueta koska FiniteDateRange ei pysty kuvaamaan sellaista

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
