### PR TITLE
Ehdottavan esiopetushakemuksen hyväksymisen esto johtajalta

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposalRow.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposalRow.tsx
@@ -105,17 +105,19 @@ export default React.memo(function PlacementProposalRow({
         <Td>
           {!submitting && (
             <FixedSpaceRow spacing="m">
-              <div>
-                <CheckIconButton
-                  data-qa="accept-button"
-                  onClick={() =>
-                    confirmationState === 'ACCEPTED'
-                      ? onChange('PENDING')
-                      : onChange('ACCEPTED')
-                  }
-                  active={confirmationState === 'ACCEPTED'}
-                />
-              </div>
+              {!placementPlan.unitAcceptDisabled && (
+                <div>
+                  <CheckIconButton
+                    data-qa="accept-button"
+                    onClick={() =>
+                      confirmationState === 'ACCEPTED'
+                        ? onChange('PENDING')
+                        : onChange('ACCEPTED')
+                    }
+                    active={confirmationState === 'ACCEPTED'}
+                  />
+                </div>
+              )}
               <div>
                 <CrossIconButton
                   data-qa="reject-button"

--- a/frontend/src/lib-common/generated/api-types/placement.ts
+++ b/frontend/src/lib-common/generated/api-types/placement.ts
@@ -202,6 +202,7 @@ export interface PlacementPlanDetails {
   preschoolDaycarePeriod: FiniteDateRange | null
   rejectedByCitizen: boolean
   type: PlacementType
+  unitAcceptDisabled: boolean
   unitConfirmationStatus: PlacementPlanConfirmationStatus
   unitId: UUID
   unitRejectOtherReason: string | null

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlan.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlan.kt
@@ -48,6 +48,7 @@ data class PlacementPlanDetails(
     val child: PlacementPlanChild,
     val unitConfirmationStatus: PlacementPlanConfirmationStatus =
         PlacementPlanConfirmationStatus.PENDING,
+    val unitAcceptDisabled: Boolean,
     val unitRejectReason: PlacementPlanRejectReason? = null,
     val unitRejectOtherReason: String? = null,
     val rejectedByCitizen: Boolean = false,


### PR DESCRIPTION
Ehdottava esiopetussysteemi menee seuraavassa järjestyksessä:

1. Ehdottavat esiopetushakemukset tuodaan järjestelmään ("optimointityökalu")
2. Palveluohjaus siirtää hakemukset johtajille
3. Johtajat tarkastavat hakemukset, mutta eivät hyväksy (hylätä voivat jolloin käsittely siirretään takaisin normaalin käytännön mukaisesti palveluohjaukselle)
4. Palveluohjaus siirtää hakemukset takaisin itselle käsittelyyn, ja lähettää sitten asiakkaille yhtenä massana sopivana ajankohtana ennen esiopetuksen hakuajan alkamista

Tässä muutoksessa halutaan estää vaiheessa 3 johtajia hyväksymästä hakemuksia, jotta ne voidaan sitten palveluohjauksen toimesta lähettää yhtenä massana.