### PR TITLE
Näytetään pedagogisen arvion toimintopainikkeet tulosteessa lomakkeen lopussa eikä sisällön päällä

### DIFF
--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
@@ -75,6 +75,10 @@ const ActionBar = styled.div`
   background-color: white;
   margin-top: ${defaultMargins.L};
   padding: ${defaultMargins.s} 0;
+
+  @media print {
+    position: relative;
+  }
 `
 
 const DocumentBasics = React.memo(function DocumentBasics({


### PR DESCRIPTION
Tulostettaessa pedagoginen arvio selaimen tulostustoiminnolla, saattoivat toimintopainikkeet ja asiakirjan julkaisun tila jäädä tulosteessa muun sisällön päälle:

<img width="452" alt="image" src="https://github.com/user-attachments/assets/a3d9dce5-d0c4-4f6d-9a7a-c679187d58fd">

Korjauksen jälkeen toimintopainikkeet ja asiakirjan julkaisun tila tulostetaan lomakkeen loppuun:

<img width="509" alt="image" src="https://github.com/user-attachments/assets/482c53f3-b9a9-4711-b84e-291269f596cd">

Korjaus, jossa julkaisun tila olisi näytetty asiakirjan lopussa ja nappeja ei olisi näytetty ollenkaan, olisi ollut hieman työläämpi korjaus, joten siksi korjattu näin.