### PR TITLE
Kevennetään CSRF-tarkistusta OWASP-suositusten mukaisesti

### DIFF
--- a/apigw/src/shared/middleware/csrf.ts
+++ b/apigw/src/shared/middleware/csrf.ts
@@ -25,10 +25,11 @@ export class InvalidAntiCsrfToken extends Error {
 // Middleware that does CSRF header checks
 export const csrf: express.RequestHandler = (req, res, next) => {
   if (requiresCsrfCheck(req)) {
-    const sessionToken = req.session?.antiCsrfToken
-    const headerToken = req.header('x-evaka-csrf')
-    if (!sessionToken || !headerToken || sessionToken !== headerToken)
-      return next(new InvalidAntiCsrfToken())
+    // For APIs that don't use traditional HTML forms, it's enough to check the existence of a custom header
+    // Reference: OWASP  Cross-Site Request Forgery Prevention - Employing Custom Request Headers for AJAX/API
+    // https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#employing-custom-request-headers-for-ajaxapi
+    const header = req.header('x-evaka-csrf')
+    if (!header) return next(new InvalidAntiCsrfToken())
   }
   next()
 }

--- a/frontend/src/citizen-frontend/api-client.ts
+++ b/frontend/src/citizen-frontend/api-client.ts
@@ -11,6 +11,7 @@ export const API_URL = '/api/application'
 export const client = axios.create({
   baseURL: API_URL
 })
+client.defaults.headers.common['x-evaka-csrf'] = '1'
 
 export const setAntiCsrfToken = (value: string | undefined) => {
   for (const method of ['delete', 'patch', 'post', 'put'] as const) {

--- a/frontend/src/citizen-frontend/messages/utils.ts
+++ b/frontend/src/citizen-frontend/messages/utils.ts
@@ -5,7 +5,10 @@
 export const sessionKeepalive = async () => {
   const response = await fetch('/api/application/auth/status', {
     method: 'GET',
-    credentials: 'include'
+    credentials: 'include',
+    headers: {
+      'x-evaka-csrf': '1'
+    }
   })
   if (!response.ok) {
     // could be e.g. temporarily offline

--- a/frontend/src/employee-frontend/api/client.ts
+++ b/frontend/src/employee-frontend/api/client.ts
@@ -11,6 +11,7 @@ export const API_URL = '/api/internal'
 export const client = axios.create({
   baseURL: API_URL
 })
+client.defaults.headers.common['x-evaka-csrf'] = '1'
 
 export const setAntiCsrfToken = (value: string | undefined) => {
   for (const method of ['delete', 'patch', 'post', 'put'] as const) {

--- a/frontend/src/employee-frontend/components/messages/utils.ts
+++ b/frontend/src/employee-frontend/components/messages/utils.ts
@@ -5,7 +5,10 @@
 export const sessionKeepalive = async () => {
   const response = await fetch('/api/internal/auth/status', {
     method: 'GET',
-    credentials: 'include'
+    credentials: 'include',
+    headers: {
+      'x-evaka-csrf': '1'
+    }
   })
   if (!response.ok) {
     // could be e.g. temporarily offline

--- a/frontend/src/employee-mobile-frontend/client.ts
+++ b/frontend/src/employee-mobile-frontend/client.ts
@@ -11,6 +11,7 @@ export const API_URL = '/api/internal'
 export const client = axios.create({
   baseURL: API_URL
 })
+client.defaults.headers.common['x-evaka-csrf'] = '1'
 
 export const setAntiCsrfToken = (value: string | undefined) => {
   for (const method of ['delete', 'patch', 'post', 'put'] as const) {


### PR DESCRIPTION
HTML-lomakkeilla ei voi asettaa custom-headereita -> custom headerin läsnäolo riittää CSRF-tarkistukseksi eikä arvolla oikeasti ole väliä

https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#employing-custom-request-headers-for-ajaxapi