### PR TITLE
Parannuksia päivämäärien ja aikojen käsittelyyn

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "e2e-ci": "LANG=fi-FI LANGUAGE=fi_FI BASE_URL=${BASE_URL:-http://localhost:9099} jest --runInBand --retries=2"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.0.2",
     "@evaka/eslint-plugin": "link:eslint-plugin",
     "@fortawesome/fontawesome-svg-core": "6.6.0",
     "@fortawesome/free-regular-svg-icons": "6.6.0",
@@ -44,7 +45,6 @@
     "core-js": "^3.38.0",
     "csstype": "^3.1.2",
     "date-fns": "^4.0.0",
-    "date-fns-tz": "^3.1.3",
     "downshift": "^9.0.4",
     "history": "^5.3.0",
     "intersection-observer": "^0.12.2",

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -7,7 +7,6 @@ import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 
 import { wrapResult } from 'lib-common/api'
-import { formatDate } from 'lib-common/date'
 import {
   ApplicationSortColumn,
   ApplicationSummary,
@@ -276,7 +275,7 @@ const ApplicationsList = React.memo(function Applications({
           />
           <span>
             {application.socialSecurityNumber ||
-              formatDate(application.dateOfBirth.toSystemTzDate())}
+              application.dateOfBirth.format()}
           </span>
         </FixedSpaceRow>
       )

--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
@@ -4,7 +4,6 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useQueryClient } from '@tanstack/react-query'
-import { formatInTimeZone } from 'date-fns-tz'
 import isEqual from 'lodash/isEqual'
 import React, {
   useCallback,
@@ -278,11 +277,7 @@ const ChildDocumentEditViewInner = React.memo(
                 <FixedSpaceRow alignItems="center" spacing="xs">
                   <span>
                     {i18n.common.saved}{' '}
-                    {formatInTimeZone(
-                      lastSaved.timestamp,
-                      'Europe/Helsinki',
-                      'HH:mm:ss'
-                    )}
+                    {lastSaved.toLocalTime().format('HH:mm:ss')}
                   </span>
                   {!saved && (
                     <Spinner size={defaultMargins.m} data-qa="saving-spinner" />

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { useQueryClient } from '@tanstack/react-query'
-import { formatInTimeZone } from 'date-fns-tz'
 import isEqual from 'lodash/isEqual'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -967,11 +966,7 @@ const DecisionEditor = React.memo(function DecisionEditor({
             >
               <span>
                 {i18n.common.saved}{' '}
-                {formatInTimeZone(
-                  lastSavedAt.timestamp,
-                  'Europe/Helsinki',
-                  'HH:mm:ss'
-                )}
+                {lastSavedAt.toLocalTime().format('HH:mm:ss')}
               </span>
               {!saved && (
                 <Spinner size={defaultMargins.m} data-qa="saving-spinner" />

--- a/frontend/src/employee-frontend/components/common/AutosaveStatusIndicator.tsx
+++ b/frontend/src/employee-frontend/components/common/AutosaveStatusIndicator.tsx
@@ -6,7 +6,6 @@ import React from 'react'
 
 import { useTranslation } from 'employee-frontend/state/i18n'
 import { AutosaveStatus } from 'employee-frontend/utils/use-autosave'
-import { formatTime } from 'lib-common/date'
 import { InformationText } from 'lib-components/typography'
 
 export default React.memo(function AutosaveStatusIndicator({
@@ -29,7 +28,7 @@ export default React.memo(function AutosaveStatusIndicator({
       case 'dirty':
       case 'clean':
         return status.savedAt
-          ? `${i18n.common.saved}\n${formatTime(status.savedAt)}`
+          ? `${i18n.common.saved}\n${status.savedAt.toLocalTime().format()}`
           : null
     }
   }

--- a/frontend/src/employee-frontend/components/reports/Occupancies.tsx
+++ b/frontend/src/employee-frontend/components/reports/Occupancies.tsx
@@ -11,13 +11,13 @@ import { Link } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 
 import { combine } from 'lib-common/api'
-import { formatDate } from 'lib-common/date'
 import { careTypes } from 'lib-common/generated/api-types/daycare'
 import { OccupancyType } from 'lib-common/generated/api-types/occupancy'
 import {
   OccupancyGroupReportResultRow,
   OccupancyUnitReportResultRow
 } from 'lib-common/generated/api-types/reports'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { Arg0 } from 'lib-common/types'
@@ -605,7 +605,11 @@ export default React.memo(function Occupancies() {
                       usedValues !== 'raw'
                         ? i18n.reports.occupancies.average
                         : undefined,
-                      ...dateCols.map((date) => formatDate(date, 'dd.MM.'))
+                      ...dateCols.map((date) =>
+                        HelsinkiDateTime.fromSystemTzDate(date)
+                          .toLocalDate()
+                          .format('dd.MM.')
+                      )
                     ].filter((label) => label !== undefined),
                     ...displayCells.map((row) =>
                       row.map((column) => column.value)
@@ -643,7 +647,9 @@ export default React.memo(function Occupancies() {
                           key={date.toDateString()}
                           colSpan={usedValues === 'raw' ? 4 : undefined}
                         >
-                          {formatDate(date, 'dd.MM.')}
+                          {HelsinkiDateTime.fromSystemTzDate(date)
+                            .toLocalDate()
+                            .format('dd.MM.')}
                         </Th>
                       ))}
                     </Tr>

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraphPlanned.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraphPlanned.tsx
@@ -10,7 +10,6 @@ import React, { useMemo, useCallback, useState } from 'react'
 import { Line } from 'react-chartjs-2'
 import styled from 'styled-components'
 
-import { formatTime } from 'lib-common/date'
 import { useBoolean } from 'lib-common/form/hooks'
 import { AttendanceReservationReportRow } from 'lib-common/generated/api-types/reports'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
@@ -125,7 +124,11 @@ const Graph = React.memo(function Graph({ queryDate, rows }: Props) {
     () =>
       tooltipParams.data ? (
         <>
-          <span>{formatTime(tooltipParams.data.date)}</span>
+          <span>
+            {HelsinkiDateTime.fromSystemTzDate(tooltipParams.data.date)
+              .toLocalTime()
+              .format()}
+          </span>
           <Gap size="xs" />
           <table>
             <tbody>

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraphRealized.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraphRealized.tsx
@@ -12,7 +12,6 @@ import React, { useMemo, useCallback, useState } from 'react'
 import { Line } from 'react-chartjs-2'
 import styled from 'styled-components'
 
-import { formatTime } from 'lib-common/date'
 import { useBoolean } from 'lib-common/form/hooks'
 import { RealtimeOccupancy } from 'lib-common/generated/api-types/occupancy'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
@@ -172,7 +171,11 @@ const Graph = React.memo(function Graph({
     () =>
       tooltipParams.data ? (
         <>
-          <span>{formatTime(tooltipParams.data.date)}</span>
+          <span>
+            {HelsinkiDateTime.fromSystemTzDate(tooltipParams.data.date)
+              .toLocalTime()
+              .format()}
+          </span>
           <Gap size="xs" />
           <table>
             <tbody>

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyGraph.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyGraph.tsx
@@ -7,8 +7,8 @@ import { fi } from 'date-fns/locale'
 import React from 'react'
 import { Line } from 'react-chartjs-2'
 
-import { formatDate } from 'lib-common/date'
 import { OccupancyResponse } from 'lib-common/generated/api-types/occupancy'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import colors from 'lib-customizations/common'
 
 type DatePoint = { x: Date; y: number | null | undefined }
@@ -68,7 +68,9 @@ function getGraphOptions(startDate: Date, endDate: Date): ChartOptions<'line'> {
           title: function (tooltipItems) {
             const tooltipItem = tooltipItems[0]
             const date = new Date(tooltipItem.parsed.x)
-            return formatDate(date)
+            return HelsinkiDateTime.fromSystemTzDate(date)
+              .toLocalDate()
+              .format()
           },
           label: function (tooltipItem) {
             return `${String(tooltipItem.parsed.y)} %`

--- a/frontend/src/employee-frontend/utils/use-autosave.ts
+++ b/frontend/src/employee-frontend/utils/use-autosave.ts
@@ -5,6 +5,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
 import { ApiFunction, Failure, Result, Success } from 'lib-common/api'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { isAutomatedTest } from 'lib-common/utils/helpers'
 import { useDebouncedCallback } from 'lib-common/utils/useDebouncedCallback'
 import { useRestApi } from 'lib-common/utils/useRestApi'
@@ -21,7 +22,7 @@ type State =
 
 export interface AutosaveStatus {
   state: State
-  savedAt?: Date
+  savedAt?: HelsinkiDateTime
 }
 
 const debounceInterval = isAutomatedTest ? 200 : 2000
@@ -87,7 +88,7 @@ export function useAutosave<T, F extends ApiFunction>({
             }
           }
 
-          return { state: 'clean', savedAt: new Date() }
+          return { state: 'clean', savedAt: HelsinkiDateTime.now() }
         })
       }
     })

--- a/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkPresent.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkPresent.tsx
@@ -8,7 +8,6 @@ import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { combine } from 'lib-common/api'
-import { formatTime } from 'lib-common/date'
 import {
   AttendanceChild,
   ChildAttendanceStatusResponse
@@ -22,7 +21,6 @@ import {
 } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import useRouteParams from 'lib-common/useRouteParams'
-import { mockNow } from 'lib-common/utils/helpers'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import Title from 'lib-components/atoms/Title'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -61,7 +59,7 @@ const MarkPresentInner = React.memo(function MarkPresentInner({
   const navigate = useNavigate()
   const { i18n } = useTranslation()
 
-  const [time, setTime] = useState(() => formatTime(mockNow() ?? new Date()))
+  const [time, setTime] = useState(() => LocalTime.nowInHelsinkiTz().format())
 
   const { mutateAsync: createArrival } = useMutationResult(
     createArrivalMutation

--- a/frontend/src/employee-mobile-frontend/staff-attendance/StaffMarkArrivedPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/StaffMarkArrivedPage.tsx
@@ -2,13 +2,12 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { addMinutes, differenceInMinutes, subMinutes } from 'date-fns'
+import { differenceInMinutes } from 'date-fns'
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { combine } from 'lib-common/api'
-import { formatTime } from 'lib-common/date'
 import {
   StaffAttendanceType,
   StaffMember,
@@ -20,7 +19,6 @@ import LocalTime from 'lib-common/local-time'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import useRouteParams from 'lib-common/useRouteParams'
-import { mockNow } from 'lib-common/utils/helpers'
 import Title from 'lib-components/atoms/Title'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import {
@@ -95,7 +93,7 @@ const StaffMarkArrivedInner = React.memo(function StaffMarkArrivedInner({
     staffMember.occupancyEffect
   )
 
-  const getNow = () => mockNow() ?? new Date()
+  const getNow = () => HelsinkiDateTime.now()
 
   const firstPlannedStartOfTheDay = useMemo(
     () =>
@@ -120,12 +118,12 @@ const StaffMarkArrivedInner = React.memo(function StaffMarkArrivedInner({
   )
 
   const selectedTimeIsWithin30MinsFromNow = useCallback(
-    (now: Date) =>
+    (now: HelsinkiDateTime) =>
       time !== undefined &&
       Math.abs(
         differenceInMinutes(
           HelsinkiDateTime.now().withTime(time).toSystemTzDate(),
-          now
+          now.toSystemTzDate()
         )
       ) <= 30,
     [time]
@@ -232,8 +230,8 @@ const StaffMarkArrivedInner = React.memo(function StaffMarkArrivedInner({
               ? {
                   status: 'warning',
                   text: i18n.common.validation.dateBetween(
-                    formatTime(subMinutes(getNow(), 30)),
-                    formatTime(addMinutes(getNow(), 30))
+                    getNow().subMinutes(30).toLocalTime().format(),
+                    getNow().addMinutes(30).toLocalTime().format()
                   )
                 }
               : undefined

--- a/frontend/src/lib-common/date.spec.ts
+++ b/frontend/src/lib-common/date.spec.ts
@@ -2,17 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { formatDate, isValidTime } from './date'
-
-describe('formatDate', () => {
-  it('should format valid date correctly', () => {
-    expect(formatDate(new Date('2019-01-01'))).toBe('01.01.2019')
-  })
-
-  it('should format undefined to empty string', () => {
-    expect(formatDate(undefined)).toBe('')
-  })
-})
+import { isValidTime } from './date'
 
 describe('isValidTime', () => {
   it.each(['23:59', '01:01', '00:01', '00:00'])(

--- a/frontend/src/lib-common/date.ts
+++ b/frontend/src/lib-common/date.ts
@@ -4,7 +4,6 @@
 
 import { Locale } from 'date-fns'
 import { enGB, fi, sv } from 'date-fns/locale'
-import { formatInTimeZone } from 'date-fns-tz'
 
 import HelsinkiDateTime from './helsinki-date-time'
 
@@ -13,9 +12,6 @@ export const locales: { fi: Locale; sv: Locale; en: Locale } = {
   sv,
   en: enGB
 }
-
-export const DATE_FORMAT_DATE_TIME = 'dd.MM.yyyy HH:mm'
-const DATE_FORMAT_TIME_ONLY = 'HH:mm'
 
 type DateWithoutLeadingZeros = 'd.M.yyyy'
 type DateWithLeadingZeros = 'dd.MM.yyyy'
@@ -33,34 +29,6 @@ export type DateFormat =
 
 type Weekday = 'EEEEEE' // ma, ti.. må, ti.. Mo, Tu
 export type DateFormatWithWeekday = Weekday | `${Weekday} ${DateFormat}`
-
-type Time = typeof DATE_FORMAT_TIME_ONLY
-type DateTimeFormat = `${FullDate} ${Time}`
-
-type FormatWithoutWeekday = DateFormat | DateTimeFormat
-type AllowedDateFormat = FormatWithoutWeekday | DateFormatWithWeekday
-
-export function formatDate<T extends AllowedDateFormat>(
-  date: Date | null | undefined,
-  ...[dateFormat, locale]: T extends DateFormatWithWeekday
-    ? [DateFormatWithWeekday, keyof typeof locales]
-    : [FormatWithoutWeekday?]
-): string {
-  return date
-    ? formatInTimeZone(
-        date,
-        'Europe/Helsinki',
-        dateFormat ?? 'dd.MM.yyyy',
-        locale ? { locale: locales[locale] } : undefined
-      )
-    : ''
-}
-
-export function formatTime(date: Date | null | undefined): string {
-  return date
-    ? formatInTimeZone(date, 'Europe/Helsinki', DATE_FORMAT_TIME_ONLY)
-    : ''
-}
 
 // matches 24h format with mandatory leading zeros "23:59" and "00:09"
 const timeRegex = /^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/

--- a/frontend/src/lib-common/helsinki-date-time.spec.ts
+++ b/frontend/src/lib-common/helsinki-date-time.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from './helsinki-date-time'
+import LocalTime from './local-time'
 
 describe('HelsinkiDateTime', () => {
   it('can be formatted into an ISO string with the TZ offset always based on Europe/Helsinki instead of local time zone', () => {
@@ -11,11 +12,48 @@ describe('HelsinkiDateTime', () => {
     const summer = HelsinkiDateTime.of(2022, 6, 1, 2, 3, 4, 5)
     expect(summer.formatIso()).toStrictEqual('2022-06-01T02:03:04.005+03:00')
   })
+  it('can be converted to LocalDate', () => {
+    const winter = HelsinkiDateTime.of(2022, 1, 1, 2, 3, 4, 5)
+    expect(winter.toLocalDate().formatIso()).toStrictEqual('2022-01-01')
+    const summer = HelsinkiDateTime.of(2022, 6, 1, 2, 3, 4, 5)
+    expect(summer.toLocalDate().formatIso()).toStrictEqual('2022-06-01')
+  })
+  it('can be converted to LocalTime', () => {
+    const winter = HelsinkiDateTime.of(2022, 1, 1, 2, 3, 4, 5)
+    expect(winter.toLocalTime().formatIso()).toStrictEqual('02:03:04.005000000')
+    const summer = HelsinkiDateTime.of(2022, 6, 1, 2, 3, 4, 5)
+    expect(summer.toLocalTime().formatIso()).toStrictEqual('02:03:04.005000000')
+  })
+  it('date can be changed', () => {
+    const winter = HelsinkiDateTime.of(2022, 1, 1, 2, 3, 4, 5)
+    const summer = HelsinkiDateTime.of(2022, 6, 1, 2, 3, 4, 5)
+    expect(winter.withDate(summer.toLocalDate()).formatIso()).toStrictEqual(
+      '2022-06-01T02:03:04.005+03:00'
+    )
+    expect(summer.withDate(winter.toLocalDate()).formatIso()).toStrictEqual(
+      '2022-01-01T02:03:04.005+02:00'
+    )
+  })
+  it('time can be changed', () => {
+    const winter = HelsinkiDateTime.of(2022, 1, 1, 2, 3, 4, 5)
+    const summer = HelsinkiDateTime.of(2022, 6, 1, 2, 3, 4, 5)
+    const newTime = LocalTime.of(2, 1, 0, 1000000)
+    expect(winter.withTime(newTime).formatIso()).toStrictEqual(
+      '2022-01-01T02:01:00.001+02:00'
+    )
+    expect(summer.withTime(newTime).formatIso()).toStrictEqual(
+      '2022-06-01T02:01:00.001+03:00'
+    )
+  })
   it('can be converted to/from JSON', () => {
     const timestamp = HelsinkiDateTime.of(2022, 1, 1, 2, 3, 4, 5)
     expect(
       HelsinkiDateTime.parseIso(timestamp.toJSON()).isEqual(timestamp)
     ).toBeTruthy()
+  })
+  it('rejects invalid dates', () => {
+    expect(() => HelsinkiDateTime.of(2022, 2, 30)).toThrow(RangeError)
+    expect(() => HelsinkiDateTime.of(2022, 1, 30, 25, 0)).toThrow(RangeError)
   })
   it('has property getters for each part of the timestamp', () => {
     const parts = [2022, 6, 1, 2, 3, 4, 5] as const

--- a/frontend/src/lib-common/helsinki-date-time.ts
+++ b/frontend/src/lib-common/helsinki-date-time.ts
@@ -2,15 +2,16 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { tz, TZDate } from '@date-fns/tz'
 import {
   addHours,
   addMinutes,
   addSeconds,
+  format,
   isValid,
   parseJSON,
   set
 } from 'date-fns'
-import { formatInTimeZone, toZonedTime, fromZonedTime } from 'date-fns-tz'
 
 import LocalDate from './local-date'
 import LocalTime from './local-time'
@@ -18,42 +19,36 @@ import { Ordered } from './ordered'
 import { isAutomatedTest } from './utils/helpers'
 
 const EUROPE_HELSINKI = 'Europe/Helsinki'
+const helsinkiTz = tz(EUROPE_HELSINKI)
 
 export default class HelsinkiDateTime implements Ordered<HelsinkiDateTime> {
   private constructor(readonly timestamp: number) {}
 
   get year(): number {
-    return toZonedTime(this.timestamp, EUROPE_HELSINKI).getFullYear()
+    return helsinkiTz(this.timestamp).getFullYear()
   }
   get month(): number {
-    return toZonedTime(this.timestamp, EUROPE_HELSINKI).getMonth() + 1
+    return helsinkiTz(this.timestamp).getMonth() + 1
   }
   get date(): number {
-    return toZonedTime(this.timestamp, EUROPE_HELSINKI).getDate()
+    return helsinkiTz(this.timestamp).getDate()
   }
   get hour(): number {
-    return toZonedTime(this.timestamp, EUROPE_HELSINKI).getHours()
+    return helsinkiTz(this.timestamp).getHours()
   }
   get minute(): number {
-    return toZonedTime(this.timestamp, EUROPE_HELSINKI).getMinutes()
+    return helsinkiTz(this.timestamp).getMinutes()
   }
   get second(): number {
-    return toZonedTime(this.timestamp, EUROPE_HELSINKI).getSeconds()
+    return helsinkiTz(this.timestamp).getSeconds()
   }
   get millisecond(): number {
-    return toZonedTime(this.timestamp, EUROPE_HELSINKI).getMilliseconds()
+    return helsinkiTz(this.timestamp).getMilliseconds()
   }
-  private mapZoned(f: (timestamp: Date) => Date): HelsinkiDateTime {
-    return HelsinkiDateTime.fromSystemTzDate(
-      fromZonedTime(
-        f(toZonedTime(this.timestamp, EUROPE_HELSINKI)),
-        EUROPE_HELSINKI
-      )
-    )
-  }
+
   withDate(date: LocalDate): HelsinkiDateTime {
-    return this.mapZoned((zoned) =>
-      set(zoned, {
+    return HelsinkiDateTime.fromSystemTzDate(
+      set(helsinkiTz(this.timestamp), {
         year: date.year,
         month: date.month - 1,
         date: date.date
@@ -61,8 +56,8 @@ export default class HelsinkiDateTime implements Ordered<HelsinkiDateTime> {
     )
   }
   withTime(time: LocalTime): HelsinkiDateTime {
-    return this.mapZoned((zoned) =>
-      set(zoned, {
+    return HelsinkiDateTime.fromSystemTzDate(
+      set(helsinkiTz(this.timestamp), {
         hours: time.hour,
         minutes: time.minute,
         seconds: time.second,
@@ -72,14 +67,10 @@ export default class HelsinkiDateTime implements Ordered<HelsinkiDateTime> {
   }
 
   format(): string {
-    return formatInTimeZone(this.timestamp, EUROPE_HELSINKI, 'dd.MM.yyyy HH:mm')
+    return format(helsinkiTz(this.timestamp), 'dd.MM.yyyy HH:mm')
   }
   formatIso(): string {
-    return formatInTimeZone(
-      this.timestamp,
-      EUROPE_HELSINKI,
-      "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
-    )
+    return format(helsinkiTz(this.timestamp), "yyyy-MM-dd'T'HH:mm:ss.SSSxxx")
   }
   toString(): string {
     return this.formatIso()
@@ -226,8 +217,14 @@ export default class HelsinkiDateTime implements Ordered<HelsinkiDateTime> {
     if (!LocalTime.tryCreate(hour, minute, second, millisToNanos(millisecond)))
       return undefined
     return HelsinkiDateTime.tryFromDate(
-      fromZonedTime(
-        new Date(year, month - 1, date, hour, minute, second, millisecond),
+      new TZDate(
+        year,
+        month - 1,
+        date,
+        hour,
+        minute,
+        second,
+        millisecond,
         EUROPE_HELSINKI
       )
     )

--- a/frontend/src/lib-common/helsinki-date-time.ts
+++ b/frontend/src/lib-common/helsinki-date-time.ts
@@ -55,7 +55,7 @@ export default class HelsinkiDateTime implements Ordered<HelsinkiDateTime> {
     return this.mapZoned((zoned) =>
       set(zoned, {
         year: date.year,
-        month: date.month,
+        month: date.month - 1,
         date: date.date
       })
     )

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2073,6 +2073,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@date-fns/tz@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@date-fns/tz@npm:1.0.2"
+  checksum: 10/6a4bf2a9d7c265a2cd471da510e7201adc00c37a9b59de933f4b9a2f688838ff14b6ba5229505dd8a3a55c6a6609c744724eb0bf887243e3f4912cabc0b6b96b
+  languageName: node
+  linkType: hard
+
 "@discoveryjs/json-ext@npm:^0.5.0":
   version: 0.5.2
   resolution: "@discoveryjs/json-ext@npm:0.5.2"
@@ -6064,15 +6071,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns-tz@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "date-fns-tz@npm:3.1.3"
-  peerDependencies:
-    date-fns: ^3.0.0
-  checksum: 10/eb5cb3b2cd152340004efda9f7905e571cf5140b8e85267b1eaa36c2f1eaa54a0f2e3b26e19794f2aca4d3b15aa3d52a5b2dadb540fcec74b239049c7792a981
-  languageName: node
-  linkType: hard
-
 "date-fns@npm:^3.3.1, date-fns@npm:^3.6.0":
   version: 3.6.0
   resolution: "date-fns@npm:3.6.0"
@@ -7099,6 +7097,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.3"
+    "@date-fns/tz": "npm:^1.0.2"
     "@eslint/compat": "npm:^1.1.1"
     "@eslint/js": "npm:^9.10.0"
     "@evaka/eslint-plugin": "link:eslint-plugin"
@@ -7147,7 +7146,6 @@ __metadata:
     css-loader: "npm:^7.1.1"
     csstype: "npm:^3.1.2"
     date-fns: "npm:^4.0.0"
-    date-fns-tz: "npm:^3.1.3"
     downshift: "npm:^9.0.4"
     esbuild: "npm:^0.23.0"
     eslint: "npm:^9.10.0"


### PR DESCRIPTION
- Käytetään `HelsinkiDateTime`, `LocalDate` ja `LocalTime` -luokkia ajan ja päivämäärän tekstimuunnoksiin joka paikassa
- Lisätään muutama testi ja kojataan pieni bugi `HelsinkiDateTime`-toteutuksessa
- Otetaan date-fns:n virallinen aikavyöhyketuki `@date-fns/tz` käyttöön