### PR TITLE
Mahdollistettu varhaiskasvatuksen tuen päätöksen toimivalta-tekstin muotoilu

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
@@ -16,6 +16,7 @@ import {
 import { Employee } from 'lib-common/generated/api-types/pis'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
+import { ParagraphDiv } from 'lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import InputField, { InputInfo } from 'lib-components/atoms/form/InputField'
@@ -625,7 +626,7 @@ export default React.memo(function AssistanceNeedDecisionForm({
       <P noMargin>{t.legalInstructionsText}</P>
 
       <H2>{t.jurisdiction}</H2>
-      <P noMargin>{t.jurisdictionText}</P>
+      <ParagraphDiv>{t.jurisdictionText()}</ParagraphDiv>
 
       <H2>{t.personsResponsible}</H2>
       <FixedSpaceColumn>

--- a/frontend/src/lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly.tsx
+++ b/frontend/src/lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly.tsx
@@ -81,7 +81,7 @@ export interface AssistanceNeedDecisionTexts {
   legalInstructions: string
   legalInstructionsText: string
   jurisdiction: string
-  jurisdictionText: string
+  jurisdictionText: () => React.ReactNode
 }
 
 const List = styled.ul`
@@ -96,6 +96,11 @@ const LabelContainer = styled.div`
 
 const Value = styled.div`
   white-space: pre-line;
+`
+
+export const ParagraphDiv = styled.div`
+  max-width: 960px;
+  margin: 0;
 `
 
 const OptionalLabelledValue = React.memo(function OptionalLabelledValue({
@@ -367,7 +372,7 @@ export default React.memo(function AssistanceNeedDecisionReadOnly({
           <P noMargin>{t.legalInstructionsText}</P>
 
           <H2>{t.jurisdiction}</H2>
-          <P noMargin>{t.jurisdictionText}</P>
+          <ParagraphDiv>{t.jurisdictionText()}</ParagraphDiv>
 
           <H2>{t.personsResponsible}</H2>
 

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -1800,7 +1800,7 @@ export default {
         legalInstructions: 'Sovelletut oikeusohjeet',
         legalInstructionsText: 'Varhaiskasvatuslaki, 3 a luku',
         jurisdiction: 'Toimivalta',
-        jurisdictionText:
+        jurisdictionText: (): React.ReactNode =>
           'Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 3 kohta',
         personsResponsible: 'Vastuuhenkilöt',
         preparator: 'Päätöksen valmistelija',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1795,7 +1795,7 @@ const sv: Translations = {
         legalInstructions: 'Tillämpade bestämmelser',
         legalInstructionsText: 'Lag om småbarnspedagogik, 3 a kap 15 §',
         jurisdiction: 'Befogenhet',
-        jurisdictionText:
+        jurisdictionText: (): React.ReactNode =>
           'Beslutanderätt i enlighet med lagstiftningen som gäller småbarnspedagogik och utbildning för tjänstemän inom Esbo stads resultatenhet svenska bildningstjänster och staben för sektorn Del A 7 § punkt 10 för beslut om särskilt stöd gäller Del A 3 § punkt 20 och Del A 3 § punkt 21',
         personsResponsible: 'Ansvarspersoner',
         preparator: 'Beredare av beslutet',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -1190,7 +1190,7 @@ export const fi = {
       legalInstructions: 'Sovelletut oikeusohjeet',
       legalInstructionsText: 'Varhaiskasvatuslaki, 3 a luku',
       jurisdiction: 'Toimivalta',
-      jurisdictionText:
+      jurisdictionText: (): React.ReactNode =>
         'Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 3 kohta',
       personsResponsible: 'Vastuuhenkilöt',
       preparator: 'Päätöksen valmistelija',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
@@ -240,7 +240,7 @@ export const sv = {
       legalInstructions: 'Tillämpade bestämmelser',
       legalInstructionsText: 'Lag om småbarnspedagogik, 3 a kap 15 §',
       jurisdiction: 'Befogenhet',
-      jurisdictionText:
+      jurisdictionText: (): React.ReactNode =>
         'Beslutanderätt i enlighet med lagstiftningen som gäller småbarnspedagogik och utbildning för tjänstemän inom Esbo stads resultatenhet svenska bildningstjänster och staben för sektorn Del A 7 § punkt 10 för beslut om särskilt stöd gäller Del A 3 § punkt 20 och Del A 3 § punkt 21',
       personsResponsible: 'Ansvarspersoner',
       preparator: 'Beredare av beslutet',


### PR DESCRIPTION
Muuttaa toimivaltatekstin kustomoinnin käyttämään ReactNode funktiota.

Vaatii kaikkien kuntien tekstikustomoinnin `assistanceNeedDecision.jurisdictionText` käännösavaimen muuttamisen funktio-muotoon `employee` ja `citizen` käyttöliittymiin (fi,sv).