### PR TITLE
Lokitetaan X-Amzn-Trace-Id (AWS trace ID) proxy:ssä

### DIFF
--- a/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -141,6 +141,7 @@ log_format json_access escape=json
     '"traceId":"$request_id",'
     '"type":"app-requests-received",'
     '"userIdHash":"",'
+    '"awsTraceId":"$http_x_amzn_trace_id",'
 {{ if eq (env.Getenv "DD_PROFILING_ENABLED" "false") "true" }}
     '"dd.trace_id":"$opentracing_context_x_datadog_trace_id",'
     '"dd.span_id":"$opentracing_context_x_datadog_parent_id",'


### PR DESCRIPTION
Testattu espoon stagingissa, lokitettu arvo näyttää esim. tältä: `Root=1-67077aac-078f7c753dea42f761b4ad78`

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
