### PR TITLE
Aktivoi valintojen poisto backspace ja delete näppäimillä monivalintakomponentissa

### DIFF
--- a/frontend/src/lib-components/atoms/form/MultiSelect.tsx
+++ b/frontend/src/lib-components/atoms/form/MultiSelect.tsx
@@ -97,7 +97,6 @@ function MultiSelect<T>({
         isMulti
         isSearchable={true}
         hideSelectedOptions={false}
-        backspaceRemovesValue={false}
         closeMenuOnSelect={closeMenuOnSelect ?? false}
         noOptionsMessage={() => (
           <span data-qa="no-options">{noOptionsMessage ?? 'Ei tuloksia'}</span>


### PR DESCRIPTION
Käytettävyysparannus kuntalaisen uuden viestin luomisen vastaanottajavalintaan.

Kytketään päälle `react-select` komponentin toiminnallisuus, joka mahdollistaa tehtyjen valintojen poiston käyttäen `Backspace` ja `Delete` näppäimiä ([github](https://github.com/JedWatson/react-select/blob/a8b8f4342cc113e921bb238de2dd69a2d345b5f8/packages/react-select/src/Select.tsx#L1591-L1601)). Vaikuttaa `Multiselect`-komponenttiin (23 käyttöpaikkaa).