### PR TITLE
Tekstipäivityksiä

### DIFF
--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1007,7 +1007,7 @@ const en: Translations = {
             'If the child has already been to the club during the previous club term, he or she has a better chance of getting a placement in the club.'
         },
         urgent: {
-          label: 'Application is urgent',
+          label: 'Application is urgent (does not apply to transfer applications)',
           attachmentsMessage: {
             text: (
               <P fitted={true}>

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1007,7 +1007,8 @@ const en: Translations = {
             'If the child has already been to the club during the previous club term, he or she has a better chance of getting a placement in the club.'
         },
         urgent: {
-          label: 'Application is urgent (does not apply to transfer applications)',
+          label:
+            'Application is urgent (does not apply to transfer applications)',
           attachmentsMessage: {
             text: (
               <P fitted={true}>

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -978,7 +978,7 @@ export default {
             'Jos lapsi on ollut kerhossa jo edellisen toimintakauden aikana, on hänellä suurempi mahdollisuus saada paikka kerhosta.'
         },
         urgent: {
-          label: 'Hakemus on kiireellinen',
+          label: 'Hakemus on kiireellinen (ei koske siirtohakemuksia)',
           attachmentsMessage: {
             text: (
               <P fitted={true}>

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -989,7 +989,7 @@ const sv: Translations = {
             'Om barnet redan har varit på klubben under föregående säsong har han eller hon större chans att få en plats i klubben.'
         },
         urgent: {
-          label: 'Ansökningen är brådskande',
+          label: 'Ansökningen är brådskande (gäller inte ansökan om byte)',
           attachmentsMessage: {
             text: (
               <P fitted={true}>

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1923,7 +1923,7 @@ const sv: Translations = {
       PRESCHOOL: 'Ansökan till förskolan',
       CLUB: 'Ansökan till klubbverksamhet'
     },
-    transferApplication: 'Ansökan om överföring',
+    transferApplication: 'om byte till en annan enhet',
     period: 'För tiden',
     created: 'Ansökan skapad',
     modified: 'Redigerad/uppdaterad',


### PR DESCRIPTION
- Hakemus on kiireellinen -> Hakemus on kiireellinen (ei koske siirtohakemuksia)
- Korjattu väärä ruotsinnos