### PR TITLE
Keskustelun aihe ja lapsen nimi poistettu keskusteluajan sähköposteista

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventServiceIntegrationTest.kt
@@ -1968,11 +1968,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             DiscussionTimeReminderData(
                 startTime = eventTimeForm.timeRange.start.inner,
                 endTime = eventTimeForm.timeRange.end.inner,
-                title = HtmlSafe(event.title),
                 date = eventTimeForm.date,
-                firstName = HtmlSafe(testChild_1.firstName),
-                lastName = HtmlSafe(testChild_1.lastName),
-                childId = testChild_1.id,
             )
 
         val reminderEmailContent =
@@ -2383,8 +2379,6 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         val emailDetails =
             DiscussionSurveyReservationNotificationData(
-                childName = HtmlSafe("${testChild_3.firstName} ${testChild_3.lastName}"),
-                title = HtmlSafe(event.title),
                 calendarEventTime =
                     CalendarEventTime(
                         id = calendarEventTimeForm.id,
@@ -2392,7 +2386,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
                         startTime = calendarEventTimeForm.startTime,
                         endTime = calendarEventTimeForm.endTime,
                         childId = reservationForm.childId,
-                    ),
+                    )
             )
 
         val reservationEmailContent =
@@ -2514,8 +2508,6 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         val emailDetails =
             DiscussionSurveyReservationNotificationData(
-                childName = HtmlSafe("${testChild_3.firstName} ${testChild_3.lastName}"),
-                title = HtmlSafe(event.title),
                 calendarEventTime =
                     CalendarEventTime(
                         id = calendarEventTimeForm.id,
@@ -2523,7 +2515,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
                         startTime = calendarEventTimeForm.startTime,
                         endTime = calendarEventTimeForm.endTime,
                         childId = reservationForm.childId,
-                    ),
+                    )
             )
 
         val reservationEmailContent =
