### PR TITLE
Poistettu henkilötunnuksen näkyminen Varhaiskasvatuksessa aloittavat/lopettavat raporteilta

### DIFF
--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -80,6 +80,16 @@ export default class ReportsPage {
     await this.page.findByDataQa('report-varda-child-errors').click()
     return new VardaErrorsReport(this.page)
   }
+
+  async openStartingPlacementsReport() {
+    await this.page.findByDataQa('report-starting-placements').click()
+    return new StartingPlacementsReport(this.page)
+  }
+
+  async openEndedPlacementsReport() {
+    await this.page.findByDataQa('report-ended-placements').click()
+    return new EndedPlacementsReport(this.page)
+  }
 }
 
 export class MissingHeadOfFamilyReport {
@@ -746,6 +756,62 @@ export class ChildAttendanceReservationByChildReport {
         await row
           .findByDataQa('attendance-reservation-end')
           .assertTextEquals(data.attendanceReservationEnd)
+      })
+    )
+  }
+}
+
+export class StartingPlacementsReport {
+  constructor(private page: Page) {}
+
+  async assertRows(
+    expected: {
+      childName: string
+      areaName: string
+      placementStart: LocalDate
+    }[]
+  ) {
+    const rows = this.page.findAllByDataQa('report-row')
+    await rows.assertCount(expected.length)
+    await Promise.all(
+      expected.map(async (data, index) => {
+        const row = rows.nth(index)
+        await row.findByDataQa('child-name').assertTextEquals(data.childName)
+        await row.findByDataQa('area-name').assertTextEquals(data.areaName)
+        await row
+          .findByDataQa('placement-start-date')
+          .assertTextEquals(data.placementStart.format())
+      })
+    )
+  }
+}
+
+export class EndedPlacementsReport {
+  constructor(private page: Page) {}
+
+  async assertRows(
+    expected: {
+      childName: string
+      areaName: string
+      unitName: string
+      placementEnd: LocalDate
+      nextPlacementStart: LocalDate
+    }[]
+  ) {
+    const rows = this.page.findAllByDataQa('report-row')
+    await rows.assertCount(expected.length)
+    await Promise.all(
+      expected.map(async (data, index) => {
+        const row = rows.nth(index)
+        await row.findByDataQa('child-name').assertTextEquals(data.childName)
+        await row.findByDataQa('area-name').assertTextEquals(data.areaName)
+        await row.findByDataQa('unit-name').assertTextEquals(data.unitName)
+        await row
+          .findByDataQa('placement-end-date')
+          .assertTextEquals(data.placementEnd.format())
+        await row
+          .findByDataQa('next-placement-start-date')
+          .assertTextEquals(data.nextPlacementStart.format())
       })
     )
   }

--- a/frontend/src/e2e-test/specs/5_employee/ended-placements-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/ended-placements-report.spec.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
+
+import config from '../../config'
+import { Fixture } from '../../dev-api/fixtures'
+import { resetServiceState } from '../../generated/api-clients'
+import { DevEmployee } from '../../generated/api-types'
+import EmployeeNav from '../../pages/employee/employee-nav'
+import ReportsPage from '../../pages/employee/reports'
+import { Page } from '../../utils/page'
+import { employeeLogin } from '../../utils/user'
+
+beforeEach(async (): Promise<void> => resetServiceState())
+
+describe('Ended placements report', () => {
+  test('works', async () => {
+    const mockedToday = LocalDate.of(2023, 6, 19)
+
+    const admin = await Fixture.employee().admin().save()
+    const area = await Fixture.careArea({ name: 'Alue 1A' }).save()
+
+    const daycare = await Fixture.daycare({
+      areaId: area.id,
+      type: ['CENTRE']
+    }).save()
+    const child = await Fixture.person({
+      ssn: null,
+      firstName: 'Testi',
+      lastName: 'Henkilö'
+    }).saveChild()
+
+    const page = await Page.open({
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0))
+    })
+
+    const endedPlacement = await Fixture.placement({
+      childId: child.id,
+      unitId: daycare.id,
+      startDate: mockedToday.subMonths(1),
+      endDate: mockedToday.subDays(2)
+    }).save()
+
+    const nextPlacement = await Fixture.placement({
+      childId: child.id,
+      unitId: daycare.id,
+      startDate: mockedToday.addMonths(1),
+      endDate: mockedToday.addMonths(2)
+    }).save()
+
+    const report = await navigateToReport(page, admin)
+    await report.assertRows([
+      {
+        childName: `${child.lastName} ${child.firstName}`,
+        areaName: area.name,
+        unitName: daycare.name,
+        placementEnd: endedPlacement.endDate,
+        nextPlacementStart: nextPlacement.startDate
+      }
+    ])
+  })
+})
+
+const navigateToReport = async (page: Page, user: DevEmployee) => {
+  await employeeLogin(page, user)
+  await page.goto(config.employeeUrl)
+  await new EmployeeNav(page).openTab('reports')
+  return await new ReportsPage(page).openEndedPlacementsReport()
+}

