### PR TITLE
Korjaus pedagogisen lomakkeen pdf-generointiin

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/DocumentHtmlGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/DocumentHtmlGenerator.kt
@@ -84,10 +84,12 @@ private val childDocumentCss =
         margin-top: 0;
     }
     
+    .question-grouped-text-fields table {
+        width: 100%;
+    }
+    
     .question-grouped-text-fields th, .question-grouped-text-fields td {
-        white-space: nowrap;
-        overflow: hidden;
-        padding-right: 24px;
+        padding-right: 16px;
     }
 """
         .trimIndent()


### PR DESCRIPTION
Nimettyjä tekstikenttiä kysymys saattoi leikkaantua pois pdf:ltä. Muutettu niin että rivittyy tarvittaessa useammalle riville.

Kaikki pdf:t voi generoida uudelleen ajamalla seuraavan SQL:n:
```
INSERT INTO async_job(type, payload, retry_count, retry_interval)
SELECT 'CreateChildDocumentPdf',
    jsonb_build_object(
        'user', NULL,
        'documentId', document_id
    ),
    3,
    interval '5 minutes'
FROM (
    SELECT id AS document_id
    FROM child_document
    WHERE document_key IS NOT NULL
 ) documents;
```
