### PR TITLE
Parannetaan kalenteritapahtumien tietokantakyselyiden suorituskykyä

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
@@ -341,12 +341,12 @@ fun Database.Read.getDaycareEventsForGuardian(
     createQuery {
             sql(
                 """
-WITH child AS NOT MATERIALIZED (
+WITH child AS MATERIALIZED (
     SELECT g.child_id id FROM guardian g WHERE g.guardian_id = ${bind(guardianId)}
     UNION
     SELECT fp.child_id FROM foster_parent fp WHERE parent_id = ${bind(guardianId)} AND valid_during && ${bind(range)}
 ),
-child_placement AS NOT MATERIALIZED (
+child_placement AS MATERIALIZED (
     SELECT p.id, p.unit_id, p.child_id, placement_without_backup.range period, null backup_group_id
     FROM placement p
     LEFT JOIN LATERAL (
@@ -405,7 +405,7 @@ fun Database.Read.getDiscussionSurveysForGuardian(
     createQuery {
             sql(
                 """
-WITH children_of_guardian AS NOT MATERIALIZED (SELECT g.child_id id
+WITH children_of_guardian AS MATERIALIZED (SELECT g.child_id id
                                 FROM guardian g
                                 WHERE g.guardian_id = ${bind(guardianId)}
                                 UNION
@@ -413,7 +413,7 @@ WITH children_of_guardian AS NOT MATERIALIZED (SELECT g.child_id id
                                 FROM foster_parent fp
                                 WHERE parent_id = ${bind(guardianId)}
                                   AND valid_during && ${bind(range)}),
-     child_placement AS NOT MATERIALIZED (SELECT p.id,
+     child_placement AS MATERIALIZED (SELECT p.id,
                                                  p.unit_id,
                                                  p.child_id,
                                                  daterange(p.start_date, p.end_date, '[]') as period

--- a/service/src/main/resources/db/migration/V443__calendar_event_indexes.sql
+++ b/service/src/main/resources/db/migration/V443__calendar_event_indexes.sql
@@ -1,0 +1,8 @@
+DROP INDEX idx$calendar_event_type;
+
+CREATE INDEX idx$calendar_event_type_period ON calendar_event USING gist(event_type, period);
+
+CREATE INDEX idx$calendar_event_time_created_by ON calendar_event_time (created_by);
+CREATE INDEX idx$calendar_event_time_modified_by ON calendar_event_time (modified_by);
+CREATE INDEX idx$calendar_event_time_event_id ON calendar_event_time (calendar_event_id);
+CREATE INDEX idx$calendar_event_time_child ON calendar_event_time (child_id) WHERE child_id IS NOT NULL;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -438,3 +438,4 @@ V439__income_statement_and_income_indexes.sql
 V440__rename_curriculum_tables_to_backup.sql
 V441__placement_modification_user_and_timestamp.sql
 V442__assistance_need_decision_no_end_date.sql
+V443__calendar_event_indexes.sql


### PR DESCRIPTION
- replace NOT MATERIALIZED with MATERIALIZED. A single guardian has a small amount of children and a relatively small amount of placements, so we *want* to materialize to prevent the query planner from trying to be too clever
- replace useless calendar_event.type index
- add missing indexes (calendar_event_time.calendar_event_id is the most important)

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
