### PR TITLE
Pävitys Jamix-synkronoinnin aikatauluun

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -129,7 +129,7 @@ enum class ScheduledJob(
     ),
     SyncJamixDiets(
         ScheduledJobs::syncJamixDiets,
-        ScheduledJobSettings(enabled = false, schedule = JobSchedule.cron("0 */10 * * * *")),
+        ScheduledJobSettings(enabled = false, schedule = JobSchedule.cron("0 */10 7-18 * * *")),
     ),
     SendPendingDecisionReminderEmails(
         ScheduledJobs::sendPendingDecisionReminderEmails,


### PR DESCRIPTION
Vältetään joka (toinen?) tiistai klo 18-22 hälytykset.