### PR TITLE
Estetään tyhjät kyselyt Digitransit API:in

### DIFF
--- a/frontend/src/citizen-frontend/map/api.ts
+++ b/frontend/src/citizen-frontend/map/api.ts
@@ -93,18 +93,20 @@ export async function fetchUnitsWithDistances(
     })
   )
 
-  if (unitsWithStraightDistance.length === 0) {
-    return []
-  }
   const unitsToQuery = sortBy(
-    unitsWithStraightDistance.filter((u) => u.straightDistance !== null),
+    unitsWithStraightDistance.filter(
+      (u) => u.location !== null && u.straightDistance !== null
+    ),
     (u) => u.straightDistance
   ).slice(0, accurateDistancesCount)
+
+  if (unitsToQuery.length === 0) {
+    return []
+  }
 
   const query = `
 {
   ${unitsToQuery
-    .filter((u) => u.location)
     .map(
       ({ id, location }) => `
     ${uuidToKey(id)}: plan(


### PR DESCRIPTION
Ennen: jos yksikkö-array oli tyhjä, syntyi virheellinen kysely joka tehtiin silti Digitransit API:in
Nyt: jos yksikkö-array on tyhjä, ei tehdä kyselyä vaan palautetaan heti tyhjä lopputulos

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
