### PR TITLE
Korjataan lapsen dokumentin muokkausnäkymän tallennuskäyttäytyminen virhetilanteissa

### DIFF
--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -847,6 +847,7 @@ export const fi = {
           'Toinen käyttäjä muokkaa asiakirjaa. Yritä myöhemmin uudelleen.',
         lockedErrorDetailed: (modifiedByName: string, opensAt: string) =>
           `Käyttäjä ${modifiedByName} on muokkaamassa asiakirjaa. Asiakirjan lukitus vapautuu ${opensAt} mikäli muokkaamista ei jatketa. Yritä myöhemmin uudelleen.`,
+        saveError: 'Asiakirjan tallentaminen epäonnistui.',
         preview: 'Esikatsele',
         publish: 'Julkaise huoltajalle',
         publishConfirmTitle: 'Haluatko varmasti julkaista huoltajalle?',


### PR DESCRIPTION
**Ennen:** Jos request epäonnistui mihin tahansa muuhun virheeseen kuin yhtäaikaiseen muokkaamiseen, lapsen dokumenttia yritettiin tallentaa ikikieriössä.

**Jälkeen:** Näytetään sen sijaan virheviesti ja yritetään uudestaan 5 sekunnin välein:

<img width="677" alt="image" src="https://github.com/user-attachments/assets/3cc09b7a-01be-4920-8fdf-30ac9d78d8f7">
