### PR TITLE
Korjataan frontend docker copy -komento

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,7 +24,7 @@ RUN yarn install --immutable
 COPY . .
 
 ARG EVAKA_CUSTOMIZATIONS=espoo
-COPY --from=customizations . src/lib-customizations/${EVAKA_CUSTOMIZATIONS}
+COPY --from=customizations . src/lib-customizations/${EVAKA_CUSTOMIZATIONS}/
 
 ARG ICONS=free
 ARG SENTRY_PUBLISH_ENABLED="false"


### PR DESCRIPTION
Yritän selvittää outoa ongelmaa frontendin docker build cachessa, joka tulee kyseiseltä riviltä.

Dokumentointi sanoo: "If you specify multiple source files, either directly or using a wildcard, then the destination must be a directory (must end with a slash /)."

Korjataan rivi dokumentaation mukaiseksi, jos se vaikka samalla korjaisi ym. ongelman.