### PR TITLE
Varoitetaan toisessa yksikössä olevista avoimista kirjauksista

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-calendar-page-base.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-calendar-page-base.ts
@@ -299,6 +299,9 @@ export class UnitStaffAttendancesTable extends Element {
 
 export class StaffAttendanceDetailsModal extends Element {
   openAttendanceWarning = this.findByDataQa(`open-attendance-warning`)
+  openAttendanceInAnotherUnitWarning = this.findByDataQa(
+    'open-attendance-in-another-unit-warning'
+  )
   arrivalTimeInputInfo = this.findByDataQa('arrival-time-input-info')
   continuationAttendance = this.findByDataQa('continuation-attendance')
   newAttendanceButton = this.findByDataQa('new-attendance')

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -563,6 +563,9 @@ describe('Realtime staff attendances', () => {
       await modal.newAttendanceButton.assertDisabled(true)
       await modal.openAttendanceWarning.waitUntilVisible()
     })
+    test('If there is open attendance entry for yesterday in another unit, warning is visible', async () => {
+      // TODO
+    })
   })
 
   describe('Staff count sums in the table', () => {

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -13,13 +13,19 @@ import {
   testDaycare2,
   Fixture,
   uuidv4,
-  familyWithTwoGuardians
+  familyWithTwoGuardians,
+  testDaycare
 } from '../../dev-api/fixtures'
 import {
   createDefaultServiceNeedOptions,
   resetServiceState
 } from '../../generated/api-clients'
-import { DevDaycare, DevEmployee, DevPerson } from '../../generated/api-types'
+import {
+  DevCareArea,
+  DevDaycare,
+  DevEmployee,
+  DevPerson
+} from '../../generated/api-types'
 import { UnitCalendarPage, UnitPage } from '../../pages/employee/units/unit'
 import { waitUntilEqual } from '../../utils'
 import { Page } from '../../utils/page'
@@ -30,6 +36,7 @@ let unitPage: UnitPage
 let calendarPage: UnitCalendarPage
 let child1Fixture: DevPerson
 let child1DaycarePlacementId: UUID
+let careArea: DevCareArea
 let daycare: DevDaycare
 let unitSupervisor: DevEmployee
 let nonGroupStaff: DevEmployee
@@ -45,7 +52,7 @@ beforeEach(async () => {
   await resetServiceState()
 
   await Fixture.family(familyWithTwoGuardians).save()
-  const careArea = await Fixture.careArea(testCareArea2).save()
+  careArea = await Fixture.careArea(testCareArea2).save()
   daycare = await Fixture.daycare({
     ...testDaycare2,
     areaId: careArea.id,
@@ -355,10 +362,16 @@ describe('Realtime staff attendances', () => {
   describe('Details modal', () => {
     let staffAttendances: UnitStaffAttendancesTable
 
-    async function prepareTest({ arrived }: { arrived: HelsinkiDateTime }) {
+    async function prepareTest({
+      arrived,
+      attendedGroupId = groupId
+    }: {
+      arrived: HelsinkiDateTime
+      attendedGroupId?: string
+    }) {
       await Fixture.realtimeStaffAttendance({
         employeeId: groupStaff.id,
-        groupId,
+        groupId: attendedGroupId,
         arrived,
         departed: null
       }).save()
@@ -564,7 +577,25 @@ describe('Realtime staff attendances', () => {
       await modal.openAttendanceWarning.waitUntilVisible()
     })
     test('If there is open attendance entry for yesterday in another unit, warning is visible', async () => {
-      // TODO
+      const anotherDaycare = await Fixture.daycare({
+        ...testDaycare,
+        areaId: careArea.id,
+        enabledPilotFeatures: ['REALTIME_STAFF_ATTENDANCE']
+      }).save()
+
+      const anotherGroupId = uuidv4()
+      await Fixture.daycareGroup({
+        id: anotherGroupId,
+        daycareId: anotherDaycare.id,
+        name: 'Toiset testailijat'
+      }).save()
+      await prepareTest({
+        arrived: mockedToday.subDays(1).toHelsinkiDateTime(LocalTime.of(21, 0)),
+        attendedGroupId: anotherGroupId
+      })
+
+      const modal = await staffAttendances.openDetails(1, mockedToday)
+      await modal.openAttendanceInAnotherUnitWarning.waitUntilVisible()
     })
   })
 

--- a/frontend/src/employee-frontend/components/unit/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/queries.ts
@@ -12,6 +12,7 @@ import {
   getUnitApplications,
   respondToPlacementProposal
 } from '../../generated/api-clients/application'
+import { getOpenAttendances } from '../../generated/api-clients/attendance'
 import {
   createBackupCare,
   updateBackupCare
@@ -89,7 +90,9 @@ export const queryKeys = createQueryKeys('unit', {
   expectedAbsences: (arg: Arg0<typeof getExpectedAbsences>) => [
     'expectedAbsences',
     arg
-  ]
+  ],
+  // TODO do we need include the userId param here somehow?
+  openAttendances: () => ['openAttendances']
 })
 
 export const areaQuery = query({
@@ -263,4 +266,9 @@ export const respondToPlacementProposalMutation = mutation({
     queryKeys.unitApplications(unitId),
     queryKeys.unitNotifications(unitId)
   ]
+})
+
+export const openAttendancesQuery = query({
+  api: getOpenAttendances,
+  queryKey: queryKeys.openAttendances
 })

--- a/frontend/src/employee-frontend/components/unit/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/queries.ts
@@ -12,7 +12,7 @@ import {
   getUnitApplications,
   respondToPlacementProposal
 } from '../../generated/api-clients/application'
-import { getOpenAttendances } from '../../generated/api-clients/attendance'
+import { getOpenGroupAttendances } from '../../generated/api-clients/attendance'
 import {
   createBackupCare,
   updateBackupCare
@@ -91,8 +91,10 @@ export const queryKeys = createQueryKeys('unit', {
     'expectedAbsences',
     arg
   ],
-  // TODO do we need include the userId param here somehow?
-  openAttendances: () => ['openAttendances']
+  openGroupAttendances: (arg: Arg0<typeof getOpenGroupAttendances>) => [
+    'openGroupAttendances',
+    arg
+  ]
 })
 
 export const areaQuery = query({
@@ -269,6 +271,6 @@ export const respondToPlacementProposalMutation = mutation({
 })
 
 export const openAttendancesQuery = query({
-  api: getOpenAttendances,
-  queryKey: queryKeys.openAttendances
+  api: getOpenGroupAttendances,
+  queryKey: queryKeys.openGroupAttendances
 })

--- a/frontend/src/employee-frontend/components/unit/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/queries.ts
@@ -12,7 +12,7 @@ import {
   getUnitApplications,
   respondToPlacementProposal
 } from '../../generated/api-clients/application'
-import { getOpenGroupAttendances } from '../../generated/api-clients/attendance'
+import { getOpenGroupAttendance } from '../../generated/api-clients/attendance'
 import {
   createBackupCare,
   updateBackupCare
@@ -91,8 +91,8 @@ export const queryKeys = createQueryKeys('unit', {
     'expectedAbsences',
     arg
   ],
-  openGroupAttendances: (arg: Arg0<typeof getOpenGroupAttendances>) => [
-    'openGroupAttendances',
+  openGroupAttendance: (arg: Arg0<typeof getOpenGroupAttendance>) => [
+    'openGroupAttendance',
     arg
   ]
 })
@@ -270,7 +270,7 @@ export const respondToPlacementProposalMutation = mutation({
   ]
 })
 
-export const openAttendancesQuery = query({
-  api: getOpenGroupAttendances,
-  queryKey: queryKeys.openGroupAttendances
+export const openAttendanceQuery = query({
+  api: getOpenGroupAttendance,
+  queryKey: queryKeys.openGroupAttendance
 })

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
@@ -82,6 +82,7 @@ interface Props<
   onSave: (body: T[]) => void
   onSuccess: () => void
   onClose: () => void
+  unitId?: string
 }
 
 export interface EditedAttendance {
@@ -119,7 +120,8 @@ function StaffAttendanceDetailsModal<
   validate,
   onSave,
   onSuccess,
-  onClose
+  onClose,
+  unitId
 }: Props<T>) {
   const { i18n } = useTranslation()
 
@@ -349,12 +351,12 @@ function StaffAttendanceDetailsModal<
   )
 
   const openAttendanceResult = useQueryResult(
-    employeeId
-      ? openAttendancesQuery({ userId: employeeId })
-      : constantQuery({ openAttendance: null })
+    employeeId && unitId
+      ? openAttendancesQuery({ userId: employeeId, unitId })
+      : constantQuery({ openGroupAttendance: null })
   )
   const openAttendance = openAttendanceResult.isSuccess
-    ? openAttendanceResult.value.openAttendance
+    ? openAttendanceResult.value.openGroupAttendance
     : null
 
   return (

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
@@ -7,6 +7,7 @@ import initial from 'lodash/initial'
 import last from 'lodash/last'
 import orderBy from 'lodash/orderBy'
 import React, { Fragment, useCallback, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 import DateRange from 'lib-common/date-range'
@@ -19,6 +20,7 @@ import { DaycareGroup } from 'lib-common/generated/api-types/daycare'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
+import { constantQuery, useQueryResult } from 'lib-common/query'
 import { presentInGroup } from 'lib-common/staff-attendance'
 import { UUID } from 'lib-common/types'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
@@ -48,6 +50,7 @@ import { faExclamationTriangle, faPlus, faTrash } from 'lib-icons'
 
 import { useTranslation } from '../../../state/i18n'
 import { errorToInputInfo } from '../../../utils/validation/input-info-helper'
+import { openAttendancesQuery } from '../queries'
 
 export interface ModalAttendance {
   id: UUID
@@ -68,6 +71,7 @@ interface Props<
 > {
   date: LocalDate
   name: string
+  employeeId?: UUID
   staffOccupancyEffectDefault: boolean
   attendances: ModalAttendance[]
   plannedAttendances: ModalPlannedAttendance[]
@@ -105,6 +109,7 @@ function StaffAttendanceDetailsModal<
 >({
   date,
   name,
+  employeeId,
   staffOccupancyEffectDefault,
   attendances,
   plannedAttendances,
@@ -343,6 +348,15 @@ function StaffAttendanceDetailsModal<
     [editState, initialEditState, requestBody]
   )
 
+  const openAttendanceResult = useQueryResult(
+    employeeId
+      ? openAttendancesQuery({ userId: employeeId })
+      : constantQuery({ openAttendance: null })
+  )
+  const openAttendance = openAttendanceResult.isSuccess
+    ? openAttendanceResult.value.openAttendance
+    : null
+
   return (
     <PlainModal margin="auto" data-qa="staff-attendance-details-modal">
       <Content>
@@ -473,6 +487,37 @@ function StaffAttendanceDetailsModal<
           </>
         )}
 
+        {!arrivalWithoutDeparture &&
+          !!openAttendance &&
+          openAttendance.date.isEqualOrBefore(date) && (
+            <FullGridWidth>
+              <FixedSpaceRow
+                justifyContent="left"
+                alignItems="center"
+                spacing="s"
+              >
+                <FontAwesomeIcon
+                  icon={faExclamationTriangle}
+                  color={colors.status.warning}
+                />
+                <div data-qa="open-attendance-in-another-unit-warning">
+                  {i18n.unit.staffAttendance.openAttendanceInAnotherUnitWarning}
+                  <Link
+                    to={`/units/${openAttendance.unitId}/calendar?group=${openAttendance.groupId ? openAttendance.groupId : 'staff'}&date=${openAttendance.date.formatIso()}&mode=week`}
+                  >
+                    {openAttendance.date.formatExotic('EEEEEE d.M.yyyy') +
+                      ' - ' +
+                      openAttendance.unitName}
+                  </Link>
+                  {
+                    i18n.unit.staffAttendance
+                      .openAttendanceInAnotherUnitWarningCont
+                  }
+                </div>
+              </FixedSpaceRow>
+              <Gap size="s" />
+            </FullGridWidth>
+          )}
         <ListGrid rowGap="s" labelWidth="auto">
           {editState.map(
             (

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
@@ -50,7 +50,7 @@ import { faExclamationTriangle, faPlus, faTrash } from 'lib-icons'
 
 import { useTranslation } from '../../../state/i18n'
 import { errorToInputInfo } from '../../../utils/validation/input-info-helper'
-import { openAttendancesQuery } from '../queries'
+import { openAttendanceQuery } from '../queries'
 
 export interface ModalAttendance {
   id: UUID
@@ -352,7 +352,7 @@ function StaffAttendanceDetailsModal<
 
   const openAttendanceResult = useQueryResult(
     employeeId && unitId
-      ? openAttendancesQuery({ userId: employeeId, unitId })
+      ? openAttendanceQuery({ userId: employeeId, unitId })
       : constantQuery({ openGroupAttendance: null })
   )
   const openAttendance = openAttendanceResult.isSuccess

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -310,7 +310,6 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
         : undefined,
     [date, target, unitId]
   )
-
   return target.type === 'employee' ? (
     <StaffAttendanceDetailsModal
       isExternal={false}
@@ -326,6 +325,7 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
       defaultGroupId={defaultGroupId}
       onClose={onClose}
       onSuccess={onSuccess}
+      unitId={unitId}
     />
   ) : (
     <StaffAttendanceDetailsModal

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -318,6 +318,7 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
       staffOccupancyEffectDefault={target.hasOccupancyEffect}
       validate={staffAttendanceValidator(detailsModalConfig)}
       name={detailsModalConfig.name}
+      employeeId={target.employeeId}
       date={detailsModalConfig.date}
       attendances={modalData.attendances}
       plannedAttendances={modalData.plannedAttendances}

--- a/frontend/src/employee-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attendance.ts
@@ -8,34 +8,36 @@ import LocalDate from 'lib-common/local-date'
 import { ExternalAttendanceBody } from 'lib-common/generated/api-types/attendance'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { OpenAttendanceResponse } from 'lib-common/generated/api-types/attendance'
+import { OpenGroupAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { StaffAttendanceBody } from 'lib-common/generated/api-types/attendance'
 import { StaffAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
-import { deserializeJsonOpenAttendanceResponse } from 'lib-common/generated/api-types/attendance'
+import { deserializeJsonOpenGroupAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { deserializeJsonStaffAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { uri } from 'lib-common/uri'
 
 
 /**
-* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.getOpenAttendances
+* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.getOpenGroupAttendances
 */
-export async function getOpenAttendances(
+export async function getOpenGroupAttendances(
   request: {
-    userId: UUID
+    userId: UUID,
+    unitId: UUID
   }
-): Promise<OpenAttendanceResponse> {
+): Promise<OpenGroupAttendanceResponse> {
   const params = createUrlSearchParams(
-    ['userId', request.userId]
+    ['userId', request.userId],
+    ['unitId', request.unitId]
   )
-  const { data: json } = await client.request<JsonOf<OpenAttendanceResponse>>({
+  const { data: json } = await client.request<JsonOf<OpenGroupAttendanceResponse>>({
     url: uri`/employee/staff-attendances/realtime/open-attendences`.toString(),
     method: 'GET',
     params
   })
-  return deserializeJsonOpenAttendanceResponse(json)
+  return deserializeJsonOpenGroupAttendanceResponse(json)
 }
 
 

--- a/frontend/src/employee-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attendance.ts
@@ -8,13 +8,35 @@ import LocalDate from 'lib-common/local-date'
 import { ExternalAttendanceBody } from 'lib-common/generated/api-types/attendance'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { OpenAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { StaffAttendanceBody } from 'lib-common/generated/api-types/attendance'
 import { StaffAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
+import { deserializeJsonOpenAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { deserializeJsonStaffAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { uri } from 'lib-common/uri'
+
+
+/**
+* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.getOpenAttendances
+*/
+export async function getOpenAttendances(
+  request: {
+    userId: UUID
+  }
+): Promise<OpenAttendanceResponse> {
+  const params = createUrlSearchParams(
+    ['userId', request.userId]
+  )
+  const { data: json } = await client.request<JsonOf<OpenAttendanceResponse>>({
+    url: uri`/employee/staff-attendances/realtime/open-attendences`.toString(),
+    method: 'GET',
+    params
+  })
+  return deserializeJsonOpenAttendanceResponse(json)
+}
 
 
 /**

--- a/frontend/src/employee-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attendance.ts
@@ -20,9 +20,9 @@ import { uri } from 'lib-common/uri'
 
 
 /**
-* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.getOpenGroupAttendances
+* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.getOpenGroupAttendance
 */
-export async function getOpenGroupAttendances(
+export async function getOpenGroupAttendance(
   request: {
     userId: UUID,
     unitId: UUID
@@ -33,7 +33,7 @@ export async function getOpenGroupAttendances(
     ['unitId', request.unitId]
   )
   const { data: json } = await client.request<JsonOf<OpenGroupAttendanceResponse>>({
-    url: uri`/employee/staff-attendances/realtime/open-attendences`.toString(),
+    url: uri`/employee/staff-attendances/realtime/open-attendence`.toString(),
     method: 'GET',
     params
   })

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -247,20 +247,20 @@ export interface GroupInfo {
 }
 
 /**
-* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.OpenAttendance
+* Generated from fi.espoo.evaka.attendance.OpenGroupAttendance
 */
-export interface OpenAttendance {
+export interface OpenGroupAttendance {
   date: LocalDate
-  groupId: UUID | null
+  groupId: UUID
   unitId: UUID
   unitName: string
 }
 
 /**
-* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.OpenAttendanceResponse
+* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.OpenGroupAttendanceResponse
 */
-export interface OpenAttendanceResponse {
-  openAttendance: OpenAttendance | null
+export interface OpenGroupAttendanceResponse {
+  openGroupAttendance: OpenGroupAttendance | null
 }
 
 /**
@@ -558,7 +558,7 @@ export function deserializeJsonExternalStaffMember(json: JsonOf<ExternalStaffMem
 }
 
 
-export function deserializeJsonOpenAttendance(json: JsonOf<OpenAttendance>): OpenAttendance {
+export function deserializeJsonOpenGroupAttendance(json: JsonOf<OpenGroupAttendance>): OpenGroupAttendance {
   return {
     ...json,
     date: LocalDate.parseIso(json.date)
@@ -566,10 +566,10 @@ export function deserializeJsonOpenAttendance(json: JsonOf<OpenAttendance>): Ope
 }
 
 
-export function deserializeJsonOpenAttendanceResponse(json: JsonOf<OpenAttendanceResponse>): OpenAttendanceResponse {
+export function deserializeJsonOpenGroupAttendanceResponse(json: JsonOf<OpenGroupAttendanceResponse>): OpenGroupAttendanceResponse {
   return {
     ...json,
-    openAttendance: (json.openAttendance != null) ? deserializeJsonOpenAttendance(json.openAttendance) : null
+    openGroupAttendance: (json.openGroupAttendance != null) ? deserializeJsonOpenGroupAttendance(json.openGroupAttendance) : null
   }
 }
 

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -247,6 +247,23 @@ export interface GroupInfo {
 }
 
 /**
+* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.OpenAttendance
+*/
+export interface OpenAttendance {
+  date: LocalDate
+  groupId: UUID | null
+  unitId: UUID
+  unitName: string
+}
+
+/**
+* Generated from fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.OpenAttendanceResponse
+*/
+export interface OpenAttendanceResponse {
+  openAttendance: OpenAttendance | null
+}
+
+/**
 * Generated from fi.espoo.evaka.attendance.PlannedStaffAttendance
 */
 export interface PlannedStaffAttendance {
@@ -537,6 +554,22 @@ export function deserializeJsonExternalStaffMember(json: JsonOf<ExternalStaffMem
   return {
     ...json,
     arrived: HelsinkiDateTime.parseIso(json.arrived)
+  }
+}
+
+
+export function deserializeJsonOpenAttendance(json: JsonOf<OpenAttendance>): OpenAttendance {
+  return {
+    ...json,
+    date: LocalDate.parseIso(json.date)
+  }
+}
+
+
+export function deserializeJsonOpenAttendanceResponse(json: JsonOf<OpenAttendanceResponse>): OpenAttendanceResponse {
+  return {
+    ...json,
+    openAttendance: (json.openAttendance != null) ? deserializeJsonOpenAttendance(json.openAttendance) : null
   }
 }
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2624,6 +2624,9 @@ export const fi = {
         'Tunteja ei voi laskea, koska päivän kirjauksista puuttuu viimeinen lähtöaika.',
       gapWarning: (gapRange: string) => `Kirjaus puuttuu välillä ${gapRange}`,
       openAttendanceWarning: (arrival: string) => `Avoin kirjaus ${arrival}`,
+      openAttendanceInAnotherUnitWarning: 'Avoin kirjaus ',
+      openAttendanceInAnotherUnitWarningCont:
+        '. Kirjaus on päätettävä ennen uuden lisäystä.',
       personCount: 'Läsnäolleiden yhteismäärä',
       personCountAbbr: 'hlö',
       unlinkOvernight: 'Erota yön yli menevä läsnäolo',

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -472,6 +472,7 @@ enum class Audit(
     StaffAttendanceExternalUpdate,
     StaffOccupancyCoefficientRead,
     StaffOccupancyCoefficientUpsert,
+    StaffOpenAttendanceRead,
     StartingPlacementsReportRead,
     SystemNotificationsSet,
     SystemNotificationsDelete,

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -318,8 +318,8 @@ class RealtimeStaffAttendanceController(private val accessControl: AccessControl
         )
     }
 
-    @GetMapping("/employee/staff-attendances/realtime/open-attendences")
-    fun getOpenGroupAttendances(
+    @GetMapping("/employee/staff-attendances/realtime/open-attendence")
+    fun getOpenGroupAttendance(
         db: Database,
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
@@ -613,9 +613,14 @@ WHERE
     )
 }
 
-fun Database.Read.getOpenAttendancesForEmployee(
-    employeeId: EmployeeId
-): RealtimeStaffAttendanceController.OpenAttendance? =
+data class OpenGroupAttendance(
+    val unitName: String,
+    val unitId: DaycareId,
+    val date: LocalDate,
+    val groupId: GroupId,
+)
+
+fun Database.Read.getOpenGroupAttendancesForEmployee(employeeId: EmployeeId): OpenGroupAttendance? =
     createQuery {
             sql(
                 """
@@ -625,4 +630,4 @@ fun Database.Read.getOpenAttendancesForEmployee(
                 """
             )
         }
-        .exactlyOneOrNull<RealtimeStaffAttendanceController.OpenAttendance>()
+        .exactlyOneOrNull<OpenGroupAttendance>()

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
@@ -612,3 +612,17 @@ WHERE
 """
     )
 }
+
+fun Database.Read.getOpenAttendancesForEmployee(
+    employeeId: EmployeeId
+): RealtimeStaffAttendanceController.OpenAttendance? =
+    createQuery {
+            sql(
+                """
+                SELECT d.name as unit_name, dg.daycare_id as unit_id, sa.arrived::date AS date, sa.group_id
+                FROM staff_attendance_realtime sa JOIN daycare_group dg ON sa.group_id = dg.id JOIN daycare d ON dg.daycare_id = d.id
+                WHERE sa.employee_id = ${bind(employeeId)} AND sa.departed IS NULL
+                """
+            )
+        }
+        .exactlyOneOrNull<RealtimeStaffAttendanceController.OpenAttendance>()


### PR DESCRIPTION
## Ennen tätä muutosta
Jos käyttäjällä oli avoin läsnäolokirjaus toisessa yksikössä, uuden kirjauksen tallennus epäonnistui ilman virheviestiä
## Tämän muutoksen jälkeen
Käyttäjälle näytetään varoitusviesti läsnäolokirjausdialogissa kun valittuna on avoimen kirjauksen päivä tai sitä myöhempi päivä. Varoitusviesti sisältää linkin suoraan k.o. yksikön kalenteriin oikealle päivälle.
<img width="498" alt="image" src="https://github.com/user-attachments/assets/735ee836-be97-433d-95a9-d3b8db243796">

