### PR TITLE
Korjaus Jamix-synkronoinnin aikatauluun

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -127,7 +127,7 @@ enum class ScheduledJob(
     ),
     SyncJamixDiets(
         ScheduledJobs::syncJamixDiets,
-        ScheduledJobSettings(enabled = false, schedule = JobSchedule.cron("0 */10 7-18 * * *")),
+        ScheduledJobSettings(enabled = false, schedule = JobSchedule.cron("0 */10 7-17 * * *")),
     ),
     SendPendingDecisionReminderEmails(
         ScheduledJobs::sendPendingDecisionReminderEmails,


### PR DESCRIPTION
https://github.com/espoon-voltti/evaka/pull/5681 part2, nyt menee oikeasti 7-18 eli päivän ensimmäinen klo 7.00 ja viimeinen klo 17.50.