### PR TITLE
Parannetaan `InvoiceGenerationLogicChooser`-rajapintaa

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceCorrectionsIntegrationTest.kt
@@ -37,8 +37,9 @@ class InvoiceCorrectionsIntegrationTest : PureJdbiTest(resetDbBeforeEach = true)
     private val productProvider: InvoiceProductProvider = TestInvoiceProductProvider()
     private val featureConfig: FeatureConfig = testFeatureConfig
     private val draftInvoiceGenerator: DraftInvoiceGenerator =
-        DraftInvoiceGenerator(productProvider, featureConfig, DefaultInvoiceGenerationLogic)
-    private val generator: InvoiceGenerator = InvoiceGenerator(draftInvoiceGenerator, featureConfig)
+        DraftInvoiceGenerator(productProvider, featureConfig)
+    private val generator: InvoiceGenerator =
+        InvoiceGenerator(draftInvoiceGenerator, featureConfig, DefaultInvoiceGenerationLogic)
     private val invoiceService =
         InvoiceService(
             InvoiceIntegrationClient.MockClient(defaultJsonMapperBuilder().build()),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -81,10 +81,18 @@ import org.junit.jupiter.api.Test
 class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     private val productProvider: InvoiceProductProvider = TestInvoiceProductProvider()
     private val featureConfig: FeatureConfig = testFeatureConfig
-    private val draftInvoiceGenerator: DraftInvoiceGenerator =
-        DraftInvoiceGenerator(productProvider, featureConfig)
-    private val generator: InvoiceGenerator =
-        InvoiceGenerator(draftInvoiceGenerator, featureConfig, DefaultInvoiceGenerationLogic)
+
+    private fun invoiceGenerator(
+        featureConfig: FeatureConfig = this.featureConfig,
+        invoiceGenerationLogicChooser: InvoiceGenerationLogicChooser = DefaultInvoiceGenerationLogic,
+    ) =
+        InvoiceGenerator(
+            DraftInvoiceGenerator(productProvider, featureConfig),
+            featureConfig,
+            invoiceGenerationLogicChooser,
+        )
+
+    private val generator: InvoiceGenerator = invoiceGenerator()
 
     @BeforeEach
     fun beforeEach() {
@@ -2159,13 +2167,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         // Override to not count unplanned absences as contract surplus days
-        val featureConfig = featureConfig.copy(unplannedAbsencesAreContractSurplusDays = false)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(unplannedAbsencesAreContractSurplusDays = false))
 
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -3661,13 +3664,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val period = FiniteDateRange.ofMonth(month)
 
         // Override to use 20 days instead when calculating a daily refund
-        val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20))
 
         val absenceDays =
             listOf(
@@ -3933,13 +3931,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         // freeSickLeaveOnContractDays = true
         // ==> 100 % discount because this case is considered a full month of sick leaves
-        val featureConfig = featureConfig.copy(freeSickLeaveOnContractDays = true)
-        val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+        val generator = invoiceGenerator(featureConfig.copy(freeSickLeaveOnContractDays = true))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -3994,13 +3986,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         insertDecisionsAndPlacementsAndServiceNeeds(decisions)
 
         // Override useContractDaysAsDailyFeeDivisor
-        val featureConfig = featureConfig.copy(useContractDaysAsDailyFeeDivisor = false)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(useContractDaysAsDailyFeeDivisor = false))
 
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -4059,13 +4046,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         // Override useContractDaysAsDailyFeeDivisor
-        val featureConfig = featureConfig.copy(useContractDaysAsDailyFeeDivisor = false)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(useContractDaysAsDailyFeeDivisor = false))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -4126,13 +4108,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         // Override useContractDaysAsDailyFeeDivisor
-        val featureConfig = featureConfig.copy(useContractDaysAsDailyFeeDivisor = false)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(useContractDaysAsDailyFeeDivisor = false))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -4198,13 +4175,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         // Override useContractDaysAsDailyFeeDivisor
-        val featureConfig = featureConfig.copy(useContractDaysAsDailyFeeDivisor = false)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(useContractDaysAsDailyFeeDivisor = false))
         // freeSickLeaveOnContractDays = false
         // ==> 50 % discount because this case is considered a normal full month of absences
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
@@ -4272,13 +4244,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         // Override useContractDaysAsDailyFeeDivisor
-        val featureConfig = featureConfig.copy(useContractDaysAsDailyFeeDivisor = false)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(useContractDaysAsDailyFeeDivisor = false))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -4321,13 +4288,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val period = FiniteDateRange.ofMonth(month)
 
         // Override to use 20 days instead when calculating a daily fee
