### PR TITLE
Lisätään sijoitusehdotuksen hylkäyksen syy hakemuksen muistiinpanoihin

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposals.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposals.tsx
@@ -300,7 +300,12 @@ export default React.memo(function PlacementProposals({
           <MutateButton
             data-qa="placement-proposals-accept-button"
             mutation={acceptPlacementProposalMutation}
-            onClick={() => ({ unitId })}
+            onClick={() => ({
+              unitId,
+              body: {
+                rejectReasons: i18n.unit.placementProposals.rejectReasons
+              }
+            })}
             onSuccess={() => undefined}
             onFailure={onAcceptFailure}
             disabled={acceptDisabled}

--- a/frontend/src/employee-frontend/generated/api-clients/application.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/application.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import { AcceptDecisionRequest } from 'lib-common/generated/api-types/application'
+import { AcceptPlacementProposalRequest } from 'lib-common/generated/api-types/application'
 import { ApplicationNote } from 'lib-common/generated/api-types/application'
 import { ApplicationNoteResponse } from 'lib-common/generated/api-types/application'
 import { ApplicationResponse } from 'lib-common/generated/api-types/application'
@@ -62,12 +63,14 @@ export async function acceptDecision(
 */
 export async function acceptPlacementProposal(
   request: {
-    unitId: UUID
+    unitId: UUID,
+    body: AcceptPlacementProposalRequest
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/placement-proposals/${request.unitId}/accept`.toString(),
-    method: 'POST'
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<AcceptPlacementProposalRequest>
   })
   return json
 }

--- a/frontend/src/lib-common/generated/api-types/application.ts
+++ b/frontend/src/lib-common/generated/api-types/application.ts
@@ -39,6 +39,13 @@ export interface AcceptDecisionRequest {
 }
 
 /**
+* Generated from fi.espoo.evaka.application.AcceptPlacementProposalRequest
+*/
+export interface AcceptPlacementProposalRequest {
+  rejectReasons: Record<PlacementPlanRejectReason, string>
+}
+
+/**
 * Generated from fi.espoo.evaka.application.Address
 */
 export interface Address {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -5,6 +5,7 @@
 package fi.espoo.evaka.application
 
 import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.application.notes.getApplicationNotes
 import fi.espoo.evaka.attachment.AttachmentType
 import fi.espoo.evaka.daycare.getChild
 import fi.espoo.evaka.decision.Decision
@@ -22,6 +23,7 @@ import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementPlan
 import fi.espoo.evaka.placement.PlacementPlanConfirmationStatus
+import fi.espoo.evaka.placement.PlacementPlanRejectReason
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getPlacementPlan
 import fi.espoo.evaka.placement.getPlacementsForChild
@@ -78,12 +80,14 @@ import fi.espoo.evaka.vtjclient.service.persondetails.legacyMockVtjDataset
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
+import kotlin.enums.enumEntries
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -1388,13 +1392,23 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId,
                 PlacementPlanConfirmationStatus.ACCEPTED,
             )
-            service.confirmPlacementProposalChanges(tx, serviceWorker, clock, testDaycare.id)
+            service.confirmPlacementProposalChanges(
+                tx,
+                serviceWorker,
+                clock,
+                testDaycare.id,
+                rejectReasons =
+                    enumEntries<PlacementPlanRejectReason>().associateBy({ it }, { it.name }),
+            )
         }
         asyncJobRunner.runPendingJobsSync(clock)
         db.read { tx ->
             // then
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_CONFIRMATION, application.status)
+
+            val notes = tx.getApplicationNotes(applicationId)
+            assertEquals(emptyList(), notes)
 
             val decisionsByApplication =
                 tx.getDecisionsByApplication(applicationId, AccessControlFilter.PermitAll)
@@ -1455,13 +1469,23 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                 applicationId,
                 PlacementPlanConfirmationStatus.ACCEPTED,
             )
-            service.confirmPlacementProposalChanges(tx, serviceWorker, clock, testDaycare.id)
+            service.confirmPlacementProposalChanges(
+                tx,
+                serviceWorker,
+                clock,
+                testDaycare.id,
+                rejectReasons =
+                    enumEntries<PlacementPlanRejectReason>().associateBy({ it }, { it.name }),
+            )
         }
         asyncJobRunner.runPendingJobsSync(clock)
         db.read { tx ->
             // then
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_UNIT_CONFIRMATION, application.status)
+
+            val notes = tx.getApplicationNotes(applicationId)
+            assertEquals(emptyList(), notes)
 
             val decisionDrafts = tx.fetchDecisionDrafts(applicationId)
             assertEquals(2, decisionDrafts.size)
@@ -1481,6 +1505,143 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
 
             assertEquals(1, tx.getParentships(testAdult_1.id, testChild_2.id).size)
             assertEquals(0, tx.getParentships(testAdult_2.id, testChild_2.id).size)
+        }
+    }
+
+    @Test
+    fun `confirmPlacementProposalChanges - reject reason is copied to application notes`() {
+        val rejectReason = "päiväkoti täynnä"
+        db.transaction { tx ->
+            // given
+            tx.insertApplication(
+                appliedType = PlacementType.PRESCHOOL_DAYCARE,
+                child = testChild_2,
+                guardian = testAdult_1,
+                applicationId = applicationId,
+                preferredStartDate = LocalDate.of(2020, 8, 1),
+            )
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
+            service.createPlacementPlan(
+                tx,
+                serviceWorker,
+                clock,
+                applicationId,
+                DaycarePlacementPlan(
+                    unitId = testDaycare.id,
+                    period = mainPeriod,
+                    preschoolDaycarePeriod = connectedPeriod,
+                ),
+            )
+            service.sendPlacementProposal(tx, serviceWorker, clock, applicationId)
+        }
+        db.transaction { tx ->
+            // when
+            service.respondToPlacementProposal(
+                tx,
+                serviceWorker,
+                clock,
+                applicationId,
+                PlacementPlanConfirmationStatus.REJECTED_NOT_CONFIRMED,
+                PlacementPlanRejectReason.REASON_1,
+            )
+            service.confirmPlacementProposalChanges(
+                tx,
+                serviceWorker,
+                clock,
+                testDaycare.id,
+                rejectReasons = mapOf(PlacementPlanRejectReason.REASON_1 to rejectReason),
+            )
+        }
+        asyncJobRunner.runPendingJobsSync(clock)
+        db.read { tx ->
+            // then
+            val application = tx.fetchApplicationDetails(applicationId)!!
+            assertEquals(ApplicationStatus.WAITING_UNIT_CONFIRMATION, application.status)
+
+            val notes = tx.getApplicationNotes(applicationId)
+            assertThat(notes)
+                .extracting({ it.applicationId }, { it.content }, { it.createdBy })
+                .containsExactly(Tuple(applicationId, rejectReason, serviceWorker.evakaUserId))
+
+            val decisionsByApplication =
+                tx.getDecisionsByApplication(applicationId, AccessControlFilter.PermitAll)
+            assertEquals(2, decisionsByApplication.size)
+            decisionsByApplication.forEach { decision ->
+                assertNull(decision.sentDate)
+                assertNull(decision.documentKey)
+            }
+            val messages = MockSfiMessagesClient.getMessages()
+            assertEquals(0, messages.size)
+        }
+    }
+
+    @Test
+    fun `confirmPlacementProposalChanges - reject other reason is copied to application notes`() {
+        val rejectReason = "päiväkoti täynnä"
+        db.transaction { tx ->
+            // given
+            tx.insertApplication(
+                appliedType = PlacementType.PRESCHOOL_DAYCARE,
+                child = testChild_2,
+                guardian = testAdult_1,
+                applicationId = applicationId,
+                preferredStartDate = LocalDate.of(2020, 8, 1),
+            )
+            service.sendApplication(tx, serviceWorker, clock, applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, applicationId)
+            service.createPlacementPlan(
+                tx,
+                serviceWorker,
+                clock,
+                applicationId,
+                DaycarePlacementPlan(
+                    unitId = testDaycare.id,
+                    period = mainPeriod,
+                    preschoolDaycarePeriod = connectedPeriod,
+                ),
+            )
+            service.sendPlacementProposal(tx, serviceWorker, clock, applicationId)
+        }
+        db.transaction { tx ->
+            // when
+            service.respondToPlacementProposal(
+                tx,
+                serviceWorker,
+                clock,
+                applicationId,
+                PlacementPlanConfirmationStatus.REJECTED_NOT_CONFIRMED,
+                PlacementPlanRejectReason.OTHER,
+                rejectReason,
+            )
+            service.confirmPlacementProposalChanges(
+                tx,
+                serviceWorker,
+                clock,
+                testDaycare.id,
+                rejectReasons = emptyMap(),
+            )
+        }
+        asyncJobRunner.runPendingJobsSync(clock)
+        db.read { tx ->
+            // then
+            val application = tx.fetchApplicationDetails(applicationId)!!
+            assertEquals(ApplicationStatus.WAITING_UNIT_CONFIRMATION, application.status)
+
+            val notes = tx.getApplicationNotes(applicationId)
+            assertThat(notes)
+                .extracting({ it.applicationId }, { it.content }, { it.createdBy })
+                .containsExactly(Tuple(applicationId, rejectReason, serviceWorker.evakaUserId))
+
+            val decisionsByApplication =
+                tx.getDecisionsByApplication(applicationId, AccessControlFilter.PermitAll)
+            assertEquals(2, decisionsByApplication.size)
+            decisionsByApplication.forEach { decision ->
+                assertNull(decision.sentDate)
+                assertNull(decision.documentKey)
+            }
+            val messages = MockSfiMessagesClient.getMessages()
+            assertEquals(0, messages.size)
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -528,10 +528,17 @@ class ApplicationControllerV2(
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,
         @PathVariable unitId: DaycareId,
+        @RequestBody body: AcceptPlacementProposalRequest,
     ) {
         db.connect { dbc ->
             dbc.transaction {
-                applicationStateService.confirmPlacementProposalChanges(it, user, clock, unitId)
+                applicationStateService.confirmPlacementProposalChanges(
+                    it,
+                    user,
+                    clock,
+                    unitId,
+                    body.rejectReasons,
+                )
             }
         }
     }
@@ -784,6 +791,10 @@ data class PlacementProposalConfirmationUpdate(
     val status: PlacementPlanConfirmationStatus,
     val reason: PlacementPlanRejectReason?,
     val otherReason: String?,
+)
+
+data class AcceptPlacementProposalRequest(
+    val rejectReasons: Map<PlacementPlanRejectReason, String>
 )
 
 data class DaycarePlacementPlan(


### PR DESCRIPTION
Kun johtaja hylkää sijoitusehdotuksen ja kirjaa hylkäykseen syyn, teksti katoaa, kun palveluohjaus palauttaa sijoitusehdotuksen sieltä johtajan tarkistettavana tilasta taaksepäin.

Tämän muutoksen myötä palveluohjaus näkee hylkäyksen syyn hakemuksen muistiinpanoista.