### PR TITLE
Kuntalaisen uuden viestin editori pysyy paikallaan skrollatessa

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -409,7 +409,7 @@ const Container = styled.div`
   max-width: 680px;
   height: 100%;
   max-height: 700px;
-  position: absolute;
+  position: fixed;
   z-index: 100;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
Ennen muutosta viestieditori skrollasi muun sivun mukana.

Muutoksen jälkeen viestieditori pysyy paikallaan oikeassa alakulmassa.