### PR TITLE
Kasvattajalle mahdollisuus poistaa lapsen kaikki yhden kyselyn keskusteluaikavaraukset kerralla

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-discussion-survey-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-discussion-survey-page.ts
@@ -158,6 +158,13 @@ export class DiscussionSurveyReadView {
     )
   }
 
+  async openReservationClearingConfirmationModal(childId: string) {
+    await this.page.findByDataQa(`clear-reservations-button-${childId}`).click()
+    return new Modal(
+      this.page.findByDataQa(`clear-reservations-confirmation-modal`)
+    )
+  }
+
   async openSurveyEditor() {
     await this.editSurveyButton.click()
     return new DiscussionSurveyEditor(this.page)

--- a/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
@@ -380,6 +380,49 @@ describe('Discussion surveys', () => {
     await surveyView.assertNoTimesExist(testDay)
   })
 
+  test("Employee can clear all child's survey reservations", async () => {
+    const testDay = mockedToday.addDays(1)
+
+    await calendarPage.selectGroup(groupId)
+    await calendarPage.weekModeButton.click()
+
+    const surveyListPage =
+      await calendarPage.calendarEventsSection.openDiscussionSurveyPage()
+    const surveyView = await surveyListPage.openDiscussionSurvey(testSurveyId)
+    await surveyView.waitUntilLoaded()
+
+    await surveyView.addEventTimeForDay(testDay, {
+      startTime: '09:00',
+      endTime: '09:30'
+    })
+    await surveyView.addEventTimeForDay(testDay, {
+      startTime: '10:00',
+      endTime: '10:30'
+    })
+    await surveyView.waitUntilLoaded()
+
+    let reservationModal = await surveyView.openReservationModal(0, testDay)
+    await reservationModal.reserveEventTimeForChild(
+      `${child1Fixture.lastName} ${child1Fixture.firstName}`
+    )
+    reservationModal = await surveyView.openReservationModal(1, testDay)
+    await reservationModal.reserveEventTimeForChild(
+      `${child1Fixture.lastName} ${child1Fixture.firstName}`
+    )
+    await surveyView.waitUntilLoaded()
+    await surveyView.assertReservedAttendeeExists(child1Fixture.id)
+
+    const confirmationModal =
+      await surveyView.openReservationClearingConfirmationModal(
+        child1Fixture.id
+      )
+    await confirmationModal.submit()
+
+    await surveyView.waitUntilLoaded()
+
+    await surveyView.assertUnreservedAttendeeExists(child1Fixture.id)
+  })
+
   test('Employee can reserve a time', async () => {
     const childData = {
       lastName: 'Högfors',

--- a/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
@@ -389,7 +389,6 @@ describe('Discussion surveys', () => {
     const surveyListPage =
       await calendarPage.calendarEventsSection.openDiscussionSurveyPage()
     const surveyView = await surveyListPage.openDiscussionSurvey(testSurveyId)
-    await surveyView.waitUntilLoaded()
 
     await surveyView.addEventTimeForDay(testDay, {
       startTime: '09:00',

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyView.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyView.tsx
@@ -4,7 +4,6 @@
 
 import groupBy from 'lodash/groupBy'
 import orderBy from 'lodash/orderBy'
-import partition from 'lodash/partition'
 import React, {
   MutableRefObject,
   useCallback,
@@ -421,13 +420,6 @@ export default React.memo(function DiscussionReservationSurveyView({
                     gp.overlapsWith(eventData.period.asDateRange())
                   )
                 )
-              const reservations = eventData.times.filter(
-                (t) => t.childId !== null
-              )
-              const [reserved, unreserved] = partition(
-                sortedPeriodInvitees,
-                (e) => reservations.some((r) => r.childId === e.child.id)
-              )
 
               return (
                 <>
@@ -435,8 +427,8 @@ export default React.memo(function DiscussionReservationSurveyView({
                     <H3>{t.discussionReservation.surveyInviteeTitle}</H3>
                     <FormFieldGroup>
                       <InviteeSection
-                        reserved={reserved}
-                        unreserved={unreserved}
+                        invitees={sortedPeriodInvitees}
+                        event={eventData}
                       />
                     </FormFieldGroup>
                   </FormSectionGroup>

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/InviteeSection.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/InviteeSection.tsx
@@ -5,7 +5,7 @@
 import { faX } from '@fortawesome/free-solid-svg-icons'
 import orderBy from 'lodash/orderBy'
 import partition from 'lodash/partition'
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -138,16 +138,19 @@ export default React.memo(function InviteeSection({
   const { i18n } = useTranslation()
   const t = i18n.unit.calendar.events.discussionReservation
 
-  const childrenWithReservations = invitees.map((i) => ({
-    child: i.child,
-    reservations: orderBy(
-      event.times.filter((t) => t.childId === i.child.id),
-      [(t) => t.date, (t) => t.startTime, (t) => t.endTime]
-    )
-  }))
-  const [reserved, unreserved] = partition(
-    childrenWithReservations,
-    (c) => c.reservations.length > 0
+  const [reserved, unreserved] = useMemo(
+    () =>
+      partition(
+        invitees.map((i) => ({
+          child: i.child,
+          reservations: orderBy(
+            event.times.filter((t) => t.childId === i.child.id),
+            [(t) => t.date, (t) => t.startTime, (t) => t.endTime]
+          )
+        })),
+        (c) => c.reservations.length > 0
+      ),
+    [invitees, event.times]
   )
 
   return (

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/InviteeSection.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/InviteeSection.tsx
@@ -2,17 +2,30 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import { faX } from '@fortawesome/free-solid-svg-icons'
+import orderBy from 'lodash/orderBy'
+import partition from 'lodash/partition'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { useTranslation } from 'employee-frontend/state/i18n'
+import {
+  CalendarEvent,
+  CalendarEventTime
+} from 'lib-common/generated/api-types/calendarevent'
 import { ChildBasics } from 'lib-common/generated/api-types/placement'
+import { UUID } from 'lib-common/types'
+import { Button } from 'lib-components/atoms/buttons/Button'
 import {
   FixedSpaceColumn,
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
+import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
 import { fontWeights } from 'lib-components/typography'
+import { defaultMargins } from 'lib-components/white-space'
+
+import { clearChildCalendarEventTimeReservationsForSurveyMutation } from '../queries'
 
 import { ChildGroupInfo } from './DiscussionSurveyView'
 
@@ -21,51 +34,137 @@ const ReservationCount = styled.span`
 `
 
 const getChildUrl = (c: { id: string }) => `/child-information/${c.id}`
-
+type InviteeInfo = { child: ChildBasics; reservations: CalendarEventTime[] }
 const ChildNameList = React.memo(function ChildNameList({
+  eventId,
   childList,
   'data-qa': dataQa
 }: {
-  childList: ChildBasics[]
+  eventId: UUID
+  childList: InviteeInfo[]
   'data-qa'?: string
 }) {
+  const { i18n } = useTranslation()
+  const [selectedInvitee, setSelectedInvitee] = useState<InviteeInfo | null>(
+    null
+  )
   return (
-    <p data-qa={dataQa}>
-      {childList.map((item, index) => (
-        <span key={item.id} data-qa={`attendee-${item.id}`}>
-          <Link to={getChildUrl(item)}>
-            {`${item.firstName} ${item.lastName}`}
-          </Link>
-          {index === childList.length - 1 ? '' : ', '}
-        </span>
+    <InviteeGrid data-qa={dataQa}>
+      {selectedInvitee && (
+        <MutateFormModal
+          resolveMutation={
+            clearChildCalendarEventTimeReservationsForSurveyMutation
+          }
+          title={
+            i18n.unit.calendar.events.discussionReservation
+              .reservationClearConfirmationTitle
+          }
+          resolveAction={() => ({
+            body: {
+              childId: selectedInvitee.child.id,
+              calendarEventId: eventId
+            },
+            eventId
+          })}
+          resolveLabel={i18n.common.remove}
+          onSuccess={() => {
+            setSelectedInvitee(null)
+          }}
+          rejectAction={() => setSelectedInvitee(null)}
+          rejectLabel={i18n.common.cancel}
+          data-qa="clear-reservations-confirmation-modal"
+        >
+          <CenteringDiv>
+            <h3 data-qa="child-name">{`${selectedInvitee.child.firstName} ${selectedInvitee.child.lastName}`}</h3>
+            {selectedInvitee.reservations.map((r, i) => (
+              <p
+                key={r.id}
+                data-qa={`reservation-datetime-${i}`}
+              >{`${r.date.format()}: ${r.startTime.format()} - ${r.endTime.format()}`}</p>
+            ))}
+          </CenteringDiv>
+        </MutateFormModal>
+      )}
+      {childList.map((item) => (
+        <React.Fragment key={item.child.id}>
+          <div>
+            <Link
+              to={getChildUrl(item.child)}
+              data-qa={`attendee-${item.child.id}`}
+            >
+              {`${item.child.firstName.split(' ')[0]} ${item.child.lastName}`}
+            </Link>
+          </div>
+          {item.reservations.length > 0 ? (
+            <div>
+              <Button
+                appearance="inline"
+                icon={faX}
+                onClick={() => setSelectedInvitee(item)}
+                text={
+                  i18n.unit.calendar.events.discussionReservation
+                    .clearReservationButtonLabel
+                }
+                data-qa={`clear-reservations-button-${item.child.id}`}
+              />
+            </div>
+          ) : (
+            <div />
+          )}
+        </React.Fragment>
       ))}
-    </p>
+    </InviteeGrid>
   )
 })
 
+const CenteringDiv = styled.div`
+  text-align: center;
+`
+
+const InviteeGrid = styled.div`
+  padding: ${defaultMargins.s};
+  display: grid;
+  grid-template-columns: [name] 60% [button] 40%;
+  gap: 4px;
+`
+
 export default React.memo(function InviteeSection({
-  reserved,
-  unreserved
+  invitees,
+  event
 }: {
-  reserved: ChildGroupInfo[]
-  unreserved: ChildGroupInfo[]
+  invitees: ChildGroupInfo[]
+  event: CalendarEvent
 }) {
   const { i18n } = useTranslation()
   const t = i18n.unit.calendar.events.discussionReservation
 
+  const childrenWithReservations = invitees.map((i) => ({
+    child: i.child,
+    reservations: orderBy(
+      event.times.filter((t) => t.childId === i.child.id),
+      [(t) => t.date, (t) => t.startTime, (t) => t.endTime]
+    )
+  }))
+  const [reserved, unreserved] = partition(
+    childrenWithReservations,
+    (c) => c.reservations.length > 0
+  )
+
   return (
     <FixedSpaceRow spacing="XL" fullWidth justifyContent="space-between">
-      <FixedSpaceColumn fullWidth>
+      <FixedSpaceColumn fullWidth spacing="xs">
         <ReservationCount>{`${t.unreservedTitle} (${unreserved.length}/${unreserved.length + reserved.length})`}</ReservationCount>
         <ChildNameList
-          childList={unreserved.map((u) => u.child)}
+          childList={unreserved}
+          eventId={event.id}
           data-qa="unreserved-attendees"
         />
       </FixedSpaceColumn>
-      <FixedSpaceColumn fullWidth>
+      <FixedSpaceColumn fullWidth spacing="xs">
         <ReservationCount>{`${t.reservedTitle} (${reserved.length}/${unreserved.length + reserved.length})`}</ReservationCount>
         <ChildNameList
-          childList={reserved.map((r) => r.child)}
+          childList={reserved}
+          eventId={event.id}
           data-qa="reserved-attendees"
         />
       </FixedSpaceColumn>

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/queries.ts
@@ -4,6 +4,7 @@
 
 import {
   addCalendarEventTime,
+  clearEventTimesInEventForChild,
   createCalendarEvent,
   deleteCalendarEvent,
   deleteCalendarEventTime,
@@ -73,6 +74,14 @@ export const setCalendarEventTimeReservationMutation = mutation({
   ) => setCalendarEventTimeReservation(arg),
   invalidateQueryKeys: ({ eventId }) => [queryKeys.discussionSurvey(eventId)]
 })
+
+export const clearChildCalendarEventTimeReservationsForSurveyMutation =
+  mutation({
+    api: (
+      arg: Arg0<typeof clearEventTimesInEventForChild> & { eventId: UUID }
+    ) => clearEventTimesInEventForChild(arg),
+    invalidateQueryKeys: ({ eventId }) => [queryKeys.discussionSurvey(eventId)]
+  })
 
 export const addCalendarEventTimeMutation = mutation({
   api: (arg: Arg0<typeof addCalendarEventTime>) => addCalendarEventTime(arg),

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/queries.ts
@@ -77,10 +77,11 @@ export const setCalendarEventTimeReservationMutation = mutation({
 
 export const clearChildCalendarEventTimeReservationsForSurveyMutation =
   mutation({
-    api: (
-      arg: Arg0<typeof clearEventTimesInEventForChild> & { eventId: UUID }
-    ) => clearEventTimesInEventForChild(arg),
-    invalidateQueryKeys: ({ eventId }) => [queryKeys.discussionSurvey(eventId)]
+    api: (arg: Arg0<typeof clearEventTimesInEventForChild>) =>
+      clearEventTimesInEventForChild(arg),
+    invalidateQueryKeys: ({ body }) => [
+      queryKeys.discussionSurvey(body.calendarEventId)
+    ]
   })
 
 export const addCalendarEventTimeMutation = mutation({

--- a/frontend/src/employee-frontend/generated/api-clients/calendarevent.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/calendarevent.ts
@@ -7,6 +7,7 @@
 import LocalDate from 'lib-common/local-date'
 import { CalendarEvent } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventForm } from 'lib-common/generated/api-types/calendarevent'
+import { CalendarEventTimeClearingForm } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeEmployeeReservationForm } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeForm } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventUpdateForm } from 'lib-common/generated/api-types/calendarevent'
@@ -34,6 +35,23 @@ export async function addCalendarEventTime(
     url: uri`/employee/calendar-event/${request.id}/time`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<CalendarEventTimeForm>
+  })
+  return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.calendarevent.CalendarEventController.clearEventTimesInEventForChild
+*/
+export async function clearEventTimesInEventForChild(
+  request: {
+    body: CalendarEventTimeClearingForm
+  }
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/employee/calendar-event/clear-survey-reservations-for-child`.toString(),
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<CalendarEventTimeClearingForm>
   })
   return json
 }

--- a/frontend/src/lib-common/generated/api-types/calendarevent.ts
+++ b/frontend/src/lib-common/generated/api-types/calendarevent.ts
@@ -79,6 +79,14 @@ export interface CalendarEventTimeCitizenReservationForm {
 }
 
 /**
+* Generated from fi.espoo.evaka.calendarevent.CalendarEventTimeClearingForm
+*/
+export interface CalendarEventTimeClearingForm {
+  calendarEventId: UUID
+  childId: UUID
+}
+
+/**
 * Generated from fi.espoo.evaka.calendarevent.CalendarEventTimeEmployeeReservationForm
 */
 export interface CalendarEventTimeEmployeeReservationForm {

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2406,7 +2406,10 @@ export const fi = {
           eventTime: {
             addError: 'Keskusteluajan lisääminen epäonnistui',
             deleteError: 'Keskusteluajan poistaminen epäonnistui'
-          }
+          },
+          reservationClearConfirmationTitle:
+            'Poistetaanko seuraavat varaukset?',
+          clearReservationButtonLabel: 'Poista varaukset'
         },
         reservedTimesLabel: 'varattua',
         freeTimesLabel: 'vapaata'

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/calendarevent/CalendarEventServiceIntegrationTest.kt
@@ -40,6 +40,9 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.dev.DevCalendarEvent
+import fi.espoo.evaka.shared.dev.DevCalendarEventAttendee
+import fi.espoo.evaka.shared.dev.DevCalendarEventTime
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.DevDaycareGroupPlacement
 import fi.espoo.evaka.shared.dev.DevEmployee
@@ -54,6 +57,7 @@ import fi.espoo.evaka.shared.domain.Conflict
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
+import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.domain.NotFound
@@ -1844,7 +1848,6 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
             )
 
         val expectedFromAddress = "${emailEnv.senderNameFi} <${emailEnv.senderAddress}>"
-        val mails = MockEmailClient.emails
         assertEquals(2, MockEmailClient.emails.size)
         assertAllEmailsFor(
             testAdult_1.copy(email = email),
@@ -2795,6 +2798,179 @@ class CalendarEventServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
         assertEquals(1, fosterParentEventResult.size)
         assertThat(fosterParentEventResult[0].timesByChild[testChild_4.id])
             .containsExactlyInAnyOrderElementsOf(expectedFosterParentEventTimes)
+    }
+
+    @Test
+    fun `only employee from same group is allowed to clear child reservations from calendar event`() {
+        val daycare1Employee = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), emptySet())
+        val daycare2Employee = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), emptySet())
+        val event =
+            DevCalendarEvent(
+                id = CalendarEventId(UUID.randomUUID()),
+                title = "Testieventti",
+                description = "Eventin kuvaus",
+                eventType = CalendarEventType.DISCUSSION_SURVEY,
+                period = FiniteDateRange(today.plusDays(3), today.plusDays(3)),
+                modifiedAt = now,
+            )
+        val eventTime =
+            DevCalendarEventTime(
+                id = CalendarEventTimeId(UUID.randomUUID()),
+                calendarEventId = event.id,
+                childId = testChild_1.id,
+                date = today.plusDays(3),
+                modifiedAt = now,
+                start = LocalTime.of(8, 0),
+                end = LocalTime.of(9, 0),
+                modifiedBy = admin.evakaUserId,
+            )
+        db.transaction { tx ->
+            tx.insert(
+                DevEmployee(id = daycare1Employee.id),
+                unitRoles = mapOf(testDaycare.id to UserRole.STAFF),
+                groupAcl = mapOf(testDaycare.id to listOf(groupId)),
+            )
+            tx.insert(
+                DevEmployee(id = daycare2Employee.id),
+                unitRoles = mapOf(testDaycare2.id to UserRole.STAFF),
+                groupAcl = mapOf(testDaycare2.id to listOf(groupId2)),
+            )
+
+            tx.insert(event)
+            tx.insert(
+                DevCalendarEventAttendee(
+                    unitId = testDaycare.id,
+                    groupId = groupId,
+                    calendarEventId = event.id,
+                )
+            )
+            tx.insert(eventTime)
+        }
+
+        val clearingForm =
+            CalendarEventTimeClearingForm(calendarEventId = event.id, childId = testChild_1.id)
+
+        assertThrows<Forbidden> {
+            calendarEventController.clearEventTimesInEventForChild(
+                dbInstance(),
+                daycare2Employee,
+                clock,
+                clearingForm,
+            )
+        }
+
+        calendarEventController.clearEventTimesInEventForChild(
+            dbInstance(),
+            daycare1Employee,
+            clock,
+            clearingForm,
+        )
+
+        val eventResult =
+            calendarEventController.getCalendarEvent(dbInstance(), admin, clock, event.id)
+
+        assertEquals(1, eventResult.times.size)
+        assertThat(eventResult.times.first().id).isEqualTo(eventTime.id)
+        assertThat(eventResult.times.first().childId).isNull()
+    }
+
+    @Test
+    fun `guardian receives notifications for only future reservations after mass cancellation`() {
+        val event =
+            DevCalendarEvent(
+                id = CalendarEventId(UUID.randomUUID()),
+                title = "Testieventti",
+                description = "Eventin kuvaus",
+                eventType = CalendarEventType.DISCUSSION_SURVEY,
+                period = FiniteDateRange(today.plusDays(3), today.plusDays(3)),
+                modifiedAt = now,
+            )
+        val pastEventTime =
+            DevCalendarEventTime(
+                id = CalendarEventTimeId(UUID.randomUUID()),
+                calendarEventId = event.id,
+                childId = testChild_3.id,
+                date = today.minusDays(3),
+                modifiedAt = now,
+                start = LocalTime.of(8, 0),
+                end = LocalTime.of(9, 0),
+                modifiedBy = admin.evakaUserId,
+            )
+        val futureEventTime =
+            DevCalendarEventTime(
+                id = CalendarEventTimeId(UUID.randomUUID()),
+                calendarEventId = event.id,
+                childId = testChild_3.id,
+                date = today.plusDays(3),
+                modifiedAt = now,
+                start = LocalTime.of(9, 0),
+                end = LocalTime.of(10, 0),
+                modifiedBy = admin.evakaUserId,
+            )
+        db.transaction { tx ->
+            tx.insertGuardian(testAdult_2.id, testChild_3.id)
+            val placementId3 =
+                tx.insert(
+                    DevPlacement(
+                        childId = testChild_3.id,
+                        unitId = testDaycare.id,
+                        startDate = placementStart,
+                        endDate = placementEnd,
+                    )
+                )
+            tx.insert(
+                DevDaycareGroupPlacement(
+                    daycarePlacementId = placementId3,
+                    daycareGroupId = groupId,
+                    startDate = placementStart,
+                    endDate = placementEnd,
+                )
+            )
+
+            tx.insert(event)
+            tx.insert(
+                DevCalendarEventAttendee(
+                    unitId = testDaycare.id,
+                    groupId = groupId,
+                    calendarEventId = event.id,
+                )
+            )
+            tx.insert(pastEventTime)
+            tx.insert(futureEventTime)
+        }
+
+        val clearingForm =
+            CalendarEventTimeClearingForm(calendarEventId = event.id, childId = testChild_3.id)
+
+        calendarEventController.clearEventTimesInEventForChild(
+            dbInstance(),
+            admin,
+            clock,
+            clearingForm,
+        )
+
+        val emailDetails =
+            DiscussionSurveyReservationNotificationData(
+                calendarEventTime =
+                    CalendarEventTime(
+                        id = futureEventTime.id,
+                        date = futureEventTime.date,
+                        startTime = futureEventTime.start,
+                        endTime = futureEventTime.end,
+                        childId = testChild_3.id,
+                    )
+            )
+
+        val cancellationEmailContent =
+            emailMessageProvider.discussionSurveyReservationCancellationNotification(
+                language = Language.fi,
+                notificationDetails = emailDetails,
+            )
+
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+
+        val expectedFromAddress = "${emailEnv.senderNameFi} <${emailEnv.senderAddress}>"
+        assertAllEmailsFor(testAdult_2, listOf(cancellationEmailContent), expectedFromAddress)
     }
 
     private fun reserveEventTime(id: CalendarEventTimeId, childId: ChildId) {

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -92,6 +92,7 @@ enum class Audit(
     CalendarEventTimeCreate,
     CalendarEventTimeDelete,
     CalendarEventTimeRead,
+    CalendarEventChildTimesCancellation,
     CalendarEventTimeReservationCreate,
     CalendarEventTimeReservationDelete,
     CalendarEventTimeReservationUpdate,

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEvent.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEvent.kt
@@ -60,11 +60,6 @@ data class AttendingChild(
     val unitName: String?,
 )
 
-data class CitizenCalendarEventResult(
-    val daycareEvents: List<CitizenCalendarEvent>,
-    val discussionSurveys: List<CitizenDiscussionSurvey>,
-)
-
 data class CitizenDiscussionSurvey(
     val id: CalendarEventId,
     val title: String,
@@ -108,6 +103,11 @@ data class CalendarEventTimeForm(val date: LocalDate, val timeRange: TimeRange)
 data class CalendarEventTimeEmployeeReservationForm(
     val calendarEventTimeId: CalendarEventTimeId,
     val childId: ChildId?,
+)
+
+data class CalendarEventTimeClearingForm(
+    val calendarEventId: CalendarEventId,
+    val childId: ChildId,
 )
 
 data class CalendarEventTimeCitizenReservationForm(

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventController.kt
@@ -342,7 +342,7 @@ class CalendarEventController(
                     val updated = resolveAttendeeChildIds(tx, event.unitId, body.tree, event.period)
                     val removed = current.minus(updated.toSet())
                     removed.forEach { childId ->
-                        tx.deleteCalendarEventTimeReservationsByChildAndEvent(
+                        tx.freeCalendarEventTimeReservationsByChildAndEvent(
                             user,
                             clock.now(),
                             calendarEventId = event.id,
@@ -481,11 +481,7 @@ class CalendarEventController(
                         tx.getDiscussionTimeDetailsByEventTimeId(body.calendarEventTimeId)
                             ?: throw BadRequest("Calendar event time not found")
 
-                    tx.deleteCalendarEventTimeReservation(
-                        user,
-                        clock.now(),
-                        body.calendarEventTimeId,
-                    )
+                    tx.freeCalendarEventTimeReservation(user, clock.now(), body.calendarEventTimeId)
 
                     if (body.childId != null) {
                         val reservationRecipients = getRecipientsForChild(tx, body.childId)
@@ -573,7 +569,7 @@ class CalendarEventController(
                             ?: throw BadRequest("Calendar event not found")
                     val cancellationRecipients = getRecipientsForChild(tx, body.childId)
 
-                    tx.deleteCalendarEventTimeReservations(
+                    tx.freeCalendarEventTimeReservations(
                         user,
                         clock.now(),
                         eventTimesToRemove.map { it.id }.toSet(),
@@ -851,11 +847,7 @@ class CalendarEventController(
                     val eventTimeDetails =
                         tx.getDiscussionTimeDetailsByEventTimeId(body.calendarEventTimeId)
                             ?: throw BadRequest("Calendar event time not found")
-                    tx.deleteCalendarEventTimeReservation(
-                        user,
-                        clock.now(),
-                        body.calendarEventTimeId,
-                    )
+                    tx.freeCalendarEventTimeReservation(user, clock.now(), body.calendarEventTimeId)
                     val recipients = getRecipientsForChild(tx, body.childId)
                     asyncJobRunner.plan(
                         tx,

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventController.kt
@@ -342,7 +342,7 @@ class CalendarEventController(
                     val updated = resolveAttendeeChildIds(tx, event.unitId, body.tree, event.period)
                     val removed = current.minus(updated.toSet())
                     removed.forEach { childId ->
-                        tx.deleteCalendarEventTimeReservations(
+                        tx.deleteCalendarEventTimeReservationsByChildAndEvent(
                             user,
                             clock.now(),
                             calendarEventId = event.id,

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
@@ -269,7 +269,7 @@ WHERE id = ${bind(eventTimeId)} AND (child_id IS NULL OR child_id = ${bind(child
         }
         .updateNoneOrOne()
 
-fun Database.Transaction.deleteCalendarEventTimeReservationsByChildAndEvent(
+fun Database.Transaction.freeCalendarEventTimeReservationsByChildAndEvent(
     user: AuthenticatedUser,
     now: HelsinkiDateTime,
     calendarEventId: CalendarEventId,
@@ -285,7 +285,7 @@ AND child_id = ${bind(childId)}
     )
 }
 
-fun Database.Transaction.deleteCalendarEventTimeReservation(
+fun Database.Transaction.freeCalendarEventTimeReservation(
     user: AuthenticatedUser,
     now: HelsinkiDateTime,
     calendarEventTimeId: CalendarEventTimeId,
@@ -299,7 +299,7 @@ WHERE id = ${bind(calendarEventTimeId)}
     )
 }
 
-fun Database.Transaction.deleteCalendarEventTimeReservations(
+fun Database.Transaction.freeCalendarEventTimeReservations(
     user: AuthenticatedUser,
     now: HelsinkiDateTime,
     calendarEventTimeIds: Set<CalendarEventTimeId>,

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
@@ -299,6 +299,23 @@ WHERE id = ${bind(calendarEventTimeId)}
     )
 }
 
+fun Database.Transaction.deleteCalendarEventTimeReservations(
+    user: AuthenticatedUser,
+    now: HelsinkiDateTime,
+    calendarEventTimeIds: Set<CalendarEventTimeId>,
+) =
+    if (calendarEventTimeIds.isEmpty()) 0
+    else
+        execute {
+            sql(
+                """
+UPDATE calendar_event_time
+SET child_id = NULL::uuid, modified_at = ${bind(now)}, modified_by = ${bind(user.evakaUserId)}
+WHERE id = ANY(${bind(calendarEventTimeIds)})
+"""
+            )
+        }
+
 fun Database.Read.getCalendarEventTimesByChildAndEvent(
     childId: PersonId,
     calendarEventId: CalendarEventId,

--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventQueries.kt
@@ -269,7 +269,7 @@ WHERE id = ${bind(eventTimeId)} AND (child_id IS NULL OR child_id = ${bind(child
         }
         .updateNoneOrOne()
 
-fun Database.Transaction.deleteCalendarEventTimeReservations(
+fun Database.Transaction.deleteCalendarEventTimeReservationsByChildAndEvent(
     user: AuthenticatedUser,
     now: HelsinkiDateTime,
     calendarEventId: CalendarEventId,


### PR DESCRIPTION
Keskusteluaikavarausten näkymän osallistujaosion lapsiluetteloa on parannettu ja lisätty varauksen omaaville nappi kaikkien varattujen aikojen poistamiseen.
![invitees](https://github.com/user-attachments/assets/75fef0af-accf-4368-a545-07243186ba62)
![modal](https://github.com/user-attachments/assets/8b5dfd7d-7d4e-472b-a19d-1761f71794f0)
Tämä mahdollistaa varausten poistamisen myös menneisyydestä. Ainoastaan tulevaisuudessa olevista poistettavista varauksista lähetetään peruutus-sähköpostit huoltajille.