### PR TITLE
Lähetetään hetuttomat lapset Vardaan eri tavalla

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/new/VardaUpdaterIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/new/VardaUpdaterIntegrationTest.kt
@@ -2595,7 +2595,7 @@ class VardaUpdaterIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `haeHenkilo is used for children without ssn`() {
+    fun `children without ssn are sent`() {
         val child = DevPerson(ssn = null, ophPersonOid = "ophPersonOid")
 
         db.transaction { tx ->
@@ -2609,8 +2609,8 @@ class VardaUpdaterIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             VardaUpdater(DateRange(LocalDate.of(2019, 1, 1), null), "organizerOid", "sourceSystem")
 
         class TestReadClient : FailEveryOperation() {
-            override fun haeHenkilo(
-                body: VardaReadClient.HaeHenkiloRequest
+            override fun getOrCreateHenkilo(
+                body: VardaReadClient.GetOrCreateHenkiloRequest
             ): VardaReadClient.HenkiloResponse =
                 VardaReadClient.HenkiloResponse(
                     url = URI.create("henkilo"),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/new/VardaUpdaterIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/varda/new/VardaUpdaterIntegrationTest.kt
@@ -2861,12 +2861,6 @@ class VardaUpdaterIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
 }
 
 open class FailEveryOperation : VardaReadClient {
-    override fun haeHenkilo(
-        body: VardaReadClient.HaeHenkiloRequest
-    ): VardaReadClient.HenkiloResponse {
-        throw NotImplementedError()
-    }
-
     override fun getOrCreateHenkilo(
         body: VardaReadClient.GetOrCreateHenkiloRequest
     ): VardaReadClient.HenkiloResponse {

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaClient.kt
@@ -30,23 +30,6 @@ private fun maskName(name: String): String =
 
 interface VardaReadClient {
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    data class HaeHenkiloRequest(
-        val henkilotunnus: String? = null,
-        val henkilo_oid: String? = null,
-    ) {
-        init {
-            check(henkilotunnus != null || henkilo_oid != null) {
-                "Both params henkilotunnus and henkilo_oid must not be null"
-            }
-        }
-
-        override fun toString(): String =
-            "HaeHenkiloRequest(henkilotunnus=${maskHenkilotunnus(henkilotunnus)}, henkilo_oid=$henkilo_oid)"
-    }
-
-    fun haeHenkilo(body: HaeHenkiloRequest): HenkiloResponse
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     data class GetOrCreateHenkiloRequest(
         val etunimet: String,
         val sukunimi: String,
@@ -252,10 +235,6 @@ class VardaClient(
 ) : VardaReadClient, VardaWriteClient, VardaUnitClient {
     private var token: String? = null
     private val baseUrl = vardaBaseUrl.ensureTrailingSlash()
-
-    override fun haeHenkilo(
-        body: VardaReadClient.HaeHenkiloRequest
-    ): VardaReadClient.HenkiloResponse = post(baseUrl.resolve("v1/hae-henkilo/"), body)
 
     override fun getOrCreateHenkilo(
         body: VardaReadClient.GetOrCreateHenkiloRequest

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/new/VardaUpdateServiceNew.kt
@@ -344,26 +344,16 @@ class VardaUpdater(
 
     private fun getVardaState(client: VardaReadClient, evakaHenkilo: Henkilo): VardaHenkiloNode {
         val henkilo =
-            if (evakaHenkilo.henkilotunnus != null) {
-                // Get or create henkilo if they have a henkilotunnus. Varda validates the name of
-                // the person, and in this case the names are probably correct since eVaka got them
-                // from VTJ.
-                client.getOrCreateHenkilo(
-                    VardaReadClient.GetOrCreateHenkiloRequest(
-                        etunimet = evakaHenkilo.etunimet,
-                        sukunimi = evakaHenkilo.sukunimi,
-                        // Avoid sending both henkilotunnus and henkilo_oid (error code HE004)
-                        henkilotunnus = evakaHenkilo.henkilotunnus,
-                        henkilo_oid = null,
-                    )
+            client.getOrCreateHenkilo(
+                VardaReadClient.GetOrCreateHenkiloRequest(
+                    etunimet = evakaHenkilo.etunimet,
+                    sukunimi = evakaHenkilo.sukunimi,
+                    // Avoid sending both henkilotunnus and henkilo_oid (error code HE004)
+                    henkilotunnus = evakaHenkilo.henkilotunnus,
+                    henkilo_oid =
+                        evakaHenkilo.henkilo_oid.takeIf { evakaHenkilo.henkilotunnus == null },
                 )
-            } else {
-                // The hae-henkilo endpoint is deprecated and limited to 500 requests/day, so only
-                // use it as a fallback if the child doesn't have a henkilotunnus.
-                client.haeHenkilo(
-                    VardaReadClient.HaeHenkiloRequest(henkilo_oid = evakaHenkilo.henkilo_oid)
-                )
-            }
+            )
         return VardaHenkiloNode(
             henkilo = henkilo,
             lapset =


### PR DESCRIPTION
Hetuttomat lapset pitää luoda Vardaan käsin eVakan ulkopuolella, ja näin saatu OPH OID kopioida eVakassa lapsen tietoihin. Tähän mennessä eVakan Varda-integraatio on sitten löytänyt hetuttoman lapsen tiedot Vardan `POST /v1/hae-henkilo/`-rajapintaa käyttäen ja voinut sitä kautta saadun "kahvan" perusteella lähettää lapsen tiedot Vardaan.

`POST /v1/hae-henkilo/` ei jostain syystä enää löydä tällä tavoin luotuja lapsia, joten käytetään tästedes `POST /v1/henkilot/`-rajapintaa. Kyseinen rajapinta vaatii hetun tai OID:n lisäksi henkilön nimen, mutta vaikuttaa siltä että nimen ei tarvitse täsmätä Vardassa olevaan nimeen kun OID on annettu, joten nimen muuttuminen ei aiheuta Varda-viennin epäonnistumista.