### PR TITLE
Korjataan päivän valinta enterillä

### DIFF
--- a/frontend/src/lib-components/molecules/date-picker/DatePickerLowLevel.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerLowLevel.tsx
@@ -154,6 +154,9 @@ export default React.memo(function DatePickerLowLevel({
     (e: React.KeyboardEvent) => {
       if (e.key === 'Esc' || e.key === 'Escape' || e.key === 'Enter') {
         e.stopPropagation()
+        if (e.key === 'Enter' && !(e.target instanceof HTMLInputElement)) {
+          return
+        }
         showDatePickerOff()
       }
     },


### PR DESCRIPTION
Saavutettavuusongelma, enterin käyttö datepickerissä.

_Ennen muutosta:_

Kun painaa enteriä käytettäessä datepickeriä näppäimistöllä, focus siirtyy datepickerin tekstikenttään ilman että päivä tulee valituksi. Jos yrittää navigoida edellinen/seuraava kuukausi -näppäimillä, focus siirtyy myös tekstikenttään ilman että kuukausi vaihtuu.

https://github.com/user-attachments/assets/432d477c-268c-4e4f-ad45-69bc272b0bfc


_Muutoksen jälkeen:_

Päivän valinta ja kuukausien selaaminen enterillä onnistuu.

https://github.com/user-attachments/assets/767d8ef9-1a8a-49e7-bbcd-9453aed3553a

(EDIT) Testeissä on monessa kohtaa käytäntö, jossa datepickerin tekstikenttään "kirjoitetaan" päivämäärä ja painetaan enter. Tämän odotetaan sulkevan datepickerin. Jotta enterillä kuitenkin pystyisi navigoimaan datepickerin kuukausinapeilla sekä valitsemaan halutun päivän, ohitetaan `showDatePickerOff` jos enter-eventin target tulee muualta kuin tekstikentästä.

