### PR TITLE
Päiväeditorin tallennuksen indikointi ilman notifikaatiota

### DIFF
--- a/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
@@ -92,7 +92,6 @@ function initialFormState(
 interface Props {
   close: () => void
   onReturn: () => void
-  onSuccess: () => void
   reservationsResponse: ReservationsResponse
   initialDate: LocalDate | undefined
   holidayPeriods: HolidayPeriod[]
@@ -101,7 +100,6 @@ interface Props {
 export default React.memo(function AbsenceModal({
   close,
   onReturn,
-  onSuccess,
   reservationsResponse,
   initialDate,
   holidayPeriods
@@ -302,6 +300,7 @@ export default React.memo(function AbsenceModal({
               <MutateButton
                 primary
                 text={i18n.common.confirm}
+                textDone={i18n.common.saveSuccess}
                 disabled={selectedChildren.state.length === 0}
                 mutation={postAbsencesMutation}
                 onClick={() => {
@@ -311,13 +310,14 @@ export default React.memo(function AbsenceModal({
                   }
                   return { body: form.value() }
                 }}
-                onSuccess={onSuccess}
+                onSuccess={close}
                 data-qa="modal-okBtn"
                 onFailure={(failure: Failure<unknown>) => {
                   setAttendanceAlreadyExistsError(
                     failure.errorCode === 'ATTENDANCE_ALREADY_EXISTS'
                   )
                 }}
+                successTimeout={2500}
               />
             </CalendarModalButtons>
           </BottomFooterContainer>

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback, useContext, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -14,7 +14,6 @@ import { ReservationsResponse } from 'lib-common/generated/api-types/reservation
 import LocalDate from 'lib-common/local-date'
 import { useQuery, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
-import { NotificationsContext } from 'lib-components/Notifications'
 import Main from 'lib-components/atoms/Main'
 import { ContentArea } from 'lib-components/layout/Container'
 import { Desktop, RenderOnlyOn } from 'lib-components/layout/responsive-layout'
@@ -25,7 +24,6 @@ import Footer from '../Footer'
 import RequireAuth from '../RequireAuth'
 import { renderResult } from '../async-rendering'
 import { useUser } from '../auth/state'
-import { useTranslation } from '../localization'
 
 import AbsenceModal from './AbsenceModal'
 import ActionPickerModal from './ActionPickerModal'
@@ -133,15 +131,6 @@ const CalendarPage = React.memo(function CalendarPage() {
       return null
     }
   }, [data])
-
-  const { addTimedNotification } = useContext(NotificationsContext)
-  const i18n = useTranslation()
-  const onSuccess = useCallback(() => {
-    closeModal()
-    addTimedNotification({
-      children: i18n.common.saveSuccess
-    })
-  }, [addTimedNotification, closeModal, i18n.common.saveSuccess])
 
   if (!user || !user.accessibleFeatures.reservations) return null
 
@@ -273,7 +262,7 @@ const CalendarPage = React.memo(function CalendarPage() {
                 <ReservationModal
                   onClose={closeModal}
                   reservationsResponse={response}
-                  onSuccess={onSuccess}
+                  onSuccess={closeModal}
                   initialStart={
                     modalState.initialRange?.start ?? firstReservableDate
                   }
@@ -293,7 +282,6 @@ const CalendarPage = React.memo(function CalendarPage() {
                           )
                       : closeModal
                   }
-                  onSuccess={onSuccess}
                   initialDate={modalState.initialDate}
                   reservationsResponse={response}
                   holidayPeriods={holidayPeriods}

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import partition from 'lodash/partition'
-import React, { useCallback, useContext, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { getDuplicateChildInfo } from 'citizen-frontend/utils/duplicated-child-utils'
@@ -44,7 +44,6 @@ import { formatFirstName } from 'lib-common/names'
 import { reservationHasTimes } from 'lib-common/reservations'
 import TimeInterval from 'lib-common/time-interval'
 import { UUID } from 'lib-common/types'
-import { NotificationsContext } from 'lib-components/Notifications'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
@@ -150,13 +149,6 @@ export default React.memo(function DayView({
   )
 
   const [editing, edit] = useBoolean(false)
-  const { addTimedNotification } = useContext(NotificationsContext)
-  const onSuccess = useCallback(() => {
-    edit.off()
-    addTimedNotification({
-      children: i18n.common.saveSuccess
-    })
-  }, [addTimedNotification, edit, i18n.common.saveSuccess])
 
   return modalData === undefined ? (
     <DayModal
@@ -172,7 +164,6 @@ export default React.memo(function DayView({
       modalData={modalData}
       onClose={onClose}
       onCancel={edit.off}
-      onSuccess={onSuccess}
       holidayPeriods={holidayPeriods}
     />
   ) : (
@@ -256,13 +247,11 @@ function Edit({
   modalData,
   onClose,
   onCancel,
-  onSuccess,
   holidayPeriods
 }: {
   modalData: ModalData
   onClose: () => void
   onCancel: () => void
-  onSuccess: () => void
   holidayPeriods: HolidayPeriod[]
 }) {
   const i18n = useTranslation()
@@ -296,9 +285,11 @@ function Edit({
         }
       }}
       disabled={!form.isValid()}
-      onSuccess={onSuccess}
+      onSuccess={onCancel}
       text={i18n.common.save}
+      textDone={i18n.common.saveSuccess}
       data-qa="save"
+      successTimeout={2500}
     />
   )
 

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -309,6 +309,7 @@ export default React.memo(function ReservationModal({
               <MutateButton
                 primary
                 text={i18n.common.confirm}
+                textDone={i18n.common.saveSuccess}
                 disabled={
                   form.state.selectedChildren.length === 0 || !form.isValid()
                 }
@@ -327,6 +328,7 @@ export default React.memo(function ReservationModal({
                 onSuccess={onSuccess}
                 onFailure={(reason) => showSaveError(reason)}
                 data-qa="modal-okBtn"
+                successTimeout={2500}
               />
             </CalendarModalButtons>
           </BottomFooterContainer>

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -4,7 +4,7 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { animated, useSpring } from '@react-spring/web'
-import React from 'react'
+import React, { useMemo } from 'react'
 import styled, { useTheme } from 'styled-components'
 
 import { useTranslations } from 'lib-components/i18n'
@@ -82,6 +82,19 @@ const AsyncButton_ = function AsyncButton<T>({
   const cross = useSpring<{ opacity: number }>({
     opacity: state === 'failure' ? 1 : 0
   })
+  const getScreenReaderText = useMemo(() => {
+    switch (state) {
+      case 'in-progress':
+        return i18n.asyncButton.inProgress
+      case 'failure':
+        return i18n.asyncButton.failure
+      case 'success':
+        return textDone || i18n.asyncButton.success
+      default:
+        return ''
+    }
+  }, [state, i18n.asyncButton, textDone])
+
   return renderBaseButton(
     {
       text,
@@ -94,22 +107,10 @@ const AsyncButton_ = function AsyncButton<T>({
     handleClick,
     ({ icon }) => (
       <>
-        {state === 'in-progress' && (
-          <ScreenReaderOnly aria-live="polite" id="in-progress">
-            {i18n.asyncButton.inProgress}
-          </ScreenReaderOnly>
-        )}
-        {state === 'failure' && (
-          <ScreenReaderOnly aria-live="assertive" id="failure">
-            {i18n.asyncButton.failure}
-          </ScreenReaderOnly>
-        )}
-        {state === 'success' && (
-          <ScreenReaderOnly aria-live="assertive" id="success">
-            {i18n.asyncButton.success}
-          </ScreenReaderOnly>
-        )}
-
+        <ScreenReaderOnly
+          aria-live={state === 'in-progress' ? 'polite' : 'assertive'}
+          aria-label={getScreenReaderText}
+        />
         <IconContainer
           style={{
             width: container.x.to((x) => `${24 * x}px`),
@@ -144,7 +145,7 @@ const AsyncButton_ = function AsyncButton<T>({
             <FontAwesomeIcon icon={faTimes} color={colors.status.danger} />
           </IconWrapper>
         </IconContainer>
-        <TextWrapper>
+        <TextWrapper aria-hidden>
           {state === 'in-progress'
             ? textInProgress
             : state === 'success'

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -4,13 +4,10 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { animated, useSpring } from '@react-spring/web'
-import React, { useMemo } from 'react'
+import React from 'react'
 import styled, { useTheme } from 'styled-components'
 
-import { useTranslations } from 'lib-components/i18n'
 import { faCheck, faTimes } from 'lib-icons'
-
-import { ScreenReaderOnly } from '../ScreenReaderOnly'
 
 import {
   AsyncButtonBehaviorProps,
@@ -62,7 +59,6 @@ const AsyncButton_ = function AsyncButton<T>({
     onFailure,
     successTimeout
   })
-  const i18n = useTranslations()
   const { colors } = useTheme()
 
   const showIcon = state !== 'idle'
@@ -82,18 +78,6 @@ const AsyncButton_ = function AsyncButton<T>({
   const cross = useSpring<{ opacity: number }>({
     opacity: state === 'failure' ? 1 : 0
   })
-  const getScreenReaderText = useMemo(() => {
-    switch (state) {
-      case 'in-progress':
-        return i18n.asyncButton.inProgress
-      case 'failure':
-        return i18n.asyncButton.failure
-      case 'success':
-        return textDone || i18n.asyncButton.success
-      default:
-        return ''
-    }
-  }, [state, i18n.asyncButton, textDone])
 
   return renderBaseButton(
     {
@@ -107,10 +91,6 @@ const AsyncButton_ = function AsyncButton<T>({
     handleClick,
     ({ icon }) => (
       <>
-        <ScreenReaderOnly
-          aria-live={state === 'in-progress' ? 'polite' : 'assertive'}
-          aria-label={getScreenReaderText}
-        />
         <IconContainer
           style={{
             width: container.x.to((x) => `${24 * x}px`),
@@ -145,7 +125,9 @@ const AsyncButton_ = function AsyncButton<T>({
             <FontAwesomeIcon icon={faTimes} color={colors.status.danger} />
           </IconWrapper>
         </IconContainer>
-        <TextWrapper aria-hidden>
+        <TextWrapper
+          aria-live={state === 'in-progress' ? 'polite' : 'assertive'}
+        >
           {state === 'in-progress'
             ? textInProgress
             : state === 'success'

--- a/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/AsyncButton.tsx
@@ -36,6 +36,7 @@ export type AsyncButtonProps<T> = BaseButtonVisualProps &
      * If true, the success icon is hidden.
      */
     hideSuccess?: boolean
+    successTimeout?: number
   }
 
 const AsyncButton_ = function AsyncButton<T>({
@@ -50,6 +51,7 @@ const AsyncButton_ = function AsyncButton<T>({
   textInProgress = text,
   textDone = text,
   hideSuccess = false,
+  successTimeout,
   ...props
 }: AsyncButtonProps<T>) {
   const { state, handleClick } = useAsyncButtonBehavior({
@@ -57,7 +59,8 @@ const AsyncButton_ = function AsyncButton<T>({
     stopPropagation,
     onClick,
     onSuccess,
-    onFailure
+    onFailure,
+    successTimeout
   })
   const i18n = useTranslations()
   const { colors } = useTheme()


### PR DESCRIPTION
**_Ennen muutosta:_**

Kun tallennetaan läsnä-/poissaoloja kuntalaisen kalenterinäkymässä, näytölle tuleva notifikaatio peittää toimintoja desktopilla ja mobiilissa.


https://github.com/user-attachments/assets/25ea76df-e589-4aab-80ca-e133b9f21d46

https://github.com/user-attachments/assets/cd706aaf-d0ae-4e8a-b3e8-767a355bd6df


_**Muutoksen jälkeen:**_

Poistettu erillinen notifikaatio ja pidennetty "Tallennettu"-tilan näyttämistä onnistuneen tallennuksen jälkeen (parametrillä muokattavissa, default 2,5s).
Muutettu myös screenReaderOnly-toiminnallisuutta AsyncButton-komponentissa jonka tarkoitus on välittää esim. voice-overille napin tilaa.
Macilla kokeiltaessa onnistuneen tallennuksen tilaa ei lausuttu alkuperäisellä setupilla ("ladataan" tuli enimmäkseen läpi sen sijaan), muokkauksen jälkeen voice-over lukee "Tallennettu". Tässä on selainkohtaisia poikkeuksia, tällä viimeisellä yhdistelmällä esim. firefoxia käytettäessä "tallennettu" päätyy luetuksi kahteen kertaan - voice-over luultavasti lukee napin tekstin erillisen aria-labelin lisäksi. Toisaalta jos ScreenReaderOnly-komponentin rendailee dynaamisesti napin "staten" mukaan, success/failure -tilat eivät tule luetuksi ollenkaan.


https://github.com/user-attachments/assets/cc7a9ac9-97e6-4dce-9fee-b3f3602c639b

https://github.com/user-attachments/assets/8f1d3745-af0c-4430-ac74-5c50b61e673c



