### PR TITLE
Läsnäolomodaalin saavutettavuusparannuksia

### DIFF
--- a/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
+++ b/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
@@ -18,13 +18,17 @@ export interface Props {
   hideErrorsBeforeTouched?: boolean
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
   dataQaPrefix?: string
+  ariaDescribedbyStart?: string
+  ariaDescribedbyEnd?: string
 }
 
 export default React.memo(function TimeRangeInputF({
   bind,
   hideErrorsBeforeTouched,
   onFocus,
-  dataQaPrefix
+  dataQaPrefix,
+  ariaDescribedbyStart,
+  ariaDescribedbyEnd
 }: Props) {
   const i18n = useTranslation()
   const [touched, setTouched] = useState([false, false])
@@ -45,6 +49,8 @@ export default React.memo(function TimeRangeInputF({
           onFocus={onFocus}
           onBlur={() => setTouched(([_, t]) => [true, t])}
           data-qa={dataQaPrefix ? `${dataQaPrefix}-start` : undefined}
+          id={dataQaPrefix ? `${dataQaPrefix}-start` : undefined}
+          aria-describedby={ariaDescribedbyStart}
         />
         <span>–</span>
         <TimeInputF
@@ -55,6 +61,8 @@ export default React.memo(function TimeRangeInputF({
           onFocus={onFocus}
           onBlur={() => setTouched(([t, _]) => [t, true])}
           data-qa={dataQaPrefix ? `${dataQaPrefix}-end` : undefined}
+          id={dataQaPrefix ? `${dataQaPrefix}-end` : undefined}
+          aria-describedby={ariaDescribedbyEnd}
         />
       </TimeRangeWrapper>
       {inputInfo !== undefined && (!hideErrorsBeforeTouched || bothTouched) ? (

--- a/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
+++ b/frontend/src/citizen-frontend/calendar/TimeRangeInput.tsx
@@ -18,8 +18,8 @@ export interface Props {
   hideErrorsBeforeTouched?: boolean
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
   dataQaPrefix?: string
-  ariaDescribedbyStart?: string
-  ariaDescribedbyEnd?: string
+  ariaDescriptionStart?: string
+  ariaDescriptionEnd?: string
 }
 
 export default React.memo(function TimeRangeInputF({
@@ -27,8 +27,8 @@ export default React.memo(function TimeRangeInputF({
   hideErrorsBeforeTouched,
   onFocus,
   dataQaPrefix,
-  ariaDescribedbyStart,
-  ariaDescribedbyEnd
+  ariaDescriptionStart,
+  ariaDescriptionEnd
 }: Props) {
   const i18n = useTranslation()
   const [touched, setTouched] = useState([false, false])
@@ -50,7 +50,7 @@ export default React.memo(function TimeRangeInputF({
           onBlur={() => setTouched(([_, t]) => [true, t])}
           data-qa={dataQaPrefix ? `${dataQaPrefix}-start` : undefined}
           id={dataQaPrefix ? `${dataQaPrefix}-start` : undefined}
-          aria-describedby={ariaDescribedbyStart}
+          aria-description={ariaDescriptionStart}
         />
         <span>–</span>
         <TimeInputF
@@ -62,7 +62,7 @@ export default React.memo(function TimeRangeInputF({
           onBlur={() => setTouched(([t, _]) => [t, true])}
           data-qa={dataQaPrefix ? `${dataQaPrefix}-end` : undefined}
           id={dataQaPrefix ? `${dataQaPrefix}-end` : undefined}
-          aria-describedby={ariaDescribedbyEnd}
+          aria-description={ariaDescriptionEnd}
         />
       </TimeRangeWrapper>
       {inputInfo !== undefined && (!hideErrorsBeforeTouched || bothTouched) ? (

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lib-components/molecules/ExpandingInfo'
 import { faPlus, fasUserMinus, faTrash, faUserMinus } from 'lib-icons'
 
+import { focusElementOnNextFrame } from '../../utils/focus'
 import TimeRangeInput from '../TimeRangeInput'
 
 import {
@@ -106,6 +107,7 @@ const ReservationTimes = React.memo(function ReservationTimes({
           <MiddleCell>{i18n.calendar.reservationModal.absent}</MiddleCell>
           <RightCell>
             <IconOnlyButton
+              id={dataQaPrefix ? `${dataQaPrefix}-absent-button` : undefined}
               data-qa={
                 dataQaPrefix ? `${dataQaPrefix}-absent-button` : undefined
               }
@@ -115,6 +117,9 @@ const ReservationTimes = React.memo(function ReservationTimes({
                   branch: 'timeRanges',
                   state: [emptyTimeRange(validTimeRange)]
                 })
+                if (dataQaPrefix) {
+                  focusElementOnNextFrame(`${dataQaPrefix}-absent-button`)
+                }
               }}
               aria-label={i18n.calendar.absentDisable}
             />
@@ -325,11 +330,17 @@ const TimeRanges = React.memo(function TimeRanges({
           <FixedSpaceRow>
             {onAbsent !== undefined ? (
               <IconOnlyButton
+                id={dataQaPrefix ? `${dataQaPrefix}-absent-button` : undefined}
                 data-qa={
                   dataQaPrefix ? `${dataQaPrefix}-absent-button` : undefined
                 }
                 icon={faUserMinus}
-                onClick={onAbsent}
+                onClick={() => {
+                  onAbsent()
+                  if (dataQaPrefix) {
+                    focusElementOnNextFrame(`${dataQaPrefix}-absent-button`)
+                  }
+                }}
                 aria-label={i18n.calendar.absentEnable}
               />
             ) : null}

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -269,6 +269,8 @@ interface LimitedLocalTimeRangeProps {
   bind: BoundForm<LimitedLocalTimeRangeField>
   hideErrorsBeforeTouched?: boolean
   dataQaPrefix?: string
+  ariaDescribedbyStart?: string
+  ariaDescribedbyEnd?: string
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
 }
 
@@ -276,6 +278,8 @@ const LimitedLocalTimeRange = React.memo(function LimitedLocalTimeRange({
   bind,
   hideErrorsBeforeTouched,
   dataQaPrefix,
+  ariaDescribedbyStart,
+  ariaDescribedbyEnd,
   onFocus
 }: LimitedLocalTimeRangeProps) {
   const value = useFormField(bind, 'value')
@@ -284,6 +288,8 @@ const LimitedLocalTimeRange = React.memo(function LimitedLocalTimeRange({
       bind={value}
       hideErrorsBeforeTouched={hideErrorsBeforeTouched}
       dataQaPrefix={dataQaPrefix}
+      ariaDescribedbyStart={ariaDescribedbyStart}
+      ariaDescribedbyEnd={ariaDescribedbyEnd}
       onFocus={onFocus}
     />
   )
@@ -350,12 +356,15 @@ const TimeRanges = React.memo(function TimeRanges({
                 data-qa={
                   dataQaPrefix ? `${dataQaPrefix}-add-res-button` : undefined
                 }
-                onClick={() =>
+                onClick={() => {
                   bind.update((prev) =>
                     // use same valid range times as first reservation
                     [prev[0], emptyTimeRange(prev[0].validRange)]
                   )
-                }
+                  if (dataQaPrefix) {
+                    focusElementOnNextFrame(`${dataQaPrefix}-time-1-start`)
+                  }
+                }}
                 aria-label={i18n.common.add}
               />
             ) : null}
@@ -370,6 +379,12 @@ const TimeRanges = React.memo(function TimeRanges({
               bind={secondTimeRange}
               hideErrorsBeforeTouched={!showAllErrors}
               dataQaPrefix={dataQaPrefix ? `${dataQaPrefix}-time-1` : undefined}
+              ariaDescribedbyStart={
+                i18n.calendar.reservationModal.secondTimeRange.start
+              }
+              ariaDescribedbyEnd={
+                i18n.calendar.reservationModal.secondTimeRange.end
+              }
               onFocus={onFocus}
             />
           </MiddleCell>

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -269,8 +269,8 @@ interface LimitedLocalTimeRangeProps {
   bind: BoundForm<LimitedLocalTimeRangeField>
   hideErrorsBeforeTouched?: boolean
   dataQaPrefix?: string
-  ariaDescribedbyStart?: string
-  ariaDescribedbyEnd?: string
+  ariaDescriptionStart?: string
+  ariaDescriptionEnd?: string
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
 }
 
@@ -278,8 +278,8 @@ const LimitedLocalTimeRange = React.memo(function LimitedLocalTimeRange({
   bind,
   hideErrorsBeforeTouched,
   dataQaPrefix,
-  ariaDescribedbyStart,
-  ariaDescribedbyEnd,
+  ariaDescriptionStart,
+  ariaDescriptionEnd,
   onFocus
 }: LimitedLocalTimeRangeProps) {
   const value = useFormField(bind, 'value')
@@ -288,8 +288,8 @@ const LimitedLocalTimeRange = React.memo(function LimitedLocalTimeRange({
       bind={value}
       hideErrorsBeforeTouched={hideErrorsBeforeTouched}
       dataQaPrefix={dataQaPrefix}
-      ariaDescribedbyStart={ariaDescribedbyStart}
-      ariaDescribedbyEnd={ariaDescribedbyEnd}
+      ariaDescriptionStart={ariaDescriptionStart}
+      ariaDescriptionEnd={ariaDescriptionEnd}
       onFocus={onFocus}
     />
   )
@@ -379,10 +379,10 @@ const TimeRanges = React.memo(function TimeRanges({
               bind={secondTimeRange}
               hideErrorsBeforeTouched={!showAllErrors}
               dataQaPrefix={dataQaPrefix ? `${dataQaPrefix}-time-1` : undefined}
-              ariaDescribedbyStart={
+              ariaDescriptionStart={
                 i18n.calendar.reservationModal.secondTimeRange.start
               }
-              ariaDescribedbyEnd={
+              ariaDescriptionEnd={
                 i18n.calendar.reservationModal.secondTimeRange.end
               }
               onFocus={onFocus}

--- a/frontend/src/lib-components/atoms/buttons/icon-only-button-visuals.tsx
+++ b/frontend/src/lib-components/atoms/buttons/icon-only-button-visuals.tsx
@@ -19,6 +19,10 @@ type PredefinedColor = 'default' | 'gray' | 'white'
  */
 export type BaseIconOnlyButtonVisualProps = {
   /**
+   * ID of the button
+   */
+  id?: string
+  /**
    * Icon to be displayed in the button
    */
   icon: IconDefinition
@@ -43,6 +47,7 @@ export type BaseIconOnlyButtonVisualProps = {
 
 export const renderBaseIconOnlyButton = (
   {
+    id,
     icon,
     type = 'button',
     disabled,
@@ -58,6 +63,7 @@ export const renderBaseIconOnlyButton = (
   children: (icon: IconDefinition, size: IconSize) => React.ReactNode
 ) => (
   <StyledButton
+    id={id}
     type={type}
     disabled={disabled}
     className={classNames(className, { disabled })}

--- a/frontend/src/lib-components/atoms/form/InputField.tsx
+++ b/frontend/src/lib-components/atoms/form/InputField.tsx
@@ -206,6 +206,7 @@ export interface InputProps extends BaseProps {
   'data-qa'?: string
   name?: string
   'aria-describedby'?: string
+  'aria-description'?: string
   hideErrorsBeforeTouched?: boolean
   required?: boolean
   autoFocus?: boolean

--- a/frontend/src/lib-components/atoms/form/TimeInput.tsx
+++ b/frontend/src/lib-components/atoms/form/TimeInput.tsx
@@ -23,6 +23,7 @@ export interface TimeInputProps
     | 'readonly'
     | 'inputRef'
     | 'aria-describedby'
+    | 'aria-description'
     | 'data-qa'
   > {
   size?: 'wide' | 'normal' | 'narrow'

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -426,6 +426,10 @@ const en: Translations = {
       },
       start: 'Start',
       end: 'End',
+      secondTimeRange: {
+        start: 'Second time range start',
+        end: 'Second time range end'
+      },
       present: 'Present',
       absent: 'Absent',
       reservationClosed: 'Reservation closed',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -428,6 +428,10 @@ export default {
       },
       start: 'Alkaa',
       end: 'Päättyy',
+      secondTimeRange: {
+        start: 'Toisen aikavälin alku',
+        end: 'Toisen aikavälin loppu'
+      },
       present: 'Läsnä',
       absent: 'Poissa',
       reservationClosed: 'Ilmoittautuminen päättynyt',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -424,6 +424,10 @@ const sv: Translations = {
       },
       start: 'Börjar',
       end: 'Slutar',
+      secondTimeRange: {
+        start: 'Toisen aikavälin alku (sv)',
+        end: 'Toisen aikavälin loppu (sv)'
+      },
       present: 'Närvarande',
       absent: 'Frånvarande',
       reservationClosed: 'Registreringen är stängd',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -425,8 +425,8 @@ const sv: Translations = {
       start: 'Börjar',
       end: 'Slutar',
       secondTimeRange: {
-        start: 'Toisen aikavälin alku (sv)',
-        end: 'Toisen aikavälin loppu (sv)'
+        start: 'Andra tidsintervall start',
+        end: 'Andra tidsintervall slut'
       },
       present: 'Närvarande',
       absent: 'Frånvarande',


### PR DESCRIPTION
*"Merkitse poissaolevaksi"-toiminnosta feedback ruudunlukijalle*:

Kun käyttäjä valitsee “Merkitse poissaolevaksi”, painettu nappi poistuu DOMista ja näppäimistö fokus siirtyy sivun päätasolle ja ruudunlukija sanoo tämän seurauksena sivun otsikon “Varhaiskasvatus, Web content”.

*Läsnäolorivin lisäämisestä ei kerrota ruudunlukijalle*:

Kun käyttäjä valitsee ➕  - Lisää [toinen aikaväli], näppäimistö focus tulee siirtää ilmestyvään ajanjakson alkukenttään. Tämän lisäksi toisen aikavälin input-kenttien ruudunlukijalle näkyviä labeleita täytyy parantaa.