### PR TITLE
Korjattu piilotetun hakemuksen päätökset-laskuri

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationQueries.kt
@@ -1241,7 +1241,6 @@ fun Database.Read.fetchApplicationNotificationCountForCitizen(citizenId: PersonI
 SELECT COUNT(*)
 FROM application a
 WHERE guardian_id = ${bind(citizenId)}
-AND NOT a.hidefromguardian
 AND NOT EXISTS (
     SELECT 1 FROM guardian_blocklist bl
     WHERE bl.child_id = a.child_id


### PR DESCRIPTION
Jos paperihakemus on luotu käyttäen "Piilota hakemus huoltajalta" -toimintoa, näkyy siitä muodostettu päätös kuitenkin huoltajalle. Tämä korjaa siihen liittyvän laskurin, joka näkyy palvelun ylänavigaatiossa.