--- a/frontend/src/e2e-test/specs/5_employee/starting-placements-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/starting-placements-report.spec.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import LocalDate from 'lib-common/local-date'
+import LocalTime from 'lib-common/local-time'
+
+import config from '../../config'
+import { Fixture } from '../../dev-api/fixtures'
+import { resetServiceState } from '../../generated/api-clients'
+import { DevEmployee } from '../../generated/api-types'
+import EmployeeNav from '../../pages/employee/employee-nav'
+import ReportsPage from '../../pages/employee/reports'
+import { Page } from '../../utils/page'
+import { employeeLogin } from '../../utils/user'
+
+beforeEach(async (): Promise<void> => resetServiceState())
+
+describe('Starting placements report', () => {
+  test('works', async () => {
+    const mockedToday = LocalDate.of(2023, 6, 19)
+
+    const admin = await Fixture.employee().admin().save()
+    const area = await Fixture.careArea({ name: 'Alue 1A' }).save()
+
+    const daycare = await Fixture.daycare({
+      areaId: area.id,
+      type: ['CENTRE']
+    }).save()
+    const child = await Fixture.person({
+      ssn: null,
+      firstName: 'Testi',
+      lastName: 'Henkilö'
+    }).saveChild()
+
+    const page = await Page.open({
+      mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0))
+    })
+
+    const placement = await Fixture.placement({
+      childId: child.id,
+      unitId: daycare.id,
+      startDate: mockedToday.addDays(1),
+      endDate: mockedToday.addMonths(2)
+    }).save()
+
+    const report = await navigateToReport(page, admin)
+    await report.assertRows([
+      {
+        childName: `${child.lastName} ${child.firstName}`,
+        areaName: area.name,
+        placementStart: placement.startDate
+      }
+    ])
+  })
+})
+
+const navigateToReport = async (page: Page, user: DevEmployee) => {
+  await employeeLogin(page, user)
+  await page.goto(config.employeeUrl)
+  await new EmployeeNav(page).openTab('reports')
+  return await new ReportsPage(page).openStartingPlacementsReport()
+}

--- a/frontend/src/employee-frontend/components/Reports.tsx
+++ b/frontend/src/employee-frontend/components/Reports.tsx
@@ -360,6 +360,7 @@ export default React.memo(function Reports() {
                       color={colors.main.m2}
                       icon={faHourglassStart}
                       i18n={i18n.reports.startingPlacements}
+                      data-qa="report-starting-placements"
                     />
                   )
                 }
@@ -373,6 +374,7 @@ export default React.memo(function Reports() {
                       color={colors.main.m2}
                       icon={faHourglassEnd}
                       i18n={i18n.reports.endedPlacements}
+                      data-qa="report-ended-placements"
                     />
                   )
                 }