-        val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20))
 
         db.transaction(insertChildParentRelation(testAdult_1.id, testChild_1.id, period))
         val decisions =
@@ -4376,13 +4338,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val period = FiniteDateRange.ofMonth(month)
 
         // Override to use 20 days instead when calculating a daily fee
-        val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20))
 
         db.transaction(insertChildParentRelation(testAdult_1.id, testChild_1.id, period))
         val decisions =
@@ -4448,13 +4405,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         initDataForAbsences(listOf(period), listOf())
 
         // Override to use 20 as the daily fee divisor
-        val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -4495,13 +4447,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         initDataForAbsences(listOf(period), absenceDays)
 
         // Override to use 20 as the daily fee divisor
-        val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -4550,13 +4497,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         initDataForAbsences(listOf(period), absenceDays)
 
         // Override to use 20 as the daily fee divisor
-        val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+            invoiceGenerator(featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -4820,13 +4762,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         // freeSickLeaveOnContractDays = true
         // ==> 100 % discount because this case is considered a full month of sick leaves
-        val featureConfig = featureConfig.copy(freeSickLeaveOnContractDays = true)
-        val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+        val generator = invoiceGenerator(featureConfig.copy(freeSickLeaveOnContractDays = true))
 
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -4981,16 +4917,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             serviceNeed = snPreschoolDaycareContractDays13,
         )
 
