### PR TITLE
Korjauksia ja parannuksia sähköpostinotifikaatioiden blokkaukseen

### DIFF
--- a/frontend/src/citizen-frontend/generated/api-clients/pis.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/pis.ts
@@ -4,7 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
-import { EmailNotificationSettings } from 'lib-common/generated/api-types/pis'
+import { EmailMessageType } from 'lib-common/generated/api-types/pis'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { PersonalDataUpdate } from 'lib-common/generated/api-types/pis'
@@ -15,8 +15,8 @@ import { uri } from 'lib-common/uri'
 /**
 * Generated from fi.espoo.evaka.pis.controllers.PersonalDataControllerCitizen.getNotificationSettings
 */
-export async function getNotificationSettings(): Promise<EmailNotificationSettings> {
-  const { data: json } = await client.request<JsonOf<EmailNotificationSettings>>({
+export async function getNotificationSettings(): Promise<EmailMessageType[]> {
+  const { data: json } = await client.request<JsonOf<EmailMessageType[]>>({
     url: uri`/citizen/personal-data/notification-settings`.toString(),
     method: 'GET'
   })
@@ -29,13 +29,13 @@ export async function getNotificationSettings(): Promise<EmailNotificationSettin
 */
 export async function updateNotificationSettings(
   request: {
-    body: EmailNotificationSettings
+    body: EmailMessageType[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/personal-data/notification-settings`.toString(),
     method: 'PUT',
-    data: request.body satisfies JsonCompatible<EmailNotificationSettings>
+    data: request.body satisfies JsonCompatible<EmailMessageType[]>
   })
   return json
 }

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -309,7 +309,7 @@ export class Fixture {
       restrictedDetailsEndDate: null,
       streetAddress: `streetAddress_${id}`,
       duplicateOf: null,
-      enabledEmailTypes: null,
+      disabledEmailTypes: [],
       forceManualFeeDecisions: false,
       invoiceRecipientName: '',
       invoicingStreetAddress: '',

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -35,6 +35,7 @@ import { DocumentContent } from 'lib-common/generated/api-types/document'
 import { DocumentStatus } from 'lib-common/generated/api-types/document'
 import { DocumentTemplateContent } from 'lib-common/generated/api-types/document'
 import { DocumentType } from 'lib-common/generated/api-types/document'
+import { EmailMessageType } from 'lib-common/generated/api-types/pis'
 import { EvakaUser } from 'lib-common/generated/api-types/user'
 import { FeeAlterationWithEffect } from 'lib-common/generated/api-types/invoicing'
 import { FeeDecisionThresholds } from 'lib-common/generated/api-types/invoicing'
@@ -702,9 +703,9 @@ export interface DevPerson {
   backupPhone: string
   dateOfBirth: LocalDate
   dateOfDeath: LocalDate | null
+  disabledEmailTypes: EmailMessageType[]
   duplicateOf: UUID | null
   email: string | null
-  enabledEmailTypes: EmailMessageType[] | null
   firstName: string
   forceManualFeeDecisions: boolean
   id: UUID
@@ -908,25 +909,6 @@ export interface EmailContent {
   subject: string
   text: string
 }
-
-/**
-* Generated from fi.espoo.evaka.pis.EmailMessageType
-*/
-export type EmailMessageType =
-  | 'TRANSACTIONAL'
-  | 'MESSAGE_NOTIFICATION'
-  | 'BULLETIN_NOTIFICATION'
-  | 'OUTDATED_INCOME_NOTIFICATION'
-  | 'NEW_CUSTOMER_INCOME_NOTIFICATION'
-  | 'CALENDAR_EVENT_NOTIFICATION'
-  | 'DECISION_NOTIFICATION'
-  | 'DOCUMENT_NOTIFICATION'
-  | 'INFORMAL_DOCUMENT_NOTIFICATION'
-  | 'MISSING_ATTENDANCE_RESERVATION_NOTIFICATION'
-  | 'MISSING_HOLIDAY_ATTENDANCE_RESERVATION_NOTIFICATION'
-  | 'DISCUSSION_TIME_RESERVATION_CONFIRMATION'
-  | 'DISCUSSION_SURVEY_CREATION_NOTIFICATION'
-  | 'DISCUSSION_TIME_RESERVATION_REMINDER'
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.MockDigitransit.Feature

--- a/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
@@ -117,23 +117,15 @@ export class CitizenNotificationSettingsSection extends Element {
   checkboxes = {
     message: new Checkbox(this.findByDataQa('message')),
     bulletin: new Checkbox(this.findByDataQa('bulletin')),
-    outdatedIncome: new Checkbox(this.findByDataQa('outdated-income')),
+    income: new Checkbox(this.findByDataQa('income')),
     calendarEvent: new Checkbox(this.findByDataQa('calendar-event')),
     decision: new Checkbox(this.findByDataQa('decision')),
     document: new Checkbox(this.findByDataQa('document')),
     informalDocument: new Checkbox(this.findByDataQa('informal-document')),
-    missingAttendanceReservation: new Checkbox(
-      this.findByDataQa('missing-attendance-reservation')
+    attendanceReservation: new Checkbox(
+      this.findByDataQa('attendance-reservation')
     ),
-    discussionTimeReservationConfirmation: new Checkbox(
-      this.findByDataQa('discussion-time-reservation-confirmation')
-    ),
-    discussionTimeReservationReminder: new Checkbox(
-      this.findByDataQa('discussion-time-reservation-reminder')
-    ),
-    discussionSurveyCreationNotificaiton: new Checkbox(
-      this.findByDataQa('discussion-survey-creation-notification')
-    )
+    discussionTime: new Checkbox(this.findByDataQa('discussion-time'))
   }
 
   async assertEditable(editable: boolean) {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-personal-details.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-personal-details.spec.ts
@@ -137,7 +137,7 @@ describe('Citizen notification settings', () => {
     await section.assertAllChecked(true)
     await section.startEditing.click()
     await section.checkboxes.message.uncheck()
-    await section.checkboxes.outdatedIncome.uncheck()
+    await section.checkboxes.income.uncheck()
     await section.checkboxes.decision.uncheck()
     await section.checkboxes.informalDocument.uncheck()
     await section.save.click()
@@ -145,20 +145,12 @@ describe('Citizen notification settings', () => {
 
     await section.checkboxes.message.waitUntilChecked(false)
     await section.checkboxes.bulletin.waitUntilChecked(true)
-    await section.checkboxes.outdatedIncome.waitUntilChecked(false)
+    await section.checkboxes.income.waitUntilChecked(false)
     await section.checkboxes.calendarEvent.waitUntilChecked(true)
     await section.checkboxes.decision.waitUntilChecked(false)
     await section.checkboxes.document.waitUntilChecked(true)
     await section.checkboxes.informalDocument.waitUntilChecked(false)
-    await section.checkboxes.missingAttendanceReservation.waitUntilChecked(true)
-    await section.checkboxes.discussionTimeReservationConfirmation.waitUntilChecked(
-      true
-    )
-    await section.checkboxes.discussionTimeReservationReminder.waitUntilChecked(
-      true
-    )
-    await section.checkboxes.discussionSurveyCreationNotificaiton.waitUntilChecked(
-      true
-    )
+    await section.checkboxes.attendanceReservation.waitUntilChecked(true)
+    await section.checkboxes.discussionTime.waitUntilChecked(true)
   })
 })

--- a/frontend/src/lib-common/generated/api-types/pis.ts
+++ b/frontend/src/lib-common/generated/api-types/pis.ts
@@ -128,21 +128,22 @@ export interface DisableSsnRequest {
 }
 
 /**
-* Generated from fi.espoo.evaka.pis.EmailNotificationSettings
+* Generated from fi.espoo.evaka.pis.EmailMessageType
 */
-export interface EmailNotificationSettings {
-  bulletin: boolean
-  calendarEvent: boolean
-  decision: boolean
-  discussionSurveyCreationNotification: boolean
-  discussionTimeReservationConfirmation: boolean
-  discussionTimeReservationReminder: boolean
-  document: boolean
-  informalDocument: boolean
-  message: boolean
-  missingAttendanceReservation: boolean
-  outdatedIncome: boolean
-}
+export const emailMessageTypes = [
+  'TRANSACTIONAL',
+  'MESSAGE_NOTIFICATION',
+  'BULLETIN_NOTIFICATION',
+  'INCOME_NOTIFICATION',
+  'CALENDAR_EVENT_NOTIFICATION',
+  'DECISION_NOTIFICATION',
+  'DOCUMENT_NOTIFICATION',
+  'INFORMAL_DOCUMENT_NOTIFICATION',
+  'ATTENDANCE_RESERVATION_NOTIFICATION',
+  'DISCUSSION_TIME_NOTIFICATION'
+] as const
+
+export type EmailMessageType = typeof emailMessageTypes[number]
 
 /**
 * Generated from fi.espoo.evaka.pis.Employee

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1777,17 +1777,17 @@ const en: Translations = {
       attendanceReservation: 'Reminders of missing attendance reservations',
       attendanceReservationInfo:
         'A reminder will be sent before the deadline if you have not registered your child’s attendance/absence for the following two weeks.',
-      discussionTime: 'Keskusteluaikoihin liittyvät ilmoitukset',
+      discussionTime: 'Notifications related to discussion appointments',
       discussionTimeInfo: (
         <div>
-          <div>Saat ilmoituksen seuraavista asioista:</div>
+          <div>You will receive notifications of the following:</div>
           <ul>
             <li>
-              kun sinulta kysytään sopivia aikoja esimerkiksi lapsesi
-              varhaiskasvatussuunnitelmaa koskevaan keskusteluun
+              when you are asked about suitable times for a discussion, e.g.
+              concerning your child’s early childhood education plan
             </li>
-            <li>varatuista ja perutuista keskustesteluajoistasi</li>
-            <li>muistutuksen ennen varattua keskusteluaikaa</li>
+            <li>booked and cancelled discussion appointments</li>
+            <li>reminders about upcoming discussion appointments</li>
           </ul>
         </div>
       )

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1761,35 +1761,36 @@ const en: Translations = {
       subtitle: 'Email notifications',
       message: 'messages sent to eVaka by staff',
       bulletin: 'bulletins sent to eVaka',
-      discussionTimeReservationConfirmation:
-        'Confirmations of discussion time reservations in eVaka',
-      discussionTimeReservationConfirmationInfo:
-        'An email confirmation is sent on reservation or cancellation of discussion times',
-      discussionTimeReservationReminder:
-        'Reminders for reserved discussion times',
-      discussionTimeReservationReminderInfo:
-        'Reminder is sent before the reserved time',
-      discussionSurveyCreationNotification:
-        'Notification for new discussion surveys opened in eVakaan',
-      discussionSurveyCreationNotificationInfo:
-        'Notification is sent when a new discussion survey concerning your child has been created',
-      outdatedIncome: 'Reminders about updating your income information',
-      outdatedIncomeInfo:
+      income: 'Reminders about updating your income information',
+      incomeInfo:
         'If your family pays less than the maximum fee for early childhood education, you must update your income information regularly. If your income information is missing or expires, you will be charged the maximum fee for early childhood education.',
-      outdatedIncomeWarning:
+      incomeWarning:
         'If your income information is missing or expires, you will be charged the maximum fee for early childhood education.',
       calendarEvent: 'Reminders about new events marked in the calendar',
       decision: 'New decisions',
-      document: 'New documents',
+      document: 'New pedagogic documents',
       documentInfo:
         'Documents refer to official documents that are not decisions. These include early childhood education plans and pedagogic assessments.',
       informalDocument: "Other documents related to the child's everyday life",
       informalDocumentInfo:
         'These documents may include, for example, images of drawings made by the child.',
-      missingAttendanceReservation:
-        'Reminders of missing attendance reservations',
-      missingAttendanceReservationInfo:
-        'A reminder will be sent before the deadline if you have not registered your child’s attendance/absence for the following two weeks.'
+      attendanceReservation: 'Reminders of missing attendance reservations',
+      attendanceReservationInfo:
+        'A reminder will be sent before the deadline if you have not registered your child’s attendance/absence for the following two weeks.',
+      discussionTime: 'Keskusteluaikoihin liittyvät ilmoitukset',
+      discussionTimeInfo: (
+        <div>
+          <div>Saat ilmoituksen seuraavista asioista:</div>
+          <ul>
+            <li>
+              kun sinulta kysytään sopivia aikoja esimerkiksi lapsesi
+              varhaiskasvatussuunnitelmaa koskevaan keskusteluun
+            </li>
+            <li>varatuista ja perutuista keskustesteluajoistasi</li>
+            <li>muistutuksen ennen varattua keskusteluaikaa</li>
+          </ul>
+        </div>
+      )
     }
   },
   income: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2003,37 +2003,38 @@ export default {
       info: 'Voit saada ilmoituksia sähköpostiin seuraavista aiheista. Asetuksia pystyy muokkaamaan muokkaa-nappia painamalla.',
       subtitle: 'Sähköpostiin lähetettävät ilmoitukset',
       message: 'eVakaan saapuneista henkilökunnan lähettämistä viesteistä',
-      bulletin: 'eVakaan saapuneista yleisistä tiedotteista',
-      discussionTimeReservationConfirmation:
-        'Vahvistukset eVakaan tehdyistä keskusteluaikavarauksista',
-      discussionTimeReservationConfirmationInfo:
-        'Vahvistusviesti lähetetään varatusta tai perutusta keskusteluaikavarauksesta',
-      discussionTimeReservationReminder:
-        'Muistutukset eVakaan tehdyistä keskusteluaikavarauksista',
-      discussionTimeReservationReminderInfo:
-        'Muistutusviesti lähetetään ennen varattua aikaa',
-      discussionSurveyCreationNotification:
-        'Ilmoitus eVakaan avatuista keskustelukyselyistä',
-      discussionSurveyCreationNotificationInfo:
-        'Ilmoitus lähetetään kun lapsesi on kutsuttu uuteen keskustelukyselyyn',
-      outdatedIncome: 'Muistutukset tulotietojen päivittämisestä',
-      outdatedIncomeInfo:
+      bulletin: 'eVakaan saapuneista kunnan yleisistä tiedotteista',
+      income: 'Muistutukset tulotietojen päivittämisestä',
+      incomeInfo:
         'Mikäli ette maksa korkeinta varhaiskasvatusmaksua, on tulotiedot päivitettävä säännöllisesti. Jos tulotiedot puuttuvat tai vanhenevat, merkitään varhaiskasvatuksesta maksettavaksi korkein maksu.',
-      outdatedIncomeWarning:
+      incomeWarning:
         'Jos tulotiedot puuttuvat tai vanhenevat, merkitään varhaiskasvatuksesta maksettavaksi korkein maksu.',
       calendarEvent:
         'Muistutukset kalenteriin merkityistä uusista tapahtumista',
       decision: 'Saapuneista päätöksistä',
-      document: 'Uusista asiakirjoista',
+      document: 'Saapuneista pedagogisista asiakirjoista',
       documentInfo:
         'Asiakirjoilla tarkoitetaan virallisia asiakirjoja, jotka eivät ole päätöksiä. Tällaisia ovat esimerkiksi varhaiskasvatussuunnitelmat ja pedagogiset arviot.',
       informalDocument: 'Muista lapsen arkeen liittyvistä dokumenteista',
       informalDocumentInfo:
         'Muut lapsen arkeen liittyvät dokumentit voivat olla esimerkiksi kuvia lapsen tekemistä piirustuksista.',
-      missingAttendanceReservation:
-        'Muistutukset puuttuvista läsnäoloilmoituksista',
-      missingAttendanceReservationInfo:
-        'Muistutus lähetetään ennen läsnäoloilmoitusten määräaikaa, mikäli jollakin lapsistasi puuttuu läsnäoloilmoitus tai poissaolomerkintä seuraavalta kahdelta viikolta.'
+      attendanceReservation: 'Muistutukset puuttuvista läsnäoloilmoituksista',
+      attendanceReservationInfo:
+        'Muistutus lähetetään ennen läsnäoloilmoitusten määräaikaa, mikäli jollakin lapsistasi puuttuu läsnäoloilmoitus tai poissaolomerkintä seuraavalta kahdelta viikolta.',
+      discussionTime: 'Keskusteluaikoihin liittyvät ilmoitukset',
+      discussionTimeInfo: (
+        <div>
+          <div>Saat ilmoituksen seuraavista asioista:</div>
+          <ul>
+            <li>
+              kun sinulta kysytään sopivia aikoja esimerkiksi lapsesi
+              varhaiskasvatussuunnitelmaa koskevaan keskusteluun
+            </li>
+            <li>varatuista ja perutuista keskustesteluajoistasi</li>
+            <li>muistutuksen ennen varattua keskusteluaikaa</li>
+          </ul>
+        </div>
+      )
     }
   },
   income: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2017,17 +2017,17 @@ const sv: Translations = {
       attendanceReservation: 'Påminnelser om närvaroanmälningar som saknas',
       attendanceReservationInfo:
         'Påminnelsen skickas före deadline för närvaroanmälan om något av dina barn saknar anmälan om närvaro eller frånvaro under de kommande två veckorna.',
-      discussionTime: 'Keskusteluaikoihin liittyvät ilmoitukset',
+      discussionTime: 'Meddelanden om samtalstider',
       discussionTimeInfo: (
         <div>
-          <div>Saat ilmoituksen seuraavista asioista:</div>
+          <div>Du får ett meddelande när vi skickar:</div>
           <ul>
             <li>
-              kun sinulta kysytään sopivia aikoja esimerkiksi lapsesi
-              varhaiskasvatussuunnitelmaa koskevaan keskusteluun
+              en förfrågan om lämpliga tider till exempel för samtal om ditt
+              barns plan för småbarnspedagogik
             </li>
-            <li>varatuista ja perutuista keskustesteluajoistasi</li>
-            <li>muistutuksen ennen varattua keskusteluaikaa</li>
+            <li>information om dina bokade och avbokade samtalstider</li>
+            <li>påminnelser inför bokade samtalstider</li>
           </ul>
         </div>
       )

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2001,35 +2001,36 @@ const sv: Translations = {
       subtitle: 'Meddelande som skickas till e-posten',
       message: 'Meddelanden som personalen skickat i eVaka',
       bulletin: 'Bulletiner i eVaka',
-      discussionTimeReservationConfirmation:
-        'Bekräftelser på bokningar av diskussionstid i eVaka',
-      discussionTimeReservationConfirmationInfo:
-        'Ett bekräftelsemeddelande skickas för en bokad eller avbokad bokning av diskussionstid.',
-      discussionTimeReservationReminder:
-        'Påminnelser om bokade diskussionstider i eVaka',
-      discussionTimeReservationReminderInfo:
-        'Ett påminnelsemeddelande skickas före den bokade tiden.',
-      discussionSurveyCreationNotification:
-        'Meddelande om öppnade diskussionsenkäter i eVaka',
-      discussionSurveyCreationNotificationInfo:
-        'Meddelandet skickas när en ny diskussionsenkät gällande ditt barn har skapats i eVaka',
-      outdatedIncome: 'Påminnelse om att uppdatera inkomstuppgifter',
-      outdatedIncomeInfo:
+      income: 'Påminnelse om att uppdatera inkomstuppgifter',
+      incomeInfo:
         'Om familjen inte betalar den högsta avgiften ska inkomstuppgifterna uppdateras regelbundet. Om inkomstuppgifterna saknas eller är föråldrade, uppbärs högsta avgift för småbarnspedagogiken.',
-      outdatedIncomeWarning:
+      incomeWarning:
         'Om inkomstuppgifterna saknas eller är föråldrade, uppbärs högsta avgift för småbarnspedagogiken.',
       calendarEvent: 'Påminnelser om nya händelser som antecknats i kalendern',
       decision: 'Om inkomna beslut',
-      document: 'Om nya dokument',
+      document: 'Om inkomna pedagogiska dokument',
       documentInfo:
         'Med dokument avses officiella handlingar som inte är beslut. Dessa kan till exempel vara planer för småbarnspedagogik eller pedagogiska bedömningar.',
       informalDocument: 'Om andra dokument som gäller barnets vardag',
       informalDocumentInfo:
         'Dessa kan till exempel vara bilder på teckningar som barnet gjort.',
-      missingAttendanceReservation:
-        'Påminnelser om närvaroanmälningar som saknas',
-      missingAttendanceReservationInfo:
-        'Påminnelsen skickas före deadline för närvaroanmälan om något av dina barn saknar anmälan om närvaro eller frånvaro under de kommande två veckorna.'
+      attendanceReservation: 'Påminnelser om närvaroanmälningar som saknas',
+      attendanceReservationInfo:
+        'Påminnelsen skickas före deadline för närvaroanmälan om något av dina barn saknar anmälan om närvaro eller frånvaro under de kommande två veckorna.',
+      discussionTime: 'Keskusteluaikoihin liittyvät ilmoitukset',
+      discussionTimeInfo: (
+        <div>
+          <div>Saat ilmoituksen seuraavista asioista:</div>
+          <ul>
+            <li>
+              kun sinulta kysytään sopivia aikoja esimerkiksi lapsesi
+              varhaiskasvatussuunnitelmaa koskevaan keskusteluun
+            </li>
+            <li>varatuista ja perutuista keskustesteluajoistasi</li>
+            <li>muistutuksen ennen varattua keskusteluaikaa</li>
+          </ul>
+        </div>
+      )
     }
   },
   income: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/emailclient/EmailTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/emailclient/EmailTest.kt
@@ -6,7 +6,7 @@ package fi.espoo.evaka.emailclient
 
 import fi.espoo.evaka.PureJdbiTest
 import fi.espoo.evaka.pis.EmailMessageType
-import fi.espoo.evaka.pis.updateEnabledEmailTypes
+import fi.espoo.evaka.pis.updateDisabledEmailTypes
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.insert
 import fi.espoo.evaka.testAdult_1
@@ -36,16 +36,18 @@ class EmailTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         // Only some notification types are enabled
         db.transaction { tx ->
-            tx.updateEnabledEmailTypes(
+            tx.updateDisabledEmailTypes(
                 testAdult_1.id,
-                listOf(
-                    EmailMessageType.TRANSACTIONAL,
-                    EmailMessageType.BULLETIN_NOTIFICATION,
-                    EmailMessageType.DOCUMENT_NOTIFICATION,
-                ),
+                // Disable all but three
+                EmailMessageType.entries.toSet() -
+                    setOf(
+                        EmailMessageType.TRANSACTIONAL,
+                        EmailMessageType.BULLETIN_NOTIFICATION,
+                        EmailMessageType.DOCUMENT_NOTIFICATION,
+                    ),
             )
         }
-        EmailMessageType.values()
+        EmailMessageType.entries
             .mapNotNull { type -> createEmail(emailType = type, toAddress = "$type@example.com") }
             .also { emails ->
                 assertEquals(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -2049,7 +2049,6 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
                 email = "optin@test.com",
                 forceManualFeeDecisions = false,
                 ssn = "291090-9986",
-                enabledEmailTypes = listOf(EmailMessageType.DECISION_NOTIFICATION),
             )
         db.transaction {
             it.insert(optInAdult, DevPersonType.RAW_ROW)
@@ -2141,7 +2140,7 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
                 ssn = "291090-9986",
                 email = "optout@test.com",
                 forceManualFeeDecisions = false,
-                enabledEmailTypes = listOf(),
+                disabledEmailTypes = setOf(EmailMessageType.DECISION_NOTIFICATION),
             )
         db.transaction {
             it.insert(optOutAdult, DevPersonType.RAW_ROW)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/VoucherValueDecisionIntegrationTest.kt
@@ -567,7 +567,6 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 email = "optin@test.com",
                 forceManualFeeDecisions = false,
                 ssn = "291090-9986",
-                enabledEmailTypes = listOf(EmailMessageType.DECISION_NOTIFICATION),
             )
         db.transaction {
             it.insert(optInAdult, DevPersonType.RAW_ROW)
@@ -658,7 +657,7 @@ class VoucherValueDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEac
                 ssn = "291090-9986",
                 email = "optout@test.com",
                 forceManualFeeDecisions = false,
-                enabledEmailTypes = listOf(),
+                disabledEmailTypes = setOf(EmailMessageType.DECISION_NOTIFICATION),
             )
         db.transaction {
             it.insert(optOutAdult, DevPersonType.RAW_ROW)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonalDataControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/PersonalDataControllerCitizenIntegrationTest.kt
@@ -5,7 +5,7 @@
 package fi.espoo.evaka.pis.controller
 
 import fi.espoo.evaka.FullApplicationTest
-import fi.espoo.evaka.pis.EmailNotificationSettings
+import fi.espoo.evaka.pis.EmailMessageType
 import fi.espoo.evaka.pis.controllers.PersonalDataControllerCitizen
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
@@ -24,28 +24,13 @@ class PersonalDataControllerCitizenIntegrationTest : FullApplicationTest(resetDb
     fun `all notifications are enabled by default`() {
         db.transaction { tx -> tx.insert(testAdult_1, DevPersonType.RAW_ROW) }
 
-        val settings =
+        val disabledTypes =
             personalDataController.getNotificationSettings(
                 dbInstance(),
                 AuthenticatedUser.Citizen(testAdult_1.id, CitizenAuthLevel.WEAK),
                 RealEvakaClock(),
             )
-        assertEquals(
-            EmailNotificationSettings(
-                message = true,
-                bulletin = true,
-                outdatedIncome = true,
-                calendarEvent = true,
-                decision = true,
-                document = true,
-                informalDocument = true,
-                missingAttendanceReservation = true,
-                discussionTimeReservationConfirmation = true,
-                discussionSurveyCreationNotification = true,
-                discussionTimeReservationReminder = true,
-            ),
-            settings,
-        )
+        assertEquals(emptySet(), disabledTypes)
     }
 
     @Test
@@ -56,18 +41,11 @@ class PersonalDataControllerCitizenIntegrationTest : FullApplicationTest(resetDb
             dbInstance(),
             AuthenticatedUser.Citizen(testAdult_1.id, CitizenAuthLevel.WEAK),
             RealEvakaClock(),
-            EmailNotificationSettings(
-                message = true,
-                bulletin = false,
-                outdatedIncome = true,
-                calendarEvent = false,
-                decision = true,
-                document = false,
-                informalDocument = true,
-                missingAttendanceReservation = false,
-                discussionTimeReservationConfirmation = true,
-                discussionSurveyCreationNotification = true,
-                discussionTimeReservationReminder = true,
+            setOf(
+                EmailMessageType.BULLETIN_NOTIFICATION,
+                EmailMessageType.CALENDAR_EVENT_NOTIFICATION,
+                EmailMessageType.DOCUMENT_NOTIFICATION,
+                EmailMessageType.ATTENDANCE_RESERVATION_NOTIFICATION,
             ),
         )
 
@@ -78,18 +56,11 @@ class PersonalDataControllerCitizenIntegrationTest : FullApplicationTest(resetDb
                 RealEvakaClock(),
             )
         assertEquals(
-            EmailNotificationSettings(
-                message = true,
-                bulletin = false,
-                outdatedIncome = true,
-                calendarEvent = false,
-                decision = true,
-                document = false,
-                informalDocument = true,
-                missingAttendanceReservation = false,
-                discussionTimeReservationConfirmation = true,
-                discussionSurveyCreationNotification = true,
-                discussionTimeReservationReminder = true,
+            setOf(
+                EmailMessageType.BULLETIN_NOTIFICATION,
+                EmailMessageType.CALENDAR_EVENT_NOTIFICATION,
+                EmailMessageType.DOCUMENT_NOTIFICATION,
+                EmailMessageType.ATTENDANCE_RESERVATION_NOTIFICATION,
             ),
             settings,
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationService.kt
@@ -114,7 +114,7 @@ class CalendarEventNotificationService(
         Email.create(
                 db,
                 msg.recipientId,
-                EmailMessageType.DISCUSSION_SURVEY_CREATION_NOTIFICATION,
+                EmailMessageType.DISCUSSION_TIME_NOTIFICATION,
                 fromAddress,
                 content,
                 "${msg.recipientId}: ${msg.eventId}",
@@ -192,7 +192,7 @@ class CalendarEventNotificationService(
         Email.create(
                 db,
                 msg.recipientId,
-                EmailMessageType.DISCUSSION_TIME_RESERVATION_CONFIRMATION,
+                EmailMessageType.DISCUSSION_TIME_NOTIFICATION,
                 fromAddress,
                 content,
                 "${eventTime.id} - ${msg.recipientId}",
@@ -228,7 +228,7 @@ class CalendarEventNotificationService(
         Email.create(
                 db,
                 msg.recipientId,
-                EmailMessageType.DISCUSSION_TIME_RESERVATION_CONFIRMATION,
+                EmailMessageType.DISCUSSION_TIME_NOTIFICATION,
                 fromAddress,
                 content,
                 "${eventTime.id} - ${msg.recipientId}",
@@ -257,7 +257,7 @@ class CalendarEventNotificationService(
         Email.create(
                 db,
                 msg.recipientId,
-                EmailMessageType.DISCUSSION_TIME_RESERVATION_REMINDER,
+                EmailMessageType.DISCUSSION_TIME_NOTIFICATION,
                 emailEnv.sender(msg.recipientLanguage),
                 emailMessageProvider.discussionTimeReservationReminder(
                     msg.recipientLanguage,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/NewCustomerIncomeNotification.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/NewCustomerIncomeNotification.kt
@@ -88,7 +88,7 @@ class NewCustomerIncomeNotification(
 
             Email.create(
                     dbc = db,
-                    emailType = EmailMessageType.NEW_CUSTOMER_INCOME_NOTIFICATION,
+                    emailType = EmailMessageType.INCOME_NOTIFICATION,
                     personId = msg.guardianId,
                     fromAddress = emailEnv.sender(language),
                     content =

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/OutdatedIncomeNotifications.kt
@@ -138,7 +138,7 @@ class OutdatedIncomeNotifications(
 
         Email.create(
                 dbc = db,
-                emailType = EmailMessageType.OUTDATED_INCOME_NOTIFICATION,
+                emailType = EmailMessageType.INCOME_NOTIFICATION,
                 personId = msg.guardianId,
                 fromAddress = emailEnv.sender(language),
                 content = emailMessageProvider.incomeNotification(msg.type, language),

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageNotificationEmailService.kt
@@ -106,7 +106,9 @@ WHERE m.id = ANY(${bind(messageIds)})
                 emailType =
                     when (thread.type) {
                         MessageType.MESSAGE -> EmailMessageType.MESSAGE_NOTIFICATION
-                        MessageType.BULLETIN -> EmailMessageType.BULLETIN_NOTIFICATION
+                        MessageType.BULLETIN ->
+                            if (isSenderMunicipalAccount) EmailMessageType.BULLETIN_NOTIFICATION
+                            else EmailMessageType.MESSAGE_NOTIFICATION
                     },
                 fromAddress = emailEnv.sender(msg.language),
                 content =

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalData.kt
@@ -4,6 +4,9 @@
 
 package fi.espoo.evaka.pis
 
+import fi.espoo.evaka.ConstList
+import fi.espoo.evaka.shared.db.DatabaseEnum
+
 data class PersonalDataUpdate(
     val preferredName: String,
     val phone: String,
@@ -11,24 +14,22 @@ data class PersonalDataUpdate(
     val email: String,
 )
 
-enum class EmailMessageType {
+@ConstList("emailMessageTypes")
+enum class EmailMessageType : DatabaseEnum {
     /**
      * Messages sent in response to a user's action (e.g. "your application was received"). These
      * messages are always sent to the receiver.
      */
     TRANSACTIONAL,
 
-    /** Notifications about new eVaka messages */
+    /** Notifications about new eVaka messages from daycare staff including bulletins sent by unit supervisor */
     MESSAGE_NOTIFICATION,
 
-    /** Notifications about new eVaka bulletins (tiedotteet) */
+    /** Notifications about new general bulletins from municipal accounts (tiedotteet) */
     BULLETIN_NOTIFICATION,
 
-    /** Reminders about expiring or missing income info */
-    OUTDATED_INCOME_NOTIFICATION,
-
-    /** Reminders for new customers about income info */
-    NEW_CUSTOMER_INCOME_NOTIFICATION,
+    /** Income related notifications such as reminders about expiring or missing income info */
+    INCOME_NOTIFICATION,
 
     /** Notifications about new calendar events of daycare groups */
     CALENDAR_EVENT_NOTIFICATION,
@@ -49,100 +50,14 @@ enum class EmailMessageType {
     INFORMAL_DOCUMENT_NOTIFICATION,
 
     /** Reminders about making attendance reservations */
-    MISSING_ATTENDANCE_RESERVATION_NOTIFICATION,
+    ATTENDANCE_RESERVATION_NOTIFICATION,
 
-    /** Reminders about missing holiday attendance reservations */
-    MISSING_HOLIDAY_ATTENDANCE_RESERVATION_NOTIFICATION,
+    /** Discussion time related notifications  */
+    DISCUSSION_TIME_NOTIFICATION;
 
-    /** Confirmation email for discussion time reservation */
-    DISCUSSION_TIME_RESERVATION_CONFIRMATION,
-
-    /** Notification on the creation of a new discussion survey * */
-    DISCUSSION_SURVEY_CREATION_NOTIFICATION,
-
-    /** Reminder of an impending discussion time reservation * */
-    DISCUSSION_TIME_RESERVATION_REMINDER,
-}
-
-data class EmailNotificationSettings(
-    val message: Boolean,
-    val bulletin: Boolean,
-    val outdatedIncome: Boolean,
-    val calendarEvent: Boolean,
-    val decision: Boolean,
-    val document: Boolean,
-    val informalDocument: Boolean,
-    val missingAttendanceReservation: Boolean,
-    val discussionTimeReservationConfirmation: Boolean,
-    val discussionSurveyCreationNotification: Boolean,
-    val discussionTimeReservationReminder: Boolean,
-) {
-    fun toNotificationTypes() =
-        listOfNotNull(
-            EmailMessageType.TRANSACTIONAL, // always enabled
-            EmailMessageType.MESSAGE_NOTIFICATION.takeIf { message },
-            EmailMessageType.BULLETIN_NOTIFICATION.takeIf { bulletin },
-            EmailMessageType.OUTDATED_INCOME_NOTIFICATION.takeIf { outdatedIncome },
-            EmailMessageType.CALENDAR_EVENT_NOTIFICATION.takeIf { calendarEvent },
-            EmailMessageType.DECISION_NOTIFICATION.takeIf { decision },
-            EmailMessageType.DOCUMENT_NOTIFICATION.takeIf { document },
-            EmailMessageType.INFORMAL_DOCUMENT_NOTIFICATION.takeIf { informalDocument },
-            EmailMessageType.MISSING_ATTENDANCE_RESERVATION_NOTIFICATION.takeIf {
-                missingAttendanceReservation
-            },
-            EmailMessageType.DISCUSSION_TIME_RESERVATION_CONFIRMATION.takeIf {
-                discussionTimeReservationConfirmation
-            },
-            EmailMessageType.DISCUSSION_SURVEY_CREATION_NOTIFICATION.takeIf {
-                discussionSurveyCreationNotification
-            },
-            EmailMessageType.DISCUSSION_TIME_RESERVATION_REMINDER.takeIf {
-                discussionTimeReservationReminder
-            },
-        )
+    override val sqlType: String = "email_message_type"
 
     companion object {
-        fun fromNotificationTypes(enabledNotificationTypes: List<EmailMessageType>?) =
-            if (enabledNotificationTypes == null) {
-                // All are enabled by default
-                EmailNotificationSettings(
-                    message = true,
-                    bulletin = true,
-                    outdatedIncome = true,
-                    calendarEvent = true,
-                    decision = true,
-                    document = true,
-                    informalDocument = true,
-                    missingAttendanceReservation = true,
-                    discussionTimeReservationConfirmation = true,
-                    discussionSurveyCreationNotification = true,
-                    discussionTimeReservationReminder = true,
-                )
-            } else {
-                EmailNotificationSettings(
-                    message = EmailMessageType.MESSAGE_NOTIFICATION in enabledNotificationTypes,
-                    bulletin = EmailMessageType.BULLETIN_NOTIFICATION in enabledNotificationTypes,
-                    outdatedIncome =
-                        EmailMessageType.OUTDATED_INCOME_NOTIFICATION in enabledNotificationTypes,
-                    calendarEvent =
-                        EmailMessageType.CALENDAR_EVENT_NOTIFICATION in enabledNotificationTypes,
-                    decision = EmailMessageType.DECISION_NOTIFICATION in enabledNotificationTypes,
-                    document = EmailMessageType.DOCUMENT_NOTIFICATION in enabledNotificationTypes,
-                    informalDocument =
-                        EmailMessageType.INFORMAL_DOCUMENT_NOTIFICATION in enabledNotificationTypes,
-                    missingAttendanceReservation =
-                        EmailMessageType.MISSING_ATTENDANCE_RESERVATION_NOTIFICATION in
-                            enabledNotificationTypes,
-                    discussionTimeReservationConfirmation =
-                        EmailMessageType.DISCUSSION_TIME_RESERVATION_CONFIRMATION in
-                            enabledNotificationTypes,
-                    discussionSurveyCreationNotification =
-                        EmailMessageType.DISCUSSION_SURVEY_CREATION_NOTIFICATION in
-                            enabledNotificationTypes,
-                    discussionTimeReservationReminder =
-                        EmailMessageType.DISCUSSION_TIME_RESERVATION_REMINDER in
-                            enabledNotificationTypes,
-                )
-            }
+        val alwaysEnabled: Set<EmailMessageType> = setOf(TRANSACTIONAL)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalData.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalData.kt
@@ -22,7 +22,10 @@ enum class EmailMessageType : DatabaseEnum {
      */
     TRANSACTIONAL,
 
-    /** Notifications about new eVaka messages from daycare staff including bulletins sent by unit supervisor */
+    /**
+     * Notifications about new eVaka messages from daycare staff including bulletins sent by unit
+     * supervisor
+     */
     MESSAGE_NOTIFICATION,
 
     /** Notifications about new general bulletins from municipal accounts (tiedotteet) */
@@ -52,7 +55,7 @@ enum class EmailMessageType : DatabaseEnum {
     /** Reminders about making attendance reservations */
     ATTENDANCE_RESERVATION_NOTIFICATION,
 
-    /** Discussion time related notifications  */
+    /** Discussion time related notifications */
     DISCUSSION_TIME_NOTIFICATION;
 
     override val sqlType: String = "email_message_type"

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalDataQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/PersonalDataQueries.kt
@@ -23,20 +23,20 @@ fun Database.Transaction.updatePersonalDetails(personId: PersonId, body: Persona
         .updateExactlyOne()
 }
 
-fun Database.Read.getEnabledEmailTypes(personId: PersonId): List<EmailMessageType> {
+fun Database.Read.getDisabledEmailTypes(personId: PersonId): Set<EmailMessageType> {
     return createQuery {
-            sql("SELECT enabled_email_types FROM person WHERE id = ${bind(personId)}")
+            sql("SELECT disabled_email_types FROM person WHERE id = ${bind(personId)}")
         }
-        .exactlyOne<List<EmailMessageType>?>() ?: EmailMessageType.values().toList()
+        .exactlyOne<Set<EmailMessageType>>()
 }
 
-fun Database.Transaction.updateEnabledEmailTypes(
+fun Database.Transaction.updateDisabledEmailTypes(
     personId: PersonId,
-    emailTypes: List<EmailMessageType>,
+    emailTypes: Set<EmailMessageType>,
 ) {
     createUpdate {
             sql(
-                "UPDATE person SET enabled_email_types = ${bind(emailTypes)} WHERE id = ${bind(personId)}"
+                "UPDATE person SET disabled_email_types = ${bind(emailTypes)} WHERE id = ${bind(personId)}"
             )
         }
         .updateExactlyOne()

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsReminders.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingHolidayReservationsReminders.kt
@@ -164,7 +164,7 @@ WHERE p.id = ANY(${bind(childIds)})
         Email.create(
                 dbc = db,
                 personId = msg.guardian,
-                emailType = EmailMessageType.MISSING_HOLIDAY_ATTENDANCE_RESERVATION_NOTIFICATION,
+                emailType = EmailMessageType.ATTENDANCE_RESERVATION_NOTIFICATION,
                 fromAddress = emailEnv.sender(language),
                 content = emailMessageProvider.missingHolidayReservationsNotification(language),
                 traceId = msg.guardian.toString(),

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingReservationsReminders.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/MissingReservationsReminders.kt
@@ -91,7 +91,7 @@ LIMIT 1
         Email.create(
                 dbc = db,
                 personId = msg.guardian,
-                emailType = EmailMessageType.MISSING_ATTENDANCE_RESERVATION_NOTIFICATION,
+                emailType = EmailMessageType.ATTENDANCE_RESERVATION_NOTIFICATION,
                 fromAddress = emailEnv.sender(language),
                 content = emailMessageProvider.missingReservationsNotification(language, msg.range),
                 traceId = msg.guardian.toString(),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -349,13 +349,13 @@ fun Database.Transaction.insert(person: DevPerson, type: DevPersonType): PersonI
 INSERT INTO person (
     id, date_of_birth, date_of_death, first_name, last_name, preferred_name, social_security_number, email, phone, language,
     street_address, postal_code, post_office, residence_code, nationalities, restricted_details_enabled, restricted_details_end_date,
-    invoicing_street_address, invoicing_postal_code, invoicing_post_office, updated_from_vtj, oph_person_oid, duplicate_of, enabled_email_types
+    invoicing_street_address, invoicing_postal_code, invoicing_post_office, updated_from_vtj, oph_person_oid, duplicate_of, disabled_email_types
 ) VALUES (
     ${bind(p.id)}, ${bind(p.dateOfBirth)}, ${bind(p.dateOfDeath)}, ${bind(p.firstName)}, ${bind(p.lastName)}, ${bind(p.preferredName)},
     ${bind(p.ssn)}, ${bind(p.email)}, ${bind(p.phone)}, ${bind(p.language)}, ${bind(p.streetAddress)}, ${bind(p.postalCode)}, ${bind(p.postOffice)},
     ${bind(p.residenceCode)}, ${bind(p.nationalities)}, ${bind(p.restrictedDetailsEnabled)}, ${bind(p.restrictedDetailsEndDate)},
     ${bind(p.invoicingStreetAddress)}, ${bind(p.invoicingPostalCode)}, ${bind(p.invoicingPostOffice)}, ${bind(p.updatedFromVtj)},
-    ${bind(p.ophPersonOid)}, ${bind(p.duplicateOf)}, ${bind(p.enabledEmailTypes)}
+    ${bind(p.ophPersonOid)}, ${bind(p.duplicateOf)}, ${bind(p.disabledEmailTypes)}
 )
 RETURNING id
 """

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -2042,7 +2042,7 @@ data class DevPerson(
     val updatedFromVtj: HelsinkiDateTime? = null,
     val ophPersonOid: String? = null,
     val duplicateOf: PersonId? = null,
-    val enabledEmailTypes: List<EmailMessageType>? = null,
+    val disabledEmailTypes: Set<EmailMessageType> = emptySet(),
 ) {
     fun toPersonDTO() =
         PersonDTO(

--- a/service/src/main/resources/db/migration/V453__email_message_type.sql
+++ b/service/src/main/resources/db/migration/V453__email_message_type.sql
@@ -1,0 +1,70 @@
+CREATE TYPE email_message_type AS ENUM (
+    'TRANSACTIONAL',
+    'MESSAGE_NOTIFICATION',
+    'BULLETIN_NOTIFICATION',
+    'INCOME_NOTIFICATION',
+    'CALENDAR_EVENT_NOTIFICATION',
+    'DECISION_NOTIFICATION',
+    'DOCUMENT_NOTIFICATION',
+    'INFORMAL_DOCUMENT_NOTIFICATION',
+    'ATTENDANCE_RESERVATION_NOTIFICATION',
+    'DISCUSSION_TIME_NOTIFICATION'
+);
+
+-- person table already has many defaults to make inserts easier, so this default may also remain
+ALTER TABLE person ADD COLUMN disabled_email_types email_message_type[] NOT NULL DEFAULT '{}'::email_message_type[];
+
+UPDATE person
+SET disabled_email_types = array_remove(
+    ARRAY [
+        CASE
+            WHEN 'MESSAGE_NOTIFICATION' = ANY(enabled_email_types)
+            THEN NULL::email_message_type
+            ELSE 'MESSAGE_NOTIFICATION'::email_message_type
+        END,
+        CASE
+            WHEN 'BULLETIN_NOTIFICATION' = ANY(enabled_email_types)
+            THEN NULL::email_message_type
+            ELSE 'BULLETIN_NOTIFICATION'::email_message_type
+        END,
+        CASE
+            WHEN '{OUTDATED_INCOME_NOTIFICATION,NEW_CUSTOMER_INCOME_NOTIFICATION}'::text[] && enabled_email_types
+            THEN NULL::email_message_type
+            ELSE 'INCOME_NOTIFICATION'::email_message_type
+        END,
+        CASE
+            WHEN 'CALENDAR_EVENT_NOTIFICATION' = ANY(enabled_email_types)
+            THEN NULL::email_message_type
+            ELSE 'CALENDAR_EVENT_NOTIFICATION'::email_message_type
+        END,
+        CASE
+            WHEN 'DECISION_NOTIFICATION' = ANY(enabled_email_types)
+            THEN NULL::email_message_type
+            ELSE 'DECISION_NOTIFICATION'::email_message_type
+        END,
+        CASE
+            WHEN 'DOCUMENT_NOTIFICATION' = ANY(enabled_email_types)
+            THEN NULL::email_message_type
+            ELSE 'DOCUMENT_NOTIFICATION'::email_message_type
+        END,
+        CASE
+            WHEN 'INFORMAL_DOCUMENT_NOTIFICATION' = ANY(enabled_email_types)
+            THEN NULL::email_message_type
+            ELSE 'INFORMAL_DOCUMENT_NOTIFICATION'::email_message_type
+        END,
+        CASE
+            WHEN '{MISSING_ATTENDANCE_RESERVATION_NOTIFICATION,MISSING_HOLIDAY_ATTENDANCE_RESERVATION_NOTIFICATION}'::text[] && enabled_email_types
+            THEN NULL::email_message_type
+            ELSE 'ATTENDANCE_RESERVATION_NOTIFICATION'::email_message_type
+        END,
+        CASE
+            WHEN '{DISCUSSION_TIME_RESERVATION_CONFIRMATION,DISCUSSION_SURVEY_CREATION_NOTIFICATION,DISCUSSION_TIME_RESERVATION_REMINDER}'::text[] && enabled_email_types
+            THEN NULL::email_message_type
+            ELSE 'DISCUSSION_TIME_NOTIFICATION'::email_message_type
+        END
+    ],
+    NULL::email_message_type
+)
+WHERE enabled_email_types IS NOT NULL;
+
+-- todo in next PR: ALTER TABLE person DROP COLUMN enabled_email_types;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -448,3 +448,4 @@ V449__pedagogical_document_modified_by.sql
 V450__titania_errors.sql
 V451__invoice_correction_target.sql
 V452__finance_decision_date_nullability.sql
+V453__email_message_type.sql


### PR DESCRIPTION
- migratoitu kantaan `enabled_email_types text[]` tilalle `disabled_email_types email_message_type[] not null`
- yhdistetty osa tyypeistä keskenään, jotta kuntalaiselle ei tule liian pitkää listaa valintoja
- ei-kunnalliset (johtajan lähettämät) tiedotteet lasketaan jatkossa kuuluvan henkilökunnan lähettämiin viesteihin
