### PR TITLE
Poistaa esiopetuksen poissaoloraportilta tulevaisuuden poissaolot

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/preschool-absence-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/preschool-absence-report.spec.ts
@@ -55,9 +55,22 @@ beforeEach(async () => {
     date: mockedToday,
     childId: child.id
   }).save()
+  await Fixture.absence({
+    absenceType: 'SICKLEAVE',
+    absenceCategory: 'NONBILLABLE',
+    date: mockedToday.addDays(1), // future absence is not included
+    childId: child.id
+  }).save()
   await Fixture.childAttendance({
     childId: child.id,
     date: mockedToday.subDays(1),
+    arrived: LocalTime.of(8, 0),
+    departed: LocalTime.of(12, 30),
+    unitId: unit.id
+  }).save()
+  await Fixture.childAttendance({
+    childId: child.id,
+    date: mockedToday.addDays(1), // future attendance is not included
     arrived: LocalTime.of(8, 0),
     departed: LocalTime.of(12, 30),
     unitId: unit.id

--- a/frontend/src/employee-frontend/components/reports/PreschoolAbsenceReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/PreschoolAbsenceReport.tsx
@@ -210,10 +210,11 @@ const PreschoolAbsenceGrid = ({
 }) => {
   const { i18n } = useTranslation()
 
+  const today = LocalDate.todayInHelsinkiTz()
   const reportResult = useQueryResult(
     preschoolAbsenceReportQuery({
       termStart: term.start,
-      termEnd: term.end,
+      termEnd: term.end.isAfter(today) ? today : term.end,
       unitId: daycare.id,
       groupId: groupId ?? null
     })


### PR DESCRIPTION
Kyseisellä raportilla ainoastaan toteuma kiinnostaa, ei suunnitelma.