### PR TITLE
Muutoksia viestien näkyvyyteen ja sallittuihin vastaanottajiin

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -145,6 +145,7 @@ export default React.memo(function MessageEditor({
   )
   const selectedChildrenInSameUnit = useMemo(
     () =>
+      selectedChildren.length === 1 ||
       selectedChildren.every(
         (c) => c.unit !== null && c.unit.id === selectedChildren[0].unit?.id
       ),

--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -133,6 +133,9 @@ export default React.memo(function MessagesPage() {
                     accountId={messageAccount.accountId}
                     closeThread={() => selectThread(undefined)}
                     thread={selectedThread}
+                    allowedReplyAccounts={
+                      receivers.getOrElse(null)?.childrenToMessageAccounts ?? {}
+                    }
                     onThreadDeleted={() => {
                       onSelectedThreadDeleted()
                       addTimedNotification({

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -345,6 +345,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 senders = setOf(accounts.employee1.id),
                 recipients = setOf(accounts.person1.id, accounts.person2.id),
                 applicationId = null,
+                children = setOf(),
             ),
             participants,
         )
@@ -379,6 +380,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 senders = setOf(accounts.employee1.id, accounts.person2.id),
                 recipients = setOf(accounts.person1.id, accounts.person2.id, accounts.employee1.id),
                 applicationId = null,
+                children = setOf(),
             ),
             participants2,
         )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemControllerCitizenTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/SystemControllerCitizenTest.kt
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.pis
+
+import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.shared.auth.AuthenticatedUser
+import fi.espoo.evaka.shared.dev.*
+import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.shared.security.PilotFeature
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class SystemControllerCitizenTest : FullApplicationTest(resetDbBeforeEach = true) {
+
+    @Autowired lateinit var systemController: SystemController
+
+    private val user = AuthenticatedUser.SystemInternalUser
+    private val clock = MockEvakaClock(2024, 10, 15, 10, 0)
+    private val area = DevCareArea()
+    private val daycare =
+        DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.MESSAGING))
+    private val child = DevPerson()
+    private val adult = DevPerson()
+
+    @BeforeEach
+    fun beforeEach() {
+        db.transaction {
+            it.insert(area)
+            it.insert(daycare)
+            it.insert(child, DevPersonType.CHILD)
+            it.insert(adult, DevPersonType.ADULT)
+            it.insert(DevGuardian(adult.id, child.id))
+        }
+    }
+
+    @Test
+    fun `citizen has full message access when child active placement exists`() {
+        db.transaction { tx ->
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = daycare.id,
+                    type = PlacementType.DAYCARE,
+                    startDate = clock.today().minusDays(1),
+                    endDate = clock.today().plusDays(1),
+                )
+            )
+        }
+        val result = systemController.citizenUser(dbInstance(), user, clock, adult.id)
+        assertTrue(result.accessibleFeatures.messages)
+        assertTrue(result.accessibleFeatures.composeNewMessage)
+    }
+
+    @Test
+    fun `citizen can read but not send messages when child placement exists in the past`() {
+        db.transaction { tx ->
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = daycare.id,
+                    type = PlacementType.DAYCARE,
+                    startDate = clock.today().minusMonths(2),
+                    endDate = clock.today().minusDays(1),
+                )
+            )
+        }
+        val result = systemController.citizenUser(dbInstance(), user, clock, adult.id)
+        assertTrue(result.accessibleFeatures.messages)
+        assertFalse(result.accessibleFeatures.composeNewMessage)
+    }
+
+    @Test
+    fun `citizen can read but not send messages when child placement exists over 2 weeks in the future`() {
+        db.transaction { tx ->
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = daycare.id,
+                    type = PlacementType.DAYCARE,
+                    startDate = clock.today().plusWeeks(2).plusDays(1),
+                    endDate = clock.today().plusMonths(2),
+                )
+            )
+        }
+        val result = systemController.citizenUser(dbInstance(), user, clock, adult.id)
+        assertTrue(result.accessibleFeatures.messages)
+        assertFalse(result.accessibleFeatures.composeNewMessage)
+    }
+
+    @Test
+    fun `citizen has full message access when child placement exists less than 2 weeks in the future`() {
+        db.transaction { tx ->
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = daycare.id,
+                    type = PlacementType.DAYCARE,
+                    startDate = clock.today().plusWeeks(2),
+                    endDate = clock.today().plusMonths(2),
+                )
+            )
+        }
+        val result = systemController.citizenUser(dbInstance(), user, clock, adult.id)
+        assertTrue(result.accessibleFeatures.messages)
+        assertTrue(result.accessibleFeatures.composeNewMessage)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -745,7 +745,7 @@ WITH user_account AS (
 ), backup_care_placements AS (
     SELECT p.id, p.unit_id, p.child_id, p.group_id
     FROM children c
-    JOIN backup_care p ON p.child_id = c.child_id AND daterange(p.start_date, p.end_date, '[]') @> ${bind(today)}
+    JOIN backup_care p ON p.child_id = c.child_id AND daterange((p.start_date - INTERVAL '2 weeks')::date, p.end_date, '[]') @> ${bind(today)}
     WHERE EXISTS (
         SELECT 1 FROM daycare u
         WHERE p.unit_id = u.id AND 'MESSAGING' = ANY(u.enabled_pilot_features)
@@ -754,10 +754,6 @@ WITH user_account AS (
     SELECT p.id, p.unit_id, p.child_id
     FROM children c
     JOIN placement p ON p.child_id = c.child_id AND daterange((p.start_date - INTERVAL '2 weeks')::date, p.end_date, '[]') @> ${bind(today)}
-    WHERE NOT EXISTS (
-        SELECT 1 FROM backup_care_placements bc
-        WHERE bc.child_id = p.child_id
-    )
     AND EXISTS (
         SELECT 1 FROM daycare u
         WHERE p.unit_id = u.id AND 'MESSAGING' = ANY(u.enabled_pilot_features)

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -753,7 +753,7 @@ WITH user_account AS (
 ), placements AS (
     SELECT p.id, p.unit_id, p.child_id
     FROM children c
-    JOIN placement p ON p.child_id = c.child_id AND daterange(p.start_date, p.end_date, '[]') @> ${bind(today)}
+    JOIN placement p ON p.child_id = c.child_id AND daterange((p.start_date - INTERVAL '2 weeks')::date, p.end_date, '[]') @> ${bind(today)}
     WHERE NOT EXISTS (
         SELECT 1 FROM backup_care_placements bc
         WHERE bc.child_id = p.child_id
@@ -783,7 +783,7 @@ personal_accounts AS (
 group_accounts AS (
     SELECT acc.id, g.name, 'GROUP' AS type, p.child_id
     FROM placements p
-    JOIN daycare_group_placement dgp ON dgp.daycare_placement_id = p.id AND ${bind(today)} BETWEEN dgp.start_date AND dgp.end_date
+    JOIN daycare_group_placement dgp ON dgp.daycare_placement_id = p.id AND ${bind(today)} BETWEEN (dgp.start_date - INTERVAL '2 weeks')::date AND dgp.end_date
     JOIN daycare_group g ON g.id = dgp.daycare_group_id
     JOIN message_account acc on g.id = acc.daycare_group_id
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/AccessControlCitizen.kt
@@ -49,7 +49,6 @@ SELECT EXISTS (
     FROM children c
     JOIN placement pl ON c.child_id = pl.child_id
     JOIN daycare u ON pl.unit_id = u.id
-    WHERE daterange(pl.start_date, pl.end_date, '[]') @> ${bind(today)}
     AND 'MESSAGING' = ANY(u.enabled_pilot_features)
     
     UNION 


### PR DESCRIPTION
Viestien toiminnallisuuteen on tehty seuraavia muutoksia.

- Kuntalaisella on pääsy viestihistoriaan aina, kun kuntalaisen lapselle löytyy sijoitus eVakasta. Sijoitus voi olla tulevaisuudessa, voimassa oleva tai päättynyt.
- Uuden viestin kirjoittaminen on sallittua kaksi viikkoa ennen sijoituksen alkua sijoituksen loppupäivään asti. Vastaanottajien on liityttävä tällaiseen sijoitukseen.
- Varasijoituksen aikana on mahdollista lähettää viesti varsinaiseen yksikköön. Varasijoitusyksikköön voi viestittää kaksi viikkoa ennen varasijoitusta varasijoituksen loppuun asti.
- Vanhoihin viestiketjuihin vastaaminen on estetty, mikäli kuntalaisella ei enää ole em. sääntöjen perusteella oikeutta lähettää viestiä kaikille viestiketjun vastaanottajille.