### PR TITLE
Kuntalaisen tuloselvityksen parannuksia

### DIFF
--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -321,7 +321,13 @@ const IncomeTypeSelection = React.memo(
     const startDateInputInfo = useMemo(
       () =>
         errorToInputInfo(
-          formData.startDate ? undefined : 'validDate',
+          formData.startDate
+            ? formData.startDate.isBefore(
+                LocalDate.todayInSystemTz().subMonths(12)
+              )
+              ? 'dateTooEarly'
+              : undefined
+            : 'validDate',
           t.validationErrors
         ),
       [formData.startDate, t]
@@ -360,7 +366,9 @@ const IncomeTypeSelection = React.memo(
     return (
       <ContentArea opaque paddingVertical="L" ref={ref}>
         <FixedSpaceColumn spacing="zero">
-          <H2 noMargin>{t.income.incomeInfo}</H2>
+          <H2 noMargin data-qa="title">
+            {t.income.incomeInfo}
+          </H2>
           <Gap size="s" />
           {showFormErrors && (
             <>
@@ -412,6 +420,16 @@ const IncomeTypeSelection = React.memo(
               />
             </div>
           </FixedSpaceRow>
+          {validateEndDate(formData.endDate) === 'dateTooLate' && (
+            <>
+              <Gap size="s" />
+              <InfoBox
+                message={t.income.errors.dateRangeInvalid}
+                thin
+                data-qa="date-range-info"
+              />
+            </>
+          )}
           <Gap size="L" />
           <H3 noMargin>{t.income.incomeType.title}</H3>
           <Gap size="s" />

--- a/frontend/src/citizen-frontend/income-statements/types/form.ts
+++ b/frontend/src/citizen-frontend/income-statements/types/form.ts
@@ -70,7 +70,7 @@ export interface Accountant {
 export const emptyIncomeStatementForm: IncomeStatementForm = {
   startDate: null,
   endDate: null,
-  highestFee: true,
+  highestFee: false,
   childIncome: false,
   gross: {
     selected: false,

--- a/frontend/src/e2e-test/pages/citizen/citizen-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-income.ts
@@ -18,6 +18,7 @@ export default class CitizenIncomePage {
   #entrepreneurDate: TextInput
   validFromDate: TextInput
   validToDate: TextInput
+  incomeStartDateInfo: Element
   incomeEndDateInfo: Element
   constructor(private readonly page: Page) {
     this.requiredAttachments = page.findByDataQa('required-attachments')
@@ -28,6 +29,7 @@ export default class CitizenIncomePage {
     )
     this.validFromDate = new TextInput(page.findByDataQa('income-start-date'))
     this.validToDate = new TextInput(page.findByDataQa('income-end-date'))
+    this.incomeStartDateInfo = page.findByDataQa('income-start-date-info')
     this.incomeEndDateInfo = page.findByDataQa('income-end-date-info')
   }
 
@@ -44,12 +46,12 @@ export default class CitizenIncomePage {
 
   async setValidFromDate(date: string) {
     await this.validFromDate.fill(date)
-    await this.validFromDate.press('Enter')
+    await this.page.findByDataQa('title').click()
   }
 
   async setValidToDate(date: string) {
     await this.validToDate.fill(date)
-    await this.validToDate.press('Enter')
+    await this.page.findByDataQa('title').click()
   }
 
   async submit() {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
@@ -64,9 +64,22 @@ describe('Income statements', () => {
 
     test('Gross income', async () => {
       await header.selectTab('income')
+
       await incomeStatementsPage.createNewIncomeStatement()
+
+      // Start date can be max 1y from now so an error is shown
+      await incomeStatementsPage.setValidFromDate(
+        LocalDate.todayInHelsinkiTz()
+          .subMonths(12)
+          .subDays(1)
+          .format('d.M.yyyy')
+      )
+      await incomeStatementsPage.incomeStartDateInfo.waitUntilVisible()
+
       await incomeStatementsPage.setValidFromDate(startDate)
+      await incomeStatementsPage.incomeStartDateInfo.waitUntilHidden()
       await incomeStatementsPage.incomeEndDateInfo.waitUntilHidden()
+
       await incomeStatementsPage.selectIncomeStatementType('gross-income')
       await incomeStatementsPage.incomeEndDateInfo.waitUntilVisible()
 

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2121,7 +2121,9 @@ const en: Translations = {
         'The form is missing some required information or the information is incorrect. Please review the information you filled in.',
       choose: 'Please select an option',
       chooseAtLeastOne: 'Select at least one option',
-      deleteFailed: 'The income statement could not be deleted'
+      deleteFailed: 'The income statement could not be deleted',
+      dateRangeInvalid:
+        'Income information can be valid for a maximum of one year'
     },
     table: {
       title: 'Income statements',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2359,7 +2359,8 @@ export default {
         'Lomakkeelta puuttuu joitakin tarvittavia tietoja tai tiedot ovat virheellisiä. Ole hyvä ja tarkista täyttämäsi tiedot.',
       choose: 'Valitse vaihtoehto',
       chooseAtLeastOne: 'Valitse vähintään yksi vaihtoehto',
-      deleteFailed: 'Tuloselvitystä ei voitu poistaa'
+      deleteFailed: 'Tuloselvitystä ei voitu poistaa',
+      dateRangeInvalid: `Tulotiedot voivat olla voimassa korkeintaan vuoden`
     },
     table: {
       title: 'Omat tuloselvitykseni',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2368,7 +2368,8 @@ const sv: Translations = {
         'Blanketten saknar vissa nödvändiga uppgifter eller uppgifterna är felaktiga. Vänligen kontrollera den information som du har fyllt i.',
       choose: 'Välj ett alternativ',
       chooseAtLeastOne: 'Välj minst ett alternativ',
-      deleteFailed: 'Inkomstutredningen kunde inte raderas'
+      deleteFailed: 'Inkomstutredningen kunde inte raderas',
+      dateRangeInvalid: 'Inkomstuppgifter kan vara giltiga i högst ett år'
     },
     table: {
       title: 'Inkomstutredningar',


### PR DESCRIPTION
- Oletusarvoisesti ei ole mikään tulotyyppi valittuna
- Jos muu kuin suostumus ja päivämääräväli yli vuoden näytetään ohje että väli voi olla maksimissaan vuosi 
- Aloituspäivä voi olla maksimissaan vuoden menneisyydessä