### PR TITLE
HOTFIX: Vaihdetaan takaisin `date-fns-tz`-kirjastoon

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
     "e2e-ci": "LANG=fi-FI LANGUAGE=fi_FI BASE_URL=${BASE_URL:-http://localhost:9099} jest --runInBand --retries=2"
   },
   "dependencies": {
-    "@date-fns/tz": "^1.0.2",
     "@evaka/eslint-plugin": "link:eslint-plugin",
     "@fortawesome/fontawesome-svg-core": "6.6.0",
     "@fortawesome/free-regular-svg-icons": "6.6.0",
@@ -45,6 +44,7 @@
     "core-js": "^3.38.0",
     "csstype": "^3.1.2",
     "date-fns": "^4.0.0",
+    "date-fns-tz": "^3.1.3",
     "downshift": "^9.0.4",
     "history": "^5.3.0",
     "intersection-observer": "^0.12.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2073,13 +2073,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@date-fns/tz@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@date-fns/tz@npm:1.0.2"
-  checksum: 10/6a4bf2a9d7c265a2cd471da510e7201adc00c37a9b59de933f4b9a2f688838ff14b6ba5229505dd8a3a55c6a6609c744724eb0bf887243e3f4912cabc0b6b96b
-  languageName: node
-  linkType: hard
-
 "@discoveryjs/json-ext@npm:^0.5.0":
   version: 0.5.2
   resolution: "@discoveryjs/json-ext@npm:0.5.2"
@@ -6071,6 +6064,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns-tz@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "date-fns-tz@npm:3.1.3"
+  peerDependencies:
+    date-fns: ^3.0.0
+  checksum: 10/eb5cb3b2cd152340004efda9f7905e571cf5140b8e85267b1eaa36c2f1eaa54a0f2e3b26e19794f2aca4d3b15aa3d52a5b2dadb540fcec74b239049c7792a981
+  languageName: node
+  linkType: hard
+
 "date-fns@npm:^3.3.1, date-fns@npm:^3.6.0":
   version: 3.6.0
   resolution: "date-fns@npm:3.6.0"
@@ -7097,7 +7099,6 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.3"
-    "@date-fns/tz": "npm:^1.0.2"
     "@eslint/compat": "npm:^1.1.1"
     "@eslint/js": "npm:^9.10.0"
     "@evaka/eslint-plugin": "link:eslint-plugin"
@@ -7146,6 +7147,7 @@ __metadata:
     css-loader: "npm:^7.1.1"
     csstype: "npm:^3.1.2"
     date-fns: "npm:^4.0.0"
+    date-fns-tz: "npm:^3.1.3"
     downshift: "npm:^9.0.4"
     esbuild: "npm:^0.23.0"
     eslint: "npm:^9.10.0"


### PR DESCRIPTION
Uudempi `@date-fns/tz`-kirjasto toimii vasta Chrome Mobile versio 95:llä ja uudemmilla (vuodelta 2021). Ainakin Espoossa näyttää olevan yhä vanhempia selaimia käytössä.

This reverts commit 125e54e07ca00aea0a1b9e3a501c2aca4c5834c2.