--- a/frontend/src/employee-frontend/components/reports/EndedPlacements.tsx
+++ b/frontend/src/employee-frontend/components/reports/EndedPlacements.tsx
@@ -178,7 +178,6 @@ export default React.memo(function EndedPlacements() {
               headers={[
                 { label: 'Lapsen sukunimi', key: 'lastName' },
                 { label: 'Lapsen etunimi', key: 'firstName' },
-                { label: 'Henkilötunnus', key: 'ssn' },
                 { label: 'Lopettaa varhaiskasvatuksessa', key: 'placementEnd' },
                 {
                   label: 'Jatkaa varhaiskasvatuksessa',
@@ -191,7 +190,6 @@ export default React.memo(function EndedPlacements() {
               <Thead>
                 <Tr>
                   <Th>{i18n.reports.common.childName}</Th>
-                  <Th>{i18n.reports.endedPlacements.ssn}</Th>
                   <Th>{i18n.reports.endedPlacements.placementEnd}</Th>
                   <Th>{i18n.reports.endedPlacements.unit}</Th>
                   <Th>{i18n.reports.endedPlacements.area}</Th>
@@ -200,17 +198,21 @@ export default React.memo(function EndedPlacements() {
               </Thead>
               <Tbody>
                 {filteredRows.map((row) => (
-                  <Tr key={row.childId}>
+                  <Tr key={row.childId} data-qa="report-row">
                     <Td>
-                      <Link to={`/child-information/${row.childId}`}>{`${
-                        row.lastName ?? ''
-                      } ${row.firstName ?? ''}`}</Link>
+                      <Link
+                        to={`/child-information/${row.childId}`}
+                        data-qa="child-name"
+                      >{`${row.lastName ?? ''} ${row.firstName ?? ''}`}</Link>
                     </Td>
-                    <Td>{row.ssn ?? ''}</Td>
-                    <Td>{row.placementEnd.format()}</Td>
-                    <Td>{row.unitName}</Td>
-                    <Td>{row.areaName}</Td>
-                    <Td>{row.nextPlacementStart?.format()}</Td>
+                    <Td data-qa="placement-end-date">
+                      {row.placementEnd.format()}
+                    </Td>
+                    <Td data-qa="unit-name">{row.unitName}</Td>
+                    <Td data-qa="area-name">{row.areaName}</Td>
+                    <Td data-qa="next-placement-start-date">
+                      {row.nextPlacementStart?.format()}
+                    </Td>
                   </Tr>
                 ))}
               </Tbody>

--- a/frontend/src/employee-frontend/components/reports/StartingPlacements.tsx
+++ b/frontend/src/employee-frontend/components/reports/StartingPlacements.tsx
@@ -176,14 +176,12 @@ export default React.memo(function StartingPlacements() {
             careAreaName: row.careAreaName,
             firstName: row.firstName,
             lastName: row.lastName,
-            ssn: row.ssn ?? row.dateOfBirth.format(),
             placementStart: row.placementStart.format()
           }))}
           headers={[
             { label: 'Palvelualue', key: 'careAreaName' },
             { label: 'Lapsen sukunimi', key: 'lastName' },
             { label: 'Lapsen etunimi', key: 'firstName' },
-            { label: 'Henkilötunnus', key: 'ssn' },
             { label: 'Aloittaa varhaiskasvatuksessa', key: 'placementStart' }
           ]}
           filename={getFilename(i18n, filters.year, filters.month)}
@@ -193,22 +191,23 @@ export default React.memo(function StartingPlacements() {
             <Tr>
               <Th>{i18n.reports.common.careAreaName}</Th>
               <Th>{i18n.reports.common.childName}</Th>
-              <Th>{i18n.reports.startingPlacements.ssn}</Th>
               <Th>{i18n.reports.startingPlacements.placementStart}</Th>
             </Tr>
           </Thead>
           {rows.isSuccess && (
             <Tbody>
               {filteredRows.map((row) => (
-                <Tr key={row.childId}>
-                  <StyledTd>{row.careAreaName}</StyledTd>
+                <Tr key={row.childId} data-qa="report-row">
+                  <StyledTd data-qa="area-name">{row.careAreaName}</StyledTd>
                   <StyledTd>
                     <Link
+                      data-qa="child-name"
                       to={`/child-information/${row.childId}`}
                     >{`${row.lastName} ${row.firstName}`}</Link>
                   </StyledTd>
-                  <StyledTd>{row.ssn ?? row.dateOfBirth.format()}</StyledTd>
-                  <StyledTd>{row.placementStart.format()}</StyledTd>
+                  <StyledTd data-qa="placement-start-date">
+                    {row.placementStart.format()}
+                  </StyledTd>
                 </Tr>
               ))}
             </Tbody>

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -308,7 +308,6 @@ export interface EndedPlacementsReportRow {
   lastName: string | null
   nextPlacementStart: LocalDate | null
   placementEnd: LocalDate
-  ssn: string | null
   unitName: string
 }
 
@@ -919,7 +918,6 @@ export interface StartingPlacementsRow {
   firstName: string
   lastName: string
   placementStart: LocalDate
-  ssn: string | null
 }
 
 /**

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/StartingPlacementsReportTest.kt
@@ -166,7 +166,6 @@ class StartingPlacementsReportTest : FullApplicationTest(resetDbBeforeEach = tru
             firstName = child.firstName,
             lastName = child.lastName,
             dateOfBirth = child.dateOfBirth,
-            ssn = child.ssn,
             placementStart = startDate,
             careAreaName = careAreaName,
         )

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/EndedPlacementsReport.kt
@@ -58,15 +58,15 @@ private fun Database.Read.getEndedPlacementsRows(
                 """
 WITH ended_placements AS (
     SELECT 
-        p.id AS child_id, p.first_name, p.last_name, p.social_security_number, 
+        p.id AS child_id, p.first_name, p.last_name,
         max(pl.end_date) AS placement_end
     FROM placement pl
     JOIN person p ON p.id = pl.child_id
     WHERE daterange(${bind(from)}, ${bind(to)}, '[]') @> pl.end_date AND pl.type != 'CLUB'::placement_type
-    GROUP BY p.id, p.first_name, p.last_name, p.social_security_number
+    GROUP BY p.id, p.first_name, p.last_name
 )
 SELECT 
-    ep.child_id, ep.first_name, ep.last_name, ep.social_security_number AS ssn,
+    ep.child_id, ep.first_name, ep.last_name,
     ep.placement_end, dc.name as unit_name, ca.name as area_name, min(next.start_date) AS next_placement_start
 FROM ended_placements ep
 JOIN placement pl
@@ -77,9 +77,9 @@ JOIN care_area ca
     ON dc.care_area_id = ca.id
 LEFT JOIN placement next
     ON next.child_id = ep.child_id AND next.start_date > ep.placement_end AND next.type != 'CLUB'::placement_type
-GROUP BY ep.child_id, ep.first_name, ep.last_name, ep.social_security_number, ep.placement_end, dc.name, ca.name
+GROUP BY ep.child_id, ep.first_name, ep.last_name, ep.placement_end, dc.name, ca.name
 HAVING min(next.start_date) IS NULL OR min(next.start_date) > ${bind(to)}
-ORDER BY last_name, first_name, social_security_number
+ORDER BY last_name, first_name, ep.child_id
 """
             )
         }
@@ -90,7 +90,6 @@ data class EndedPlacementsReportRow(
     val childId: ChildId,
     val firstName: String?,
     val lastName: String?,
-    val ssn: String?,
     val placementEnd: LocalDate,
     val unitName: String,
     val areaName: String,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/StartingPlacementsReport.kt
@@ -53,7 +53,6 @@ data class StartingPlacementsRow(
     val firstName: String,
     val lastName: String,
     val dateOfBirth: LocalDate,
-    val ssn: String?,
     val placementStart: LocalDate,
     val careAreaName: String,
 )
@@ -69,7 +68,7 @@ private fun Database.Read.getStartingPlacementsRows(
     return createQuery {
             sql(
                 """
-SELECT p.child_id, p.start_date AS placement_start, c.first_name, c.last_name, c.date_of_birth, c.social_security_number AS ssn,
+SELECT p.child_id, p.start_date AS placement_start, c.first_name, c.last_name, c.date_of_birth,
     (CASE
         WHEN u.provider_type = 'PRIVATE_SERVICE_VOUCHER' THEN 'palvelusetelialue'
         ELSE ca.name


### PR DESCRIPTION
Henkilötunnustiedot poistettu molemmilta raporteilta. Tarvittaessa ne ovat nähtävissä seuraamalla lapsen nimen linkkiä lapsen tiedot sivulle.

Lisätty myös yksinkertaiset testit raporttien toiminnan varmistamiseen.