### PR TITLE
Korjaus laskuhakun tuloksiin, kun löydetyissä laskuissa ei ole yhtään riviä

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -362,6 +362,21 @@ class InvoiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     }
 
     @Test
+    fun `search returns invoices without rows correctly`() {
+        val testInvoice =
+            DevInvoice(
+                status = InvoiceStatus.DRAFT,
+                headOfFamilyId = testAdult_1.id,
+                areaId = testArea.id,
+                rows = emptyList(),
+            )
+        db.transaction { tx -> tx.insert(listOf(testInvoice)) }
+
+        val result = searchInvoices(SearchInvoicesRequest(page = 1))
+        assertEqualEnough(listOf(toSummary(testInvoice)), result)
+    }
+
+    @Test
     fun `search gives correct total and page composition when using filters`() {
         db.transaction { tx -> tx.insert(testInvoices) }
         val sent =

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
@@ -297,14 +297,14 @@ JOIN invoice ON invoice_ids.id = invoice.id
 JOIN person as head ON invoice.head_of_family = head.id
 JOIN LATERAL (
     SELECT
-        jsonb_agg(DISTINCT jsonb_build_object(
+        coalesce(jsonb_agg(DISTINCT jsonb_build_object(
             'id', row.child,
             'dateOfBirth', child.date_of_birth,
             'firstName', child.first_name,
             'lastName', child.last_name,
             'ssn', child.social_security_number
-        )) AS children,
-        SUM(row.amount * row.unit_price) AS total_price
+        )), '[]'::jsonb) AS children,
+        coalesce(sum(row.amount * row.unit_price), 0) AS total_price
     FROM invoice_row AS row
     JOIN person AS child ON row.child = child.id
     WHERE row.invoice_id = invoice.id


### PR DESCRIPTION
Laskuhaku ei toiminut, jos jossain löydetyistä laskuista ei ollut lainkaan rivejä. Tällaisia laskuja ei tällä hetkellä pitäisi muodostua, mutta historiallisesti näin on saattanut olla.