### PR TITLE
Poistetaan vanhat käyttämättömät tuen tarpeen tietokantataulut

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/PersonIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/PersonIntegrationTest.kt
@@ -94,7 +94,6 @@ class PersonIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                 PersonReference("application_other_guardian", "guardian_id"),
                 PersonReference("assistance_action", "child_id"),
                 PersonReference("assistance_factor", "child_id"),
-                PersonReference("assistance_need", "child_id"),
                 PersonReference("assistance_need_decision", "child_id"),
                 PersonReference("assistance_need_decision_guardian", "person_id"),
                 PersonReference("assistance_need_preschool_decision", "child_id"),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/SchemaConventionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/SchemaConventionsTest.kt
@@ -36,10 +36,7 @@ class SchemaConventionsTest : PureJdbiTest(resetDbBeforeEach = false) {
                 "assistance_action",
                 "assistance_action_option",
                 "assistance_action_option_ref",
-                "assistance_basis_option",
-                "assistance_basis_option_ref",
                 "assistance_factor",
-                "assistance_need",
                 "assistance_need_decision",
                 "assistance_need_decision_guardian",
                 "assistance_need_preschool_decision",
@@ -136,9 +133,7 @@ class SchemaConventionsTest : PureJdbiTest(resetDbBeforeEach = false) {
                 "application_other_guardian",
                 "assistance_action",
                 "assistance_action_option",
-                "assistance_basis_option",
                 "assistance_factor",
-                "assistance_need",
                 "assistance_need_decision",
                 "assistance_need_preschool_decision",
                 "assistance_need_voucher_coefficient",
@@ -432,7 +427,6 @@ class SchemaConventionsTest : PureJdbiTest(resetDbBeforeEach = false) {
             setOf(
                 ColumnRef("application_note", "updated_by"),
                 ColumnRef("assistance_action", "updated_by"),
-                ColumnRef("assistance_need", "updated_by"),
                 ColumnRef("fee_alteration", "updated_by"),
                 ColumnRef("income", "updated_by"),
             )
@@ -514,7 +508,6 @@ class SchemaConventionsTest : PureJdbiTest(resetDbBeforeEach = false) {
             setOf(
                 ColumnRef("archived_process_history", "entered_by"),
                 ColumnRef("assistance_action_option_ref", "option_id"),
-                ColumnRef("assistance_basis_option_ref", "option_id"),
                 ColumnRef("assistance_factor", "modified_by"),
                 ColumnRef("child_document", "content_modified_by"),
                 ColumnRef("child_document_read", "person_id"),

--- a/service/src/main/resources/db/migration/V456__legacy_assistance_need_tables.sql
+++ b/service/src/main/resources/db/migration/V456__legacy_assistance_need_tables.sql
@@ -1,0 +1,3 @@
+DROP TABLE assistance_basis_option_ref;
+DROP TABLE assistance_basis_option;
+DROP TABLE assistance_need;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -451,3 +451,4 @@ V452__finance_decision_date_nullability.sql
 V453__email_message_type.sql
 V454__foster_parent_modified_metadata.sql
 V455__generate_invoice_ids.sql
+V456__legacy_assistance_need_tables.sql


### PR DESCRIPTION
Nämä taulut ovat olleet käyttämättömänä 2023 syksystä lähtien. Poistetaan myös `application_view` sarake joka ei ole käytössä ja on katsonut muutenkin väärää taulua

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
