### PR TITLE
Parannetaan `days_in_range` SQL-funktiota, korjataan samalla regressio

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DaysInRangeSqlTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/DaysInRangeSqlTest.kt
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.db
+
+import fi.espoo.evaka.PureJdbiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.intellij.lang.annotations.Language
+import org.jdbi.v3.core.JdbiException
+import org.junit.jupiter.api.assertThrows
+import org.postgresql.util.PSQLState
+
+class DaysInRangeSqlTest : PureJdbiTest(resetDbBeforeEach = false) {
+    private fun daysInRange(@Language("SQL", prefix = "SELECT ") dateRangeSql: String): Int? =
+        db.read { it.createQuery { sql("SELECT days_in_range($dateRangeSql)") }.exactlyOne<Int?>() }
+
+    @Test
+    fun `it works correctly with all endpoint inclusivity combinations`() {
+        // postgres seems to internally always convert dateranges to `[)` inclusivity and the
+        // constructor function does the necessary off-by-one adjustment depending on the input.
+        // Even so we test all 4 possible cases to detect any possible regressions in the future
+        assertEquals(2, daysInRange("daterange('2020-01-01', '2020-01-02', '[]')"))
+        assertEquals(1, daysInRange("daterange('2020-01-01', '2020-01-02', '[)')"))
+        assertEquals(1, daysInRange("daterange('2020-01-01', '2020-01-02', '(]')"))
+        assertEquals(0, daysInRange("daterange('2020-01-01', '2020-01-02', '()')"))
+    }
+
+    @Test
+    fun `it returns 0 when the range is empty`() {
+        assertEquals(0, daysInRange("'empty'::daterange"))
+    }
+
+    @Test
+    fun `it returns NULL when the entire range is NULL`() {
+        assertNull(daysInRange("NULL::daterange"))
+    }
+
+    @Test
+    fun `it throws an sql datetime overflow error if either endpoint is NULL, infinity, or -infinity`() {
+        fun assertDateTimeOverflow(f: () -> Any?) {
+            val psqlException = assertThrows<JdbiException> { f() }.psqlCause()
+            assertEquals(PSQLState.DATETIME_OVERFLOW.state, psqlException?.sqlState)
+        }
+        assertDateTimeOverflow { daysInRange("daterange('2020-01-01', NULL, '[]')") }
+        assertDateTimeOverflow { daysInRange("daterange(NULL, '2020-01-02', '[]')") }
+        assertDateTimeOverflow { daysInRange("daterange('2020-01-01', 'infinity', '[]')") }
+        assertDateTimeOverflow { daysInRange("daterange('-infinity', '2020-01-02', '[]')") }
+    }
+}

--- a/service/src/main/resources/db/migration/V444__better_days_in_range.sql
+++ b/service/src/main/resources/db/migration/V444__better_days_in_range.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION days_in_range(daterange) RETURNS integer
+LANGUAGE sql IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT
+RETURN
+CASE $1
+  WHEN 'empty' THEN 0
+  ELSE
+    (CASE
+        WHEN upper($1) IS NULL THEN 'infinity' -- invalid case, and converting to infinity here gives a nicer error
+        WHEN upper_inc($1) THEN upper($1) - 1
+        ELSE upper($1)
+    END)
+    -
+    (CASE
+        WHEN lower($1) IS NULL THEN '-infinity' -- invalid case, and converting to -infinity here gives a nicer error
+        WHEN lower_inc($1) THEN lower($1)
+        ELSE lower($1) + 1
+    END)
+END;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -439,3 +439,4 @@ V440__rename_curriculum_tables_to_backup.sql
 V441__placement_modification_user_and_timestamp.sql
 V442__assistance_need_decision_no_end_date.sql
 V443__calendar_event_indexes.sql
+V444__better_days_in_range.sql


### PR DESCRIPTION
<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
