### PR TITLE
Korjataan päänavigaation sijainti Firefox mobiiliselaimella

### DIFF
--- a/frontend/src/citizen-frontend/navigation/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/MobileNav.tsx
@@ -159,7 +159,7 @@ const BottomBar = styled.nav`
   height: ${mobileBottomNavHeight}px;
   width: 100%;
   padding: ${defaultMargins.xs};
-  position: sticky;
+  position: fixed;
   bottom: 0;
   left: 0;
   box-shadow: 0px -2px 4px rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
## Ennen tätä muutosta
Kun Firefoxin sositepalkki piiloutuu scrollatessa, päänavigaation nappuloiden aktiivinen alue ei siirtynyt alaspäin, vaikka niiden visuaalinen esitys siirtyikin viewportin "uuteen alalaitaan".
![tempFileForShare_20241126-122217](https://github.com/user-attachments/assets/ba63e0f7-b443-492d-9596-f6836c3048a6)

`<nav>` elementin sijainti ennen scrollausta

![tempFileForShare_20241126-121721](https://github.com/user-attachments/assets/8c283f36-e671-4021-98cc-92fca54709c4)
`<nav>` elementin sijainti scrollauksen ja osoitepalkin piiloutumisen jälkeen

Tämä johti siihen, että "Läsnäolot / Poissaolot / Keskustelut" nappia painaessa aktivoituikin Viestit, Lapset tai Valikko painike, riippuen mistä kohtaa leveyssuunnassa nappia painoi.

## Tämän muutoksen jälkeen
Päämenu on ankkuroitu alalaitaan `position: fixed` säännöllä ja se pitää nappien hitboxit oikeassa kohdassa myös mobiili Firefox selaimella skrollauksen jälkeen.