### PR TITLE
Parannuksia päivämodaalin yhteensopivuuteen selaimen käännöstoiminnon kanssa

### DIFF
--- a/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
+++ b/frontend/src/citizen-frontend/calendar/AttendanceInfo.tsx
@@ -143,10 +143,10 @@ function AttendanceInfoWithServiceUsage({
         usedService.usedServiceMinutes > 0 ? (
           <>
             {usedService.usedServiceRanges.map((timeRange, index, array) => (
-              <React.Fragment key={index}>
+              <span key={index}>
                 {timeRange.format()}
                 {index < array.length - 1 && ', '}
-              </React.Fragment>
+              </span>
             ))}{' '}
             (<HoursMinutes minutes={usedService.usedServiceMinutes} />)
           </>

--- a/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthlyHoursSummary.tsx
@@ -34,17 +34,11 @@ export const HoursMinutes = ({ minutes }: { minutes: number }) => {
   if (hours === 0 && minutes === 0) {
     return '-'
   }
-  return (
-    <>
-      {hours > 0 && (
-        <>
-          {hours} {i18n.calendar.monthSummary.hours}
-        </>
-      )}
-      {extraMinutes != 0 &&
-        ' ' + extraMinutes + ' ' + i18n.calendar.monthSummary.minutes}
-    </>
-  )
+  return `${hours > 0 ? `${hours} ${i18n.calendar.monthSummary.hours}` : ''}${
+    extraMinutes != 0
+      ? ` ${extraMinutes} ${i18n.calendar.monthSummary.minutes}`
+      : ''
+  }`
 }
 export type MonthlyTimeSummary = {
   name: string


### PR DESCRIPTION
## Ennen tätä muutosta
Kun käyttäjä vaihtoi päivänäkymän modaalin päivältä toiselle, front-end kaatui virheeseen
> Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.

jos käyttäjällä oli selaimen automaattikäännös käytössä ja "Käytetty palveluntarve" muuttui `usedServiceRanges.length > 0` tyyppisestä `usedServiceRanges.length === 0` tyyppiseksi tai toisinpäin.
![image](https://github.com/user-attachments/assets/dc8dbeaf-a373-4e1e-95e8-82037d6a63d8)
![image](https://github.com/user-attachments/assets/b54e2e7a-dcf6-4377-ae49-242aabad610b)

## Tämän muutoksen jälkeen
Frontti ei kaadu, koska React ei koita poistaa sellaisia `TextNode`ja Dom:ista jotka selaimen käännöstoiminto on hävittänyt sieltä.