### PR TITLE
Varoitetaan toisessa yksikössä olevista avoimista kirjauksista mobiilissa

### DIFF
--- a/frontend/src/e2e-test/pages/mobile/staff-page.ts
+++ b/frontend/src/e2e-test/pages/mobile/staff-page.ts
@@ -157,6 +157,7 @@ export class StaffAttendancePage {
     shiftTimeText: Element
     attendanceTimeTexts: ElementCollection
     attendanceTimes: ElementCollection
+    openAttendanceWarning: Element
   }
   externalMemberPage: {
     arrivalTime: Element
@@ -238,7 +239,10 @@ export class StaffAttendancePage {
       attendanceTimes: page.findAllByDataQa('attendance-time'),
       markArrivedBtn: page.findByDataQa('mark-arrived-btn'),
       shiftTimeText: page.findByDataQa('shift-time'),
-      attendanceTimeTexts: page.findAllByDataQa('attendance-time')
+      attendanceTimeTexts: page.findAllByDataQa('attendance-time'),
+      openAttendanceWarning: page.findByDataQa(
+        'open-attendance-in-another-unit-warning'
+      )
     }
     this.externalMemberPage = {
       arrivalTime: page.findByDataQa('arrival-time'),

--- a/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts
@@ -335,6 +335,7 @@ describe('Realtime staff attendance page', () => {
     await staffAttendancePage.staffMemberPage.openAttendanceWarning.assertTextEquals(
       'Avoin kirjaus ke 4.5.2022 - Alkuräjähdyksen päiväkoti. Kirjaus on päätettävä ennen uuden lisäystä.'
     )
+
     await staffAttendancePage.assertEmployeeStatus('Poissa')
     await staffAttendancePage.staffMemberPage.markArrivedBtn.assertDisabled(
       true

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
@@ -82,7 +82,6 @@ interface Props<
   onSave: (body: T[]) => void
   onSuccess: () => void
   onClose: () => void
-  unitId?: string
 }
 
 export interface EditedAttendance {
@@ -120,8 +119,7 @@ function StaffAttendanceDetailsModal<
   validate,
   onSave,
   onSuccess,
-  onClose,
-  unitId
+  onClose
 }: Props<T>) {
   const { i18n } = useTranslation()
 
@@ -351,8 +349,8 @@ function StaffAttendanceDetailsModal<
   )
 
   const openAttendanceResult = useQueryResult(
-    employeeId && unitId
-      ? openAttendanceQuery({ userId: employeeId, unitId })
+    employeeId
+      ? openAttendanceQuery({ userId: employeeId })
       : constantQuery({ openGroupAttendance: null })
   )
   const openAttendance = openAttendanceResult.isSuccess

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -325,7 +325,6 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
       defaultGroupId={defaultGroupId}
       onClose={onClose}
       onSuccess={onSuccess}
-      unitId={unitId}
     />
   ) : (
     <StaffAttendanceDetailsModal

--- a/frontend/src/employee-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attendance.ts
@@ -24,13 +24,11 @@ import { uri } from 'lib-common/uri'
 */
 export async function getOpenGroupAttendance(
   request: {
-    userId: UUID,
-    unitId: UUID
+    userId: UUID
   }
 ): Promise<OpenGroupAttendanceResponse> {
   const params = createUrlSearchParams(
-    ['userId', request.userId],
-    ['unitId', request.unitId]
+    ['userId', request.userId]
   )
   const { data: json } = await client.request<JsonOf<OpenGroupAttendanceResponse>>({
     url: uri`/employee/staff-attendances/realtime/open-attendence`.toString(),

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/attendance.ts
@@ -301,7 +301,7 @@ export async function getOpenGroupAttendance(
     ['userId', request.userId]
   )
   const { data: json } = await client.request<JsonOf<OpenGroupAttendanceResponse>>({
-    url: uri`/employee-mobile/realtime-staff-attendances/open-attendence`.toString(),
+    url: uri`/employee-mobile/realtime-staff-attendances/open-attendance`.toString(),
     method: 'GET',
     params
   })

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/attendance.ts
@@ -18,6 +18,7 @@ import { ExternalStaffDepartureRequest } from 'lib-common/generated/api-types/at
 import { FullDayAbsenceRequest } from 'lib-common/generated/api-types/attendance'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { OpenGroupAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { StaffArrivalRequest } from 'lib-common/generated/api-types/attendance'
 import { StaffAttendanceUpdateRequest } from 'lib-common/generated/api-types/attendance'
 import { StaffAttendanceUpdateResponse } from 'lib-common/generated/api-types/attendance'
@@ -31,6 +32,7 @@ import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonAttendanceChild } from 'lib-common/generated/api-types/attendance'
 import { deserializeJsonChildAttendanceStatusResponse } from 'lib-common/generated/api-types/attendance'
 import { deserializeJsonCurrentDayStaffAttendanceResponse } from 'lib-common/generated/api-types/attendance'
+import { deserializeJsonOpenGroupAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { deserializeJsonStaffMember } from 'lib-common/generated/api-types/attendance'
 import { uri } from 'lib-common/uri'
 
@@ -284,6 +286,26 @@ export async function getEmployeeAttendances(
     params
   })
   return deserializeJsonStaffMember(json)
+}
+
+
+/**
+* Generated from fi.espoo.evaka.attendance.MobileRealtimeStaffAttendanceController.getOpenGroupAttendance
+*/
+export async function getOpenGroupAttendance(
+  request: {
+    userId: UUID
+  }
+): Promise<OpenGroupAttendanceResponse> {
+  const params = createUrlSearchParams(
+    ['userId', request.userId]
+  )
+  const { data: json } = await client.request<JsonOf<OpenGroupAttendanceResponse>>({
+    url: uri`/employee-mobile/realtime-staff-attendances/open-attendence`.toString(),
+    method: 'GET',
+    params
+  })
+  return deserializeJsonOpenGroupAttendanceResponse(json)
 }
 
 

--- a/frontend/src/employee-mobile-frontend/staff-attendance/StaffMemberPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/StaffMemberPage.tsx
@@ -62,7 +62,7 @@ export default React.memo(function StaffMemberPage({
   )
 
   const openAttendanceResult = useQueryResult(
-    employeeId && unitId
+    employeeId
       ? openAttendanceQuery({ userId: employeeId })
       : constantQuery({ openGroupAttendance: null })
   )

--- a/frontend/src/employee-mobile-frontend/staff-attendance/queries.ts
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/queries.ts
@@ -9,6 +9,7 @@ import { Arg0, UUID } from 'lib-common/types'
 import {
   getAttendancesByUnit,
   getEmployeeAttendances,
+  getOpenGroupAttendance,
   markArrival,
   markDeparture,
   markExternalArrival,
@@ -36,7 +37,12 @@ const queryKeys = createQueryKeys('staffAttendance', {
     employeeId: UUID,
     from: LocalDate,
     to: LocalDate
-  ) => ['unit', unitId, 'employeeId', employeeId, 'range', from, to]
+  ) => ['unit', unitId, 'employeeId', employeeId, 'range', from, to],
+
+  openGroupAttendance: (arg: Arg0<typeof getOpenGroupAttendance>) => [
+    'openGroupAttendance',
+    arg
+  ]
 })
 
 export const staffAttendanceQuery = query({
@@ -76,4 +82,9 @@ export const externalStaffDepartureMutation = mutation({
 export const staffAttendanceMutation = mutation({
   api: setAttendances,
   invalidateQueryKeys: ({ unitId }) => [queryKeys.unit(unitId)]
+})
+
+export const openAttendanceQuery = query({
+  api: getOpenGroupAttendance,
+  queryKey: queryKeys.openGroupAttendance
 })

--- a/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
+++ b/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
@@ -306,7 +306,10 @@ export const fi = {
         dateTooEarly: 'Tarkista',
         dateTooLate: 'Tarkista'
       },
-      add: '+ Lisää uusi kirjaus'
+      add: '+ Lisää uusi kirjaus',
+      openAttendanceInAnotherUnitWarning: 'Avoin kirjaus ',
+      openAttendanceInAnotherUnitWarningCont:
+        '. Kirjaus on päätettävä ennen uuden lisäystä.'
     },
     timeDiffTooBigNotification:
       'Voit tehdä sisäänkirjauksen +/- 30 min päähän nykyhetkestä. Kirjauksia voi tarvittaessa muokata työpöytäselaimen kautta.',

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceController.kt
@@ -7,12 +7,15 @@ package fi.espoo.evaka.attendance
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.absence.getDaycareIdByGroup
+import fi.espoo.evaka.attendance.RealtimeStaffAttendanceController.OpenGroupAttendanceResponse
+import fi.espoo.evaka.pairing.getDevice
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.StaffAttendanceExternalId
 import fi.espoo.evaka.shared.StaffAttendanceRealtimeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.auth.getDaycareAclRows
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.mapPSQLException
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -613,5 +616,33 @@ class MobileRealtimeStaffAttendanceController(private val ac: AccessControl) {
         }
 
         return listOf(ongoingAttendance.copy(departed = departureTime))
+    }
+
+    @GetMapping("open-attendence")
+    fun getOpenGroupAttendance(
+        db: Database,
+        user: AuthenticatedUser.MobileDevice,
+        clock: EvakaClock,
+        @RequestParam userId: EmployeeId,
+    ): OpenGroupAttendanceResponse {
+        val openAttendance =
+            db.connect { dbc ->
+                    dbc.transaction { tx ->
+                        val mobileDevice = tx.getDevice(user.id)
+
+                        val targetUserBelongsToUnitAssiciatedWithDevice =
+                            mobileDevice.unitIds.any { unitId ->
+                                tx.getDaycareAclRows(unitId, false).any { it.employee.id == userId }
+                            }
+                        if (!targetUserBelongsToUnitAssiciatedWithDevice) {
+                            throw BadRequest(
+                                "User doesn't belong to an unit which the device is associated with"
+                            )
+                        }
+                        tx.getOpenGroupAttendancesForEmployee(userId)
+                    }
+                }
+                .also { Audit.StaffOpenAttendanceRead.log(targetId = AuditId(userId)) }
+        return OpenGroupAttendanceResponse(openAttendance)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -1432,7 +1432,11 @@ sealed interface Action {
             IsEmployee.self(),
         ),
         ACTIVATE(HasGlobalRole(ADMIN)),
-        DEACTIVATE(HasGlobalRole(ADMIN));
+        DEACTIVATE(HasGlobalRole(ADMIN)),
+        READ_OPEN_GROUP_ATTENDANCE(
+            IsMobile(false).isAssociatedWithEmployee(),
+            IsEmployee.isInSameUnitWithEmployee(),
+        );
 
         override fun toString(): String = "${javaClass.name}.$name"
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsEmployee.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsEmployee.kt
@@ -298,4 +298,16 @@ SELECT EXISTS (
                     }
             },
         )
+
+    fun isInSameUnitWithEmployee() =
+        rule<EmployeeId> { user, _ ->
+            sql(
+                """
+    SELECT targetacl.employee_id as id
+    FROM daycare_acl useracl
+    JOIN daycare_acl targetacl ON useracl.daycare_id = targetacl.daycare_id
+    WHERE useracl.employee_id = ${bind(user.id)}
+"""
+            )
+        }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsMobile.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/IsMobile.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.shared.ChildImageId
 import fi.espoo.evaka.shared.ChildStickyNoteId
 import fi.espoo.evaka.shared.DatabaseTable
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupNoteId
 import fi.espoo.evaka.shared.Id
@@ -221,6 +222,24 @@ WHERE EXISTS (
     LEFT JOIN daycare_acl acl ON md.employee_id = acl.employee_id
     WHERE md.id = ${bind(user.id)} AND (md.unit_id = g.daycare_id OR acl.daycare_id = g.daycare_id)
 )
+"""
+            )
+        }
+
+    fun isAssociatedWithEmployee() =
+        rule<EmployeeId> { user, _ ->
+            sql(
+                """
+    SELECT acl.employee_id as id
+    FROM mobile_device md
+    JOIN daycare_acl acl ON md.unit_id = acl.daycare_id
+    WHERE md.id = ${bind(user.id)}
+    UNION ALL
+    SELECT targetacl.employee_id as id
+    FROM mobile_device md
+    JOIN daycare_acl useracl ON md.employee_id = useracl.employee_id
+    JOIN daycare_acl targetacl ON useracl.daycare_id = targetacl.daycare_id
+    WHERE md.id = ${bind(user.id)}
 """
             )
         }


### PR DESCRIPTION
## Ennen tätä muutosta
Jos käyttäjällä oli avoin läsnäolokirjaus toisessa yksikössä, uuden kirjauksen tallennus epäonnistui ilman virheviestiä
## Tämän muutoksen jälkeen
Käyttäjälle näytetään varoitusviesti läsnäolokirjaus näkymässä ja "Kirjaudu läsnäolevaksi" nappi ei ole aktiivinen.
<img width="359" alt="image" src="https://github.com/user-attachments/assets/629d0abc-8991-43ac-be0f-86fee6dccf81">

