### PR TITLE
Estetään `org.opensaml`-riipuvuuden asentaminen servicessä

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
     implementation("org.springframework.ws:spring-ws-security") {
         exclude("org.bouncycastle", "bcpkix-jdk15on")
         exclude("org.bouncycastle", "bcprov-jdk15on")
+        exclude("org.opensaml")
     }
     implementation("org.springframework.ws:spring-ws-support") {
         exclude("org.eclipse.angus", "angus-mail")
@@ -167,6 +168,7 @@ dependencies {
     integrationTestImplementation("org.apache.cxf:cxf-rt-ws-security") {
         exclude("org.bouncycastle", "bcpkix-jdk15on")
         exclude("org.bouncycastle", "bcprov-jdk15on")
+        exclude("org.opensaml")
     }
 
     implementation(project(":sficlient"))

--- a/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiMessagesSoapClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sficlient/SfiMessagesSoapClient.kt
@@ -29,7 +29,6 @@ import javax.xml.datatype.DatatypeFactory
 import javax.xml.datatype.XMLGregorianCalendar
 import mu.KotlinLogging
 import org.apache.commons.text.StringEscapeUtils
-import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.apache.wss4j.common.crypto.Merlin
 import org.apache.wss4j.dom.WSConstants
 import org.apache.wss4j.dom.handler.WSHandlerConstants
@@ -79,7 +78,7 @@ class SfiMessagesSoapClient(
                     // Via API has no public DNS so there is no CN/alt name to verify against.
                     //     - VIA API has known IPs which should be set to /etc/hosts and then the
                     // NoopVerifier should be removed
-                    setHostnameVerifier(NoopHostnameVerifier())
+                    setHostnameVerifier { _, _ -> true }
                 }
             )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/vtjclient/config/XroadSoapClientConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/vtjclient/config/XroadSoapClientConfig.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.vtjclient.soap.ObjectFactory
 import fi.espoo.voltti.logging.MdcKey
 import jakarta.xml.bind.helpers.DefaultValidationEventHandler
 import mu.KotlinLogging
-import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
@@ -102,7 +101,7 @@ class XroadSoapClientConfig {
             // The trust store must only contain end-entity certificates (no CA certificates)
             // TODO: Either keep using single certs or fix the certs and host names for security
             // servers
-            setHostnameVerifier(NoopHostnameVerifier())
+            setHostnameVerifier { _, _ -> true }
         }
 
     @Bean
@@ -120,7 +119,7 @@ class XroadSoapClientConfig {
             // The trust store must only contain end-entity certificates (no CA certificates)
             // TODO: Either keep using single certs or fix the certs and host names for security
             // servers
-            setHostnameVerifier(NoopHostnameVerifier())
+            setHostnameVerifier { _, _ -> true }
         }
 
     @Bean


### PR DESCRIPTION
Se aiheutti OWASP-virheen, eikä koko riippuvuutta edes tarvita.