### PR TITLE
Korjauksia lapsikohtaiset läsnäoloajat -raporttiin

### DIFF
--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -573,42 +573,48 @@ export class PreschoolAbsenceReport {
   }
 }
 
-export class ChildAttendanceReservationReport {
-  constructor(private page: Page) {}
+export class ChildAttendanceReservationByChildReport {
+  startDateInput: DatePicker
+  endDateInput: DatePicker
+  unitSelector: Combobox
+  groupSelector: MultiSelect
+  filterByTime: Checkbox
+  startTimeInput: TextInput
+  endTimeInput: TextInput
+  searchButton: Element
+
+  constructor(private page: Page) {
+    this.startDateInput = new DatePicker(page.findByDataQa('start-date'))
+    this.endDateInput = new DatePicker(page.findByDataQa('end-date'))
+    this.unitSelector = new Combobox(page.findByDataQa('unit-select'))
+    this.groupSelector = new MultiSelect(page.findByDataQa('group-select'))
+    this.filterByTime = new Checkbox(page.findByDataQa('filter-by-time'))
+    this.searchButton = page.findByDataQa('search-button')
+    this.startTimeInput = new TextInput(page.findByDataQa('start-time-filter'))
+    this.endTimeInput = new TextInput(page.findByDataQa('end-time-filter'))
+  }
 
   async setDates(startDate: LocalDate, endDate: LocalDate) {
-    const startDateInput = new DatePicker(this.page.findByDataQa('start-date'))
-    await startDateInput.fill(startDate)
-    const endDateInput = new DatePicker(this.page.findByDataQa('end-date'))
-    await endDateInput.fill(endDate)
+    await this.startDateInput.fill(startDate)
+    await this.endDateInput.fill(endDate)
   }
 
   async endDate(date: LocalDate) {
-    const endDateInput = new DatePicker(this.page.findByDataQa('end-date'))
-    await endDateInput.fill(date)
+    await this.endDateInput.fill(date)
   }
 
   async selectUnit(unitName: string) {
-    const unitSelector = new Combobox(this.page.findByDataQa('unit-select'))
-    await unitSelector.fillAndSelectFirst(unitName)
+    await this.unitSelector.fillAndSelectFirst(unitName)
   }
 
   async selectGroup(groupName: string) {
-    const groupSelector = new MultiSelect(
-      this.page.findByDataQa('group-select')
-    )
-    await groupSelector.fillAndSelectFirst(groupName)
+    await this.groupSelector.fillAndSelectFirst(groupName)
   }
 
   async selectTimeFilter(startTime: string, endTime: string) {
-    const startTimeInput = new TextInput(
-      this.page.findByDataQa('start-time-filter')
-    )
-    const endTimeInput = new TextInput(
-      this.page.findByDataQa('end-time-filter')
-    )
-    await startTimeInput.fill(startTime)
-    await endTimeInput.fill(endTime)
+    await this.filterByTime.check()
+    await this.startTimeInput.fill(startTime)
+    await this.endTimeInput.fill(endTime)
   }
 
   async assertRows(

--- a/frontend/src/e2e-test/specs/5_employee/child-attendance-reservation-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-attendance-reservation-report.spec.ts
@@ -21,7 +21,7 @@ import {
   resetServiceState
 } from '../../generated/api-clients'
 import { DevEmployee, DevPerson } from '../../generated/api-types'
-import { ChildAttendanceReservationReport } from '../../pages/employee/reports'
+import { ChildAttendanceReservationByChildReport } from '../../pages/employee/reports'
 import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
 
@@ -77,10 +77,11 @@ describe('Child attendance reservation report', () => {
     await page.goto(
       `${config.employeeUrl}/reports/attendance-reservation-by-child`
     )
-    const report = new ChildAttendanceReservationReport(page)
+    const report = new ChildAttendanceReservationByChildReport(page)
     await report.setDates(mockedTime, mockedTime)
     await report.selectUnit(testDaycare.name)
     await report.selectGroup(testDaycareGroup.name)
+    await report.searchButton.click()
     await report.assertRows([
       {
         childName: `${child.lastName} ${child.firstName}`,
@@ -95,6 +96,7 @@ describe('Child attendance reservation report', () => {
     ])
 
     await report.selectTimeFilter('00:00', '09:59')
+    await report.searchButton.click()
     await report.assertRows([
       {
         childName: `${child.lastName} ${child.firstName}`,
@@ -104,6 +106,7 @@ describe('Child attendance reservation report', () => {
     ])
 
     await report.selectTimeFilter('14:00', '23:59')
+    await report.searchButton.click()
     await report.assertRows([
       {
         childName: `${child.lastName} ${child.firstName}`,

--- a/frontend/src/employee-frontend/components/reports/AttendanceReservationByChild.tsx
+++ b/frontend/src/employee-frontend/components/reports/AttendanceReservationByChild.tsx
@@ -2,69 +2,74 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { groupBy } from 'lodash/fp'
+import sortBy from 'lodash/sortBy'
+import unzip from 'lodash/unzip'
 import React, { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { DefaultTheme, useTheme } from 'styled-components'
+import { useTheme } from 'styled-components'
 
 import FiniteDateRange from 'lib-common/finite-date-range'
-import { AttendanceReservationReportByChildRow } from 'lib-common/generated/api-types/reports'
+import {
+  AttendanceReservationReportByChildBody,
+  AttendanceReservationReportByChildGroup,
+  AttendanceReservationReportByChildItem
+} from 'lib-common/generated/api-types/reports'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { constantQuery, useQueryResult } from 'lib-common/query'
+import TimeRange from 'lib-common/time-range'
 import { UUID } from 'lib-common/types'
 import { useUniqueId } from 'lib-common/utils/useUniqueId'
 import { StaticChip } from 'lib-components/atoms/Chip'
-import Loader from 'lib-components/atoms/Loader'
 import Title from 'lib-components/atoms/Title'
+import { Button } from 'lib-components/atoms/buttons/Button'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
-import InputField from 'lib-components/atoms/form/InputField'
+import Checkbox from 'lib-components/atoms/form/Checkbox'
 import MultiSelect from 'lib-components/atoms/form/MultiSelect'
+import TimeInput from 'lib-components/atoms/form/TimeInput'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { Tbody, Th, Thead, Tr } from 'lib-components/layout/Table'
 import DateRangePicker from 'lib-components/molecules/date-picker/DateRangePicker'
-import { Translations } from 'lib-customizations/employee'
 
-import ReportDownload from '../../components/reports/ReportDownload'
-import { useTranslation } from '../../state/i18n'
+import { Translations, useTranslation } from '../../state/i18n'
+import { formatName } from '../../utils'
+import { renderResult } from '../async-rendering'
 import { FlexRow } from '../common/styled/containers'
 import { unitGroupsQuery, unitsQuery } from '../unit/queries'
 
 import { AttendanceReservationReportTd } from './AttendanceReservation'
+import ReportDownload from './ReportDownload'
 import { FilterLabel, FilterRow, TableScrollable } from './common'
-import { attendanceReservationReportByUnitAndChildQuery } from './queries'
+import { attendanceReservationReportByChildQuery } from './queries'
 
-interface AttendanceReservationReportFilters {
-  range: FiniteDateRange
-  groupIds: UUID[]
-}
+// lodash's `unzip` is equivalent to a transpose operation on an array of
+// arrays. It forces the arrays to the same length and adds undefineds for
+// missing items. This is not reflected by unzip's type, so a type annotation
+// is needed.
+const transpose: <T>(arr: T[][]) => (T | undefined)[][] = unzip
 
 const dateFormat = 'EEEEEE d.M.'
-const timeFormat = 'HH:mm'
 
 type OrderBy = 'start' | 'end'
 const orderByOptions: OrderBy[] = ['start', 'end']
 
 export default React.memo(function AttendanceReservationByChild() {
   const { lang, i18n } = useTranslation()
-  const theme = useTheme()
 
   const [unitId, setUnitId] = useState<UUID | null>(null)
-  const [filters, setFilters] = useState<AttendanceReservationReportFilters>(
-    () => {
-      const defaultDate = LocalDate.todayInSystemTz().addWeeks(1)
-
-      return {
-        range: new FiniteDateRange(
-          defaultDate.startOfWeek(),
-          defaultDate.endOfWeek()
-        ),
-        groupIds: []
-      }
-    }
-  )
+  const [range, setRange] = useState(() => {
+    const defaultDate = LocalDate.todayInSystemTz().addWeeks(1)
+    return new FiniteDateRange(
+      defaultDate.startOfWeek(),
+      defaultDate.endOfWeek()
+    )
+  })
+  const [groupIds, setGroupIds] = useState<UUID[]>([])
   const [orderBy, setOrderBy] = useState<OrderBy>('start')
 
+  const [filterByTime, setFilterByTime] = useState(false)
   const [startTime, setStartTime] = useState<string>('00:00')
   const [endTime, setEndTime] = useState<string>('23:59')
 
@@ -72,56 +77,44 @@ export default React.memo(function AttendanceReservationByChild() {
   const groups = useQueryResult(
     unitId ? unitGroupsQuery({ daycareId: unitId }) : constantQuery([])
   )
-  const report = useQueryResult(
-    queryOrDefault(
-      attendanceReservationReportByUnitAndChildQuery,
-      []
-    )(
-      unitId !== null
-        ? {
-            unitId,
-            start: filters.range.start,
-            end: filters.range.end,
-            groupIds: filters.groupIds
-          }
+
+  const [activeParams, setActiveParams] = useState<{
+    body: AttendanceReservationReportByChildBody
+    orderBy: OrderBy
+    timeFilter: TimeRange | undefined
+  } | null>(null)
+
+  const search = () => {
+    const timeFilterValid =
+      !filterByTime ||
+      validateTimeFilter(startTime, endTime, i18n) === undefined
+    const timeFilter =
+      filterByTime && timeFilterValid
+        ? new TimeRange(LocalTime.parse(startTime), LocalTime.parse(endTime))
         : undefined
-    )
-  )
 
-  const parsedStartTime = useMemo(
-    () => LocalTime.tryParse(startTime),
-    [startTime]
-  )
-  const parsedEndTime = useMemo(() => LocalTime.tryParse(endTime), [endTime])
-
-  const rowReservationTimeIsWithinTimeFilter = (
-    row: AttendanceReservationReportByChildRow
-  ) => {
-    return (
-      parsedStartTime &&
-      parsedEndTime &&
-      ((row.reservationStartTime !== null &&
-        row.reservationStartTime.isEqualOrAfter(parsedStartTime) &&
-        row.reservationStartTime.isEqualOrBefore(parsedEndTime)) ||
-        (row.reservationEndTime !== null &&
-          row.reservationEndTime.isEqualOrAfter(parsedStartTime) &&
-          row.reservationEndTime.isEqualOrBefore(parsedEndTime)))
-    )
+    if (unitId && timeFilterValid) {
+      setActiveParams({
+        body: { unitId, range, groupIds },
+        orderBy,
+        timeFilter
+      })
+    }
   }
-
-  const sortedRows = report
-    .map<AttendanceReservationReportByChildRow[]>((rows) =>
-      rows.sort(
-        (a, b) =>
-          compareByGroup(a, b, lang) ||
-          compareByDate(a, b) ||
-          (orderBy === 'start' ? compareByStartTime(a, b) : 0) ||
-          (orderBy === 'end' ? compareByEndTime(a, b) : 0) ||
-          compareByChildName(a, b, lang)
-      )
-    )
-    .getOrElse<AttendanceReservationReportByChildRow[]>([])
-    .filter((row) => rowReservationTimeIsWithinTimeFilter(row))
+  const reportData = useQueryResult(
+    activeParams
+      ? attendanceReservationReportByChildQuery({ body: activeParams.body })
+      : constantQuery([])
+  )
+  const report = useMemo(
+    () =>
+      reportData.map((groups) =>
+        groups.map((group) =>
+          toTableData(group, orderBy, activeParams?.timeFilter)
+        )
+      ),
+    [activeParams?.timeFilter, orderBy, reportData]
+  )
 
   const sortedUnits = units
     .map((data) => data.sort((a, b) => a.name.localeCompare(b.name, lang)))
@@ -130,93 +123,7 @@ export default React.memo(function AttendanceReservationByChild() {
     .map((data) => data.sort((a, b) => a.name.localeCompare(b.name, lang)))
     .getOrElse([])
 
-  const dates = sortedRows
-    .map((row) => row.date)
-    .filter(
-      (value, index, array) =>
-        array.findIndex((date) => date.isEqual(value)) === index
-    )
-    .sort((a, b) => a.compareTo(b))
-
-  const rowsByGroup = sortedRows.reduce<
-    Record<string, (AttendanceReservationReportByChildRow | undefined)[][]>
-  >((data, row) => {
-    const groupKey = row.groupId ?? 'ungrouped'
-    const rows = data[groupKey] ?? []
-    const columnIndex = dates.findIndex((date) => date.isEqual(row.date))
-    const rowIndex = rows.findIndex((row) => row[columnIndex] === undefined)
-    if (rowIndex !== -1) {
-      rows[rowIndex][columnIndex] = row
-    } else {
-      const columns = []
-      dates.forEach(() => columns.push(undefined))
-      columns[columnIndex] = row
-      rows.push(columns)
-    }
-    data[groupKey] = rows
-    return data
-  }, {})
-  const entries = Object.entries(rowsByGroup)
-  const showGroupTitle = entries.length > 1
-
-  const tableComponents = entries.map(([groupId, rows]) => {
-    const groupName = showGroupTitle
-      ? sortedGroups.find((group) => group.id === groupId)?.name ??
-        i18n.reports.attendanceReservationByChild.ungrouped
-      : undefined
-    return (
-      <TableScrollable
-        key={groupId}
-        data-qa="report-attendance-reservation-by-child-table"
-      >
-        <caption>{groupName}</caption>
-        <Thead sticky>
-          <Tr>
-            {dates.map((date) => (
-              <Th key={date.formatIso()} colSpan={3} align="center">
-                {date.format(dateFormat, lang)}
-              </Th>
-            ))}
-          </Tr>
-          <Tr>
-            {dates.map((date) => (
-              <React.Fragment key={date.formatIso()}>
-                <Th>{i18n.reports.common.child}</Th>
-                <Th>
-                  {
-                    i18n.reports.attendanceReservationByChild
-                      .reservationStartTime
-                  }
-                </Th>
-                <Th>
-                  {i18n.reports.attendanceReservationByChild.reservationEndTime}
-                </Th>
-              </React.Fragment>
-            ))}
-          </Tr>
-        </Thead>
-        <Tbody>{getTableBody(rows, dates, i18n, theme)}</Tbody>
-      </TableScrollable>
-    )
-  })
-
   const periodAriaId = useUniqueId()
-
-  const validateTimeFilter = (
-    startTime: string,
-    endTime: string
-  ): { status: 'warning'; text: string } | undefined => {
-    const startTimeLocalTime = LocalTime.tryParse(startTime)
-    const endTimeLocalTime = LocalTime.tryParse(endTime)
-    return !startTimeLocalTime ||
-      !endTimeLocalTime ||
-      endTimeLocalTime.isEqualOrBefore(startTimeLocalTime)
-      ? {
-          status: 'warning',
-          text: i18n.reports.attendanceReservationByChild.timeFilterError
-        }
-      : undefined
-  }
 
   return (
     <Container>
@@ -232,14 +139,11 @@ export default React.memo(function AttendanceReservationByChild() {
           </FilterLabel>
           <FlexRow>
             <DateRangePicker
-              start={filters.range.start}
-              end={filters.range.end}
+              start={range.start}
+              end={range.end}
               onChange={(start, end) => {
                 if (start !== null && end !== null) {
-                  setFilters({
-                    ...filters,
-                    range: new FiniteDateRange(start, end)
-                  })
+                  setRange(new FiniteDateRange(start, end))
                 }
               }}
               locale={lang}
@@ -254,7 +158,7 @@ export default React.memo(function AttendanceReservationByChild() {
               items={sortedUnits}
               onChange={(selectedItem) => {
                 setUnitId(selectedItem !== null ? selectedItem.id : null)
-                setFilters({ ...filters, groupIds: [] })
+                setGroupIds([])
               }}
               selectedItem={
                 sortedUnits.find((unit) => unit.id === unitId) ?? null
@@ -271,13 +175,12 @@ export default React.memo(function AttendanceReservationByChild() {
             <MultiSelect
               options={sortedGroups}
               onChange={(selectedItems) =>
-                setFilters({
-                  ...filters,
-                  groupIds: selectedItems.map((selectedItem) => selectedItem.id)
-                })
+                setGroupIds(
+                  selectedItems.map((selectedItem) => selectedItem.id)
+                )
               }
               value={sortedGroups.filter((group) =>
-                filters.groupIds.includes(group.id)
+                groupIds.includes(group.id)
               )}
               getOptionId={(group) => group.id}
               getOptionLabel={(group) => group.name}
@@ -311,150 +214,306 @@ export default React.memo(function AttendanceReservationByChild() {
             {i18n.reports.common.clock}
           </FilterLabel>
           <FlexRow>
-            <InputField
-              value={startTime}
-              onChange={(time) => setStartTime(time)}
-              hideErrorsBeforeTouched={true}
-              width="xs"
-              data-qa="start-time-filter"
-              info={validateTimeFilter(startTime, endTime)}
+            <Checkbox
+              label={i18n.reports.attendanceReservationByChild.filterByTime}
+              checked={filterByTime}
+              onChange={setFilterByTime}
+              data-qa="filter-by-time"
             />
-            <InputField
-              value={endTime}
-              onChange={(time) => setEndTime(time)}
-              hideErrorsBeforeTouched={true}
-              width="xs"
-              data-qa="end-time-filter"
-              info={validateTimeFilter(startTime, endTime)}
-            />
+            {filterByTime && (
+              <>
+                <TimeInput
+                  value={startTime}
+                  onChange={(time) => setStartTime(time)}
+                  hideErrorsBeforeTouched={true}
+                  data-qa="start-time-filter"
+                  info={validateTimeFilter(startTime, endTime, i18n)}
+                />
+                <TimeInput
+                  value={endTime}
+                  onChange={(time) => setEndTime(time)}
+                  hideErrorsBeforeTouched={true}
+                  data-qa="end-time-filter"
+                  info={validateTimeFilter(startTime, endTime, i18n)}
+                />
+              </>
+            )}
           </FlexRow>
         </FilterRow>
+        <FilterRow>
+          <Button
+            primary
+            text={i18n.common.search}
+            onClick={search}
+            data-qa="search-button"
+          />
+        </FilterRow>
 
-        {unitId !== null && report.isLoading && <Loader />}
-        {report.isFailure && <span>{i18n.common.loadingFailed}</span>}
-        {report.isSuccess && (
-          <>
-            <ReportDownload
-              data={sortedRows.map((row) => ({
-                ...row,
-                childName: getChildName(row),
-                date: row.date.format(),
-                absenceType:
-                  row.absenceType !== null
-                    ? i18n.absences.absenceTypes[row.absenceType]
-                    : '',
-                reservationStartTime:
-                  row.absenceType === null
-                    ? row.reservationStartTime?.format(timeFormat)
-                    : '',
-                reservationEndTime:
-                  row.absenceType === null
-                    ? row.reservationEndTime?.format(timeFormat)
-                    : ''
-              }))}
-              headers={[
-                ...(filters.groupIds.length > 0
-                  ? [
-                      {
-                        label: i18n.reports.common.groupName,
-                        key: 'groupName' as const
-                      }
-                    ]
-                  : []),
-                {
-                  label: i18n.reports.common.child,
-                  key: 'childName'
-                },
-                {
-                  label: i18n.reports.common.date,
-                  key: 'date'
-                },
-                {
-                  label: i18n.reports.attendanceReservationByChild.absenceType,
-                  key: 'absenceType'
-                },
-                {
-                  label:
-                    i18n.reports.attendanceReservationByChild
-                      .reservationStartTime,
-                  key: 'reservationStartTime'
-                },
-                {
-                  label:
-                    i18n.reports.attendanceReservationByChild
-                      .reservationEndTime,
-                  key: 'reservationEndTime'
-                }
-              ]}
-              filename={`${i18n.reports.attendanceReservationByChild.title} ${
-                sortedUnits.find((unit) => unit.id === unitId)?.name ?? ''
-              } ${filters.range.start.formatIso()}-${filters.range.end.formatIso()}.csv`}
-            />
-            {tableComponents}
-          </>
-        )}
+        {renderResult(report, (report) => {
+          if (activeParams === null || report === null) return null
+          return (
+            <>
+              <ReportDownload
+                data={report.flatMap(({ groupName, rows }) =>
+                  transpose(rows).flatMap((row) =>
+                    row.flatMap((item) =>
+                      item
+                        ? {
+                            ...(groupName !== null ? { groupName } : {}),
+                            childName: `${item.childLastName} ${item.childFirstName}`,
+                            date: item.date.format(),
+                            fullDayAbsence: item.fullDayAbsence ? 'Poissa' : '',
+                            reservationStartTime: item.fullDayAbsence
+                              ? ''
+                              : item.reservation?.start.format() ?? '-',
+                            reservationEndTime: item.fullDayAbsence
+                              ? ''
+                              : item.reservation?.end.format() ?? '-'
+                          }
+                        : []
+                    )
+                  )
+                )}
+                headers={[
+                  ...(report.length > 0 && report[0].groupId !== null
+                    ? [
+                        {
+                          label: i18n.reports.common.groupName,
+                          key: 'groupName' as const
+                        }
+                      ]
+                    : []),
+                  {
+                    label: i18n.reports.common.child,
+                    key: 'childName'
+                  },
+                  {
+                    label: i18n.reports.common.date,
+                    key: 'date'
+                  },
+                  {
+                    label: i18n.reports.attendanceReservationByChild.absence,
+                    key: 'fullDayAbsence'
+                  },
+                  {
+                    label:
+                      i18n.reports.attendanceReservationByChild
+                        .reservationStartTime,
+                    key: 'reservationStartTime'
+                  },
+                  {
+                    label:
+                      i18n.reports.attendanceReservationByChild
+                        .reservationEndTime,
+                    key: 'reservationEndTime'
+                  }
+                ]}
+                filename={`${i18n.reports.attendanceReservationByChild.title} ${
+                  sortedUnits.find((unit) => unit.id === unitId)?.name ?? ''
+                } ${activeParams.body.range.start.formatIso()}-${activeParams.body.range.end.formatIso()}.csv`}
+              />
+              {report.map(({ groupId, groupName, headings, rows }) => (
+                <GroupData
+                  key={groupId}
+                  groupName={groupName}
+                  headings={headings}
+                  rows={rows}
+                />
+              ))}
+            </>
+          )
+        })}
       </ContentArea>
     </Container>
   )
 })
 
-const getTableBody = (
-  rows: (AttendanceReservationReportByChildRow | undefined)[][],
-  dates: LocalDate[],
-  i18n: Translations,
-  theme: DefaultTheme
-) => {
-  const components: React.ReactNode[] = []
-  rows.forEach((row, rowIndex) => {
-    components.push(
-      <Tr key={`row-${rowIndex}`} data-qa="child-attendance-reservation-row">
-        {getTableRow(row, rowIndex, dates, i18n, theme)}
-      </Tr>
-    )
-  })
-  return components
+function validateTimeFilter(
+  startTime: string,
+  endTime: string,
+  i18n: Translations
+): { status: 'warning'; text: string } | undefined {
+  const startTimeLocalTime = LocalTime.tryParse(startTime)
+  const endTimeLocalTime = LocalTime.tryParse(endTime)
+  return !startTimeLocalTime ||
+    !endTimeLocalTime ||
+    endTimeLocalTime.isEqualOrBefore(startTimeLocalTime)
+    ? {
+        status: 'warning',
+        text: i18n.reports.attendanceReservationByChild.timeFilterError
+      }
+    : undefined
 }
 
-const getTableRow = (
-  row: (AttendanceReservationReportByChildRow | undefined)[],
-  rowIndex: number,
-  dates: LocalDate[],
-  i18n: Translations,
-  theme: DefaultTheme
-) => {
-  const components: React.ReactNode[] = []
-  const isFirstRow = rowIndex === 0
-  row.forEach((column, columnIndex) => {
-    const date = dates[columnIndex]
-    const isToday = date.isToday()
-    const isFuture = date.isAfter(LocalDate.todayInHelsinkiTz())
-    components.push(
-      <React.Fragment key={`row-${rowIndex}-column-${columnIndex}`}>
-        <AttendanceReservationReportTd
-          borderEdge={[
-            'left',
-            ...(isToday && isFirstRow ? (['top'] as const) : [])
-          ]}
-          isToday={isToday}
-          isFuture={isFuture}
-        >
-          {column && (
-            <>
-              {column.isBackupCare && (
+function toTableData(
+  group: AttendanceReservationReportByChildGroup,
+  orderBy: OrderBy,
+  timeFilter: TimeRange | undefined
+): {
+  groupId: string | null
+  groupName: string | null
+  headings: LocalDate[]
+  rows: (AttendanceReservationReportByChildItem | undefined)[][]
+} {
+  const filtered =
+    timeFilter !== undefined
+      ? group.items.filter(
+          (item) =>
+            item.reservation !== null &&
+            timeFilter.intersection(item.reservation) !== undefined
+        )
+      : group.items
+  const sorted = sortBy(filtered, [
+    (item) => item.date.formatIso(),
+    (item) => {
+      if (item.fullDayAbsence) return 'z' // absences last
+      if (!item.reservation) return 'y' // missing reservation second last
+      if (orderBy === 'start') return item.reservation.start.formatIso()
+      return item.reservation.end.formatIso()
+    }
+  ])
+
+  // We want a table like this:
+  //
+  // | date1 | date2 | date3 |
+  // +-------+-------+-------+
+  // | item1 | item2 | item3 |
+  // | item1 |       | item3 |
+
+  // Currently we have:
+  //
+  // sorted = [item1, item1, item2, item3, item3]
+
+  const grouped = groupBy((item) => item.date.formatIso(), sorted)
+  // grouped = {
+  //   date1: [item1, item1],
+  //   date2: [item2],
+  //   date3: [item3, item3]
+  // }
+
+  const values = Object.values(grouped)
+  // values = [
+  //   [item1, item1]
+  //   [item2]
+  //   [item3, item3]
+  // ]
+
+  const rows = transpose(values)
+  // rows = [
+  //   [item1, item2, item3]
+  //   [item1, undef, item3]
+  // ]
+
+  const headings = Object.keys(grouped).map((date) => LocalDate.parseIso(date))
+  // headings = [date1, date2, date3]
+
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+    headings,
+    rows
+  }
+}
+
+const GroupData = React.memo(function GroupData({
+  groupName,
+  headings,
+  rows
+}: {
+  groupName: string | null
+  headings: LocalDate[]
+  rows: (AttendanceReservationReportByChildItem | undefined)[][]
+}) {
+  const { lang, i18n } = useTranslation()
+  return (
+    <TableScrollable>
+      {groupName !== null && <caption>{groupName}</caption>}
+      <Thead sticky>
+        <Tr>
+          {headings.map((date) => (
+            <Th key={date.formatIso()} colSpan={3} align="center">
+              {date.format(dateFormat, lang)}
+            </Th>
+          ))}
+        </Tr>
+        <Tr>
+          {headings.map((date) => (
+            <React.Fragment key={date.formatIso()}>
+              <Th>{i18n.reports.common.child}</Th>
+              <Th>
+                {i18n.reports.attendanceReservationByChild.reservationStartTime}
+              </Th>
+              <Th>
+                {i18n.reports.attendanceReservationByChild.reservationEndTime}
+              </Th>
+            </React.Fragment>
+          ))}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {rows.map((row, index) => (
+          <Row key={index} items={row} isFirstRow={index === 0} />
+        ))}
+      </Tbody>
+    </TableScrollable>
+  )
+})
+
+const Row = React.memo(function Row({
+  items,
+  isFirstRow
+}: {
+  items: (AttendanceReservationReportByChildItem | undefined)[]
+  isFirstRow: boolean
+}) {
+  const { i18n } = useTranslation()
+  const theme = useTheme()
+  const today = LocalDate.todayInHelsinkiTz()
+
+  return (
+    <Tr data-qa="child-attendance-reservation-row">
+      {items.map((item, index) => {
+        if (!item) {
+          return (
+            <AttendanceReservationReportTd
+              key={index}
+              borderEdge={['left' as const, 'right' as const]}
+              isToday={false}
+              isFuture={false}
+              colSpan={3}
+            />
+          )
+        }
+
+        const isToday = item.date.isEqual(today)
+        const isFuture = item.date.isAfter(today)
+
+        return (
+          <React.Fragment key={item.date.formatIso()}>
+            <AttendanceReservationReportTd
+              borderEdge={[
+                'left' as const,
+                ...(isToday && isFirstRow ? (['top'] as const) : [])
+              ]}
+              isToday={isToday}
+              isFuture={isFuture}
+            >
+              {item.backupCare && (
                 <StaticChip color={theme.colors.main.m1}>v</StaticChip>
               )}
               <Link
-                to={`/child-information/${column.childId}`}
+                to={`/child-information/${item.childId}`}
                 data-qa="child-name"
               >
-                {getChildName(column)}
+                {formatName(
+                  item.childFirstName,
+                  item.childLastName,
+                  i18n,
+                  true
+                )}
               </Link>
-            </>
-          )}
-        </AttendanceReservationReportTd>
-        {column !== undefined && (
-          <React.Fragment>
-            {column.absenceType !== null && (
+            </AttendanceReservationReportTd>
+            {item.fullDayAbsence ? (
               <AttendanceReservationReportTd
                 borderEdge={[
                   'right',
@@ -464,18 +523,17 @@ const getTableRow = (
                 isFuture={isFuture}
                 colSpan={2}
               >
-                {i18n.absences.absenceTypes[column.absenceType]}
+                {i18n.reports.attendanceReservationByChild.absence}
               </AttendanceReservationReportTd>
-            )}
-            {column.absenceType === null && (
-              <React.Fragment>
+            ) : item.reservation ? (
+              <>
                 <AttendanceReservationReportTd
                   borderEdge={isToday && isFirstRow ? ['top'] : []}
                   isToday={isToday}
                   isFuture={isFuture}
                   data-qa="attendance-reservation-start"
                 >
-                  {column.reservationStartTime?.format(timeFormat)}
+                  {item.reservation.start.format()}
                 </AttendanceReservationReportTd>
                 <AttendanceReservationReportTd
                   borderEdge={[
@@ -486,68 +544,25 @@ const getTableRow = (
                   isFuture={isFuture}
                   data-qa="attendance-reservation-end"
                 >
-                  {column.reservationEndTime?.format(timeFormat)}
+                  {item.reservation.end.format()}
                 </AttendanceReservationReportTd>
-              </React.Fragment>
+              </>
+            ) : (
+              <AttendanceReservationReportTd
+                borderEdge={[
+                  'right',
+                  ...(isToday && isFirstRow ? (['top'] as const) : [])
+                ]}
+                isToday={isToday}
+                isFuture={isFuture}
+                colSpan={2}
+              >
+                {i18n.reports.attendanceReservationByChild.noReservation}
+              </AttendanceReservationReportTd>
             )}
           </React.Fragment>
-        )}
-        {column === undefined && (
-          <AttendanceReservationReportTd
-            borderEdge={[
-              'right',
-              ...(isToday && isFirstRow ? (['top'] as const) : [])
-            ]}
-            isToday={isToday}
-            isFuture={isFuture}
-            colSpan={2}
-          />
-        )}
-      </React.Fragment>
-    )
-  })
-  return components
-}
-
-const compareByGroup = (
-  a: AttendanceReservationReportByChildRow,
-  b: AttendanceReservationReportByChildRow,
-  lang: string
-) => (a.groupName ?? '').localeCompare(b.groupName ?? '', lang)
-
-const compareByDate = (
-  a: AttendanceReservationReportByChildRow,
-  b: AttendanceReservationReportByChildRow
-) => a.date.compareTo(b.date)
-
-const compareByStartTime = (
-  a: AttendanceReservationReportByChildRow,
-  b: AttendanceReservationReportByChildRow
-) => compareByTime(a.reservationStartTime, b.reservationStartTime)
-
-const compareByEndTime = (
-  a: AttendanceReservationReportByChildRow,
-  b: AttendanceReservationReportByChildRow
-) => compareByTime(a.reservationEndTime, b.reservationEndTime)
-
-const compareByTime = (a: LocalTime | null, b: LocalTime | null) => {
-  if (a !== null && b !== null) {
-    return a.compareTo(b)
-  }
-  if (a !== null) {
-    return -1
-  }
-  if (b !== null) {
-    return 1
-  }
-  return 0
-}
-
-const compareByChildName = (
-  a: AttendanceReservationReportByChildRow,
-  b: AttendanceReservationReportByChildRow,
-  lang: string
-) => getChildName(a).localeCompare(getChildName(b), lang)
-
-const getChildName = (row: AttendanceReservationReportByChildRow) =>
-  `${row.childLastName} ${row.childFirstName}`.trim()
+        )
+      })}
+    </Tr>
+  )
+})

--- a/frontend/src/employee-frontend/components/reports/AttendanceReservationByChild.tsx
+++ b/frontend/src/employee-frontend/components/reports/AttendanceReservationByChild.tsx
@@ -6,14 +6,12 @@ import React, { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { DefaultTheme, useTheme } from 'styled-components'
 
-import { Loading, wrapResult } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { AttendanceReservationReportByChildRow } from 'lib-common/generated/api-types/reports'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { constantQuery, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
-import { useApiState } from 'lib-common/utils/useRestApi'
 import { useUniqueId } from 'lib-common/utils/useUniqueId'
 import { StaticChip } from 'lib-components/atoms/Chip'
 import Loader from 'lib-components/atoms/Loader'
@@ -28,17 +26,13 @@ import DateRangePicker from 'lib-components/molecules/date-picker/DateRangePicke
 import { Translations } from 'lib-customizations/employee'
 
 import ReportDownload from '../../components/reports/ReportDownload'
-import { getAttendanceReservationReportByUnitAndChild } from '../../generated/api-clients/reports'
 import { useTranslation } from '../../state/i18n'
 import { FlexRow } from '../common/styled/containers'
 import { unitGroupsQuery, unitsQuery } from '../unit/queries'
 
 import { AttendanceReservationReportTd } from './AttendanceReservation'
 import { FilterLabel, FilterRow, TableScrollable } from './common'
-
-const getAttendanceReservationReportByUnitAndChildResult = wrapResult(
-  getAttendanceReservationReportByUnitAndChild
-)
+import { attendanceReservationReportByUnitAndChildQuery } from './queries'
 
 interface AttendanceReservationReportFilters {
   range: FiniteDateRange
@@ -78,19 +72,20 @@ export default React.memo(function AttendanceReservationByChild() {
   const groups = useQueryResult(
     unitId ? unitGroupsQuery({ daycareId: unitId }) : constantQuery([])
   )
-  const [report] = useApiState(
-    () =>
+  const report = useQueryResult(
+    queryOrDefault(
+      attendanceReservationReportByUnitAndChildQuery,
+      []
+    )(
       unitId !== null
-        ? getAttendanceReservationReportByUnitAndChildResult({
+        ? {
             unitId,
             start: filters.range.start,
             end: filters.range.end,
             groupIds: filters.groupIds
-          })
-        : Promise.resolve(
-            Loading.of<AttendanceReservationReportByChildRow[]>()
-          ),
-    [unitId, filters]
+          }
+        : undefined
+    )
   )
 
   const parsedStartTime = useMemo(

--- a/frontend/src/employee-frontend/components/reports/queries.ts
+++ b/frontend/src/employee-frontend/components/reports/queries.ts
@@ -6,6 +6,7 @@ import { mutation, query } from 'lib-common/query'
 import { Arg0, UUID } from 'lib-common/types'
 
 import {
+  getAttendanceReservationReportByUnitAndChild,
   getChildAttendanceReport,
   getCustomerFeesReport,
   getExceededServiceNeedReportRows,
@@ -36,6 +37,9 @@ import { createQueryKeys } from '../../query'
 import { OccupancyReportFilters } from './Occupancies'
 
 const queryKeys = createQueryKeys('reports', {
+  attendanceReservationByUnitAndChild: (
+    filters: Arg0<typeof getAttendanceReservationReportByUnitAndChild>
+  ) => ['attendanceReservationByUnitAndChild', filters],
   childAttendance: (filters: Arg0<typeof getChildAttendanceReport>) => [
     'childAttendance',
     filters
@@ -79,6 +83,11 @@ const queryKeys = createQueryKeys('reports', {
     'preschoolAbsenceReport',
     filters
   ]
+})
+
+export const attendanceReservationReportByUnitAndChildQuery = query({
+  api: getAttendanceReservationReportByUnitAndChild,
+  queryKey: queryKeys.attendanceReservationByUnitAndChild
 })
 
 export const childAttendanceReportQuery = query({

--- a/frontend/src/employee-frontend/components/reports/queries.ts
+++ b/frontend/src/employee-frontend/components/reports/queries.ts
@@ -6,7 +6,7 @@ import { mutation, query } from 'lib-common/query'
 import { Arg0, UUID } from 'lib-common/types'
 
 import {
-  getAttendanceReservationReportByUnitAndChild,
+  getAttendanceReservationReportByChild,
   getChildAttendanceReport,
   getCustomerFeesReport,
   getExceededServiceNeedReportRows,
@@ -37,8 +37,8 @@ import { createQueryKeys } from '../../query'
 import { OccupancyReportFilters } from './Occupancies'
 
 const queryKeys = createQueryKeys('reports', {
-  attendanceReservationByUnitAndChild: (
-    filters: Arg0<typeof getAttendanceReservationReportByUnitAndChild>
+  attendanceReservationByChild: (
+    filters: Arg0<typeof getAttendanceReservationReportByChild>
   ) => ['attendanceReservationByUnitAndChild', filters],
   childAttendance: (filters: Arg0<typeof getChildAttendanceReport>) => [
     'childAttendance',
@@ -85,9 +85,9 @@ const queryKeys = createQueryKeys('reports', {
   ]
 })
 
-export const attendanceReservationReportByUnitAndChildQuery = query({
-  api: getAttendanceReservationReportByUnitAndChild,
-  queryKey: queryKeys.attendanceReservationByUnitAndChild
+export const attendanceReservationReportByChildQuery = query({
+  api: getAttendanceReservationReportByChild,
+  queryKey: queryKeys.attendanceReservationByChild
 })
 
 export const childAttendanceReportQuery = query({

--- a/frontend/src/employee-frontend/generated/api-clients/reports.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reports.ts
@@ -10,7 +10,8 @@ import { ApplicationsReportRow } from 'lib-common/generated/api-types/reports'
 import { AssistanceNeedDecisionsReportRow } from 'lib-common/generated/api-types/reports'
 import { AssistanceNeedsAndActionsReport } from 'lib-common/generated/api-types/reports'
 import { AssistanceNeedsAndActionsReportByChild } from 'lib-common/generated/api-types/reports'
-import { AttendanceReservationReportByChildRow } from 'lib-common/generated/api-types/reports'
+import { AttendanceReservationReportByChildBody } from 'lib-common/generated/api-types/reports'
+import { AttendanceReservationReportByChildGroup } from 'lib-common/generated/api-types/reports'
 import { AttendanceReservationReportRow } from 'lib-common/generated/api-types/reports'
 import { CareType } from 'lib-common/generated/api-types/daycare'
 import { ChildAgeLanguageReportRow } from 'lib-common/generated/api-types/reports'
@@ -29,6 +30,7 @@ import { FamilyDaycareMealReportResult } from 'lib-common/generated/api-types/re
 import { FinanceDecisionType } from 'lib-common/generated/api-types/invoicing'
 import { FuturePreschoolersReportRow } from 'lib-common/generated/api-types/reports'
 import { InvoiceReport } from 'lib-common/generated/api-types/reports'
+import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { ManualDuplicationReportRow } from 'lib-common/generated/api-types/reports'
 import { ManualDuplicationReportViewMode } from 'lib-common/generated/api-types/reports'
@@ -62,7 +64,7 @@ import { VardaUnitErrorReportRow } from 'lib-common/generated/api-types/reports'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonAssistanceNeedDecisionsReportRow } from 'lib-common/generated/api-types/reports'
-import { deserializeJsonAttendanceReservationReportByChildRow } from 'lib-common/generated/api-types/reports'
+import { deserializeJsonAttendanceReservationReportByChildGroup } from 'lib-common/generated/api-types/reports'
 import { deserializeJsonAttendanceReservationReportRow } from 'lib-common/generated/api-types/reports'
 import { deserializeJsonChildAttendanceReportRow } from 'lib-common/generated/api-types/reports'
 import { deserializeJsonDuplicatePeopleReportRow } from 'lib-common/generated/api-types/reports'
@@ -171,6 +173,23 @@ export async function getAssistanceNeedsAndActionsReportByChild(
 
 
 /**
+* Generated from fi.espoo.evaka.reports.AttendanceReservationReportController.getAttendanceReservationReportByChild
+*/
+export async function getAttendanceReservationReportByChild(
+  request: {
+    body: AttendanceReservationReportByChildBody
+  }
+): Promise<AttendanceReservationReportByChildGroup[]> {
+  const { data: json } = await client.request<JsonOf<AttendanceReservationReportByChildGroup[]>>({
+    url: uri`/employee/reports/attendance-reservation/by-child`.toString(),
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<AttendanceReservationReportByChildBody>
+  })
+  return json.map(e => deserializeJsonAttendanceReservationReportByChildGroup(e))
+}
+
+
+/**
 * Generated from fi.espoo.evaka.reports.AttendanceReservationReportController.getAttendanceReservationReportByUnit
 */
 export async function getAttendanceReservationReportByUnit(
@@ -192,31 +211,6 @@ export async function getAttendanceReservationReportByUnit(
     params
   })
   return json.map(e => deserializeJsonAttendanceReservationReportRow(e))
-}
-
-
-/**
-* Generated from fi.espoo.evaka.reports.AttendanceReservationReportController.getAttendanceReservationReportByUnitAndChild
-*/
-export async function getAttendanceReservationReportByUnitAndChild(
-  request: {
-    unitId: UUID,
-    start: LocalDate,
-    end: LocalDate,
-    groupIds?: UUID[] | null
-  }
-): Promise<AttendanceReservationReportByChildRow[]> {
-  const params = createUrlSearchParams(
-    ['start', request.start.formatIso()],
-    ['end', request.end.formatIso()],
-    ...(request.groupIds?.map((e): [string, string | null | undefined] => ['groupIds', e]) ?? [])
-  )
-  const { data: json } = await client.request<JsonOf<AttendanceReservationReportByChildRow[]>>({
-    url: uri`/employee/reports/attendance-reservation/${request.unitId}/by-child`.toString(),
-    method: 'GET',
-    params
-  })
-  return json.map(e => deserializeJsonAttendanceReservationReportByChildRow(e))
 }
 
 

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -7,7 +7,6 @@
 import FiniteDateRange from '../../finite-date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
-import LocalTime from '../../local-time'
 import TimeInterval from '../../time-interval'
 import TimeRange from '../../time-range'
 import { AbsenceType } from './absence'
@@ -115,21 +114,34 @@ export interface AssistanceNeedsAndActionsReportRowByChild {
 }
 
 /**
-* Generated from fi.espoo.evaka.reports.AttendanceReservationReportByChildRow
+* Generated from fi.espoo.evaka.reports.AttendanceReservationReportController.AttendanceReservationReportByChildBody
 */
-export interface AttendanceReservationReportByChildRow {
-  absenceId: UUID | null
-  absenceType: AbsenceType | null
+export interface AttendanceReservationReportByChildBody {
+  groupIds: UUID[]
+  range: FiniteDateRange
+  unitId: UUID
+}
+
+/**
+* Generated from fi.espoo.evaka.reports.AttendanceReservationReportByChildGroup
+*/
+export interface AttendanceReservationReportByChildGroup {
+  groupId: UUID | null
+  groupName: string | null
+  items: AttendanceReservationReportByChildItem[]
+}
+
+/**
+* Generated from fi.espoo.evaka.reports.AttendanceReservationReportByChildItem
+*/
+export interface AttendanceReservationReportByChildItem {
+  backupCare: boolean
   childFirstName: string
   childId: UUID
   childLastName: string
   date: LocalDate
-  groupId: UUID | null
-  groupName: string | null
-  isBackupCare: boolean
-  reservationEndTime: LocalTime | null
-  reservationId: UUID | null
-  reservationStartTime: LocalTime | null
+  fullDayAbsence: boolean
+  reservation: TimeRange | null
 }
 
 /**
@@ -957,12 +969,27 @@ export function deserializeJsonAssistanceNeedDecisionsReportRow(json: JsonOf<Ass
 }
 
 
-export function deserializeJsonAttendanceReservationReportByChildRow(json: JsonOf<AttendanceReservationReportByChildRow>): AttendanceReservationReportByChildRow {
+export function deserializeJsonAttendanceReservationReportByChildBody(json: JsonOf<AttendanceReservationReportByChildBody>): AttendanceReservationReportByChildBody {
+  return {
+    ...json,
+    range: FiniteDateRange.parseJson(json.range)
+  }
+}
+
+
+export function deserializeJsonAttendanceReservationReportByChildGroup(json: JsonOf<AttendanceReservationReportByChildGroup>): AttendanceReservationReportByChildGroup {
+  return {
+    ...json,
+    items: json.items.map(e => deserializeJsonAttendanceReservationReportByChildItem(e))
+  }
+}
+
+
+export function deserializeJsonAttendanceReservationReportByChildItem(json: JsonOf<AttendanceReservationReportByChildItem>): AttendanceReservationReportByChildItem {
   return {
     ...json,
     date: LocalDate.parseIso(json.date),
-    reservationEndTime: (json.reservationEndTime != null) ? LocalTime.parseIso(json.reservationEndTime) : null,
-    reservationStartTime: (json.reservationStartTime != null) ? LocalTime.parseIso(json.reservationStartTime) : null
+    reservation: (json.reservation != null) ? TimeRange.parseJson(json.reservation) : null
   }
 }
 

--- a/frontend/src/lib-common/time-range-endpoint.ts
+++ b/frontend/src/lib-common/time-range-endpoint.ts
@@ -39,6 +39,14 @@ namespace TimeRangeEndpoint {
       return new End(this.__inner)
     }
 
+    format(pattern = 'HH:mm'): string {
+      return this.__inner.format(pattern)
+    }
+
+    formatIso(): string {
+      return this.__inner.formatIso()
+    }
+
     /** @deprecated Use the range operations of TimeRange instead */
     asLocalTime(): LocalTime {
       return this.__inner
@@ -79,6 +87,14 @@ namespace TimeRangeEndpoint {
 
     asEnd(): End {
       return this
+    }
+
+    format(pattern = 'HH:mm'): string {
+      return this.__inner.format(pattern)
+    }
+
+    formatIso(): string {
+      return this.__inner.formatIso()
     }
 
     /** @deprecated Use the range operations of TimeRange instead */

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3584,7 +3584,9 @@ export const fi = {
         start: 'Tuloaika',
         end: 'Lähtöaika'
       },
-      absenceType: 'Poissaolo',
+      absence: 'Poissaolo',
+      noReservation: 'Varaus puuttuu',
+      filterByTime: 'Suodata ajan perusteella',
       reservationStartTime: 'Tulo',
       reservationEndTime: 'Lähtö',
       timeFilterError: 'Virhe'

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AttendanceReservationReportController.kt
@@ -4,18 +4,15 @@
 
 package fi.espoo.evaka.reports
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
-import fi.espoo.evaka.absence.AbsenceType
 import fi.espoo.evaka.absence.getAbsencesOfChildrenByRange
 import fi.espoo.evaka.dailyservicetimes.getDailyServiceTimesForChildren
 import fi.espoo.evaka.daycare.CareType
 import fi.espoo.evaka.daycare.getDaycare
 import fi.espoo.evaka.occupancy.familyUnitPlacementCoefficient
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.shared.AbsenceId
-import fi.espoo.evaka.shared.AttendanceReservationId
+import fi.espoo.evaka.serviceneed.ShiftCareType
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.GroupId
@@ -26,6 +23,7 @@ import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.HelsinkiDateTimeRange
+import fi.espoo.evaka.shared.domain.TimeRange
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import java.math.BigDecimal
@@ -36,6 +34,8 @@ import java.time.Period
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
@@ -91,50 +91,48 @@ class AttendanceReservationReportController(private val accessControl: AccessCon
             }
     }
 
-    @GetMapping(
-        "/reports/attendance-reservation/{unitId}/by-child", // deprecated
-        "/employee/reports/attendance-reservation/{unitId}/by-child",
+    data class AttendanceReservationReportByChildBody(
+        val range: FiniteDateRange,
+        val unitId: DaycareId,
+        val groupIds: List<GroupId>,
     )
-    fun getAttendanceReservationReportByUnitAndChild(
+
+    @PostMapping("/employee/reports/attendance-reservation/by-child")
+    fun getAttendanceReservationReportByChild(
         db: Database,
         clock: EvakaClock,
         user: AuthenticatedUser.Employee,
-        @PathVariable unitId: DaycareId,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) start: LocalDate,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) end: LocalDate,
-        @RequestParam groupIds: List<GroupId>?,
-    ): List<AttendanceReservationReportByChildRow> {
-        return db.connect { dbc ->
+        @RequestBody body: AttendanceReservationReportByChildBody,
+    ): List<AttendanceReservationReportByChildGroup> =
+        db.connect { dbc ->
                 dbc.read { tx ->
                     accessControl.requirePermissionFor(
                         tx,
                         user,
                         clock,
                         Action.Unit.READ_ATTENDANCE_RESERVATION_REPORT,
-                        unitId,
+                        body.unitId,
                     )
                     tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
-                    tx.getAttendanceReservationReportByChild(
-                        start,
-                        end,
-                        unitId,
-                        groupIds?.ifEmpty { null },
+                    getAttendanceReservationReportByChild(
+                        tx,
+                        body.range,
+                        body.unitId,
+                        body.groupIds.ifEmpty { null },
                     )
                 }
             }
             .also {
                 Audit.AttendanceReservationReportRead.log(
-                    targetId = AuditId(unitId),
+                    targetId = AuditId(body.unitId),
                     meta =
                         mapOf(
-                            "groupIds" to groupIds,
-                            "start" to start,
-                            "end" to end,
-                            "count" to it.size,
+                            "groupIds" to body.groupIds,
+                            "start" to body.range.start,
+                            "end" to body.range.end,
                         ),
                 )
             }
-    }
 }
 
 private data class PlacementInfoRow(
@@ -145,6 +143,7 @@ private data class PlacementInfoRow(
     val placementType: PlacementType,
     val occupancyCoefficientUnder: Double,
     val occupancyCoefficientOver: Double,
+    val backupCare: Boolean,
 )
 
 private fun Database.Read.getPlacementInfo(
@@ -167,7 +166,8 @@ SELECT
     dg.name AS group_name,
     pl.type AS placement_type,
     default_sno.occupancy_coefficient AS occupancy_coefficient_over, 
-    default_sno.occupancy_coefficient_under_3y AS occupancy_coefficient_under
+    default_sno.occupancy_coefficient_under_3y AS occupancy_coefficient_under,
+    false AS backup_care
 FROM dates
 JOIN placement pl ON daterange(pl.start_date, pl.end_date, '[]') @> dates.date
 LEFT JOIN daycare_group_placement dgp on pl.id = dgp.daycare_placement_id AND daterange(dgp.start_date, dgp.end_date, '[]') @> dates.date
@@ -179,7 +179,7 @@ AND NOT EXISTS(
     FROM backup_care bc
     WHERE bc.child_id = pl.child_id AND daterange(bc.start_date, bc.end_date, '[]') @> dates.date
 )
-UNION
+UNION ALL
 SELECT 
     dates.date, 
     bc.child_id,
@@ -187,7 +187,8 @@ SELECT
     dg.name AS group_name,
     pl.type AS placement_type,
     default_sno.occupancy_coefficient AS occupancy_coefficient_over, 
-    default_sno.occupancy_coefficient_under_3y AS occupancy_coefficient_under
+    default_sno.occupancy_coefficient_under_3y AS occupancy_coefficient_under,
+    true AS backup_care
 FROM dates
 JOIN backup_care bc ON daterange(bc.start_date, bc.end_date, '[]') @> dates.date
 JOIN placement pl ON daterange(pl.start_date, pl.end_date, '[]') @> dates.date AND pl.child_id = bc.child_id
@@ -200,16 +201,21 @@ WHERE bc.unit_id = ${bind(unitId)} AND (${bind(groupIds)}::uuid[] IS NULL OR dg.
         .toList<PlacementInfoRow>()
 }
 
-private data class ChildRow(val childId: ChildId, val dateOfBirth: LocalDate)
+private data class ChildRow(
+    val childId: ChildId,
+    val dateOfBirth: LocalDate,
+    val lastName: String,
+    val firstName: String,
+)
 
 private fun Database.Read.getChildInfo(children: Set<ChildId>): List<ChildRow> {
     return createQuery {
             sql(
                 """
-SELECT p.id as child_id, p.date_of_birth
+SELECT p.id as child_id, p.date_of_birth, p.last_name, p.first_name
 FROM person p
 WHERE p.id = ANY(${bind(children)})
-    """
+"""
             )
         }
         .toList<ChildRow>()
@@ -218,6 +224,7 @@ WHERE p.id = ANY(${bind(children)})
 private data class ServiceNeedRow(
     val range: FiniteDateRange,
     val childId: ChildId,
+    val shiftCare: ShiftCareType,
     val occupancyCoefficientUnder: Double,
     val occupancyCoefficientOver: Double,
 )
@@ -233,6 +240,7 @@ private fun Database.Read.getServiceNeeds(
 SELECT
     pl.child_id,
     daterange(sn.start_date, sn.end_date, '[]') * daterange(${bind(start)}, ${bind(end)}, '[]') as range,
+    sn.shift_care,
     sno.occupancy_coefficient_under_3y AS occupancy_coefficient_under,
     sno.occupancy_coefficient AS occupancy_coefficient_over
 FROM service_need sn
@@ -451,66 +459,144 @@ fun getAttendanceReservationReport(
         }
 }
 
-private fun Database.Read.getAttendanceReservationReportByChild(
-    start: LocalDate,
-    end: LocalDate,
+private fun getAttendanceReservationReportByChild(
+    tx: Database.Read,
+    range: FiniteDateRange,
     unitId: DaycareId,
     groupIds: List<GroupId>?,
-): List<AttendanceReservationReportByChildRow> {
-    return createQuery {
-            sql(
-                """
-WITH
-dates AS (SELECT generate_series::date AS date FROM generate_series(${bind(start)}, ${bind(end)}, interval '1 day')),
-children AS (
-  SELECT
-    g.id AS group_id, g.name AS group_name,
-    date, p.id, p.last_name, p.first_name, bc.id IS NOT NULL AS is_backup_care
-  FROM dates date
-  JOIN placement pl ON date BETWEEN pl.start_date AND pl.end_date
-  JOIN person p ON p.id = pl.child_id
-  LEFT JOIN daycare_group_placement dgp ON dgp.daycare_placement_id = pl.id AND date BETWEEN dgp.start_date AND dgp.end_date
-  LEFT JOIN backup_care bc ON bc.child_id = p.id AND date BETWEEN bc.start_date AND bc.end_date
-  JOIN daycare u ON u.id = coalesce(bc.unit_id, pl.unit_id)
-  LEFT JOIN daycare_group g ON g.daycare_id = u.id AND g.id = coalesce(bc.group_id, dgp.daycare_group_id)
-  WHERE u.id = ${bind(unitId)}
-    AND (${bind(groupIds)}::uuid[] IS NULL OR g.id = ANY(${bind(groupIds)}))
-    AND extract(isodow FROM date) = ANY(coalesce(u.shift_care_operation_days, u.operation_days))
-)
-SELECT
-  ${if (groupIds != null) "c.group_id, c.group_name" else "NULL AS group_id, NULL as group_name"},
-  c.date,
-  c.id AS child_id,
-  c.last_name AS child_last_name,
-  c.first_name AS child_first_name,
-  c.is_backup_care,
-  a.id AS absence_id,
-  a.absence_type,
-  r.id AS reservation_id,
-  COALESCE(r.start_time, (daily_service_time_for_date(c.date, c.id)).start) AS reservation_start_time,
-  COALESCE(r.end_time, (daily_service_time_for_date(c.date, c.id)).end) AS reservation_end_time
-FROM children c
-LEFT JOIN absence a ON a.child_id = c.id AND a.date = c.date
-LEFT JOIN attendance_reservation r ON r.child_id = c.id AND r.date = c.date AND r.start_time IS NOT NULL AND r.end_time IS NOT NULL
-"""
-            )
+): List<AttendanceReservationReportByChildGroup> {
+    val daycare = tx.getDaycare(unitId)!!
+
+    val placementStuff = tx.getPlacementInfo(range.start, range.end, unitId, groupIds)
+    val allChildren = placementStuff.map { it.childId }.toSet()
+    val childInfoMap = tx.getChildInfo(allChildren).associateBy { it.childId }
+    val serviceNeedsMap =
+        tx.getServiceNeeds(range.start, range.end, allChildren).groupBy { it.childId }
+    val reservationsMap = tx.getReservations(range, allChildren)
+    val absences =
+        tx.getAbsencesOfChildrenByRange(allChildren, range.asDateRange())
+            .groupBy { it.childId }
+            .mapValues { (_, absences) ->
+                absences.groupBy({ it.date }, { it.category }).mapValues { it.value.toSet() }
+            }
+    val serviceTimesMap = tx.getDailyServiceTimesForChildren(allChildren.toSet())
+
+    val rows =
+        placementStuff.flatMap { placementInfo ->
+            val serviceNeed =
+                serviceNeedsMap[placementInfo.childId]?.firstOrNull {
+                    it.range.includes(placementInfo.date)
+                }
+            val operationDays =
+                daycare.shiftCareOperationDays.takeIf {
+                    serviceNeed != null && serviceNeed.shiftCare != ShiftCareType.NONE
+                } ?: daycare.operationDays
+            if (!operationDays.contains(placementInfo.date.dayOfWeek.value)) {
+                return@flatMap emptyList()
+            }
+
+            val reservations =
+                (reservationsMap[placementInfo.childId] ?: emptyList())
+                    .filter { it.start.toLocalDate() == placementInfo.date }
+                    .sortedBy { it.start }
+                    .map { TimeRange(it.start.toLocalTime(), it.end.toLocalTime()) }
+            val serviceTimes =
+                serviceTimesMap[placementInfo.childId]
+                    ?.firstOrNull { it.validityPeriod.includes(placementInfo.date) }
+                    ?.getTimesOnDate(placementInfo.date)
+            val absenceCategories =
+                absences[placementInfo.childId]?.get(placementInfo.date) ?: emptySet()
+            val fullDayAbsence =
+                absenceCategories == placementInfo.placementType.absenceCategories()
+
+            val entry = { reservation: TimeRange?, absent: Boolean ->
+                AttendanceReservationByChildEntry(
+                    childId = placementInfo.childId,
+                    groupId = placementInfo.groupId,
+                    groupName = placementInfo.groupName,
+                    date = placementInfo.date,
+                    reservation = reservation,
+                    fullDayAbsence = absent,
+                    backupCare = placementInfo.backupCare,
+                )
+            }
+            if (fullDayAbsence) {
+                listOf(entry(null, true))
+            } else {
+                val effectiveReservations = reservations.ifEmpty { listOfNotNull(serviceTimes) }
+                if (effectiveReservations.isEmpty()) {
+                    listOf(entry(null, false))
+                } else {
+                    effectiveReservations.map { entry(it, false) }
+                }
+            }
         }
-        .toList<AttendanceReservationReportByChildRow>()
+
+    return if (groupIds == null) {
+        // Whole unit as one "group"
+        listOf(
+            AttendanceReservationReportByChildGroup(
+                groupId = null,
+                groupName = null,
+                items = toItems(rows, childInfoMap),
+            )
+        )
+    } else {
+        rows
+            .groupBy { it.groupId }
+            .map { (groupId, rowsOfGroup) ->
+                AttendanceReservationReportByChildGroup(
+                    groupId = groupId,
+                    groupName = rowsOfGroup.firstOrNull()?.groupName,
+                    items = toItems(rowsOfGroup, childInfoMap),
+                )
+            }
+            .sortedBy { it.groupName }
+    }
 }
 
-data class AttendanceReservationReportByChildRow(
+private data class AttendanceReservationByChildEntry(
+    val childId: ChildId,
     val groupId: GroupId?,
     val groupName: String?,
+    val date: LocalDate,
+    val reservation: TimeRange?,
+    val fullDayAbsence: Boolean,
+    val backupCare: Boolean,
+)
+
+private fun toItems(
+    rows: List<AttendanceReservationByChildEntry>,
+    childInfoMap: Map<ChildId, ChildRow>,
+): List<AttendanceReservationReportByChildItem> =
+    rows
+        .map { row ->
+            val childInfo = childInfoMap[row.childId]!!
+            AttendanceReservationReportByChildItem(
+                childId = row.childId,
+                childFirstName = childInfo.firstName,
+                childLastName = childInfo.lastName,
+                date = row.date,
+                reservation = row.reservation,
+                fullDayAbsence = row.fullDayAbsence,
+                backupCare = row.backupCare,
+            )
+        }
+        .sortedWith(compareBy({ it.date }, { it.childLastName }, { it.childFirstName }))
+
+data class AttendanceReservationReportByChildGroup(
+    // `groupId` and `groupName` will be null if the report covers the whole unit
+    val groupId: GroupId?,
+    val groupName: String?,
+    val items: List<AttendanceReservationReportByChildItem>,
+)
+
+data class AttendanceReservationReportByChildItem(
     val date: LocalDate,
     val childId: ChildId,
     val childLastName: String,
     val childFirstName: String,
-    val isBackupCare: Boolean,
-    val absenceId: AbsenceId?,
-    val absenceType: AbsenceType?,
-    val reservationId: AttendanceReservationId?,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-    val reservationStartTime: LocalTime?,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-    val reservationEndTime: LocalTime?,
+    val reservation: TimeRange?,
+    val fullDayAbsence: Boolean,
+    val backupCare: Boolean,
 )


### PR DESCRIPTION
- Näytetään myös poissaolevat lapset ja lapset ilman varauksia
- Näytetään vain tulossa olevat lapset jos kellonaikasuodatus on päällä
- Näytetään oikein lapset joilla on osapäivän poissaolo
- Lisätty Hae-nappi josta varsinainen raportin haku tehdään