### PR TITLE
Lisätään raakaraportille palveluntarve

### DIFF
--- a/frontend/src/employee-frontend/components/reports/Raw.tsx
+++ b/frontend/src/employee-frontend/components/reports/Raw.tsx
@@ -158,6 +158,7 @@ export default React.memo(function Raw() {
                 { label: 'Varahoidossa yksikössä', key: 'backupUnitId' },
                 { label: 'Varahoidossa ryhmässä', key: 'backupGroupId' },
                 { label: 'Palveluntarve merkitty', key: 'hasServiceNeed' },
+                { label: 'Palveluntarve', key: 'serviceNeed' },
                 { label: 'Osapäiväinen', key: 'partDay' },
                 { label: 'Osaviikkoinen', key: 'partWeek' },
                 { label: 'Vuorohoito', key: 'shiftCare' },

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -758,6 +758,7 @@ export interface RawReportRow {
   postOffice: string
   postalCode: string
   realizedCapacity: number
+  serviceNeed: string | null
   shiftCare: boolean
   staffDimensioning: number
   unitId: UUID

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/RawReportControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/RawReportControllerTest.kt
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.reports
+
+import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevEmployee
+import fi.espoo.evaka.shared.dev.DevPerson
+import fi.espoo.evaka.shared.dev.DevPersonType
+import fi.espoo.evaka.shared.dev.DevPlacement
+import fi.espoo.evaka.shared.dev.DevServiceNeed
+import fi.espoo.evaka.shared.dev.insert
+import fi.espoo.evaka.shared.dev.insertServiceNeedOption
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.snDaycareFullDay35
+import fi.espoo.evaka.snDefaultDaycare
+import java.time.LocalDate
+import java.time.LocalTime
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class RawReportControllerTest : FullApplicationTest(resetDbBeforeEach = true) {
+
+    @Autowired private lateinit var rawReportController: RawReportController
+
+    @Test
+    fun `service need works`() {
+        val user =
+            db.transaction { tx ->
+                val admin = DevEmployee(roles = setOf(UserRole.ADMIN))
+                tx.insert(admin)
+                admin.user
+            }
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 10, 23), LocalTime.of(8, 47)))
+        db.transaction { tx ->
+            val areaId = tx.insert(DevCareArea())
+            val unitId = tx.insert(DevDaycare(areaId = areaId))
+            tx.insertServiceNeedOption(snDefaultDaycare)
+            tx.insertServiceNeedOption(snDaycareFullDay35)
+
+            tx.insert(DevPerson(firstName = "Eka"), DevPersonType.CHILD).also { childId ->
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            childId = childId,
+                            unitId = unitId,
+                            startDate = clock.today(),
+                            endDate = clock.today(),
+                        )
+                    )
+                tx.insert(
+                    DevServiceNeed(
+                        placementId = placementId,
+                        optionId = snDaycareFullDay35.id,
+                        startDate = clock.today(),
+                        endDate = clock.today(),
+                        confirmedBy = user.evakaUserId,
+                    )
+                )
+            }
+
+            tx.insert(DevPerson(firstName = "Toka"), DevPersonType.CHILD).also { childId ->
+                tx.insert(
+                    DevPlacement(
+                        childId = childId,
+                        unitId = unitId,
+                        startDate = clock.today(),
+                        endDate = clock.today(),
+                    )
+                )
+            }
+        }
+
+        val rows =
+            rawReportController.getRawReport(
+                dbInstance(),
+                user,
+                clock,
+                clock.today(),
+                clock.today(),
+            )
+
+        assertThat(rows)
+            .extracting({ it.firstName }, { it.serviceNeed })
+            .containsExactlyInAnyOrder(Tuple("Eka", snDaycareFullDay35.nameFi), Tuple("Toka", null))
+    }
+}

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/RawReportControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/RawReportControllerTest.kt
@@ -89,7 +89,10 @@ class RawReportControllerTest : FullApplicationTest(resetDbBeforeEach = true) {
             )
 
         assertThat(rows)
-            .extracting({ it.firstName }, { it.serviceNeed })
-            .containsExactlyInAnyOrder(Tuple("Eka", snDaycareFullDay35.nameFi), Tuple("Toka", null))
+            .extracting({ it.firstName }, { it.hasServiceNeed }, { it.serviceNeed })
+            .containsExactlyInAnyOrder(
+                Tuple("Eka", true, snDaycareFullDay35.nameFi),
+                Tuple("Toka", false, null),
+            )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -110,7 +110,7 @@ SELECT
     bc.unit_id as backup_unit_id,
     bc.group_id as backup_group_id,
 
-    sn IS NOT NULL AS has_service_need,
+    sn.id IS NOT NULL AS has_service_need,
     sno.name_fi AS service_need,
     coalesce(sno.part_day, false) AS part_day,
     coalesce(sn.part_week, false) AS part_week,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -111,6 +111,7 @@ SELECT
     bc.group_id as backup_group_id,
 
     sn IS NOT NULL AS has_service_need,
+    sno.name_fi AS service_need,
     coalesce(sno.part_day, false) AS part_day,
     coalesce(sn.part_week, false) AS part_week,
     coalesce(sn.shift_care, 'NONE') = 'FULL' AS shift_care,
@@ -195,6 +196,7 @@ data class RawReportRow(
     val backupUnitId: DaycareId?,
     val backupGroupId: GroupId?,
     val hasServiceNeed: Boolean,
+    val serviceNeed: String?,
     val partDay: Boolean,
     val partWeek: Boolean,
     val shiftCare: Boolean,


### PR DESCRIPTION
Lisäksi korjaa "Palveluntarve merkitty" -kentän, jos esim. palveluntarve kulkeutuu hakemukselta sijoitukselle (jolloin `service_need` -taulun `confirmed_by` & `confirmed_at` on `null`).