-        val featureConfig =
-            featureConfig.copy(
-                maxContractDaySurplusThreshold = 13,
-                useContractDaysAsDailyFeeDivisor = false,
-            )
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
+            invoiceGenerator(
+                featureConfig.copy(
+                    maxContractDaySurplusThreshold = 13,
+                    useContractDaysAsDailyFeeDivisor = false,
+                )
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5063,16 +4995,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         insertDecisionsAndPlacementsAndServiceNeeds(listOf(decision))
         insertAbsences(testChild_1.id, plannedAbsenceDays)
 
-        val featureConfig =
-            featureConfig.copy(
-                maxContractDaySurplusThreshold = 13,
-                useContractDaysAsDailyFeeDivisor = false,
-            )
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
+            invoiceGenerator(
+                featureConfig.copy(
+                    maxContractDaySurplusThreshold = 13,
+                    useContractDaysAsDailyFeeDivisor = false,
+                )
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5248,13 +5176,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         // Override maxContractDaySurplusThreshold feature config
-        val featureConfig = featureConfig.copy(maxContractDaySurplusThreshold = 16)
-        val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+        val generator = invoiceGenerator(featureConfig.copy(maxContractDaySurplusThreshold = 16))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -5302,13 +5224,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         // Override maxContractDaySurplusThreshold feature config
-        val featureConfig = featureConfig.copy(maxContractDaySurplusThreshold = 16)
-        val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+        val generator = invoiceGenerator(featureConfig.copy(maxContractDaySurplusThreshold = 16))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -5411,16 +5327,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         // Override useContractDaysAsDailyFeeDivisor and maxContractDaySurplusThreshold feature
         // configs
-        val featureConfig =
-            featureConfig.copy(
-                useContractDaysAsDailyFeeDivisor = false,
-                maxContractDaySurplusThreshold = 16,
-            )
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
+            invoiceGenerator(
+                featureConfig.copy(
+                    useContractDaysAsDailyFeeDivisor = false,
+                    maxContractDaySurplusThreshold = 16,
+                )
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5474,16 +5386,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         // Override useContractDaysAsDailyFeeDivisor and maxContractDaySurplusThreshold feature
         // configs
-        val featureConfig =
-            featureConfig.copy(
-                useContractDaysAsDailyFeeDivisor = false,
-                maxContractDaySurplusThreshold = 16,
-            )
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
+            invoiceGenerator(
+                featureConfig.copy(
+                    useContractDaysAsDailyFeeDivisor = false,
+                    maxContractDaySurplusThreshold = 16,
+                )
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5544,16 +5452,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         // Override useContractDaysAsDailyFeeDivisor and maxContractDaySurplusThreshold feature
         // configs
-        val featureConfig =
-            featureConfig.copy(
-                useContractDaysAsDailyFeeDivisor = false,
-                maxContractDaySurplusThreshold = 16,
-            )
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
+            invoiceGenerator(
+                featureConfig.copy(
+                    useContractDaysAsDailyFeeDivisor = false,
+                    maxContractDaySurplusThreshold = 16,
+                )
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5626,16 +5530,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
 
         // Override useContractDaysAsDailyFeeDivisor and maxContractDaySurplusThreshold feature
         // configs
-        val featureConfig =
-            featureConfig.copy(
-                useContractDaysAsDailyFeeDivisor = false,
-                maxContractDaySurplusThreshold = 16,
-            )
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
+            invoiceGenerator(
+                featureConfig.copy(
+                    useContractDaysAsDailyFeeDivisor = false,
+                    maxContractDaySurplusThreshold = 16,
+                )
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5713,13 +5613,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         initDataForAbsences(listOf(period), free)
 
         // Override freeAbsenceGivesADailyRefund feature config
-        val featureConfig = featureConfig.copy(freeAbsenceGivesADailyRefund = false)
-        val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+        val generator = invoiceGenerator(featureConfig.copy(freeAbsenceGivesADailyRefund = false))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -5751,13 +5645,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         initDataForAbsences(listOf(period), free, serviceNeed = snDaycareContractDays15)
 
         // Override freeAbsenceGivesADailyRefund feature config
-        val featureConfig = featureConfig.copy(freeAbsenceGivesADailyRefund = false)
-        val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                DefaultInvoiceGenerationLogic,
-            )
+        val generator = invoiceGenerator(featureConfig.copy(freeAbsenceGivesADailyRefund = false))
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
         val result = db.read(getAllInvoices)
@@ -5786,13 +5674,12 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         initDataForAbsences(listOf(period), listOf(), testChild_1)
 
         val generator =
-            InvoiceGenerator(
-                DraftInvoiceGenerator(productProvider, featureConfig),
-                featureConfig,
-                object : InvoiceGenerationLogicChooser {
-                    override fun getFreeChildren(tx: Database.Read, month: YearMonth) =
-                        setOf(testChild_1.id)
-                },
+            invoiceGenerator(
+                invoiceGenerationLogicChooser =
+                    object : InvoiceGenerationLogicChooser {
+                        override fun getFreeChildren(tx: Database.Read, month: YearMonth) =
+                            setOf(testChild_1.id)
+                    }
             )
 
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
@@ -5969,10 +5856,8 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         }
 
         val generator =
-            InvoiceGenerator(
-                draftInvoiceGenerator,
-                featureConfig.copy(freeJulyStartOnSeptember = freeJulyStartOnSeptember),
-                DefaultInvoiceGenerationLogic,
+            invoiceGenerator(
+                featureConfig.copy(freeJulyStartOnSeptember = freeJulyStartOnSeptember)
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, invoicingMonth) }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -70,7 +70,6 @@ import fi.espoo.evaka.toFeeDecisionServiceNeed
 import java.math.BigDecimal
 import java.time.DayOfWeek
 import java.time.LocalDate
-import java.time.Month
 import java.time.YearMonth
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -83,8 +82,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     private val productProvider: InvoiceProductProvider = TestInvoiceProductProvider()
     private val featureConfig: FeatureConfig = testFeatureConfig
     private val draftInvoiceGenerator: DraftInvoiceGenerator =
-        DraftInvoiceGenerator(productProvider, featureConfig, DefaultInvoiceGenerationLogic)
-    private val generator: InvoiceGenerator = InvoiceGenerator(draftInvoiceGenerator, featureConfig)
+        DraftInvoiceGenerator(productProvider, featureConfig)
+    private val generator: InvoiceGenerator =
+        InvoiceGenerator(draftInvoiceGenerator, featureConfig, DefaultInvoiceGenerationLogic)
 
     @BeforeEach
     fun beforeEach() {
@@ -2162,12 +2162,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(unplannedAbsencesAreContractSurplusDays = false)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
 
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
@@ -3667,12 +3664,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
 
         val absenceDays =
@@ -3942,12 +3936,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(freeSickLeaveOnContractDays = true)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -4006,12 +3997,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(useContractDaysAsDailyFeeDivisor = false)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
 
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
@@ -4074,12 +4062,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(useContractDaysAsDailyFeeDivisor = false)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -4144,12 +4129,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(useContractDaysAsDailyFeeDivisor = false)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -4219,12 +4201,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(useContractDaysAsDailyFeeDivisor = false)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         // freeSickLeaveOnContractDays = false
         // ==> 50 % discount because this case is considered a normal full month of absences
@@ -4296,12 +4275,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(useContractDaysAsDailyFeeDivisor = false)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -4348,12 +4324,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
 
         db.transaction(insertChildParentRelation(testAdult_1.id, testChild_1.id, period))
@@ -4406,12 +4379,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
 
         db.transaction(insertChildParentRelation(testAdult_1.id, testChild_1.id, period))
@@ -4481,12 +4451,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -4531,12 +4498,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -4589,12 +4553,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(dailyFeeDivisorOperationalDaysOverride = 20)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -4862,12 +4823,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(freeSickLeaveOnContractDays = true)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
 
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
@@ -5030,12 +4988,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             )
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5115,12 +5070,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             )
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5299,12 +5251,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(maxContractDaySurplusThreshold = 16)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5356,12 +5305,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(maxContractDaySurplusThreshold = 16)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5472,12 +5418,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             )
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5538,12 +5481,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             )
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5611,12 +5551,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             )
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5696,12 +5633,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             )
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5782,12 +5716,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(freeAbsenceGivesADailyRefund = false)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5823,12 +5754,9 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val featureConfig = featureConfig.copy(freeAbsenceGivesADailyRefund = false)
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    DefaultInvoiceGenerationLogic,
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
 
