### PR TITLE
Validate pull request labels

### DIFF
--- a/.github/workflows/validate-labels.yml
+++ b/.github/workflows/validate-labels.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2017-2024 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+name: 'Validate PR labels'
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+jobs:
+  validate-labels:
+    if: ${{ github.event.pull_request.state == 'open' && !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          echo '${{ toJSON(github.event.pull_request.labels[*].name) }}' | bin/validate-labels.js

--- a/bin/validate-labels.js
+++ b/bin/validate-labels.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// Usage in a GitHub Actions workflow:
+//
+// echo '${{ toJSON(github.event.pull_request.labels[*].name) }}' | bin/check-labels.js
+//
+
+function main() {
+  let inputData = ''
+
+  const stdin = process.stdin;
+  stdin.setEncoding('utf-8')
+  stdin.on('data', (data) => {
+      inputData += data
+  });
+
+  stdin.on('end', () => {
+    let json
+    try {
+        json = JSON.parse(inputData);
+    } catch (error) {
+        console.error('An error occurred while parsing JSON:', error.message);
+        process.exit(1);
+    }
+    if (!validateLabels(json)) {
+      console.error('Each pull request must have exactly one of the following labels:', knownLabels.join(', '));
+      console.error('Other labels are ignored by the validation.')
+      console.error('This pull request has the following labels:', json.join(', '));
+      process.exit(1);
+    }
+  });
+}
+
+const knownLabels = [
+  'no-changelog',
+  'breaking',
+  'enhancement',
+  'bug',
+  'tech',
+  'dependencies'
+];
+
+function validateLabels(labels) {
+  const numKnownLabels = labels.reduce(
+    (acc, label) => (knownLabels.includes(label)) ? acc + 1 : acc,
+    0
+  );
+  return numKnownLabels === 1;
+}
+
+main();


### PR DESCRIPTION
Pull request labels drive the weekly changelog generation, which in turn aids in demo preparations. Having correct labels is important.

Add a workflow that enforces our label rule:

Each pull request must have exactly one of the following labels:
- `no-changelog`
- `breaking`
- `enhancement`
- `bug`
- `tech`
- `dependencies`

Other labels are ignored in validation.