### PR TITLE
Rajoitetaan uuden työntekijän näkemiä ryhmäpostilaatikon viestejä

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1315,7 +1315,11 @@ export class FamilyBuilder extends FixtureBuilder<Family> {
 
 export class EmployeeBuilder extends FixtureBuilder<DevEmployee> {
   daycareAcl: { unitId: string; role: ScopedRole }[]
-  groupAcl: { groupId: string; created: HelsinkiDateTime | null }[]
+  groupAcl: {
+    groupId: string
+    created?: HelsinkiDateTime
+    updated?: HelsinkiDateTime
+  }[]
 
   constructor(data: DevEmployee) {
     super(data)
@@ -1370,8 +1374,12 @@ export class EmployeeBuilder extends FixtureBuilder<DevEmployee> {
     return this
   }
 
-  withGroupAcl(groupId: string, created: HelsinkiDateTime | null = null): this {
-    this.groupAcl.push({ groupId, created })
+  withGroupAcl(
+    groupId: string,
+    created?: HelsinkiDateTime,
+    updated?: HelsinkiDateTime
+  ): this {
+    this.groupAcl.push({ groupId, created, updated })
     return this
   }
 
@@ -1387,10 +1395,11 @@ export class EmployeeBuilder extends FixtureBuilder<DevEmployee> {
     }
     if (this.groupAcl.length > 0) {
       await createDaycareGroupAclRows({
-        body: this.groupAcl.map(({ groupId, created }) => ({
+        body: this.groupAcl.map(({ groupId, created, updated }) => ({
           groupId,
           employeeId: this.data.id,
-          created
+          created: created ?? HelsinkiDateTime.now(),
+          updated: updated ?? HelsinkiDateTime.now()
         }))
       })
     }

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1315,7 +1315,7 @@ export class FamilyBuilder extends FixtureBuilder<Family> {
 
 export class EmployeeBuilder extends FixtureBuilder<DevEmployee> {
   daycareAcl: { unitId: string; role: ScopedRole }[]
-  groupAcl: string[]
+  groupAcl: { groupId: string; created: HelsinkiDateTime | null }[]
 
   constructor(data: DevEmployee) {
     super(data)
@@ -1370,8 +1370,8 @@ export class EmployeeBuilder extends FixtureBuilder<DevEmployee> {
     return this
   }
 
-  withGroupAcl(groupId: string): this {
-    this.groupAcl.push(groupId)
+  withGroupAcl(groupId: string, created: HelsinkiDateTime | null = null): this {
+    this.groupAcl.push({ groupId, created })
     return this
   }
 
@@ -1387,9 +1387,10 @@ export class EmployeeBuilder extends FixtureBuilder<DevEmployee> {
     }
     if (this.groupAcl.length > 0) {
       await createDaycareGroupAclRows({
-        body: this.groupAcl.map((groupId) => ({
+        body: this.groupAcl.map(({ groupId, created }) => ({
           groupId,
-          employeeId: this.data.id
+          employeeId: this.data.id,
+          created
         }))
       })
     }

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -492,9 +492,10 @@ export interface DevDaycareGroup {
 * Generated from fi.espoo.evaka.shared.dev.DevDaycareGroupAcl
 */
 export interface DevDaycareGroupAcl {
-  created: HelsinkiDateTime | null
+  created: HelsinkiDateTime
   employeeId: UUID
   groupId: UUID
+  updated: HelsinkiDateTime
 }
 
 /**
@@ -1320,7 +1321,8 @@ export function deserializeJsonDevDaycareGroup(json: JsonOf<DevDaycareGroup>): D
 export function deserializeJsonDevDaycareGroupAcl(json: JsonOf<DevDaycareGroupAcl>): DevDaycareGroupAcl {
   return {
     ...json,
-    created: (json.created != null) ? HelsinkiDateTime.parseIso(json.created) : null
+    created: HelsinkiDateTime.parseIso(json.created),
+    updated: HelsinkiDateTime.parseIso(json.updated)
   }
 }
 

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -492,6 +492,7 @@ export interface DevDaycareGroup {
 * Generated from fi.espoo.evaka.shared.dev.DevDaycareGroupAcl
 */
 export interface DevDaycareGroupAcl {
+  created: HelsinkiDateTime | null
   employeeId: UUID
   groupId: UUID
 }
@@ -1312,6 +1313,14 @@ export function deserializeJsonDevDaycareGroup(json: JsonOf<DevDaycareGroup>): D
     ...json,
     endDate: (json.endDate != null) ? LocalDate.parseIso(json.endDate) : null,
     startDate: LocalDate.parseIso(json.startDate)
+  }
+}
+
+
+export function deserializeJsonDevDaycareGroupAcl(json: JsonOf<DevDaycareGroupAcl>): DevDaycareGroupAcl {
+  return {
+    ...json,
+    created: (json.created != null) ? HelsinkiDateTime.parseIso(json.created) : null
   }
 }
 

--- a/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/messages.spec.ts
@@ -132,9 +132,9 @@ beforeEach(async () => {
     roles: []
   })
     .withDaycareAcl(testDaycare.id, 'STAFF')
-    .withGroupAcl(daycareGroup.id)
-    .withGroupAcl(daycareGroup2.id)
-    .withGroupAcl(daycareGroup3.id)
+    .withGroupAcl(daycareGroup.id, mockedDateAt10)
+    .withGroupAcl(daycareGroup2.id, mockedDateAt10)
+    .withGroupAcl(daycareGroup3.id, mockedDateAt10)
     .save()
 
   const staff2 = await Fixture.employee({

--- a/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
@@ -77,7 +77,7 @@ beforeEach(async () => {
 
   staff = await Fixture.employee()
     .staff(testDaycare.id)
-    .withGroupAcl(testDaycareGroup.id)
+    .withGroupAcl(testDaycareGroup.id, mockedDateAt10, mockedDateAt10)
     .save()
 
   unitSupervisor = await Fixture.employee()

--- a/frontend/src/e2e-test/specs/7_messaging/municipal-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/municipal-messaging.spec.ts
@@ -120,7 +120,7 @@ beforeEach(async () => {
   messenger = await Fixture.employee().messenger().save()
   staff = await Fixture.employee()
     .staff(testDaycare.id)
-    .withGroupAcl(testDaycareGroup.id)
+    .withGroupAcl(testDaycareGroup.id, messageSendTime, messageSendTime)
     .save()
 })
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceControllerIntegrationTest.kt
@@ -84,8 +84,8 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
             tx.insertDaycareAclRow(testDaycare2.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
-            tx.insertDaycareGroupAcl(testDaycare2.id, employee.id, listOf(groupId2))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.insertDaycareGroupAcl(testDaycare2.id, employee.id, listOf(groupId2), now)
 
             tx.markStaffArrival(
                 employee.id,
@@ -110,7 +110,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
         }
 
         val arrivalTime = HelsinkiDateTime.of(today, LocalTime.of(8, 0))
@@ -146,7 +146,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
         }
 
         val arrivalTime = HelsinkiDateTime.of(today, LocalTime.of(8, 0))
@@ -176,7 +176,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
         }
 
         val arrivalTime = HelsinkiDateTime.of(today, LocalTime.of(8, 0))
@@ -211,7 +211,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -243,7 +243,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -276,7 +276,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -309,7 +309,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -351,7 +351,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -376,7 +376,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
         }
 
         val lastLoginBeforeArrival = db.read { db -> db.getEmployeeLastLogin(employee.id) }
@@ -402,7 +402,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -438,7 +438,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -464,7 +464,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -488,7 +488,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -531,7 +531,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -570,7 +570,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -596,7 +596,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -629,7 +629,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -671,7 +671,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -708,7 +708,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -757,7 +757,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -792,7 +792,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -828,7 +828,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -873,7 +873,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -908,7 +908,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId))
+            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceControllerIntegrationTest.kt
@@ -63,7 +63,7 @@ class RealtimeStaffAttendanceControllerIntegrationTest :
             tx.insertDaycareAclRow(testDaycare2.id, supervisor.id, UserRole.UNIT_SUPERVISOR)
             tx.insertDaycareAclRow(testDaycare.id, staff.id, UserRole.STAFF)
             tx.insertDaycareAclRow(testDaycare2.id, staff.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, staff.id, listOf(groupId1))
+            tx.insertDaycareGroupAcl(testDaycare.id, staff.id, listOf(groupId1), now)
 
             tx.upsertOccupancyCoefficient(
                 OccupancyCoefficientUpsert(testDaycare.id, staff.id, BigDecimal(7))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -84,7 +84,7 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             it.insertDaycareAclRow(daycareId, supervisorId, UserRole.UNIT_SUPERVISOR)
 
             it.insertDaycareAclRow(daycareId, employee1Id, UserRole.STAFF)
-            it.insertDaycareGroupAcl(daycareId, employee1Id, listOf(groupId))
+            it.insertDaycareGroupAcl(daycareId, employee1Id, listOf(groupId), clock.now())
 
             // employee2 has no groups
             it.insertDaycareAclRow(daycareId, employee2Id, UserRole.STAFF)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -276,7 +276,12 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
 
             employee1Account = tx.upsertEmployeeMessageAccount(employee1.id)
             tx.insertDaycareAclRow(testDaycare.id, employee1.id, UserRole.UNIT_SUPERVISOR)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee1.id, listOf(groupId1, groupId2))
+            tx.insertDaycareGroupAcl(
+                testDaycare.id,
+                employee1.id,
+                listOf(groupId1, groupId2),
+                clock.now(),
+            )
 
             tx.insert(DevEmployee(id = employee2.id, firstName = "Foo", lastName = "Supervisor"))
             employee2Account = tx.upsertEmployeeMessageAccount(employee2.id)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
@@ -160,6 +160,7 @@ class InactiveEmployeesRoleResetIntegrationTest : PureJdbiTest(resetDbBeforeEach
                     daycareId = unitId,
                     employeeId = employeeId,
                     groupIds = listOf(groupId),
+                    firstOfAugust2021,
                 )
                 it.setDaycareGroupAclUpdated(groupId, employeeId, firstOfAugust2021.minusDays(5))
                 employeeId

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -154,12 +154,18 @@ class MessageController(
         return db.connect { dbc ->
                 requireMessageAccountAccess(dbc, user, clock, accountId)
                 dbc.read {
+                    val groupAccountAccessFrom =
+                        it.getStartDateOfGroupAccountAccess(
+                            accountId,
+                            (user as? AuthenticatedUser.Employee)?.id,
+                        )
                     it.getReceivedThreads(
                         accountId,
                         pageSize = 20,
                         page,
                         featureConfig.municipalMessageAccountName,
                         featureConfig.serviceWorkerMessageAccountName,
+                        groupAccountMessagesVisibleFrom = groupAccountAccessFrom?.minusWeeks(1),
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -7,17 +7,7 @@ package fi.espoo.evaka.messaging
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.application.personHasSentApplicationWithId
-import fi.espoo.evaka.shared.ApplicationId
-import fi.espoo.evaka.shared.AttachmentId
-import fi.espoo.evaka.shared.DaycareId
-import fi.espoo.evaka.shared.FeatureConfig
-import fi.espoo.evaka.shared.GroupId
-import fi.espoo.evaka.shared.MessageAccountId
-import fi.espoo.evaka.shared.MessageContentId
-import fi.espoo.evaka.shared.MessageDraftId
-import fi.espoo.evaka.shared.MessageId
-import fi.espoo.evaka.shared.MessageThreadId
-import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.*
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -131,8 +121,12 @@ class MessageController(
         clock: EvakaClock,
         @PathVariable accountId: MessageAccountId,
         @RequestParam page: Int,
-    ): PagedMessageThreads =
-        getReceivedMessages(db, user as AuthenticatedUser, clock, accountId, page)
+    ): PagedMessageThreads {
+        return db.connect { dbc ->
+            requireMessageAccountAccess(dbc, user, clock, accountId)
+            getReceivedMessages(dbc, user.id, accountId, page)
+        }
+    }
 
     @GetMapping("/employee-mobile/messages/{accountId}/received")
     fun getReceivedMessages(
@@ -141,33 +135,29 @@ class MessageController(
         clock: EvakaClock,
         @PathVariable accountId: MessageAccountId,
         @RequestParam page: Int,
-    ): PagedMessageThreads =
-        getReceivedMessages(db, user as AuthenticatedUser, clock, accountId, page)
-
-    private fun getReceivedMessages(
-        db: Database,
-        user: AuthenticatedUser,
-        clock: EvakaClock,
-        @PathVariable accountId: MessageAccountId,
-        @RequestParam page: Int,
     ): PagedMessageThreads {
         return db.connect { dbc ->
-                requireMessageAccountAccess(dbc, user, clock, accountId)
-                dbc.read {
-                    val groupAccountAccessFrom =
-                        it.getStartDateOfGroupAccountAccess(
-                            accountId,
-                            (user as? AuthenticatedUser.Employee)?.id,
-                        )
-                    it.getReceivedThreads(
-                        accountId,
-                        pageSize = 20,
-                        page,
-                        featureConfig.municipalMessageAccountName,
-                        featureConfig.serviceWorkerMessageAccountName,
-                        groupAccountMessagesVisibleFrom = groupAccountAccessFrom?.minusWeeks(1),
-                    )
-                }
+            requireMessageAccountAccess(dbc, user, clock, accountId)
+            getReceivedMessages(dbc, user.employeeId!!, accountId, page)
+        }
+    }
+
+    private fun getReceivedMessages(
+        dbc: Database.Connection,
+        employeeId: EmployeeId,
+        accountId: MessageAccountId,
+        page: Int,
+    ): PagedMessageThreads {
+        return dbc.read {
+                val accountAccessLimit = it.getAccountAccessLimit(accountId, employeeId)
+                it.getReceivedThreads(
+                    accountId,
+                    pageSize = 20,
+                    page,
+                    featureConfig.municipalMessageAccountName,
+                    featureConfig.serviceWorkerMessageAccountName,
+                    accountAccessLimit = accountAccessLimit,
+                )
             }
             .also {
                 Audit.MessagingReceivedMessagesRead.log(
@@ -192,6 +182,8 @@ class MessageController(
                     if (archiveFolderId == null) {
                         PagedMessageThreads(emptyList(), 0, 0)
                     } else {
+                        val accountAccessLimit = it.getAccountAccessLimit(accountId, user.id)
+
                         it.getReceivedThreads(
                             accountId,
                             pageSize = 20,
@@ -199,6 +191,7 @@ class MessageController(
                             featureConfig.municipalMessageAccountName,
                             featureConfig.serviceWorkerMessageAccountName,
                             archiveFolderId,
+                            accountAccessLimit,
                         )
                     }
                 }
@@ -221,7 +214,10 @@ class MessageController(
     ): PagedMessageCopies {
         return db.connect { dbc ->
                 requireMessageAccountAccess(dbc, user, clock, accountId)
-                dbc.read { it.getMessageCopiesByAccount(accountId, pageSize = 20, page) }
+                dbc.read {
+                    val accountAccessLimit = it.getAccountAccessLimit(accountId, user.id)
+                    it.getMessageCopiesByAccount(accountId, pageSize = 20, page, accountAccessLimit)
+                }
             }
             .also {
                 Audit.MessagingReceivedMessageCopiesRead.log(
@@ -238,7 +234,12 @@ class MessageController(
         clock: EvakaClock,
         @PathVariable accountId: MessageAccountId,
         @RequestParam page: Int,
-    ): PagedSentMessages = getSentMessages(db, user as AuthenticatedUser, clock, accountId, page)
+    ): PagedSentMessages {
+        return db.connect { dbc ->
+            requireMessageAccountAccess(dbc, user, clock, accountId)
+            getSentMessages(dbc, user.id, accountId, page)
+        }
+    }
 
     @GetMapping("/employee-mobile/messages/{accountId}/sent")
     fun getSentMessages(
@@ -247,18 +248,22 @@ class MessageController(
         clock: EvakaClock,
         @PathVariable accountId: MessageAccountId,
         @RequestParam page: Int,
-    ): PagedSentMessages = getSentMessages(db, user as AuthenticatedUser, clock, accountId, page)
-
-    private fun getSentMessages(
-        db: Database,
-        user: AuthenticatedUser,
-        clock: EvakaClock,
-        @PathVariable accountId: MessageAccountId,
-        @RequestParam page: Int,
     ): PagedSentMessages {
         return db.connect { dbc ->
-                requireMessageAccountAccess(dbc, user, clock, accountId)
-                dbc.read { it.getMessagesSentByAccount(accountId, pageSize = 20, page) }
+            requireMessageAccountAccess(dbc, user, clock, accountId)
+            getSentMessages(dbc, user.employeeId!!, accountId, page)
+        }
+    }
+
+    private fun getSentMessages(
+        dbc: Database.Connection,
+        employeeId: EmployeeId,
+        accountId: MessageAccountId,
+        page: Int,
+    ): PagedSentMessages {
+        return dbc.read {
+                val accountAccessLimit = it.getAccountAccessLimit(accountId, employeeId)
+                it.getMessagesSentByAccount(accountId, pageSize = 20, page, accountAccessLimit)
             }
             .also {
                 Audit.MessagingSentMessagesRead.log(
@@ -598,7 +603,12 @@ class MessageController(
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,
         @PathVariable accountId: MessageAccountId,
-    ): List<DraftContent> = getDraftMessages(db, user as AuthenticatedUser, clock, accountId)
+    ): List<DraftContent> {
+        return db.connect { dbc ->
+            requireMessageAccountAccess(dbc, user, clock, accountId)
+            getDraftMessages(dbc, accountId, user.id)
+        }
+    }
 
     @GetMapping("/employee-mobile/messages/{accountId}/drafts")
     fun getDraftMessages(
@@ -606,17 +616,21 @@ class MessageController(
         user: AuthenticatedUser.MobileDevice,
         clock: EvakaClock,
         @PathVariable accountId: MessageAccountId,
-    ): List<DraftContent> = getDraftMessages(db, user as AuthenticatedUser, clock, accountId)
-
-    private fun getDraftMessages(
-        db: Database,
-        user: AuthenticatedUser,
-        clock: EvakaClock,
-        @PathVariable accountId: MessageAccountId,
     ): List<DraftContent> {
         return db.connect { dbc ->
-                requireMessageAccountAccess(dbc, user, clock, accountId)
-                dbc.transaction { it.getDrafts(accountId) }
+            requireMessageAccountAccess(dbc, user, clock, accountId)
+            getDraftMessages(dbc, accountId, user.employeeId!!)
+        }
+    }
+
+    private fun getDraftMessages(
+        dbc: Database.Connection,
+        accountId: MessageAccountId,
+        employeeId: EmployeeId,
+    ): List<DraftContent> {
+        return dbc.transaction {
+                val accountAccessLimit = it.getAccountAccessLimit(accountId, employeeId)
+                it.getDrafts(accountId, accountAccessLimit)
             }
             .also {
                 Audit.MessagingDraftsRead.log(
@@ -650,7 +664,7 @@ class MessageController(
     ): MessageDraftId {
         return db.connect { dbc ->
                 requireMessageAccountAccess(dbc, user, clock, accountId)
-                dbc.transaction { it.initDraft(accountId) }
+                dbc.transaction { it.initDraft(accountId, clock.now()) }
             }
             .also { messageDraftId ->
                 Audit.MessagingCreateDraft.log(

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -505,13 +505,7 @@ WHERE
     tp.participant_id = ${bind(accountId)} AND
     tp.last_received_timestamp IS NOT NULL AND
     NOT t.is_copy AND
-    ${
-        if (folderId == null) {
-            "tp.folder_id IS NULL"
-        } else {
-            "tp.folder_id = ${bind(folderId)}"
-        }
-    } AND
+    tp.folder_id IS NOT DISTINCT FROM ${bind(folderId)} AND 
     EXISTS (SELECT 1 FROM message m WHERE m.thread_id = t.id AND m.sent_at IS NOT NULL) AND
     ${predicate(groupAccessPredicate.forTable("tp"))}
 ORDER BY tp.last_message_timestamp DESC

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AclQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AclQueries.kt
@@ -122,7 +122,7 @@ fun Database.Transaction.insertDaycareGroupAcl(
     daycareId: DaycareId,
     employeeId: EmployeeId,
     groupIds: Collection<GroupId>,
-    now: HelsinkiDateTime = HelsinkiDateTime.now(),
+    now: HelsinkiDateTime,
 ) =
     executeBatch(groupIds) {
         sql(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AclQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/AclQueries.kt
@@ -8,6 +8,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import org.jdbi.v3.core.mapper.Nested
 
 data class DaycareAclRow(
@@ -121,12 +122,13 @@ fun Database.Transaction.insertDaycareGroupAcl(
     daycareId: DaycareId,
     employeeId: EmployeeId,
     groupIds: Collection<GroupId>,
+    now: HelsinkiDateTime = HelsinkiDateTime.now(),
 ) =
     executeBatch(groupIds) {
         sql(
             """
 INSERT INTO daycare_group_acl
-SELECT id, ${bind(employeeId)}
+SELECT id, ${bind(employeeId)}, ${bind(now)}, ${bind(now)}
 FROM daycare_group
 WHERE id = ${bind { it }} AND daycare_id = ${bind(daycareId)}
 """

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -1139,8 +1139,8 @@ fun Database.Transaction.insert(row: DevDaycareGroupAcl) {
     createUpdate {
             sql(
                 """
-INSERT INTO daycare_group_acl (daycare_group_id, employee_id${if (row.created != null) ", created, updated" else ""})
-VALUES (${bind(row.groupId)}, ${bind(row.employeeId)}${if (row.created != null) ", " + bind(row.created) + ", " + bind(row.created) else ""})
+INSERT INTO daycare_group_acl (daycare_group_id, employee_id, created, updated)
+VALUES (${bind(row.groupId)}, ${bind(row.employeeId)}, ${bind(row.created)}, ${bind(row.updated)})
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -1139,8 +1139,8 @@ fun Database.Transaction.insert(row: DevDaycareGroupAcl) {
     createUpdate {
             sql(
                 """
-INSERT INTO daycare_group_acl (daycare_group_id, employee_id)
-VALUES (${bind(row.groupId)}, ${bind(row.employeeId)})
+INSERT INTO daycare_group_acl (daycare_group_id, employee_id${if (row.created != null) ", created, updated" else ""})
+VALUES (${bind(row.groupId)}, ${bind(row.employeeId)}${if (row.created != null) ", " + bind(row.created) + ", " + bind(row.created) else ""})
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -287,6 +287,7 @@ fun Database.Transaction.insert(
     row: DevEmployee,
     unitRoles: Map<DaycareId, UserRole> = mapOf(),
     groupAcl: Map<DaycareId, Collection<GroupId>> = mapOf(),
+    now: HelsinkiDateTime = HelsinkiDateTime.now(),
 ) =
     createUpdate {
             sql(
@@ -305,7 +306,7 @@ RETURNING id
                 insertDaycareAclRow(daycareId, employeeId, role)
             }
             groupAcl.forEach { (daycareId, groups) ->
-                insertDaycareGroupAcl(daycareId, employeeId, groups)
+                insertDaycareGroupAcl(daycareId, employeeId, groups, now)
             }
         }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -2159,7 +2159,11 @@ data class DevApplicationWithForm(
     val formModified: HelsinkiDateTime,
 )
 
-data class DevDaycareGroupAcl(val groupId: GroupId, val employeeId: EmployeeId)
+data class DevDaycareGroupAcl(
+    val groupId: GroupId,
+    val employeeId: EmployeeId,
+    val created: HelsinkiDateTime? = null,
+)
 
 data class DevServiceNeed(
     val id: ServiceNeedId = ServiceNeedId(UUID.randomUUID()),

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -2162,7 +2162,8 @@ data class DevApplicationWithForm(
 data class DevDaycareGroupAcl(
     val groupId: GroupId,
     val employeeId: EmployeeId,
-    val created: HelsinkiDateTime? = null,
+    val created: HelsinkiDateTime = HelsinkiDateTime.now(),
+    val updated: HelsinkiDateTime = HelsinkiDateTime.now(),
 )
 
 data class DevServiceNeed(


### PR DESCRIPTION
Muutoksen jälkeen työntekijä ei näe viestiketjuja, jotka on lähetetty aikaisemmin kuin viikkoa ennen ryhmään luvitukseen päivämäärää. Yksikön esimies näkee kuitenkin edelleen koko ryhmäpostilaatikon viestihistorian.