### PR TITLE
MultiSelect-komponentin yhteensopivuus selaimen automaattikäännöksen kanssa

### DIFF
--- a/frontend/src/lib-components/atoms/form/MultiSelect.tsx
+++ b/frontend/src/lib-components/atoms/form/MultiSelect.tsx
@@ -50,9 +50,25 @@ function MultiSelect<T>({
 }: MultiSelectProps<T>) {
   const { colors } = useTheme()
 
+  // If MsEdge's translation feature is active and react-select uses aria live
+  // messaging, the React app crashes when the dropdown menu is closed. Because
+  // of this we disable aria live messaging when MsEdge's translation feature is
+  // active.
+  // https://github.com/JedWatson/react-select/issues/5816
+  const msEdgeTranslationActive = !!document.querySelector('*[_msttexthash]')
+  const ariaLiveMessages = msEdgeTranslationActive
+    ? {
+        guidance: () => '',
+        onChange: () => '',
+        onFilter: () => '',
+        onFocus: () => ''
+      }
+    : undefined
+
   return (
     <div data-qa={props['data-qa']} className="multi-select">
       <ReactSelect
+        ariaLiveMessages={ariaLiveMessages}
         styles={{
           menu: (base) => ({
             ...base,


### PR DESCRIPTION
## Ennen tätä muutosta
https://github.com/user-attachments/assets/04c72327-1543-4934-961a-ffbab9768396

Ms Edge selaimen automaattikäännösominaisuutta käyttäessä koko front-end sovellus kaatui kun MultiSelect:in drop-down suljetaan.

## Tämän muutoksen jälkeen
Kun Ms Edgen automaattikäännosominaisuuden käyttö havaitaan, MultiSelect käyttää tyhjiä aria live viestejä joka workaroundaa [react-selectin ongelman](https://github.com/JedWatson/react-select/issues/5816)