### PR TITLE
Skrollauksen helpottaminen Toimintojen avaus -sivulla 

### DIFF
--- a/frontend/src/employee-frontend/components/UnitFeaturesPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitFeaturesPage.tsx
@@ -5,6 +5,7 @@
 import isEqual from 'lodash/isEqual'
 import React, { useCallback, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
+import styled from 'styled-components'
 
 import { useTranslation } from 'employee-frontend/state/i18n'
 import { Failure, wrapResult } from 'lib-common/api'
@@ -23,8 +24,8 @@ import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import MultiSelect from 'lib-components/atoms/form/MultiSelect'
-import { Container, ContentArea } from 'lib-components/layout/Container'
-import { Tbody, Td, Thead, Tr } from 'lib-components/layout/Table'
+import { ContentArea } from 'lib-components/layout/Container'
+import { Table, Tbody, Td, Thead, Tr } from 'lib-components/layout/Table'
 import { H1, LabelLike } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { unitProviderTypes } from 'lib-customizations/employee'
@@ -35,10 +36,20 @@ import {
 } from '../generated/api-clients/daycare'
 
 import { renderResult } from './async-rendering'
-import { TableScrollable } from './reports/common'
 
 const getUnitFeaturesResult = wrapResult(getUnitFeatures)
 const updateUnitFeaturesResult = wrapResult(updateUnitFeatures)
+
+const StyledContentArea = styled(ContentArea)`
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 88px + 32px);
+`
+// 88 px = header height, 32 px = ContentArea paddingBottom -> horizontal scroll bar always at the bottom of the screen
+
+const TableContainer = styled.div`
+  overflow: auto;
+`
 
 export default React.memo(function UnitFeaturesPage() {
   const { i18n } = useTranslation()
@@ -114,8 +125,8 @@ export default React.memo(function UnitFeaturesPage() {
   }, [undoAction, updateFeatures])
 
   return (
-    <Container>
-      <ContentArea opaque>
+    <div>
+      <StyledContentArea opaque>
         <H1>{i18n.unitFeatures.page.title}</H1>
 
         <LabelLike>{i18n.unitFeatures.page.providerType}</LabelLike>
@@ -153,73 +164,75 @@ export default React.memo(function UnitFeaturesPage() {
           text={i18n.unitFeatures.page.undo}
         />
         <Gap size="s" />
-        {renderResult(filteredUnits, (units) => (
-          <TableScrollable>
-            <Thead sticky>
-              <Tr>
-                <Td>{i18n.unitFeatures.page.unit}</Td>
-                {pilotFeatures.map((f) => {
-                  const allSelected = units.every(({ features }) =>
-                    features.includes(f)
-                  )
+        <TableContainer>
+          {renderResult(filteredUnits, (units) => (
+            <Table>
+              <Thead sticky>
+                <Tr>
+                  <Td>{i18n.unitFeatures.page.unit}</Td>
+                  {pilotFeatures.map((f) => {
+                    const allSelected = units.every(({ features }) =>
+                      features.includes(f)
+                    )
 
-                  return (
-                    <Td key={f}>
-                      <div>{i18n.unitFeatures.pilotFeatures[f]}</div>
-                      <Gap size="xs" />
-                      <div>
-                        <Button
-                          appearance="link"
-                          onClick={() => {
-                            void updateFeatures(
-                              units
-                                .filter(
-                                  ({ features }) =>
-                                    features.includes(f) === allSelected
-                                )
-                                .map(({ id }) => id),
-                              [f],
-                              !allSelected
-                            )
-                          }}
-                          text={
-                            allSelected
-                              ? i18n.unitFeatures.page.unselectAll
-                              : i18n.unitFeatures.page.selectAll
-                          }
-                        />
-                      </div>
-                    </Td>
-                  )
-                })}
-              </Tr>
-            </Thead>
-            <Tbody>
-              {units.map((unit) => (
-                <Tr key={unit.id}>
-                  <Td>
-                    <Link to={`/units/${unit.id}`}>{unit.name}</Link>
-                    <div>{i18n.common.providerType[unit.providerType]}</div>
-                  </Td>
-                  {pilotFeatures.map((f) => (
-                    <Td key={f}>
-                      <Checkbox
-                        label={f}
-                        hiddenLabel
-                        checked={unit.features.includes(f)}
-                        onChange={(value) =>
-                          updateFeatures([unit.id], [f], value)
-                        }
-                        disabled={submitting}
-                      />
-                    </Td>
-                  ))}
+                    return (
+                      <Td key={f}>
+                        <div>{i18n.unitFeatures.pilotFeatures[f]}</div>
+                        <Gap size="xs" />
+                        <div>
+                          <Button
+                            appearance="link"
+                            onClick={() => {
+                              void updateFeatures(
+                                units
+                                  .filter(
+                                    ({ features }) =>
+                                      features.includes(f) === allSelected
+                                  )
+                                  .map(({ id }) => id),
+                                [f],
+                                !allSelected
+                              )
+                            }}
+                            text={
+                              allSelected
+                                ? i18n.unitFeatures.page.unselectAll
+                                : i18n.unitFeatures.page.selectAll
+                            }
+                          />
+                        </div>
+                      </Td>
+                    )
+                  })}
                 </Tr>
-              ))}
-            </Tbody>
-          </TableScrollable>
-        ))}
-      </ContentArea>
-    </Container>
+              </Thead>
+              <Tbody>
+                {units.map((unit) => (
+                  <Tr key={unit.id}>
+                    <Td>
+                      <Link to={`/units/${unit.id}`}>{unit.name}</Link>
+                      <div>{i18n.common.providerType[unit.providerType]}</div>
+                    </Td>
+                    {pilotFeatures.map((f) => (
+                      <Td key={f}>
+                        <Checkbox
+                          label={f}
+                          hiddenLabel
+                          checked={unit.features.includes(f)}
+                          onChange={(value) =>
+                            updateFeatures([unit.id], [f], value)
+                          }
+                          disabled={submitting}
+                        />
+                      </Td>
+                    ))}
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          ))}
+        </TableContainer>
+      </StyledContentArea>
+    </div>
   )
 })


### PR DESCRIPTION
Sivun asettelua on muutettu siten, että vaakasuuntainen vierityspalkki on koko ajan näkyvissä.

Video pieneltä 1024x768 -kokoiselta näytöltä:
https://github.com/user-attachments/assets/72f2a360-dab4-4416-b9f4-926664451939

Näkymä isolla näytöllä:
<img width="981" alt="Screenshot 2024-10-16 at 13 47 15" src="https://github.com/user-attachments/assets/6387715b-ebe0-4bde-ae52-ba7b84745d1d">
