### PR TITLE
Kuntalaisen vastatessa viestiin viestikenttä avautuu ruudulle näkyviin kokonaisuudessaan

### DIFF
--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -129,9 +129,16 @@ export const MessageContainer = styled.li`
   }
 `
 
-export const ReplyEditorContainer = styled.div`
+const StyledReplyEditorContainer = styled.div`
   ${messageContainerStyles}
 `
+
+const ReplyEditorContainer = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(function ReplyEditorContainer(props, ref) {
+  return <StyledReplyEditorContainer ref={ref} {...props} />
+})
 
 const formatMessageAccountName = (
   account: MessageAccount,
@@ -230,10 +237,10 @@ export default React.memo(function ThreadView({
   const hideReplyEditor = useReplyEditorVisible.off
   useEffect(() => hideReplyEditor(), [hideReplyEditor, threadId])
 
-  const autoScrollRef = useRef<HTMLSpanElement>(null)
+  const autoScrollRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
-    scrollRefIntoView(autoScrollRef)
-  }, [messages, replyEditorVisible])
+    scrollRefIntoView(autoScrollRef, undefined, 'end')
+  }, [replyEditorVisible])
 
   const titleRowRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
@@ -301,7 +308,7 @@ export default React.memo(function ThreadView({
         ))}
       </MessageList>
       {replyEditorVisible ? (
-        <ReplyEditorContainer>
+        <ReplyEditorContainer ref={autoScrollRef}>
           <MessageReplyEditor
             mutation={replyToThreadMutation}
             onSubmit={() => ({
@@ -366,7 +373,6 @@ export default React.memo(function ThreadView({
           </>
         )
       )}
-      {replyEditorVisible && <span ref={autoScrollRef} />}
       {confirmDelete && (
         <ConfirmDeleteThread
           threadId={threadId}

--- a/frontend/src/lib-common/utils/scrolling.ts
+++ b/frontend/src/lib-common/utils/scrolling.ts
@@ -35,9 +35,14 @@ export function scrollToRef(
 
 export function scrollRefIntoView(
   ref: MutableRefObject<HTMLElement | null>,
-  timeout = 0
+  timeout = 0,
+  blockPosition: ScrollLogicalPosition = 'start'
 ) {
-  scrollIntoViewWithTimeout(() => ref.current ?? undefined, timeout)
+  scrollIntoViewWithTimeout(
+    () => ref.current ?? undefined,
+    timeout,
+    blockPosition
+  )
 }
 
 export function scrollIntoViewSoftKeyboard(
@@ -78,13 +83,14 @@ function scrollWithTimeout(
 
 function scrollIntoViewWithTimeout(
   getElement: () => HTMLElement | undefined,
-  timeout = 0
+  timeout = 0,
+  blockPosition: ScrollLogicalPosition
 ) {
   if (isAutomatedTest) return
 
   withTimeout(() => {
     const elem = getElement()
-    if (elem) elem.scrollIntoView({ behavior: 'smooth' })
+    if (elem) elem.scrollIntoView({ behavior: 'smooth', block: blockPosition })
   }, timeout)
 }
 

--- a/frontend/src/lib-components/atoms/form/TextArea.tsx
+++ b/frontend/src/lib-components/atoms/form/TextArea.tsx
@@ -25,6 +25,7 @@ interface TextAreaInputProps extends BaseProps {
   maxLength?: number
   type?: string
   autoFocus?: boolean
+  preventAutoFocusScroll?: boolean
   placeholder?: string
   info?: InputInfo
   align?: 'left' | 'right'
@@ -48,6 +49,7 @@ const TextArea = React.memo(function TextArea({
   maxLength,
   type,
   autoFocus,
+  preventAutoFocusScroll,
   placeholder,
   info,
   id,
@@ -90,6 +92,7 @@ const TextArea = React.memo(function TextArea({
         maxLength={maxLength}
         type={type}
         autoFocus={autoFocus}
+        preventAutoFocusScroll={preventAutoFocusScroll}
         className={classNames(className, infoStatus)}
         data-qa={dataQa}
         id={id}
@@ -136,11 +139,18 @@ export const TextAreaF = React.memo(function TextAreaF({
   )
 })
 
+interface TextAreaAutosizeProps extends React.HTMLProps<HTMLTextAreaElement> {
+  preventAutoFocusScroll?: boolean
+}
+
 const TextareaAutosize = React.memo(function TextAreaAutosize({
   rows = 1,
   ...props
-}: React.HTMLProps<HTMLTextAreaElement>) {
+}: TextAreaAutosizeProps) {
   const textarea = useRef<HTMLTextAreaElement | null>(null)
+  const { autoFocus, preventAutoFocusScroll, ...textAreaProps } = props
+  const isNonScrollingAutoFocus = autoFocus && preventAutoFocusScroll
+  const isScollingAutoFocus = autoFocus && !preventAutoFocusScroll
 
   useEffect(() => {
     const el = textarea.current
@@ -156,8 +166,19 @@ const TextareaAutosize = React.memo(function TextAreaAutosize({
     if (textarea.current) autosize.update(textarea.current)
   })
 
+  useEffect(() => {
+    if (isNonScrollingAutoFocus) {
+      textarea.current?.focus({ preventScroll: true })
+    }
+  }, [isNonScrollingAutoFocus])
+
   return (
-    <textarea {...props} rows={rows} ref={textarea}>
+    <textarea
+      {...textAreaProps}
+      rows={rows}
+      ref={textarea}
+      autoFocus={isScollingAutoFocus}
+    >
       {props.children}
     </textarea>
   )

--- a/frontend/src/lib-components/atoms/form/TextArea.tsx
+++ b/frontend/src/lib-components/atoms/form/TextArea.tsx
@@ -4,7 +4,7 @@
 
 import autosize from 'autosize'
 import classNames from 'classnames'
-import React, { RefObject, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { BoundFormState } from 'lib-common/form/hooks'
@@ -34,7 +34,6 @@ interface TextAreaInputProps extends BaseProps {
   'aria-describedby'?: string
   hideErrorsBeforeTouched?: boolean
   required?: boolean
-  inputRef?: RefObject<HTMLTextAreaElement>
   wrapperClassName?: string
 }
 
@@ -56,8 +55,7 @@ const TextArea = React.memo(function TextArea({
   className,
   'aria-describedby': ariaId,
   hideErrorsBeforeTouched,
-  required,
-  inputRef
+  required
 }: TextAreaInputProps) {
   const [touched, setTouched] = useState(false)
 
@@ -97,7 +95,6 @@ const TextArea = React.memo(function TextArea({
         id={id}
         aria-describedby={ariaId}
         required={required ?? false}
-        ref={inputRef}
         rows={rows}
       />
       {!!infoText && (

--- a/frontend/src/lib-components/messages/MessageReplyEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageReplyEditor.tsx
@@ -102,6 +102,7 @@ function MessageReplyEditor<T, R>({
           onChange={(value) => onUpdateContent(value)}
           data-qa="message-reply-content"
           autoFocus
+          preventAutoFocusScroll={true}
         />
       </EditorRow>
       <EditorRow>


### PR DESCRIPTION
Ennen muutosta:

https://drive.google.com/file/d/1-eL2YvbmqrWjgKcJ5yJHGw7ihkD2lxDQ/view

Muutoksen jälkeen:

https://github.com/user-attachments/assets/09c58d35-5667-4fa7-862b-07b1be0ae8dc

Ts. periaatteena on, että ruutua vieritetään niin, että viestieditorin alareuna on ruudun alareunan tasalla. Tämä mahdollistaa mahdollisimman monen viestiketjun aikaisemman viestin näkymisen viestieditorin ollessa auki.

Jos viestieditori mahtuu ruudulle ilman vierittämisen tarvetta, vieritystä ei kuitenkaan tapahdu:

https://github.com/user-attachments/assets/24911ab8-cc9d-4a33-afe6-2a199ec45371