### PR TITLE
Ei deaktivoida valmiiksi epäaktiivisia työntekijöitä uudelleen

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
@@ -270,7 +270,7 @@ class InactiveEmployeesRoleResetIntegrationTest : PureJdbiTest(resetDbBeforeEach
                 DevEmployee(
                     lastLogin = firstOfAugust2021.minusDays(daysToDeactivation),
                     roles = setOf(UserRole.ADMIN),
-                    active = false
+                    active = false,
                 )
             )
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
@@ -256,6 +256,29 @@ class InactiveEmployeesRoleResetIntegrationTest : PureJdbiTest(resetDbBeforeEach
         assertEquals(1, db.read { it.listPersonalDevices(employeeId).size })
     }
 
+    @Test
+    fun `only active employees are deactivated`() {
+        db.transaction {
+            it.insert(
+                DevEmployee(
+                    lastLogin = firstOfAugust2021.minusDays(daysToDeactivation),
+                    roles = setOf(UserRole.ADMIN),
+                )
+            )
+
+            it.insert(
+                DevEmployee(
+                    lastLogin = firstOfAugust2021.minusDays(daysToDeactivation),
+                    roles = setOf(UserRole.ADMIN),
+                    active = false
+                )
+            )
+        }
+
+        val deactivated = db.transaction { it.deactivateInactiveEmployees(firstOfAugust2021) }
+        assertEquals(1, deactivated.size)
+    }
+
     private fun Database.Transaction.setDaycareAclUpdated(
         unitId: DaycareId,
         employeeId: EmployeeId,

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/EmployeeQueries.kt
@@ -535,6 +535,7 @@ fun Database.Read.getInactiveEmployees(now: HelsinkiDateTime): List<EmployeeId> 
         SELECT max(ts)
         FROM unnest(ARRAY[e.last_login, d.updated, dg.updated]) ts
     ) < ${bind(now)} - interval '56 days'
+    AND e.active = true
 """
             )
         }


### PR DESCRIPTION
Lisätty työntekijöiden deaktivointiin tarkistus, jossa jätetään jo valmiiksi epäaktiiviset työntekijät käsittelemättä.

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
