### PR TITLE
Korjataan viimeisen laskutetun kuukauden päättely

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
@@ -620,3 +620,9 @@ WHERE id = ${bind(replacedInvoiceId)}
             .updateExactlyOne()
     }
 }
+
+fun Database.Read.getLastInvoicedMonth(): YearMonth? =
+    createQuery { sql("SELECT MAX(invoice_date) AS month FROM invoice WHERE status = 'SENT'") }
+        .exactlyOneOrNull<YearMonth>()
+        // Invoices of month M are sent in month M+1
+        ?.minusMonths(1)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -11,6 +11,7 @@ import fi.espoo.evaka.children.getChildIdsByHeadsOfFamily
 import fi.espoo.evaka.invoicing.data.deleteDraftInvoices
 import fi.espoo.evaka.invoicing.data.feeDecisionQuery
 import fi.espoo.evaka.invoicing.data.getFeeThresholds
+import fi.espoo.evaka.invoicing.data.getLastInvoicedMonth
 import fi.espoo.evaka.invoicing.data.getSentInvoicesOfMonth
 import fi.espoo.evaka.invoicing.data.insertDraftInvoices
 import fi.espoo.evaka.invoicing.domain.ChildWithDateOfBirth
@@ -130,7 +131,10 @@ class InvoiceGenerator(
         }
 
         val monthsToGenerate = 12L
-        val latestMonth = YearMonth.of(today.year, today.month).minusMonths(1)
+
+        val latestMonth: YearMonth =
+            dbc.read { tx -> tx.getLastInvoicedMonth() }
+                ?: YearMonth.of(today.year, today.month).minusMonths(1)
         val earliestMonth =
             maxOf(replacementInvoicesStart, latestMonth.minusMonths(monthsToGenerate - 1))
 


### PR DESCRIPTION
Oikaisulaskuja muodostetaan 12 kuukautta taaksepäin viimeisestä laskutetusta kuukaudesta. Päätellään viimeinen laskutettu kuukausi lähetetyistä laskuista sen sijaan että käytettäisiin aina edeltävää kuukautta.