### PR TITLE
Korjataan väärinymmärrys Suomi.fi REST salasanan vaihdossa

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/sficlient/rest/MockSfiMessagesRestEndpoint.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/sficlient/rest/MockSfiMessagesRestEndpoint.kt
@@ -50,11 +50,9 @@ class MockSfiMessagesRestEndpoint {
         @RequestBody body: ChangePasswordRequestBody,
     ): ResponseEntity<Any> =
         lock.withLock {
-            val accessToken = authorization?.removePrefix("Bearer ")
+            val accessToken = body.accessToken
             if (!tokens.contains(accessToken)) {
-                ResponseEntity.status(401).body(ApiError("Invalid token"))
-            } else if (body.accessToken != accessToken) {
-                ResponseEntity.status(400).body(ApiError("Invalid token in body"))
+                ResponseEntity.status(400).body(ApiError("Invalid token"))
             } else if (body.currentPassword != password) {
                 ResponseEntity.status(400).body(ApiError("Invalid password"))
             } else {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/sficlient/rest/SfiMessagesRestClientIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/sficlient/rest/SfiMessagesRestClientIntegrationTest.kt
@@ -195,4 +195,19 @@ class SfiMessagesRestClientIntegrationTest : FullApplicationTest(resetDbBeforeEa
         client.send(message)
         assertEquals(1, MockSfiMessagesRestEndpoint.getCapturedMessages().size)
     }
+
+    @Test
+    fun `password change handles access token expiry gracefully`() {
+        client.send(message)
+        assertEquals(1, MockSfiMessagesRestEndpoint.getCapturedMessages().size)
+        MockSfiMessagesRestEndpoint.clearTokens()
+        val oldPassword = MockSfiMessagesRestEndpoint.getCurrentPassword()
+        client.rotatePassword()
+        val newPassword = MockSfiMessagesRestEndpoint.getCurrentPassword()
+        assertNotEquals(oldPassword, newPassword)
+
+        // sending a message should still work after password change
+        client.send(message)
+        assertEquals(1, MockSfiMessagesRestEndpoint.getCapturedMessages().size)
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/sficlient/rest/SfiMessagesRestClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/sficlient/rest/SfiMessagesRestClient.kt
@@ -286,13 +286,11 @@ class SfiMessagesRestClient(
                 }
             }
 
-        val authorization = authorizationHeader.get()
-        val accessToken = authorization.value.removePrefix("Bearer ")
+        val accessToken = getAccessToken(current.password)
         httpClient
             .newCall(
                 Request.Builder()
                     .url(config.urls.changePassword)
-                    .header("Authorization", authorizationHeader.get().value)
                     .header("Accept", "application/json")
                     .post(
                         jsonRequestBody(


### PR DESCRIPTION
`/v1/change-password`:

- palauttaa 400 jos access token on vanhentunut -> okhttp:n authenticator-mekanismi ei toimi koska se vaatii 401-koodin
- ei näytä käyttävän Authorization-headeria ollenkaan

:arrow_down: 

Skipataan access token cache kokonaan ja haetaan aina uusi ennen salasanan vaihtoa

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