@@ -2635,8 +2627,6 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
 
         val emailDetails =
             DiscussionSurveyReservationNotificationData(
-                childName = HtmlSafe("${testChild_3.firstName} ${testChild_3.lastName}"),
-                title = HtmlSafe(event.title),
                 calendarEventTime =
                     CalendarEventTime(
                         id = calendarEventTimeForm.id,
@@ -2644,7 +2634,7 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
                         startTime = calendarEventTimeForm.startTime,
                         endTime = calendarEventTimeForm.endTime,
                         childId = reservationForm.childId,
-                    ),
+                    )
             )
 
         val cancellationEmailContent =

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationService.kt
@@ -187,11 +187,7 @@ class CalendarEventNotificationService(
             emailMessageProvider.discussionSurveyReservationNotification(
                 language = msg.language,
                 notificationDetails =
-                    DiscussionSurveyReservationNotificationData(
-                        title = HtmlSafe(msg.eventTitle),
-                        calendarEventTime = eventTime,
-                        childName = HtmlSafe("${child.firstName} ${child.lastName}"),
-                    ),
+                    DiscussionSurveyReservationNotificationData(calendarEventTime = eventTime),
             )
         Email.create(
                 db,
@@ -227,11 +223,7 @@ class CalendarEventNotificationService(
             emailMessageProvider.discussionSurveyReservationCancellationNotification(
                 language = msg.language,
                 notificationDetails =
-                    DiscussionSurveyReservationNotificationData(
-                        title = HtmlSafe(msg.eventTitle),
-                        calendarEventTime = eventTime,
-                        childName = HtmlSafe("${child.firstName} ${child.lastName}"),
-                    ),
+                    DiscussionSurveyReservationNotificationData(calendarEventTime = eventTime),
             )
         Email.create(
                 db,

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.GroupId
-import fi.espoo.evaka.shared.HtmlSafe
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.PredicateSql
@@ -560,13 +559,9 @@ WHERE cet.id = ${bind(eventTimeId)}
         .exactlyOneOrNull<RawRow>()
         ?.let {
             DiscussionTimeReminderData(
-                title = HtmlSafe(it.title),
-                firstName = HtmlSafe(it.firstName),
-                lastName = HtmlSafe(it.lastName),
                 date = it.date,
                 startTime = it.startTime,
                 endTime = it.endTime,
-                childId = it.childId,
             )
         }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -603,24 +603,18 @@ $unsubscribeEn
             html =
                 """
 <p>Lapsellenne on varattu keskusteluaika</p>
-<p>${notificationDetails.title}</p>
-<p>${notificationDetails.childName}</p>
 <p>${notificationDetails.calendarEventTime.date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))}</p>
 <p>${notificationDetails.calendarEventTime.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${notificationDetails.calendarEventTime.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}</p>
 <p>Varauksen voi peruuttaa 2 arkipäivää ennen varattua aikaa suoraan eVakan kalenterinäkymästä. Myöhempää peruutusta varten ota yhteyttä henkilökuntaan.</p>
 $unsubscribeFi
 <hr>
 <p>En diskussionstid har reserverats för ditt barn</p>
-<p>${notificationDetails.title}</p>
-<p>${notificationDetails.childName}</p>
 <p>${notificationDetails.calendarEventTime.date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))}</p>
 <p>${notificationDetails.calendarEventTime.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${notificationDetails.calendarEventTime.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}</p>
 <p>Bokningen kan avbokas 2 arbetsdagar före bokad tid direkt från eVakas kalendervy. För senare avbokning, vänligen kontakta personalen.</p>
 $unsubscribeSv
 <hr>
 <p>New discussion time reserved for your child</p>
-<p>${notificationDetails.title}</p>
-<p>${notificationDetails.childName}</p>
 <p>${notificationDetails.calendarEventTime.date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))}</p>
 <p>${notificationDetails.calendarEventTime.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${notificationDetails.calendarEventTime.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}</p>
 <p>Reservation can be cancelled 2 business days before the reserved time using the eVaka calendar view. For later cancellations contact the daycare staff.</p>
@@ -641,22 +635,16 @@ $unsubscribeEn
             html =
                 """
 <p>Lapsellenne varattu keskusteluaika on peruttu</p>
-<p>${notificationDetails.title}</p>
-<p>${notificationDetails.childName}</p>
 <p>${notificationDetails.calendarEventTime.date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))}</p>
 <p>${notificationDetails.calendarEventTime.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${notificationDetails.calendarEventTime.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}</p>
 $unsubscribeFi
 <hr>
 <p>Den diskussionstid som bokats för ditt barn har avbokats</p>
-<p>${notificationDetails.title}</p>
-<p>${notificationDetails.childName}</p>
 <p>${notificationDetails.calendarEventTime.date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))}</p>
 <p>${notificationDetails.calendarEventTime.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${notificationDetails.calendarEventTime.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}</p>
 $unsubscribeSv
 <hr>
 <p>Discussion time reserved for your child has been cancelled</p>
-<p>${notificationDetails.title}</p>
-<p>${notificationDetails.childName}</p>
 <p>${notificationDetails.calendarEventTime.date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))}</p>
 <p>${notificationDetails.calendarEventTime.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${notificationDetails.calendarEventTime.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}</p>
 $unsubscribeEn
@@ -705,24 +693,18 @@ $unsubscribeEn
             html =
                 """
 <p>Lapsellenne on varattu keskusteluaika</p>
-<p>${reminderData.title}</p>
-<p>${reminderData.firstName} ${reminderData.lastName}</p>
 <p>${reminderData.date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))}</p>
 <p>${reminderData.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${reminderData.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}</p>
 <p>Varauksen voi peruuttaa 2 arkipäivää ennen varattua aikaa suoraan eVakan kalenterinäkymästä. Myöhempää peruutusta varten ota yhteyttä henkilökuntaan.</p>
 $unsubscribeFi
 <hr>
 <p>En diskussionstid har bokats för ditt barn</p>
-<p>${reminderData.title}</p>
-<p>${reminderData.firstName} ${reminderData.lastName}</p>
 <p>${reminderData.date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))}</p>
 <p>${reminderData.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${reminderData.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}</p>
 <p>Bokningen kan avbokas 2 arbetsdagar före den bokade tiden direkt från eVakas kalendervy. För senare avbokningar, vänligen kontakta personalen.</p>
 $unsubscribeSv
 <hr>
 <p>New discussion time reserved for your child</p>
-<p>${reminderData.title}</p>
-<p>${reminderData.firstName} ${reminderData.lastName}</p>
 <p>${reminderData.date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))}</p>
 <p>${reminderData.startTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - ${reminderData.endTime.format(DateTimeFormatter.ofPattern("HH:mm"))}</p>
 <p>Reservation can be cancelled 2 business days before the reserved time using the eVaka calendar view. For later cancellations contact the daycare staff.</p>

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
@@ -137,20 +137,12 @@ data class MessageThreadData(
 data class CalendarEventNotificationData(val title: HtmlSafe<String>, val period: FiniteDateRange)
 
 data class DiscussionTimeReminderData(
-    val title: HtmlSafe<String>,
-    val firstName: HtmlSafe<String>,
-    val lastName: HtmlSafe<String>,
     val date: LocalDate,
     val startTime: LocalTime,
     val endTime: LocalTime,
-    val childId: ChildId,
 )
 
-data class DiscussionSurveyReservationNotificationData(
-    val title: HtmlSafe<String>,
-    val childName: HtmlSafe<String>,
-    val calendarEventTime: CalendarEventTime,
-)
+data class DiscussionSurveyReservationNotificationData(val calendarEventTime: CalendarEventTime)
 
 data class DiscussionSurveyCreationNotificationData(
     val eventTitle: HtmlSafe<String>,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1551,8 +1551,6 @@ VALUES (${bind(body.id)}, ${bind(body.guardianId)})
                     emailMessageProvider.discussionSurveyReservationNotification(
                         Language.fi,
                         DiscussionSurveyReservationNotificationData(
-                            childName = HtmlSafe("Terttu Testaaja"),
-                            title = HtmlSafe("Testikeskustelun otsikko"),
                             calendarEventTime =
                                 CalendarEventTime(
                                     id = CalendarEventTimeId(UUID.randomUUID()),
@@ -1560,15 +1558,13 @@ VALUES (${bind(body.id)}, ${bind(body.guardianId)})
                                     startTime = LocalTime.of(12, 20),
                                     endTime = LocalTime.of(12, 50),
                                     childId = null,
-                                ),
+                                )
                         ),
                     )
                 EmailMessageType.discussionTimeCancellation ->
                     emailMessageProvider.discussionSurveyReservationCancellationNotification(
                         Language.fi,
                         DiscussionSurveyReservationNotificationData(
-                            childName = HtmlSafe("Terttu Testaaja"),
-                            title = HtmlSafe("Testikeskustelun otsikko"),
                             calendarEventTime =
                                 CalendarEventTime(
                                     id = CalendarEventTimeId(UUID.randomUUID()),
@@ -1576,7 +1572,7 @@ VALUES (${bind(body.id)}, ${bind(body.guardianId)})
                                     startTime = LocalTime.of(12, 20),
                                     endTime = LocalTime.of(12, 50),
                                     childId = null,
-                                ),
+                                )
                         ),
                     )
                 EmailMessageType.discussionTimeReservationReminder ->
@@ -1584,12 +1580,8 @@ VALUES (${bind(body.id)}, ${bind(body.guardianId)})
                         Language.fi,
                         DiscussionTimeReminderData(
                             date = LocalDate.now(),
-                            firstName = HtmlSafe("Terttu"),
-                            lastName = HtmlSafe("Testaaja"),
                             startTime = LocalTime.of(12, 20),
                             endTime = LocalTime.of(12, 50),
-                            childId = PersonId(UUID.randomUUID()),
-                            title = HtmlSafe("VASU-keskustelut 2029 syksy"),
                         ),
                     )
                 EmailMessageType.discussionSurveyCreation ->


### PR DESCRIPTION
Lapsen nimi ja keskustelun aihe poistettu seuraavista sähköposteista:

- keskusteluajan varausilmoitus
- keskusteluajan peruutusilmoitus
- keskusteluajan muistutus