### PR TITLE
Lisätään tuki useammalle tietokannalle composeen

### DIFF
--- a/compose/db/entry/init_evaka.sh
+++ b/compose/db/entry/init_evaka.sh
@@ -4,15 +4,38 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+function create_database() {
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DATABASE" <<EOSQL
+        CREATE DATABASE "$1_local";
+        CREATE DATABASE "$1_it" OWNER evaka_it;
+
+        GRANT ALL PRIVILEGES ON DATABASE "$1_local" TO "evaka_migration_role_local" WITH GRANT OPTION;
+        GRANT ALL PRIVILEGES ON DATABASE "$1_it" TO "evaka_migration_role_local" WITH GRANT OPTION;
+EOSQL
+
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$1_local" <<EOSQL
+        GRANT ALL ON SCHEMA "public" TO "evaka_migration_role_local";
+
+        -- DevDataInitializer creates a few helper functions
+        GRANT CREATE ON SCHEMA "public" TO "evaka_application_local";
+EOSQL
+
+    PGPASSWORD=flyway psql -v ON_ERROR_STOP=1 --username evaka_migration_local --dbname "$1_local" <<EOSQL
+        -- The reset_database function, used in e2e tests, truncates tables and resets sequences
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT TRUNCATE ON TABLES TO "evaka_application_local";
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT UPDATE ON SEQUENCES TO "evaka_application_local";
+EOSQL
+
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$1_it" <<EOSQL
+        GRANT ALL ON SCHEMA "public" TO "evaka_migration_role_local";
+EOSQL
+}
+
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DATABASE" <<EOSQL
     CREATE ROLE evaka_it WITH SUPERUSER LOGIN PASSWORD 'evaka_it';
-    CREATE DATABASE "evaka_local";
-    CREATE DATABASE "evaka_it" OWNER evaka_it;
 
     -- Migration role to manage the migrations.
     CREATE ROLE "evaka_migration_role_local";
-    GRANT ALL PRIVILEGES ON DATABASE "evaka_local" TO "evaka_migration_role_local" WITH GRANT OPTION;
-    GRANT ALL PRIVILEGES ON DATABASE "evaka_it" TO "evaka_migration_role_local" WITH GRANT OPTION;
 
     -- (App) user-level role to connect to the database with least required privileges.
     CREATE ROLE "evaka_application_role_local";
@@ -26,19 +49,8 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DATABASE
       IN ROLE "evaka_application_role_local";
 EOSQL
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname evaka_local <<EOSQL
-    GRANT ALL ON SCHEMA "public" TO "evaka_migration_role_local";
-
-    -- DevDataInitializer creates a few helper functions
-    GRANT CREATE ON SCHEMA "public" TO "evaka_application_local";
-EOSQL
-
-PGPASSWORD=flyway psql -v ON_ERROR_STOP=1 --username evaka_migration_local --dbname evaka_local <<EOSQL
-    -- The reset_database function, used in e2e tests, truncates tables and resets sequences
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT TRUNCATE ON TABLES TO "evaka_application_local";
-    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT UPDATE ON SEQUENCES TO "evaka_application_local";
-EOSQL
-
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname evaka_it <<EOSQL
-    GRANT ALL ON SCHEMA "public" TO "evaka_migration_role_local";
-EOSQL
+databases=${EVAKA_DATABASES:-evaka}
+for database in ${databases//,/ }
+do
+    create_database "$database"
+done


### PR DESCRIPTION
Tällä hetkellä `compose/db` luo instanssiin tietokannat `evaka_local` ja `evaka_it`. Tämä lisää ympäristömuuttujan, jolla voidaan luoda myös muita tietokantoja. Esim. Tampere `docker-compose.yml`:

```
services:
  db:
    build: evaka/compose/db
    environment: evaka,evaka_tampere,evaka_vesilahti,evaka_hameenkyro,...
    ...
```