### PR TITLE
Henkilökunnan ei-reaaliaikaisen läsnäolokirjauksen voi tyhjentää

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-month-calendar-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-month-calendar-page.ts
@@ -138,17 +138,17 @@ export class UnitMonthCalendarPage extends UnitCalendarPageBase {
     }
   }
 
-  async fillStaffAttendance(n: number, staffCount: number) {
+  async fillStaffAttendance(n: number, staffCount: string) {
     const cell = this.#staffAttendanceCells.nth(n)
-    await new TextInput(cell.find('input')).fill(staffCount.toString())
+    await new TextInput(cell.find('input')).fill(staffCount)
 
     // Wait until saved
     await waitUntilEqual(() => cell.getAttribute('data-state'), 'clean')
   }
 
-  async assertStaffAttendance(n: number, staffCount: number) {
+  async assertStaffAttendance(n: number, staffCount: string) {
     const input = new TextInput(this.#staffAttendanceCells.nth(n).find('input'))
-    await input.assertValueEquals(staffCount.toString())
+    await input.assertValueEquals(staffCount)
   }
 }
 

--- a/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
@@ -234,7 +234,7 @@ describe('Employee - Unit month calendar', () => {
     )
   })
 
-  test('User can add a staff attendance', async () => {
+  test('User can edit staff attendances', async () => {
     await unitPage.navigateToUnit(testDaycare.id)
     const groupsPage = await unitPage.openGroupsPage()
 
@@ -243,13 +243,26 @@ describe('Employee - Unit month calendar', () => {
     )
     const monthCalendarPage = await groupSection.openMonthCalendar()
 
-    await monthCalendarPage.fillStaffAttendance(0, 3)
+    // Add new attendance
+    await monthCalendarPage.fillStaffAttendance(0, '3')
 
     // Change to another page and back to reload data
     await unitPage.openGroupsPage()
     await groupSection.openMonthCalendar()
 
-    await monthCalendarPage.assertStaffAttendance(0, 3)
+    await monthCalendarPage.assertStaffAttendance(0, '3')
+
+    // Clear attendance
+    await monthCalendarPage.fillStaffAttendance(0, '')
+    await unitPage.openGroupsPage()
+    await groupSection.openMonthCalendar()
+    await monthCalendarPage.assertStaffAttendance(0, '')
+
+    // 0 is preserved
+    await monthCalendarPage.fillStaffAttendance(0, '0')
+    await unitPage.openGroupsPage()
+    await groupSection.openMonthCalendar()
+    await monthCalendarPage.assertStaffAttendance(0, '0')
   })
 
   describe('Holiday period reservations', () => {

--- a/frontend/src/employee-frontend/components/absences/StaffAttendance.tsx
+++ b/frontend/src/employee-frontend/components/absences/StaffAttendance.tsx
@@ -58,7 +58,7 @@ export default React.memo(function StaffAttendance({
   }, [groupId, selectedDate])
 
   const updateAttendance = useCallback(
-    (date: LocalDate, count: number) =>
+    (date: LocalDate, count: number | null) =>
       upsertStaffAttendanceResult({
         groupId,
         body: {
@@ -85,7 +85,7 @@ interface StaffAttendanceRowProps {
   days: GroupMonthCalendarDay[]
   emptyCols: number[]
   groupAttendances: Result<StaffAttendanceForDates>
-  updateAttendance: (date: LocalDate, count: number) => Promise<unknown>
+  updateAttendance: (date: LocalDate, count: number | null) => Promise<unknown>
 }
 
 const StaffAttendanceRow = React.memo(function StaffAttendanceRow({
@@ -177,7 +177,7 @@ const InactiveCellContainer = styled.div`
 interface StaffAttendanceCellProps {
   date: LocalDate
   initialCount: number | undefined
-  updateAttendance: (date: LocalDate, count: number) => Promise<unknown>
+  updateAttendance: (date: LocalDate, count: number | null) => Promise<unknown>
 }
 
 const StaffAttendanceCell = React.memo(function StaffAttendanceCell({
@@ -200,7 +200,7 @@ const StaffAttendanceCell = React.memo(function StaffAttendanceCell({
 
   const save = useCallback(
     async (value: string) => {
-      const numberValue = stringToNumber(value)
+      const numberValue = value === '' ? null : stringToNumber(value)
       if (numberValue !== undefined) {
         await updateAttendance(date, numberValue)
       }


### PR DESCRIPTION
Aikaisemmin jos *Henkilökuntaa paikalla* -kenttään syötetyn arvon tyhjensi, tällä ei ollut mitään vaikutusta. Sen sijaan kentässä aikaisemmin ollut arvo jäi voimaan.

Korjauksen jälkeen kentän tyhjentäminen poistaa *Henkilökuntaa paikalla* -tiedon. Jos samalle päivälle on olemassa ei-kasvatusvastuullisten henkilöiden paikallaolotieto, ei *Henkilökuntaa paikalla* tietoa voi poistaa. Tässä tilanteessa kentän tyhjentäminen antaa *Henkilökuntaa paikalla* -tiedolle arvon 0.