### PR TITLE
Poistetaan curl frontend-imagesta

### DIFF
--- a/compose/e2e/playwright.Dockerfile
+++ b/compose/e2e/playwright.Dockerfile
@@ -13,5 +13,6 @@ RUN apt-get update \
 RUN yarn exec playwright install --with-deps
 
 COPY ./playwright/bin/run-tests.sh /bin/
+COPY ./playwright/bin/wait-for-url.sh /bin/
 
 CMD ["/bin/run-tests.sh"]

--- a/compose/e2e/playwright/bin/run-tests.sh
+++ b/compose/e2e/playwright/bin/run-tests.sh
@@ -22,9 +22,9 @@ yarn install --immutable
 yarn exec playwright install
 
 echo 'INFO: Waiting for compose stack to be up ...'
-./wait-for-url.sh "${PROXY_URL}/api/internal/dev-api"
-./wait-for-url.sh "${KEYCLOAK_URL}/auth/realms/evaka-customer/account/" "200"
-./wait-for-url.sh "${DUMMY_SUOMIFI_URL}/health" "200"
+wait-for-url.sh "${PROXY_URL}/api/internal/dev-api"
+wait-for-url.sh "${KEYCLOAK_URL}/auth/realms/evaka-customer/account/" "200"
+wait-for-url.sh "${DUMMY_SUOMIFI_URL}/health" "200"
 
 echo "Running tests ..."
 

--- a/compose/e2e/playwright/bin/wait-for-url.sh
+++ b/compose/e2e/playwright/bin/wait-for-url.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2017-2022 City of Espoo
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+url="$1"
+code="${2:-200}"
+healthcheck() {
+	curl -sSw "%{http_code}" --connect-timeout 3 --max-time 5 "$url" -o /dev/null
+}
+
+TRIES=60
+
+while [ $TRIES -gt 0 ]; do
+	STATUS=$(healthcheck)
+
+	if [ "$STATUS" = "${code}" ]; then
+		exit 0
+	fi
+	echo "Got $STATUS for $url - retrying ..."
+	sleep 5s
+	TRIES=$((TRIES - 1))
+done
+
+echo "Failed to wait for code $code from $url"
+
+exit 1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -88,7 +88,8 @@ RUN cd /tmp \
  && curl -sSfLO https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz \
  && echo "${DD_OPENTRACING_CPP_SHA256}  linux-amd64-libdd_opentracing_plugin.so.gz" | sha256sum -c - \
  && gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so \
- && rm linux-amd64-libdd_opentracing_plugin.so.gz
+ && rm linux-amd64-libdd_opentracing_plugin.so.gz \
+ && apt-get remove --auto-remove -y curl
 
 COPY ./proxy/files/bin/ /bin/
 COPY ./proxy/files/internal/ /internal/


### PR DESCRIPTION
`curl`illa on riippuvuus `openldap`-kirjastoon, jossa on korjaamattomia haavoittuvuuksia. Poistetaan `curl` `frontend` imagesta ja lisätään se `playwright`-imageen, jossa sitä tarvitaan. `playwright` image on käytössä vain GitHubissa testejä ajettaessa, joten haavoittuvuudella ei ole siellä merkitystä.