### PR TITLE
Yksikön täyttö- ja käyttöastegraafin parannuksia

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-calendar-page-base.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-calendar-page-base.ts
@@ -22,6 +22,8 @@ import { UnitCalendarEventsSection } from './unit'
 
 /** Common elements and actions for both month and week calendar pages */
 export class UnitCalendarPageBase {
+  filterStartdate: DatePicker
+  graphModeSelect: Select
   occupancies: UnitOccupanciesSection
   monthModeButton: Element
   weekModeButton: Element
@@ -31,6 +33,10 @@ export class UnitCalendarPageBase {
   calendarEventsSection: UnitCalendarEventsSection
 
   constructor(protected readonly page: Page) {
+    this.filterStartdate = new DatePicker(
+      page.findByDataQa('unit-filter-start-date')
+    )
+    this.graphModeSelect = new Select(page.findByDataQa('graph-mode-select'))
     this.occupancies = new UnitOccupanciesSection(
       page.findByDataQa('occupancies')
     )
@@ -52,9 +58,7 @@ export class UnitCalendarPageBase {
   }
 
   async setFilterStartDate(date: LocalDate) {
-    await new DatePicker(this.page.findByDataQa('unit-filter-start-date')).fill(
-      date.format()
-    )
+    await this.filterStartdate.fill(date.format())
     await this.waitUntilLoaded()
   }
 
@@ -62,6 +66,10 @@ export class UnitCalendarPageBase {
     await this.page
       .find(`[data-qa="unit-filter-period-${period.replace(' ', '-')}"]`)
       .click()
+  }
+
+  async selectGraphMode(mode: 'PLANNED' | 'REALIZED') {
+    await this.graphModeSelect.selectOption(mode)
   }
 
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
@@ -124,8 +132,14 @@ export class UnitCalendarPageBase {
 }
 
 export class UnitOccupanciesSection extends Element {
-  #graph = this.find('canvas')
-  #noDataPlaceholder = this.findByDataQa('no-data-placeholder')
+  #graph: Element
+  #noDataPlaceholder: Element
+
+  constructor(value: Element) {
+    super(value)
+    this.#graph = this.find('canvas')
+    this.#noDataPlaceholder = this.findByDataQa('no-data-placeholder')
+  }
 
   #elem = (
     which: 'minimum' | 'maximum' | 'no-valid-values',

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -142,6 +142,7 @@ describe('Realtime staff attendances', () => {
 
     calendarPage = await openCalendar()
     await calendarPage.occupancies.assertGraphIsVisible()
+    await calendarPage.selectGraphMode('REALIZED')
     await calendarPage.setFilterStartDate(LocalDate.of(2022, 3, 1))
     await calendarPage.occupancies.assertGraphHasNoData()
   })

--- a/frontend/src/employee-frontend/components/unit/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/queries.ts
@@ -63,13 +63,13 @@ export const queryKeys = createQueryKeys('unit', {
   unitRealizedOccupanciesForDay: (
     unitId: UUID,
     date: LocalDate,
-    groupId: UUID | null
-  ) => ['unitRealizedOccupanciesForDay', unitId, date, groupId],
+    groupIds: UUID[] | null
+  ) => ['unitRealizedOccupanciesForDay', unitId, date, groupIds],
   unitPlannedOccupanciesForDay: (
     unitId: UUID,
     date: LocalDate,
-    groupId: UUID | null
-  ) => ['unitPlannedOccupanciesForDay', unitId, date, groupId],
+    groupIds: UUID[] | null
+  ) => ['unitPlannedOccupanciesForDay', unitId, date, groupIds],
   unitApplications: (unitId: UUID) => ['unitApplications', unitId],
   unitGroups: (unitId: UUID) => ['unitGroups', unitId],
   unitSpeculatedOccupancyRates: (
@@ -125,14 +125,14 @@ export const unitOccupanciesQuery = query({
 
 export const unitRealizedOccupanciesForDayQuery = query({
   api: getUnitRealizedOccupanciesForDay,
-  queryKey: ({ unitId, date, groupId }) =>
-    queryKeys.unitRealizedOccupanciesForDay(unitId, date, groupId ?? null)
+  queryKey: ({ unitId, body }) =>
+    queryKeys.unitRealizedOccupanciesForDay(unitId, body.date, body.groupIds)
 })
 
 export const unitPlannedOccupanciesForDayQuery = query({
   api: getUnitPlannedOccupanciesForDay,
-  queryKey: ({ unitId, date, groupId }) =>
-    queryKeys.unitPlannedOccupanciesForDay(unitId, date, groupId ?? null)
+  queryKey: ({ unitId, body }) =>
+    queryKeys.unitPlannedOccupanciesForDay(unitId, body.date, body.groupIds)
 })
 
 export const unitApplicationsQuery = query({

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
@@ -53,7 +53,7 @@ export default React.memo(function OccupancyContainer({
   const { i18n } = useTranslation()
   const [open, setOpen] = useState(true)
   const [groupId, setGroupId] = useState<UUID | null>(null)
-  const [mode, setMode] = useState<DayGraphMode>('REALIZED')
+  const [mode, setMode] = useState<DayGraphMode>('PLANNED')
 
   return (
     <CollapsibleContentArea

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { Dispatch, SetStateAction, useState } from 'react'
+import React, { Dispatch, SetStateAction, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { DaycareGroupResponse } from 'lib-common/generated/api-types/daycare'
@@ -55,6 +55,15 @@ export default React.memo(function OccupancyContainer({
   const [groupId, setGroupId] = useState<UUID | null>(null)
   const [mode, setMode] = useState<DayGraphMode>('PLANNED')
 
+  const activeGroups = useMemo(
+    () =>
+      groups.filter(
+        (group) =>
+          group.endDate === null || group.endDate.isEqualOrAfter(endDate)
+      ),
+    [endDate, groups]
+  )
+
   return (
     <CollapsibleContentArea
       title={<H3 noMargin>{i18n.unit.occupancies}</H3>}
@@ -71,9 +80,9 @@ export default React.memo(function OccupancyContainer({
       <FixedSpaceRow alignItems="center">
         <Label>{i18n.unit.occupancy.display}</Label>
         <Select
-          items={[null, ...groups]}
+          items={[null, ...activeGroups]}
           selectedItem={
-            groupId ? groups.find((g) => g.id === groupId) ?? null : null
+            groupId ? activeGroups.find((g) => g.id === groupId) ?? null : null
           }
           onChange={(g) => setGroupId(g ? g.id : null)}
           getItemValue={(g: DaycareGroupResponse | null) => (g ? g.id : '')}

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
@@ -111,6 +111,7 @@ export default React.memo(function OccupancyContainer({
                 if (newMode !== null) setMode(newMode)
               }}
               getItemLabel={(item) => i18n.unit.occupancy.realtime.modes[item]}
+              data-qa="graph-mode-select"
             />
           </>
         ) : (

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupanciesForSingleDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupanciesForSingleDay.tsx
@@ -42,17 +42,17 @@ export const LegendSquare = styled.div<{ color: string; small?: boolean }>`
 export const RealtimeRealizedOccupanciesForSingleDay = React.memo(
   function RealtimeRealizedOccupanciesForSingleDay({
     unitId,
-    groupId,
+    groupIds,
     date,
     shiftCareUnit
   }: {
     unitId: UUID
-    groupId: UUID | null
+    groupIds: UUID[] | null
     date: LocalDate
     shiftCareUnit: boolean
   }) {
     const occupancies = useQueryResult(
-      unitRealizedOccupanciesForDayQuery({ unitId, date, groupId })
+      unitRealizedOccupanciesForDayQuery({ unitId, body: { date, groupIds } })
     )
 
     return renderResult(occupancies, (occupancies, isReloading) => (
@@ -70,15 +70,15 @@ export const RealtimeRealizedOccupanciesForSingleDay = React.memo(
 export const RealtimePlannedOccupanciesForSingleDay = React.memo(
   function RealtimePlannedOccupanciesForSingleDay({
     unitId,
-    groupId,
+    groupIds,
     date
   }: {
     unitId: UUID
-    groupId: UUID | null
+    groupIds: UUID[] | null
     date: LocalDate
   }) {
     const rows = useQueryResult(
-      unitPlannedOccupanciesForDayQuery({ unitId, date, groupId })
+      unitPlannedOccupanciesForDayQuery({ unitId, body: { date, groupIds } })
     )
 
     return renderResult(rows, (rows, isReloading) => (

--- a/frontend/src/employee-frontend/generated/api-clients/occupancy.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/occupancy.ts
@@ -6,6 +6,8 @@
 
 import LocalDate from 'lib-common/local-date'
 import { AttendanceReservationReportRow } from 'lib-common/generated/api-types/reports'
+import { GetUnitOccupanciesForDayBody } from 'lib-common/generated/api-types/occupancy'
+import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { OccupancyResponseSpeculated } from 'lib-common/generated/api-types/occupancy'
 import { RealtimeOccupancy } from 'lib-common/generated/api-types/occupancy'
@@ -78,18 +80,13 @@ export async function getUnitOccupancies(
 export async function getUnitPlannedOccupanciesForDay(
   request: {
     unitId: UUID,
-    date: LocalDate,
-    groupId?: UUID | null
+    body: GetUnitOccupanciesForDayBody
   }
 ): Promise<AttendanceReservationReportRow[]> {
-  const params = createUrlSearchParams(
-    ['date', request.date.formatIso()],
-    ['groupId', request.groupId]
-  )
   const { data: json } = await client.request<JsonOf<AttendanceReservationReportRow[]>>({
     url: uri`/employee/occupancy/units/${request.unitId}/day/planned`.toString(),
-    method: 'GET',
-    params
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<GetUnitOccupanciesForDayBody>
   })
   return json.map(e => deserializeJsonAttendanceReservationReportRow(e))
 }
@@ -101,18 +98,13 @@ export async function getUnitPlannedOccupanciesForDay(
 export async function getUnitRealizedOccupanciesForDay(
   request: {
     unitId: UUID,
-    date: LocalDate,
-    groupId?: UUID | null
+    body: GetUnitOccupanciesForDayBody
   }
 ): Promise<RealtimeOccupancy> {
-  const params = createUrlSearchParams(
-    ['date', request.date.formatIso()],
-    ['groupId', request.groupId]
-  )
   const { data: json } = await client.request<JsonOf<RealtimeOccupancy>>({
     url: uri`/employee/occupancy/units/${request.unitId}/day/realized`.toString(),
-    method: 'GET',
-    params
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<GetUnitOccupanciesForDayBody>
   })
   return deserializeJsonRealtimeOccupancy(json)
 }

--- a/frontend/src/lib-common/generated/api-types/occupancy.ts
+++ b/frontend/src/lib-common/generated/api-types/occupancy.ts
@@ -6,6 +6,7 @@
 
 import FiniteDateRange from '../../finite-date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
+import LocalDate from '../../local-date'
 import { Caretakers } from './daycare'
 import { JsonOf } from '../../json'
 import { UUID } from '../../types'
@@ -26,6 +27,14 @@ export interface ChildOccupancyAttendance {
   capacity: number
   childId: UUID
   departed: HelsinkiDateTime | null
+}
+
+/**
+* Generated from fi.espoo.evaka.occupancy.OccupancyController.GetUnitOccupanciesForDayBody
+*/
+export interface GetUnitOccupanciesForDayBody {
+  date: LocalDate
+  groupIds: UUID[] | null
 }
 
 /**
@@ -148,6 +157,14 @@ export function deserializeJsonChildOccupancyAttendance(json: JsonOf<ChildOccupa
     ...json,
     arrived: HelsinkiDateTime.parseIso(json.arrived),
     departed: (json.departed != null) ? HelsinkiDateTime.parseIso(json.departed) : null
+  }
+}
+
+
+export function deserializeJsonGetUnitOccupanciesForDayBody(json: JsonOf<GetUnitOccupanciesForDayBody>): GetUnitOccupanciesForDayBody {
+  return {
+    ...json,
+    date: LocalDate.parseIso(json.date)
   }
 }
 

--- a/frontend/src/lib-components/atoms/dropdowns/TreeDropdown.tsx
+++ b/frontend/src/lib-components/atoms/dropdowns/TreeDropdown.tsx
@@ -21,7 +21,7 @@ import { IconOnlyButton } from '../buttons/IconOnlyButton'
 const DropdownContainer = styled.div`
   border: 1px solid ${(p) => p.theme.colors.grayscale.g70};
   border-radius: 4px;
-  padding: ${defaultMargins.xs};
+  padding: ${defaultMargins.xxs} ${defaultMargins.xs};
   display: flex;
   gap: ${defaultMargins.xs};
   justify-content: space-between;
@@ -135,6 +135,10 @@ const ValueChip = styled.div`
   flex-wrap: wrap;
   gap: ${defaultMargins.xs};
   align-items: center;
+`
+
+const Placeholder = styled.div`
+  padding: ${defaultMargins.xxs} ${defaultMargins.xs};
 `
 
 /**
@@ -375,7 +379,11 @@ function TreeDropdown<N extends TreeNode>({
         data-qa-expanded={active}
       >
         <DropdownContainerContent data-qa="selected-values">
-          {treeValue.length === 0 ? placeholder : treeValue}
+          {treeValue.length === 0 ? (
+            <Placeholder>{placeholder}</Placeholder>
+          ) : (
+            treeValue
+          )}
         </DropdownContainerContent>
         <IconOnlyButton icon={faChevronDown} aria-label={i18n.expandDropdown} />
       </DropdownContainer>

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/occupancy/OccupancyControllerIntegrationTest.kt
@@ -955,7 +955,7 @@ class OccupancyControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
             tx.insert(staffAttendance3)
         }
 
-        val occupanciesForUnit = getUnitRealizedOccupanciesForDay(today, groupId = null)
+        val occupanciesForUnit = getUnitRealizedOccupanciesForDay(today, groupIds = null)
         assertEquals(
             RealtimeOccupancy(
                 childAttendances =
@@ -1001,7 +1001,7 @@ class OccupancyControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
             occupanciesForUnit,
         )
 
-        val occupanciesForGroup1 = getUnitRealizedOccupanciesForDay(today, group1.id)
+        val occupanciesForGroup1 = getUnitRealizedOccupanciesForDay(today, listOf(group1.id))
         assertEquals(
             RealtimeOccupancy(
                 childAttendances =
@@ -1091,13 +1091,12 @@ class OccupancyControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
             groupId,
         )
 
-    private fun getUnitRealizedOccupanciesForDay(date: LocalDate, groupId: GroupId?) =
+    private fun getUnitRealizedOccupanciesForDay(date: LocalDate, groupIds: List<GroupId>?) =
         occupancyController.getUnitRealizedOccupanciesForDay(
             dbInstance(),
             AuthenticatedUser.Employee(testDecisionMaker_1.id, setOf(UserRole.SERVICE_WORKER)),
             mockClock,
             testDaycare.id,
-            date,
-            groupId,
+            OccupancyController.GetUnitOccupanciesForDayBody(date, groupIds),
         )
 }


### PR DESCRIPTION
- Parannetaan puu-valitsimen ulkonäköä
- Näytetään oletuksena suunnitelma (ennen näytettiin toteuma)
- Piilotetaan lakkautetut ryhmät ryhmävalikosta
- Sallitaan useamman kuin yhden ryhmän valinta yhtä aikaa:

<img width="773" alt="image" src="https://github.com/user-attachments/assets/0115b37f-248c-4456-a79f-50322abc56d4">
