### PR TITLE
Varoitetaan avoimista kirjauksista vain jos ne ovat toisessa yksikössä

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
@@ -82,6 +82,7 @@ interface Props<
   onSave: (body: T[]) => void
   onSuccess: () => void
   onClose: () => void
+  unitId: string
 }
 
 export interface EditedAttendance {
@@ -119,7 +120,8 @@ function StaffAttendanceDetailsModal<
   validate,
   onSave,
   onSuccess,
-  onClose
+  onClose,
+  unitId
 }: Props<T>) {
   const { i18n } = useTranslation()
 
@@ -357,6 +359,9 @@ function StaffAttendanceDetailsModal<
     ? openAttendanceResult.value.openGroupAttendance
     : null
 
+  const openAttendanceInAnotherUnit =
+    !!openAttendance && openAttendance.unitId !== unitId
+
   return (
     <PlainModal margin="auto" data-qa="staff-attendance-details-modal">
       <Content>
@@ -488,7 +493,7 @@ function StaffAttendanceDetailsModal<
         )}
 
         {!arrivalWithoutDeparture &&
-          !!openAttendance &&
+          openAttendanceInAnotherUnit &&
           openAttendance.date.isEqualOrBefore(date) && (
             <FullGridWidth>
               <FixedSpaceRow

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -325,6 +325,7 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
       defaultGroupId={defaultGroupId}
       onClose={onClose}
       onSuccess={onSuccess}
+      unitId={unitId}
     />
   ) : (
     <StaffAttendanceDetailsModal
@@ -343,6 +344,7 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
       defaultGroupId={defaultGroupId}
       onClose={onClose}
       onSuccess={onSuccess}
+      unitId={unitId}
     />
   )
 })

--- a/frontend/src/employee-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attendance.ts
@@ -31,7 +31,7 @@ export async function getOpenGroupAttendance(
     ['userId', request.userId]
   )
   const { data: json } = await client.request<JsonOf<OpenGroupAttendanceResponse>>({
-    url: uri`/employee/staff-attendances/realtime/open-attendence`.toString(),
+    url: uri`/employee/staff-attendances/realtime/open-attendance`.toString(),
     method: 'GET',
     params
   })

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceController.kt
@@ -308,7 +308,7 @@ class RealtimeStaffAttendanceController(private val accessControl: AccessControl
         )
     }
 
-    @GetMapping("/employee/staff-attendances/realtime/open-attendence")
+    @GetMapping("/employee/staff-attendances/realtime/open-attendance")
     fun getOpenGroupAttendance(
         db: Database,
         user: AuthenticatedUser.Employee,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -1457,6 +1457,7 @@ sealed interface Action {
         ACTIVATE(HasGlobalRole(ADMIN)),
         DEACTIVATE(HasGlobalRole(ADMIN)),
         READ_OPEN_GROUP_ATTENDANCE(
+            HasGlobalRole(ADMIN),
             IsMobile(false).isAssociatedWithEmployee(),
             IsEmployee.isInSameUnitWithEmployee(),
         );


### PR DESCRIPTION
## Ennen tätä muutosta
Työntekijän desktop-versio varoitti myös samassa yksikössä olevista avoimista kirjauksista
## Tämän muutoksen jälkeen
Varoitus näytetään vain toisessa yksikössä olevista avoimista korjauksista.

Tämä muutos korjaa myös näppäilyvirheen open attendances routen pathissä ja sallii avoimien kirjausten haun pääkäyttäjälle