### PR TITLE
Focus-tyylien palauttaminen

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -654,8 +654,8 @@ const DayCell = styled.button<{
         `
       : ''};
 
-  :focus {
-    box-shadow: 0 0 0 4px ${(p) => p.theme.colors.main.m2Focus};
+  &:focus {
+    outline: 2px solid ${(p) => p.theme.colors.main.m2};
     z-index: 1;
   }
 `

--- a/frontend/src/citizen-frontend/calendar/DayElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayElem.tsx
@@ -165,8 +165,9 @@ const Day = styled.button<{
         ? `background-color: ${colors.accents.a10powder}`
         : undefined};
 
-  :focus {
+  &:focus {
     outline: 2px solid ${(p) => p.theme.colors.main.m2Focus};
+    z-index: 1;
   }
 `
 const DayColumn = styled(FixedSpaceColumn)<{

--- a/frontend/src/employee-frontend/components/Header.tsx
+++ b/frontend/src/employee-frontend/components/Header.tsx
@@ -121,7 +121,7 @@ const NavbarLink = styled(NavLink)`
       font-weight: ${fontWeights.bold};
     }
   }
-  :focus {
+  &:focus {
     border-color: ${(p) => p.theme.colors.main.m3};
   }
   :hover {

--- a/frontend/src/lib-components/atoms/buttons/LinkButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/LinkButton.tsx
@@ -36,13 +36,15 @@ export default styled.a`
   justify-content: center;
   align-items: center;
 
-  :hover {
+  &:hover {
     background-color: ${(p) => p.theme.colors.main.m2Hover};
   }
-  :focus {
-    background-color: ${(p) => p.theme.colors.main.m2Focus};
+  &:focus {
+    box-shadow:
+      0 0 0 2px ${(p) => p.theme.colors.grayscale.g0},
+      0 0 0 4px ${(p) => p.theme.colors.main.m2Focus};
   }
-  :active {
+  &:active {
     background-color: ${(p) => p.theme.colors.main.m2Active};
   }
 `

--- a/frontend/src/lib-components/layout/Container.tsx
+++ b/frontend/src/lib-components/layout/Container.tsx
@@ -188,7 +188,7 @@ export const TitleContainer = styled.button`
   padding: ${defaultMargins.xs};
   width: calc(100% + 2 * ${defaultMargins.xs});
 
-  :focus {
+  &:focus {
     border-color: ${(p) => p.theme.colors.main.m2Focus};
   }
 

--- a/frontend/src/lib-components/molecules/DatePickerDeprecated.tsx
+++ b/frontend/src/lib-components/molecules/DatePickerDeprecated.tsx
@@ -49,11 +49,13 @@ const StyledInput = styled.input`
   background-color: transparent;
   padding-bottom: calc(0.5em - 1px);
 
-  :focus {
-    padding-bottom: calc(calc(0.5em - 1px) - 1px);
-    border-bottom-width: 2px;
-    border-color: ${(p) => p.theme.colors.main.m2};
+  &:focus {
     outline: none;
+  }
+  &:focus-visible {
+    border-radius: 2px;
+    border-width: 2px;
+    border-color: ${(p) => p.theme.colors.main.m2Focus};
   }
 `
 

--- a/frontend/src/lib-components/molecules/Tabs.tsx
+++ b/frontend/src/lib-components/molecules/Tabs.tsx
@@ -154,7 +154,7 @@ const tabStyles = css<{
       : css`
           border: 2px solid transparent;
 
-          :focus {
+          &:focus {
             border-color: ${p.theme.colors.main.m1};
           }
         `}


### PR DESCRIPTION
Taskina lisätä focus-tyyli kalenterinäkymään. Ominaisuus toteutettu aikaisemmin, hajonnut styled-components -kirjaston päivityksen 5 -> 6 yhteydessä ( https://styled-components.com/docs/faqs#nested-syntax-handling ), selector ei kohdistu oikein ilman &-merkkiä.

Osassa focus-tyyli toimi ainakin osittain tästä huolimatta.

Ennen | Jälkeen
--- | ---
![240920-calendar-focus-pre](https://github.com/user-attachments/assets/1134c9f9-2508-402e-9499-f47c64dc301b) | ![240920-calendar-focus-post](https://github.com/user-attachments/assets/98baafac-8b04-48d1-91d2-6d9db1f0edfd)

Käyty läpi muutkin kohdat joissa focus- yms user-action pseudo-selectorit jääneet "piiloon" päivityksen myötä. Muokatun Tabs-komponentin desktop-näkymä ei tällä hetkellä käytössä.

Ennen | Jälkeen
--- | ---
DayElem | 
![240920-calendar-mobile-pre-425x736 Medium](https://github.com/user-attachments/assets/5e1dd0c8-8b01-432e-a15f-7192b838006b) | ![240920-calendar-mobile-post-425x736 Medium](https://github.com/user-attachments/assets/ef649f92-f8b8-4f14-91cf-af14168caabe)
Header | 
![240920-header-pre](https://github.com/user-attachments/assets/aa6c9c8c-68ac-4889-ab3e-4af43604e84a) | ![240920-header-post](https://github.com/user-attachments/assets/778bc6af-76b2-412e-a9ee-21597145f0ef)
LinkButton | 
![240920-linkbutton-pre](https://github.com/user-attachments/assets/0dd4d591-8ebc-444c-b844-f519972f6b58) | ![240923-linkbutton-post](https://github.com/user-attachments/assets/250e24b2-c85a-454d-8385-d0031a8a43b5)
Container / TitleContainer | 
![240920-collapsible-pre](https://github.com/user-attachments/assets/a15e8a29-1aee-4101-9bbb-d7897805d4c6) | ![240920-collapsible-post](https://github.com/user-attachments/assets/9837a11b-8381-40bd-9bf5-1bab6f91eaf6)
DatePicker | 
![240920-datepicker-pre](https://github.com/user-attachments/assets/004b2706-a6cf-4856-8e24-0bc446896631) | ![240923-datepicker-post](https://github.com/user-attachments/assets/903ebf50-3c93-4aca-ba2d-a0595e999308)

(edit) DatePickerissä oli pelkkä alleviivaus korostettuna, nyt samanlainen focus kuin muissa inputeissa