### PR TITLE
Sijoitusehdotuksen hylkäämisestä luotava muistilappu siirtyy palveluohjauksen muistilapuksi

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/notes/ApplicationNoteQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/notes/ApplicationNoteQueries.kt
@@ -100,6 +100,12 @@ FROM updated_note n
         }
         .exactlyOne()
 
+fun Database.Read.getServiceWorkerApplicationNote(id: ApplicationId) =
+    createQuery {
+            sql("SELECT application.service_worker_note FROM application WHERE id = ${bind(id)}")
+        }
+        .exactlyOne<String>()
+
 fun Database.Transaction.updateServiceWorkerApplicationNote(id: ApplicationId, content: String) =
     createUpdate {
             sql(


### PR DESCRIPTION
Aiemmin tehdyssä muutoksessa sijoitusehdotuksen hylkäämisen syy kirjattiin erilliseksi muistilapuksi hakemukselle. Tämä muutos vaihtaa syyn kirjaamispaikan palveluohjauksen sisäiseen muistilappuun. Mikäli muistilapulla on jo sisältöä, syy kirjataan aiemman sisällön perään rivinvaihdolla erotettuna. Syyn lisäksi lapulle kirjataan hylkäyksen tehneen käyttäjän nimi ja tapahtuman aika.