### PR TITLE
Automaattinen poissolojen luonti varausten luonnin yhteydessä päälle Espoon tuotannossa

### DIFF
--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -108,6 +108,7 @@ const features: Features = {
     noAbsenceType: false,
     discussionReservations: true,
     forceUnpublishDocumentTemplate: false,
+    automaticFixedScheduleAbsences: true,
     invoiceDisplayAccountNumber: true
   }
 }


### PR DESCRIPTION
Itse ominaisuus on toteutettu PR:ssä #5300 