### PR TITLE
Näytetään Varda-tila oikein Hetuttomat lapset -raportilla

### DIFF
--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -99,6 +99,7 @@ export class MissingHeadOfFamilyReport {
 
 export class NonSsnChildrenReport {
   #nameHeader: Element
+
   constructor(private page: Page) {
     this.#nameHeader = page.findByDataQa(`child-name-header`)
   }
@@ -111,8 +112,8 @@ export class NonSsnChildrenReport {
     expected: {
       childName: string
       dateOfBirth: string
-      personOid: string
-      vardaOid: string
+      ophPersonOid: string
+      lastSentToVarda: string
     }[]
   ) {
     const rows = this.page.findAllByDataQa('non-ssn-child-row')
@@ -121,8 +122,12 @@ export class NonSsnChildrenReport {
       const row = rows.nth(index)
       await row.findByDataQa('child-name').assertTextEquals(data.childName)
       await row.findByDataQa('date-of-birth').assertTextEquals(data.dateOfBirth)
-      await row.findByDataQa('person-oid').assertTextEquals(data.personOid)
-      await row.findByDataQa('varda-oid').assertTextEquals(data.vardaOid)
+      await row
+        .findByDataQa('oph-person-oid')
+        .assertTextEquals(data.ophPersonOid)
+      await row
+        .findByDataQa('last-sent-to-varda')
+        .assertTextEquals(data.lastSentToVarda)
     }
   }
 }
@@ -130,6 +135,7 @@ export class NonSsnChildrenReport {
 export class ApplicationsReport {
   #table: Element
   #areaSelector: Combobox
+
   constructor(private page: Page) {
     this.#table = page.findByDataQa(`report-application-table`)
     this.#areaSelector = new Combobox(page.findByDataQa('select-area'))
@@ -223,6 +229,7 @@ export class PlacementGuaranteeReport {
 
 export class PlacementSketchingReport {
   #applicationStatus: MultiSelect
+
   constructor(private page: Page) {
     this.#applicationStatus = new MultiSelect(
       page.findByDataQa('select-application-status')
@@ -266,6 +273,7 @@ export class VoucherServiceProvidersReport {
   #year: Select
   #area: Select
   #downloadCsvLink: Element
+
   constructor(private page: Page) {
     this.#month = new Select(page.findByDataQa('select-month'))
     this.#year = new Select(page.findByDataQa('select-year'))
@@ -322,6 +330,7 @@ export class VoucherServiceProvidersReport {
 
 export class ServiceVoucherUnitReport {
   #childRows: ElementCollection
+
   constructor(private page: Page) {
     this.#childRows = page.findAllByDataQa('child-row')
   }
@@ -390,6 +399,7 @@ export class ManualDuplicationReport {
 export class VardaErrorsReport {
   #errorsTable: Element
   #errorRows: ElementCollection
+
   constructor(private page: Page) {
     this.#errorsTable = page.findByDataQa('varda-errors-table')
     this.#errorRows = page.findAll('[data-qa="varda-error-row"]')
@@ -417,6 +427,7 @@ export class VardaErrorsReport {
 
 export class AssistanceNeedDecisionsReport {
   rows: ElementCollection
+
   constructor(page: Page) {
     this.rows = page.findAllByDataQa('assistance-need-decision-row')
   }
@@ -451,6 +462,7 @@ export class AssistanceNeedDecisionsReportDecision {
   annulReasonInput: TextInput
   modalOkBtn: Element
   mismatchModalLink: Element
+
   constructor(private page: Page) {
     this.decisionMaker = page.findByDataQa('labelled-value-decision-maker')
     this.decisionStatus = new StaticChip(page.findByDataQa('decision-status'))
@@ -489,6 +501,7 @@ export class AssistanceNeedPreschoolDecisionsReportDecision {
   modalOkBtn: Element
   status: Element
   annulmentReason: Element
+
   constructor(page: Page) {
     this.returnForEditBtn = page.findByDataQa('return-for-edit-button')
     this.approveBtn = page.findByDataQa('approve-button')
@@ -507,6 +520,7 @@ export class AssistanceNeedsAndActionsReport {
   needsAndActionsRows: ElementCollection
   childRows: ElementCollection
   careAreaSelect: Combobox
+
   constructor(private page: Page) {
     this.needsAndActionsRows = page.findAllByDataQa(
       'assistance-needs-and-actions-row'

--- a/frontend/src/e2e-test/specs/5_employee/non-ssn-children-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/non-ssn-children-report.spec.ts
@@ -125,14 +125,14 @@ const assertReport = async (report: NonSsnChildrenReport) => {
     {
       childName: `${child.lastName} ${child.firstName}`,
       dateOfBirth: child.dateOfBirth.format(),
-      personOid: child.ophPersonOid ?? '',
-      vardaOid: ''
+      ophPersonOid: child.ophPersonOid ?? '',
+      lastSentToVarda: '-'
     },
     {
       childName: `${child2.lastName} ${child2.firstName}`,
       dateOfBirth: child2.dateOfBirth.format(),
-      personOid: child2.ophPersonOid ?? '',
-      vardaOid: ''
+      ophPersonOid: child2.ophPersonOid ?? '',
+      lastSentToVarda: '-'
     }
   ]
 

--- a/frontend/src/employee-frontend/components/reports/NonSsnChildren.tsx
+++ b/frontend/src/employee-frontend/components/reports/NonSsnChildren.tsx
@@ -71,7 +71,8 @@ export default React.memo(function NonSsnChildren() {
             <ReportDownload
               data={rows.map((row) => ({
                 ...row,
-                dateOfBirth: row.dateOfBirth.format()
+                dateOfBirth: row.dateOfBirth.format(),
+                lastSentToVarda: row.lastSentToVarda?.format() ?? '-'
               }))}
               headers={[
                 {
@@ -88,11 +89,11 @@ export default React.memo(function NonSsnChildren() {
                 },
                 {
                   label: i18n.reports.nonSsnChildren.personOid,
-                  key: 'existingPersonOid'
+                  key: 'ophPersonOid'
                 },
                 {
-                  label: i18n.reports.nonSsnChildren.vardaOid,
-                  key: 'vardaOid'
+                  label: i18n.reports.nonSsnChildren.lastSentToVarda,
+                  key: 'lastSentToVarda'
                 }
               ]}
               filename={`Hetuttomat lapset ${LocalDate.todayInHelsinkiTz().formatIso()}.csv`}
@@ -138,7 +139,7 @@ export default React.memo(function NonSsnChildren() {
                         : undefined
                     }
                     onClick={() =>
-                      sortBy(['existingPersonOid', 'lastName', 'firstName'])
+                      sortBy(['ophPersonOid', 'lastName', 'firstName'])
                     }
                   >
                     {i18n.reports.nonSsnChildren.personOid}
@@ -154,10 +155,10 @@ export default React.memo(function NonSsnChildren() {
                         : undefined
                     }
                     onClick={() =>
-                      sortBy(['vardaOid', 'lastName', 'firstName'])
+                      sortBy(['lastSentToVarda', 'lastName', 'firstName'])
                     }
                   >
-                    {i18n.reports.nonSsnChildren.vardaOid}
+                    {i18n.reports.nonSsnChildren.lastSentToVarda}
                   </SortableTh>
                 </Tr>
               </Thead>
@@ -170,8 +171,10 @@ export default React.memo(function NonSsnChildren() {
                       </Link>
                     </Td>
                     <Td data-qa="date-of-birth">{row.dateOfBirth.format()}</Td>
-                    <Td data-qa="person-oid">{row.existingPersonOid}</Td>
-                    <Td data-qa="varda-oid">{row.vardaOid}</Td>
+                    <Td data-qa="oph-person-oid">{row.ophPersonOid}</Td>
+                    <Td data-qa="last-sent-to-varda">
+                      {row.lastSentToVarda?.format() ?? '-'}
+                    </Td>
                   </Tr>
                 ))}
               </Tbody>

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -525,10 +525,10 @@ export interface MissingServiceNeedReportRow {
 export interface NonSsnChildrenReportRow {
   childId: UUID
   dateOfBirth: LocalDate
-  existingPersonOid: string | null
   firstName: string
   lastName: string
-  vardaOid: string | null
+  lastSentToVarda: HelsinkiDateTime | null
+  ophPersonOid: string | null
 }
 
 /**
@@ -1068,7 +1068,8 @@ export function deserializeJsonMissingHeadOfFamilyReportRow(json: JsonOf<Missing
 export function deserializeJsonNonSsnChildrenReportRow(json: JsonOf<NonSsnChildrenReportRow>): NonSsnChildrenReportRow {
   return {
     ...json,
-    dateOfBirth: LocalDate.parseIso(json.dateOfBirth)
+    dateOfBirth: LocalDate.parseIso(json.dateOfBirth),
+    lastSentToVarda: (json.lastSentToVarda != null) ? HelsinkiDateTime.parseIso(json.lastSentToVarda) : null
   }
 }
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3993,8 +3993,8 @@ export const fi = {
         'Raportti hetuttomista sijoitetuista lapsista OID-tietojen tarkistamiseen',
       childName: 'Lapsen nimi',
       dateOfBirth: 'Syntymäpäivä',
-      vardaOid: 'Varda-tietojen OID',
       personOid: 'Lapsen tietojen OID',
+      lastSentToVarda: 'Viety Vardaan viimeksi',
       total: 'Yhteensä'
     },
     placementCount: {


### PR DESCRIPTION
Hettutomat lapset -raportin Varda-tiedot eivät päivittyneet oikein, koska raportti käytti vanhan Varda-integraation tietokantatauluja.

Otetaan uuden integraation tiedot käyttöön, ja näyteään raportilla viimeisin onnistunut Vardaanvientiaika.

<img width="1165" alt="Screenshot 2024-09-23 at 13 30 26" src="https://github.com/user-attachments/assets/89cfd64b-1f71-4578-bb79-6fe3714ca396">
