### PR TITLE
Vaihtoehtoinen poissaolokyselyn tyyppi

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -36,6 +36,7 @@ import DiscussionReservationModal from './discussion-reservation-modal/Discussio
 import DiscussionSurveyModal from './discussion-reservation-modal/DiscussionSurveyModal'
 import { showModalEventTime } from './discussion-reservation-modal/discussion-survey'
 import FixedPeriodSelectionModal from './holiday-modal/FixedPeriodSelectionModal'
+import OpenRangesSelectionModal from './holiday-modal/OpenRangesSelectionModal'
 import { useExtendedReservationsRange } from './hooks'
 import {
   activeQuestionnaireQuery,
@@ -319,6 +320,14 @@ const CalendarPage = React.memo(function CalendarPage() {
                 >
                   {questionnaire.questionnaire.type === 'FIXED_PERIOD' ? (
                     <FixedPeriodSelectionModal
+                      close={closeModal}
+                      questionnaire={questionnaire.questionnaire}
+                      availableChildren={response.children}
+                      eligibleChildren={questionnaire.eligibleChildren}
+                      previousAnswers={questionnaire.previousAnswers}
+                    />
+                  ) : questionnaire.questionnaire.type === 'OPEN_RANGES' ? (
+                    <OpenRangesSelectionModal
                       close={closeModal}
                       questionnaire={questionnaire.questionnaire}
                       availableChildren={response.children}

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -317,13 +317,17 @@ const CalendarPage = React.memo(function CalendarPage() {
                       : 'WEAK'
                   }
                 >
-                  <FixedPeriodSelectionModal
-                    close={closeModal}
-                    questionnaire={questionnaire.questionnaire}
-                    availableChildren={response.children}
-                    eligibleChildren={questionnaire.eligibleChildren}
-                    previousAnswers={questionnaire.previousAnswers}
-                  />
+                  {questionnaire.questionnaire.type === 'FIXED_PERIOD' ? (
+                    <FixedPeriodSelectionModal
+                      close={closeModal}
+                      questionnaire={questionnaire.questionnaire}
+                      availableChildren={response.children}
+                      eligibleChildren={questionnaire.eligibleChildren}
+                      previousAnswers={questionnaire.previousAnswers}
+                    />
+                  ) : (
+                    <div>Not Yet Implemented</div>
+                  )}
                 </RequireAuth>
               )}
             </div>

--- a/frontend/src/citizen-frontend/calendar/holiday-modal/FixedPeriodSelectionModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/holiday-modal/FixedPeriodSelectionModal.tsx
@@ -9,7 +9,7 @@ import { useLang, useTranslation } from 'citizen-frontend/localization'
 import { getDuplicateChildInfo } from 'citizen-frontend/utils/duplicated-child-utils'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import {
-  FixedPeriodQuestionnaire,
+  HolidayQuestionnaire,
   FixedPeriodsBody,
   HolidayQuestionnaireAnswer
 } from 'lib-common/generated/api-types/holidayperiod'
@@ -25,6 +25,8 @@ import ModalAccessibilityWrapper from '../../ModalAccessibilityWrapper'
 import { answerFixedPeriodQuestionnaireMutation } from '../queries'
 
 import { PeriodSelector } from './PeriodSelector'
+
+import FixedPeriodQuestionnaire = HolidayQuestionnaire.FixedPeriodQuestionnaire
 
 type FormState = FixedPeriodsBody['fixedPeriods']
 
@@ -75,9 +77,10 @@ export default React.memo(function FixedPeriodSelectionModal({
     <ModalAccessibilityWrapper>
       <MutateFormModal
         mobileFullScreen
-        title={questionnaire.title[lang]}
+        title={questionnaire.title[lang]} // eslint-disable-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
         resolveMutation={answerFixedPeriodQuestionnaireMutation}
         resolveAction={() => ({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
           id: questionnaire.id,
           body: { fixedPeriods }
         })}
@@ -89,10 +92,11 @@ export default React.memo(function FixedPeriodSelectionModal({
       >
         <FixedSpaceColumn>
           <HolidaySection>
+            {/* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access */}
             <div>{questionnaire.description[lang]}</div>
             <ExternalLink
               text={i18n.calendar.holidayModal.additionalInformation}
-              href={questionnaire.descriptionLink[lang]}
+              href={questionnaire.descriptionLink[lang]} // eslint-disable-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
               newTab
             />
           </HolidaySection>
@@ -114,9 +118,10 @@ export default React.memo(function FixedPeriodSelectionModal({
                   value={fixedPeriods[child.id] ?? null}
                   onSelectPeriod={selectPeriod(child.id)}
                 />
-              ) : questionnaire.conditions.continuousPlacement ? (
+              ) : questionnaire.conditions.continuousPlacement ? ( // eslint-disable-line @typescript-eslint/no-unsafe-member-access
                 <div data-qa="not-eligible">
                   {i18n.calendar.holidayModal.notEligible(
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
                     questionnaire.conditions.continuousPlacement
                   )}
                 </div>

--- a/frontend/src/citizen-frontend/calendar/holiday-modal/OpenRangesSelectionModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/holiday-modal/OpenRangesSelectionModal.tsx
@@ -114,7 +114,7 @@ export default React.memo(function OpenRangesSelectionModal({
               {eligibleChildren.includes(child.id) ? (
                 <RangeSelector
                   period={questionnaire.period}
-                  value={openRanges[child.id] ? openRanges[child.id] : []}
+                  value={openRanges[child.id] ?? []}
                   onSelectRanges={selectRanges(child.id)}
                 />
               ) : questionnaire.conditions.continuousPlacement ? (

--- a/frontend/src/citizen-frontend/calendar/holiday-modal/OpenRangesSelectionModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/holiday-modal/OpenRangesSelectionModal.tsx
@@ -35,7 +35,6 @@ const initializeForm = (
   children.reduce(
     (acc, child) => ({
       ...acc,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       [child.id]:
         previousAnswers.find((a) => a.childId === child.id)?.openRanges ?? []
     }),

--- a/frontend/src/citizen-frontend/calendar/holiday-modal/OpenRangesSelectionModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/holiday-modal/OpenRangesSelectionModal.tsx
@@ -1,17 +1,15 @@
-// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
-import { useLang, useTranslation } from 'citizen-frontend/localization'
-import { getDuplicateChildInfo } from 'citizen-frontend/utils/duplicated-child-utils'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import {
   HolidayQuestionnaire,
-  FixedPeriodsBody,
-  HolidayQuestionnaireAnswer
+  HolidayQuestionnaireAnswer,
+  OpenRangesBody
 } from 'lib-common/generated/api-types/holidayperiod'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
 import { formatFirstName } from 'lib-common/names'
@@ -22,11 +20,13 @@ import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
 import { H2 } from 'lib-components/typography'
 
 import ModalAccessibilityWrapper from '../../ModalAccessibilityWrapper'
-import { answerFixedPeriodQuestionnaireMutation } from '../queries'
+import { useLang, useTranslation } from '../../localization'
+import { getDuplicateChildInfo } from '../../utils/duplicated-child-utils'
+import { answerOpenRangesQuestionnaireMutation } from '../queries'
 
-import { PeriodSelector } from './PeriodSelector'
+import { RangeSelector } from './RangesSelector'
 
-type FormState = FixedPeriodsBody['fixedPeriods']
+type FormState = OpenRangesBody['openRanges']
 
 const initializeForm = (
   children: ReservationChild[],
@@ -35,21 +35,22 @@ const initializeForm = (
   children.reduce(
     (acc, child) => ({
       ...acc,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       [child.id]:
-        previousAnswers.find((a) => a.childId === child.id)?.fixedPeriod ?? null
+        previousAnswers.find((a) => a.childId === child.id)?.openRanges ?? []
     }),
     {}
   )
 
 interface Props {
   close: () => void
-  questionnaire: HolidayQuestionnaire.FixedPeriodQuestionnaire
+  questionnaire: HolidayQuestionnaire.OpenRangesQuestionnaire
   availableChildren: ReservationChild[]
   eligibleChildren: UUID[]
   previousAnswers: HolidayQuestionnaireAnswer[]
 }
 
-export default React.memo(function FixedPeriodSelectionModal({
+export default React.memo(function OpenRangesSelectionModal({
   close,
   questionnaire,
   availableChildren,
@@ -59,14 +60,17 @@ export default React.memo(function FixedPeriodSelectionModal({
   const i18n = useTranslation()
   const [lang] = useLang()
 
-  const [fixedPeriods, setFixedPeriods] = useState<FormState>(() =>
+  const [openRanges, setOpenRanges] = useState<FormState>(() =>
     initializeForm(availableChildren, previousAnswers)
   )
 
-  const selectPeriod = useCallback(
-    (childId: string) => (period: FiniteDateRange | null) =>
-      setFixedPeriods((prev) => ({ ...prev, [childId]: period })),
-    [setFixedPeriods]
+  const selectRanges = useCallback(
+    (childId: string) => (ranges: FiniteDateRange[]) =>
+      setOpenRanges((prev) => ({
+        ...prev,
+        [childId]: ranges
+      })),
+    [setOpenRanges]
   )
 
   const duplicateChildInfo = getDuplicateChildInfo(availableChildren, i18n)
@@ -76,20 +80,21 @@ export default React.memo(function FixedPeriodSelectionModal({
       <MutateFormModal
         mobileFullScreen
         title={questionnaire.title[lang]}
-        resolveMutation={answerFixedPeriodQuestionnaireMutation}
+        resolveMutation={answerOpenRangesQuestionnaireMutation}
         resolveAction={() => ({
           id: questionnaire.id,
-          body: { fixedPeriods }
+          body: { openRanges }
         })}
-        onSuccess={close}
         resolveLabel={i18n.common.confirm}
+        onSuccess={close}
         rejectAction={close}
         rejectLabel={i18n.common.cancel}
-        data-qa="fixed-period-selection-modal"
+        data-qa="open-ranges-selection-modal"
       >
         <FixedSpaceColumn>
           <HolidaySection>
             <div>{questionnaire.description[lang]}</div>
+            <div>{questionnaire.period.format()}</div>
             <ExternalLink
               text={i18n.calendar.holidayModal.additionalInformation}
               href={questionnaire.descriptionLink[lang]}
@@ -108,11 +113,10 @@ export default React.memo(function FixedPeriodSelectionModal({
                   : ''}
               </H2>
               {eligibleChildren.includes(child.id) ? (
-                <PeriodSelector
-                  label={questionnaire.periodOptionLabel[lang]}
-                  options={questionnaire.periodOptions}
-                  value={fixedPeriods[child.id] ?? null}
-                  onSelectPeriod={selectPeriod(child.id)}
+                <RangeSelector
+                  period={questionnaire.period}
+                  value={openRanges[child.id] ? openRanges[child.id] : []}
+                  onSelectRanges={selectRanges(child.id)}
                 />
               ) : questionnaire.conditions.continuousPlacement ? (
                 <div data-qa="not-eligible">

--- a/frontend/src/citizen-frontend/calendar/holiday-modal/RangesSelector.tsx
+++ b/frontend/src/citizen-frontend/calendar/holiday-modal/RangesSelector.tsx
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import isEqual from 'lodash/isEqual'
+import React, { useCallback, useContext } from 'react'
+
+import FiniteDateRange from 'lib-common/finite-date-range'
+import { localDateRange } from 'lib-common/form/fields'
+import { array, object, required, transformed } from 'lib-common/form/form'
+import { useForm, useFormElems, useFormFields } from 'lib-common/form/hooks'
+import {
+  StateOf,
+  ValidationError,
+  ValidationSuccess
+} from 'lib-common/form/types'
+import UnderRowStatusIcon from 'lib-components/atoms/StatusIcon'
+import { Button } from 'lib-components/atoms/buttons/Button'
+import { InputFieldUnderRow } from 'lib-components/atoms/form/InputField'
+import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
+import { DateRangePickerF } from 'lib-components/molecules/date-picker/DateRangePicker'
+import { Gap } from 'lib-components/white-space'
+import { faPlus, faTrash } from 'lib-icons'
+
+import { useTranslation } from '../../localization'
+import { LocalizationContext } from '../../localization/state'
+
+interface Props {
+  period: FiniteDateRange
+  value: FiniteDateRange[]
+  onSelectRanges: (selection: FiniteDateRange[]) => void
+}
+
+function checkForOverlappingRanges(ranges: FiniteDateRange[]): boolean {
+  const rangesProcessed: FiniteDateRange[] = []
+
+  for (const value of ranges) {
+    if (rangesProcessed.some((range) => value.overlaps(range))) {
+      return true
+    }
+    rangesProcessed.push(value)
+  }
+  return false
+}
+
+const rangesForm = transformed(
+  object({
+    period: required(localDateRange()),
+    ranges: array(required(localDateRange()))
+  }),
+  ({ period, ranges }) => {
+    if (ranges.length > 0) {
+      if (ranges.some((range) => range.start.isBefore(period.start))) {
+        return ValidationError.field('ranges', 'dateTooEarly')
+      }
+      if (ranges.some((range) => range.end.isAfter(period.end))) {
+        return ValidationError.field('ranges', 'dateTooLate')
+      }
+      if (checkForOverlappingRanges(ranges)) {
+        return ValidationError.field('ranges', 'rangesOverlap')
+      }
+    }
+    return ValidationSuccess.of(ranges)
+  }
+)
+
+function initialFormState(
+  period: FiniteDateRange,
+  ranges: FiniteDateRange[]
+): StateOf<typeof rangesForm> {
+  return {
+    period: localDateRange.fromRange(period),
+    ranges:
+      ranges.length > 0
+        ? ranges.map((range) => localDateRange.fromRange(range))
+        : [localDateRange.empty()]
+  }
+}
+
+export const RangeSelector = React.memo(function RangeSelector({
+  period,
+  value,
+  onSelectRanges
+}: Props) {
+  const i18n = useTranslation()
+  const { lang } = useContext(LocalizationContext)
+
+  const form = useForm(
+    rangesForm,
+    () => initialFormState(period, value),
+    {
+      ...i18n.validationErrors,
+      rangesOverlap: i18n.calendar.holidayModal.rangesOverlap
+    },
+    {
+      onUpdate: (prevState, nextState, form) => {
+        const shape = form.shape()
+        const prev = shape.ranges.validate(prevState.ranges)
+        const next = shape.ranges.validate(nextState.ranges)
+
+        if (!next.isValid) return nextState
+        const ranges = next.value
+
+        if (!prev.isValid) return nextState
+
+        const prevRanges = prev.value
+        if (!isEqual(prevRanges, ranges)) {
+          onSelectRanges(ranges)
+        } else {
+          onSelectRanges(ranges)
+        }
+
+        return nextState
+      }
+    }
+  )
+
+  const { ranges } = useFormFields(form)
+  const rangeElems = useFormElems(ranges)
+
+  const addRangeEntry = useCallback(() => {
+    ranges.update((prev) => [...prev, localDateRange.empty()])
+  }, [ranges])
+
+  const removeRangeEntry = useCallback(
+    (index: number) => {
+      ranges.update((prev) => [
+        ...prev.slice(0, index),
+        ...prev.slice(index + 1)
+      ])
+    },
+    [ranges]
+  )
+
+  return (
+    <div>
+      {rangeElems.map((range, i) => (
+        <FixedSpaceRow
+          key={`tb-${i}`}
+          data-qa="range"
+          alignItems="center"
+          spacing="m"
+        >
+          <div className="bold">{`${i + 1}.`}</div>
+          <DateRangePickerF
+            hideErrorsBeforeTouched
+            bind={range}
+            locale={lang}
+            data-qa={`range-input-${i + 1}`}
+          />
+
+          <Button
+            appearance="inline"
+            text={i18n.common.delete}
+            icon={faTrash}
+            data-qa="range-break-button"
+            onClick={() => removeRangeEntry(i)}
+          />
+        </FixedSpaceRow>
+      ))}
+
+      {!ranges.isValid() && ranges.inputInfo() ? (
+        <InputFieldUnderRow className="warning">
+          <span data-qa="remove-range-info">{ranges.inputInfo()?.text}</span>
+          <UnderRowStatusIcon status="warning" />
+        </InputFieldUnderRow>
+      ) : undefined}
+
+      <Gap size="L" />
+
+      <Button
+        appearance="inline"
+        text={i18n.calendar.holidayModal.addTimePeriod}
+        icon={faPlus}
+        data-qa="add-range-button"
+        onClick={addRangeEntry}
+      />
+    </div>
+  )
+})

--- a/frontend/src/citizen-frontend/calendar/queries.ts
+++ b/frontend/src/citizen-frontend/calendar/queries.ts
@@ -14,7 +14,8 @@ import {
 } from '../generated/api-clients/calendarevent'
 import { getDailyServiceTimeNotifications } from '../generated/api-clients/dailyservicetimes'
 import {
-  answerFixedPeriodQuestionnaire, answerOpenRangeQuestionnaire,
+  answerFixedPeriodQuestionnaire,
+  answerOpenRangeQuestionnaire,
   getActiveQuestionnaires,
   getHolidayPeriods
 } from '../generated/api-clients/holidayperiod'

--- a/frontend/src/citizen-frontend/calendar/queries.ts
+++ b/frontend/src/citizen-frontend/calendar/queries.ts
@@ -14,7 +14,7 @@ import {
 } from '../generated/api-clients/calendarevent'
 import { getDailyServiceTimeNotifications } from '../generated/api-clients/dailyservicetimes'
 import {
-  answerFixedPeriodQuestionnaire,
+  answerFixedPeriodQuestionnaire, answerOpenRangeQuestionnaire,
   getActiveQuestionnaires,
   getHolidayPeriods
 } from '../generated/api-clients/holidayperiod'
@@ -95,6 +95,14 @@ export const activeQuestionnaireQuery = query({
 
 export const answerFixedPeriodQuestionnaireMutation = mutation({
   api: answerFixedPeriodQuestionnaire,
+  invalidateQueryKeys: () => [
+    activeQuestionnaireQuery().queryKey,
+    queryKeys.allReservations()
+  ]
+})
+
+export const answerOpenRangesQuestionnaireMutation = mutation({
+  api: answerOpenRangeQuestionnaire,
   invalidateQueryKeys: () => [
     activeQuestionnaireQuery().queryKey,
     queryKeys.allReservations()

--- a/frontend/src/citizen-frontend/generated/api-clients/holidayperiod.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/holidayperiod.ts
@@ -10,6 +10,7 @@ import { HolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
 import { HolidayQuestionnaireId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { OpenRangesBody } from 'lib-common/generated/api-types/holidayperiod'
 import { client } from '../../api-client'
 import { deserializeJsonActiveQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
 import { deserializeJsonHolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
@@ -29,6 +30,24 @@ export async function answerFixedPeriodQuestionnaire(
     url: uri`/citizen/holiday-period/questionnaire/fixed-period/${request.id}`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<FixedPeriodsBody>
+  })
+  return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.holidayperiod.HolidayPeriodControllerCitizen.answerOpenRangeQuestionnaire
+*/
+export async function answerOpenRangeQuestionnaire(
+  request: {
+    id: HolidayQuestionnaireId,
+    body: OpenRangesBody
+  }
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/citizen/holiday-period/questionnaire/open-range/${request.id}`.toString(),
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<OpenRangesBody>
   })
   return json
 }

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -24,7 +24,7 @@ import {
 import { ClubTerm } from 'lib-common/generated/api-types/daycare'
 import { DocumentContent } from 'lib-common/generated/api-types/document'
 import {
-  FixedPeriodQuestionnaire,
+  HolidayQuestionnaire,
   HolidayPeriod
 } from 'lib-common/generated/api-types/holidayperiod'
 import {
@@ -148,6 +148,8 @@ import {
   ReservationInsert,
   VoucherValueDecision
 } from '../generated/api-types'
+
+import FixedPeriodQuestionnaire = HolidayQuestionnaire.FixedPeriodQuestionnaire
 
 const uniqueLabel = (l = 7): string =>
   Math.random().toString(36).substring(0, l)

--- a/frontend/src/e2e-test/generated/api-clients.ts
+++ b/frontend/src/e2e-test/generated/api-clients.ts
@@ -91,7 +91,6 @@ import { EmployeeId } from 'lib-common/generated/api-types/shared'
 import { FeeDecision } from 'lib-common/generated/api-types/invoicing'
 import { FeeThresholds } from 'lib-common/generated/api-types/invoicing'
 import { FeeThresholdsId } from 'lib-common/generated/api-types/shared'
-import { FixedPeriodQuestionnaireBody } from 'lib-common/generated/api-types/holidayperiod'
 import { GroupId } from 'lib-common/generated/api-types/shared'
 import { GroupNoteBody } from 'lib-common/generated/api-types/note'
 import { GroupNoteId } from 'lib-common/generated/api-types/shared'
@@ -111,6 +110,7 @@ import { PlacementPlan } from './api-types'
 import { PostPairingChallengeReq } from 'lib-common/generated/api-types/pairing'
 import { PostPairingReq } from 'lib-common/generated/api-types/pairing'
 import { PostPairingResponseReq } from 'lib-common/generated/api-types/pairing'
+import { QuestionnaireBody } from 'lib-common/generated/api-types/holidayperiod'
 import { ReservationInsert } from './api-types'
 import { ServiceNeedOption } from 'lib-common/generated/api-types/serviceneed'
 import { SfiMessage } from './api-types'
@@ -1188,7 +1188,7 @@ export async function createHolidayPeriod(
 export async function createHolidayQuestionnaire(
   request: {
     id: HolidayQuestionnaireId,
-    body: FixedPeriodQuestionnaireBody
+    body: QuestionnaireBody
   },
   options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<void> {
@@ -1197,7 +1197,7 @@ export async function createHolidayQuestionnaire(
       url: uri`/holiday-period/questionnaire/${request.id}`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
-      data: request.body satisfies JsonCompatible<FixedPeriodQuestionnaireBody>
+      data: request.body satisfies JsonCompatible<QuestionnaireBody>
     })
     return json
   } catch (e) {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
-import { FixedPeriodQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
+import { HolidayQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
@@ -27,6 +27,8 @@ import CitizenCalendarPage from '../../pages/citizen/citizen-calendar'
 import CitizenHeader from '../../pages/citizen/citizen-header'
 import { Page } from '../../utils/page'
 import { enduserLogin } from '../../utils/user'
+
+import FixedPeriodQuestionnaire = HolidayQuestionnaire.FixedPeriodQuestionnaire
 
 let page: Page
 

--- a/frontend/src/employee-frontend/components/holiday-term-periods/FixedPeriodQuestionnaireForm.tsx
+++ b/frontend/src/employee-frontend/components/holiday-term-periods/FixedPeriodQuestionnaireForm.tsx
@@ -82,7 +82,6 @@ const parseDateRanges = (s: string) =>
 
 const formToQuestionnaireBody = (
   s: FormState
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 ): QuestionnaireBody.FixedPeriodQuestionnaireBody | undefined => {
   if (!s.start || !s.end) {
     return undefined
@@ -149,36 +148,33 @@ const emptyFormState: FormState = {
 }
 
 const toFormState = (
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   p: HolidayQuestionnaire.FixedPeriodQuestionnaire | undefined
 ): FormState =>
   p
     ? {
         type: 'FIXED_PERIOD',
         absenceType: 'FREE_ABSENCE',
-        requiresStrongAuth: p.requiresStrongAuth, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        titleFi: p.title.fi, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        titleSv: p.title.sv, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        titleEn: p.title.en, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        descriptionFi: p.description.fi, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        descriptionSv: p.description.sv, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        descriptionEn: p.description.en, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        descriptionLinkFi: p.descriptionLink.fi, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        descriptionLinkSv: p.descriptionLink.sv, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        descriptionLinkEn: p.descriptionLink.en, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        start: p.active.start, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        end: p.active.end, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        periodOptions: p.periodOptions.map((r) => r.format()).join(', '), // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
-        periodOptionLabelFi: p.periodOptionLabel.fi, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        periodOptionLabelSv: p.periodOptionLabel.sv, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        periodOptionLabelEn: p.periodOptionLabel.en, // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        requiresStrongAuth: p.requiresStrongAuth,
+        titleFi: p.title.fi,
+        titleSv: p.title.sv,
+        titleEn: p.title.en,
+        descriptionFi: p.description.fi,
+        descriptionSv: p.description.sv,
+        descriptionEn: p.description.en,
+        descriptionLinkFi: p.descriptionLink.fi,
+        descriptionLinkSv: p.descriptionLink.sv,
+        descriptionLinkEn: p.descriptionLink.en,
+        start: p.active.start,
+        end: p.active.end,
+        periodOptions: p.periodOptions.map((r) => r.format()).join(', '),
+        periodOptionLabelFi: p.periodOptionLabel.fi,
+        periodOptionLabelSv: p.periodOptionLabel.sv,
+        periodOptionLabelEn: p.periodOptionLabel.en,
+
         conditionContinuousPlacementStart:
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           p.conditions.continuousPlacement?.start ?? null,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
         conditionContinuousPlacementEnd:
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           p.conditions.continuousPlacement?.end ?? null
       }
     : emptyFormState
@@ -295,12 +291,11 @@ export default React.memo(function FixedPeriodQuestionnaireForm({
   )
 
   const onSubmit = useCallback(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const body = isValid && formToQuestionnaireBody(form)
     if (!body) return
     return questionnaire
-      ? updateFixedPeriodQuestionnaire({ id: questionnaire.id, body }) // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-      : createFixedPeriodQuestionnaire({ body }) // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+      ? updateFixedPeriodQuestionnaire({ id: questionnaire.id, body })
+      : createFixedPeriodQuestionnaire({ body })
   }, [
     createFixedPeriodQuestionnaire,
     updateFixedPeriodQuestionnaire,

--- a/frontend/src/employee-frontend/components/holiday-term-periods/OpenRangesQuestionnaireForm.tsx
+++ b/frontend/src/employee-frontend/components/holiday-term-periods/OpenRangesQuestionnaireForm.tsx
@@ -60,7 +60,6 @@ interface FormState {
 
 const formToQuestionnaireBody = (
   s: FormState
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 ): QuestionnaireBody.OpenRangesQuestionnaireBody | undefined => {
   if (!s.start || !s.end || !s.periodStart || !s.periodEnd) {
     return undefined
@@ -122,35 +121,30 @@ const emptyFormState: FormState = {
 }
 
 const toFormState = (
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   p: HolidayQuestionnaire.OpenRangesQuestionnaire | undefined
 ): FormState =>
   p
     ? {
         type: 'OPEN_RANGES',
         absenceType: 'FREE_ABSENCE',
-        requiresStrongAuth: p.requiresStrongAuth, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        titleFi: p.title.fi, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        titleSv: p.title.sv, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        titleEn: p.title.en, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        descriptionFi: p.description.fi, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        descriptionSv: p.description.sv, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        descriptionEn: p.description.en, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        descriptionLinkFi: p.descriptionLink.fi, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        descriptionLinkSv: p.descriptionLink.sv, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        descriptionLinkEn: p.descriptionLink.en, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        start: p.active.start, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        end: p.active.end, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        periodStart: p.period.start, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        periodEnd: p.period.end, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        absenceTypeThreshold: p.absenceTypeThreshold, // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        requiresStrongAuth: p.requiresStrongAuth,
+        titleFi: p.title.fi,
+        titleSv: p.title.sv,
+        titleEn: p.title.en,
+        descriptionFi: p.description.fi,
+        descriptionSv: p.description.sv,
+        descriptionEn: p.description.en,
+        descriptionLinkFi: p.descriptionLink.fi,
+        descriptionLinkSv: p.descriptionLink.sv,
+        descriptionLinkEn: p.descriptionLink.en,
+        start: p.active.start,
+        end: p.active.end,
+        periodStart: p.period.start,
+        periodEnd: p.period.end,
+        absenceTypeThreshold: p.absenceTypeThreshold,
         conditionContinuousPlacementStart:
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           p.conditions.continuousPlacement?.start ?? null,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         conditionContinuousPlacementEnd:
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           p.conditions.continuousPlacement?.end ?? null
       }
     : emptyFormState
@@ -158,7 +152,7 @@ const toFormState = (
 interface Props {
   onSuccess: () => void
   onCancel: () => void
-  questionnaire: HolidayQuestionnaire.OpenRangesQuestionnaire
+  questionnaire?: HolidayQuestionnaire.OpenRangesQuestionnaire
 }
 
 export default React.memo(function OpenRangesQuestionnaireForm({
@@ -278,12 +272,11 @@ export default React.memo(function OpenRangesQuestionnaireForm({
   )
 
   const onSubmit = useCallback(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const body = isValid && formToQuestionnaireBody(form)
     if (!body) return
     return questionnaire
-      ? updateOpenRangesQuestionnaire({ id: questionnaire.id, body }) // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-      : createOpenRangesQuestionnaire({ body }) // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+      ? updateOpenRangesQuestionnaire({ id: questionnaire.id, body })
+      : createOpenRangesQuestionnaire({ body })
   }, [
     createOpenRangesQuestionnaire,
     updateOpenRangesQuestionnaire,
@@ -473,8 +466,7 @@ export default React.memo(function OpenRangesQuestionnaireForm({
           hideErrorsBeforeTouched={hideErrorsBeforeTouched}
         />
 
-        {/*todo: juttuja*/}
-        <Label inputRow>{i18n.holidayQuestionnaires.period}</Label>
+        <Label inputRow>{i18n.holidayQuestionnaires.period} *</Label>
         <FixedSpaceRow alignItems="center">
           <DatePicker
             info={useMemo(
@@ -506,27 +498,32 @@ export default React.memo(function OpenRangesQuestionnaireForm({
         </FixedSpaceRow>
 
         <Label inputRow>
-          {i18n.holidayQuestionnaires.absenceTypeThreshold}
+          {i18n.holidayQuestionnaires.absenceTypeThreshold} *
         </Label>
-        <InputField
-          width="L"
-          placeholder="0"
-          type="number"
-          value={form.absenceTypeThreshold.toString()}
-          onChange={(absenceTypeThreshold) =>
-            update({ absenceTypeThreshold: parseInt(absenceTypeThreshold, 10) })
-          }
-          data-qa="input-absence-type-threshold"
-          info={useMemo(
-            () =>
-              errorToInputInfo(
-                errors.absenceTypeThreshold,
-                i18n.validationErrors
-              ),
-            [errors.absenceTypeThreshold, i18n]
-          )}
-          hideErrorsBeforeTouched={hideErrorsBeforeTouched}
-        />
+        <FixedSpaceRow alignItems="center">
+          <InputField
+            width="s"
+            placeholder="0"
+            type="number"
+            value={form.absenceTypeThreshold.toString()}
+            onChange={(absenceTypeThreshold) =>
+              update({
+                absenceTypeThreshold: parseInt(absenceTypeThreshold, 10)
+              })
+            }
+            data-qa="input-absence-type-threshold"
+            info={useMemo(
+              () =>
+                errorToInputInfo(
+                  errors.absenceTypeThreshold,
+                  i18n.validationErrors
+                ),
+              [errors.absenceTypeThreshold, i18n]
+            )}
+            hideErrorsBeforeTouched={hideErrorsBeforeTouched}
+          />
+          <span>{i18n.holidayQuestionnaires.days}</span>
+        </FixedSpaceRow>
 
         <Label inputRow>
           {i18n.holidayQuestionnaires.conditionContinuousPlacement}

--- a/frontend/src/employee-frontend/components/holiday-term-periods/OpenRangesQuestionnaireForm.tsx
+++ b/frontend/src/employee-frontend/components/holiday-term-periods/OpenRangesQuestionnaireForm.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 import React, { useCallback, useMemo, useState } from 'react'
 
 import FiniteDateRange from 'lib-common/finite-date-range'

--- a/frontend/src/employee-frontend/components/holiday-term-periods/QuestionnaireEditor.tsx
+++ b/frontend/src/employee-frontend/components/holiday-term-periods/QuestionnaireEditor.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router'
 import { useQueryResult } from 'lib-common/query'
 import useRouteParams from 'lib-common/useRouteParams'
 import Container, { ContentArea } from 'lib-components/layout/Container'
+import { featureFlags } from 'lib-customizations/employee'
 
 import { renderResult } from '../async-rendering'
 
@@ -33,10 +34,17 @@ export default React.memo(function QuestionnaireEditor() {
     <Container>
       <ContentArea opaque>
         {id === 'new' ? (
-          <FixedPeriodQuestionnaireForm
-            onSuccess={navigateToList}
-            onCancel={navigateToList}
-          />
+          featureFlags.holidayQuestionnaireType === 'OPEN_RANGES' ? (
+            <OpenRangesQuestionnaireForm
+              onSuccess={navigateToList}
+              onCancel={navigateToList}
+            />
+          ) : (
+            <FixedPeriodQuestionnaireForm
+              onSuccess={navigateToList}
+              onCancel={navigateToList}
+            />
+          )
         ) : (
           renderResult(questionnaire, (questionnaire) =>
             questionnaire.type === 'FIXED_PERIOD' ? (
@@ -45,12 +53,14 @@ export default React.memo(function QuestionnaireEditor() {
                 onSuccess={navigateToList}
                 onCancel={navigateToList}
               />
-            ) : (
+            ) : questionnaire.type === 'OPEN_RANGES' ? (
               <OpenRangesQuestionnaireForm
                 questionnaire={questionnaire}
                 onSuccess={navigateToList}
                 onCancel={navigateToList}
               />
+            ) : (
+              <div>Not Yet Implemented</div>
             )
           )
         )}

--- a/frontend/src/employee-frontend/components/holiday-term-periods/QuestionnaireEditor.tsx
+++ b/frontend/src/employee-frontend/components/holiday-term-periods/QuestionnaireEditor.tsx
@@ -2,14 +2,14 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback } from 'react'
+import React, { useCallback, useContext } from 'react'
 import { useNavigate } from 'react-router'
 
 import { useQueryResult } from 'lib-common/query'
 import useRouteParams from 'lib-common/useRouteParams'
 import Container, { ContentArea } from 'lib-components/layout/Container'
-import { featureFlags } from 'lib-customizations/employee'
 
+import { UserContext } from '../../state/user'
 import { renderResult } from '../async-rendering'
 
 import FixedPeriodQuestionnaireForm from './FixedPeriodQuestionnaireForm'
@@ -18,6 +18,7 @@ import { questionnaireQuery } from './queries'
 
 export default React.memo(function QuestionnaireEditor() {
   const { id } = useRouteParams(['id'])
+  const { user } = useContext(UserContext)
 
   const questionnaire = useQueryResult(questionnaireQuery({ id }), {
     enabled: id !== 'new'
@@ -34,7 +35,7 @@ export default React.memo(function QuestionnaireEditor() {
     <Container>
       <ContentArea opaque>
         {id === 'new' ? (
-          featureFlags.holidayQuestionnaireType === 'OPEN_RANGES' ? (
+          user?.accessibleFeatures.openRangesHolidayQuestionnaire ? (
             <OpenRangesQuestionnaireForm
               onSuccess={navigateToList}
               onCancel={navigateToList}

--- a/frontend/src/employee-frontend/components/holiday-term-periods/QuestionnaireEditor.tsx
+++ b/frontend/src/employee-frontend/components/holiday-term-periods/QuestionnaireEditor.tsx
@@ -12,6 +12,7 @@ import Container, { ContentArea } from 'lib-components/layout/Container'
 import { renderResult } from '../async-rendering'
 
 import FixedPeriodQuestionnaireForm from './FixedPeriodQuestionnaireForm'
+import OpenRangesQuestionnaireForm from './OpenRangesQuestionnaireForm'
 import { questionnaireQuery } from './queries'
 
 export default React.memo(function QuestionnaireEditor() {
@@ -37,13 +38,21 @@ export default React.memo(function QuestionnaireEditor() {
             onCancel={navigateToList}
           />
         ) : (
-          renderResult(questionnaire, (questionnaire) => (
-            <FixedPeriodQuestionnaireForm
-              questionnaire={questionnaire}
-              onSuccess={navigateToList}
-              onCancel={navigateToList}
-            />
-          ))
+          renderResult(questionnaire, (questionnaire) =>
+            questionnaire.type === 'FIXED_PERIOD' ? (
+              <FixedPeriodQuestionnaireForm
+                questionnaire={questionnaire}
+                onSuccess={navigateToList}
+                onCancel={navigateToList}
+              />
+            ) : (
+              <OpenRangesQuestionnaireForm
+                questionnaire={questionnaire}
+                onSuccess={navigateToList}
+                onCancel={navigateToList}
+              />
+            )
+          )
         )}
       </ContentArea>
     </Container>

--- a/frontend/src/employee-frontend/components/holiday-term-periods/queries.ts
+++ b/frontend/src/employee-frontend/components/holiday-term-periods/queries.ts
@@ -106,12 +106,12 @@ export const deleteHolidayPeriodMutation = mutation({
   ]
 })
 
-export const createFixedPeriodQuestionnaireMutation = mutation({
+export const createQuestionnaireMutation = mutation({
   api: createHolidayQuestionnaire,
   invalidateQueryKeys: () => [queryKeys.questionnaires()]
 })
 
-export const updateFixedPeriodQuestionnaireMutation = mutation({
+export const updateQuestionnaireMutation = mutation({
   api: updateHolidayQuestionnaire,
   invalidateQueryKeys: ({ id }) => [
     queryKeys.questionnaires(),

--- a/frontend/src/employee-frontend/generated/api-clients/holidayperiod.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/holidayperiod.ts
@@ -4,18 +4,18 @@
 
 // GENERATED FILE: no manual modifications
 
-import { FixedPeriodQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
-import { FixedPeriodQuestionnaireBody } from 'lib-common/generated/api-types/holidayperiod'
 import { HolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
 import { HolidayPeriodCreate } from 'lib-common/generated/api-types/holidayperiod'
 import { HolidayPeriodId } from 'lib-common/generated/api-types/shared'
 import { HolidayPeriodUpdate } from 'lib-common/generated/api-types/holidayperiod'
+import { HolidayQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
 import { HolidayQuestionnaireId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { QuestionnaireBody } from 'lib-common/generated/api-types/holidayperiod'
 import { client } from '../../api/client'
-import { deserializeJsonFixedPeriodQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
 import { deserializeJsonHolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
+import { deserializeJsonHolidayQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
 import { uri } from 'lib-common/uri'
 
 
@@ -103,13 +103,13 @@ export async function updateHolidayPeriod(
 */
 export async function createHolidayQuestionnaire(
   request: {
-    body: FixedPeriodQuestionnaireBody
+    body: QuestionnaireBody
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/holiday-period/questionnaire`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<FixedPeriodQuestionnaireBody>
+    data: request.body satisfies JsonCompatible<QuestionnaireBody>
   })
   return json
 }
@@ -138,24 +138,24 @@ export async function getQuestionnaire(
   request: {
     id: HolidayQuestionnaireId
   }
-): Promise<FixedPeriodQuestionnaire> {
-  const { data: json } = await client.request<JsonOf<FixedPeriodQuestionnaire>>({
+): Promise<HolidayQuestionnaire> {
+  const { data: json } = await client.request<JsonOf<HolidayQuestionnaire>>({
     url: uri`/employee/holiday-period/questionnaire/${request.id}`.toString(),
     method: 'GET'
   })
-  return deserializeJsonFixedPeriodQuestionnaire(json)
+  return deserializeJsonHolidayQuestionnaire(json)
 }
 
 
 /**
 * Generated from fi.espoo.evaka.holidayperiod.HolidayQuestionnaireController.getQuestionnaires
 */
-export async function getQuestionnaires(): Promise<FixedPeriodQuestionnaire[]> {
-  const { data: json } = await client.request<JsonOf<FixedPeriodQuestionnaire[]>>({
+export async function getQuestionnaires(): Promise<HolidayQuestionnaire[]> {
+  const { data: json } = await client.request<JsonOf<HolidayQuestionnaire[]>>({
     url: uri`/employee/holiday-period/questionnaire`.toString(),
     method: 'GET'
   })
-  return json.map(e => deserializeJsonFixedPeriodQuestionnaire(e))
+  return json.map(e => deserializeJsonHolidayQuestionnaire(e))
 }
 
 
@@ -165,13 +165,13 @@ export async function getQuestionnaires(): Promise<FixedPeriodQuestionnaire[]> {
 export async function updateHolidayQuestionnaire(
   request: {
     id: HolidayQuestionnaireId,
-    body: FixedPeriodQuestionnaireBody
+    body: QuestionnaireBody
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/holiday-period/questionnaire/${request.id}`.toString(),
     method: 'PUT',
-    data: request.body satisfies JsonCompatible<FixedPeriodQuestionnaireBody>
+    data: request.body satisfies JsonCompatible<QuestionnaireBody>
   })
   return json
 }

--- a/frontend/src/lib-common/generated/api-types/holidayperiod.ts
+++ b/frontend/src/lib-common/generated/api-types/holidayperiod.ts
@@ -19,39 +19,7 @@ import { Translatable } from './shared'
 export interface ActiveQuestionnaire {
   eligibleChildren: PersonId[]
   previousAnswers: HolidayQuestionnaireAnswer[]
-  questionnaire: FixedPeriodQuestionnaire
-}
-
-/**
-* Generated from fi.espoo.evaka.holidayperiod.FixedPeriodQuestionnaire
-*/
-export interface FixedPeriodQuestionnaire {
-  absenceType: AbsenceType
-  active: FiniteDateRange
-  conditions: QuestionnaireConditions
-  description: Translatable
-  descriptionLink: Translatable
-  id: HolidayQuestionnaireId
-  periodOptionLabel: Translatable
-  periodOptions: FiniteDateRange[]
-  requiresStrongAuth: boolean
-  title: Translatable
-  type: QuestionnaireType
-}
-
-/**
-* Generated from fi.espoo.evaka.holidayperiod.FixedPeriodQuestionnaireBody
-*/
-export interface FixedPeriodQuestionnaireBody {
-  absenceType: AbsenceType
-  active: FiniteDateRange
-  conditions: QuestionnaireConditions
-  description: Translatable
-  descriptionLink: Translatable
-  periodOptionLabel: Translatable
-  periodOptions: FiniteDateRange[]
-  requiresStrongAuth: boolean
-  title: Translatable
+  questionnaire: HolidayQuestionnaire
 }
 
 /**
@@ -120,6 +88,49 @@ export interface HolidayPeriodUpdate {
   reservationsOpenOn: LocalDate
 }
 
+
+export namespace HolidayQuestionnaire {
+  /**
+  * Generated from fi.espoo.evaka.holidayperiod.HolidayQuestionnaire.FixedPeriodQuestionnaire
+  */
+  export interface FixedPeriodQuestionnaire {
+    type: 'FIXED_PERIOD'
+    absenceType: AbsenceType
+    active: FiniteDateRange
+    conditions: QuestionnaireConditions
+    description: Translatable
+    descriptionLink: Translatable
+    id: HolidayQuestionnaireId
+    periodOptionLabel: Translatable
+    periodOptions: FiniteDateRange[]
+    requiresStrongAuth: boolean
+    title: Translatable
+  }
+
+  /**
+  * Generated from fi.espoo.evaka.holidayperiod.HolidayQuestionnaire.OpenRangesQuestionnaire
+  */
+  export interface OpenRangesQuestionnaire {
+    type: 'OPEN_RANGES'
+    absenceType: AbsenceType
+    absenceTypeThreshold: number
+    active: FiniteDateRange
+    conditions: QuestionnaireConditions
+    description: Translatable
+    descriptionLink: Translatable
+    id: HolidayQuestionnaireId
+    period: FiniteDateRange
+    requiresStrongAuth: boolean
+    title: Translatable
+  }
+}
+
+/**
+* Generated from fi.espoo.evaka.holidayperiod.HolidayQuestionnaire
+*/
+export type HolidayQuestionnaire = HolidayQuestionnaire.FixedPeriodQuestionnaire | HolidayQuestionnaire.OpenRangesQuestionnaire
+
+
 /**
 * Generated from fi.espoo.evaka.holidayperiod.HolidayQuestionnaireAnswer
 */
@@ -128,6 +139,54 @@ export interface HolidayQuestionnaireAnswer {
   fixedPeriod: FiniteDateRange | null
   questionnaireId: HolidayQuestionnaireId
 }
+
+/**
+* Generated from fi.espoo.evaka.holidayperiod.OpenRangesBody
+*/
+export interface OpenRangesBody {
+  openRanges: Partial<Record<PersonId, FiniteDateRange[]>>
+}
+
+
+export namespace QuestionnaireBody {
+  /**
+  * Generated from fi.espoo.evaka.holidayperiod.QuestionnaireBody.FixedPeriodQuestionnaireBody
+  */
+  export interface FixedPeriodQuestionnaireBody {
+    type: 'FIXED_PERIOD'
+    absenceType: AbsenceType
+    active: FiniteDateRange
+    conditions: QuestionnaireConditions
+    description: Translatable
+    descriptionLink: Translatable
+    periodOptionLabel: Translatable
+    periodOptions: FiniteDateRange[]
+    requiresStrongAuth: boolean
+    title: Translatable
+  }
+
+  /**
+  * Generated from fi.espoo.evaka.holidayperiod.QuestionnaireBody.OpenRangesQuestionnaireBody
+  */
+  export interface OpenRangesQuestionnaireBody {
+    type: 'OPEN_RANGES'
+    absenceType: AbsenceType
+    absenceTypeThreshold: number
+    active: FiniteDateRange
+    conditions: QuestionnaireConditions
+    description: Translatable
+    descriptionLink: Translatable
+    period: FiniteDateRange
+    requiresStrongAuth: boolean
+    title: Translatable
+  }
+}
+
+/**
+* Generated from fi.espoo.evaka.holidayperiod.QuestionnaireBody
+*/
+export type QuestionnaireBody = QuestionnaireBody.FixedPeriodQuestionnaireBody | QuestionnaireBody.OpenRangesQuestionnaireBody
+
 
 /**
 * Generated from fi.espoo.evaka.holidayperiod.QuestionnaireConditions
@@ -148,27 +207,7 @@ export function deserializeJsonActiveQuestionnaire(json: JsonOf<ActiveQuestionna
   return {
     ...json,
     previousAnswers: json.previousAnswers.map(e => deserializeJsonHolidayQuestionnaireAnswer(e)),
-    questionnaire: deserializeJsonFixedPeriodQuestionnaire(json.questionnaire)
-  }
-}
-
-
-export function deserializeJsonFixedPeriodQuestionnaire(json: JsonOf<FixedPeriodQuestionnaire>): FixedPeriodQuestionnaire {
-  return {
-    ...json,
-    active: FiniteDateRange.parseJson(json.active),
-    conditions: deserializeJsonQuestionnaireConditions(json.conditions),
-    periodOptions: json.periodOptions.map(e => FiniteDateRange.parseJson(e))
-  }
-}
-
-
-export function deserializeJsonFixedPeriodQuestionnaireBody(json: JsonOf<FixedPeriodQuestionnaireBody>): FixedPeriodQuestionnaireBody {
-  return {
-    ...json,
-    active: FiniteDateRange.parseJson(json.active),
-    conditions: deserializeJsonQuestionnaireConditions(json.conditions),
-    periodOptions: json.periodOptions.map(e => FiniteDateRange.parseJson(e))
+    questionnaire: deserializeJsonHolidayQuestionnaire(json.questionnaire)
   }
 }
 
@@ -228,10 +267,74 @@ export function deserializeJsonHolidayPeriodUpdate(json: JsonOf<HolidayPeriodUpd
 }
 
 
+
+export function deserializeJsonHolidayQuestionnaireFixedPeriodQuestionnaire(json: JsonOf<HolidayQuestionnaire.FixedPeriodQuestionnaire>): HolidayQuestionnaire.FixedPeriodQuestionnaire {
+  return {
+    ...json,
+    active: FiniteDateRange.parseJson(json.active),
+    conditions: deserializeJsonQuestionnaireConditions(json.conditions),
+    periodOptions: json.periodOptions.map(e => FiniteDateRange.parseJson(e))
+  }
+}
+
+export function deserializeJsonHolidayQuestionnaireOpenRangesQuestionnaire(json: JsonOf<HolidayQuestionnaire.OpenRangesQuestionnaire>): HolidayQuestionnaire.OpenRangesQuestionnaire {
+  return {
+    ...json,
+    active: FiniteDateRange.parseJson(json.active),
+    conditions: deserializeJsonQuestionnaireConditions(json.conditions),
+    period: FiniteDateRange.parseJson(json.period)
+  }
+}
+export function deserializeJsonHolidayQuestionnaire(json: JsonOf<HolidayQuestionnaire>): HolidayQuestionnaire {
+  switch (json.type) {
+    case 'FIXED_PERIOD': return deserializeJsonHolidayQuestionnaireFixedPeriodQuestionnaire(json)
+    case 'OPEN_RANGES': return deserializeJsonHolidayQuestionnaireOpenRangesQuestionnaire(json)
+    default: return json
+  }
+}
+
+
 export function deserializeJsonHolidayQuestionnaireAnswer(json: JsonOf<HolidayQuestionnaireAnswer>): HolidayQuestionnaireAnswer {
   return {
     ...json,
     fixedPeriod: (json.fixedPeriod != null) ? FiniteDateRange.parseJson(json.fixedPeriod) : null
+  }
+}
+
+
+export function deserializeJsonOpenRangesBody(json: JsonOf<OpenRangesBody>): OpenRangesBody {
+  return {
+    ...json,
+    openRanges: Object.fromEntries(Object.entries(json.openRanges).map(
+      ([k, v]) => [k, v !== undefined ? v.map(e => FiniteDateRange.parseJson(e)) : v]
+    ))
+  }
+}
+
+
+
+export function deserializeJsonQuestionnaireBodyFixedPeriodQuestionnaireBody(json: JsonOf<QuestionnaireBody.FixedPeriodQuestionnaireBody>): QuestionnaireBody.FixedPeriodQuestionnaireBody {
+  return {
+    ...json,
+    active: FiniteDateRange.parseJson(json.active),
+    conditions: deserializeJsonQuestionnaireConditions(json.conditions),
+    periodOptions: json.periodOptions.map(e => FiniteDateRange.parseJson(e))
+  }
+}
+
+export function deserializeJsonQuestionnaireBodyOpenRangesQuestionnaireBody(json: JsonOf<QuestionnaireBody.OpenRangesQuestionnaireBody>): QuestionnaireBody.OpenRangesQuestionnaireBody {
+  return {
+    ...json,
+    active: FiniteDateRange.parseJson(json.active),
+    conditions: deserializeJsonQuestionnaireConditions(json.conditions),
+    period: FiniteDateRange.parseJson(json.period)
+  }
+}
+export function deserializeJsonQuestionnaireBody(json: JsonOf<QuestionnaireBody>): QuestionnaireBody {
+  switch (json.type) {
+    case 'FIXED_PERIOD': return deserializeJsonQuestionnaireBodyFixedPeriodQuestionnaireBody(json)
+    case 'OPEN_RANGES': return deserializeJsonQuestionnaireBodyOpenRangesQuestionnaireBody(json)
+    default: return json
   }
 }
 

--- a/frontend/src/lib-common/generated/api-types/holidayperiod.ts
+++ b/frontend/src/lib-common/generated/api-types/holidayperiod.ts
@@ -137,6 +137,7 @@ export type HolidayQuestionnaire = HolidayQuestionnaire.FixedPeriodQuestionnaire
 export interface HolidayQuestionnaireAnswer {
   childId: PersonId
   fixedPeriod: FiniteDateRange | null
+  openRanges: FiniteDateRange[]
   questionnaireId: HolidayQuestionnaireId
 }
 
@@ -297,7 +298,8 @@ export function deserializeJsonHolidayQuestionnaire(json: JsonOf<HolidayQuestion
 export function deserializeJsonHolidayQuestionnaireAnswer(json: JsonOf<HolidayQuestionnaireAnswer>): HolidayQuestionnaireAnswer {
   return {
     ...json,
-    fixedPeriod: (json.fixedPeriod != null) ? FiniteDateRange.parseJson(json.fixedPeriod) : null
+    fixedPeriod: (json.fixedPeriod != null) ? FiniteDateRange.parseJson(json.fixedPeriod) : null,
+    openRanges: json.openRanges.map(e => FiniteDateRange.parseJson(e))
   }
 }
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -126,6 +126,7 @@ export interface EmployeeFeatures {
   financeBasics: boolean
   holidayAndTermPeriods: boolean
   messages: boolean
+  openRangesHolidayQuestionnaire: boolean
   personSearch: boolean
   personalMobileDevice: boolean
   pinCode: boolean

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -484,7 +484,9 @@ const en: Translations = {
       addTimePeriod: 'Add holiday',
       emptySelection: 'No free absences',
       notEligible: (period: FiniteDateRange) =>
-        `The questionnaire doesn't concern the child, because he or she hasn't been in early childhood education continuously during ${period.format()}.`
+        `The questionnaire doesn't concern the child, because he or she hasn't been in early childhood education continuously during ${period.format()}.`,
+      rangesOverlap:
+        'There is already a overlapping entry for this period. If necessary, edit the previous time period.'
     },
     previousDay: 'Previous day',
     nextDay: 'Next day',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -486,7 +486,9 @@ export default {
       addTimePeriod: 'Lisää ajankohta',
       emptySelection: 'Ei maksutonta poissaoloa',
       notEligible: (period: FiniteDateRange) =>
-        `Kysely ei koske lasta, koska hän ei ole ollut varhaiskasvatuksessa yhtäjaksoisesti ${period.format()}.`
+        `Kysely ei koske lasta, koska hän ei ole ollut varhaiskasvatuksessa yhtäjaksoisesti ${period.format()}.`,
+      rangesOverlap:
+        'Tälle ajanjaksolle on jo päällekkäinen merkintä. Muokkaa tarvittaessa edellistä ajanjaksoa.'
     },
     previousDay: 'Edellinen päivä',
     nextDay: 'Seuraava päivä',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -483,7 +483,8 @@ const sv: Translations = {
       emptySelection: 'Ingen gratis ledighet',
       notEligible: (period: FiniteDateRange) =>
         `Enkäten rör inte barnet, eftersom hen inte varit i småbarnspedagogiken oavbrutet under tiden ${period.format()}.`,
-      rangesOverlap: 'Det finns redan en dubblettpost för denna period. Om det behövs, redigera föregående tidsperiod.'
+      rangesOverlap:
+        'Det finns redan en dubblettpost för denna period. Om det behövs, redigera föregående tidsperiod.'
     },
     previousDay: 'Föregående dag',
     nextDay: 'Nästa dag',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -482,7 +482,8 @@ const sv: Translations = {
       addTimePeriod: 'Lägg till en period',
       emptySelection: 'Ingen gratis ledighet',
       notEligible: (period: FiniteDateRange) =>
-        `Enkäten rör inte barnet, eftersom hen inte varit i småbarnspedagogiken oavbrutet under tiden ${period.format()}.`
+        `Enkäten rör inte barnet, eftersom hen inte varit i småbarnspedagogiken oavbrutet under tiden ${period.format()}.`,
+      rangesOverlap: 'Det finns redan en dubblettpost för denna period. Om det behövs, redigera föregående tidsperiod.'
     },
     previousDay: 'Föregående dag',
     nextDay: 'Nästa dag',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4863,7 +4863,8 @@ export const fi = {
   holidayQuestionnaires: {
     confirmDelete: 'Haluatko varmasti poistaa kyselyn?',
     types: {
-      FIXED_PERIOD: 'Kiinteä kausi'
+      FIXED_PERIOD: 'Kiinteä kausi',
+      OPEN_RANGES: 'Avoin kausi'
     },
     questionnaires: 'Poissaolokyselyt',
     absenceType: 'Poissaolon tyyppi',
@@ -4879,7 +4880,9 @@ export const fi = {
       '30.5.2022-24.8.2022, 6.6.2022-31.8.2022, pilkuilla tai rivinvaihdoilla erotettuna',
     requiresStrongAuth: 'Vahva tunnistautuminen',
     conditionContinuousPlacement:
-      'Kyselyyn voi vastata jos lapsella yhtäjaksoinen sijoitus'
+      'Kyselyyn voi vastata jos lapsella yhtäjaksoinen sijoitus',
+    period: 'Poissaolokausi',
+    absenceTypeThreshold: 'Yhtenäisen poissaolon minimipituus'
   },
   terms: {
     term: 'Lukukausi',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4882,7 +4882,8 @@ export const fi = {
     conditionContinuousPlacement:
       'Kyselyyn voi vastata jos lapsella yhtäjaksoinen sijoitus',
     period: 'Poissaolokausi',
-    absenceTypeThreshold: 'Yhtenäisen poissaolon minimipituus'
+    absenceTypeThreshold: 'Yhtenäisen poissaolon minimipituus',
+    days: 'päivää'
   },
   terms: {
     term: 'Lukukausi',

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -44,8 +44,7 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: true,
     multiSelectDeparture: true,
-    weakLogin: true,
-    holidayQuestionnaireType: 'FIXED_PERIOD'
+    weakLogin: true
   },
   staging: {
     environmentLabel: 'Staging',
@@ -80,8 +79,7 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: true,
     multiSelectDeparture: true,
-    weakLogin: true,
-    holidayQuestionnaireType: 'FIXED_PERIOD'
+    weakLogin: true
   },
   prod: {
     environmentLabel: null,
@@ -115,8 +113,7 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: false,
     multiSelectDeparture: false,
-    weakLogin: false,
-    holidayQuestionnaireType: 'FIXED_PERIOD'
+    weakLogin: false
   }
 }
 

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -44,7 +44,8 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: true,
     multiSelectDeparture: true,
-    weakLogin: true
+    weakLogin: true,
+    holidayQuestionnaireType: 'FIXED_PERIOD'
   },
   staging: {
     environmentLabel: 'Staging',
@@ -79,7 +80,8 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: true,
     multiSelectDeparture: true,
-    weakLogin: true
+    weakLogin: true,
+    holidayQuestionnaireType: 'FIXED_PERIOD'
   },
   prod: {
     environmentLabel: null,
@@ -113,7 +115,8 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: false,
     multiSelectDeparture: false,
-    weakLogin: false
+    weakLogin: false,
+    holidayQuestionnaireType: 'FIXED_PERIOD'
   }
 }
 

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -21,7 +21,6 @@ import {
 import LocalDate from 'lib-common/local-date'
 import { Theme } from 'lib-common/theme'
 import { DeepReadonly } from 'lib-common/types'
-import { HolidayQuestionnaire } from '../lib-common/generated/api-types/holidayperiod'
 
 import {
   Lang as LangCitizen,

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -21,6 +21,7 @@ import {
 import LocalDate from 'lib-common/local-date'
 import { Theme } from 'lib-common/theme'
 import { DeepReadonly } from 'lib-common/types'
+import { HolidayQuestionnaire } from '../lib-common/generated/api-types/holidayperiod'
 
 import {
   Lang as LangCitizen,
@@ -278,6 +279,12 @@ interface BaseFeatureFlags {
    * Enable support for citizen weak login
    */
   weakLogin?: boolean
+
+  /**
+   * Select the type of holiday questionnaire
+   * Note the corresponding backend environment variable feature flag.
+   */
+  holidayQuestionnaireType?: 'FIXED_PERIOD' | 'OPEN_RANGES'
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -278,12 +278,6 @@ interface BaseFeatureFlags {
    * Enable support for citizen weak login
    */
   weakLogin?: boolean
-
-  /**
-   * Select the type of holiday questionnaire
-   * Note the corresponding backend environment variable feature flag.
-   */
-  holidayQuestionnaireType?: 'FIXED_PERIOD' | 'OPEN_RANGES'
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
@@ -4,43 +4,44 @@
 
 package fi.espoo.evaka.holidayperiod
 
-import com.github.kittinunf.fuel.core.extensions.jsonBody
-import com.github.kittinunf.fuel.jackson.responseObject
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.absence.AbsenceType
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.insertPlacement
 import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.HolidayQuestionnaireId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
-import fi.espoo.evaka.shared.auth.asUser
+import fi.espoo.evaka.shared.config.testFeatureConfig
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.dev.DevCareArea
+import fi.espoo.evaka.shared.dev.DevDaycare
+import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.insert
+import fi.espoo.evaka.shared.domain.BadRequest
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.domain.Translatable
-import fi.espoo.evaka.testAdult_1
-import fi.espoo.evaka.testArea
-import fi.espoo.evaka.testChild_1
-import fi.espoo.evaka.testChild_2
-import fi.espoo.evaka.testChild_3
-import fi.espoo.evaka.testChild_4
-import fi.espoo.evaka.testDaycare
-import fi.espoo.evaka.withMockedTime
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.UUID
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
 
 class HolidayPeriodControllerCitizenIntegrationTest :
     FullApplicationTest(resetDbBeforeEach = true) {
+    @Autowired private lateinit var holidayPeriodControllerCitizen: HolidayPeriodControllerCitizen
+
     private val emptyTranslatable = Translatable("", "", "")
     private val freePeriodQuestionnaire =
-        FixedPeriodQuestionnaireBody(
+        QuestionnaireBody.FixedPeriodQuestionnaireBody(
             active = FiniteDateRange(LocalDate.of(2021, 4, 1), LocalDate.of(2021, 5, 31)),
             periodOptions =
                 listOf(
@@ -55,28 +56,43 @@ class HolidayPeriodControllerCitizenIntegrationTest :
             absenceType = AbsenceType.FREE_ABSENCE,
             requiresStrongAuth = false,
         )
+    private val freeRangesQuestionnaire =
+        QuestionnaireBody.OpenRangesQuestionnaireBody(
+            active = FiniteDateRange(LocalDate.of(2021, 4, 1), LocalDate.of(2021, 5, 31)),
+            period = FiniteDateRange(LocalDate.of(2021, 6, 1), LocalDate.of(2021, 8, 31)),
+            absenceTypeThreshold = 30,
+            description = emptyTranslatable,
+            descriptionLink = emptyTranslatable,
+            conditions = QuestionnaireConditions(),
+            title = emptyTranslatable,
+            absenceType = AbsenceType.FREE_ABSENCE,
+            requiresStrongAuth = false,
+        )
     private val mockToday: LocalDate = freePeriodQuestionnaire.active.end.minusWeeks(1)
 
-    private val child1 = testChild_1
-    private val parent = testAdult_1
+    final val area = DevCareArea()
+    val daycare = DevDaycare(areaId = area.id)
+    val child1 = DevPerson(id = ChildId(UUID.randomUUID()))
+    val child2 = DevPerson(id = ChildId(UUID.randomUUID()))
+    val child3 = DevPerson(id = ChildId(UUID.randomUUID()))
+    val child4 = DevPerson(id = ChildId(UUID.randomUUID()))
+    private val parent = DevPerson()
     private val authenticatedParent = AuthenticatedUser.Citizen(parent.id, CitizenAuthLevel.STRONG)
 
     @BeforeEach
     fun setUp() {
         db.transaction { tx ->
-            tx.insert(testArea)
-            tx.insert(testDaycare)
-            tx.insert(testAdult_1, DevPersonType.ADULT)
-            listOf(testChild_1, testChild_2, testChild_3, testChild_4).forEach {
-                tx.insert(it, DevPersonType.CHILD)
-            }
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(parent, DevPersonType.ADULT)
+            listOf(child1, child2, child3, child4).forEach { tx.insert(it, DevPersonType.CHILD) }
 
             tx.insertGuardian(parent.id, child1.id)
 
             tx.insertPlacement(
                 PlacementType.DAYCARE,
                 child1.id,
-                testDaycare.id,
+                daycare.id,
                 mockToday.minusYears(2),
                 mockToday.plusYears(1),
                 false,
@@ -86,7 +102,6 @@ class HolidayPeriodControllerCitizenIntegrationTest :
 
     @Test
     fun `active questionnaire is eligible for all children when there are no conditions`() {
-        val child2 = testChild_2
         db.transaction { tx -> tx.insertGuardian(parent.id, child2.id) }
         createFixedPeriodQuestionnaire(freePeriodQuestionnaire)
 
@@ -98,9 +113,6 @@ class HolidayPeriodControllerCitizenIntegrationTest :
 
     @Test
     fun `active questionnaire is eligible for children that fulfil the continuous placement condition`() {
-        val child2 = testChild_2
-        val child3 = testChild_3
-        val child4 = testChild_4
         val condition = FiniteDateRange(mockToday, mockToday.plusMonths(1))
 
         db.transaction { tx ->
@@ -114,7 +126,7 @@ class HolidayPeriodControllerCitizenIntegrationTest :
             tx.insertPlacement(
                 PlacementType.DAYCARE,
                 child3.id,
-                testDaycare.id,
+                daycare.id,
                 condition.start,
                 condition.end.minusDays(1),
                 false,
@@ -123,7 +135,7 @@ class HolidayPeriodControllerCitizenIntegrationTest :
             tx.insertPlacement(
                 PlacementType.DAYCARE,
                 child4.id,
-                testDaycare.id,
+                daycare.id,
                 condition.start,
                 condition.start.plusDays(5),
                 false,
@@ -131,7 +143,7 @@ class HolidayPeriodControllerCitizenIntegrationTest :
             tx.insertPlacement(
                 PlacementType.DAYCARE,
                 child4.id,
-                testDaycare.id,
+                daycare.id,
                 condition.start.plusDays(6),
                 condition.end,
                 false,
@@ -169,10 +181,11 @@ class HolidayPeriodControllerCitizenIntegrationTest :
                 id,
                 child1.id,
                 FiniteDateRange(firstOption.start, firstOption.end),
+                listOf(),
             )
         assertEquals(
             listOf(expectedAnswer),
-            db.read { it.getQuestionnaireAnswers(id, listOf(child1.id, testChild_2.id)) },
+            db.read { it.getQuestionnaireAnswers(id, listOf(child1.id, child2.id)) },
         )
 
         assertEquals(listOf(expectedAnswer), getActiveQuestionnaires(mockToday)[0].previousAnswers)
@@ -181,19 +194,22 @@ class HolidayPeriodControllerCitizenIntegrationTest :
     @Test
     fun `free absences cannot be saved outside of a free period`() {
         val id = createFixedPeriodQuestionnaire(freePeriodQuestionnaire)
-        reportFreePeriods(id, freeAbsence(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 5)), 400)
+        assertThrows<BadRequest> {
+            reportFreePeriods(id, freeAbsence(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 5)))
+        }
     }
 
     @Test
     fun `free absences cannot be saved after the deadline`() {
         val id = createFixedPeriodQuestionnaire(freePeriodQuestionnaire)
         val firstOption = freePeriodQuestionnaire.periodOptions.first()
-        reportFreePeriods(
-            id,
-            freeAbsence(firstOption.start, firstOption.end),
-            400,
-            freePeriodQuestionnaire.active.end.plusDays(1),
-        )
+        assertThrows<BadRequest> {
+            reportFreePeriods(
+                id,
+                freeAbsence(firstOption.start, firstOption.end),
+                freePeriodQuestionnaire.active.end.plusDays(1),
+            )
+        }
     }
 
     @Test
@@ -217,7 +233,6 @@ class HolidayPeriodControllerCitizenIntegrationTest :
 
     @Test
     fun `free absences cannot be saved if a child is not eligible`() {
-        val child2 = testChild_2
         db.transaction { tx ->
             tx.insertGuardian(parent.id, child2.id)
             // child2 has no placement
@@ -234,43 +249,118 @@ class HolidayPeriodControllerCitizenIntegrationTest :
             )
 
         val firstOption = freePeriodQuestionnaire.periodOptions[0]
-        reportFreePeriods(
+        assertThrows<BadRequest> {
+            reportFreePeriods(
+                id,
+                FixedPeriodsBody(mapOf(child1.id to firstOption, child2.id to firstOption)),
+            )
+        }
+    }
+
+    @Test
+    fun `correct type of active questionnaire is fetched based on feature flag`() {
+        createOpenRangesQuestionnaire(freeRangesQuestionnaire)
+
+        val response =
+            getActiveQuestionnaires(
+                mockToday,
+                testFeatureConfig.copy(holidayQuestionnaireType = QuestionnaireType.OPEN_RANGES),
+            )
+
+        assertEquals(1, response.size)
+    }
+
+    @Test
+    fun `free absences are saved only when length of absence exceeds threshold`() {
+        val id = createOpenRangesQuestionnaire(freeRangesQuestionnaire)
+        reportFreeRanges(
             id,
-            FixedPeriodsBody(mapOf(child1.id to firstOption, child2.id to firstOption)),
-            expectedStatus = 400,
+            openAbsences(
+                listOf(
+                    FiniteDateRange(
+                        freeRangesQuestionnaire.period.start,
+                        freeRangesQuestionnaire.period.start.plusDays(30),
+                    ),
+                    FiniteDateRange(
+                        freeRangesQuestionnaire.period.end.minusDays(10),
+                        freeRangesQuestionnaire.period.end,
+                    ),
+                )
+            ),
+        )
+        val absences = db.read { it.getAllAbsences() }
+        assertEquals(
+            Absence(
+                child1.id,
+                freeRangesQuestionnaire.period.start,
+                freeRangesQuestionnaire.absenceType,
+            ),
+            absences.first(),
+        )
+        assertEquals(
+            Absence(child1.id, freeRangesQuestionnaire.period.end, AbsenceType.OTHER_ABSENCE),
+            absences.last(),
         )
     }
 
-    private fun getActiveQuestionnaires(mockedDay: LocalDate): List<ActiveQuestionnaire> {
-        val (_, _, res) =
-            http
-                .get("/citizen/holiday-period/questionnaire")
-                .asUser(authenticatedParent)
-                .withMockedTime(HelsinkiDateTime.of(mockedDay, LocalTime.of(0, 0)))
-                .responseObject<List<ActiveQuestionnaire>>(jsonMapper)
-        return res.get()
+    private fun getActiveQuestionnaires(
+        mockedDay: LocalDate,
+        config: FeatureConfig = testFeatureConfig,
+    ): List<ActiveQuestionnaire> {
+        val mockClock =
+            MockEvakaClock(HelsinkiDateTime.Companion.of(mockedDay, LocalTime.of(11, 0)))
+        return holidayPeriodControllerCitizen.getActiveQuestionnaires(
+            dbInstance(),
+            authenticatedParent,
+            mockClock,
+            config,
+        )
     }
 
     private fun reportFreePeriods(
         id: HolidayQuestionnaireId,
         body: FixedPeriodsBody,
-        expectedStatus: Int = 200,
         mockedDay: LocalDate = mockToday,
     ) {
-        http
-            .post("/citizen/holiday-period/questionnaire/fixed-period/$id")
-            .jsonBody(jsonMapper.writeValueAsString(body))
-            .asUser(authenticatedParent)
-            .withMockedTime(HelsinkiDateTime.of(mockedDay, LocalTime.of(0, 0)))
-            .response()
-            .also { assertEquals(expectedStatus, it.second.statusCode) }
+        val mockClock =
+            MockEvakaClock(HelsinkiDateTime.Companion.of(mockedDay, LocalTime.of(11, 0)))
+        holidayPeriodControllerCitizen.answerFixedPeriodQuestionnaire(
+            dbInstance(),
+            authenticatedParent,
+            mockClock,
+            id,
+            body,
+        )
     }
 
     private fun freeAbsence(start: LocalDate, end: LocalDate) =
         FixedPeriodsBody(mapOf(child1.id to FiniteDateRange(start, end)))
 
-    private fun createFixedPeriodQuestionnaire(body: FixedPeriodQuestionnaireBody) =
-        db.transaction { it.createFixedPeriodQuestionnaire(body) }
+    private fun createFixedPeriodQuestionnaire(
+        body: QuestionnaireBody.FixedPeriodQuestionnaireBody
+    ) = db.transaction { it.createFixedPeriodQuestionnaire(body) }
+
+    private fun reportFreeRanges(
+        id: HolidayQuestionnaireId,
+        body: OpenRangesBody,
+        mockedDay: LocalDate = mockToday,
+    ) {
+        val mockClock =
+            MockEvakaClock(HelsinkiDateTime.Companion.of(mockedDay, LocalTime.of(11, 0)))
+        holidayPeriodControllerCitizen.answerOpenRangeQuestionnaire(
+            dbInstance(),
+            authenticatedParent,
+            mockClock,
+            id,
+            body,
+        )
+    }
+
+    private fun openAbsences(ranges: List<FiniteDateRange>) =
+        OpenRangesBody(mapOf(child1.id to ranges))
+
+    private fun createOpenRangesQuestionnaire(body: QuestionnaireBody.OpenRangesQuestionnaireBody) =
+        db.transaction { it.createOpenRangesQuestionnaire(body) }
 
     private data class Absence(val childId: ChildId, val date: LocalDate, val type: AbsenceType)
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
@@ -10,11 +10,9 @@ import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.insertPlacement
 import fi.espoo.evaka.shared.ChildId
-import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.HolidayQuestionnaireId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
-import fi.espoo.evaka.shared.config.testFeatureConfig
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -261,11 +259,7 @@ class HolidayPeriodControllerCitizenIntegrationTest :
     fun `correct type of active questionnaire is fetched based on feature flag`() {
         createOpenRangesQuestionnaire(freeRangesQuestionnaire)
 
-        val response =
-            getActiveQuestionnaires(
-                mockToday,
-                testFeatureConfig.copy(holidayQuestionnaireType = QuestionnaireType.OPEN_RANGES),
-            )
+        val response = getActiveQuestionnaires(mockToday)
 
         assertEquals(1, response.size)
     }
@@ -303,17 +297,13 @@ class HolidayPeriodControllerCitizenIntegrationTest :
         )
     }
 
-    private fun getActiveQuestionnaires(
-        mockedDay: LocalDate,
-        config: FeatureConfig = testFeatureConfig,
-    ): List<ActiveQuestionnaire> {
+    private fun getActiveQuestionnaires(mockedDay: LocalDate): List<ActiveQuestionnaire> {
         val mockClock =
             MockEvakaClock(HelsinkiDateTime.Companion.of(mockedDay, LocalTime.of(11, 0)))
         return holidayPeriodControllerCitizen.getActiveQuestionnaires(
             dbInstance(),
             authenticatedParent,
             mockClock,
-            config,
         )
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodQuestionnaireIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodQuestionnaireIntegrationTest.kt
@@ -13,21 +13,21 @@ import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 
 class HolidayPeriodQuestionnaireIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
+    val emptyTranslatable = Translatable("", "", "")
+    val summerRange =
+        FiniteDateRange(start = LocalDate.of(2021, 6, 1), end = LocalDate.of(2021, 8, 31))
+    val active = FiniteDateRange(summerRange.start.minusMonths(2), summerRange.start.minusMonths(1))
+
     @Test
     fun `fixed period questionnaires can be saved`() {
-        val emptyTranslatable = Translatable("", "", "")
-        val summerRange =
-            FiniteDateRange(start = LocalDate.of(2021, 6, 1), end = LocalDate.of(2021, 8, 31))
         val options =
             listOf(
                 FiniteDateRange(LocalDate.of(2021, 7, 1), LocalDate.of(2021, 7, 7)),
                 FiniteDateRange(LocalDate.of(2021, 7, 8), LocalDate.of(2021, 7, 14)),
             )
-        val active =
-            FiniteDateRange(summerRange.start.minusMonths(2), summerRange.start.minusMonths(1))
         val summerQuestionnaire =
             createFixedPeriodQuestionnaire(
-                FixedPeriodQuestionnaireBody(
+                QuestionnaireBody.FixedPeriodQuestionnaireBody(
                     description =
                         Translatable("Varaathan \n 'quote' \"double\" loma-aikasi", "", ""),
                     active = active,
@@ -50,10 +50,45 @@ class HolidayPeriodQuestionnaireIntegrationTest : PureJdbiTest(resetDbBeforeEach
         assertEquals(options, summerQuestionnaire.periodOptions)
     }
 
-    private fun createFixedPeriodQuestionnaire(body: FixedPeriodQuestionnaireBody) =
+    @Test
+    fun `open ranges questionnaires can be saved`() {
+        val period = FiniteDateRange(LocalDate.of(2021, 6, 1), LocalDate.of(2021, 8, 31))
+        val summerQuestionnaire =
+            createOpenRangesQuestionnaire(
+                QuestionnaireBody.OpenRangesQuestionnaireBody(
+                    description =
+                        Translatable("Varaathan \n 'quote' \"double\" loma-aikasi", "", ""),
+                    active = active,
+                    descriptionLink = emptyTranslatable,
+                    period = period,
+                    absenceTypeThreshold = 10,
+                    title = Translatable("avoin maksuton", "öppna gratis", "open free"),
+                    conditions =
+                        QuestionnaireConditions(
+                            continuousPlacement =
+                                FiniteDateRange(LocalDate.of(2020, 9, 1), summerRange.end)
+                        ),
+                    absenceType = AbsenceType.FREE_ABSENCE,
+                    requiresStrongAuth = false,
+                )
+            )
+
+        assertEquals("avoin maksuton", summerQuestionnaire.title.fi)
+        assertEquals(active, summerQuestionnaire.active)
+        assertEquals(period, summerQuestionnaire.period)
+    }
+
+    private fun createFixedPeriodQuestionnaire(
+        body: QuestionnaireBody.FixedPeriodQuestionnaireBody
+    ) =
         db.transaction {
             it.createFixedPeriodQuestionnaire(body).let { id ->
                 it.getFixedPeriodQuestionnaire(id)!!
             }
+        }
+
+    private fun createOpenRangesQuestionnaire(body: QuestionnaireBody.OpenRangesQuestionnaireBody) =
+        db.transaction {
+            it.createOpenRangesQuestionnaire(body).let { id -> it.getOpenRangesQuestionnaire(id)!! }
         }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/SchemaConventionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/SchemaConventionsTest.kt
@@ -554,6 +554,7 @@ class SchemaConventionsTest : PureJdbiTest(resetDbBeforeEach = false) {
                 ColumnRef("holiday_period", "period"),
                 ColumnRef("holiday_period_questionnaire", "active"),
                 ColumnRef("holiday_period_questionnaire", "condition_continuous_placement"),
+                ColumnRef("holiday_period_questionnaire", "period"),
                 ColumnRef("holiday_questionnaire_answer", "fixed_period"),
                 ColumnRef("invoice_correction", "period"),
                 ColumnRef("payment", "period"),

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -17,6 +17,7 @@ import fi.espoo.evaka.espoo.bi.EspooBiHttpClient
 import fi.espoo.evaka.espoo.bi.EspooBiJob
 import fi.espoo.evaka.espoo.bi.MockEspooBiClient
 import fi.espoo.evaka.espoo.invoicing.EspooIncomeCoefficientMultiplierProvider
+import fi.espoo.evaka.holidayperiod.QuestionnaireType
 import fi.espoo.evaka.invoicing.domain.PaymentIntegrationClient
 import fi.espoo.evaka.invoicing.integration.EspooInvoiceIntegrationClient
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
@@ -222,6 +223,7 @@ class EspooConfig {
                             archiveDurationMonths = 120 * 12,
                         ),
                 ),
+            holidayQuestionnaireType = QuestionnaireType.FIXED_PERIOD,
         )
 
     @Bean

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaireQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaireQueries.kt
@@ -212,7 +212,7 @@ INSERT INTO holiday_period_questionnaire (
     absence_type_threshold
 )
 VALUES (
-    ${bind(QuestionnaireType.FIXED_PERIOD)},
+    ${bind(QuestionnaireType.OPEN_RANGES)},
     ${bind(data.absenceType)},
     ${bind(data.requiresStrongAuth)},
     ${bind(data.active)},
@@ -220,7 +220,7 @@ VALUES (
     ${bindJson(data.description)},
     ${bindJson(data.descriptionLink)},
     ${bind(data.conditions.continuousPlacement)},
-    ${bind(data.period)}
+    ${bind(data.period)},
     ${bind(data.absenceTypeThreshold)}
 )
 RETURNING id
@@ -239,7 +239,7 @@ fun Database.Transaction.updateOpenRangesQuestionnaire(
                 """
 UPDATE holiday_period_questionnaire
 SET
-    type = ${bind(QuestionnaireType.FIXED_PERIOD)},
+    type = ${bind(QuestionnaireType.OPEN_RANGES)},
     absence_type = ${bind(data.absenceType)},
     requires_strong_auth = ${bind(data.requiresStrongAuth)},
     active = ${bind(data.active)},
@@ -270,16 +270,19 @@ INSERT INTO holiday_questionnaire_answer (
     questionnaire_id,
     child_id,
     fixed_period,
+    open_ranges,
     modified_by
 )
 VALUES (
     ${bind { it.questionnaireId }},
     ${bind { it.childId }},
     ${bind { it.fixedPeriod }},
+    ${bind { it.openRanges }},
     ${bind(modifiedBy)}
 )
 ON CONFLICT(questionnaire_id, child_id)
     DO UPDATE SET fixed_period = EXCLUDED.fixed_period,
+                  open_ranges = EXCLUDED.open_ranges,
                   modified_by  = EXCLUDED.modified_by
 """
         )
@@ -293,7 +296,7 @@ fun Database.Read.getQuestionnaireAnswers(
     createQuery {
             sql(
                 """
-SELECT questionnaire_id, child_id, fixed_period
+SELECT questionnaire_id, child_id, fixed_period, open_ranges
 FROM holiday_questionnaire_answer
 WHERE questionnaire_id = ${bind(id)} AND child_id = ANY(${bind(childIds)})
         """

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaires.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaires.kt
@@ -109,4 +109,5 @@ data class HolidayQuestionnaireAnswer(
     val questionnaireId: HolidayQuestionnaireId,
     val childId: ChildId,
     val fixedPeriod: FiniteDateRange?,
+    val openRanges: List<FiniteDateRange>,
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
@@ -312,7 +312,9 @@ class SystemController(
                             placementTool =
                                 permittedGlobalActions.contains(Action.Global.PLACEMENT_TOOL),
                             replacementInvoices = env.replacementInvoicesStart != null,
-                            openRangesHolidayQuestionnaire = featureConfig.holidayQuestionnaireType == QuestionnaireType.OPEN_RANGES
+                            openRangesHolidayQuestionnaire =
+                                featureConfig.holidayQuestionnaireType ==
+                                    QuestionnaireType.OPEN_RANGES,
                         )
 
                     EmployeeUserResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/SystemController.kt
@@ -9,11 +9,13 @@ import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.Sensitive
 import fi.espoo.evaka.daycare.anyUnitHasFeature
+import fi.espoo.evaka.holidayperiod.QuestionnaireType
 import fi.espoo.evaka.identity.ExternalId
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.pairing.*
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.MobileDeviceId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -46,6 +48,7 @@ class SystemController(
     private val env: EvakaEnv,
     private val passwordService: PasswordService,
     private val webPush: WebPush?,
+    private val featureConfig: FeatureConfig,
 ) {
     @PostMapping("/system/citizen-login")
     fun citizenLogin(
@@ -309,6 +312,7 @@ class SystemController(
                             placementTool =
                                 permittedGlobalActions.contains(Action.Global.PLACEMENT_TOOL),
                             replacementInvoices = env.replacementInvoicesStart != null,
+                            openRangesHolidayQuestionnaire = featureConfig.holidayQuestionnaireType == QuestionnaireType.OPEN_RANGES
                         )
 
                     EmployeeUserResponse(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.shared
 
 import fi.espoo.evaka.application.ApplicationStatus
 import fi.espoo.evaka.application.ApplicationType
+import fi.espoo.evaka.holidayperiod.QuestionnaireType
 import fi.espoo.evaka.shared.auth.UserRole
 import java.time.MonthDay
 
@@ -155,6 +156,9 @@ data class FeatureConfig(
 
     /** Status of the applications created by placement tool */
     val placementToolApplicationStatus: ApplicationStatus = ApplicationStatus.SENT,
+
+    /** Type of holiday questionnaire */
+    val holidayQuestionnaireType: QuestionnaireType = QuestionnaireType.FIXED_PERIOD,
 )
 
 enum class ArchiveProcessType {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/EmployeeFeatures.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/EmployeeFeatures.kt
@@ -27,4 +27,5 @@ data class EmployeeFeatures(
     val submitPatuReport: Boolean,
     val placementTool: Boolean,
     val replacementInvoices: Boolean,
+    val openRangesHolidayQuestionnaire: Boolean
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/EmployeeFeatures.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/EmployeeFeatures.kt
@@ -27,5 +27,5 @@ data class EmployeeFeatures(
     val submitPatuReport: Boolean,
     val placementTool: Boolean,
     val replacementInvoices: Boolean,
-    val openRangesHolidayQuestionnaire: Boolean
+    val openRangesHolidayQuestionnaire: Boolean,
 )

--- a/service/src/main/resources/db/migration/V474__holiday_questionnaire_open_ranges.sql
+++ b/service/src/main/resources/db/migration/V474__holiday_questionnaire_open_ranges.sql
@@ -1,0 +1,3 @@
+ALTER TABLE holiday_period_questionnaire
+    ADD COLUMN period daterange,
+    ADD COLUMN absence_type_threshold integer;

--- a/service/src/main/resources/db/migration/V474__holiday_questionnaire_open_ranges.sql
+++ b/service/src/main/resources/db/migration/V474__holiday_questionnaire_open_ranges.sql
@@ -1,3 +1,6 @@
 ALTER TABLE holiday_period_questionnaire
     ADD COLUMN period daterange,
     ADD COLUMN absence_type_threshold integer;
+
+ALTER TABLE  holiday_questionnaire_answer
+    ADD COLUMN open_ranges daterange[]

--- a/service/src/main/resources/db/migration/V474__holiday_questionnaire_open_ranges.sql
+++ b/service/src/main/resources/db/migration/V474__holiday_questionnaire_open_ranges.sql
@@ -2,5 +2,9 @@ ALTER TABLE holiday_period_questionnaire
     ADD COLUMN period daterange,
     ADD COLUMN absence_type_threshold integer;
 
+ALTER TABLE holiday_period_questionnaire
+    ADD CONSTRAINT period_null_or_valid
+        CHECK ((period IS NULL OR NOT (lower_inf(period) OR upper_inf(period))));
+
 ALTER TABLE  holiday_questionnaire_answer
     ADD COLUMN open_ranges daterange[]

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -469,3 +469,4 @@ V470__cascade_citizen_user_delete.sql
 V471__application_confidentiality.sql
 V472__employee_ssn.sql
 V473__person_municipality_of_residence.sql
+V474__holiday_questionnaire_open_ranges.sql


### PR DESCRIPTION
- Kyselyyn määritetään aikaväli ja yhtäjaksoisen poissaolon minimipituus
- Vastaukseen voi valita useita vapaavalintaisia poissaolovälejä kyselyn aikavälin sisällä
- Mikäli vastauksen aikaväli on pidempi kuin kyselyyn määritetty minimipituus, luodaan maksuton poissaolo
- Muussa tapauksessa luodaan tavallinen poissaolo

Lisätty [ohjeisiin](https://github.com/espoon-voltti/evaka/wiki/Varaukset,-l%C3%A4sn%C3%A4olot-ja-poissaolot) kappale loma-aikakyselyistä

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
