### PR TITLE
Viestinäkymän kohdennuksen palautus

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
+import { focusElementOnNextFrame } from 'citizen-frontend/utils/focus'
 import { combine, isLoading, Result } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { CitizenCalendarEvent } from 'lib-common/generated/api-types/calendarevent'
@@ -197,7 +198,7 @@ const CalendarPage = React.memo(function CalendarPage() {
                   selectDate={openDayModal}
                   onClose={() => {
                     closeModal()
-                    findElementAndFocus(
+                    focusElementOnNextFrame(
                       `calendar-day-${modalState.date.formatIso()}`
                     )
                   }}
@@ -471,16 +472,6 @@ function buildQueryString(modal: URLModalState): string {
     case 'discussion-reservations':
       return `modal=discussion-reservations${modal.selectedChildId ? '&selectedChildId=' + modal.selectedChildId : ''}${modal.selectedEventId ? '&selectedEventId=' + modal.selectedEventId : ''}`
   }
-}
-
-function findElementAndFocus(id: string): void {
-  const focusElement = () => {
-    const element = document.getElementById(id)
-    if (element) {
-      element.focus()
-    }
-  }
-  requestAnimationFrame(focusElement)
 }
 
 const DesktopOnly = styled(Desktop)`

--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -10,6 +10,7 @@ import Footer, { footerHeightDesktop } from 'citizen-frontend/Footer'
 import { renderResult } from 'citizen-frontend/async-rendering'
 import { useUser } from 'citizen-frontend/auth/state'
 import { useTranslation } from 'citizen-frontend/localization'
+import { focusElementAfterDelay } from 'citizen-frontend/utils/focus'
 import { combine } from 'lib-common/api'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -150,9 +151,13 @@ export default React.memo(function MessagesPage() {
                           i18n.messages.messageEditor.messageSentNotification,
                         dataQa: 'message-sent-notification'
                       })
+                      focusElementAfterDelay('new-message-btn')
                     }}
                     onFailure={() => setDisplaySendError(true)}
-                    onClose={() => changeEditorVisibility(false)}
+                    onClose={() => {
+                      changeEditorVisibility(false)
+                      focusElementAfterDelay('new-message-btn')
+                    }}
                     displaySendError={displaySendError}
                   />
                 )

--- a/frontend/src/citizen-frontend/messages/ThreadList.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadList.tsx
@@ -77,6 +77,7 @@ export default React.memo(function ThreadList({
               onClick={() => setEditorVisible(true)}
               primary
               data-qa="new-message-btn"
+              id="new-message-btn"
               disabled={!newMessageButtonEnabled}
             />
           </HeaderContainer>

--- a/frontend/src/citizen-frontend/utils/focus.ts
+++ b/frontend/src/citizen-frontend/utils/focus.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+function focusElement(id: string): void {
+  const element = document.getElementById(id)
+  if (element) {
+    element.focus()
+  }
+}
+
+export function focusElementOnNextFrame(id: string): void {
+  requestAnimationFrame(() => {
+    focusElement(id)
+  })
+}
+
+export function focusElementAfterDelay(id: string, timeout = 25): void {
+  setTimeout(() => {
+    focusElement(id)
+  }, timeout)
+}

--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -85,6 +85,10 @@ export default class CitizenMessagesPage {
       .assertTextEquals(content)
   }
 
+  async assertNewMessageButtonIsFocused() {
+    await this.newMessageButton.assertFocused(true)
+  }
+
   async assertAriaLiveExistsAndIncludesNotification() {
     await this.page
       .findByDataQa('notification-container')

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -417,6 +417,7 @@ describe('Sending and receiving messages', () => {
         )
         await citizenMessagesPage.assertAriaLiveExistsAndIncludesNotification()
         await citizenMessagesPage.assertTimedNotification('Viesti lähetetty')
+        await citizenMessagesPage.assertNewMessageButtonIsFocused()
       })
 
       test('Citizen with shift care child can send attachments', async () => {

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -276,6 +276,13 @@ export class Element {
   async evaluate<R>(fn: (el: HTMLElement | SVGElement) => R): Promise<R> {
     return this.locator.evaluate(fn)
   }
+
+  get focused(): Promise<boolean> {
+    return this.locator.evaluate((el) => el === document.activeElement)
+  }
+  async assertFocused(focused: boolean): Promise<void> {
+    await waitUntilEqual(() => this.focused, focused)
+  }
 }
 
 export class TextInput extends Element {

--- a/frontend/src/lib-components/atoms/buttons/LegacyButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/LegacyButton.tsx
@@ -88,6 +88,7 @@ export interface ButtonProps extends BaseProps {
   primary?: boolean
   disabled?: boolean
   type?: 'submit' | 'button'
+  id?: string
 }
 
 /**
@@ -100,6 +101,7 @@ export const LegacyButton = React.memo(function LegacyButton({
   primary = false,
   disabled = false,
   type = 'button',
+  id,
   ...props
 }: ButtonProps) {
   const handleOnClick = useThrottledEventHandler(onClick)
@@ -110,6 +112,7 @@ export const LegacyButton = React.memo(function LegacyButton({
       onClick={handleOnClick}
       disabled={disabled}
       type={type}
+      id={id}
     >
       {'children' in props ? props.children : props.text}
     </StyledButton>


### PR DESCRIPTION
Ennen muutosta:
Uuden viestin lähetyksen jälkeen focus meni päätasolle.

Muutoksen jälkeen:
Asetetaan kohdistus "Uusi viesti" -nappiin, josta toiminto avattiin.

https://github.com/user-attachments/assets/b3223ef3-fd59-4161-99dc-56e1b145a25c