@@ -5855,23 +5783,16 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         val month = YearMonth.of(2019, 1)
         val period = FiniteDateRange.ofMonth(month)
 
-        initDataForAbsences(listOf(period), listOf())
+        initDataForAbsences(listOf(period), listOf(), testChild_1)
 
         val generator =
             InvoiceGenerator(
-                DraftInvoiceGenerator(
-                    productProvider,
-                    featureConfig,
-                    object : InvoiceGenerationLogicChooser {
-                        override fun logicForMonth(
-                            tx: Database.Read,
-                            year: Int,
-                            month: Month,
-                            childId: ChildId,
-                        ) = InvoiceGenerationLogic.Free
-                    },
-                ),
+                DraftInvoiceGenerator(productProvider, featureConfig),
                 featureConfig,
+                object : InvoiceGenerationLogicChooser {
+                    override fun getFreeChildren(tx: Database.Read, month: YearMonth) =
+                        setOf(testChild_1.id)
+                },
             )
 
         db.transaction { generator.createAndStoreAllDraftInvoices(it, month) }
@@ -6051,6 +5972,7 @@ class InvoiceGeneratorIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
             InvoiceGenerator(
                 draftInvoiceGenerator,
                 featureConfig.copy(freeJulyStartOnSeptember = freeJulyStartOnSeptember),
+                DefaultInvoiceGenerationLogic,
             )
         db.transaction { generator.createAndStoreAllDraftInvoices(it, invoicingMonth) }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
