### PR TITLE
Tiedotteita ei lähetetä suljettuihin ryhmiin

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -1302,6 +1302,7 @@ WHERE id = ${bind(id)}
 fun Database.Read.getStaffCopyRecipients(
     senderId: MessageAccountId,
     recipients: Collection<MessageRecipient>,
+    date: LocalDate,
 ): Set<MessageAccountId> {
     val areaIds = recipients.mapNotNull { it.toAreaId() }
     val unitIds = recipients.mapNotNull { it.toUnitId() }
@@ -1318,6 +1319,7 @@ JOIN daycare u ON u.id = acl.daycare_id
 JOIN daycare_group g ON u.id = g.daycare_id
 JOIN message_account receiver_acc ON g.id = receiver_acc.daycare_group_id
 WHERE sender_acc.id = ${bind(senderId)}
+AND (g.end_date IS NULL OR g.end_date > ${bind(date)})
 AND (u.care_area_id = ANY(${bind(areaIds)}) OR u.id = ANY(${bind(unitIds)}) OR g.id = ANY(${bind(groupIds)}))
 """
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
@@ -112,7 +112,7 @@ class MessageService(
             tx.getMessageAccountsForRecipients(sender, recipients, filters, now.toLocalDate())
         if (messageRecipients.isEmpty()) return null
 
-        val staffCopyRecipients = tx.getStaffCopyRecipients(sender, recipients)
+        val staffCopyRecipients = tx.getStaffCopyRecipients(sender, recipients, now.toLocalDate())
 
         val recipientGroups: List<Pair<Set<MessageAccountId>, Set<ChildId?>>> =
             if (type == MessageType.BULLETIN) {


### PR DESCRIPTION
Ennen muutosta ryhmän päättymispäivää ei huomioitu lähetettäessä henkilökunnan kopioita tiedotteista, joten tiedotteet päätyivät myös päättyneen ryhmän postilaatikkoon.

Muutoksen jälkeen päättymispäivä huomioidaan, ja ryhmän päättymispäivästä alkaen tiedotteet eivät mene ryhmän postilaatikkoon. Ryhmän alkamispäivää ei edelleenkään huomioida, joten tiedotteet menevät ryhmiin, jotka on jo perustettu, mutta joiden alkupäivä on tulevaisuudessa.