### PR TITLE
Maksupäätöksien hakuun uusi hakuehto: ei avoimia tuloselvityksiä

### DIFF
--- a/frontend/src/lib-common/generated/api-types/invoicing.ts
+++ b/frontend/src/lib-common/generated/api-types/invoicing.ts
@@ -54,7 +54,8 @@ export const feeDecisionDistinctiveParams = [
   'RETROACTIVE',
   'NO_STARTING_PLACEMENTS',
   'MAX_FEE_ACCEPTED',
-  'PRESCHOOL_CLUB'
+  'PRESCHOOL_CLUB',
+  'NO_OPEN_INCOME_STATEMENTS'
 ] as const
 
 export type DistinctiveParams = typeof feeDecisionDistinctiveParams[number]

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3077,7 +3077,7 @@ export const fi = {
       NO_STARTING_PLACEMENTS: 'Piilota uudet aloittavat lapset',
       MAX_FEE_ACCEPTED: 'Suostumus korkeimpaan maksuun',
       PRESCHOOL_CLUB: 'Vain esiopetuksen kerho',
-      NO_OPEN_INCOME_STATEMENTS: 'Piilota avonaiset tuloselvitykset'
+      NO_OPEN_INCOME_STATEMENTS: 'Ei avoimia tuloselvityksiä'
     },
     status: {
       DRAFT: 'Luonnos',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3076,7 +3076,8 @@ export const fi = {
       RETROACTIVE: 'Takautuva päätös',
       NO_STARTING_PLACEMENTS: 'Piilota uudet aloittavat lapset',
       MAX_FEE_ACCEPTED: 'Suostumus korkeimpaan maksuun',
-      PRESCHOOL_CLUB: 'Vain esiopetuksen kerho'
+      PRESCHOOL_CLUB: 'Vain esiopetuksen kerho',
+      NO_OPEN_INCOME_STATEMENTS: 'Piilota avonaiset tuloselvitykset'
     },
     status: {
       DRAFT: 'Luonnos',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -525,6 +525,21 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
     }
 
     @Test
+    fun `search works with distinctions param PRESCHOOL_CLUB`() {
+        db.transaction { tx -> tx.upsertFeeDecisions(testDecisions + preschoolClubDecisions) }
+        val result =
+            searchDecisions(
+                SearchFeeDecisionRequest(
+                    page = 0,
+                    distinctions = listOf(DistinctiveParams.PRESCHOOL_CLUB),
+                )
+            )
+
+        assertEquals(2, result.data.size)
+        assertEqualEnough(preschoolClubDecisions.map { toSummary(it) }, result.data)
+    }
+
+    @Test
     fun `search works as expected with existing area param`() {
         db.transaction { tx -> tx.upsertFeeDecisions(testDecisions) }
 
@@ -2023,21 +2038,6 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             )
 
         getPdf(decision.id, adminUser)
-    }
-
-    @Test
-    fun `search works with distinctions param PRESCHOOL_CLUB`() {
-        db.transaction { tx -> tx.upsertFeeDecisions(testDecisions + preschoolClubDecisions) }
-        val result =
-            searchDecisions(
-                SearchFeeDecisionRequest(
-                    page = 0,
-                    distinctions = listOf(DistinctiveParams.PRESCHOOL_CLUB),
-                )
-            )
-
-        assertEquals(2, result.data.size)
-        assertEqualEnough(preschoolClubDecisions.map { toSummary(it) }, result.data)
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/FeeDecisionController.kt
@@ -68,6 +68,7 @@ enum class DistinctiveParams {
     NO_STARTING_PLACEMENTS,
     MAX_FEE_ACCEPTED,
     PRESCHOOL_CLUB,
+    NO_OPEN_INCOME_STATEMENTS,
 }
 
 @RestController


### PR DESCRIPTION
Maksupäätöksien hakuun on lisätty uusi hakuehto: ei avoimia tuloselvityksiä. Kun se on valittuna, sellaisia maksupäätöksiä ei näytetä, joihin liittyy avoimia tuloselvityksiä. Tuloselvityksistä huomioidaan koko jääkaappiperheen selvitykset, jotka koskevat ajanjaksoa alkaen 14 kuukautta sitten kuluvaan päivään asti.

<img width="1345" alt="image" src="https://github.com/user-attachments/assets/ded13a71-2834-4e18-a96c-fb74c10990bd">
