### PR TITLE
Korjaus kasvatusvastuullisuuteen / täyttöasteeseen mobiilissa

### DIFF
--- a/frontend/src/employee-mobile-frontend/staff-attendance/StaffAttendanceEditPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/StaffAttendanceEditPage.tsx
@@ -125,7 +125,9 @@ const staffAttendanceForm = mapped(
       output.arrivedTime,
       output.departedTime
     ),
-    hasStaffOccupancyEffect: output.occupancyEffect
+    hasStaffOccupancyEffect: ['TRAINING', 'OTHER_WORK'].includes(output.type)
+      ? false
+      : output.occupancyEffect
   })
 )
 
@@ -613,6 +615,7 @@ const StaffAttendanceEditor = ({
           </>
         )}
       </FixedSpaceRow>
+      <Gap size="s" />
       <FixedSpaceRow alignItems="end" flexWrap="wrap">
         {featureFlags.staffAttendanceTypes && (
           <div>
@@ -655,11 +658,15 @@ const StaffAttendanceEditor = ({
           </IconContainer>
         </FixedSpaceRow>
       </FixedSpaceRow>
-      <CheckboxF
-        bind={occupancyEffect}
-        label={i18n.staff.staffOccupancyEffect}
-        data-qa="occupancy-effect"
-      />
+      <Gap size="s" />
+      {featureFlags.staffAttendanceTypes &&
+      ['TRAINING', 'OTHER_WORK'].includes(type.value()) ? null : (
+        <CheckboxF
+          bind={occupancyEffect}
+          label={i18n.staff.staffOccupancyEffect}
+          data-qa="occupancy-effect"
+        />
+      )}
     </FlexColumn>
   )
 }

--- a/frontend/src/lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly.tsx
+++ b/frontend/src/lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly.tsx
@@ -321,7 +321,8 @@ export default React.memo(function DecisionFormReadView({
                   ))}
                 {decision.form.otherRepresentativeHeard && (
                   <li>
-                    {`${t.otherRepresentative}: ${decision.form.otherRepresentativeDetails}`}
+                    {t.otherRepresentative}: $
+                    {decision.form.otherRepresentativeDetails}
                   </li>
                 )}
               </StyledUl>

--- a/frontend/src/lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly.tsx
+++ b/frontend/src/lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly.tsx
@@ -321,8 +321,7 @@ export default React.memo(function DecisionFormReadView({
                   ))}
                 {decision.form.otherRepresentativeHeard && (
                   <li>
-                    {t.otherRepresentative}: $
-                    {decision.form.otherRepresentativeDetails}
+                    {`${t.otherRepresentative}: ${decision.form.otherRepresentativeDetails}`}
                   </li>
                 )}
               </StyledUl>

--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/MobileUnitController.kt
@@ -192,6 +192,7 @@ fun Database.Read.fetchUnitInfo(unitId: DaycareId, date: LocalDate): UnitInfo {
                 WHERE sa.departed IS NULL AND dc.id = ${bind(unitId)}
                   AND daterange(dg.start_date, dg.end_date, '[]') @> ${bind(date)}
                   AND 'REALTIME_STAFF_ATTENDANCE' = ANY(dc.enabled_pilot_features)
+                  AND sa.type NOT IN ('OTHER_WORK', 'TRAINING')
         
                 UNION ALL
         


### PR DESCRIPTION
Jos henkilökunnan läsnäolon tyypiksi valitsee mobiilin muokkaa kirjauksia näkymässä joko koulutus tai muu työasia, piilotetaan kasvatusvastuullisuus-rasti ja tulkitaan aina ei-kasvatusvastuulliseksi. Lisätty myös mobiilin täyttöastelaskentaan lisävarmistus joka myös jättää huomiotta tämän tyyppiset kirjaukset.