### PR TITLE
Kalenterin kuukausinäkymä

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
@@ -681,12 +681,27 @@ const StickyTopBar = styled.div`
   margin-bottom: ${defaultMargins.L};
 `
 
-const ButtonContainer = styled(Container)`
+const ButtonContainer = styled.div`
   height: 100%;
   display: flex;
   justify-content: flex-end;
   align-items: center;
   gap: ${defaultMargins.L};
+  margin: 0 auto;
+  padding-right: ${defaultMargins.s};
+
+  @media screen and (min-width: 1152px) and (max-width: 1215px) {
+    max-width: 1152px;
+    width: 1152px;
+  }
+  @media screen and (min-width: 1216px) {
+    max-width: 1152px;
+    width: 1152px;
+  }
+  @media screen and (min-width: 1408px) {
+    max-width: 1344px;
+    width: 1344px;
+  }
 `
 
 const gridPattern = (includeWeekends: boolean) => css`

--- a/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
@@ -144,6 +144,44 @@ export default React.memo(function CalendarMonthView({
   const [selectedMonthIndex, setSelectedMonthIndex] = useState(1)
   const selectedMonthData = calendarMonths[selectedMonthIndex]
 
+  const prevMonth = useCallback(() => {
+    setSelectedMonthIndex((prevIndex) =>
+      prevIndex > 0 ? prevIndex - 1 : prevIndex
+    )
+  }, [])
+  const nextMonth = useCallback(() => {
+    setSelectedMonthIndex((prevIndex) =>
+      prevIndex < calendarMonths.length - 1 ? prevIndex + 1 : prevIndex
+    )
+  }, [calendarMonths.length])
+
+  const isDateInCurrentMonth = useCallback(() => {
+    if (!selectedDate) return false
+    return selectedMonthData.weeks.some((w) => {
+      return w.calendarDays.some((d) => d.date.isEqual(selectedDate))
+    })
+  }, [selectedDate, selectedMonthData.weeks])
+
+  const firstDayOfMonth = useMemo(() => {
+    return selectedMonthData.weeks[0].calendarDays[0].date
+  }, [selectedMonthData.weeks])
+
+  useEffect(() => {
+    if (selectedDate && !isDateInCurrentMonth()) {
+      if (selectedDate.isBefore(firstDayOfMonth)) {
+        prevMonth()
+      } else {
+        nextMonth()
+      }
+    }
+  }, [
+    firstDayOfMonth,
+    isDateInCurrentMonth,
+    nextMonth,
+    prevMonth,
+    selectedDate
+  ])
+
   useEffect(() => {
     const top = todayRef.current?.getBoundingClientRect().top
 
@@ -179,17 +217,6 @@ export default React.memo(function CalendarMonthView({
   )
   const { summaryInfoOpen, toggleSummaryInfo, displayAlert } =
     useSummaryInfo(childSummaries)
-
-  const prevMonth = useCallback(() => {
-    setSelectedMonthIndex((prevIndex) =>
-      prevIndex > 0 ? prevIndex - 1 : prevIndex
-    )
-  }, [])
-  const nextMonth = useCallback(() => {
-    setSelectedMonthIndex((prevIndex) =>
-      prevIndex < calendarMonths.length - 1 ? prevIndex + 1 : prevIndex
-    )
-  }, [calendarMonths.length])
 
   return (
     <>

--- a/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
@@ -796,7 +796,7 @@ const DayCellDate = styled.div<{ inactive: boolean; holiday: boolean }>`
 `
 
 const MonthSummaryInfoBox = styled(ExpandingInfoBox)`
-  margin: ${defaultMargins.s} 0 ${defaultMargins.xs};
+  margin: 0 0 ${defaultMargins.xs};
   width: 100%;
 `
 

--- a/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
@@ -22,7 +22,6 @@ import {
 } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
-import { scrollToPos } from 'lib-common/utils/scrolling'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import LegacyInlineButton from 'lib-components/atoms/buttons/LegacyInlineButton'
@@ -47,7 +46,6 @@ import {
 
 import { useUser } from '../auth/state'
 import { useLang, useTranslation } from '../localization'
-import { headerHeightDesktop } from '../navigation/const'
 
 import {
   CalendarEventCount,
@@ -181,16 +179,6 @@ export default React.memo(function CalendarMonthView({
     prevMonth,
     selectedDate
   ])
-
-  useEffect(() => {
-    const top = todayRef.current?.getBoundingClientRect().top
-
-    if (top) {
-      scrollToPos({
-        top: top - headerHeightDesktop * 2 - 32
-      })
-    }
-  }, [])
 
   const onCreateAbsences = useCallback(
     () => onCreateAbsencesClicked(undefined),

--- a/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
@@ -207,7 +207,7 @@ export default React.memo(function CalendarMonthView({
     [childData, selectedMonthData.month, selectedMonthData.year]
   )
   const { summaryInfoOpen, toggleSummaryInfo, displayAlert } =
-    useMonthlySummaryInfo(childSummaries, selectedMonthIndex)
+    useMonthlySummaryInfo(childSummaries, selectedMonthData)
 
   return (
     <>

--- a/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
@@ -56,7 +56,7 @@ import MonthlyHoursSummary, { MonthlyTimeSummary } from './MonthlyHoursSummary'
 import ReportHolidayLabel from './ReportHolidayLabel'
 import { ChildImageData, getChildImages } from './RoundChildImages'
 import { BackgroundHighlightType, Reservations } from './calendar-elements'
-import { useSummaryInfo } from './hooks'
+import { useMonthlySummaryInfo } from './hooks'
 import { activeQuestionnaireQuery, holidayPeriodsQuery } from './queries'
 import { isQuestionnaireAvailable } from './utils'
 
@@ -197,14 +197,17 @@ export default React.memo(function CalendarMonthView({
   )
 
   const childImages = useMemo(() => getChildImages(childData), [childData])
-
-  const childSummaries = getSummaryForMonth(
-    childData,
-    selectedMonthData.year,
-    selectedMonthData.month
+  const childSummaries = useMemo(
+    () =>
+      getSummaryForMonth(
+        childData,
+        selectedMonthData.year,
+        selectedMonthData.month
+      ),
+    [childData, selectedMonthData.month, selectedMonthData.year]
   )
   const { summaryInfoOpen, toggleSummaryInfo, displayAlert } =
-    useSummaryInfo(childSummaries)
+    useMonthlySummaryInfo(childSummaries, selectedMonthIndex)
 
   return (
     <>

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -74,6 +74,10 @@ function useEventsDefaultRange(): Result<CitizenCalendarEvent[]> {
 const CalendarPage = React.memo(function CalendarPage() {
   const user = useUser()
 
+  // TODO wip for featureFlags.calendarMonthView
+  const [overrideToUseCalendarList, setOverrideToUseCalendarList] =
+    useState(false)
+
   const data = useReservationsDefaultRange()
   const events = useEventsDefaultRange()
 
@@ -182,7 +186,15 @@ const CalendarPage = React.memo(function CalendarPage() {
                 </ContentArea>
               </RenderOnlyOn>
               <RenderOnlyOn desktop>
-                {featureFlags.calendarMonthView ? (
+                {featureFlags.calendarMonthView && (
+                  <CalendarToggle
+                    value={overrideToUseCalendarList}
+                    onClick={() =>
+                      setOverrideToUseCalendarList(!overrideToUseCalendarList)
+                    }
+                  />
+                )}
+                {featureFlags.calendarMonthView && overrideToUseCalendarList ? (
                   <CalendarMonthView
                     childData={response.children}
                     calendarDays={response.days}
@@ -531,3 +543,27 @@ export default React.memo(function CalendarPageWrapper() {
     </>
   )
 })
+
+const CalendarToggle: React.FC<{
+  value: boolean
+  onClick: () => void
+}> = ({ value, onClick }) => {
+  return (
+    <button
+      id="wip-calendar-toggle"
+      style={{
+        display: 'block',
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        zIndex: 100,
+        padding: '4px 8px',
+        minWidth: '120px'
+      }}
+      tabIndex={-1}
+      onClick={onClick}
+    >
+      {value ? 'List view' : 'Month view'}
+    </button>
+  )
+}

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -31,6 +31,7 @@ import AbsenceModal from './AbsenceModal'
 import ActionPickerModal from './ActionPickerModal'
 import CalendarGridView from './CalendarGridView'
 import CalendarListView from './CalendarListView'
+import CalendarMonthView from './CalendarMonthView'
 import CalendarNotifications from './CalendarNotifications'
 import DailyServiceTimeNotifications from './DailyServiceTimeNotifications'
 import DayView from './DayView'
@@ -181,28 +182,53 @@ const CalendarPage = React.memo(function CalendarPage() {
                 </ContentArea>
               </RenderOnlyOn>
               <RenderOnlyOn desktop>
-                <CalendarGridView
-                  childData={response.children}
-                  calendarDays={response.days}
-                  onCreateReservationClicked={
-                    openReservationModalWithoutInitialRange
-                  }
-                  onCreateAbsencesClicked={(date) =>
-                    openAbsenceModal(date, false)
-                  }
-                  onOpenDiscussionReservationsClicked={
-                    openDiscussionSurveyModal
-                  }
-                  onReportHolidaysClicked={openHolidayModal}
-                  selectedDate={
-                    modalState?.type === 'day' ? modalState.date : undefined
-                  }
-                  selectDate={openDayModal}
-                  includeWeekends={true}
-                  dayIsReservable={dayIsReservable}
-                  events={events}
-                  isDiscussionActionVisible={showDiscussions}
-                />
+                {featureFlags.calendarMonthView ? (
+                  <CalendarMonthView
+                    childData={response.children}
+                    calendarDays={response.days}
+                    onCreateReservationClicked={
+                      openReservationModalWithoutInitialRange
+                    }
+                    onCreateAbsencesClicked={(date) =>
+                      openAbsenceModal(date, false)
+                    }
+                    onOpenDiscussionReservationsClicked={
+                      openDiscussionSurveyModal
+                    }
+                    onReportHolidaysClicked={openHolidayModal}
+                    selectedDate={
+                      modalState?.type === 'day' ? modalState.date : undefined
+                    }
+                    selectDate={openDayModal}
+                    includeWeekends={true}
+                    dayIsReservable={dayIsReservable}
+                    events={events}
+                    isDiscussionActionVisible={showDiscussions}
+                  />
+                ) : (
+                  <CalendarGridView
+                    childData={response.children}
+                    calendarDays={response.days}
+                    onCreateReservationClicked={
+                      openReservationModalWithoutInitialRange
+                    }
+                    onCreateAbsencesClicked={(date) =>
+                      openAbsenceModal(date, false)
+                    }
+                    onOpenDiscussionReservationsClicked={
+                      openDiscussionSurveyModal
+                    }
+                    onReportHolidaysClicked={openHolidayModal}
+                    selectedDate={
+                      modalState?.type === 'day' ? modalState.date : undefined
+                    }
+                    selectDate={openDayModal}
+                    includeWeekends={true}
+                    dayIsReservable={dayIsReservable}
+                    events={events}
+                    isDiscussionActionVisible={showDiscussions}
+                  />
+                )}
               </RenderOnlyOn>
               {modalState?.type === 'day' && (
                 <DayView

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -194,7 +194,8 @@ const CalendarPage = React.memo(function CalendarPage() {
                     }
                   />
                 )}
-                {featureFlags.calendarMonthView && overrideToUseCalendarList ? (
+                {featureFlags.calendarMonthView &&
+                !overrideToUseCalendarList ? (
                   <CalendarMonthView
                     childData={response.children}
                     calendarDays={response.days}
@@ -563,7 +564,7 @@ const CalendarToggle: React.FC<{
       tabIndex={-1}
       onClick={onClick}
     >
-      {value ? 'List view' : 'Month view'}
+      {value ? 'Month view' : 'List view'}
     </button>
   )
 }

--- a/frontend/src/citizen-frontend/calendar/DayElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayElem.tsx
@@ -117,7 +117,6 @@ export default React.memo(function DayElem({
         <Reservations
           data={calendarDay}
           childImages={childImages}
-          isReservable={isReservable}
           backgroundHighlight={highlight}
         />
       </ReservationsContainer>

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -777,7 +777,7 @@ function findAdjacentDates(
     return { navigateToPreviousDate: undefined, navigateToNextDate: undefined }
   }
   const previousDate =
-    todayIndex > 1 ? reservationsResponse.days[todayIndex - 1].date : undefined
+    todayIndex >= 1 ? reservationsResponse.days[todayIndex - 1].date : undefined
   const nextDate =
     todayIndex < reservationsResponse.days.length - 1
       ? reservationsResponse.days[todayIndex + 1].date

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -26,7 +26,7 @@ import {
   FixedSpaceColumn,
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
-import { Light } from 'lib-components/typography'
+import { Italic } from 'lib-components/typography'
 import { featureFlags } from 'lib-customizations/citizen'
 
 import { Translations, useTranslation } from '../localization'
@@ -36,13 +36,11 @@ import RoundChildImages, { ChildImageData } from './RoundChildImages'
 export const Reservations = React.memo(function Reservations({
   data,
   childImages,
-  backgroundHighlight,
-  isReservable
+  backgroundHighlight
 }: {
   data: ReservationResponseDay
   childImages: ChildImageData[]
-  backgroundHighlight: 'nonEditableAbsence' | 'holidayPeriod' | undefined
-  isReservable: boolean
+  backgroundHighlight: BackgroundHighlightType
 }) {
   const i18n = useTranslation()
   const showAttendanceWarning = data.children.some(
@@ -61,7 +59,7 @@ export const Reservations = React.memo(function Reservations({
     [data.children, i18n]
   )
 
-  return data.children.length === 0 && data.holiday && !isReservable ? (
+  return data.children.length === 0 && data.holiday ? (
     <Holiday />
   ) : (
     <div>
@@ -111,12 +109,12 @@ export const Reservations = React.memo(function Reservations({
 
 export const Holiday = React.memo(function Holiday() {
   const i18n = useTranslation()
-  return <Light data-qa="holiday">{i18n.calendar.holiday}</Light>
+  return <Italic data-qa="holiday">{i18n.calendar.holiday}</Italic>
 })
 
 const GroupedElementText = styled.div<{
   $type: DailyChildGroupElementType
-  $backgroundHighlight: 'nonEditableAbsence' | 'holidayPeriod' | undefined
+  $backgroundHighlight: BackgroundHighlightType
   $clamp?: boolean
 }>`
   word-break: break-word;
@@ -131,7 +129,8 @@ const GroupedElementText = styled.div<{
 
   ${(p) =>
     p.$type === 'missingReservation' &&
-    p.$backgroundHighlight !== 'holidayPeriod'
+    p.$backgroundHighlight !== 'holidayPeriod' &&
+    p.$backgroundHighlight !== 'past'
       ? `color: ${p.theme.colors.accents.a2orangeDark};`
       : undefined}
 `
@@ -145,6 +144,13 @@ type DailyChildGroupElementType =
   | 'missingReservation'
   | 'absentFree'
   | 'absentPlanned'
+
+export type BackgroundHighlightType =
+  | 'nonEditableAbsence'
+  | 'holidayPeriod'
+  | 'holiday'
+  | 'past'
+  | undefined
 
 interface DailyChildGroupElement {
   type: DailyChildGroupElementType

--- a/frontend/src/citizen-frontend/calendar/hooks.ts
+++ b/frontend/src/citizen-frontend/calendar/hooks.ts
@@ -44,3 +44,32 @@ export function useSummaryInfo(childSummaries: MonthlyTimeSummary[]) {
 
   return { summaryInfoOpen, displayAlert, toggleSummaryInfo }
 }
+
+export function useMonthlySummaryInfo(
+  childSummaries: MonthlyTimeSummary[],
+  selectedMonthData: { month: number; year: number }
+) {
+  const [summaryInfoOpen, setSummaryInfoOpen] = useState(false)
+  const [displayAlert, setDisplayAlert] = useState(false)
+
+  useEffect(() => {
+    setSummaryInfoOpen(false)
+
+    const shouldDisplayAlert = childSummaries.some(
+      ({ reservedMinutes, usedServiceMinutes, serviceNeedMinutes }) =>
+        reservedMinutes > serviceNeedMinutes ||
+        usedServiceMinutes > serviceNeedMinutes
+    )
+
+    setDisplayAlert(shouldDisplayAlert)
+    if (shouldDisplayAlert) {
+      setSummaryInfoOpen(true)
+    }
+  }, [childSummaries, selectedMonthData.month, selectedMonthData.year])
+
+  const toggleSummaryInfo = useCallback(() => {
+    setSummaryInfoOpen((prev) => !prev)
+  }, [])
+
+  return { summaryInfoOpen, displayAlert, toggleSummaryInfo }
+}

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -61,7 +61,7 @@ async function openCalendarPage(
     mockedTime:
       options?.mockedTime ?? today.toHelsinkiDateTime(LocalTime.of(12, 0)),
     citizenCustomizations: {
-      featureFlags: options?.featureFlags
+      featureFlags: { calendarMonthView: false, ...options?.featureFlags }
     }
   })
   await enduserLogin(page, testAdult)
@@ -1201,7 +1201,10 @@ describe('Citizen calendar child visibility', () => {
     })
 
     page = await Page.open({
-      mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
+      mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0)),
+      citizenCustomizations: {
+        featureFlags: { calendarMonthView: false }
+      }
     })
     await enduserLogin(page, testAdult)
     header = new CitizenHeader(page, 'desktop')

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-show-service-usage.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-show-service-usage.spec.ts
@@ -25,7 +25,10 @@ let page: Page
 
 async function openCalendarPage() {
   page = await Page.open({
-    mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
+    mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0)),
+    citizenCustomizations: {
+      featureFlags: { calendarMonthView: false }
+    }
   })
   await enduserLogin(page, testAdult)
   const header = new CitizenHeader(page, 'desktop')

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-start-after-holiday-deadline.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-start-after-holiday-deadline.spec.ts
@@ -33,7 +33,10 @@ let guardian: DevPerson
 beforeEach(async () => {
   await resetServiceState()
   page = await Page.open({
-    mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0))
+    mockedTime: mockedDate.toHelsinkiDateTime(LocalTime.of(12, 0)),
+    citizenCustomizations: {
+      featureFlags: { calendarMonthView: false }
+    }
   })
 
   const area = await Fixture.careArea(testCareArea).save()

--- a/frontend/src/lib-components/molecules/TimedToast.tsx
+++ b/frontend/src/lib-components/molecules/TimedToast.tsx
@@ -39,7 +39,7 @@ export default React.memo(function TimedToast({
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const location = useLocation()
   const initialUrlPath = useRef(location.pathname)
-  const onCLose_ = useStableCallback(onClose)
+  const onClose_ = useStableCallback(onClose)
 
   const stopTimer = () => {
     if (timerRef.current) {
@@ -49,20 +49,20 @@ export default React.memo(function TimedToast({
 
   useEffect(() => {
     timerRef.current = setTimeout(() => {
-      onCLose_()
+      onClose_()
     }, defaultDuration)
     return () => {
       if (timerRef.current) {
         clearTimeout(timerRef.current)
       }
     }
-  }, [onCLose_])
+  }, [onClose_])
 
   useEffect(() => {
     if (location.pathname !== initialUrlPath.current) {
-      onCLose_()
+      onClose_()
     }
-  }, [location.pathname, onCLose_])
+  }, [location.pathname, onClose_])
 
   return (
     <ToastRoot

--- a/frontend/src/lib-components/molecules/TimedToast.tsx
+++ b/frontend/src/lib-components/molecules/TimedToast.tsx
@@ -104,9 +104,7 @@ const ToastRoot = styled.div`
   }
   background-color: ${(p) => p.theme.colors.grayscale.g0};
   border-radius: 16px;
-  box-shadow:
-    4px 4px 8px rgba(15, 15, 15, 0.15),
-    -2px 0 4px rgba(15, 15, 15, 0.15);
+  outline: 1px solid ${(p) => p.theme.colors.main.m1};
   z-index: ${modalZIndex - 5};
   cursor: pointer;
   pointer-events: auto;

--- a/frontend/src/lib-components/molecules/Toast.tsx
+++ b/frontend/src/lib-components/molecules/Toast.tsx
@@ -71,9 +71,7 @@ const ToastRoot = styled.div<{
   padding: ${defaultMargins.s};
   background-color: ${(p) => p.theme.colors.grayscale.g0};
   border-radius: 16px;
-  box-shadow:
-    4px 4px 8px rgba(15, 15, 15, 0.15),
-    -2px 0 4px rgba(15, 15, 15, 0.15);
+  outline: 1px solid ${(p) => p.theme.colors.main.m1};
   z-index: ${modalZIndex - 5};
   cursor: ${(p) => (p.showPointer ? 'pointer' : 'auto')};
   pointer-events: auto;

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -42,7 +42,8 @@ const features: Features = {
     jamixIntegration: true,
     forceUnpublishDocumentTemplate: true,
     invoiceDisplayAccountNumber: true,
-    serviceApplications: true
+    serviceApplications: true,
+    calendarMonthView: true
   },
   staging: {
     environmentLabel: 'Staging',
@@ -108,7 +109,8 @@ const features: Features = {
     discussionReservations: true,
     forceUnpublishDocumentTemplate: false,
     invoiceDisplayAccountNumber: true,
-    serviceApplications: false
+    serviceApplications: false,
+    calendarMonthView: false
   }
 }
 

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -42,8 +42,7 @@ const features: Features = {
     jamixIntegration: true,
     forceUnpublishDocumentTemplate: true,
     invoiceDisplayAccountNumber: true,
-    serviceApplications: true,
-    calendarMonthView: true
+    serviceApplications: true
   },
   staging: {
     environmentLabel: 'Staging',
@@ -76,7 +75,8 @@ const features: Features = {
     jamixIntegration: true,
     forceUnpublishDocumentTemplate: true,
     invoiceDisplayAccountNumber: true,
-    serviceApplications: true
+    serviceApplications: true,
+    calendarMonthView: true
   },
   prod: {
     environmentLabel: null,

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -42,7 +42,8 @@ const features: Features = {
     jamixIntegration: true,
     forceUnpublishDocumentTemplate: true,
     invoiceDisplayAccountNumber: true,
-    serviceApplications: true
+    serviceApplications: true,
+    calendarMonthView: true
   },
   staging: {
     environmentLabel: 'Staging',

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -262,6 +262,12 @@ interface BaseFeatureFlags {
    * Show the Titania errors report in the reports list
    */
   titaniaErrorsReport?: boolean
+
+  /**
+   * Display a single month in the citizen calendar view instead of multiple
+   * scrollable months.
+   */
+  calendarMonthView?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>


### PR DESCRIPTION
_Ennen muutosta_:
Kuntalaisen kalenterinäkymä oli skrollattavissa haetun ajanjakson (nykyhetkestä kuukausi taaksepäin -> n.vuosi eteenpäin) verran.

_Muutoksen jälkeen_:
Saavutettavuusraportin ehdotusten pohjalta näytetään kalenterissa kuukausi kerrallaan.
- kalenteria voi navigoida sen ylläolevista napeista
- siirretty poissa- ja läsnäolojen palkki sivun alalaidasta kalenterin yläpuolelle
- näytetään myös mahdolliset edellisen ja seuraavan kuukauden päivät kalenterilla, jos niitä osuu kuukauden ensimmäiselle ja viimeiselle viikolle
- menneisyyden päivistä poistettu haalea overlay, vaihdettu taustaväri kontrastiltaan riittävän harmaaksi
- vaihdettu notifikaation box-shadow outlineksi - saavutettavuus korjaus toastin erottumiseksi taustasta
