### PR TITLE
Päiväeditorin sulkeminen kohdistaa kalenteripäivään

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarGridView.tsx
@@ -526,6 +526,7 @@ const Day = React.memo(function Day({
       $selected={selected}
       onClick={onClick}
       data-qa={`desktop-calendar-day-${day.date.formatIso()}`}
+      id={`calendar-day-${day.date.formatIso()}`}
     >
       <DayCellHeader>
         <DayCellDate

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -195,7 +195,12 @@ const CalendarPage = React.memo(function CalendarPage() {
                   date={modalState.date}
                   reservationsResponse={response}
                   selectDate={openDayModal}
-                  onClose={closeModal}
+                  onClose={() => {
+                    closeModal()
+                    findElementAndFocus(
+                      `calendar-day-${modalState.date.formatIso()}`
+                    )
+                  }}
                   openAbsenceModal={(date) => openAbsenceModal(date, true)}
                   events={events}
                   holidayPeriods={holidayPeriods}
@@ -466,6 +471,16 @@ function buildQueryString(modal: URLModalState): string {
     case 'discussion-reservations':
       return `modal=discussion-reservations${modal.selectedChildId ? '&selectedChildId=' + modal.selectedChildId : ''}${modal.selectedEventId ? '&selectedEventId=' + modal.selectedEventId : ''}`
   }
+}
+
+function findElementAndFocus(id: string): void {
+  const focusElement = () => {
+    const element = document.getElementById(id)
+    if (element) {
+      element.focus()
+    }
+  }
+  requestAnimationFrame(focusElement)
 }
 
 const DesktopOnly = styled(Desktop)`

--- a/frontend/src/citizen-frontend/calendar/DayElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayElem.tsx
@@ -98,6 +98,7 @@ export default React.memo(function DayElem({
       $highlight={highlight}
       onClick={handleClick}
       data-qa={`mobile-calendar-day-${calendarDay.date.formatIso()}`}
+      id={`calendar-day-${calendarDay.date.formatIso()}`}
     >
       <DayColumn
         spacing="xxs"

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -324,6 +324,33 @@ export default class CitizenCalendarPage {
     const childImages = this.dayCell(date).findAllByDataQa('child-image')
     await childImages.assertCount(expectedCount)
   }
+
+  async getPageActiveElementDetails() {
+    return await this.page.page.evaluate(() => {
+      const activeElement = document.activeElement
+      let computedStyle: CSSStyleDeclaration = {} as CSSStyleDeclaration
+      if (activeElement) {
+        computedStyle = getComputedStyle(activeElement)
+      }
+      return {
+        id: activeElement?.id,
+        dataQa: activeElement?.getAttribute('data-qa'),
+        computedStyle
+      }
+    })
+  }
+
+  readonly desktopFocusColor = 'rgb(0, 71, 182)'
+  readonly mobileFocusColor = 'rgb(77, 127, 204)'
+
+  async assertDayIsFocusedAndStyled(dayId: string) {
+    const activeElement = await this.getPageActiveElementDetails()
+    expect(activeElement.id).toBe(dayId)
+    expect([this.desktopFocusColor, this.mobileFocusColor]).toContain(
+      activeElement.computedStyle.outlineColor
+    )
+    expect(activeElement.computedStyle.outlineWidth).toBe('2px')
+  }
 }
 
 type ReadOnlyDayState =

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
@@ -184,4 +184,13 @@ describe.each(e)('Citizen calendar (%s)', (env) => {
 
     await dayView.close()
   })
+
+  test('After close, focus is set to the correct day and style', async () => {
+    const todayId = `calendar-day-${today.formatIso()}`
+    const dayView = await calendarPage.openDayView(today)
+
+    await dayView.close()
+
+    await calendarPage.assertDayIsFocusedAndStyled(todayId)
+  })
 })


### PR DESCRIPTION
### Ennen tätä muutosta
Päiväeditoria suljettaessa kohdistus hävisi kalenterista

### Tämän muutoksen jälkeen
Asetetaan kohdistus kalenterissa oikealle päivälle kun päiväeditori-modaali suljetaan


 https://github.com/user-attachments/assets/6450913e-131d-4816-a7b6-35bfe3f41b57


https://github.com/user-attachments/assets/d914a966-15d5-4797-bf34-6c987f76f37b

