### PR TITLE
Salli vastaaminen erityisopettajan ja muun päiväkotihenkilöstön viesteihin

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -171,9 +171,9 @@ export default React.memo(function MessageEditor({
         selectedChildrenInSameUnit &&
         message.children.some(
           (childId) =>
-            receiverOptions.childrenToMessageAccounts[childId]?.includes(
-              account.id
-            ) ?? false
+            receiverOptions.childrenToMessageAccounts[
+              childId
+            ]?.newMessage.includes(account.id) ?? false
         )
     )
     const [primary, secondary] = partition(accounts, isPrimaryRecipient)
@@ -259,7 +259,8 @@ export default React.memo(function MessageEditor({
                                       (childId) =>
                                         receiverOptions.childrenToMessageAccounts[
                                           childId
-                                        ]?.includes(accountId) ?? false
+                                        ]?.newMessage.includes(accountId) ??
+                                        false
                                     )
                                 )
                                 setMessage((message) => ({

--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -133,7 +133,7 @@ export default React.memo(function MessagesPage() {
                     accountId={messageAccount.accountId}
                     closeThread={() => selectThread(undefined)}
                     thread={selectedThread}
-                    allowedReplyAccounts={
+                    allowedAccounts={
                       receivers.getOrElse(null)?.childrenToMessageAccounts ?? {}
                     }
                     onThreadDeleted={() => {

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -16,6 +16,7 @@ import styled, { css } from 'styled-components'
 
 import { useBoolean } from 'lib-common/form/hooks'
 import {
+  ChildMessageAccountAccess,
   CitizenMessageThread,
   Message,
   MessageAccount
@@ -211,7 +212,7 @@ const SingleMessage = React.memo(
 interface Props {
   accountId: UUID
   thread: CitizenMessageThread.Regular
-  allowedReplyAccounts: Record<string, string[]>
+  allowedAccounts: Record<UUID, ChildMessageAccountAccess>
   closeThread: () => void
   onThreadDeleted: () => void
 }
@@ -233,7 +234,7 @@ export default React.memo(
         sensitive,
         children
       },
-      allowedReplyAccounts,
+      allowedAccounts,
       closeThread,
       onThreadDeleted
     }: Props,
@@ -290,11 +291,11 @@ export default React.memo(
       // applications don't have children, enable reply for them
       if (children.length === 0) return true
 
-      const allowedAccounts = new Set(
-        children.flatMap((c) => allowedReplyAccounts[c.childId])
+      const allowedReplyAccounts = new Set(
+        children.flatMap((c) => allowedAccounts[c.childId]?.reply ?? [])
       )
-      return recipients.every((r) => allowedAccounts.has(r.id))
-    }, [allowedReplyAccounts, children, recipients])
+      return recipients.every((r) => allowedReplyAccounts.has(r.id))
+    }, [allowedAccounts, children, recipients])
 
     return (
       <ThreadContainer data-qa="thread-reader">

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -29,6 +29,14 @@ export interface AuthorizedMessageAccount {
 }
 
 /**
+* Generated from fi.espoo.evaka.messaging.MessageControllerCitizen.ChildMessageAccountAccess
+*/
+export interface ChildMessageAccountAccess {
+  newMessage: UUID[]
+  reply: UUID[]
+}
+
+/**
 * Generated from fi.espoo.evaka.messaging.CitizenMessageBody
 */
 export interface CitizenMessageBody {
@@ -102,7 +110,7 @@ export interface DraftContent {
 * Generated from fi.espoo.evaka.messaging.MessageControllerCitizen.GetReceiversResponse
 */
 export interface GetReceiversResponse {
-  childrenToMessageAccounts: Record<UUID, UUID[]>
+  childrenToMessageAccounts: Record<UUID, ChildMessageAccountAccess>
   messageAccounts: MessageAccount[]
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
@@ -250,7 +250,7 @@ class MessageService(
             val isApplication = applicationId != null
             val validRecipients =
                 db.read { it.getCitizenReceivers(today, senderAccount) }
-                    .mapValues { entry -> entry.value.map { it.id }.toSet() }
+                    .mapValues { entry -> entry.value.reply.map { it.id }.toSet() }
             val allRecipientsValid =
                 recipientAccountIds.all { recipient ->
                     children.any { child -> validRecipients[child]?.contains(recipient) ?: false }


### PR DESCRIPTION
Tannoisten muutosten (https://github.com/espoon-voltti/evaka/pull/5839) jälkeen kuntalainen ei pystynyt vastaamaan erityisopettajalta tulleeseen viestiin. Yleisemmin vastaaminen oli sallittua vain sellaisiin viesteihin, jotka oli lähetetty ryhmätililtä tai yksikön johtajalta.

Muutoksen jälkeen viesteihin vastaaminen on sallittua silloin, kun viestiketjun jokainen osallistuja on jokin seuraavista:
- sellaisen päiväkodin henkilöstön jäsen, johon on voimassa oleva tai kahden viikon sisällä alkava sijoitus
- ryhmätili ryhmään, johon on voimassa oleva tai kahden viikon sisällä alkava ryhmitys.