### PR TITLE
db-scheduler-kirjaston päivityksen vaatima tietokantamuutos

### DIFF
--- a/service/src/main/resources/db/migration/V464__scheduled_tasks_priority.sql
+++ b/service/src/main/resources/db/migration/V464__scheduled_tasks_priority.sql
@@ -1,0 +1,1 @@
+ALTER TABLE scheduled_tasks ADD COLUMN priority SMALLINT;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -459,3 +459,4 @@ V460__modification_metadata.sql
 V461__replacement_invoices.sql
 V462__drop_table_holiday.sql
 V463__calendar_event_modified_by.sql
+V464__scheduled_tasks_priority.sql


### PR DESCRIPTION
Lisätään sarake `priority`. Kirjasto toimii ilmankin, mutta jossain tulevaisuuden versiossa sarake vaaditaan, joten se kannattaa luoda jo nyt.

Ks. [db-schedulerin päivitysohjeet](https://github.com/kagkarlsson/db-scheduler?tab=readme-ov-file#versions--upgrading)