@@ -83,10 +83,7 @@ class DraftInvoiceGenerator(
 ) {
     private val config = InvoiceGeneratorConfig.fromFeatureConfig(featureConfig)
 
-    fun generateDraftInvoices(
-        tx: Database.Read,
-        invoiceInput: InvoiceGeneratorInput,
-    ): List<Invoice> {
+    fun generateDraftInvoices(invoiceInput: InvoiceGeneratorInput): List<Invoice> {
         val headsOfFamily = invoiceInput.decisions.keys + invoiceInput.temporaryPlacements.keys
         return headsOfFamily.mapNotNull { headOfFamilyId ->
             try {
@@ -103,7 +100,6 @@ class DraftInvoiceGenerator(
                     Tracing.headOfFamilyId withValue headOfFamilyId,
                 ) {
                     generateDraftInvoice(
-                        tx,
                         invoiceInput,
                         HeadOfFamilyInput(
                             config,
@@ -123,7 +119,6 @@ class DraftInvoiceGenerator(
     }
 
     private fun generateDraftInvoice(
-        tx: Database.Read,
         invoiceInput: InvoiceGeneratorInput,
         headInput: HeadOfFamilyInput,
     ): Invoice? {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
@@ -37,31 +37,16 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.DayOfWeek
 import java.time.LocalDate
-import java.time.Month
+import java.time.YearMonth
 import java.util.UUID
 import org.springframework.stereotype.Component
 
-enum class InvoiceGenerationLogic {
-    Default,
-    Free,
-}
-
 interface InvoiceGenerationLogicChooser {
-    fun logicForMonth(
-        tx: Database.Read,
-        year: Int,
-        month: Month,
-        childId: ChildId,
-    ): InvoiceGenerationLogic
+    fun getFreeChildren(tx: Database.Read, month: YearMonth): Set<ChildId>
 }
 
 object DefaultInvoiceGenerationLogic : InvoiceGenerationLogicChooser {
-    override fun logicForMonth(
-        tx: Database.Read,
-        year: Int,
-        month: Month,
-        childId: ChildId,
-    ): InvoiceGenerationLogic = InvoiceGenerationLogic.Default
+    override fun getFreeChildren(tx: Database.Read, month: YearMonth): Set<ChildId> = emptySet()
 }
 
 data class InvoiceGeneratorConfig(
@@ -94,7 +79,6 @@ data class InvoiceGeneratorConfig(
 class DraftInvoiceGenerator(
     private val productProvider: InvoiceProductProvider,
     featureConfig: FeatureConfig,
-    private val invoiceGenerationLogicChooser: InvoiceGenerationLogicChooser,
     private val tracer: Tracer = noopTracer(),
 ) {
     private val config = InvoiceGeneratorConfig.fromFeatureConfig(featureConfig)
@@ -174,7 +158,7 @@ class DraftInvoiceGenerator(
                                             ?.let { decision.validDuring to it }
                                     }
                                     .filterNot { (_, part) ->
-                                        invoiceInput.isFreeJulyChild(part.child.id)
+                                        invoiceInput.freeChildren.contains(part.child.id)
                                     }
                                     .map { (decisionPeriod, part) ->
                                         relevantPeriod.intersection(decisionPeriod)!! to
@@ -192,15 +176,6 @@ class DraftInvoiceGenerator(
         val rows =
             rowInputsByChild
                 .flatMap { (child, rowInputs) ->
-                    val logic =
-                        invoiceGenerationLogicChooser.logicForMonth(
-                            tx,
-                            invoiceInput.invoicePeriod.start.year,
-                            invoiceInput.invoicePeriod.start.month,
-                            child.id,
-                        )
-                    if (logic == InvoiceGenerationLogic.Free) return@flatMap listOf()
-
                     val childInput = ChildInput(config, invoiceInput, headInput, child)
 
                     val invoiceRows = mutableListOf<InvoiceRow>()
@@ -626,13 +601,11 @@ class DraftInvoiceGenerator(
         val businessDays: DateSet,
         val feeThresholds: FeeThresholds,
         val absences: Map<ChildId, List<Pair<AbsenceType, DateSet>>>,
-        private val freeChildren: Set<ChildId>,
+        val freeChildren: Set<ChildId>,
         val codebtors: Map<PersonId, PersonId?>,
         val defaultServiceNeedOptions: Map<PlacementType, ServiceNeedOption>,
     ) {
         val businessDayCount = businessDays.ranges().map { it.durationInDays() }.sum().toInt()
-
-        fun isFreeJulyChild(childId: ChildId): Boolean = freeChildren.contains(childId)
     }
 
     class HeadOfFamilyInput(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -56,7 +56,7 @@ class InvoiceGenerator(
         tx.createUpdate { sql("LOCK TABLE invoice IN EXCLUSIVE MODE") }.execute()
         val invoiceCalculationData =
             tracer.withSpan("calculateInvoiceData") { calculateInvoiceData(tx, month) }
-        val invoices = draftInvoiceGenerator.generateDraftInvoices(tx, invoiceCalculationData)
+        val invoices = draftInvoiceGenerator.generateDraftInvoices(invoiceCalculationData)
         val invoicesWithCorrections =
             tracer.withSpan("applyCorrections") {
                 applyCorrections(tx, invoices, month, invoiceCalculationData.areaIds)


### PR DESCRIPTION
Sen sijaan että jokaisen lapsen kohdalla kysyttäisiin "onko tämän lapsen lasku ilmainen tässä kuussa", kysytään aluksi "anna kaikki tämän kuun ilmaiset lapset" ja käytetään sitä dataa laskujen generoinnissa.

Tämä mahdollistaa laskujen generoinnin ajamisen tietokantatransaktion ulkopuolella.