### PR TITLE
Korjataan osapäivän poissaolojen käsittely raportilla ja yksikön käyttöastegraafissa

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceQueries.kt
@@ -467,6 +467,18 @@ fun Database.Read.getAbsencesOfChildByRange(childId: ChildId, range: DateRange):
         }
     )
 
+fun Database.Read.getAbsencesOfChildrenByRange(
+    childIds: Set<ChildId>,
+    range: DateRange,
+): List<Absence> =
+    getAbsences(
+        Predicate {
+            where(
+                "between_start_and_end(${bind(range)}, $it.date) AND $it.child_id = ANY(${bind(childIds)})"
+            )
+        }
+    )
+
 fun Database.Read.getAbsencesOfChildByDate(childId: ChildId, date: LocalDate): List<Absence> =
     getAbsences(Predicate { where("$it.date = ${bind(date)} AND $it.child_id = ${bind(childId)}") })
 

--- a/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/occupancy/OccupancyController.kt
@@ -276,7 +276,7 @@ class OccupancyController(
                         unitId,
                     )
                     getAttendanceReservationReport(
-                        db = tx,
+                        tx = tx,
                         start = date,
                         end = date,
                         unitId = unitId,


### PR DESCRIPTION
Korjaa osapäivän poissaolojen käsittelyn Päiväkohtaiset lapsen tulo- ja lähtöajat -raportilla sekä yksikön reealiaikaisen käyttöasteen graafissa.