### PR TITLE
Toisella perhepäivähoitajalla varahoidossa oleva lapsi nousee perhepäivähoidossa olevien lasten ateriaraportille

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/FamilyDaycareMealReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/FamilyDaycareMealReportTest.kt
@@ -515,17 +515,17 @@ internal class FamilyDaycareMealReportTest : FullApplicationTest(resetDbBeforeEa
                                         lunchCount = 1,
                                         snackCount = 1,
                                         childResults =
-                                        listOf(
-                                            FamilyDaycareMealReport
-                                                .FamilyDaycareMealChildResult(
-                                                    childId = childPId,
-                                                    firstName = "Peter",
-                                                    lastName = "Placer",
-                                                    breakfastCount = 1,
-                                                    lunchCount = 1,
-                                                    snackCount = 1,
-                                                ),
-                                        ),
+                                            listOf(
+                                                FamilyDaycareMealReport
+                                                    .FamilyDaycareMealChildResult(
+                                                        childId = childPId,
+                                                        firstName = "Peter",
+                                                        lastName = "Placer",
+                                                        breakfastCount = 1,
+                                                        lunchCount = 1,
+                                                        snackCount = 1,
+                                                    )
+                                            ),
                                     ),
                                     FamilyDaycareMealReport.FamilyDaycareMealDaycareResult(
                                         daycareName = "Family Daycare B",
@@ -554,7 +554,7 @@ internal class FamilyDaycareMealReportTest : FullApplicationTest(resetDbBeforeEa
                                                         snackCount = 1,
                                                     ),
                                             ),
-                                    )
+                                    ),
                                 ),
                         ),
                     ),


### PR DESCRIPTION
Toisella perhepäivähoitajalla varahoidossa oleva lapsi nousee perhepäivähoidossa olevien lasten ateriaraportille.

Aiemmin ateriamääriä ei huomioitu raportissa, jos siirtyi toiselle perhepäivähoitajalle varahoitoon.'

Kuvassa näkyy vanha ja uusi toiminnallisuus.

![image](https://github.com/user-attachments/assets/710de5a6-36df-4ade-b9e9-3d076b237b98)


