### PR TITLE
Näytetään tulotiedon päättymispäivä tuloselvitykset-listassa, versio 2

### DIFF
--- a/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
@@ -65,6 +65,7 @@ export class FeeDecisionsPage {
   #sendFeeDecisionsButton: AsyncButton
   #openDecisionHandlerSelectModalButton: AsyncButton
   #firstFeeDecisionRow: Element
+
   constructor(private readonly page: Page) {
     this.#feeDecisionListPage = page.findByDataQa('fee-decisions-page')
     this.#navigateBackButton = page.findByDataQa('navigate-back')
@@ -137,6 +138,7 @@ export class FeeDecisionDetailsPage {
   #decisionHandler: Element
   #openDecisionHandlerSelectModalButton: AsyncButton
   #childIncome: ElementCollection
+
   constructor(private readonly page: Page) {
     this.#partnerName = page.findByDataQa('partner')
     this.#headOfFamily = page.findByDataQa('head-of-family')
@@ -186,6 +188,7 @@ export class ValueDecisionsPage {
   #sendValueDecisionsButton: AsyncButton
   #openDecisionHandlerSelectModalButton: AsyncButton
   #firstValueDecisionRow: Element
+
   constructor(private readonly page: Page) {
     this.#fromDateInput = new DatePickerDeprecated(
       page.findByDataQa('value-decisions-start-date')
@@ -270,6 +273,7 @@ export class ValueDecisionDetailsPage {
   #sendDecisionButton: Element
   #openDecisionHandlerSelectModalButton: AsyncButton
   #childIncome: ElementCollection
+
   constructor(private readonly page: Page) {
     this.#partnerName = page.findByDataQa('partner')
     this.#headOfFamily = page.findByDataQa('head-of-family')
@@ -321,6 +325,7 @@ export class FinanceDecisionHandlerSelectModal {
   #decisionHandlerSelect: Select
   #decisionHandlerSelectModalResolveBtn: AsyncButton
   #decisionHandlerSelectModalRejectBtn: AsyncButton
+
   constructor(readonly page: Page) {
     this.#decisionHandlerSelect = new Select(
       page.findByDataQa('finance-decision-handler-select')
@@ -363,6 +368,7 @@ export class InvoicesPage {
   #markInvoiceSentButton: AsyncButton
   #invoices: Element
   #sendInvoicesButton: AsyncButton
+
   constructor(private readonly page: Page) {
     this.#invoicesPage = page.findByDataQa('invoices-page')
     this.#invoiceDetailsPage = page.findByDataQa('invoice-details-page')
@@ -475,9 +481,12 @@ export class InvoicesPage {
 }
 
 export class IncomeStatementsPage {
+  searchButton: Element
   incomeStatementRows: ElementCollection
+
   constructor(private readonly page: Page) {
     this.incomeStatementRows = page.findAll(`[data-qa="income-statement-row"]`)
+    this.searchButton = page.findByDataQa('search-button')
   }
 
   #providerTypeFilter = (type: ProviderType) =>

--- a/frontend/src/e2e-test/specs/4_finance/income-staments.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/income-staments.spec.ts
@@ -78,6 +78,7 @@ describe('Income statements', () => {
     })
 
     let incomeStatementsPage = await navigateToIncomeStatements()
+    await incomeStatementsPage.searchButton.click()
     await incomeStatementsPage.incomeStatementRows.assertCount(2)
     const personProfilePage =
       await incomeStatementsPage.openNthIncomeStatementForGuardian(1)
@@ -102,6 +103,7 @@ describe('Income statements', () => {
     )
 
     incomeStatementsPage = await navigateToIncomeStatements()
+    await incomeStatementsPage.searchButton.click()
     await incomeStatementsPage.incomeStatementRows.assertCount(1)
   })
 
@@ -142,18 +144,22 @@ describe('Income statements', () => {
     })
 
     const incomeStatementsPage = await navigateToIncomeStatements()
+    await incomeStatementsPage.searchButton.click()
     await incomeStatementsPage.waitUntilLoaded()
+
     // No filters -> is shown
     await incomeStatementsPage.incomeStatementRows.assertCount(1)
 
     // Filter by the placed unit provider type -> is shown
     await incomeStatementsPage.selectProviderType(testDaycare.providerType)
+    await incomeStatementsPage.searchButton.click()
     await incomeStatementsPage.waitUntilLoaded()
     await incomeStatementsPage.incomeStatementRows.assertCount(1)
 
     // Filter by other unit provider type -> not shown
     await incomeStatementsPage.unSelectProviderType(testDaycare.providerType)
     await incomeStatementsPage.selectProviderType('EXTERNAL_PURCHASED')
+    await incomeStatementsPage.searchButton.click()
     await incomeStatementsPage.waitUntilLoaded()
     await incomeStatementsPage.incomeStatementRows.assertCount(0)
   })
@@ -175,6 +181,7 @@ describe('Income statements', () => {
     })
 
     const incomeStatementsPage = await navigateToIncomeStatements()
+    await incomeStatementsPage.searchButton.click()
     await incomeStatementsPage.incomeStatementRows.assertCount(1)
     await incomeStatementsPage.assertNthIncomeStatement(
       0,

--- a/frontend/src/employee-frontend/components/common/Filters.tsx
+++ b/frontend/src/employee-frontend/components/common/Filters.tsx
@@ -72,6 +72,7 @@ import { FlexRow } from './styled/containers'
 interface Props {
   freeText?: string
   setFreeText?: (s: string) => void
+  onSearch?: () => void
   clearFilters: () => void
   column1?: React.JSX.Element
   column2?: React.JSX.Element
@@ -117,6 +118,7 @@ export function Filters({
   freeText,
   setFreeText,
   clearFilters,
+  onSearch,
   column1,
   column2,
   column3,
@@ -146,6 +148,17 @@ export function Filters({
           onClick={clearFilters}
           text={i18n.filters.clear}
         />
+        {onSearch && (
+          <>
+            <Gap horizontal size="s" />
+            <Button
+              primary
+              text={i18n.common.search}
+              onClick={onSearch}
+              data-qa="search-button"
+            />
+          </>
+        )}
       </ClearOptions>
     </FiltersContainer>
   )

--- a/frontend/src/employee-frontend/components/income-statements/IncomeStatementFilters.tsx
+++ b/frontend/src/employee-frontend/components/income-statements/IncomeStatementFilters.tsx
@@ -19,7 +19,11 @@ import {
   ProviderTypeFilter
 } from '../common/Filters'
 
-export default React.memo(function IncomeStatementsFilters() {
+export default React.memo(function IncomeStatementsFilters({
+  onSearch
+}: {
+  onSearch: () => void
+}) {
   const {
     incomeStatements: { searchFilters, setSearchFilters, clearSearchFilters },
     shared: { availableAreas }
@@ -74,6 +78,7 @@ export default React.memo(function IncomeStatementsFilters() {
   return (
     <Filters
       clearFilters={clearSearchFilters}
+      onSearch={onSearch}
       column1={
         <AreaFilter
           areas={availableAreas.getOrElse([])}

--- a/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
+++ b/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
@@ -86,6 +86,12 @@ function IncomeStatementsList({
           >
             {i18n.incomeStatement.table.startDate}
           </SortableTh>
+          <SortableTh
+            sorted={isSorted('INCOME_END_DATE')}
+            onClick={toggleSort('INCOME_END_DATE')}
+          >
+            {i18n.incomeStatement.table.incomeEndDate}
+          </SortableTh>
           <Th>{i18n.incomeStatement.table.type}</Th>
           <Th minimalWidth={true}>{i18n.incomeStatement.table.link}</Th>
           <Th minimalWidth={true}>{i18n.incomeStatement.table.note}</Th>
@@ -109,6 +115,7 @@ function IncomeStatementsList({
             <Td>{row.primaryCareArea}</Td>
             <Td>{row.created.toLocalDate().format()}</Td>
             <Td>{row.startDate.format()}</Td>
+            <Td>{row.incomeEndDate?.format() ?? '-'}</Td>
             <Td data-qa="income-statement-type">
               {i18n.incomeStatement.statementTypes[row.type].toLowerCase()}
             </Td>

--- a/frontend/src/employee-frontend/components/income-statements/queries.ts
+++ b/frontend/src/employee-frontend/components/income-statements/queries.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { query } from 'lib-common/query'
+import { Arg0 } from 'lib-common/types'
+
+import { getIncomeStatementsAwaitingHandler } from '../../generated/api-clients/incomestatement'
+import { createQueryKeys } from '../../query'
+
+export const queryKeys = createQueryKeys('incomeStatements', {
+  incomeStatementsAwaitingHandler: (
+    arg: Arg0<typeof getIncomeStatementsAwaitingHandler>
+  ) => ['incomeStatementsAwaitingHandler', arg]
+})
+
+export const incomeStatementsAwaitingHandlerQuery = query({
+  api: (arg: Arg0<typeof getIncomeStatementsAwaitingHandler>) =>
+    getIncomeStatementsAwaitingHandler(arg),
+  queryKey: queryKeys.incomeStatementsAwaitingHandler
+})

--- a/frontend/src/employee-frontend/query.ts
+++ b/frontend/src/employee-frontend/query.ts
@@ -14,6 +14,7 @@ export type QueryKeyPrefix =
   | 'employees'
   | 'financeBasics'
   | 'holidayPeriods'
+  | 'incomeStatements'
   | 'reports'
   | 'timeline'
   | 'unit'

--- a/frontend/src/lib-common/generated/api-types/incomestatement.ts
+++ b/frontend/src/lib-common/generated/api-types/incomestatement.ts
@@ -157,6 +157,7 @@ export interface IncomeStatementAwaitingHandler {
   created: HelsinkiDateTime
   handlerNote: string
   id: UUID
+  incomeEndDate: LocalDate | null
   personId: UUID
   personName: string
   primaryCareArea: string | null
@@ -214,6 +215,7 @@ export type IncomeStatementBody = IncomeStatementBody.ChildIncome | IncomeStatem
 export type IncomeStatementSortParam =
   | 'CREATED'
   | 'START_DATE'
+  | 'INCOME_END_DATE'
 
 /**
 * Generated from fi.espoo.evaka.incomestatement.IncomeStatementType
@@ -374,6 +376,7 @@ export function deserializeJsonIncomeStatementAwaitingHandler(json: JsonOf<Incom
   return {
     ...json,
     created: HelsinkiDateTime.parseIso(json.created),
+    incomeEndDate: (json.incomeEndDate != null) ? LocalDate.parseIso(json.incomeEndDate) : null,
     startDate: LocalDate.parseIso(json.startDate)
   }
 }

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2089,6 +2089,7 @@ export const fi = {
       area: 'Alue',
       created: 'Luotu',
       startDate: 'Voimassa',
+      incomeEndDate: 'Tulotieto päättyy',
       type: 'Tyyppi',
       link: 'Selvitys',
       note: 'Muistiinpano'

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
@@ -194,4 +194,5 @@ data class SearchIncomeStatementsRequest(
 enum class IncomeStatementSortParam {
     CREATED,
     START_DATE,
+    INCOME_END_DATE,
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -22,6 +22,7 @@ import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.data.DateSet
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.Predicate
+import fi.espoo.evaka.shared.db.PredicateSql
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
@@ -438,13 +439,13 @@ fun Database.Read.getPlannedAbsenceEnabledRanges(
 ): Map<ChildId, DateSet> {
     val enabledForHourBasedServiceNeedsPredicate =
         if (enabledForHourBasedServiceNeeds) {
-            Predicate {
+            PredicateSql {
                 where(
                     "COALESCE(sno.daycare_hours_per_month, sno_default.daycare_hours_per_month) IS NOT NULL"
                 )
             }
         } else {
-            Predicate.alwaysFalse()
+            PredicateSql.alwaysFalse()
         }
 
     return createQuery {
@@ -462,7 +463,7 @@ fun Database.Read.getPlannedAbsenceEnabledRanges(
                 daterange(pl.start_date, pl.end_date, '[]') && ${bind(range)} AND
                 daterange(sn.start_date, sn.end_date, '[]') && ${bind(range)} AND (
                     COALESCE(sno.contract_days_per_month, sno_default.contract_days_per_month) IS NOT NULL OR
-                    ${predicate(enabledForHourBasedServiceNeedsPredicate.forTable(""))}
+                    ${predicate(enabledForHourBasedServiceNeedsPredicate)}
                 )
             GROUP BY child_id
             """

--- a/service/src/main/resources/db/migration/V436_income_statement_and_income_indexes.sql
+++ b/service/src/main/resources/db/migration/V436_income_statement_and_income_indexes.sql
@@ -1,0 +1,4 @@
+DROP INDEX idx$income_statement_handler_id_null;
+CREATE INDEX idx$income_statement_created_handler_id_null ON income_statement (created) WHERE handler_id IS NULL;
+CREATE INDEX idx$income_statement_start_date_handler_id_null ON income_statement (start_date) WHERE handler_id IS NULL;
+CREATE INDEX idx$income_valid_to_effect_not_incomplete ON income (person_id, valid_to DESC) WHERE effect <> 'INCOMPLETE';

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -432,3 +432,4 @@ V432__document_template_placement_types.sql
 V433__child_document_template_index.sql
 V434__more_staff_indexes.sql
 V435__archived_process_fix_trigger.sql
+V436_income_statement_and_income_indexes.sql


### PR DESCRIPTION
* Lisätään tuloselvitykset-listaan uusi sarake "Tulotieto päättyy", jossa on henkilön viimeisimmän tulotiedon päättymispäivä. Jos tulotietoa ei ole tai päättymispäivä on tyhjä, näytetään "-". Listan voi järjestää tämän sarakkeen mukaan.
* Tuloselvitykset-listan hakufiltterien päivittäminen tapahtuu Hae-nappia painamalla. Tällä vältetään turhia hakuja taustajärjestelmään.
* Teknisiä parannuksia tuloselvityslistan suorituskykyyn.

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/a789ce4d-98c4-402d-836e-8a22592d6ad3">

Edellinen versio (#5604) aiheutti niin paljon tietokantakuormaa, että se piti revertoida.