### PR TITLE
Lisätään maksatukseen eräpäivän konfigurointi

### DIFF
--- a/frontend/src/employee-frontend/components/payments/PaymentsPage.tsx
+++ b/frontend/src/employee-frontend/components/payments/PaymentsPage.tsx
@@ -14,6 +14,7 @@ import { DatePickerDeprecated } from 'lib-components/molecules/DatePickerDepreca
 import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
 import { Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
+import { getPaymentsDueDate } from 'lib-customizations/employee'
 
 import { useTranslation } from '../../state/i18n'
 
@@ -98,7 +99,7 @@ const Modal = React.memo(function Modal({
   const { i18n } = useTranslation()
   const [paymentDate, setPaymentDate] = useState(LocalDate.todayInHelsinkiTz())
   const [dueDate, setDueDate] = useState(
-    LocalDate.todayInHelsinkiTz().addBusinessDays(10)
+    getPaymentsDueDate ?? LocalDate.todayInHelsinkiTz().addBusinessDays(10)
   )
 
   return (

--- a/frontend/src/lib-customizations/employee.tsx
+++ b/frontend/src/lib-customizations/employee.tsx
@@ -44,7 +44,8 @@ const {
   placementTypes,
   placementPlanRejectReasons,
   unitProviderTypes,
-  voucherValueDecisionTypes
+  voucherValueDecisionTypes,
+  getPaymentsDueDate
 }: EmployeeCustomizations = customizations
 export {
   appConfig,
@@ -57,7 +58,8 @@ export {
   placementPlanRejectReasons,
   preschoolAssistanceLevels,
   unitProviderTypes,
-  voucherValueDecisionTypes
+  voucherValueDecisionTypes,
+  getPaymentsDueDate
 }
 
 export type Lang = 'fi' | 'sv'

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -18,6 +18,7 @@ import {
   PlacementPlanRejectReason,
   PlacementType
 } from 'lib-common/generated/api-types/placement'
+import LocalDate from 'lib-common/local-date'
 import { Theme } from 'lib-common/theme'
 import { DeepReadonly } from 'lib-common/types'
 
@@ -287,6 +288,7 @@ export interface EmployeeCustomizations {
   preschoolAssistanceLevels: PreschoolAssistanceLevel[]
   unitProviderTypes: ProviderType[]
   voucherValueDecisionTypes: VoucherValueDecisionType[]
+  getPaymentsDueDate?: () => LocalDate
 }
 
 export interface EmployeeMobileCustomizations {


### PR DESCRIPTION
Tällä hetkellä maksatuksen eräpäivän oletus on kovakoodattuna nykyinen päivä + 10 arkipäivää. Tampereella tämä pitää olla nykyinen päivä.