### PR TITLE
Tarkistus seuraavan esiopetuskauden olemassaolosta ehdottavan EO:n työkaluun

### DIFF
--- a/frontend/src/employee-frontend/components/placement-tool/PlacementToolPage.tsx
+++ b/frontend/src/employee-frontend/components/placement-tool/PlacementToolPage.tsx
@@ -2,31 +2,56 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { useMemo } from 'react'
 
+import { useQueryResult } from 'lib-common/query'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import FileUpload from 'lib-components/molecules/FileUpload'
 import { H1, P } from 'lib-components/typography'
 
 import { useTranslation } from '../../state/i18n'
+import { renderResult } from '../async-rendering'
+import WarningLabel from '../common/WarningLabel'
 
 import { deletePlacementFile, uploadPlacementFile } from './api'
+import { nextPreschoolTermQuery } from './queries'
 
 export default React.memo(function PlacementToolPage() {
   const { i18n } = useTranslation()
+  const preschoolTermResult = useQueryResult(nextPreschoolTermQuery())
+
+  const nextPreschoolTerm = useMemo(
+    () =>
+      preschoolTermResult.map((r) => {
+        return r.length > 0 ? r[0] : null
+      }),
+    [preschoolTermResult]
+  )
 
   return (
     <Container>
       <ContentArea opaque>
         <H1>{i18n.placementTool.title}</H1>
-        <P>{i18n.placementTool.description}</P>
-        <FileUpload
-          files={[]}
-          onUpload={uploadPlacementFile}
-          onDelete={deletePlacementFile}
-          getDownloadUrl={() => ''}
-          allowedFileTypes={['csv']}
-        />
+        {renderResult(nextPreschoolTerm, (term) => (
+          <>
+            <P>{i18n.placementTool.description}</P>
+            {term ? (
+              <>
+                <P>{`${i18n.placementTool.preschoolTermNotification} ${term.finnishPreschool.format()}`}</P>
+                <FileUpload
+                  disabled={term === null}
+                  files={[]}
+                  onUpload={uploadPlacementFile}
+                  onDelete={deletePlacementFile}
+                  getDownloadUrl={() => ''}
+                  allowedFileTypes={['csv']}
+                />
+              </>
+            ) : (
+              <WarningLabel text={i18n.placementTool.preschoolTermWarning} />
+            )}
+          </>
+        ))}
       </ContentArea>
     </Container>
   )

--- a/frontend/src/employee-frontend/components/placement-tool/queries.ts
+++ b/frontend/src/employee-frontend/components/placement-tool/queries.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { getNextPreschoolTerm } from 'employee-frontend/generated/api-clients/application'
+import { createQueryKeys } from 'employee-frontend/query'
+import { query } from 'lib-common/query'
+
+const queryKeys = createQueryKeys('placementTool', {
+  nextPreschoolTerm: () => ['nextPreschoolTerm']
+})
+
+export const nextPreschoolTermQuery = query({
+  api: getNextPreschoolTerm,
+  queryKey: () => queryKeys.nextPreschoolTerm()
+})

--- a/frontend/src/employee-frontend/generated/api-clients/application.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/application.ts
@@ -20,6 +20,7 @@ import { PaperApplicationCreateRequest } from 'lib-common/generated/api-types/ap
 import { PersonApplicationSummary } from 'lib-common/generated/api-types/application'
 import { PlacementPlanDraft } from 'lib-common/generated/api-types/placement'
 import { PlacementProposalConfirmationUpdate } from 'lib-common/generated/api-types/application'
+import { PreschoolTerm } from 'lib-common/generated/api-types/daycare'
 import { RejectDecisionRequest } from 'lib-common/generated/api-types/application'
 import { SearchApplicationRequest } from 'lib-common/generated/api-types/application'
 import { SimpleBatchRequest } from 'lib-common/generated/api-types/application'
@@ -33,6 +34,7 @@ import { deserializeJsonDecisionDraftGroup } from 'lib-common/generated/api-type
 import { deserializeJsonPagedApplicationSummaries } from 'lib-common/generated/api-types/application'
 import { deserializeJsonPersonApplicationSummary } from 'lib-common/generated/api-types/application'
 import { deserializeJsonPlacementPlanDraft } from 'lib-common/generated/api-types/placement'
+import { deserializeJsonPreschoolTerm } from 'lib-common/generated/api-types/daycare'
 import { deserializeJsonUnitApplications } from 'lib-common/generated/api-types/application'
 import { uri } from 'lib-common/uri'
 
@@ -339,6 +341,18 @@ export async function updateDecisionDrafts(
     data: request.body satisfies JsonCompatible<DecisionDraftUpdate[]>
   })
   return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.application.PlacementToolController.getNextPreschoolTerm
+*/
+export async function getNextPreschoolTerm(): Promise<PreschoolTerm[]> {
+  const { data: json } = await client.request<JsonOf<PreschoolTerm[]>>({
+    url: uri`/employee/placement-tool/next-term`.toString(),
+    method: 'GET'
+  })
+  return json.map(e => deserializeJsonPreschoolTerm(e))
 }
 
 

--- a/frontend/src/employee-frontend/query.ts
+++ b/frontend/src/employee-frontend/query.ts
@@ -24,6 +24,7 @@ export type QueryKeyPrefix =
   | 'personDetails'
   | 'systemNotifications'
   | 'invoices'
+  | 'placementTool'
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4938,7 +4938,10 @@ export const fi = {
   placementTool: {
     title: 'Optimointityökalu',
     description:
-      'Voit luoda optimointityökalulla tuotetuista sijoitusehdotuksista hakemukset eVakaan. Hakemukset luodaan suoraan odottamaan päätöstä.'
+      'Voit luoda optimointityökalulla tuotetuista sijoitusehdotuksista hakemukset eVakaan. Hakemukset luodaan suoraan odottamaan päätöstä.',
+    preschoolTermNotification: 'Hakemukset luodaan seuravaan esiopetuskauteen:',
+    preschoolTermWarning:
+      'eVakasta puuttuu seuraavan esiopetuskauden määrittely. Esiopetuskausi tarvitaan hakemusten luontia varten.'
   },
   components
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PlacementToolServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PlacementToolServiceIntegrationTest.kt
@@ -55,6 +55,7 @@ import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.whenever
@@ -528,5 +529,12 @@ ${child.ssn!!};${unit.id}
         assertEquals(summary.preferredUnitId, unit.id)
         val child = db.read { it.getPersonBySSN(child.ssn!!) }
         assertEquals(summary.childId, child!!.id)
+    }
+
+    @Test
+    fun `next preschool term is received correctly`() {
+        val nextTerms = controller.getNextPreschoolTerm(dbInstance(), admin, clock)
+        assertTrue(nextTerms.isNotEmpty())
+        assertEquals(preschoolTerm, nextTerms[0])
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PlacementToolController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PlacementToolController.kt
@@ -5,6 +5,8 @@
 package fi.espoo.evaka.application
 
 import fi.espoo.evaka.Audit
+import fi.espoo.evaka.AuditId
+import fi.espoo.evaka.daycare.PreschoolTerm
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
@@ -12,6 +14,7 @@ import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
 import java.util.UUID
 import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
@@ -46,5 +49,31 @@ class PlacementToolController(
                 }
             }
             .also { Audit.PlacementTool.log() }
+    }
+
+    @GetMapping("/next-term")
+    fun getNextPreschoolTerm(
+        db: Database,
+        user: AuthenticatedUser.Employee,
+        clock: EvakaClock,
+    ): List<PreschoolTerm> {
+        return db.connect { dbc ->
+                dbc.transaction { tx ->
+                    accessControl.requirePermissionFor(
+                        tx,
+                        user,
+                        clock,
+                        Action.Global.PLACEMENT_TOOL,
+                    )
+                    listOfNotNull(
+                        placementToolService.findNextPreschoolTerm(date = clock.today(), tx = tx)
+                    )
+                }
+            }
+            .also {
+                Audit.PlacementTool.log(
+                    objectId = it.firstOrNull()?.let { term -> AuditId(term.id) }
+                )
+            }
     }
 }


### PR DESCRIPTION
Ehdottavan esiopetuksen työkalu vaatii tulevan esiopetuskauden olemassaolon. Muutoksen jälkeen puuttuva esiopetuskausi estää CSV:n latauksen ja näyttää pääkäyttäjälle varoituksen.