### PR TITLE
Laskujen generoinnin suorituskykyparannuksia

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -3615,7 +3615,7 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     }
 
     @Test
-    fun `invoice codebtor is not set when partner on decision is not any child's guardian`() {
+    fun `invoice codebtor is not set when partner on decision is not a guardian of any of the children`() {
         val month = YearMonth.of(2019, 1)
         val period = FiniteDateRange.ofMonth(month)
         initByPeriodAndPlacementType(
@@ -3635,6 +3635,30 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
         result.first().let { invoice ->
             assertEquals(testAdult_1.id, invoice.headOfFamily.id)
             assertNull(invoice.codebtor)
+        }
+    }
+
+    @Test
+    fun `invoice codebtor is set when partner on decision is guardian of one of the children`() {
+        val month = YearMonth.of(2019, 1)
+        val period = FiniteDateRange.ofMonth(month)
+        initByPeriodAndPlacementType(
+            period,
+            PlacementType.DAYCARE,
+            children = listOf(testChild_1, testChild_2),
+            partner = testAdult_2.id,
+        )
+        db.transaction {
+            it.insertGuardian(testAdult_1.id, testChild_1.id)
+            it.insertGuardian(testAdult_2.id, testChild_2.id)
+        }
+
+        db.transaction { generator.generateAllDraftInvoices(it, month) }
+        val result = db.read { it.getAllInvoices() }
+        assertEquals(1, result.size)
+        result.first().let { invoice ->
+            assertEquals(testAdult_1.id, invoice.headOfFamily.id)
+            assertEquals(testAdult_2.id, invoice.codebtor?.id)
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -5656,8 +5656,14 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             invoiceGenerator(
                 invoiceGenerationLogicChooser =
                     object : InvoiceGenerationLogicChooser {
-                        override fun getFreeChildren(tx: Database.Read, month: YearMonth) =
-                            setOf(testChild_1.id)
+                        override fun getFreeChildren(
+                            tx: Database.Read,
+                            month: YearMonth,
+                            childIds: Set<ChildId>,
+                        ): Set<ChildId> {
+                            assertEquals(setOf(testChild_1.id), childIds)
+                            return childIds
+                        }
                     }
             )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/children/ChildrenQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/children/ChildrenQueries.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka.children
 
 import fi.espoo.evaka.shared.ChildId
-import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.db.Database
 import java.time.LocalDate
@@ -64,19 +63,3 @@ SELECT child_id FROM foster_parent WHERE parent_id = ${bind(userId)} AND valid_d
             )
         }
         .toList()
-
-fun Database.Read.getActivePlacementUnitsForChildren(
-    today: LocalDate,
-    childIds: Set<ChildId>,
-): Map<DaycareId, List<ChildId>> =
-    createQuery {
-            sql(
-                """
-SELECT unit_id, child_id
-FROM placement
-WHERE child_id = ANY (${bind(childIds)}) AND daterange(start_date, end_date, '[]') @> ${bind(today)}
-"""
-            )
-        }
-        .toList { column<DaycareId>("unit_id") to column<ChildId>("child_id") }
-        .groupBy({ it.first }, { it.second })

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
@@ -13,6 +13,7 @@ import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionDifference
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionStatus
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionSummary
 import fi.espoo.evaka.invoicing.domain.VoucherValueDecisionType
+import fi.espoo.evaka.invoicing.partnerIsCodebtor
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
@@ -486,7 +487,7 @@ WHERE decision.id = ${bind(id)}
             it.copy(
                 partnerIsCodebtor =
                     partnerIsCodebtor(
-                        it.headOfFamily.id,
+                        this,
                         it.partner?.id,
                         listOf(it.child.id),
                         FiniteDateRange(it.validFrom, it.validTo),

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
@@ -38,11 +38,15 @@ import java.time.YearMonth
 import org.springframework.stereotype.Component
 
 interface InvoiceGenerationLogicChooser {
-    fun getFreeChildren(tx: Database.Read, month: YearMonth): Set<ChildId>
+    fun getFreeChildren(tx: Database.Read, month: YearMonth, childIds: Set<ChildId>): Set<ChildId>
 }
 
 object DefaultInvoiceGenerationLogic : InvoiceGenerationLogicChooser {
-    override fun getFreeChildren(tx: Database.Read, month: YearMonth): Set<ChildId> = emptySet()
+    override fun getFreeChildren(
+        tx: Database.Read,
+        month: YearMonth,
+        childIds: Set<ChildId>,
+    ): Set<ChildId> = emptySet()
 }
 
 data class InvoiceGeneratorConfig(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/FeeDecisionService.kt
@@ -20,7 +20,6 @@ import fi.espoo.evaka.invoicing.data.getFeeDecisionDocumentKey
 import fi.espoo.evaka.invoicing.data.getFeeDecisionsByIds
 import fi.espoo.evaka.invoicing.data.lockFeeDecisions
 import fi.espoo.evaka.invoicing.data.lockFeeDecisionsForHeadOfFamily
-import fi.espoo.evaka.invoicing.data.partnerIsCodebtor
 import fi.espoo.evaka.invoicing.data.removeFeeDecisionIgnore
 import fi.espoo.evaka.invoicing.data.setFeeDecisionSent
 import fi.espoo.evaka.invoicing.data.setFeeDecisionToIgnored
@@ -230,16 +229,7 @@ class FeeDecisionService(
 
     fun createFeeDecisionPdf(tx: Database.Transaction, id: FeeDecisionId) {
         val decision =
-            tx.getFeeDecision(id)?.let {
-                val partnerIsCodebtor =
-                    tx.partnerIsCodebtor(
-                        it.headOfFamily.id,
-                        it.partner?.id,
-                        it.children.map { c -> c.child.id },
-                        it.validDuring,
-                    )
-                it.copy(partnerIsCodebtor = partnerIsCodebtor)
-            } ?: throw NotFound("No fee decision found with ID ($id)")
+            tx.getFeeDecision(id) ?: throw NotFound("No fee decision found with ID ($id)")
 
         if (!decision.documentKey.isNullOrBlank()) {
             throw Conflict("Fee decision $id has document key already!")

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/VoucherValueDecisionService.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.invoicing.data.getValueDecisionsByIds
 import fi.espoo.evaka.invoicing.data.getVoucherValueDecision
 import fi.espoo.evaka.invoicing.data.getVoucherValueDecisionDocumentKey
 import fi.espoo.evaka.invoicing.data.markVoucherValueDecisionsSent
-import fi.espoo.evaka.invoicing.data.partnerIsCodebtor
 import fi.espoo.evaka.invoicing.data.removeVoucherValueDecisionIgnore
 import fi.espoo.evaka.invoicing.data.setVoucherValueDecisionToIgnored
 import fi.espoo.evaka.invoicing.data.setVoucherValueDecisionType
@@ -38,7 +37,6 @@ import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.EvakaClock
-import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.NotFound
 import fi.espoo.evaka.shared.domain.OfficialLanguage
 import fi.espoo.evaka.shared.message.IMessageProvider
@@ -203,17 +201,8 @@ class VoucherValueDecisionService(
         tx: Database.Read,
         decisionId: VoucherValueDecisionId,
     ): VoucherValueDecisionDetailed =
-        tx.getVoucherValueDecision(decisionId)?.let {
-            it.copy(
-                partnerIsCodebtor =
-                    tx.partnerIsCodebtor(
-                        it.headOfFamily.id,
-                        it.partner?.id,
-                        listOf(it.child.id),
-                        FiniteDateRange(it.validFrom, it.validTo),
-                    )
-            )
-        } ?: error("No voucher value decision found with ID ($decisionId)")
+        tx.getVoucherValueDecision(decisionId)
+            ?: error("No voucher value decision found with ID ($decisionId)")
 
     private fun generatePdf(
         decision: VoucherValueDecisionDetailed,


### PR DESCRIPTION
- Haetaan kanssavelalliset kahdella SQL-queryllä kaikille maksupäätöksille, sen sijaan että tehtäisiin yksi SQL-query per maksupäätös.
- Rajataan poissaolohakua lasten ID:illä, jolloin indeksien käytön pitäisi olla tehokkaampaa. Haku myös kohdistuu vain niihin lapsiin, joiden poissoloista ollaan oikeasti kiinnostuneita.
- Valmistaudutaan yksittäisen päämiehen laskujen generointiin rajaamalla myös muuta haettua dataa lasten ID:illä