### PR TITLE
Tulotietojen sivun ulkonäön bugikorjaus

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationList.tsx
+++ b/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationList.tsx
@@ -88,6 +88,7 @@ export default React.memo(function FeeAlterationList({
                 }`}</Dates>
                 <span>{feeAlteration.notes}</span>
               </FixedSpaceRow>
+              <RightHandSide>
               {feeAlteration.modifiedAt && (
                 <FixedSpaceRow spacing="L">
                   <Tooltip
@@ -124,6 +125,7 @@ export default React.memo(function FeeAlterationList({
                   />
                 )}
               </FixedSpaceRow>
+              </RightHandSide>
             </FixedSpaceRow>
             {feeAlteration.attachments.length > 0 && (
               <FeeAlterationAttachments
@@ -183,4 +185,9 @@ const Dates = styled.span`
 const FileIcon = styled(FontAwesomeIcon)`
   color: ${(p) => p.theme.colors.main.m2};
   margin-right: ${defaultMargins.s};
+`
+
+const RightHandSide = styled(FixedSpaceRow)`
+  min-width: 50%;
+  justify-content: space-between;
 `

--- a/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationList.tsx
+++ b/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationList.tsx
@@ -89,42 +89,42 @@ export default React.memo(function FeeAlterationList({
                 <span>{feeAlteration.notes}</span>
               </FixedSpaceRow>
               <RightHandSide>
-              {feeAlteration.modifiedAt && (
-                <FixedSpaceRow spacing="L">
-                  <Tooltip
-                    tooltip={
-                      feeAlteration.modifiedBy &&
-                      i18n.childInformation.feeAlteration.lastModifiedBy(
-                        feeAlteration.modifiedBy.name
-                      )
-                    }
-                  >
-                    {i18n.childInformation.feeAlteration.lastModifiedAt(
-                      feeAlteration.modifiedAt.format()
-                    )}
-                  </Tooltip>
-                </FixedSpaceRow>
-              )}
-              <FixedSpaceRow>
-                {permittedActions.includes('UPDATE') && (
-                  <IconOnlyButton
-                    icon={faPen}
-                    onClick={() => {
-                      if (feeAlteration.id !== null) {
-                        toggleEditing(feeAlteration.id)
+                {feeAlteration.modifiedAt && (
+                  <FixedSpaceRow spacing="L">
+                    <Tooltip
+                      tooltip={
+                        feeAlteration.modifiedBy &&
+                        i18n.childInformation.feeAlteration.lastModifiedBy(
+                          feeAlteration.modifiedBy.name
+                        )
                       }
-                    }}
-                    aria-label={i18n.common.edit}
-                  />
+                    >
+                      {i18n.childInformation.feeAlteration.lastModifiedAt(
+                        feeAlteration.modifiedAt.format()
+                      )}
+                    </Tooltip>
+                  </FixedSpaceRow>
                 )}
-                {permittedActions.includes('DELETE') && (
-                  <IconOnlyButton
-                    icon={faTrash}
-                    onClick={() => toggleDeleteModal(feeAlteration)}
-                    aria-label={i18n.common.remove}
-                  />
-                )}
-              </FixedSpaceRow>
+                <FixedSpaceRow>
+                  {permittedActions.includes('UPDATE') && (
+                    <IconOnlyButton
+                      icon={faPen}
+                      onClick={() => {
+                        if (feeAlteration.id !== null) {
+                          toggleEditing(feeAlteration.id)
+                        }
+                      }}
+                      aria-label={i18n.common.edit}
+                    />
+                  )}
+                  {permittedActions.includes('DELETE') && (
+                    <IconOnlyButton
+                      icon={faTrash}
+                      onClick={() => toggleDeleteModal(feeAlteration)}
+                      aria-label={i18n.common.remove}
+                    />
+                  )}
+                </FixedSpaceRow>
               </RightHandSide>
             </FixedSpaceRow>
             {feeAlteration.attachments.length > 0 && (

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemHeader.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemHeader.tsx
@@ -41,6 +41,11 @@ const Row = styled(FixedSpaceRow)`
   align-items: center;
 `
 
+const RightHandSide = styled(Row)`
+  min-width: 50%;
+  justify-content: space-between;
+`
+
 interface Props {
   title: string
   isOpen: boolean
@@ -83,6 +88,7 @@ const IncomeItemHeader = React.memo(function IncomeItemHeader({
           <span>{period}</span>
         </Title>
       </ItemTitle>
+      <RightHandSide>
       {modifiedAt && (
         <Row>
           <Tooltip
@@ -127,6 +133,7 @@ const IncomeItemHeader = React.memo(function IncomeItemHeader({
           aria-label={isOpen ? i18n.common.close : i18n.common.open}
         />
       </Row>
+      </RightHandSide>
     </Container>
   )
 })

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemHeader.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemHeader.tsx
@@ -89,50 +89,50 @@ const IncomeItemHeader = React.memo(function IncomeItemHeader({
         </Title>
       </ItemTitle>
       <RightHandSide>
-      {modifiedAt && (
+        {modifiedAt && (
+          <Row>
+            <Tooltip
+              tooltip={
+                modifiedBy &&
+                i18n.personProfile.income.lastModifiedBy(modifiedBy.name)
+              }
+            >
+              {i18n.personProfile.income.lastModifiedAt(modifiedAt.format())}
+            </Tooltip>
+          </Row>
+        )}
         <Row>
-          <Tooltip
-            tooltip={
-              modifiedBy &&
-              i18n.personProfile.income.lastModifiedBy(modifiedBy.name)
-            }
-          >
-            {i18n.personProfile.income.lastModifiedAt(modifiedAt.format())}
-          </Tooltip>
+          {permittedActions.includes('UPDATE') && (
+            <Button
+              icon={faPen}
+              onClick={() => {
+                startEditing()
+                if (!isOpen) toggle()
+              }}
+              disabled={!editable}
+              data-qa="edit-income-item"
+              aria-label={i18n.common.edit}
+            />
+          )}
+          {permittedActions.includes('DELETE') && (
+            <Button
+              icon={faTrash}
+              onClick={() => {
+                startDeleting()
+              }}
+              disabled={!editable}
+              data-qa="delete-income-item"
+              aria-label={i18n.common.remove}
+            />
+          )}
+          <ToggleButton
+            icon={isOpen ? faChevronUp : faChevronDown}
+            onClick={toggle}
+            disabled={!toggleable}
+            data-qa="toggle-income-item"
+            aria-label={isOpen ? i18n.common.close : i18n.common.open}
+          />
         </Row>
-      )}
-      <Row>
-        {permittedActions.includes('UPDATE') && (
-          <Button
-            icon={faPen}
-            onClick={() => {
-              startEditing()
-              if (!isOpen) toggle()
-            }}
-            disabled={!editable}
-            data-qa="edit-income-item"
-            aria-label={i18n.common.edit}
-          />
-        )}
-        {permittedActions.includes('DELETE') && (
-          <Button
-            icon={faTrash}
-            onClick={() => {
-              startDeleting()
-            }}
-            disabled={!editable}
-            data-qa="delete-income-item"
-            aria-label={i18n.common.remove}
-          />
-        )}
-        <ToggleButton
-          icon={isOpen ? faChevronUp : faChevronDown}
-          onClick={toggle}
-          disabled={!toggleable}
-          data-qa="toggle-income-item"
-          aria-label={isOpen ? i18n.common.close : i18n.common.open}
-        />
-      </Row>
       </RightHandSide>
     </Container>
   )


### PR DESCRIPTION
Korjannut tulotietojen sivua niin, että sarakkeet pysyvät suorina.

Alkuperäiinen: 
![image](https://github.com/user-attachments/assets/0ca3a56a-5603-4a5f-af3c-0680db277224)

Korjattu:
![2024-11-28-114316_1499x836_scrot](https://github.com/user-attachments/assets/279ab273-5e74-4e7e-8bb1-55feab30f49a)