### PR TITLE
Generoidut api-clientit tukemaan extra headereja

### DIFF
--- a/frontend/src/citizen-frontend/generated/api-clients/application.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/application.ts
@@ -10,6 +10,7 @@ import { ApplicationDetails } from 'lib-common/generated/api-types/application'
 import { ApplicationFormUpdate } from 'lib-common/generated/api-types/application'
 import { ApplicationType } from 'lib-common/generated/api-types/application'
 import { ApplicationsOfChild } from 'lib-common/generated/api-types/application'
+import { AxiosHeaders } from 'axios'
 import { CitizenApplicationUpdate } from 'lib-common/generated/api-types/application'
 import { CitizenChildren } from 'lib-common/generated/api-types/application'
 import { CreateApplicationBody } from 'lib-common/generated/api-types/application'
@@ -36,11 +37,13 @@ export async function acceptDecision(
   request: {
     applicationId: UUID,
     body: AcceptDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/applications/${request.applicationId}/actions/accept-decision`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AcceptDecisionRequest>
   })
   return json
@@ -53,11 +56,13 @@ export async function acceptDecision(
 export async function createApplication(
   request: {
     body: CreateApplicationBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/citizen/applications`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CreateApplicationBody>
   })
   return json
@@ -70,11 +75,13 @@ export async function createApplication(
 export async function deleteOrCancelUnprocessedApplication(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/applications/${request.applicationId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -86,11 +93,13 @@ export async function deleteOrCancelUnprocessedApplication(
 export async function getApplication(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ApplicationDetails> {
   const { data: json } = await client.request<JsonOf<ApplicationDetails>>({
     url: uri`/citizen/applications/${request.applicationId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonApplicationDetails(json)
 }
@@ -99,10 +108,13 @@ export async function getApplication(
 /**
 * Generated from fi.espoo.evaka.application.ApplicationControllerCitizen.getApplicationChildren
 */
-export async function getApplicationChildren(): Promise<CitizenChildren[]> {
+export async function getApplicationChildren(
+  headers?: AxiosHeaders
+): Promise<CitizenChildren[]> {
   const { data: json } = await client.request<JsonOf<CitizenChildren[]>>({
     url: uri`/citizen/applications/children`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonCitizenChildren(e))
 }
@@ -114,11 +126,13 @@ export async function getApplicationChildren(): Promise<CitizenChildren[]> {
 export async function getApplicationDecisions(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DecisionWithValidStartDatePeriod[]> {
   const { data: json } = await client.request<JsonOf<DecisionWithValidStartDatePeriod[]>>({
     url: uri`/citizen/applications/${request.applicationId}/decisions`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonDecisionWithValidStartDatePeriod(e))
 }
@@ -130,11 +144,13 @@ export async function getApplicationDecisions(
 export async function getChildDuplicateApplications(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Record<ApplicationType, boolean>> {
   const { data: json } = await client.request<JsonOf<Record<ApplicationType, boolean>>>({
     url: uri`/citizen/applications/duplicates/${request.childId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -146,11 +162,13 @@ export async function getChildDuplicateApplications(
 export async function getChildPlacementStatusByApplicationType(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Record<ApplicationType, boolean>> {
   const { data: json } = await client.request<JsonOf<Record<ApplicationType, boolean>>>({
     url: uri`/citizen/applications/active-placements/${request.childId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -159,10 +177,13 @@ export async function getChildPlacementStatusByApplicationType(
 /**
 * Generated from fi.espoo.evaka.application.ApplicationControllerCitizen.getDecisions
 */
-export async function getDecisions(): Promise<ApplicationDecisions> {
+export async function getDecisions(
+  headers?: AxiosHeaders
+): Promise<ApplicationDecisions> {
   const { data: json } = await client.request<JsonOf<ApplicationDecisions>>({
     url: uri`/citizen/decisions`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonApplicationDecisions(json)
 }
@@ -171,10 +192,13 @@ export async function getDecisions(): Promise<ApplicationDecisions> {
 /**
 * Generated from fi.espoo.evaka.application.ApplicationControllerCitizen.getGuardianApplicationNotifications
 */
-export async function getGuardianApplicationNotifications(): Promise<number> {
+export async function getGuardianApplicationNotifications(
+  headers?: AxiosHeaders
+): Promise<number> {
   const { data: json } = await client.request<JsonOf<number>>({
     url: uri`/citizen/applications/by-guardian/notifications`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -183,10 +207,13 @@ export async function getGuardianApplicationNotifications(): Promise<number> {
 /**
 * Generated from fi.espoo.evaka.application.ApplicationControllerCitizen.getGuardianApplications
 */
-export async function getGuardianApplications(): Promise<ApplicationsOfChild[]> {
+export async function getGuardianApplications(
+  headers?: AxiosHeaders
+): Promise<ApplicationsOfChild[]> {
   const { data: json } = await client.request<JsonOf<ApplicationsOfChild[]>>({
     url: uri`/citizen/applications/by-guardian`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonApplicationsOfChild(e))
 }
@@ -195,10 +222,13 @@ export async function getGuardianApplications(): Promise<ApplicationsOfChild[]> 
 /**
 * Generated from fi.espoo.evaka.application.ApplicationControllerCitizen.getLiableCitizenFinanceDecisions
 */
-export async function getLiableCitizenFinanceDecisions(): Promise<FinanceDecisionCitizenInfo[]> {
+export async function getLiableCitizenFinanceDecisions(
+  headers?: AxiosHeaders
+): Promise<FinanceDecisionCitizenInfo[]> {
   const { data: json } = await client.request<JsonOf<FinanceDecisionCitizenInfo[]>>({
     url: uri`/citizen/finance-decisions/by-liable-citizen`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonFinanceDecisionCitizenInfo(e))
 }
@@ -211,11 +241,13 @@ export async function rejectDecision(
   request: {
     applicationId: UUID,
     body: RejectDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/applications/${request.applicationId}/actions/reject-decision`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<RejectDecisionRequest>
   })
   return json
@@ -229,11 +261,13 @@ export async function saveApplicationAsDraft(
   request: {
     applicationId: UUID,
     body: ApplicationFormUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/applications/${request.applicationId}/draft`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ApplicationFormUpdate>
   })
   return json
@@ -246,11 +280,13 @@ export async function saveApplicationAsDraft(
 export async function sendApplication(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/applications/${request.applicationId}/actions/send-application`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -263,11 +299,13 @@ export async function updateApplication(
   request: {
     applicationId: UUID,
     body: CitizenApplicationUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/applications/${request.applicationId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<CitizenApplicationUpdate>
   })
   return json

--- a/frontend/src/citizen-frontend/generated/api-clients/assistanceneed.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/assistanceneed.ts
@@ -8,6 +8,7 @@ import { AssistanceNeedDecision } from 'lib-common/generated/api-types/assistanc
 import { AssistanceNeedDecisionCitizenListItem } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedPreschoolDecision } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedPreschoolDecisionCitizenListItem } from 'lib-common/generated/api-types/assistanceneed'
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
 import { UnreadAssistanceNeedDecisionItem } from 'lib-common/generated/api-types/assistanceneed'
@@ -25,11 +26,13 @@ import { uri } from 'lib-common/uri'
 export async function getAssistanceNeedDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedDecision> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedDecision>>({
     url: uri`/citizen/children/assistance-need-decision/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonAssistanceNeedDecision(json)
 }
@@ -38,10 +41,13 @@ export async function getAssistanceNeedDecision(
 /**
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionCitizenController.getAssistanceNeedDecisionUnreadCount
 */
-export async function getAssistanceNeedDecisionUnreadCount(): Promise<UnreadAssistanceNeedDecisionItem[]> {
+export async function getAssistanceNeedDecisionUnreadCount(
+  headers?: AxiosHeaders
+): Promise<UnreadAssistanceNeedDecisionItem[]> {
   const { data: json } = await client.request<JsonOf<UnreadAssistanceNeedDecisionItem[]>>({
     url: uri`/citizen/children/assistance-need-decisions/unread-counts`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -50,10 +56,13 @@ export async function getAssistanceNeedDecisionUnreadCount(): Promise<UnreadAssi
 /**
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionCitizenController.getAssistanceNeedDecisions
 */
-export async function getAssistanceNeedDecisions(): Promise<AssistanceNeedDecisionCitizenListItem[]> {
+export async function getAssistanceNeedDecisions(
+  headers?: AxiosHeaders
+): Promise<AssistanceNeedDecisionCitizenListItem[]> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedDecisionCitizenListItem[]>>({
     url: uri`/citizen/assistance-need-decisions`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonAssistanceNeedDecisionCitizenListItem(e))
 }
@@ -65,11 +74,13 @@ export async function getAssistanceNeedDecisions(): Promise<AssistanceNeedDecisi
 export async function markAssistanceNeedDecisionAsRead(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/children/assistance-need-decision/${request.id}/read`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -81,11 +92,13 @@ export async function markAssistanceNeedDecisionAsRead(
 export async function getAssistanceNeedPreschoolDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedPreschoolDecision> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedPreschoolDecision>>({
     url: uri`/citizen/children/assistance-need-preschool-decisions/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonAssistanceNeedPreschoolDecision(json)
 }
@@ -94,10 +107,13 @@ export async function getAssistanceNeedPreschoolDecision(
 /**
 * Generated from fi.espoo.evaka.assistanceneed.preschooldecision.AssistanceNeedPreschoolDecisionCitizenController.getAssistanceNeedPreschoolDecisionUnreadCount
 */
-export async function getAssistanceNeedPreschoolDecisionUnreadCount(): Promise<UnreadAssistanceNeedDecisionItem[]> {
+export async function getAssistanceNeedPreschoolDecisionUnreadCount(
+  headers?: AxiosHeaders
+): Promise<UnreadAssistanceNeedDecisionItem[]> {
   const { data: json } = await client.request<JsonOf<UnreadAssistanceNeedDecisionItem[]>>({
     url: uri`/citizen/children/assistance-need-preschool-decisions/unread-counts`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -106,10 +122,13 @@ export async function getAssistanceNeedPreschoolDecisionUnreadCount(): Promise<U
 /**
 * Generated from fi.espoo.evaka.assistanceneed.preschooldecision.AssistanceNeedPreschoolDecisionCitizenController.getAssistanceNeedPreschoolDecisions
 */
-export async function getAssistanceNeedPreschoolDecisions(): Promise<AssistanceNeedPreschoolDecisionCitizenListItem[]> {
+export async function getAssistanceNeedPreschoolDecisions(
+  headers?: AxiosHeaders
+): Promise<AssistanceNeedPreschoolDecisionCitizenListItem[]> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedPreschoolDecisionCitizenListItem[]>>({
     url: uri`/citizen/assistance-need-preschool-decisions`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonAssistanceNeedPreschoolDecisionCitizenListItem(e))
 }
@@ -121,11 +140,13 @@ export async function getAssistanceNeedPreschoolDecisions(): Promise<AssistanceN
 export async function markAssistanceNeedPreschoolDecisionAsRead(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/children/assistance-need-preschool-decisions/${request.id}/read`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }

--- a/frontend/src/citizen-frontend/generated/api-clients/attachment.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/attachment.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
 import { client } from '../../api-client'
@@ -16,11 +17,13 @@ import { uri } from 'lib-common/uri'
 export async function deleteAttachment(
   request: {
     attachmentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/attachments/${request.attachmentId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }

--- a/frontend/src/citizen-frontend/generated/api-clients/calendarevent.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/calendarevent.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { CalendarEventTime } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeCitizenReservationForm } from 'lib-common/generated/api-types/calendarevent'
 import { CitizenCalendarEvent } from 'lib-common/generated/api-types/calendarevent'
@@ -24,11 +25,13 @@ import { uri } from 'lib-common/uri'
 export async function addCalendarEventTimeReservation(
   request: {
     body: CalendarEventTimeCitizenReservationForm
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/calendar-event/reservation`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CalendarEventTimeCitizenReservationForm>
   })
   return json
@@ -42,7 +45,8 @@ export async function deleteCalendarEventTimeReservation(
   request: {
     calendarEventTimeId: UUID,
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['calendarEventTimeId', request.calendarEventTimeId],
@@ -51,6 +55,7 @@ export async function deleteCalendarEventTimeReservation(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/calendar-event/reservation`.toString(),
     method: 'DELETE',
+    headers,
     params
   })
   return json
@@ -64,7 +69,8 @@ export async function getCitizenCalendarEvents(
   request: {
     start: LocalDate,
     end: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CitizenCalendarEvent[]> {
   const params = createUrlSearchParams(
     ['start', request.start.formatIso()],
@@ -73,6 +79,7 @@ export async function getCitizenCalendarEvents(
   const { data: json } = await client.request<JsonOf<CitizenCalendarEvent[]>>({
     url: uri`/citizen/calendar-events`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonCitizenCalendarEvent(e))
@@ -86,7 +93,8 @@ export async function getReservableCalendarEventTimes(
   request: {
     eventId: UUID,
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CalendarEventTime[]> {
   const params = createUrlSearchParams(
     ['childId', request.childId]
@@ -94,6 +102,7 @@ export async function getReservableCalendarEventTimes(
   const { data: json } = await client.request<JsonOf<CalendarEventTime[]>>({
     url: uri`/citizen/calendar-event/${request.eventId}/time`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonCalendarEventTime(e))

--- a/frontend/src/citizen-frontend/generated/api-clients/children.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/children.ts
@@ -6,6 +6,7 @@
 
 import YearMonth from 'lib-common/year-month'
 import { AttendanceSummary } from 'lib-common/generated/api-types/children'
+import { AxiosHeaders } from 'axios'
 import { ChildAndPermittedActions } from 'lib-common/generated/api-types/children'
 import { DailyServiceTimes } from 'lib-common/generated/api-types/dailyservicetimes'
 import { JsonOf } from 'lib-common/json'
@@ -24,11 +25,13 @@ export async function getChildAttendanceSummary(
   request: {
     childId: UUID,
     yearMonth: YearMonth
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AttendanceSummary> {
   const { data: json } = await client.request<JsonOf<AttendanceSummary>>({
     url: uri`/citizen/children/${request.childId}/attendance-summary/${request.yearMonth.formatIso()}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -40,11 +43,13 @@ export async function getChildAttendanceSummary(
 export async function getChildDailyServiceTimes(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DailyServiceTimes[]> {
   const { data: json } = await client.request<JsonOf<DailyServiceTimes[]>>({
     url: uri`/citizen/children/${request.childId}/daily-service-times`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonDailyServiceTimes(e))
 }
@@ -56,11 +61,13 @@ export async function getChildDailyServiceTimes(
 export async function getChildServiceNeeds(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ServiceNeedSummary[]> {
   const { data: json } = await client.request<JsonOf<ServiceNeedSummary[]>>({
     url: uri`/citizen/children/${request.childId}/service-needs`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonServiceNeedSummary(e))
 }
@@ -69,10 +76,13 @@ export async function getChildServiceNeeds(
 /**
 * Generated from fi.espoo.evaka.children.ChildControllerCitizen.getChildren
 */
-export async function getChildren(): Promise<ChildAndPermittedActions[]> {
+export async function getChildren(
+  headers?: AxiosHeaders
+): Promise<ChildAndPermittedActions[]> {
   const { data: json } = await client.request<JsonOf<ChildAndPermittedActions[]>>({
     url: uri`/citizen/children`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }

--- a/frontend/src/citizen-frontend/generated/api-clients/dailyservicetimes.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/dailyservicetimes.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
@@ -17,11 +18,13 @@ import { uri } from 'lib-common/uri'
 export async function dismissDailyServiceTimeNotification(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/daily-service-time-notifications/dismiss`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -31,10 +34,13 @@ export async function dismissDailyServiceTimeNotification(
 /**
 * Generated from fi.espoo.evaka.dailyservicetimes.DailyServiceTimesCitizenController.getDailyServiceTimeNotifications
 */
-export async function getDailyServiceTimeNotifications(): Promise<UUID[]> {
+export async function getDailyServiceTimeNotifications(
+  headers?: AxiosHeaders
+): Promise<UUID[]> {
   const { data: json } = await client.request<JsonOf<UUID[]>>({
     url: uri`/citizen/daily-service-time-notifications`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }

--- a/frontend/src/citizen-frontend/generated/api-clients/daycare.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/daycare.ts
@@ -7,6 +7,7 @@
 import LocalDate from 'lib-common/local-date'
 import { ApplicationType } from 'lib-common/generated/api-types/application'
 import { ApplicationUnitType } from 'lib-common/generated/api-types/daycare'
+import { AxiosHeaders } from 'axios'
 import { ClubTerm } from 'lib-common/generated/api-types/daycare'
 import { JsonOf } from 'lib-common/json'
 import { PreschoolTerm } from 'lib-common/generated/api-types/daycare'
@@ -25,11 +26,13 @@ import { uri } from 'lib-common/uri'
 export async function getAllApplicableUnits(
   request: {
     applicationType: ApplicationType
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PublicUnit[]> {
   const { data: json } = await client.request<JsonOf<PublicUnit[]>>({
     url: uri`/citizen/public/units/${request.applicationType}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPublicUnit(e))
 }
@@ -43,7 +46,8 @@ export async function getApplicationUnits(
     type: ApplicationUnitType,
     date: LocalDate,
     shiftCare?: boolean | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PublicUnit[]> {
   const params = createUrlSearchParams(
     ['type', request.type.toString()],
@@ -53,6 +57,7 @@ export async function getApplicationUnits(
   const { data: json } = await client.request<JsonOf<PublicUnit[]>>({
     url: uri`/citizen/units`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonPublicUnit(e))
@@ -62,10 +67,13 @@ export async function getApplicationUnits(
 /**
 * Generated from fi.espoo.evaka.daycare.controllers.TermsController.getClubTerms
 */
-export async function getClubTerms(): Promise<ClubTerm[]> {
+export async function getClubTerms(
+  headers?: AxiosHeaders
+): Promise<ClubTerm[]> {
   const { data: json } = await client.request<JsonOf<ClubTerm[]>>({
     url: uri`/citizen/public/club-terms`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonClubTerm(e))
 }
@@ -74,10 +82,13 @@ export async function getClubTerms(): Promise<ClubTerm[]> {
 /**
 * Generated from fi.espoo.evaka.daycare.controllers.TermsController.getPreschoolTerms
 */
-export async function getPreschoolTerms(): Promise<PreschoolTerm[]> {
+export async function getPreschoolTerms(
+  headers?: AxiosHeaders
+): Promise<PreschoolTerm[]> {
   const { data: json } = await client.request<JsonOf<PreschoolTerm[]>>({
     url: uri`/citizen/public/preschool-terms`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPreschoolTerm(e))
 }

--- a/frontend/src/citizen-frontend/generated/api-clients/document.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/document.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { ChildDocumentCitizenDetails } from 'lib-common/generated/api-types/document'
 import { ChildDocumentCitizenSummary } from 'lib-common/generated/api-types/document'
 import { JsonOf } from 'lib-common/json'
@@ -21,11 +22,13 @@ import { uri } from 'lib-common/uri'
 export async function getDocument(
   request: {
     documentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildDocumentCitizenDetails> {
   const { data: json } = await client.request<JsonOf<ChildDocumentCitizenDetails>>({
     url: uri`/citizen/child-documents/${request.documentId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonChildDocumentCitizenDetails(json)
 }
@@ -37,7 +40,8 @@ export async function getDocument(
 export async function getDocuments(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildDocumentCitizenSummary[]> {
   const params = createUrlSearchParams(
     ['childId', request.childId]
@@ -45,6 +49,7 @@ export async function getDocuments(
   const { data: json } = await client.request<JsonOf<ChildDocumentCitizenSummary[]>>({
     url: uri`/citizen/child-documents`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonChildDocumentCitizenSummary(e))
@@ -54,10 +59,13 @@ export async function getDocuments(
 /**
 * Generated from fi.espoo.evaka.document.childdocument.ChildDocumentControllerCitizen.getUnreadDocumentsCount
 */
-export async function getUnreadDocumentsCount(): Promise<Record<UUID, number>> {
+export async function getUnreadDocumentsCount(
+  headers?: AxiosHeaders
+): Promise<Record<UUID, number>> {
   const { data: json } = await client.request<JsonOf<Record<UUID, number>>>({
     url: uri`/citizen/child-documents/unread-count`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -69,11 +77,13 @@ export async function getUnreadDocumentsCount(): Promise<Record<UUID, number>> {
 export async function putDocumentRead(
   request: {
     documentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/child-documents/${request.documentId}/read`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }

--- a/frontend/src/citizen-frontend/generated/api-clients/holidayperiod.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/holidayperiod.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import { ActiveQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
+import { AxiosHeaders } from 'axios'
 import { FixedPeriodsBody } from 'lib-common/generated/api-types/holidayperiod'
 import { HolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
 import { JsonCompatible } from 'lib-common/json'
@@ -23,11 +24,13 @@ export async function answerFixedPeriodQuestionnaire(
   request: {
     id: UUID,
     body: FixedPeriodsBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/holiday-period/questionnaire/fixed-period/${request.id}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<FixedPeriodsBody>
   })
   return json
@@ -37,10 +40,13 @@ export async function answerFixedPeriodQuestionnaire(
 /**
 * Generated from fi.espoo.evaka.holidayperiod.HolidayPeriodControllerCitizen.getActiveQuestionnaires
 */
-export async function getActiveQuestionnaires(): Promise<ActiveQuestionnaire[]> {
+export async function getActiveQuestionnaires(
+  headers?: AxiosHeaders
+): Promise<ActiveQuestionnaire[]> {
   const { data: json } = await client.request<JsonOf<ActiveQuestionnaire[]>>({
     url: uri`/citizen/holiday-period/questionnaire`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonActiveQuestionnaire(e))
 }
@@ -49,10 +55,13 @@ export async function getActiveQuestionnaires(): Promise<ActiveQuestionnaire[]> 
 /**
 * Generated from fi.espoo.evaka.holidayperiod.HolidayPeriodControllerCitizen.getHolidayPeriods
 */
-export async function getHolidayPeriods(): Promise<HolidayPeriod[]> {
+export async function getHolidayPeriods(
+  headers?: AxiosHeaders
+): Promise<HolidayPeriod[]> {
   const { data: json } = await client.request<JsonOf<HolidayPeriod[]>>({
     url: uri`/citizen/holiday-period`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonHolidayPeriod(e))
 }

--- a/frontend/src/citizen-frontend/generated/api-clients/incomestatement.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/incomestatement.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { ChildBasicInfo } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeStatement } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeStatementBody } from 'lib-common/generated/api-types/incomestatement'
@@ -27,7 +28,8 @@ export async function createChildIncomeStatement(
     childId: UUID,
     draft?: boolean | null,
     body: IncomeStatementBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['draft', request.draft?.toString()]
@@ -35,6 +37,7 @@ export async function createChildIncomeStatement(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/income-statements/child/${request.childId}`.toString(),
     method: 'POST',
+    headers,
     params,
     data: request.body satisfies JsonCompatible<IncomeStatementBody>
   })
@@ -49,7 +52,8 @@ export async function createIncomeStatement(
   request: {
     draft?: boolean | null,
     body: IncomeStatementBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['draft', request.draft?.toString()]
@@ -57,6 +61,7 @@ export async function createIncomeStatement(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/income-statements`.toString(),
     method: 'POST',
+    headers,
     params,
     data: request.body satisfies JsonCompatible<IncomeStatementBody>
   })
@@ -70,11 +75,13 @@ export async function createIncomeStatement(
 export async function deleteIncomeStatement(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/income-statements/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -87,11 +94,13 @@ export async function getChildIncomeStatement(
   request: {
     childId: UUID,
     incomeStatementId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<IncomeStatement> {
   const { data: json } = await client.request<JsonOf<IncomeStatement>>({
     url: uri`/citizen/income-statements/child/${request.childId}/${request.incomeStatementId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonIncomeStatement(json)
 }
@@ -103,11 +112,13 @@ export async function getChildIncomeStatement(
 export async function getChildIncomeStatementStartDates(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<LocalDate[]> {
   const { data: json } = await client.request<JsonOf<LocalDate[]>>({
     url: uri`/citizen/income-statements/child/start-dates/${request.childId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => LocalDate.parseIso(e))
 }
@@ -120,7 +131,8 @@ export async function getChildIncomeStatements(
   request: {
     childId: UUID,
     page: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedIncomeStatements> {
   const params = createUrlSearchParams(
     ['page', request.page.toString()]
@@ -128,6 +140,7 @@ export async function getChildIncomeStatements(
   const { data: json } = await client.request<JsonOf<PagedIncomeStatements>>({
     url: uri`/citizen/income-statements/child/${request.childId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonPagedIncomeStatements(json)
@@ -140,11 +153,13 @@ export async function getChildIncomeStatements(
 export async function getIncomeStatement(
   request: {
     incomeStatementId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<IncomeStatement> {
   const { data: json } = await client.request<JsonOf<IncomeStatement>>({
     url: uri`/citizen/income-statements/${request.incomeStatementId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonIncomeStatement(json)
 }
@@ -153,10 +168,13 @@ export async function getIncomeStatement(
 /**
 * Generated from fi.espoo.evaka.incomestatement.IncomeStatementControllerCitizen.getIncomeStatementChildren
 */
-export async function getIncomeStatementChildren(): Promise<ChildBasicInfo[]> {
+export async function getIncomeStatementChildren(
+  headers?: AxiosHeaders
+): Promise<ChildBasicInfo[]> {
   const { data: json } = await client.request<JsonOf<ChildBasicInfo[]>>({
     url: uri`/citizen/income-statements/children`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -165,10 +183,13 @@ export async function getIncomeStatementChildren(): Promise<ChildBasicInfo[]> {
 /**
 * Generated from fi.espoo.evaka.incomestatement.IncomeStatementControllerCitizen.getIncomeStatementStartDates
 */
-export async function getIncomeStatementStartDates(): Promise<LocalDate[]> {
+export async function getIncomeStatementStartDates(
+  headers?: AxiosHeaders
+): Promise<LocalDate[]> {
   const { data: json } = await client.request<JsonOf<LocalDate[]>>({
     url: uri`/citizen/income-statements/start-dates/`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => LocalDate.parseIso(e))
 }
@@ -180,7 +201,8 @@ export async function getIncomeStatementStartDates(): Promise<LocalDate[]> {
 export async function getIncomeStatements(
   request: {
     page: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedIncomeStatements> {
   const params = createUrlSearchParams(
     ['page', request.page.toString()]
@@ -188,6 +210,7 @@ export async function getIncomeStatements(
   const { data: json } = await client.request<JsonOf<PagedIncomeStatements>>({
     url: uri`/citizen/income-statements`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonPagedIncomeStatements(json)
@@ -201,11 +224,13 @@ export async function removeChildIncomeStatement(
   request: {
     childId: UUID,
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/income-statements/child/${request.childId}/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -220,7 +245,8 @@ export async function updateChildIncomeStatement(
     incomeStatementId: UUID,
     draft?: boolean | null,
     body: IncomeStatementBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['draft', request.draft?.toString()]
@@ -228,6 +254,7 @@ export async function updateChildIncomeStatement(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/income-statements/child/${request.childId}/${request.incomeStatementId}`.toString(),
     method: 'PUT',
+    headers,
     params,
     data: request.body satisfies JsonCompatible<IncomeStatementBody>
   })
@@ -243,7 +270,8 @@ export async function updateIncomeStatement(
     incomeStatementId: UUID,
     draft?: boolean | null,
     body: IncomeStatementBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['draft', request.draft?.toString()]
@@ -251,6 +279,7 @@ export async function updateIncomeStatement(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/income-statements/${request.incomeStatementId}`.toString(),
     method: 'PUT',
+    headers,
     params,
     data: request.body satisfies JsonCompatible<IncomeStatementBody>
   })

--- a/frontend/src/citizen-frontend/generated/api-clients/invoicing.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/invoicing.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { client } from '../../api-client'
 import { uri } from 'lib-common/uri'
@@ -13,10 +14,13 @@ import { uri } from 'lib-common/uri'
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.IncomeControllerCitizen.getExpiringIncome
 */
-export async function getExpiringIncome(): Promise<LocalDate[]> {
+export async function getExpiringIncome(
+  headers?: AxiosHeaders
+): Promise<LocalDate[]> {
   const { data: json } = await client.request<JsonOf<LocalDate[]>>({
     url: uri`/citizen/income/expiring`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => LocalDate.parseIso(e))
 }

--- a/frontend/src/citizen-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/messaging.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { CitizenMessageBody } from 'lib-common/generated/api-types/messaging'
 import { GetReceiversResponse } from 'lib-common/generated/api-types/messaging'
 import { JsonCompatible } from 'lib-common/json'
@@ -26,11 +27,13 @@ import { uri } from 'lib-common/uri'
 export async function archiveThread(
   request: {
     threadId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/messages/threads/${request.threadId}/archive`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -39,10 +42,13 @@ export async function archiveThread(
 /**
 * Generated from fi.espoo.evaka.messaging.MessageControllerCitizen.getMyAccount
 */
-export async function getMyAccount(): Promise<MyAccountResponse> {
+export async function getMyAccount(
+  headers?: AxiosHeaders
+): Promise<MyAccountResponse> {
   const { data: json } = await client.request<JsonOf<MyAccountResponse>>({
     url: uri`/citizen/messages/my-account`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -54,7 +60,8 @@ export async function getMyAccount(): Promise<MyAccountResponse> {
 export async function getReceivedMessages(
   request: {
     page: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedCitizenMessageThreads> {
   const params = createUrlSearchParams(
     ['page', request.page.toString()]
@@ -62,6 +69,7 @@ export async function getReceivedMessages(
   const { data: json } = await client.request<JsonOf<PagedCitizenMessageThreads>>({
     url: uri`/citizen/messages/received`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonPagedCitizenMessageThreads(json)
@@ -71,10 +79,13 @@ export async function getReceivedMessages(
 /**
 * Generated from fi.espoo.evaka.messaging.MessageControllerCitizen.getReceivers
 */
-export async function getReceivers(): Promise<GetReceiversResponse> {
+export async function getReceivers(
+  headers?: AxiosHeaders
+): Promise<GetReceiversResponse> {
   const { data: json } = await client.request<JsonOf<GetReceiversResponse>>({
     url: uri`/citizen/messages/receivers`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -83,10 +94,13 @@ export async function getReceivers(): Promise<GetReceiversResponse> {
 /**
 * Generated from fi.espoo.evaka.messaging.MessageControllerCitizen.getUnreadMessages
 */
-export async function getUnreadMessages(): Promise<number> {
+export async function getUnreadMessages(
+  headers?: AxiosHeaders
+): Promise<number> {
   const { data: json } = await client.request<JsonOf<number>>({
     url: uri`/citizen/messages/unread-count`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -98,11 +112,13 @@ export async function getUnreadMessages(): Promise<number> {
 export async function markThreadRead(
   request: {
     threadId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/messages/threads/${request.threadId}/read`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -114,11 +130,13 @@ export async function markThreadRead(
 export async function newMessage(
   request: {
     body: CitizenMessageBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/citizen/messages`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CitizenMessageBody>
   })
   return json
@@ -132,11 +150,13 @@ export async function replyToThread(
   request: {
     messageId: UUID,
     body: ReplyToMessageBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ThreadReply> {
   const { data: json } = await client.request<JsonOf<ThreadReply>>({
     url: uri`/citizen/messages/${request.messageId}/reply`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ReplyToMessageBody>
   })
   return deserializeJsonThreadReply(json)

--- a/frontend/src/citizen-frontend/generated/api-clients/pedagogicaldocument.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/pedagogicaldocument.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { PedagogicalDocumentCitizen } from 'lib-common/generated/api-types/pedagogicaldocument'
 import { UUID } from 'lib-common/types'
@@ -18,11 +19,13 @@ import { uri } from 'lib-common/uri'
 export async function getPedagogicalDocumentsForChild(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PedagogicalDocumentCitizen[]> {
   const { data: json } = await client.request<JsonOf<PedagogicalDocumentCitizen[]>>({
     url: uri`/citizen/children/${request.childId}/pedagogical-documents`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPedagogicalDocumentCitizen(e))
 }
@@ -31,10 +34,13 @@ export async function getPedagogicalDocumentsForChild(
 /**
 * Generated from fi.espoo.evaka.pedagogicaldocument.PedagogicalDocumentControllerCitizen.getUnreadPedagogicalDocumentCount
 */
-export async function getUnreadPedagogicalDocumentCount(): Promise<Record<UUID, number>> {
+export async function getUnreadPedagogicalDocumentCount(
+  headers?: AxiosHeaders
+): Promise<Record<UUID, number>> {
   const { data: json } = await client.request<JsonOf<Record<UUID, number>>>({
     url: uri`/citizen/pedagogical-documents/unread-count`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -46,11 +52,13 @@ export async function getUnreadPedagogicalDocumentCount(): Promise<Record<UUID, 
 export async function markPedagogicalDocumentRead(
   request: {
     documentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/pedagogical-documents/${request.documentId}/mark-read`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }

--- a/frontend/src/citizen-frontend/generated/api-clients/pis.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/pis.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { EmailMessageType } from 'lib-common/generated/api-types/pis'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
@@ -16,10 +17,13 @@ import { uri } from 'lib-common/uri'
 /**
 * Generated from fi.espoo.evaka.pis.controllers.PersonalDataControllerCitizen.getNotificationSettings
 */
-export async function getNotificationSettings(): Promise<EmailMessageType[]> {
+export async function getNotificationSettings(
+  headers?: AxiosHeaders
+): Promise<EmailMessageType[]> {
   const { data: json } = await client.request<JsonOf<EmailMessageType[]>>({
     url: uri`/citizen/personal-data/notification-settings`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -31,11 +35,13 @@ export async function getNotificationSettings(): Promise<EmailMessageType[]> {
 export async function updateNotificationSettings(
   request: {
     body: EmailMessageType[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/personal-data/notification-settings`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<EmailMessageType[]>
   })
   return json
@@ -48,11 +54,13 @@ export async function updateNotificationSettings(
 export async function updatePassword(
   request: {
     body: UpdatePasswordRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/personal-data/password`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<UpdatePasswordRequest>
   })
   return json
@@ -65,11 +73,13 @@ export async function updatePassword(
 export async function updatePersonalData(
   request: {
     body: PersonalDataUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/personal-data`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<PersonalDataUpdate>
   })
   return json

--- a/frontend/src/citizen-frontend/generated/api-clients/placement.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/placement.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { ChildPlacementResponse } from 'lib-common/generated/api-types/placement'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
@@ -20,11 +21,13 @@ import { uri } from 'lib-common/uri'
 export async function getPlacements(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildPlacementResponse> {
   const { data: json } = await client.request<JsonOf<ChildPlacementResponse>>({
     url: uri`/citizen/children/${request.childId}/placements`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonChildPlacementResponse(json)
 }
@@ -37,11 +40,13 @@ export async function postPlacementTermination(
   request: {
     childId: UUID,
     body: PlacementTerminationRequestBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/children/${request.childId}/placements/terminate`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PlacementTerminationRequestBody>
   })
   return json

--- a/frontend/src/citizen-frontend/generated/api-clients/reservations.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/reservations.ts
@@ -6,6 +6,7 @@
 
 import LocalDate from 'lib-common/local-date'
 import { AbsenceRequest } from 'lib-common/generated/api-types/reservations'
+import { AxiosHeaders } from 'axios'
 import { DailyReservationRequest } from 'lib-common/generated/api-types/reservations'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
@@ -23,7 +24,8 @@ export async function getReservations(
   request: {
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ReservationsResponse> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -32,6 +34,7 @@ export async function getReservations(
   const { data: json } = await client.request<JsonOf<ReservationsResponse>>({
     url: uri`/citizen/reservations`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonReservationsResponse(json)
@@ -44,11 +47,13 @@ export async function getReservations(
 export async function postAbsences(
   request: {
     body: AbsenceRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/absences`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AbsenceRequest>
   })
   return json
@@ -61,11 +66,13 @@ export async function postAbsences(
 export async function postReservations(
   request: {
     body: DailyReservationRequest[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/reservations`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DailyReservationRequest[]>
   })
   return json

--- a/frontend/src/citizen-frontend/generated/api-clients/serviceneed.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/serviceneed.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { CitizenServiceApplication } from 'lib-common/generated/api-types/serviceneed'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
@@ -27,7 +28,8 @@ import { uri } from 'lib-common/uri'
 export async function getServiceNeedOptionPublicInfos(
   request: {
     placementTypes?: PlacementType[] | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ServiceNeedOptionPublicInfo[]> {
   const params = createUrlSearchParams(
     ...(request.placementTypes?.map((e): [string, string | null | undefined] => ['placementTypes', e.toString()]) ?? [])
@@ -35,6 +37,7 @@ export async function getServiceNeedOptionPublicInfos(
   const { data: json } = await client.request<JsonOf<ServiceNeedOptionPublicInfo[]>>({
     url: uri`/citizen/public/service-needs/options`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonServiceNeedOptionPublicInfo(e))
@@ -47,11 +50,13 @@ export async function getServiceNeedOptionPublicInfos(
 export async function createServiceApplication(
   request: {
     body: ServiceApplicationCreateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/service-applications`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ServiceApplicationCreateRequest>
   })
   return json
@@ -64,11 +69,13 @@ export async function createServiceApplication(
 export async function deleteServiceApplication(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/service-applications/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -80,7 +87,8 @@ export async function deleteServiceApplication(
 export async function getChildServiceApplications(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CitizenServiceApplication[]> {
   const params = createUrlSearchParams(
     ['childId', request.childId]
@@ -88,6 +96,7 @@ export async function getChildServiceApplications(
   const { data: json } = await client.request<JsonOf<CitizenServiceApplication[]>>({
     url: uri`/citizen/service-applications`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonCitizenServiceApplication(e))
@@ -101,7 +110,8 @@ export async function getChildServiceNeedOptions(
   request: {
     childId: UUID,
     date: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ServiceNeedOptionBasics[]> {
   const params = createUrlSearchParams(
     ['childId', request.childId],
@@ -110,6 +120,7 @@ export async function getChildServiceNeedOptions(
   const { data: json } = await client.request<JsonOf<ServiceNeedOptionBasics[]>>({
     url: uri`/citizen/service-applications/options`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonServiceNeedOptionBasics(e))

--- a/frontend/src/citizen-frontend/generated/api-clients/systemnotifications.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/systemnotifications.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { CurrentNotificationResponse } from 'lib-common/generated/api-types/systemnotifications'
 import { JsonOf } from 'lib-common/json'
 import { client } from '../../api-client'
@@ -14,10 +15,13 @@ import { uri } from 'lib-common/uri'
 /**
 * Generated from fi.espoo.evaka.systemnotifications.SystemNotificationsController.getCurrentSystemNotificationCitizen
 */
-export async function getCurrentSystemNotificationCitizen(): Promise<CurrentNotificationResponse> {
+export async function getCurrentSystemNotificationCitizen(
+  headers?: AxiosHeaders
+): Promise<CurrentNotificationResponse> {
   const { data: json } = await client.request<JsonOf<CurrentNotificationResponse>>({
     url: uri`/citizen/public/system-notifications/current`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonCurrentNotificationResponse(json)
 }

--- a/frontend/src/e2e-test/dev-api/index.ts
+++ b/frontend/src/e2e-test/dev-api/index.ts
@@ -15,6 +15,7 @@ import { BaseError } from 'make-error-cause'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 
 import config from '../config'
+import { runJobs, simpleAction } from '../generated/api-clients'
 import { DevPerson, MockVtjDataset } from '../generated/api-types'
 
 export class DevApiError extends BaseError {
@@ -72,13 +73,7 @@ export async function execSimpleApplicationAction(
   mockedTime: HelsinkiDateTime
 ): Promise<void> {
   try {
-    await devClient.post(
-      `/applications/${applicationId}/actions/${action}`,
-      null,
-      {
-        headers: clockHeader(mockedTime)
-      }
-    )
+    await simpleAction({ applicationId, action }, clockHeader(mockedTime))
   } catch (e) {
     throw new DevApiError(e)
   }
@@ -99,9 +94,7 @@ export async function runPendingAsyncJobs(
   mockedTime: HelsinkiDateTime
 ): Promise<void> {
   try {
-    await devClient.post(`/run-jobs`, null, {
-      headers: clockHeader(mockedTime)
-    })
+    await runJobs(clockHeader(mockedTime))
   } catch (e) {
     throw new DevApiError(e)
   }

--- a/frontend/src/e2e-test/generated/api-clients.ts
+++ b/frontend/src/e2e-test/generated/api-clients.ts
@@ -8,6 +8,7 @@ import LocalDate from 'lib-common/local-date'
 import { Absence } from 'lib-common/generated/api-types/absence'
 import { ApplicationDetails } from 'lib-common/generated/api-types/application'
 import { Autocomplete } from './api-types'
+import { AxiosHeaders } from 'axios'
 import { Caretaker } from './api-types'
 import { ChildDailyNoteBody } from 'lib-common/generated/api-types/note'
 import { ChildStickyNoteBody } from 'lib-common/generated/api-types/note'
@@ -112,12 +113,14 @@ import { uri } from 'lib-common/uri'
 export async function addAbsence(
   request: {
     body: DevAbsence
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/absence`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevAbsence>
     })
     return json
@@ -134,12 +137,14 @@ export async function addAclRoleForDaycare(
   request: {
     daycareId: UUID,
     body: DaycareAclInsert
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/daycares/${request.daycareId}/acl`.toString(),
       method: 'PUT',
+      headers,
       data: request.body satisfies JsonCompatible<DaycareAclInsert>
     })
     return json
@@ -155,12 +160,14 @@ export async function addAclRoleForDaycare(
 export async function addCalendarEvent(
   request: {
     body: DevCalendarEvent
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/calendar-event`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevCalendarEvent>
     })
     return json
@@ -176,12 +183,14 @@ export async function addCalendarEvent(
 export async function addCalendarEventAttendee(
   request: {
     body: DevCalendarEventAttendee
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/calendar-event-attendee`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevCalendarEventAttendee>
     })
     return json
@@ -197,12 +206,14 @@ export async function addCalendarEventAttendee(
 export async function addCalendarEventTime(
   request: {
     body: DevCalendarEventTime
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/calendar-event-time`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevCalendarEventTime>
     })
     return json
@@ -218,12 +229,14 @@ export async function addCalendarEventTime(
 export async function addDailyServiceTime(
   request: {
     body: DevDailyServiceTimes
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/daily-service-time`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevDailyServiceTimes>
     })
     return json
@@ -239,12 +252,14 @@ export async function addDailyServiceTime(
 export async function addDailyServiceTimeNotification(
   request: {
     body: DevDailyServiceTimeNotification
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<number> {
   try {
     const { data: json } = await devClient.request<JsonOf<number>>({
       url: uri`/daily-service-time-notification`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevDailyServiceTimeNotification>
     })
     return json
@@ -260,12 +275,14 @@ export async function addDailyServiceTimeNotification(
 export async function addPayment(
   request: {
     body: DevPayment
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/payments`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevPayment>
     })
     return json
@@ -281,12 +298,14 @@ export async function addPayment(
 export async function addStaffAttendance(
   request: {
     body: DevStaffAttendance
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/realtime-staff-attendance`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevStaffAttendance>
     })
     return json
@@ -302,12 +321,14 @@ export async function addStaffAttendance(
 export async function addStaffAttendancePlan(
   request: {
     body: DevStaffAttendancePlan
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/staff-attendance-plan`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevStaffAttendancePlan>
     })
     return json
@@ -320,11 +341,14 @@ export async function addStaffAttendancePlan(
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.cleanUpMessages
 */
-export async function cleanUpMessages(): Promise<void> {
+export async function cleanUpMessages(
+  headers?: AxiosHeaders
+): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/messages/clean-up`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -340,12 +364,14 @@ export async function createApplicationPlacementPlan(
   request: {
     applicationId: UUID,
     body: DaycarePlacementPlan
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/applications/${request.applicationId}/actions/create-placement-plan`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DaycarePlacementPlan>
     })
     return json
@@ -361,12 +387,14 @@ export async function createApplicationPlacementPlan(
 export async function createApplications(
   request: {
     body: DevApplicationWithForm[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID[]> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID[]>>({
       url: uri`/applications`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevApplicationWithForm[]>
     })
     return json
@@ -382,12 +410,14 @@ export async function createApplications(
 export async function createAssistanceAction(
   request: {
     body: DevAssistanceAction[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/assistance-action`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevAssistanceAction[]>
     })
     return json
@@ -403,12 +433,14 @@ export async function createAssistanceAction(
 export async function createAssistanceActionOption(
   request: {
     body: DevAssistanceActionOption[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/assistance-action-option`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevAssistanceActionOption[]>
     })
     return json
@@ -424,12 +456,14 @@ export async function createAssistanceActionOption(
 export async function createAssistanceFactors(
   request: {
     body: DevAssistanceFactor[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/assistance-factors`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevAssistanceFactor[]>
     })
     return json
@@ -445,12 +479,14 @@ export async function createAssistanceFactors(
 export async function createAssistanceNeedDecisions(
   request: {
     body: DevAssistanceNeedDecision[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/assistance-need-decisions`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevAssistanceNeedDecision[]>
     })
     return json
@@ -466,12 +502,14 @@ export async function createAssistanceNeedDecisions(
 export async function createAssistanceNeedPreschoolDecisions(
   request: {
     body: DevAssistanceNeedPreschoolDecision[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/assistance-need-preschool-decisions`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevAssistanceNeedPreschoolDecision[]>
     })
     return json
@@ -487,12 +525,14 @@ export async function createAssistanceNeedPreschoolDecisions(
 export async function createAssistanceNeedVoucherCoefficients(
   request: {
     body: DevAssistanceNeedVoucherCoefficient[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/assistance-need-voucher-coefficients`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevAssistanceNeedVoucherCoefficient[]>
     })
     return json
@@ -508,12 +548,14 @@ export async function createAssistanceNeedVoucherCoefficients(
 export async function createBackupCares(
   request: {
     body: DevBackupCare[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/backup-cares`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevBackupCare[]>
     })
     return json
@@ -529,12 +571,14 @@ export async function createBackupCares(
 export async function createBackupPickup(
   request: {
     body: DevBackupPickup[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/backup-pickup`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevBackupPickup[]>
     })
     return json
@@ -550,12 +594,14 @@ export async function createBackupPickup(
 export async function createCareAreas(
   request: {
     body: DevCareArea[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/care-areas`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevCareArea[]>
     })
     return json
@@ -571,12 +617,14 @@ export async function createCareAreas(
 export async function createChildDocument(
   request: {
     body: DevChildDocument
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/child-documents`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevChildDocument>
     })
     return json
@@ -592,12 +640,14 @@ export async function createChildDocument(
 export async function createChildren(
   request: {
     body: DevChild[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/children`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevChild[]>
     })
     return json
@@ -613,12 +663,14 @@ export async function createChildren(
 export async function createClubTerm(
   request: {
     body: DevClubTerm
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/club-term`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevClubTerm>
     })
     return json
@@ -634,12 +686,14 @@ export async function createClubTerm(
 export async function createDaycareAssistances(
   request: {
     body: DevDaycareAssistance[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/daycare-assistances`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevDaycareAssistance[]>
     })
     return json
@@ -655,12 +709,14 @@ export async function createDaycareAssistances(
 export async function createDaycareCaretakers(
   request: {
     body: Caretaker[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/daycare-caretakers`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<Caretaker[]>
     })
     return json
@@ -676,12 +732,14 @@ export async function createDaycareCaretakers(
 export async function createDaycareGroupAclRows(
   request: {
     body: DevDaycareGroupAcl[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/daycare-group-acl`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevDaycareGroupAcl[]>
     })
     return json
@@ -697,12 +755,14 @@ export async function createDaycareGroupAclRows(
 export async function createDaycareGroupPlacement(
   request: {
     body: DevDaycareGroupPlacement[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/daycare-group-placements`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevDaycareGroupPlacement[]>
     })
     return json
@@ -718,12 +778,14 @@ export async function createDaycareGroupPlacement(
 export async function createDaycareGroups(
   request: {
     body: DevDaycareGroup[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/daycare-groups`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevDaycareGroup[]>
     })
     return json
@@ -739,12 +801,14 @@ export async function createDaycareGroups(
 export async function createDaycarePlacements(
   request: {
     body: DevPlacement[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/daycare-placements`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevPlacement[]>
     })
     return json
@@ -760,12 +824,14 @@ export async function createDaycarePlacements(
 export async function createDaycares(
   request: {
     body: DevDaycare[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/daycares`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevDaycare[]>
     })
     return json
@@ -781,12 +847,14 @@ export async function createDaycares(
 export async function createDecisionPdf(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/decisions/${request.id}/actions/create-pdf`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -801,12 +869,14 @@ export async function createDecisionPdf(
 export async function createDecisions(
   request: {
     body: DecisionRequest[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/decisions`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DecisionRequest[]>
     })
     return json
@@ -822,12 +892,14 @@ export async function createDecisions(
 export async function createDefaultPlacementPlan(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/applications/${request.applicationId}/actions/create-default-placement-plan`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -839,11 +911,14 @@ export async function createDefaultPlacementPlan(
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.createDefaultServiceNeedOptions
 */
-export async function createDefaultServiceNeedOptions(): Promise<void> {
+export async function createDefaultServiceNeedOptions(
+  headers?: AxiosHeaders
+): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/service-need-options`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -858,12 +933,14 @@ export async function createDefaultServiceNeedOptions(): Promise<void> {
 export async function createDocumentTemplate(
   request: {
     body: DevDocumentTemplate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/document-templates`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevDocumentTemplate>
     })
     return json
@@ -879,12 +956,14 @@ export async function createDocumentTemplate(
 export async function createEmployee(
   request: {
     body: DevEmployee
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/employee`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevEmployee>
     })
     return json
@@ -900,12 +979,14 @@ export async function createEmployee(
 export async function createEmployeePins(
   request: {
     body: DevEmployeePin[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/employee-pin`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevEmployeePin[]>
     })
     return json
@@ -921,12 +1002,14 @@ export async function createEmployeePins(
 export async function createFamilyContact(
   request: {
     body: DevFamilyContact[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/family-contact`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevFamilyContact[]>
     })
     return json
@@ -942,12 +1025,14 @@ export async function createFamilyContact(
 export async function createFeeDecisions(
   request: {
     body: FeeDecision[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/fee-decisions`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<FeeDecision[]>
     })
     return json
@@ -963,12 +1048,14 @@ export async function createFeeDecisions(
 export async function createFeeThresholds(
   request: {
     body: FeeThresholds
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/fee-thresholds`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<FeeThresholds>
     })
     return json
@@ -984,12 +1071,14 @@ export async function createFeeThresholds(
 export async function createFosterParent(
   request: {
     body: DevFosterParent[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/foster-parent`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevFosterParent[]>
     })
     return json
@@ -1005,12 +1094,14 @@ export async function createFosterParent(
 export async function createFridgeChild(
   request: {
     body: DevFridgeChild[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/fridge-child`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevFridgeChild[]>
     })
     return json
@@ -1026,12 +1117,14 @@ export async function createFridgeChild(
 export async function createFridgePartner(
   request: {
     body: DevFridgePartner[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/fridge-partner`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevFridgePartner[]>
     })
     return json
@@ -1048,12 +1141,14 @@ export async function createHolidayPeriod(
   request: {
     id: UUID,
     body: HolidayPeriodCreate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/holiday-period/${request.id}`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<HolidayPeriodCreate>
     })
     return json
@@ -1070,12 +1165,14 @@ export async function createHolidayQuestionnaire(
   request: {
     id: UUID,
     body: FixedPeriodQuestionnaireBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/holiday-period/questionnaire/${request.id}`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<FixedPeriodQuestionnaireBody>
     })
     return json
@@ -1091,12 +1188,14 @@ export async function createHolidayQuestionnaire(
 export async function createIncome(
   request: {
     body: DevIncome
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/income`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevIncome>
     })
     return json
@@ -1112,12 +1211,14 @@ export async function createIncome(
 export async function createIncomeNotification(
   request: {
     body: IncomeNotification
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/income-notifications`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<IncomeNotification>
     })
     return json
@@ -1133,12 +1234,14 @@ export async function createIncomeNotification(
 export async function createIncomeStatement(
   request: {
     body: DevIncomeStatement
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/income-statement`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevIncomeStatement>
     })
     return json
@@ -1154,12 +1257,14 @@ export async function createIncomeStatement(
 export async function createInvoices(
   request: {
     body: DevInvoice[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/invoices`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevInvoice[]>
     })
     return json
@@ -1172,11 +1277,14 @@ export async function createInvoices(
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.createMessageAccounts
 */
-export async function createMessageAccounts(): Promise<void> {
+export async function createMessageAccounts(
+  headers?: AxiosHeaders
+): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/message-account/upsert-all`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -1191,12 +1299,14 @@ export async function createMessageAccounts(): Promise<void> {
 export async function createOtherAssistanceMeasures(
   request: {
     body: DevOtherAssistanceMeasure[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/other-assistance-measures`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevOtherAssistanceMeasure[]>
     })
     return json
@@ -1212,12 +1322,14 @@ export async function createOtherAssistanceMeasures(
 export async function createParentships(
   request: {
     body: DevParentship[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/parentship`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevParentship[]>
     })
     return json
@@ -1233,12 +1345,14 @@ export async function createParentships(
 export async function createPedagogicalDocuments(
   request: {
     body: DevPedagogicalDocument[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/pedagogical-document`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevPedagogicalDocument[]>
     })
     return json
@@ -1255,7 +1369,8 @@ export async function createPerson(
   request: {
     type: DevPersonType,
     body: DevPerson
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const params = createUrlSearchParams(
@@ -1264,6 +1379,7 @@ export async function createPerson(
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/person/create`.toString(),
       method: 'POST',
+      headers,
       params,
       data: request.body satisfies JsonCompatible<DevPerson>
     })
@@ -1281,12 +1397,14 @@ export async function createPlacementPlan(
   request: {
     applicationId: UUID,
     body: PlacementPlan
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/placement-plan/${request.applicationId}`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<PlacementPlan>
     })
     return json
@@ -1302,12 +1420,14 @@ export async function createPlacementPlan(
 export async function createPreschoolAssistances(
   request: {
     body: DevPreschoolAssistance[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/preschool-assistances`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevPreschoolAssistance[]>
     })
     return json
@@ -1323,12 +1443,14 @@ export async function createPreschoolAssistances(
 export async function createPreschoolTerm(
   request: {
     body: DevPreschoolTerm
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/preschool-term`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevPreschoolTerm>
     })
     return json
@@ -1344,12 +1466,14 @@ export async function createPreschoolTerm(
 export async function createServiceApplications(
   request: {
     body: DevServiceApplication[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/service-applications`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevServiceApplication[]>
     })
     return json
@@ -1365,12 +1489,14 @@ export async function createServiceApplications(
 export async function createServiceNeedOption(
   request: {
     body: ServiceNeedOption[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/service-need-option`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<ServiceNeedOption[]>
     })
     return json
@@ -1386,12 +1512,14 @@ export async function createServiceNeedOption(
 export async function createServiceNeeds(
   request: {
     body: DevServiceNeed[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/service-need`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevServiceNeed[]>
     })
     return json
@@ -1407,12 +1535,14 @@ export async function createServiceNeeds(
 export async function createVoucherValueDecisions(
   request: {
     body: VoucherValueDecision[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/value-decisions`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<VoucherValueDecision[]>
     })
     return json
@@ -1425,11 +1555,14 @@ export async function createVoucherValueDecisions(
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.createVoucherValues
 */
-export async function createVoucherValues(): Promise<void> {
+export async function createVoucherValues(
+  headers?: AxiosHeaders
+): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/voucher-values`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -1444,12 +1577,14 @@ export async function createVoucherValues(): Promise<void> {
 export async function deleteDaycareCostCenter(
   request: {
     daycareId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/daycare/${request.daycareId}/cost-center`.toString(),
-      method: 'DELETE'
+      method: 'DELETE',
+      headers
     })
     return json
   } catch (e) {
@@ -1464,12 +1599,14 @@ export async function deleteDaycareCostCenter(
 export async function deletePlacement(
   request: {
     placementId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/placement/${request.placementId}`.toString(),
-      method: 'DELETE'
+      method: 'DELETE',
+      headers
     })
     return json
   } catch (e) {
@@ -1481,11 +1618,14 @@ export async function deletePlacement(
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.digitransitAutocomplete
 */
-export async function digitransitAutocomplete(): Promise<Autocomplete> {
+export async function digitransitAutocomplete(
+  headers?: AxiosHeaders
+): Promise<Autocomplete> {
   try {
     const { data: json } = await devClient.request<JsonOf<Autocomplete>>({
       url: uri`/digitransit/autocomplete`.toString(),
-      method: 'GET'
+      method: 'GET',
+      headers
     })
     return json
   } catch (e) {
@@ -1500,12 +1640,14 @@ export async function digitransitAutocomplete(): Promise<Autocomplete> {
 export async function forceFullVtjRefresh(
   request: {
     person: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/persons/${request.person}/force-full-vtj-refresh`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -1517,11 +1659,14 @@ export async function forceFullVtjRefresh(
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.generateReplacementDraftInvoices
 */
-export async function generateReplacementDraftInvoices(): Promise<void> {
+export async function generateReplacementDraftInvoices(
+  headers?: AxiosHeaders
+): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/generate-replacement-draft-invoices`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -1537,7 +1682,8 @@ export async function getAbsences(
   request: {
     childId: UUID,
     date: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Absence[]> {
   try {
     const params = createUrlSearchParams(
@@ -1547,6 +1693,7 @@ export async function getAbsences(
     const { data: json } = await devClient.request<JsonOf<Absence[]>>({
       url: uri`/absences`.toString(),
       method: 'GET',
+      headers,
       params
     })
     return json.map(e => deserializeJsonAbsence(e))
@@ -1562,12 +1709,14 @@ export async function getAbsences(
 export async function getApplication(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ApplicationDetails> {
   try {
     const { data: json } = await devClient.request<JsonOf<ApplicationDetails>>({
       url: uri`/applications/${request.applicationId}`.toString(),
-      method: 'GET'
+      method: 'GET',
+      headers
     })
     return deserializeJsonApplicationDetails(json)
   } catch (e) {
@@ -1582,12 +1731,14 @@ export async function getApplication(
 export async function getApplicationDecisions(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Decision[]> {
   try {
     const { data: json } = await devClient.request<JsonOf<Decision[]>>({
       url: uri`/applications/${request.applicationId}/decisions`.toString(),
-      method: 'GET'
+      method: 'GET',
+      headers
     })
     return json.map(e => deserializeJsonDecision(e))
   } catch (e) {
@@ -1602,12 +1753,14 @@ export async function getApplicationDecisions(
 export async function getCitizen(
   request: {
     ssn: string
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Citizen> {
   try {
     const { data: json } = await devClient.request<JsonOf<Citizen>>({
       url: uri`/citizen/ssn/${request.ssn}`.toString(),
-      method: 'GET'
+      method: 'GET',
+      headers
     })
     return json
   } catch (e) {
@@ -1619,11 +1772,14 @@ export async function getCitizen(
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.getCitizens
 */
-export async function getCitizens(): Promise<Citizen[]> {
+export async function getCitizens(
+  headers?: AxiosHeaders
+): Promise<Citizen[]> {
   try {
     const { data: json } = await devClient.request<JsonOf<Citizen[]>>({
       url: uri`/citizen`.toString(),
-      method: 'GET'
+      method: 'GET',
+      headers
     })
     return json
   } catch (e) {
@@ -1635,11 +1791,14 @@ export async function getCitizens(): Promise<Citizen[]> {
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.getEmployees
 */
-export async function getEmployees(): Promise<Employee[]> {
+export async function getEmployees(
+  headers?: AxiosHeaders
+): Promise<Employee[]> {
   try {
     const { data: json } = await devClient.request<JsonOf<Employee[]>>({
       url: uri`/employee`.toString(),
-      method: 'GET'
+      method: 'GET',
+      headers
     })
     return json.map(e => deserializeJsonEmployee(e))
   } catch (e) {
@@ -1651,11 +1810,14 @@ export async function getEmployees(): Promise<Employee[]> {
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.getMessages
 */
-export async function getMessages(): Promise<SfiMessage[]> {
+export async function getMessages(
+  headers?: AxiosHeaders
+): Promise<SfiMessage[]> {
   try {
     const { data: json } = await devClient.request<JsonOf<SfiMessage[]>>({
       url: uri`/messages`.toString(),
-      method: 'GET'
+      method: 'GET',
+      headers
     })
     return json
   } catch (e) {
@@ -1667,11 +1829,14 @@ export async function getMessages(): Promise<SfiMessage[]> {
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.getSentEmails
 */
-export async function getSentEmails(): Promise<Email[]> {
+export async function getSentEmails(
+  headers?: AxiosHeaders
+): Promise<Email[]> {
   try {
     const { data: json } = await devClient.request<JsonOf<Email[]>>({
       url: uri`/emails`.toString(),
-      method: 'GET'
+      method: 'GET',
+      headers
     })
     return json
   } catch (e) {
@@ -1683,11 +1848,14 @@ export async function getSentEmails(): Promise<Email[]> {
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.getStaffAttendances
 */
-export async function getStaffAttendances(): Promise<StaffMemberAttendance[]> {
+export async function getStaffAttendances(
+  headers?: AxiosHeaders
+): Promise<StaffMemberAttendance[]> {
   try {
     const { data: json } = await devClient.request<JsonOf<StaffMemberAttendance[]>>({
       url: uri`/realtime-staff-attendance`.toString(),
-      method: 'GET'
+      method: 'GET',
+      headers
     })
     return json.map(e => deserializeJsonStaffMemberAttendance(e))
   } catch (e) {
@@ -1699,11 +1867,14 @@ export async function getStaffAttendances(): Promise<StaffMemberAttendance[]> {
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.healthCheck
 */
-export async function healthCheck(): Promise<void> {
+export async function healthCheck(
+  headers?: AxiosHeaders
+): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/`.toString(),
-      method: 'GET'
+      method: 'GET',
+      headers
     })
     return json
   } catch (e) {
@@ -1718,12 +1889,14 @@ export async function healthCheck(): Promise<void> {
 export async function insertChild(
   request: {
     body: DevPerson
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/child`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevPerson>
     })
     return json
@@ -1739,12 +1912,14 @@ export async function insertChild(
 export async function insertGuardians(
   request: {
     body: DevGuardian[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/guardian`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevGuardian[]>
     })
     return json
@@ -1760,12 +1935,14 @@ export async function insertGuardians(
 export async function postAttendances(
   request: {
     body: DevChildAttendance[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/attendances`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevChildAttendance[]>
     })
     return json
@@ -1782,12 +1959,14 @@ export async function postChildDailyNote(
   request: {
     childId: UUID,
     body: ChildDailyNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/children/${request.childId}/child-daily-notes`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<ChildDailyNoteBody>
     })
     return json
@@ -1804,12 +1983,14 @@ export async function postChildStickyNote(
   request: {
     childId: UUID,
     body: ChildStickyNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/children/${request.childId}/child-sticky-notes`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<ChildStickyNoteBody>
     })
     return json
@@ -1825,12 +2006,14 @@ export async function postChildStickyNote(
 export async function postDigitransitQuery(
   request: {
     body: string
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<string> {
   try {
     const { data: json } = await devClient.request<JsonOf<string>>({
       url: uri`/digitransit/query`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<string>
     })
     return json
@@ -1847,12 +2030,14 @@ export async function postGroupNote(
   request: {
     groupId: UUID,
     body: GroupNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/daycare-groups/${request.groupId}/group-notes`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<GroupNoteBody>
     })
     return json
@@ -1868,12 +2053,14 @@ export async function postGroupNote(
 export async function postMobileDevice(
   request: {
     body: DevMobileDevice
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/mobile/devices`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevMobileDevice>
     })
     return json
@@ -1889,12 +2076,14 @@ export async function postMobileDevice(
 export async function postPairing(
   request: {
     body: PostPairingReq
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Pairing> {
   try {
     const { data: json } = await devClient.request<JsonOf<Pairing>>({
       url: uri`/mobile/pairings`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<PostPairingReq>
     })
     return deserializeJsonPairing(json)
@@ -1910,12 +2099,14 @@ export async function postPairing(
 export async function postPairingChallenge(
   request: {
     body: PostPairingChallengeReq
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Pairing> {
   try {
     const { data: json } = await devClient.request<JsonOf<Pairing>>({
       url: uri`/mobile/pairings/challenge`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<PostPairingChallengeReq>
     })
     return deserializeJsonPairing(json)
@@ -1932,12 +2123,14 @@ export async function postPairingResponse(
   request: {
     id: UUID,
     body: PostPairingResponseReq
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Pairing> {
   try {
     const { data: json } = await devClient.request<JsonOf<Pairing>>({
       url: uri`/mobile/pairings/${request.id}/response`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<PostPairingResponseReq>
     })
     return deserializeJsonPairing(json)
@@ -1953,12 +2146,14 @@ export async function postPairingResponse(
 export async function postPersonalMobileDevice(
   request: {
     body: DevPersonalMobileDevice
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/mobile/personal-devices`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevPersonalMobileDevice>
     })
     return json
@@ -1974,12 +2169,14 @@ export async function postPersonalMobileDevice(
 export async function postReservations(
   request: {
     body: DailyReservationRequest[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/reservations`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DailyReservationRequest[]>
     })
     return json
@@ -1995,12 +2192,14 @@ export async function postReservations(
 export async function postReservationsRaw(
   request: {
     body: ReservationInsert[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/reservations/raw`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<ReservationInsert[]>
     })
     return json
@@ -2016,12 +2215,14 @@ export async function postReservationsRaw(
 export async function putDiets(
   request: {
     body: SpecialDiet[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/diets`.toString(),
       method: 'PUT',
+      headers,
       data: request.body satisfies JsonCompatible<SpecialDiet[]>
     })
     return json
@@ -2037,12 +2238,14 @@ export async function putDiets(
 export async function putDigitransitAutocomplete(
   request: {
     body: Autocomplete
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/digitransit/autocomplete`.toString(),
       method: 'PUT',
+      headers,
       data: request.body satisfies JsonCompatible<Autocomplete>
     })
     return json
@@ -2058,12 +2261,14 @@ export async function putDigitransitAutocomplete(
 export async function rejectDecisionByCitizen(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/decisions/${request.id}/actions/reject-by-citizen`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -2075,11 +2280,14 @@ export async function rejectDecisionByCitizen(
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.resetServiceState
 */
-export async function resetServiceState(): Promise<void> {
+export async function resetServiceState(
+  headers?: AxiosHeaders
+): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/reset-service-state`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -2091,11 +2299,14 @@ export async function resetServiceState(): Promise<void> {
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.runJobs
 */
-export async function runJobs(): Promise<void> {
+export async function runJobs(
+  headers?: AxiosHeaders
+): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/run-jobs`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -2110,12 +2321,14 @@ export async function runJobs(): Promise<void> {
 export async function setPersonEmail(
   request: {
     body: DevPersonEmail
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<number> {
   try {
     const { data: json } = await devClient.request<JsonOf<number>>({
       url: uri`/person-email`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevPersonEmail>
     })
     return json
@@ -2131,7 +2344,8 @@ export async function setPersonEmail(
 export async function setTestMode(
   request: {
     enabled: boolean
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const params = createUrlSearchParams(
@@ -2140,6 +2354,7 @@ export async function setTestMode(
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/test-mode`.toString(),
       method: 'POST',
+      headers,
       params
     })
     return json
@@ -2156,12 +2371,14 @@ export async function simpleAction(
   request: {
     applicationId: UUID,
     action: string
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/applications/${request.applicationId}/actions/${request.action}`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers
     })
     return json
   } catch (e) {
@@ -2176,12 +2393,14 @@ export async function simpleAction(
 export async function terminatePlacement(
   request: {
     body: DevTerminatePlacementRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/placement/terminate`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevTerminatePlacementRequest>
     })
     return json
@@ -2197,12 +2416,14 @@ export async function terminatePlacement(
 export async function upsertPerson(
   request: {
     body: DevPerson
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   try {
     const { data: json } = await devClient.request<JsonOf<UUID>>({
       url: uri`/person`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevPerson>
     })
     return json
@@ -2218,12 +2439,14 @@ export async function upsertPerson(
 export async function upsertStaffOccupancyCoefficient(
   request: {
     body: DevUpsertStaffOccupancyCoefficient
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/occupancy-coefficient`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<DevUpsertStaffOccupancyCoefficient>
     })
     return json
@@ -2239,12 +2462,14 @@ export async function upsertStaffOccupancyCoefficient(
 export async function upsertVtjDataset(
   request: {
     body: MockVtjDataset
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/vtj-persons`.toString(),
       method: 'POST',
+      headers,
       data: request.body satisfies JsonCompatible<MockVtjDataset>
     })
     return json

--- a/frontend/src/employee-frontend/components/employee/EmployeePinCodePage.tsx
+++ b/frontend/src/employee-frontend/components/employee/EmployeePinCodePage.tsx
@@ -64,10 +64,10 @@ export default React.memo(function EmployeePinCodePage() {
     setDirty(pin.length > 0)
   }
 
-  function savePinCode() {
-    return upsertPinCodeResult({ body: { pin } })
-      .then(() => setDirty(false))
-      .then(isPinLockedResult)
+  async function savePinCode() {
+    await upsertPinCodeResult({ body: { pin } })
+    setDirty(false)
+    return isPinLockedResult()
   }
 
   function getInputInfo(): InputInfo | undefined {

--- a/frontend/src/employee-frontend/generated/api-clients/absence.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/absence.ts
@@ -6,6 +6,7 @@
 
 import { Absence } from 'lib-common/generated/api-types/absence'
 import { AbsenceUpsert } from 'lib-common/generated/api-types/absence'
+import { AxiosHeaders } from 'axios'
 import { GroupMonthCalendar } from 'lib-common/generated/api-types/absence'
 import { HolidayReservationsDelete } from 'lib-common/generated/api-types/absence'
 import { JsonCompatible } from 'lib-common/json'
@@ -26,11 +27,13 @@ export async function addPresences(
   request: {
     groupId: UUID,
     body: Presence[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/absences/${request.groupId}/present`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<Presence[]>
   })
   return json
@@ -44,11 +47,13 @@ export async function deleteHolidayReservations(
   request: {
     groupId: UUID,
     body: HolidayReservationsDelete[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/absences/${request.groupId}/delete-holiday-reservations`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<HolidayReservationsDelete[]>
   })
   return json
@@ -63,7 +68,8 @@ export async function getAbsencesOfChild(
     childId: UUID,
     year: number,
     month: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Absence[]> {
   const params = createUrlSearchParams(
     ['year', request.year.toString()],
@@ -72,6 +78,7 @@ export async function getAbsencesOfChild(
   const { data: json } = await client.request<JsonOf<Absence[]>>({
     url: uri`/employee/absences/by-child/${request.childId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonAbsence(e))
@@ -86,7 +93,8 @@ export async function groupMonthCalendar(
     groupId: UUID,
     year: number,
     month: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<GroupMonthCalendar> {
   const params = createUrlSearchParams(
     ['year', request.year.toString()],
@@ -95,6 +103,7 @@ export async function groupMonthCalendar(
   const { data: json } = await client.request<JsonOf<GroupMonthCalendar>>({
     url: uri`/employee/absences/${request.groupId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonGroupMonthCalendar(json)
@@ -108,11 +117,13 @@ export async function upsertAbsences(
   request: {
     groupId: UUID,
     body: AbsenceUpsert[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/absences/${request.groupId}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AbsenceUpsert[]>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/application.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/application.ts
@@ -10,6 +10,7 @@ import { ApplicationNote } from 'lib-common/generated/api-types/application'
 import { ApplicationNoteResponse } from 'lib-common/generated/api-types/application'
 import { ApplicationResponse } from 'lib-common/generated/api-types/application'
 import { ApplicationUpdate } from 'lib-common/generated/api-types/application'
+import { AxiosHeaders } from 'axios'
 import { DaycarePlacementPlan } from 'lib-common/generated/api-types/application'
 import { DecisionDraftGroup } from 'lib-common/generated/api-types/application'
 import { DecisionDraftUpdate } from 'lib-common/generated/api-types/decision'
@@ -47,11 +48,13 @@ export async function acceptDecision(
   request: {
     applicationId: UUID,
     body: AcceptDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/${request.applicationId}/actions/accept-decision`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AcceptDecisionRequest>
   })
   return json
@@ -65,11 +68,13 @@ export async function acceptPlacementProposal(
   request: {
     unitId: UUID,
     body: AcceptPlacementProposalRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/placement-proposals/${request.unitId}/accept`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AcceptPlacementProposalRequest>
   })
   return json
@@ -82,11 +87,13 @@ export async function acceptPlacementProposal(
 export async function createPaperApplication(
   request: {
     body: PaperApplicationCreateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/applications`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PaperApplicationCreateRequest>
   })
   return json
@@ -100,11 +107,13 @@ export async function createPlacementPlan(
   request: {
     applicationId: UUID,
     body: DaycarePlacementPlan
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/${request.applicationId}/actions/create-placement-plan`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DaycarePlacementPlan>
   })
   return json
@@ -117,11 +126,13 @@ export async function createPlacementPlan(
 export async function getApplicationDetails(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ApplicationResponse> {
   const { data: json } = await client.request<JsonOf<ApplicationResponse>>({
     url: uri`/employee/applications/${request.applicationId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonApplicationResponse(json)
 }
@@ -133,11 +144,13 @@ export async function getApplicationDetails(
 export async function getApplicationSummaries(
   request: {
     body: SearchApplicationRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedApplicationSummaries> {
   const { data: json } = await client.request<JsonOf<PagedApplicationSummaries>>({
     url: uri`/employee/applications/search`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SearchApplicationRequest>
   })
   return deserializeJsonPagedApplicationSummaries(json)
@@ -150,11 +163,13 @@ export async function getApplicationSummaries(
 export async function getChildApplicationSummaries(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PersonApplicationSummary[]> {
   const { data: json } = await client.request<JsonOf<PersonApplicationSummary[]>>({
     url: uri`/employee/applications/by-child/${request.childId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPersonApplicationSummary(e))
 }
@@ -166,11 +181,13 @@ export async function getChildApplicationSummaries(
 export async function getDecisionDrafts(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DecisionDraftGroup> {
   const { data: json } = await client.request<JsonOf<DecisionDraftGroup>>({
     url: uri`/employee/applications/${request.applicationId}/decision-drafts`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonDecisionDraftGroup(json)
 }
@@ -182,11 +199,13 @@ export async function getDecisionDrafts(
 export async function getGuardianApplicationSummaries(
   request: {
     guardianId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PersonApplicationSummary[]> {
   const { data: json } = await client.request<JsonOf<PersonApplicationSummary[]>>({
     url: uri`/employee/applications/by-guardian/${request.guardianId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPersonApplicationSummary(e))
 }
@@ -198,11 +217,13 @@ export async function getGuardianApplicationSummaries(
 export async function getPlacementPlanDraft(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PlacementPlanDraft> {
   const { data: json } = await client.request<JsonOf<PlacementPlanDraft>>({
     url: uri`/employee/applications/${request.applicationId}/placement-draft`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonPlacementPlanDraft(json)
 }
@@ -214,11 +235,13 @@ export async function getPlacementPlanDraft(
 export async function getUnitApplications(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UnitApplications> {
   const { data: json } = await client.request<JsonOf<UnitApplications>>({
     url: uri`/employee/applications/units/${request.unitId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonUnitApplications(json)
 }
@@ -231,11 +254,13 @@ export async function rejectDecision(
   request: {
     applicationId: UUID,
     body: RejectDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/${request.applicationId}/actions/reject-decision`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<RejectDecisionRequest>
   })
   return json
@@ -249,11 +274,13 @@ export async function respondToPlacementProposal(
   request: {
     applicationId: UUID,
     body: PlacementProposalConfirmationUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/${request.applicationId}/actions/respond-to-placement-proposal`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PlacementProposalConfirmationUpdate>
   })
   return json
@@ -266,11 +293,13 @@ export async function respondToPlacementProposal(
 export async function sendApplication(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/${request.applicationId}/actions/send-application`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -283,11 +312,13 @@ export async function simpleApplicationAction(
   request: {
     applicationId: UUID,
     action: string
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/${request.applicationId}/actions/${request.action}`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -300,11 +331,13 @@ export async function simpleBatchAction(
   request: {
     action: string,
     body: SimpleBatchRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/batch/actions/${request.action}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SimpleBatchRequest>
   })
   return json
@@ -318,11 +351,13 @@ export async function updateApplication(
   request: {
     applicationId: UUID,
     body: ApplicationUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/${request.applicationId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ApplicationUpdate>
   })
   return json
@@ -336,11 +371,13 @@ export async function updateDecisionDrafts(
   request: {
     applicationId: UUID,
     body: DecisionDraftUpdate[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/applications/${request.applicationId}/decision-drafts`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<DecisionDraftUpdate[]>
   })
   return json
@@ -350,10 +387,13 @@ export async function updateDecisionDrafts(
 /**
 * Generated from fi.espoo.evaka.application.PlacementToolController.getNextPreschoolTerm
 */
-export async function getNextPreschoolTerm(): Promise<PreschoolTerm[]> {
+export async function getNextPreschoolTerm(
+  headers?: AxiosHeaders
+): Promise<PreschoolTerm[]> {
   const { data: json } = await client.request<JsonOf<PreschoolTerm[]>>({
     url: uri`/employee/placement-tool/next-term`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPreschoolTerm(e))
 }
@@ -366,11 +406,13 @@ export async function createNote(
   request: {
     applicationId: UUID,
     body: NoteRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ApplicationNote> {
   const { data: json } = await client.request<JsonOf<ApplicationNote>>({
     url: uri`/employee/note/application/${request.applicationId}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<NoteRequest>
   })
   return deserializeJsonApplicationNote(json)
@@ -383,11 +425,13 @@ export async function createNote(
 export async function deleteNote(
   request: {
     noteId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/note/${request.noteId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -399,11 +443,13 @@ export async function deleteNote(
 export async function getNotes(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ApplicationNoteResponse[]> {
   const { data: json } = await client.request<JsonOf<ApplicationNoteResponse[]>>({
     url: uri`/employee/note/application/${request.applicationId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonApplicationNoteResponse(e))
 }
@@ -416,11 +462,13 @@ export async function updateNote(
   request: {
     noteId: UUID,
     body: NoteRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/note/${request.noteId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<NoteRequest>
   })
   return json
@@ -434,11 +482,13 @@ export async function updateServiceWorkerNote(
   request: {
     applicationId: UUID,
     body: NoteRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/note/service-worker/application/${request.applicationId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<NoteRequest>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/assistance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/assistance.ts
@@ -9,6 +9,7 @@ import { AssistanceActionOption } from 'lib-common/generated/api-types/assistanc
 import { AssistanceActionRequest } from 'lib-common/generated/api-types/assistanceaction'
 import { AssistanceFactorUpdate } from 'lib-common/generated/api-types/assistance'
 import { AssistanceResponse } from 'lib-common/generated/api-types/assistance'
+import { AxiosHeaders } from 'axios'
 import { DaycareAssistanceUpdate } from 'lib-common/generated/api-types/assistance'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
@@ -28,11 +29,13 @@ export async function createAssistanceAction(
   request: {
     childId: UUID,
     body: AssistanceActionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceAction> {
   const { data: json } = await client.request<JsonOf<AssistanceAction>>({
     url: uri`/employee/children/${request.childId}/assistance-actions`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AssistanceActionRequest>
   })
   return deserializeJsonAssistanceAction(json)
@@ -46,11 +49,13 @@ export async function createAssistanceFactor(
   request: {
     child: UUID,
     body: AssistanceFactorUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/children/${request.child}/assistance-factors`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AssistanceFactorUpdate>
   })
   return json
@@ -64,11 +69,13 @@ export async function createDaycareAssistance(
   request: {
     child: UUID,
     body: DaycareAssistanceUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/children/${request.child}/daycare-assistances`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DaycareAssistanceUpdate>
   })
   return json
@@ -82,11 +89,13 @@ export async function createOtherAssistanceMeasure(
   request: {
     child: UUID,
     body: OtherAssistanceMeasureUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/children/${request.child}/other-assistance-measures`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<OtherAssistanceMeasureUpdate>
   })
   return json
@@ -100,11 +109,13 @@ export async function createPreschoolAssistance(
   request: {
     child: UUID,
     body: PreschoolAssistanceUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/children/${request.child}/preschool-assistances`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PreschoolAssistanceUpdate>
   })
   return json
@@ -117,11 +128,13 @@ export async function createPreschoolAssistance(
 export async function deleteAssistanceAction(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-actions/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -133,11 +146,13 @@ export async function deleteAssistanceAction(
 export async function deleteAssistanceFactor(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-factors/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -149,11 +164,13 @@ export async function deleteAssistanceFactor(
 export async function deleteDaycareAssistance(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycare-assistances/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -165,11 +182,13 @@ export async function deleteDaycareAssistance(
 export async function deleteOtherAssistanceMeasure(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/other-assistance-measures/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -181,11 +200,13 @@ export async function deleteOtherAssistanceMeasure(
 export async function deletePreschoolAssistance(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/preschool-assistances/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -194,10 +215,13 @@ export async function deletePreschoolAssistance(
 /**
 * Generated from fi.espoo.evaka.assistance.AssistanceController.getAssistanceActionOptions
 */
-export async function getAssistanceActionOptions(): Promise<AssistanceActionOption[]> {
+export async function getAssistanceActionOptions(
+  headers?: AxiosHeaders
+): Promise<AssistanceActionOption[]> {
   const { data: json } = await client.request<JsonOf<AssistanceActionOption[]>>({
     url: uri`/employee/assistance-action-options`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -209,11 +233,13 @@ export async function getAssistanceActionOptions(): Promise<AssistanceActionOpti
 export async function getChildAssistance(
   request: {
     child: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceResponse> {
   const { data: json } = await client.request<JsonOf<AssistanceResponse>>({
     url: uri`/employee/children/${request.child}/assistance`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonAssistanceResponse(json)
 }
@@ -226,11 +252,13 @@ export async function updateAssistanceAction(
   request: {
     id: UUID,
     body: AssistanceActionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceAction> {
   const { data: json } = await client.request<JsonOf<AssistanceAction>>({
     url: uri`/employee/assistance-actions/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<AssistanceActionRequest>
   })
   return deserializeJsonAssistanceAction(json)
@@ -244,11 +272,13 @@ export async function updateAssistanceFactor(
   request: {
     id: UUID,
     body: AssistanceFactorUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-factors/${request.id}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AssistanceFactorUpdate>
   })
   return json
@@ -262,11 +292,13 @@ export async function updateDaycareAssistance(
   request: {
     id: UUID,
     body: DaycareAssistanceUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycare-assistances/${request.id}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DaycareAssistanceUpdate>
   })
   return json
@@ -280,11 +312,13 @@ export async function updateOtherAssistanceMeasure(
   request: {
     id: UUID,
     body: OtherAssistanceMeasureUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/other-assistance-measures/${request.id}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<OtherAssistanceMeasureUpdate>
   })
   return json
@@ -298,11 +332,13 @@ export async function updatePreschoolAssistance(
   request: {
     id: UUID,
     body: PreschoolAssistanceUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/preschool-assistances/${request.id}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PreschoolAssistanceUpdate>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/assistanceneed.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/assistanceneed.ts
@@ -17,6 +17,7 @@ import { AssistanceNeedPreschoolDecisionResponse } from 'lib-common/generated/ap
 import { AssistanceNeedVoucherCoefficient } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedVoucherCoefficientRequest } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedVoucherCoefficientResponse } from 'lib-common/generated/api-types/assistanceneed'
+import { AxiosHeaders } from 'axios'
 import { DecideAssistanceNeedDecisionRequest } from 'lib-common/generated/api-types/assistanceneed'
 import { DecideAssistanceNeedPreschoolDecisionRequest } from 'lib-common/generated/api-types/assistanceneed'
 import { Employee } from 'lib-common/generated/api-types/pis'
@@ -45,11 +46,13 @@ export async function annulAssistanceNeedDecision(
   request: {
     id: UUID,
     body: AnnulAssistanceNeedDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-decision/${request.id}/annul`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AnnulAssistanceNeedDecisionRequest>
   })
   return json
@@ -63,11 +66,13 @@ export async function createAssistanceNeedDecision(
   request: {
     childId: UUID,
     body: AssistanceNeedDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedDecision> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedDecision>>({
     url: uri`/employee/children/${request.childId}/assistance-needs/decision`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AssistanceNeedDecisionRequest>
   })
   return deserializeJsonAssistanceNeedDecision(json)
@@ -81,11 +86,13 @@ export async function decideAssistanceNeedDecision(
   request: {
     id: UUID,
     body: DecideAssistanceNeedDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-decision/${request.id}/decide`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DecideAssistanceNeedDecisionRequest>
   })
   return json
@@ -98,11 +105,13 @@ export async function decideAssistanceNeedDecision(
 export async function deleteAssistanceNeedDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-decision/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -114,11 +123,13 @@ export async function deleteAssistanceNeedDecision(
 export async function getAssistanceDecisionMakerOptions(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Employee[]> {
   const { data: json } = await client.request<JsonOf<Employee[]>>({
     url: uri`/employee/assistance-need-decision/${request.id}/decision-maker-option`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonEmployee(e))
 }
@@ -130,11 +141,13 @@ export async function getAssistanceDecisionMakerOptions(
 export async function getAssistanceNeedDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedDecisionResponse> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedDecisionResponse>>({
     url: uri`/employee/assistance-need-decision/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonAssistanceNeedDecisionResponse(json)
 }
@@ -146,11 +159,13 @@ export async function getAssistanceNeedDecision(
 export async function getAssistanceNeedDecisions(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedDecisionBasicsResponse[]> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedDecisionBasicsResponse[]>>({
     url: uri`/employee/children/${request.childId}/assistance-needs/decisions`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonAssistanceNeedDecisionBasicsResponse(e))
 }
@@ -162,11 +177,13 @@ export async function getAssistanceNeedDecisions(
 export async function markAssistanceNeedDecisionAsOpened(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-decision/${request.id}/mark-as-opened`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -178,11 +195,13 @@ export async function markAssistanceNeedDecisionAsOpened(
 export async function revertToUnsentAssistanceNeedDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-decision/${request.id}/revert-to-unsent`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -194,11 +213,13 @@ export async function revertToUnsentAssistanceNeedDecision(
 export async function sendAssistanceNeedDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-decision/${request.id}/send`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -211,11 +232,13 @@ export async function updateAssistanceNeedDecision(
   request: {
     id: UUID,
     body: AssistanceNeedDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-decision/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<AssistanceNeedDecisionRequest>
   })
   return json
@@ -229,11 +252,13 @@ export async function updateAssistanceNeedDecisionDecisionMaker(
   request: {
     id: UUID,
     body: UpdateDecisionMakerForAssistanceNeedDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-decision/${request.id}/update-decision-maker`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UpdateDecisionMakerForAssistanceNeedDecisionRequest>
   })
   return json
@@ -247,11 +272,13 @@ export async function annulAssistanceNeedPreschoolDecision(
   request: {
     id: UUID,
     body: AnnulAssistanceNeedPreschoolDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-preschool-decisions/${request.id}/annul`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<AnnulAssistanceNeedPreschoolDecisionRequest>
   })
   return json
@@ -264,11 +291,13 @@ export async function annulAssistanceNeedPreschoolDecision(
 export async function createAssistanceNeedPreschoolDecision(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedPreschoolDecision> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedPreschoolDecision>>({
     url: uri`/employee/children/${request.childId}/assistance-need-preschool-decisions`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return deserializeJsonAssistanceNeedPreschoolDecision(json)
 }
@@ -281,11 +310,13 @@ export async function decideAssistanceNeedPreschoolDecision(
   request: {
     id: UUID,
     body: DecideAssistanceNeedPreschoolDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-preschool-decisions/${request.id}/decide`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<DecideAssistanceNeedPreschoolDecisionRequest>
   })
   return json
@@ -298,11 +329,13 @@ export async function decideAssistanceNeedPreschoolDecision(
 export async function deleteAssistanceNeedPreschoolDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-preschool-decisions/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -314,11 +347,13 @@ export async function deleteAssistanceNeedPreschoolDecision(
 export async function getAssistanceNeedPreschoolDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedPreschoolDecisionResponse> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedPreschoolDecisionResponse>>({
     url: uri`/employee/assistance-need-preschool-decisions/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonAssistanceNeedPreschoolDecisionResponse(json)
 }
@@ -330,11 +365,13 @@ export async function getAssistanceNeedPreschoolDecision(
 export async function getAssistanceNeedPreschoolDecisions(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedPreschoolDecisionBasicsResponse[]> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedPreschoolDecisionBasicsResponse[]>>({
     url: uri`/employee/children/${request.childId}/assistance-need-preschool-decisions`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonAssistanceNeedPreschoolDecisionBasicsResponse(e))
 }
@@ -346,11 +383,13 @@ export async function getAssistanceNeedPreschoolDecisions(
 export async function getAssistancePreschoolDecisionMakerOptions(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Employee[]> {
   const { data: json } = await client.request<JsonOf<Employee[]>>({
     url: uri`/employee/assistance-need-preschool-decisions/${request.id}/decision-maker-options`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonEmployee(e))
 }
@@ -362,11 +401,13 @@ export async function getAssistancePreschoolDecisionMakerOptions(
 export async function markAssistanceNeedPreschoolDecisionAsOpened(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-preschool-decisions/${request.id}/mark-as-opened`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -378,11 +419,13 @@ export async function markAssistanceNeedPreschoolDecisionAsOpened(
 export async function revertAssistanceNeedPreschoolDecisionToUnsent(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-preschool-decisions/${request.id}/unsend`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -394,11 +437,13 @@ export async function revertAssistanceNeedPreschoolDecisionToUnsent(
 export async function sendAssistanceNeedPreschoolDecisionForDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-preschool-decisions/${request.id}/send`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -411,11 +456,13 @@ export async function updateAssistanceNeedPreschoolDecision(
   request: {
     id: UUID,
     body: AssistanceNeedPreschoolDecisionForm
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-preschool-decisions/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<AssistanceNeedPreschoolDecisionForm>
   })
   return json
@@ -429,11 +476,13 @@ export async function updateAssistanceNeedPreschoolDecisionDecisionMaker(
   request: {
     id: UUID,
     body: UpdateDecisionMakerForAssistanceNeedPreschoolDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-preschool-decisions/${request.id}/decision-maker`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<UpdateDecisionMakerForAssistanceNeedPreschoolDecisionRequest>
   })
   return json
@@ -447,11 +496,13 @@ export async function createAssistanceNeedVoucherCoefficient(
   request: {
     childId: UUID,
     body: AssistanceNeedVoucherCoefficientRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedVoucherCoefficient> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedVoucherCoefficient>>({
     url: uri`/employee/children/${request.childId}/assistance-need-voucher-coefficients`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AssistanceNeedVoucherCoefficientRequest>
   })
   return deserializeJsonAssistanceNeedVoucherCoefficient(json)
@@ -464,11 +515,13 @@ export async function createAssistanceNeedVoucherCoefficient(
 export async function deleteAssistanceNeedVoucherCoefficient(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/assistance-need-voucher-coefficients/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -480,11 +533,13 @@ export async function deleteAssistanceNeedVoucherCoefficient(
 export async function getAssistanceNeedVoucherCoefficients(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedVoucherCoefficientResponse[]> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedVoucherCoefficientResponse[]>>({
     url: uri`/employee/children/${request.childId}/assistance-need-voucher-coefficients`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonAssistanceNeedVoucherCoefficientResponse(e))
 }
@@ -497,11 +552,13 @@ export async function updateAssistanceNeedVoucherCoefficient(
   request: {
     id: UUID,
     body: AssistanceNeedVoucherCoefficientRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedVoucherCoefficient> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedVoucherCoefficient>>({
     url: uri`/employee/assistance-need-voucher-coefficients/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<AssistanceNeedVoucherCoefficientRequest>
   })
   return deserializeJsonAssistanceNeedVoucherCoefficient(json)

--- a/frontend/src/employee-frontend/generated/api-clients/attachment.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attachment.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
@@ -16,11 +17,13 @@ import { uri } from 'lib-common/uri'
 export async function deleteAttachment(
   request: {
     attachmentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/attachments/${request.attachmentId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }

--- a/frontend/src/employee-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attendance.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { ExternalAttendanceBody } from 'lib-common/generated/api-types/attendance'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
@@ -25,7 +26,8 @@ import { uri } from 'lib-common/uri'
 export async function getOpenGroupAttendance(
   request: {
     userId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<OpenGroupAttendanceResponse> {
   const params = createUrlSearchParams(
     ['userId', request.userId]
@@ -33,6 +35,7 @@ export async function getOpenGroupAttendance(
   const { data: json } = await client.request<JsonOf<OpenGroupAttendanceResponse>>({
     url: uri`/employee/staff-attendances/realtime/open-attendance`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonOpenGroupAttendanceResponse(json)
@@ -47,7 +50,8 @@ export async function getRealtimeStaffAttendances(
     unitId: UUID,
     start: LocalDate,
     end: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<StaffAttendanceResponse> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId],
@@ -57,6 +61,7 @@ export async function getRealtimeStaffAttendances(
   const { data: json } = await client.request<JsonOf<StaffAttendanceResponse>>({
     url: uri`/employee/staff-attendances/realtime`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonStaffAttendanceResponse(json)
@@ -69,11 +74,13 @@ export async function getRealtimeStaffAttendances(
 export async function upsertDailyExternalRealtimeAttendances(
   request: {
     body: ExternalAttendanceBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/staff-attendances/realtime/upsert-external`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ExternalAttendanceBody>
   })
   return json
@@ -86,11 +93,13 @@ export async function upsertDailyExternalRealtimeAttendances(
 export async function upsertDailyStaffRealtimeAttendances(
   request: {
     body: StaffAttendanceBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/staff-attendances/realtime/upsert`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<StaffAttendanceBody>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/backupcare.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/backupcare.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { BackupCareCreateResponse } from 'lib-common/generated/api-types/backupcare'
 import { BackupCareUpdateRequest } from 'lib-common/generated/api-types/backupcare'
 import { ChildBackupCaresResponse } from 'lib-common/generated/api-types/backupcare'
@@ -23,11 +24,13 @@ export async function createBackupCare(
   request: {
     childId: UUID,
     body: NewBackupCare
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<BackupCareCreateResponse> {
   const { data: json } = await client.request<JsonOf<BackupCareCreateResponse>>({
     url: uri`/employee/children/${request.childId}/backup-cares`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<NewBackupCare>
   })
   return json
@@ -40,11 +43,13 @@ export async function createBackupCare(
 export async function deleteBackupCare(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/backup-cares/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -56,11 +61,13 @@ export async function deleteBackupCare(
 export async function getChildBackupCares(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildBackupCaresResponse> {
   const { data: json } = await client.request<JsonOf<ChildBackupCaresResponse>>({
     url: uri`/employee/children/${request.childId}/backup-cares`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonChildBackupCaresResponse(json)
 }
@@ -73,11 +80,13 @@ export async function updateBackupCare(
   request: {
     id: UUID,
     body: BackupCareUpdateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/backup-cares/${request.id}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<BackupCareUpdateRequest>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/backuppickup.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/backuppickup.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { ChildBackupPickup } from 'lib-common/generated/api-types/backuppickup'
 import { ChildBackupPickupContent } from 'lib-common/generated/api-types/backuppickup'
 import { ChildBackupPickupCreateResponse } from 'lib-common/generated/api-types/backuppickup'
@@ -21,11 +22,13 @@ export async function createBackupPickup(
   request: {
     childId: UUID,
     body: ChildBackupPickupContent
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildBackupPickupCreateResponse> {
   const { data: json } = await client.request<JsonOf<ChildBackupPickupCreateResponse>>({
     url: uri`/employee/children/${request.childId}/backup-pickups`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ChildBackupPickupContent>
   })
   return json
@@ -38,11 +41,13 @@ export async function createBackupPickup(
 export async function deleteBackupPickup(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/backup-pickups/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -54,11 +59,13 @@ export async function deleteBackupPickup(
 export async function getBackupPickups(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildBackupPickup[]> {
   const { data: json } = await client.request<JsonOf<ChildBackupPickup[]>>({
     url: uri`/employee/children/${request.childId}/backup-pickups`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -71,11 +78,13 @@ export async function updateBackupPickup(
   request: {
     id: UUID,
     body: ChildBackupPickupContent
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/backup-pickups/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ChildBackupPickupContent>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/calendarevent.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/calendarevent.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { CalendarEvent } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventForm } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeClearingForm } from 'lib-common/generated/api-types/calendarevent'
@@ -29,11 +30,13 @@ export async function addCalendarEventTime(
   request: {
     id: UUID,
     body: CalendarEventTimeForm
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/calendar-event/${request.id}/time`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CalendarEventTimeForm>
   })
   return json
@@ -46,11 +49,13 @@ export async function addCalendarEventTime(
 export async function clearEventTimesInEventForChild(
   request: {
     body: CalendarEventTimeClearingForm
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/calendar-event/clear-survey-reservations-for-child`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CalendarEventTimeClearingForm>
   })
   return json
@@ -63,11 +68,13 @@ export async function clearEventTimesInEventForChild(
 export async function createCalendarEvent(
   request: {
     body: CalendarEventForm
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/calendar-event`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CalendarEventForm>
   })
   return json
@@ -80,11 +87,13 @@ export async function createCalendarEvent(
 export async function deleteCalendarEvent(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/calendar-event/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -96,11 +105,13 @@ export async function deleteCalendarEvent(
 export async function deleteCalendarEventTime(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/calendar-event-time/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -112,11 +123,13 @@ export async function deleteCalendarEventTime(
 export async function getCalendarEvent(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CalendarEvent> {
   const { data: json } = await client.request<JsonOf<CalendarEvent>>({
     url: uri`/employee/calendar-event/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonCalendarEvent(json)
 }
@@ -131,7 +144,8 @@ export async function getGroupDiscussionReservationDays(
     groupId: UUID,
     start: LocalDate,
     end: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DiscussionReservationDay[]> {
   const params = createUrlSearchParams(
     ['start', request.start.formatIso()],
@@ -140,6 +154,7 @@ export async function getGroupDiscussionReservationDays(
   const { data: json } = await client.request<JsonOf<DiscussionReservationDay[]>>({
     url: uri`/employee/units/${request.unitId}/groups/${request.groupId}/discussion-reservation-days`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonDiscussionReservationDay(e))
@@ -153,11 +168,13 @@ export async function getGroupDiscussionSurveys(
   request: {
     unitId: UUID,
     groupId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CalendarEvent[]> {
   const { data: json } = await client.request<JsonOf<CalendarEvent[]>>({
     url: uri`/employee/units/${request.unitId}/groups/${request.groupId}/discussion-surveys`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonCalendarEvent(e))
 }
@@ -171,7 +188,8 @@ export async function getUnitCalendarEvents(
     unitId: UUID,
     start: LocalDate,
     end: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CalendarEvent[]> {
   const params = createUrlSearchParams(
     ['start', request.start.formatIso()],
@@ -180,6 +198,7 @@ export async function getUnitCalendarEvents(
   const { data: json } = await client.request<JsonOf<CalendarEvent[]>>({
     url: uri`/employee/units/${request.unitId}/calendar-events`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonCalendarEvent(e))
@@ -193,11 +212,13 @@ export async function modifyCalendarEvent(
   request: {
     id: UUID,
     body: CalendarEventUpdateForm
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/calendar-event/${request.id}`.toString(),
     method: 'PATCH',
+    headers,
     data: request.body satisfies JsonCompatible<CalendarEventUpdateForm>
   })
   return json
@@ -210,11 +231,13 @@ export async function modifyCalendarEvent(
 export async function setCalendarEventTimeReservation(
   request: {
     body: CalendarEventTimeEmployeeReservationForm
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/calendar-event/reservation`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CalendarEventTimeEmployeeReservationForm>
   })
   return json
@@ -228,11 +251,13 @@ export async function updateCalendarEvent(
   request: {
     id: UUID,
     body: CalendarEventUpdateForm
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/calendar-event/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<CalendarEventUpdateForm>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/dailyservicetimes.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/dailyservicetimes.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { DailyServiceTimesEndDate } from 'lib-common/generated/api-types/dailyservicetimes'
 import { DailyServiceTimesResponse } from 'lib-common/generated/api-types/dailyservicetimes'
 import { DailyServiceTimesValue } from 'lib-common/generated/api-types/dailyservicetimes'
@@ -21,11 +22,13 @@ import { uri } from 'lib-common/uri'
 export async function deleteDailyServiceTimes(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daily-service-times/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -37,11 +40,13 @@ export async function deleteDailyServiceTimes(
 export async function getDailyServiceTimes(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DailyServiceTimesResponse[]> {
   const { data: json } = await client.request<JsonOf<DailyServiceTimesResponse[]>>({
     url: uri`/employee/children/${request.childId}/daily-service-times`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonDailyServiceTimesResponse(e))
 }
@@ -54,11 +59,13 @@ export async function postDailyServiceTimes(
   request: {
     childId: UUID,
     body: DailyServiceTimesValue
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/children/${request.childId}/daily-service-times`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DailyServiceTimesValue>
   })
   return json
@@ -72,11 +79,13 @@ export async function putDailyServiceTimes(
   request: {
     id: UUID,
     body: DailyServiceTimesValue
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daily-service-times/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<DailyServiceTimesValue>
   })
   return json
@@ -90,11 +99,13 @@ export async function putDailyServiceTimesEnd(
   request: {
     id: UUID,
     body: DailyServiceTimesEndDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daily-service-times/${request.id}/end`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<DailyServiceTimesEndDate>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/daycare.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/daycare.ts
@@ -10,6 +10,7 @@ import { AdditionalInformation } from 'lib-common/generated/api-types/daycare'
 import { ApplicationType } from 'lib-common/generated/api-types/application'
 import { ApplicationUnitType } from 'lib-common/generated/api-types/daycare'
 import { AreaJSON } from 'lib-common/generated/api-types/daycare'
+import { AxiosHeaders } from 'axios'
 import { CaretakerRequest } from 'lib-common/generated/api-types/daycare'
 import { CaretakersResponse } from 'lib-common/generated/api-types/daycare'
 import { ChildResponse } from 'lib-common/generated/api-types/daycare'
@@ -62,11 +63,13 @@ import { uri } from 'lib-common/uri'
 export async function getAdditionalInfo(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AdditionalInformation> {
   const { data: json } = await client.request<JsonOf<AdditionalInformation>>({
     url: uri`/employee/children/${request.childId}/additional-information`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -78,11 +81,13 @@ export async function getAdditionalInfo(
 export async function getChild(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildResponse> {
   const { data: json } = await client.request<JsonOf<ChildResponse>>({
     url: uri`/employee/children/${request.childId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonChildResponse(json)
 }
@@ -95,11 +100,13 @@ export async function updateAdditionalInfo(
   request: {
     childId: UUID,
     body: AdditionalInformation
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/children/${request.childId}/additional-information`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<AdditionalInformation>
   })
   return json
@@ -114,11 +121,13 @@ export async function createCaretakers(
     daycareId: UUID,
     groupId: UUID,
     body: CaretakerRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/groups/${request.groupId}/caretakers`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CaretakerRequest>
   })
   return json
@@ -131,11 +140,13 @@ export async function createCaretakers(
 export async function createDaycare(
   request: {
     body: DaycareFields
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CreateDaycareResponse> {
   const { data: json } = await client.request<JsonOf<CreateDaycareResponse>>({
     url: uri`/employee/daycares`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DaycareFields>
   })
   return json
@@ -149,11 +160,13 @@ export async function createGroup(
   request: {
     daycareId: UUID,
     body: CreateGroupRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DaycareGroup> {
   const { data: json } = await client.request<JsonOf<DaycareGroup>>({
     url: uri`/employee/daycares/${request.daycareId}/groups`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CreateGroupRequest>
   })
   return deserializeJsonDaycareGroup(json)
@@ -167,11 +180,13 @@ export async function deleteGroup(
   request: {
     daycareId: UUID,
     groupId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/groups/${request.groupId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -184,11 +199,13 @@ export async function getCaretakers(
   request: {
     daycareId: UUID,
     groupId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CaretakersResponse> {
   const { data: json } = await client.request<JsonOf<CaretakersResponse>>({
     url: uri`/employee/daycares/${request.daycareId}/groups/${request.groupId}/caretakers`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonCaretakersResponse(json)
 }
@@ -200,11 +217,13 @@ export async function getCaretakers(
 export async function getDaycare(
   request: {
     daycareId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DaycareResponse> {
   const { data: json } = await client.request<JsonOf<DaycareResponse>>({
     url: uri`/employee/daycares/${request.daycareId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonDaycareResponse(json)
 }
@@ -216,7 +235,8 @@ export async function getDaycare(
 export async function getDaycares(
   request: {
     includeClosed?: boolean | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Daycare[]> {
   const params = createUrlSearchParams(
     ['includeClosed', request.includeClosed?.toString()]
@@ -224,6 +244,7 @@ export async function getDaycares(
   const { data: json } = await client.request<JsonOf<Daycare[]>>({
     url: uri`/employee/daycares`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonDaycare(e))
@@ -238,7 +259,8 @@ export async function getGroups(
     daycareId: UUID,
     from?: LocalDate | null,
     to?: LocalDate | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DaycareGroup[]> {
   const params = createUrlSearchParams(
     ['from', request.from?.formatIso()],
@@ -247,6 +269,7 @@ export async function getGroups(
   const { data: json } = await client.request<JsonOf<DaycareGroup[]>>({
     url: uri`/employee/daycares/${request.daycareId}/groups`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonDaycareGroup(e))
@@ -256,10 +279,13 @@ export async function getGroups(
 /**
 * Generated from fi.espoo.evaka.daycare.controllers.DaycareController.getUnitFeatures
 */
-export async function getUnitFeatures(): Promise<UnitFeatures[]> {
+export async function getUnitFeatures(
+  headers?: AxiosHeaders
+): Promise<UnitFeatures[]> {
   const { data: json } = await client.request<JsonOf<UnitFeatures[]>>({
     url: uri`/employee/daycares/features`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -273,7 +299,8 @@ export async function getUnitGroupDetails(
     unitId: UUID,
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UnitGroupDetails> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -282,6 +309,7 @@ export async function getUnitGroupDetails(
   const { data: json } = await client.request<JsonOf<UnitGroupDetails>>({
     url: uri`/employee/daycares/${request.unitId}/group-details`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonUnitGroupDetails(json)
@@ -294,11 +322,13 @@ export async function getUnitGroupDetails(
 export async function getUnitNotifications(
   request: {
     daycareId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UnitNotifications> {
   const { data: json } = await client.request<JsonOf<UnitNotifications>>({
     url: uri`/employee/daycares/${request.daycareId}/notifications`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -312,11 +342,13 @@ export async function removeCaretakers(
     daycareId: UUID,
     groupId: UUID,
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/groups/${request.groupId}/caretakers/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -331,11 +363,13 @@ export async function updateCaretakers(
     groupId: UUID,
     id: UUID,
     body: CaretakerRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/groups/${request.groupId}/caretakers/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<CaretakerRequest>
   })
   return json
@@ -349,11 +383,13 @@ export async function updateDaycare(
   request: {
     daycareId: UUID,
     body: DaycareFields
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<DaycareFields>
   })
   return json
@@ -368,11 +404,13 @@ export async function updateGroup(
     daycareId: UUID,
     groupId: UUID,
     body: GroupUpdateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/groups/${request.groupId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<GroupUpdateRequest>
   })
   return json
@@ -385,11 +423,13 @@ export async function updateGroup(
 export async function updateUnitFeatures(
   request: {
     body: UpdateFeaturesRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/unit-features`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<UpdateFeaturesRequest>
   })
   return json
@@ -402,11 +442,13 @@ export async function updateUnitFeatures(
 export async function getAllApplicableUnits(
   request: {
     applicationType: ApplicationType
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PublicUnit[]> {
   const { data: json } = await client.request<JsonOf<PublicUnit[]>>({
     url: uri`/employee/public/units/${request.applicationType}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPublicUnit(e))
 }
@@ -420,7 +462,8 @@ export async function getApplicationUnits(
     type: ApplicationUnitType,
     date: LocalDate,
     shiftCare?: boolean | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PublicUnit[]> {
   const params = createUrlSearchParams(
     ['type', request.type.toString()],
@@ -430,6 +473,7 @@ export async function getApplicationUnits(
   const { data: json } = await client.request<JsonOf<PublicUnit[]>>({
     url: uri`/employee/units`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonPublicUnit(e))
@@ -439,10 +483,13 @@ export async function getApplicationUnits(
 /**
 * Generated from fi.espoo.evaka.daycare.controllers.LocationController.getAreas
 */
-export async function getAreas(): Promise<AreaJSON[]> {
+export async function getAreas(
+  headers?: AxiosHeaders
+): Promise<AreaJSON[]> {
   const { data: json } = await client.request<JsonOf<AreaJSON[]>>({
     url: uri`/employee/areas`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -456,7 +503,8 @@ export async function getUnits(
     type: UnitTypeFilter,
     areaIds?: UUID[] | null,
     from?: LocalDate | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UnitStub[]> {
   const params = createUrlSearchParams(
     ['type', request.type.toString()],
@@ -466,6 +514,7 @@ export async function getUnits(
   const { data: json } = await client.request<JsonOf<UnitStub[]>>({
     url: uri`/employee/filters/units`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -480,7 +529,8 @@ export async function getStaffAttendancesByGroup(
     groupId: UUID,
     year: number,
     month: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<StaffAttendanceForDates> {
   const params = createUrlSearchParams(
     ['year', request.year.toString()],
@@ -489,6 +539,7 @@ export async function getStaffAttendancesByGroup(
   const { data: json } = await client.request<JsonOf<StaffAttendanceForDates>>({
     url: uri`/employee/staff-attendances/group/${request.groupId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonStaffAttendanceForDates(json)
@@ -502,11 +553,13 @@ export async function upsertStaffAttendance(
   request: {
     groupId: UUID,
     body: StaffAttendanceUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/staff-attendances/group/${request.groupId}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<StaffAttendanceUpdate>
   })
   return json
@@ -519,11 +572,13 @@ export async function upsertStaffAttendance(
 export async function createClubTerm(
   request: {
     body: ClubTermRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/club-terms`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ClubTermRequest>
   })
   return json
@@ -536,11 +591,13 @@ export async function createClubTerm(
 export async function createPreschoolTerm(
   request: {
     body: PreschoolTermRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/preschool-terms`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PreschoolTermRequest>
   })
   return json
@@ -553,11 +610,13 @@ export async function createPreschoolTerm(
 export async function deleteClubTerm(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/club-terms/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -569,11 +628,13 @@ export async function deleteClubTerm(
 export async function deletePreschoolTerm(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/preschool-terms/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -582,10 +643,13 @@ export async function deletePreschoolTerm(
 /**
 * Generated from fi.espoo.evaka.daycare.controllers.TermsController.getClubTerms
 */
-export async function getClubTerms(): Promise<ClubTerm[]> {
+export async function getClubTerms(
+  headers?: AxiosHeaders
+): Promise<ClubTerm[]> {
   const { data: json } = await client.request<JsonOf<ClubTerm[]>>({
     url: uri`/employee/public/club-terms`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonClubTerm(e))
 }
@@ -594,10 +658,13 @@ export async function getClubTerms(): Promise<ClubTerm[]> {
 /**
 * Generated from fi.espoo.evaka.daycare.controllers.TermsController.getPreschoolTerms
 */
-export async function getPreschoolTerms(): Promise<PreschoolTerm[]> {
+export async function getPreschoolTerms(
+  headers?: AxiosHeaders
+): Promise<PreschoolTerm[]> {
   const { data: json } = await client.request<JsonOf<PreschoolTerm[]>>({
     url: uri`/employee/public/preschool-terms`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPreschoolTerm(e))
 }
@@ -610,11 +677,13 @@ export async function updateClubTerm(
   request: {
     id: UUID,
     body: ClubTermRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/club-terms/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ClubTermRequest>
   })
   return json
@@ -628,11 +697,13 @@ export async function updatePreschoolTerm(
   request: {
     id: UUID,
     body: PreschoolTermRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/preschool-terms/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<PreschoolTermRequest>
   })
   return json
@@ -647,11 +718,13 @@ export async function addFullAclForRole(
     daycareId: UUID,
     employeeId: UUID,
     body: FullAclInfo
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/full-acl/${request.employeeId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<FullAclInfo>
   })
   return json
@@ -665,11 +738,13 @@ export async function createTemporaryEmployee(
   request: {
     unitId: UUID,
     body: TemporaryEmployee
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/daycares/${request.unitId}/temporary`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<TemporaryEmployee>
   })
   return json
@@ -683,11 +758,13 @@ export async function deleteEarlyChildhoodEducationSecretary(
   request: {
     daycareId: UUID,
     employeeId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/earlychildhoodeducationsecretary/${request.employeeId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -700,11 +777,13 @@ export async function deleteSpecialEducationTeacher(
   request: {
     daycareId: UUID,
     employeeId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/specialeducationteacher/${request.employeeId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -717,11 +796,13 @@ export async function deleteStaff(
   request: {
     daycareId: UUID,
     employeeId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/staff/${request.employeeId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -734,11 +815,13 @@ export async function deleteTemporaryEmployee(
   request: {
     unitId: UUID,
     employeeId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.unitId}/temporary/${request.employeeId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -751,11 +834,13 @@ export async function deleteTemporaryEmployeeAcl(
   request: {
     unitId: UUID,
     employeeId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.unitId}/temporary/${request.employeeId}/acl`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -768,11 +853,13 @@ export async function deleteUnitSupervisor(
   request: {
     daycareId: UUID,
     employeeId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/supervisors/${request.employeeId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -784,11 +871,13 @@ export async function deleteUnitSupervisor(
 export async function getDaycareAcl(
   request: {
     daycareId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DaycareAclRow[]> {
   const { data: json } = await client.request<JsonOf<DaycareAclRow[]>>({
     url: uri`/employee/daycares/${request.daycareId}/acl`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -801,11 +890,13 @@ export async function getTemporaryEmployee(
   request: {
     unitId: UUID,
     employeeId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<TemporaryEmployee> {
   const { data: json } = await client.request<JsonOf<TemporaryEmployee>>({
     url: uri`/employee/daycares/${request.unitId}/temporary/${request.employeeId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -817,11 +908,13 @@ export async function getTemporaryEmployee(
 export async function getTemporaryEmployees(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Employee[]> {
   const { data: json } = await client.request<JsonOf<Employee[]>>({
     url: uri`/employee/daycares/${request.unitId}/temporary`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonEmployee(e))
 }
@@ -835,11 +928,13 @@ export async function updateGroupAclWithOccupancyCoefficient(
     daycareId: UUID,
     employeeId: UUID,
     body: AclUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.daycareId}/staff/${request.employeeId}/groups`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<AclUpdate>
   })
   return json
@@ -854,11 +949,13 @@ export async function updateTemporaryEmployee(
     unitId: UUID,
     employeeId: UUID,
     body: TemporaryEmployee
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/daycares/${request.unitId}/temporary/${request.employeeId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<TemporaryEmployee>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/decision.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/decision.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { DecisionListResponse } from 'lib-common/generated/api-types/decision'
 import { DecisionUnit } from 'lib-common/generated/api-types/decision'
 import { JsonOf } from 'lib-common/json'
@@ -17,10 +18,13 @@ import { uri } from 'lib-common/uri'
 /**
 * Generated from fi.espoo.evaka.decision.DecisionController.getDecisionUnits
 */
-export async function getDecisionUnits(): Promise<DecisionUnit[]> {
+export async function getDecisionUnits(
+  headers?: AxiosHeaders
+): Promise<DecisionUnit[]> {
   const { data: json } = await client.request<JsonOf<DecisionUnit[]>>({
     url: uri`/employee/decisions/units`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -32,7 +36,8 @@ export async function getDecisionUnits(): Promise<DecisionUnit[]> {
 export async function getDecisionsByGuardian(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DecisionListResponse> {
   const params = createUrlSearchParams(
     ['id', request.id]
@@ -40,6 +45,7 @@ export async function getDecisionsByGuardian(
   const { data: json } = await client.request<JsonOf<DecisionListResponse>>({
     url: uri`/employee/decisions/by-guardian`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonDecisionListResponse(json)

--- a/frontend/src/employee-frontend/generated/api-clients/document.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/document.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import DateRange from 'lib-common/date-range'
+import { AxiosHeaders } from 'axios'
 import { ChildDocumentCreateRequest } from 'lib-common/generated/api-types/document'
 import { ChildDocumentSummaryWithPermittedActions } from 'lib-common/generated/api-types/document'
 import { ChildDocumentWithPermittedActions } from 'lib-common/generated/api-types/document'
@@ -36,11 +37,13 @@ import { uri } from 'lib-common/uri'
 export async function createTemplate(
   request: {
     body: DocumentTemplateBasicsRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DocumentTemplate> {
   const { data: json } = await client.request<JsonOf<DocumentTemplate>>({
     url: uri`/employee/document-templates`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DocumentTemplateBasicsRequest>
   })
   return deserializeJsonDocumentTemplate(json)
@@ -53,11 +56,13 @@ export async function createTemplate(
 export async function deleteDraftTemplate(
   request: {
     templateId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/document-templates/${request.templateId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -70,11 +75,13 @@ export async function duplicateTemplate(
   request: {
     templateId: UUID,
     body: DocumentTemplateBasicsRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DocumentTemplate> {
   const { data: json } = await client.request<JsonOf<DocumentTemplate>>({
     url: uri`/employee/document-templates/${request.templateId}/duplicate`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DocumentTemplateBasicsRequest>
   })
   return deserializeJsonDocumentTemplate(json)
@@ -87,11 +94,13 @@ export async function duplicateTemplate(
 export async function exportTemplate(
   request: {
     templateId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ExportedDocumentTemplate> {
   const { data: json } = await client.request<JsonOf<ExportedDocumentTemplate>>({
     url: uri`/employee/document-templates/${request.templateId}/export`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonExportedDocumentTemplate(json)
 }
@@ -103,11 +112,13 @@ export async function exportTemplate(
 export async function forceUnpublishTemplate(
   request: {
     templateId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/document-templates/${request.templateId}/force-unpublish`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -119,7 +130,8 @@ export async function forceUnpublishTemplate(
 export async function getActiveTemplates(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DocumentTemplateSummary[]> {
   const params = createUrlSearchParams(
     ['childId', request.childId]
@@ -127,6 +139,7 @@ export async function getActiveTemplates(
   const { data: json } = await client.request<JsonOf<DocumentTemplateSummary[]>>({
     url: uri`/employee/document-templates/active`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonDocumentTemplateSummary(e))
@@ -139,11 +152,13 @@ export async function getActiveTemplates(
 export async function getTemplate(
   request: {
     templateId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DocumentTemplate> {
   const { data: json } = await client.request<JsonOf<DocumentTemplate>>({
     url: uri`/employee/document-templates/${request.templateId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonDocumentTemplate(json)
 }
@@ -152,10 +167,13 @@ export async function getTemplate(
 /**
 * Generated from fi.espoo.evaka.document.DocumentTemplateController.getTemplates
 */
-export async function getTemplates(): Promise<DocumentTemplateSummary[]> {
+export async function getTemplates(
+  headers?: AxiosHeaders
+): Promise<DocumentTemplateSummary[]> {
   const { data: json } = await client.request<JsonOf<DocumentTemplateSummary[]>>({
     url: uri`/employee/document-templates`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonDocumentTemplateSummary(e))
 }
@@ -167,11 +185,13 @@ export async function getTemplates(): Promise<DocumentTemplateSummary[]> {
 export async function importTemplate(
   request: {
     body: ExportedDocumentTemplate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DocumentTemplate> {
   const { data: json } = await client.request<JsonOf<DocumentTemplate>>({
     url: uri`/employee/document-templates/import`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ExportedDocumentTemplate>
   })
   return deserializeJsonDocumentTemplate(json)
@@ -184,11 +204,13 @@ export async function importTemplate(
 export async function publishTemplate(
   request: {
     templateId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/document-templates/${request.templateId}/publish`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -201,11 +223,13 @@ export async function updateDraftTemplateBasics(
   request: {
     templateId: UUID,
     body: DocumentTemplateBasicsRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/document-templates/${request.templateId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<DocumentTemplateBasicsRequest>
   })
   return json
@@ -219,11 +243,13 @@ export async function updateDraftTemplateContent(
   request: {
     templateId: UUID,
     body: DocumentTemplateContent
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/document-templates/${request.templateId}/content`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<DocumentTemplateContent>
   })
   return json
@@ -237,11 +263,13 @@ export async function updateTemplateValidity(
   request: {
     templateId: UUID,
     body: DateRange
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/document-templates/${request.templateId}/validity`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<DateRange>
   })
   return json
@@ -254,11 +282,13 @@ export async function updateTemplateValidity(
 export async function createDocument(
   request: {
     body: ChildDocumentCreateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/child-documents`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ChildDocumentCreateRequest>
   })
   return json
@@ -271,11 +301,13 @@ export async function createDocument(
 export async function deleteDraftDocument(
   request: {
     documentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/child-documents/${request.documentId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -287,11 +319,13 @@ export async function deleteDraftDocument(
 export async function getDocument(
   request: {
     documentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildDocumentWithPermittedActions> {
   const { data: json } = await client.request<JsonOf<ChildDocumentWithPermittedActions>>({
     url: uri`/employee/child-documents/${request.documentId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonChildDocumentWithPermittedActions(json)
 }
@@ -303,7 +337,8 @@ export async function getDocument(
 export async function getDocuments(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildDocumentSummaryWithPermittedActions[]> {
   const params = createUrlSearchParams(
     ['childId', request.childId]
@@ -311,6 +346,7 @@ export async function getDocuments(
   const { data: json } = await client.request<JsonOf<ChildDocumentSummaryWithPermittedActions[]>>({
     url: uri`/employee/child-documents`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonChildDocumentSummaryWithPermittedActions(e))
@@ -324,11 +360,13 @@ export async function nextDocumentStatus(
   request: {
     documentId: UUID,
     body: StatusChangeRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/child-documents/${request.documentId}/next-status`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<StatusChangeRequest>
   })
   return json
@@ -342,11 +380,13 @@ export async function prevDocumentStatus(
   request: {
     documentId: UUID,
     body: StatusChangeRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/child-documents/${request.documentId}/prev-status`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<StatusChangeRequest>
   })
   return json
@@ -359,11 +399,13 @@ export async function prevDocumentStatus(
 export async function publishDocument(
   request: {
     documentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/child-documents/${request.documentId}/publish`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -375,11 +417,13 @@ export async function publishDocument(
 export async function takeDocumentWriteLock(
   request: {
     documentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DocumentLockResponse> {
   const { data: json } = await client.request<JsonOf<DocumentLockResponse>>({
     url: uri`/employee/child-documents/${request.documentId}/lock`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return deserializeJsonDocumentLockResponse(json)
 }
@@ -392,11 +436,13 @@ export async function updateDocumentContent(
   request: {
     documentId: UUID,
     body: DocumentContent
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/child-documents/${request.documentId}/content`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<DocumentContent>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/holidayperiod.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/holidayperiod.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { FixedPeriodQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
 import { FixedPeriodQuestionnaireBody } from 'lib-common/generated/api-types/holidayperiod'
 import { HolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
@@ -24,11 +25,13 @@ import { uri } from 'lib-common/uri'
 export async function createHolidayPeriod(
   request: {
     body: HolidayPeriodCreate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<HolidayPeriod> {
   const { data: json } = await client.request<JsonOf<HolidayPeriod>>({
     url: uri`/employee/holiday-period`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<HolidayPeriodCreate>
   })
   return deserializeJsonHolidayPeriod(json)
@@ -41,11 +44,13 @@ export async function createHolidayPeriod(
 export async function deleteHolidayPeriod(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/holiday-period/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -57,11 +62,13 @@ export async function deleteHolidayPeriod(
 export async function getHolidayPeriod(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<HolidayPeriod> {
   const { data: json } = await client.request<JsonOf<HolidayPeriod>>({
     url: uri`/employee/holiday-period/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonHolidayPeriod(json)
 }
@@ -70,10 +77,13 @@ export async function getHolidayPeriod(
 /**
 * Generated from fi.espoo.evaka.holidayperiod.HolidayPeriodController.getHolidayPeriods
 */
-export async function getHolidayPeriods(): Promise<HolidayPeriod[]> {
+export async function getHolidayPeriods(
+  headers?: AxiosHeaders
+): Promise<HolidayPeriod[]> {
   const { data: json } = await client.request<JsonOf<HolidayPeriod[]>>({
     url: uri`/employee/holiday-period`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonHolidayPeriod(e))
 }
@@ -86,11 +96,13 @@ export async function updateHolidayPeriod(
   request: {
     id: UUID,
     body: HolidayPeriodUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/holiday-period/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<HolidayPeriodUpdate>
   })
   return json
@@ -103,11 +115,13 @@ export async function updateHolidayPeriod(
 export async function createHolidayQuestionnaire(
   request: {
     body: FixedPeriodQuestionnaireBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/holiday-period/questionnaire`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<FixedPeriodQuestionnaireBody>
   })
   return json
@@ -120,11 +134,13 @@ export async function createHolidayQuestionnaire(
 export async function deleteHolidayQuestionnaire(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/holiday-period/questionnaire/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -136,11 +152,13 @@ export async function deleteHolidayQuestionnaire(
 export async function getQuestionnaire(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FixedPeriodQuestionnaire> {
   const { data: json } = await client.request<JsonOf<FixedPeriodQuestionnaire>>({
     url: uri`/employee/holiday-period/questionnaire/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonFixedPeriodQuestionnaire(json)
 }
@@ -149,10 +167,13 @@ export async function getQuestionnaire(
 /**
 * Generated from fi.espoo.evaka.holidayperiod.HolidayQuestionnaireController.getQuestionnaires
 */
-export async function getQuestionnaires(): Promise<FixedPeriodQuestionnaire[]> {
+export async function getQuestionnaires(
+  headers?: AxiosHeaders
+): Promise<FixedPeriodQuestionnaire[]> {
   const { data: json } = await client.request<JsonOf<FixedPeriodQuestionnaire[]>>({
     url: uri`/employee/holiday-period/questionnaire`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonFixedPeriodQuestionnaire(e))
 }
@@ -165,11 +186,13 @@ export async function updateHolidayQuestionnaire(
   request: {
     id: UUID,
     body: FixedPeriodQuestionnaireBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/holiday-period/questionnaire/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<FixedPeriodQuestionnaireBody>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/incomestatement.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/incomestatement.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { ChildBasicInfo } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeStatement } from 'lib-common/generated/api-types/incomestatement'
 import { JsonCompatible } from 'lib-common/json'
@@ -28,11 +29,13 @@ export async function getIncomeStatement(
   request: {
     personId: UUID,
     incomeStatementId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<IncomeStatement> {
   const { data: json } = await client.request<JsonOf<IncomeStatement>>({
     url: uri`/employee/income-statements/person/${request.personId}/${request.incomeStatementId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonIncomeStatement(json)
 }
@@ -44,11 +47,13 @@ export async function getIncomeStatement(
 export async function getIncomeStatementChildren(
   request: {
     guardianId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildBasicInfo[]> {
   const { data: json } = await client.request<JsonOf<ChildBasicInfo[]>>({
     url: uri`/employee/income-statements/guardian/${request.guardianId}/children`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -61,7 +66,8 @@ export async function getIncomeStatements(
   request: {
     personId: UUID,
     page: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedIncomeStatements> {
   const params = createUrlSearchParams(
     ['page', request.page.toString()]
@@ -69,6 +75,7 @@ export async function getIncomeStatements(
   const { data: json } = await client.request<JsonOf<PagedIncomeStatements>>({
     url: uri`/employee/income-statements/person/${request.personId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonPagedIncomeStatements(json)
@@ -81,11 +88,13 @@ export async function getIncomeStatements(
 export async function getIncomeStatementsAwaitingHandler(
   request: {
     body: SearchIncomeStatementsRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedIncomeStatementsAwaitingHandler> {
   const { data: json } = await client.request<JsonOf<PagedIncomeStatementsAwaitingHandler>>({
     url: uri`/employee/income-statements/awaiting-handler`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SearchIncomeStatementsRequest>
   })
   return deserializeJsonPagedIncomeStatementsAwaitingHandler(json)
@@ -99,11 +108,13 @@ export async function setIncomeStatementHandled(
   request: {
     incomeStatementId: UUID,
     body: SetIncomeStatementHandledBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/income-statements/${request.incomeStatementId}/handled`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SetIncomeStatementHandledBody>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/invoicing.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/invoicing.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { CreateRetroactiveFeeDecisionsBody } from 'lib-common/generated/api-types/invoicing'
 import { Employee } from 'lib-common/generated/api-types/pis'
 import { FeeAlteration } from 'lib-common/generated/api-types/invoicing'
@@ -73,11 +74,13 @@ import { uri } from 'lib-common/uri'
 export async function createFeeAlteration(
   request: {
     body: FeeAlteration
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-alterations`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<FeeAlteration>
   })
   return json
@@ -90,11 +93,13 @@ export async function createFeeAlteration(
 export async function deleteFeeAlteration(
   request: {
     feeAlterationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-alterations/${request.feeAlterationId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -106,7 +111,8 @@ export async function deleteFeeAlteration(
 export async function getFeeAlterations(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FeeAlterationWithPermittedActions[]> {
   const params = createUrlSearchParams(
     ['personId', request.personId]
@@ -114,6 +120,7 @@ export async function getFeeAlterations(
   const { data: json } = await client.request<JsonOf<FeeAlterationWithPermittedActions[]>>({
     url: uri`/employee/fee-alterations`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonFeeAlterationWithPermittedActions(e))
@@ -127,11 +134,13 @@ export async function updateFeeAlteration(
   request: {
     feeAlterationId: UUID,
     body: FeeAlteration
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-alterations/${request.feeAlterationId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<FeeAlteration>
   })
   return json
@@ -145,7 +154,8 @@ export async function confirmFeeDecisionDrafts(
   request: {
     decisionHandlerId?: UUID | null,
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['decisionHandlerId', request.decisionHandlerId]
@@ -153,6 +163,7 @@ export async function confirmFeeDecisionDrafts(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-decisions/confirm`.toString(),
     method: 'POST',
+    headers,
     params,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
@@ -167,11 +178,13 @@ export async function generateRetroactiveFeeDecisions(
   request: {
     id: UUID,
     body: CreateRetroactiveFeeDecisionsBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-decisions/head-of-family/${request.id}/create-retroactive`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CreateRetroactiveFeeDecisionsBody>
   })
   return json
@@ -184,11 +197,13 @@ export async function generateRetroactiveFeeDecisions(
 export async function getFeeDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FeeDecisionDetailed> {
   const { data: json } = await client.request<JsonOf<FeeDecisionDetailed>>({
     url: uri`/employee/fee-decisions/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonFeeDecisionDetailed(json)
 }
@@ -200,11 +215,13 @@ export async function getFeeDecision(
 export async function getHeadOfFamilyFeeDecisions(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FeeDecision[]> {
   const { data: json } = await client.request<JsonOf<FeeDecision[]>>({
     url: uri`/employee/fee-decisions/head-of-family/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonFeeDecision(e))
 }
@@ -216,11 +233,13 @@ export async function getHeadOfFamilyFeeDecisions(
 export async function ignoreFeeDecisionDrafts(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-decisions/ignore`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -233,11 +252,13 @@ export async function ignoreFeeDecisionDrafts(
 export async function searchFeeDecisions(
   request: {
     body: SearchFeeDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedFeeDecisionSummaries> {
   const { data: json } = await client.request<JsonOf<PagedFeeDecisionSummaries>>({
     url: uri`/employee/fee-decisions/search`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SearchFeeDecisionRequest>
   })
   return deserializeJsonPagedFeeDecisionSummaries(json)
@@ -250,11 +271,13 @@ export async function searchFeeDecisions(
 export async function setFeeDecisionSent(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-decisions/mark-sent`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -268,11 +291,13 @@ export async function setFeeDecisionType(
   request: {
     id: UUID,
     body: FeeDecisionTypeRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-decisions/set-type/${request.id}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<FeeDecisionTypeRequest>
   })
   return json
@@ -285,11 +310,13 @@ export async function setFeeDecisionType(
 export async function unignoreFeeDecisionDrafts(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-decisions/unignore`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -302,11 +329,13 @@ export async function unignoreFeeDecisionDrafts(
 export async function generateDecisions(
   request: {
     body: GenerateDecisionsBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-decision-generator/generate`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<GenerateDecisionsBody>
   })
   return json
@@ -319,11 +348,13 @@ export async function generateDecisions(
 export async function createFeeThresholds(
   request: {
     body: FeeThresholds
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/finance-basics/fee-thresholds`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<FeeThresholds>
   })
   return json
@@ -336,11 +367,13 @@ export async function createFeeThresholds(
 export async function createVoucherValue(
   request: {
     body: ServiceNeedOptionVoucherValueRange
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/finance-basics/voucher-values`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ServiceNeedOptionVoucherValueRange>
   })
   return json
@@ -353,11 +386,13 @@ export async function createVoucherValue(
 export async function deleteVoucherValue(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/finance-basics/voucher-values/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -366,10 +401,13 @@ export async function deleteVoucherValue(
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.FinanceBasicsController.getFeeThresholds
 */
-export async function getFeeThresholds(): Promise<FeeThresholdsWithId[]> {
+export async function getFeeThresholds(
+  headers?: AxiosHeaders
+): Promise<FeeThresholdsWithId[]> {
   const { data: json } = await client.request<JsonOf<FeeThresholdsWithId[]>>({
     url: uri`/employee/finance-basics/fee-thresholds`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonFeeThresholdsWithId(e))
 }
@@ -378,10 +416,13 @@ export async function getFeeThresholds(): Promise<FeeThresholdsWithId[]> {
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.FinanceBasicsController.getVoucherValues
 */
-export async function getVoucherValues(): Promise<Record<UUID, ServiceNeedOptionVoucherValueRangeWithId[]>> {
+export async function getVoucherValues(
+  headers?: AxiosHeaders
+): Promise<Record<UUID, ServiceNeedOptionVoucherValueRangeWithId[]>> {
   const { data: json } = await client.request<JsonOf<Record<UUID, ServiceNeedOptionVoucherValueRangeWithId[]>>>({
     url: uri`/employee/finance-basics/voucher-values`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return Object.fromEntries(Object.entries(json).map(
     ([k, v]) => [k, v.map(e => deserializeJsonServiceNeedOptionVoucherValueRangeWithId(e))]
@@ -396,11 +437,13 @@ export async function updateFeeThresholds(
   request: {
     id: UUID,
     body: FeeThresholds
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/finance-basics/fee-thresholds/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<FeeThresholds>
   })
   return json
@@ -414,11 +457,13 @@ export async function updateVoucherValue(
   request: {
     id: UUID,
     body: ServiceNeedOptionVoucherValueRange
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/finance-basics/voucher-values/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ServiceNeedOptionVoucherValueRange>
   })
   return json
@@ -428,10 +473,13 @@ export async function updateVoucherValue(
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.FinanceDecisionController.getSelectableFinanceDecisionHandlers
 */
-export async function getSelectableFinanceDecisionHandlers(): Promise<Employee[]> {
+export async function getSelectableFinanceDecisionHandlers(
+  headers?: AxiosHeaders
+): Promise<Employee[]> {
   const { data: json } = await client.request<JsonOf<Employee[]>>({
     url: uri`/employee/finance-decisions/selectable-handlers`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonEmployee(e))
 }
@@ -443,11 +491,13 @@ export async function getSelectableFinanceDecisionHandlers(): Promise<Employee[]
 export async function createIncome(
   request: {
     body: IncomeRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/incomes`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<IncomeRequest>
   })
   return json
@@ -460,11 +510,13 @@ export async function createIncome(
 export async function deleteIncome(
   request: {
     incomeId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/incomes/${request.incomeId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -473,10 +525,13 @@ export async function deleteIncome(
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.IncomeController.getIncomeMultipliers
 */
-export async function getIncomeMultipliers(): Promise<Record<IncomeCoefficient, number>> {
+export async function getIncomeMultipliers(
+  headers?: AxiosHeaders
+): Promise<Record<IncomeCoefficient, number>> {
   const { data: json } = await client.request<JsonOf<Record<IncomeCoefficient, number>>>({
     url: uri`/employee/incomes/multipliers`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -488,7 +543,8 @@ export async function getIncomeMultipliers(): Promise<Record<IncomeCoefficient, 
 export async function getIncomeNotifications(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<IncomeNotification[]> {
   const params = createUrlSearchParams(
     ['personId', request.personId]
@@ -496,6 +552,7 @@ export async function getIncomeNotifications(
   const { data: json } = await client.request<JsonOf<IncomeNotification[]>>({
     url: uri`/employee/incomes/notifications`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonIncomeNotification(e))
@@ -505,10 +562,13 @@ export async function getIncomeNotifications(
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.IncomeController.getIncomeTypeOptions
 */
-export async function getIncomeTypeOptions(): Promise<IncomeTypeOptions> {
+export async function getIncomeTypeOptions(
+  headers?: AxiosHeaders
+): Promise<IncomeTypeOptions> {
   const { data: json } = await client.request<JsonOf<IncomeTypeOptions>>({
     url: uri`/employee/incomes/types`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -520,7 +580,8 @@ export async function getIncomeTypeOptions(): Promise<IncomeTypeOptions> {
 export async function getPersonIncomes(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<IncomeWithPermittedActions[]> {
   const params = createUrlSearchParams(
     ['personId', request.personId]
@@ -528,6 +589,7 @@ export async function getPersonIncomes(
   const { data: json } = await client.request<JsonOf<IncomeWithPermittedActions[]>>({
     url: uri`/employee/incomes`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonIncomeWithPermittedActions(e))
@@ -541,11 +603,13 @@ export async function updateIncome(
   request: {
     incomeId: UUID,
     body: IncomeRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/incomes/${request.incomeId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<IncomeRequest>
   })
   return json
@@ -555,10 +619,13 @@ export async function updateIncome(
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.InvoiceController.createDraftInvoices
 */
-export async function createDraftInvoices(): Promise<void> {
+export async function createDraftInvoices(
+  headers?: AxiosHeaders
+): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoices/create-drafts`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -570,11 +637,13 @@ export async function createDraftInvoices(): Promise<void> {
 export async function createReplacementDraftsForHeadOfFamily(
   request: {
     headOfFamilyId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoices/create-replacement-drafts/${request.headOfFamilyId}`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -586,11 +655,13 @@ export async function createReplacementDraftsForHeadOfFamily(
 export async function deleteDraftInvoices(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoices/delete-drafts`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -603,11 +674,13 @@ export async function deleteDraftInvoices(
 export async function getHeadOfFamilyInvoices(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<InvoiceDetailed[]> {
   const { data: json } = await client.request<JsonOf<InvoiceDetailed[]>>({
     url: uri`/employee/invoices/head-of-family/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonInvoiceDetailed(e))
 }
@@ -619,11 +692,13 @@ export async function getHeadOfFamilyInvoices(
 export async function getInvoice(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<InvoiceDetailedResponse> {
   const { data: json } = await client.request<JsonOf<InvoiceDetailedResponse>>({
     url: uri`/employee/invoices/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonInvoiceDetailedResponse(json)
 }
@@ -632,10 +707,13 @@ export async function getInvoice(
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.InvoiceController.getInvoiceCodes
 */
-export async function getInvoiceCodes(): Promise<InvoiceCodes> {
+export async function getInvoiceCodes(
+  headers?: AxiosHeaders
+): Promise<InvoiceCodes> {
   const { data: json } = await client.request<JsonOf<InvoiceCodes>>({
     url: uri`/employee/invoices/codes`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -647,11 +725,13 @@ export async function getInvoiceCodes(): Promise<InvoiceCodes> {
 export async function markInvoicesSent(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoices/mark-sent`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -665,11 +745,13 @@ export async function markReplacementDraftSent(
   request: {
     invoiceId: UUID,
     body: MarkReplacementDraftSentRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoices/${request.invoiceId}/mark-replacement-draft-sent`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<MarkReplacementDraftSentRequest>
   })
   return json
@@ -682,11 +764,13 @@ export async function markReplacementDraftSent(
 export async function searchInvoices(
   request: {
     body: SearchInvoicesRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedInvoiceSummaryResponses> {
   const { data: json } = await client.request<JsonOf<PagedInvoiceSummaryResponses>>({
     url: uri`/employee/invoices/search`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SearchInvoicesRequest>
   })
   return deserializeJsonPagedInvoiceSummaryResponses(json)
@@ -701,7 +785,8 @@ export async function sendInvoices(
     invoiceDate?: LocalDate | null,
     dueDate?: LocalDate | null,
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['invoiceDate', request.invoiceDate?.formatIso()],
@@ -710,6 +795,7 @@ export async function sendInvoices(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoices/send`.toString(),
     method: 'POST',
+    headers,
     params,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
@@ -723,11 +809,13 @@ export async function sendInvoices(
 export async function sendInvoicesByDate(
   request: {
     body: InvoicePayload
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoices/send/by-date`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<InvoicePayload>
   })
   return json
@@ -740,11 +828,13 @@ export async function sendInvoicesByDate(
 export async function createInvoiceCorrection(
   request: {
     body: InvoiceCorrectionInsert
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoice-corrections`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<InvoiceCorrectionInsert>
   })
   return json
@@ -757,11 +847,13 @@ export async function createInvoiceCorrection(
 export async function deleteInvoiceCorrection(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoice-corrections/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -773,11 +865,13 @@ export async function deleteInvoiceCorrection(
 export async function getPersonInvoiceCorrections(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<InvoiceCorrectionWithPermittedActions[]> {
   const { data: json } = await client.request<JsonOf<InvoiceCorrectionWithPermittedActions[]>>({
     url: uri`/employee/invoice-corrections/${request.personId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonInvoiceCorrectionWithPermittedActions(e))
 }
@@ -790,11 +884,13 @@ export async function updateInvoiceCorrectionNote(
   request: {
     id: UUID,
     body: NoteUpdateBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoice-corrections/${request.id}/note`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<NoteUpdateBody>
   })
   return json
@@ -807,11 +903,13 @@ export async function updateInvoiceCorrectionNote(
 export async function confirmDraftPayments(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/payments/confirm`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -821,10 +919,13 @@ export async function confirmDraftPayments(
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.PaymentController.createPaymentDrafts
 */
-export async function createPaymentDrafts(): Promise<void> {
+export async function createPaymentDrafts(
+  headers?: AxiosHeaders
+): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/payments/create-drafts`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -836,11 +937,13 @@ export async function createPaymentDrafts(): Promise<void> {
 export async function deleteDraftPayments(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/payments/delete-drafts`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -853,11 +956,13 @@ export async function deleteDraftPayments(
 export async function revertPaymentsToDrafts(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/payments/revert-to-draft`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -870,11 +975,13 @@ export async function revertPaymentsToDrafts(
 export async function searchPayments(
   request: {
     body: SearchPaymentsRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedPayments> {
   const { data: json } = await client.request<JsonOf<PagedPayments>>({
     url: uri`/employee/payments/search`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SearchPaymentsRequest>
   })
   return deserializeJsonPagedPayments(json)
@@ -887,11 +994,13 @@ export async function searchPayments(
 export async function sendPayments(
   request: {
     body: SendPaymentsRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/payments/send`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SendPaymentsRequest>
   })
   return json
@@ -905,11 +1014,13 @@ export async function generateRetroactiveVoucherValueDecisions(
   request: {
     id: UUID,
     body: CreateRetroactiveFeeDecisionsBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/value-decisions/head-of-family/${request.id}/create-retroactive`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CreateRetroactiveFeeDecisionsBody>
   })
   return json
@@ -922,11 +1033,13 @@ export async function generateRetroactiveVoucherValueDecisions(
 export async function getHeadOfFamilyVoucherValueDecisions(
   request: {
     headOfFamilyId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<VoucherValueDecisionSummary[]> {
   const { data: json } = await client.request<JsonOf<VoucherValueDecisionSummary[]>>({
     url: uri`/employee/value-decisions/head-of-family/${request.headOfFamilyId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonVoucherValueDecisionSummary(e))
 }
@@ -938,11 +1051,13 @@ export async function getHeadOfFamilyVoucherValueDecisions(
 export async function getVoucherValueDecision(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<VoucherValueDecisionDetailed> {
   const { data: json } = await client.request<JsonOf<VoucherValueDecisionDetailed>>({
     url: uri`/employee/value-decisions/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonVoucherValueDecisionDetailed(json)
 }
@@ -954,11 +1069,13 @@ export async function getVoucherValueDecision(
 export async function ignoreVoucherValueDecisionDrafts(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/value-decisions/ignore`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -971,11 +1088,13 @@ export async function ignoreVoucherValueDecisionDrafts(
 export async function markVoucherValueDecisionSent(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/value-decisions/mark-sent`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json
@@ -988,11 +1107,13 @@ export async function markVoucherValueDecisionSent(
 export async function searchVoucherValueDecisions(
   request: {
     body: SearchVoucherValueDecisionRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedVoucherValueDecisionSummaries> {
   const { data: json } = await client.request<JsonOf<PagedVoucherValueDecisionSummaries>>({
     url: uri`/employee/value-decisions/search`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SearchVoucherValueDecisionRequest>
   })
   return deserializeJsonPagedVoucherValueDecisionSummaries(json)
@@ -1006,7 +1127,8 @@ export async function sendVoucherValueDecisionDrafts(
   request: {
     decisionHandlerId?: UUID | null,
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['decisionHandlerId', request.decisionHandlerId]
@@ -1014,6 +1136,7 @@ export async function sendVoucherValueDecisionDrafts(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/value-decisions/send`.toString(),
     method: 'POST',
+    headers,
     params,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
@@ -1028,11 +1151,13 @@ export async function setVoucherValueDecisionType(
   request: {
     id: UUID,
     body: VoucherValueDecisionTypeRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/value-decisions/set-type/${request.id}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<VoucherValueDecisionTypeRequest>
   })
   return json
@@ -1045,11 +1170,13 @@ export async function setVoucherValueDecisionType(
 export async function unignoreVoucherValueDecisionDrafts(
   request: {
     body: UUID[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/value-decisions/unignore`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<UUID[]>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/jamix.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/jamix.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
@@ -19,7 +20,8 @@ export async function sendJamixOrders(
   request: {
     unitId: UUID,
     date: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId],
@@ -28,6 +30,7 @@ export async function sendJamixOrders(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/jamix/send-orders`.toString(),
     method: 'PUT',
+    headers,
     params
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/messaging.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import { AuthorizedMessageAccount } from 'lib-common/generated/api-types/messaging'
+import { AxiosHeaders } from 'axios'
 import { CreateMessageResponse } from 'lib-common/generated/api-types/messaging'
 import { DraftContent } from 'lib-common/generated/api-types/messaging'
 import { JsonCompatible } from 'lib-common/json'
@@ -42,11 +43,13 @@ export async function archiveThread(
   request: {
     accountId: UUID,
     threadId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/messages/${request.accountId}/threads/${request.threadId}/archive`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -59,11 +62,13 @@ export async function createMessage(
   request: {
     accountId: UUID,
     body: PostMessageBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CreateMessageResponse> {
   const { data: json } = await client.request<JsonOf<CreateMessageResponse>>({
     url: uri`/employee/messages/${request.accountId}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PostMessageBody>
   })
   return json
@@ -77,11 +82,13 @@ export async function createMessagePreflightCheck(
   request: {
     accountId: UUID,
     body: PostMessagePreflightBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PostMessagePreflightResponse> {
   const { data: json } = await client.request<JsonOf<PostMessagePreflightResponse>>({
     url: uri`/employee/messages/${request.accountId}/preflight-check`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PostMessagePreflightBody>
   })
   return json
@@ -95,11 +102,13 @@ export async function deleteDraftMessage(
   request: {
     accountId: UUID,
     draftId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/messages/${request.accountId}/drafts/${request.draftId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -108,10 +117,13 @@ export async function deleteDraftMessage(
 /**
 * Generated from fi.espoo.evaka.messaging.MessageController.getAccountsByUser
 */
-export async function getAccountsByUser(): Promise<AuthorizedMessageAccount[]> {
+export async function getAccountsByUser(
+  headers?: AxiosHeaders
+): Promise<AuthorizedMessageAccount[]> {
   const { data: json } = await client.request<JsonOf<AuthorizedMessageAccount[]>>({
     url: uri`/employee/messages/my-accounts`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -124,7 +136,8 @@ export async function getArchivedMessages(
   request: {
     accountId: UUID,
     page: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedMessageThreads> {
   const params = createUrlSearchParams(
     ['page', request.page.toString()]
@@ -132,6 +145,7 @@ export async function getArchivedMessages(
   const { data: json } = await client.request<JsonOf<PagedMessageThreads>>({
     url: uri`/employee/messages/${request.accountId}/archived`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonPagedMessageThreads(json)
@@ -144,11 +158,13 @@ export async function getArchivedMessages(
 export async function getDraftMessages(
   request: {
     accountId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DraftContent[]> {
   const { data: json } = await client.request<JsonOf<DraftContent[]>>({
     url: uri`/employee/messages/${request.accountId}/drafts`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonDraftContent(e))
 }
@@ -161,7 +177,8 @@ export async function getMessageCopies(
   request: {
     accountId: UUID,
     page: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedMessageCopies> {
   const params = createUrlSearchParams(
     ['page', request.page.toString()]
@@ -169,6 +186,7 @@ export async function getMessageCopies(
   const { data: json } = await client.request<JsonOf<PagedMessageCopies>>({
     url: uri`/employee/messages/${request.accountId}/copies`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonPagedMessageCopies(json)
@@ -182,7 +200,8 @@ export async function getReceivedMessages(
   request: {
     accountId: UUID,
     page: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedMessageThreads> {
   const params = createUrlSearchParams(
     ['page', request.page.toString()]
@@ -190,6 +209,7 @@ export async function getReceivedMessages(
   const { data: json } = await client.request<JsonOf<PagedMessageThreads>>({
     url: uri`/employee/messages/${request.accountId}/received`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonPagedMessageThreads(json)
@@ -199,10 +219,13 @@ export async function getReceivedMessages(
 /**
 * Generated from fi.espoo.evaka.messaging.MessageController.getReceiversForNewMessage
 */
-export async function getReceiversForNewMessage(): Promise<MessageReceiversResponse[]> {
+export async function getReceiversForNewMessage(
+  headers?: AxiosHeaders
+): Promise<MessageReceiversResponse[]> {
   const { data: json } = await client.request<JsonOf<MessageReceiversResponse[]>>({
     url: uri`/employee/messages/receivers`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -215,7 +238,8 @@ export async function getSentMessages(
   request: {
     accountId: UUID,
     page: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedSentMessages> {
   const params = createUrlSearchParams(
     ['page', request.page.toString()]
@@ -223,6 +247,7 @@ export async function getSentMessages(
   const { data: json } = await client.request<JsonOf<PagedSentMessages>>({
     url: uri`/employee/messages/${request.accountId}/sent`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonPagedSentMessages(json)
@@ -236,11 +261,13 @@ export async function getThread(
   request: {
     accountId: UUID,
     threadId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<MessageThread> {
   const { data: json } = await client.request<JsonOf<MessageThread>>({
     url: uri`/employee/messages/${request.accountId}/thread/${request.threadId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonMessageThread(json)
 }
@@ -252,11 +279,13 @@ export async function getThread(
 export async function getThreadByApplicationId(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ThreadByApplicationResponse> {
   const { data: json } = await client.request<JsonOf<ThreadByApplicationResponse>>({
     url: uri`/employee/messages/application/${request.applicationId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonThreadByApplicationResponse(json)
 }
@@ -265,10 +294,13 @@ export async function getThreadByApplicationId(
 /**
 * Generated from fi.espoo.evaka.messaging.MessageController.getUnreadMessages
 */
-export async function getUnreadMessages(): Promise<UnreadCountByAccount[]> {
+export async function getUnreadMessages(
+  headers?: AxiosHeaders
+): Promise<UnreadCountByAccount[]> {
   const { data: json } = await client.request<JsonOf<UnreadCountByAccount[]>>({
     url: uri`/employee/messages/unread`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -280,11 +312,13 @@ export async function getUnreadMessages(): Promise<UnreadCountByAccount[]> {
 export async function initDraftMessage(
   request: {
     accountId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/messages/${request.accountId}/drafts`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -297,11 +331,13 @@ export async function markThreadRead(
   request: {
     accountId: UUID,
     threadId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/messages/${request.accountId}/threads/${request.threadId}/read`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -315,11 +351,13 @@ export async function replyToThread(
     accountId: UUID,
     messageId: UUID,
     body: ReplyToMessageBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ThreadReply> {
   const { data: json } = await client.request<JsonOf<ThreadReply>>({
     url: uri`/employee/messages/${request.accountId}/${request.messageId}/reply`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ReplyToMessageBody>
   })
   return deserializeJsonThreadReply(json)
@@ -334,11 +372,13 @@ export async function updateDraftMessage(
     accountId: UUID,
     draftId: UUID,
     body: UpdatableDraftContent
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/messages/${request.accountId}/drafts/${request.draftId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<UpdatableDraftContent>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/note.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/note.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { ChildDailyNote } from 'lib-common/generated/api-types/note'
 import { ChildDailyNoteBody } from 'lib-common/generated/api-types/note'
 import { ChildStickyNote } from 'lib-common/generated/api-types/note'
@@ -28,11 +29,13 @@ import { uri } from 'lib-common/uri'
 export async function getNotesByGroup(
   request: {
     groupId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<NotesByGroupResponse> {
   const { data: json } = await client.request<JsonOf<NotesByGroupResponse>>({
     url: uri`/employee/daycare-groups/${request.groupId}/notes`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonNotesByGroupResponse(json)
 }
@@ -45,11 +48,13 @@ export async function createChildDailyNote(
   request: {
     childId: UUID,
     body: ChildDailyNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/children/${request.childId}/child-daily-notes`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ChildDailyNoteBody>
   })
   return json
@@ -62,11 +67,13 @@ export async function createChildDailyNote(
 export async function deleteChildDailyNote(
   request: {
     noteId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/child-daily-notes/${request.noteId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -79,11 +86,13 @@ export async function updateChildDailyNote(
   request: {
     noteId: UUID,
     body: ChildDailyNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildDailyNote> {
   const { data: json } = await client.request<JsonOf<ChildDailyNote>>({
     url: uri`/employee/child-daily-notes/${request.noteId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ChildDailyNoteBody>
   })
   return deserializeJsonChildDailyNote(json)
@@ -97,11 +106,13 @@ export async function createChildStickyNote(
   request: {
     childId: UUID,
     body: ChildStickyNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/children/${request.childId}/child-sticky-notes`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ChildStickyNoteBody>
   })
   return json
@@ -114,11 +125,13 @@ export async function createChildStickyNote(
 export async function deleteChildStickyNote(
   request: {
     noteId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/child-sticky-notes/${request.noteId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -131,11 +144,13 @@ export async function updateChildStickyNote(
   request: {
     noteId: UUID,
     body: ChildStickyNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildStickyNote> {
   const { data: json } = await client.request<JsonOf<ChildStickyNote>>({
     url: uri`/employee/child-sticky-notes/${request.noteId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ChildStickyNoteBody>
   })
   return deserializeJsonChildStickyNote(json)
@@ -149,11 +164,13 @@ export async function createGroupNote(
   request: {
     groupId: UUID,
     body: GroupNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/daycare-groups/${request.groupId}/group-notes`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<GroupNoteBody>
   })
   return json
@@ -166,11 +183,13 @@ export async function createGroupNote(
 export async function deleteGroupNote(
   request: {
     noteId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/group-notes/${request.noteId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -183,11 +202,13 @@ export async function updateGroupNote(
   request: {
     noteId: UUID,
     body: GroupNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<GroupNote> {
   const { data: json } = await client.request<JsonOf<GroupNote>>({
     url: uri`/employee/group-notes/${request.noteId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<GroupNoteBody>
   })
   return deserializeJsonGroupNote(json)

--- a/frontend/src/employee-frontend/generated/api-clients/occupancy.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/occupancy.ts
@@ -6,6 +6,7 @@
 
 import LocalDate from 'lib-common/local-date'
 import { AttendanceReservationReportRow } from 'lib-common/generated/api-types/reports'
+import { AxiosHeaders } from 'axios'
 import { GetUnitOccupanciesForDayBody } from 'lib-common/generated/api-types/occupancy'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
@@ -32,7 +33,8 @@ export async function getOccupancyPeriodsSpeculated(
     to: LocalDate,
     preschoolDaycareFrom?: LocalDate | null,
     preschoolDaycareTo?: LocalDate | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<OccupancyResponseSpeculated> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -43,6 +45,7 @@ export async function getOccupancyPeriodsSpeculated(
   const { data: json } = await client.request<JsonOf<OccupancyResponseSpeculated>>({
     url: uri`/employee/occupancy/by-unit/${request.unitId}/speculated/${request.applicationId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -58,7 +61,8 @@ export async function getUnitOccupancies(
     from: LocalDate,
     to: LocalDate,
     groupId?: UUID | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UnitOccupancies> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -68,6 +72,7 @@ export async function getUnitOccupancies(
   const { data: json } = await client.request<JsonOf<UnitOccupancies>>({
     url: uri`/employee/occupancy/units/${request.unitId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonUnitOccupancies(json)
@@ -81,11 +86,13 @@ export async function getUnitPlannedOccupanciesForDay(
   request: {
     unitId: UUID,
     body: GetUnitOccupanciesForDayBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AttendanceReservationReportRow[]> {
   const { data: json } = await client.request<JsonOf<AttendanceReservationReportRow[]>>({
     url: uri`/employee/occupancy/units/${request.unitId}/day/planned`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<GetUnitOccupanciesForDayBody>
   })
   return json.map(e => deserializeJsonAttendanceReservationReportRow(e))
@@ -99,11 +106,13 @@ export async function getUnitRealizedOccupanciesForDay(
   request: {
     unitId: UUID,
     body: GetUnitOccupanciesForDayBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<RealtimeOccupancy> {
   const { data: json } = await client.request<JsonOf<RealtimeOccupancy>>({
     url: uri`/employee/occupancy/units/${request.unitId}/day/realized`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<GetUnitOccupanciesForDayBody>
   })
   return deserializeJsonRealtimeOccupancy(json)

--- a/frontend/src/employee-frontend/generated/api-clients/pairing.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/pairing.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { MobileDevice } from 'lib-common/generated/api-types/pairing'
@@ -25,11 +26,13 @@ import { uri } from 'lib-common/uri'
 export async function deleteMobileDevice(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/mobile-devices/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -41,7 +44,8 @@ export async function deleteMobileDevice(
 export async function getMobileDevices(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<MobileDevice[]> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId]
@@ -49,6 +53,7 @@ export async function getMobileDevices(
   const { data: json } = await client.request<JsonOf<MobileDevice[]>>({
     url: uri`/employee/mobile-devices`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -58,10 +63,13 @@ export async function getMobileDevices(
 /**
 * Generated from fi.espoo.evaka.pairing.MobileDevicesController.getPersonalMobileDevices
 */
-export async function getPersonalMobileDevices(): Promise<MobileDevice[]> {
+export async function getPersonalMobileDevices(
+  headers?: AxiosHeaders
+): Promise<MobileDevice[]> {
   const { data: json } = await client.request<JsonOf<MobileDevice[]>>({
     url: uri`/employee/mobile-devices/personal`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -74,11 +82,13 @@ export async function putMobileDeviceName(
   request: {
     id: UUID,
     body: RenameRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/mobile-devices/${request.id}/name`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<RenameRequest>
   })
   return json
@@ -91,11 +101,13 @@ export async function putMobileDeviceName(
 export async function getPairingStatus(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PairingStatusRes> {
   const { data: json } = await client.request<JsonOf<PairingStatusRes>>({
     url: uri`/employee/public/pairings/${request.id}/status`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -107,11 +119,13 @@ export async function getPairingStatus(
 export async function postPairing(
   request: {
     body: PostPairingReq
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Pairing> {
   const { data: json } = await client.request<JsonOf<Pairing>>({
     url: uri`/employee/pairings`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PostPairingReq>
   })
   return deserializeJsonPairing(json)
@@ -125,11 +139,13 @@ export async function postPairingResponse(
   request: {
     id: UUID,
     body: PostPairingResponseReq
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Pairing> {
   const { data: json } = await client.request<JsonOf<Pairing>>({
     url: uri`/employee/pairings/${request.id}/response`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PostPairingResponseReq>
   })
   return deserializeJsonPairing(json)

--- a/frontend/src/employee-frontend/generated/api-clients/pedagogicaldocument.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/pedagogicaldocument.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { PedagogicalDocument } from 'lib-common/generated/api-types/pedagogicaldocument'
@@ -20,11 +21,13 @@ import { uri } from 'lib-common/uri'
 export async function createPedagogicalDocument(
   request: {
     body: PedagogicalDocumentPostBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PedagogicalDocument> {
   const { data: json } = await client.request<JsonOf<PedagogicalDocument>>({
     url: uri`/employee/pedagogical-document`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PedagogicalDocumentPostBody>
   })
   return deserializeJsonPedagogicalDocument(json)
@@ -37,11 +40,13 @@ export async function createPedagogicalDocument(
 export async function deletePedagogicalDocument(
   request: {
     documentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/pedagogical-document/${request.documentId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -53,11 +58,13 @@ export async function deletePedagogicalDocument(
 export async function getChildPedagogicalDocuments(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PedagogicalDocument[]> {
   const { data: json } = await client.request<JsonOf<PedagogicalDocument[]>>({
     url: uri`/employee/pedagogical-document/child/${request.childId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPedagogicalDocument(e))
 }
@@ -70,11 +77,13 @@ export async function updatePedagogicalDocument(
   request: {
     documentId: UUID,
     body: PedagogicalDocumentPostBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PedagogicalDocument> {
   const { data: json } = await client.request<JsonOf<PedagogicalDocument>>({
     url: uri`/employee/pedagogical-document/${request.documentId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<PedagogicalDocumentPostBody>
   })
   return deserializeJsonPedagogicalDocument(json)

--- a/frontend/src/employee-frontend/generated/api-clients/pis.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/pis.ts
@@ -6,6 +6,7 @@
 
 import DateRange from 'lib-common/date-range'
 import { AddSsnRequest } from 'lib-common/generated/api-types/pis'
+import { AxiosHeaders } from 'axios'
 import { CreateFosterParentRelationshipBody } from 'lib-common/generated/api-types/pis'
 import { CreatePersonBody } from 'lib-common/generated/api-types/pis'
 import { DisableSsnRequest } from 'lib-common/generated/api-types/pis'
@@ -71,11 +72,13 @@ import { uri } from 'lib-common/uri'
 export async function activateEmployee(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/employees/${request.id}/activate`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -87,11 +90,13 @@ export async function activateEmployee(
 export async function createEmployee(
   request: {
     body: NewEmployee
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Employee> {
   const { data: json } = await client.request<JsonOf<Employee>>({
     url: uri`/employee/employees`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<NewEmployee>
   })
   return deserializeJsonEmployee(json)
@@ -104,11 +109,13 @@ export async function createEmployee(
 export async function deactivateEmployee(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/employees/${request.id}/deactivate`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -120,11 +127,13 @@ export async function deactivateEmployee(
 export async function deleteEmployee(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/employees/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -137,7 +146,8 @@ export async function deleteEmployeeDaycareRoles(
   request: {
     id: UUID,
     daycareId?: UUID | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['daycareId', request.daycareId]
@@ -145,6 +155,7 @@ export async function deleteEmployeeDaycareRoles(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/employees/${request.id}/daycare-roles`.toString(),
     method: 'DELETE',
+    headers,
     params
   })
   return json
@@ -157,11 +168,13 @@ export async function deleteEmployeeDaycareRoles(
 export async function getEmployee(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Employee> {
   const { data: json } = await client.request<JsonOf<Employee>>({
     url: uri`/employee/employees/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonEmployee(json)
 }
@@ -173,11 +186,13 @@ export async function getEmployee(
 export async function getEmployeeDetails(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<EmployeeWithDaycareRoles> {
   const { data: json } = await client.request<JsonOf<EmployeeWithDaycareRoles>>({
     url: uri`/employee/employees/${request.id}/details`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonEmployeeWithDaycareRoles(json)
 }
@@ -186,10 +201,13 @@ export async function getEmployeeDetails(
 /**
 * Generated from fi.espoo.evaka.pis.controllers.EmployeeController.getEmployeePreferredFirstName
 */
-export async function getEmployeePreferredFirstName(): Promise<EmployeePreferredFirstName> {
+export async function getEmployeePreferredFirstName(
+  headers?: AxiosHeaders
+): Promise<EmployeePreferredFirstName> {
   const { data: json } = await client.request<JsonOf<EmployeePreferredFirstName>>({
     url: uri`/employee/employees/preferred-first-name`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -198,10 +216,13 @@ export async function getEmployeePreferredFirstName(): Promise<EmployeePreferred
 /**
 * Generated from fi.espoo.evaka.pis.controllers.EmployeeController.getEmployees
 */
-export async function getEmployees(): Promise<Employee[]> {
+export async function getEmployees(
+  headers?: AxiosHeaders
+): Promise<Employee[]> {
   const { data: json } = await client.request<JsonOf<Employee[]>>({
     url: uri`/employee/employees`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonEmployee(e))
 }
@@ -210,10 +231,13 @@ export async function getEmployees(): Promise<Employee[]> {
 /**
 * Generated from fi.espoo.evaka.pis.controllers.EmployeeController.getFinanceDecisionHandlers
 */
-export async function getFinanceDecisionHandlers(): Promise<Employee[]> {
+export async function getFinanceDecisionHandlers(
+  headers?: AxiosHeaders
+): Promise<Employee[]> {
   const { data: json } = await client.request<JsonOf<Employee[]>>({
     url: uri`/employee/employees/finance-decision-handler`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonEmployee(e))
 }
@@ -222,10 +246,13 @@ export async function getFinanceDecisionHandlers(): Promise<Employee[]> {
 /**
 * Generated from fi.espoo.evaka.pis.controllers.EmployeeController.isPinLocked
 */
-export async function isPinLocked(): Promise<boolean> {
+export async function isPinLocked(
+  headers?: AxiosHeaders
+): Promise<boolean> {
   const { data: json } = await client.request<JsonOf<boolean>>({
     url: uri`/employee/employees/pin-code/is-pin-locked`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -237,11 +264,13 @@ export async function isPinLocked(): Promise<boolean> {
 export async function searchEmployees(
   request: {
     body: SearchEmployeeRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedEmployeesWithDaycareRoles> {
   const { data: json } = await client.request<JsonOf<PagedEmployeesWithDaycareRoles>>({
     url: uri`/employee/employees/search`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SearchEmployeeRequest>
   })
   return deserializeJsonPagedEmployeesWithDaycareRoles(json)
@@ -254,11 +283,13 @@ export async function searchEmployees(
 export async function setEmployeePreferredFirstName(
   request: {
     body: EmployeeSetPreferredFirstNameUpdateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/employees/preferred-first-name`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<EmployeeSetPreferredFirstNameUpdateRequest>
   })
   return json
@@ -272,11 +303,13 @@ export async function updateEmployeeGlobalRoles(
   request: {
     id: UUID,
     body: UserRole[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/employees/${request.id}/global-roles`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<UserRole[]>
   })
   return json
@@ -290,11 +323,13 @@ export async function upsertEmployeeDaycareRoles(
   request: {
     id: UUID,
     body: UpsertEmployeeDaycareRolesRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/employees/${request.id}/daycare-roles`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<UpsertEmployeeDaycareRolesRequest>
   })
   return json
@@ -307,11 +342,13 @@ export async function upsertEmployeeDaycareRoles(
 export async function upsertPinCode(
   request: {
     body: PinCode
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/employees/pin-code`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PinCode>
   })
   return json
@@ -324,11 +361,13 @@ export async function upsertPinCode(
 export async function getFamilyByPerson(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FamilyOverview> {
   const { data: json } = await client.request<JsonOf<FamilyOverview>>({
     url: uri`/employee/family/by-adult/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonFamilyOverview(json)
 }
@@ -340,7 +379,8 @@ export async function getFamilyByPerson(
 export async function getFamilyContactSummary(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FamilyContact[]> {
   const params = createUrlSearchParams(
     ['childId', request.childId]
@@ -348,6 +388,7 @@ export async function getFamilyContactSummary(
   const { data: json } = await client.request<JsonOf<FamilyContact[]>>({
     url: uri`/employee/family/contacts`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -360,11 +401,13 @@ export async function getFamilyContactSummary(
 export async function updateFamilyContactDetails(
   request: {
     body: FamilyContactUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/family/contacts`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<FamilyContactUpdate>
   })
   return json
@@ -377,11 +420,13 @@ export async function updateFamilyContactDetails(
 export async function updateFamilyContactPriority(
   request: {
     body: FamilyContactPriorityUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/family/contacts/priority`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<FamilyContactPriorityUpdate>
   })
   return json
@@ -394,11 +439,13 @@ export async function updateFamilyContactPriority(
 export async function createFosterParentRelationship(
   request: {
     body: CreateFosterParentRelationshipBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/foster-parent`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CreateFosterParentRelationshipBody>
   })
   return json
@@ -411,11 +458,13 @@ export async function createFosterParentRelationship(
 export async function deleteFosterParentRelationship(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/foster-parent/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -427,11 +476,13 @@ export async function deleteFosterParentRelationship(
 export async function getFosterChildren(
   request: {
     parentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FosterParentRelationship[]> {
   const { data: json } = await client.request<JsonOf<FosterParentRelationship[]>>({
     url: uri`/employee/foster-parent/by-parent/${request.parentId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonFosterParentRelationship(e))
 }
@@ -443,11 +494,13 @@ export async function getFosterChildren(
 export async function getFosterParents(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FosterParentRelationship[]> {
   const { data: json } = await client.request<JsonOf<FosterParentRelationship[]>>({
     url: uri`/employee/foster-parent/by-child/${request.childId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonFosterParentRelationship(e))
 }
@@ -460,11 +513,13 @@ export async function updateFosterParentRelationshipValidity(
   request: {
     id: UUID,
     body: DateRange
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/foster-parent/${request.id}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DateRange>
   })
   return json
@@ -477,11 +532,13 @@ export async function updateFosterParentRelationshipValidity(
 export async function createParentship(
   request: {
     body: ParentshipRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/parentships`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ParentshipRequest>
   })
   return json
@@ -494,11 +551,13 @@ export async function createParentship(
 export async function deleteParentship(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/parentships/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -510,11 +569,13 @@ export async function deleteParentship(
 export async function getParentship(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Parentship> {
   const { data: json } = await client.request<JsonOf<Parentship>>({
     url: uri`/employee/parentships/${request.id}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonParentship(json)
 }
@@ -527,7 +588,8 @@ export async function getParentships(
   request: {
     headOfChildId?: UUID | null,
     childId?: UUID | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ParentshipWithPermittedActions[]> {
   const params = createUrlSearchParams(
     ['headOfChildId', request.headOfChildId],
@@ -536,6 +598,7 @@ export async function getParentships(
   const { data: json } = await client.request<JsonOf<ParentshipWithPermittedActions[]>>({
     url: uri`/employee/parentships`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonParentshipWithPermittedActions(e))
@@ -548,11 +611,13 @@ export async function getParentships(
 export async function retryParentship(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/parentships/${request.id}/retry`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -565,11 +630,13 @@ export async function updateParentship(
   request: {
     id: UUID,
     body: ParentshipUpdateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/parentships/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ParentshipUpdateRequest>
   })
   return json
@@ -582,11 +649,13 @@ export async function updateParentship(
 export async function createPartnership(
   request: {
     body: PartnershipRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/partnerships`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PartnershipRequest>
   })
   return json
@@ -599,11 +668,13 @@ export async function createPartnership(
 export async function deletePartnership(
   request: {
     partnershipId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/partnerships/${request.partnershipId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -615,11 +686,13 @@ export async function deletePartnership(
 export async function getPartnership(
   request: {
     partnershipId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Partnership> {
   const { data: json } = await client.request<JsonOf<Partnership>>({
     url: uri`/employee/partnerships/${request.partnershipId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonPartnership(json)
 }
@@ -631,7 +704,8 @@ export async function getPartnership(
 export async function getPartnerships(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PartnershipWithPermittedActions[]> {
   const params = createUrlSearchParams(
     ['personId', request.personId]
@@ -639,6 +713,7 @@ export async function getPartnerships(
   const { data: json } = await client.request<JsonOf<PartnershipWithPermittedActions[]>>({
     url: uri`/employee/partnerships`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonPartnershipWithPermittedActions(e))
@@ -651,11 +726,13 @@ export async function getPartnerships(
 export async function retryPartnership(
   request: {
     partnershipId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/partnerships/${request.partnershipId}/retry`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -668,11 +745,13 @@ export async function updatePartnership(
   request: {
     partnershipId: UUID,
     body: PartnershipUpdateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/partnerships/${request.partnershipId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<PartnershipUpdateRequest>
   })
   return json
@@ -686,11 +765,13 @@ export async function addSsn(
   request: {
     personId: UUID,
     body: AddSsnRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PersonJSON> {
   const { data: json } = await client.request<JsonOf<PersonJSON>>({
     url: uri`/employee/person/${request.personId}/ssn`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<AddSsnRequest>
   })
   return deserializeJsonPersonJSON(json)
@@ -700,10 +781,13 @@ export async function addSsn(
 /**
 * Generated from fi.espoo.evaka.pis.controllers.PersonController.createEmpty
 */
-export async function createEmpty(): Promise<PersonIdentityResponseJSON> {
+export async function createEmpty(
+  headers?: AxiosHeaders
+): Promise<PersonIdentityResponseJSON> {
   const { data: json } = await client.request<JsonOf<PersonIdentityResponseJSON>>({
     url: uri`/employee/person`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -715,11 +799,13 @@ export async function createEmpty(): Promise<PersonIdentityResponseJSON> {
 export async function createPerson(
   request: {
     body: CreatePersonBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/person/create`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<CreatePersonBody>
   })
   return json
@@ -733,11 +819,13 @@ export async function disableSsn(
   request: {
     personId: UUID,
     body: DisableSsnRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/person/${request.personId}/ssn/disable`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<DisableSsnRequest>
   })
   return json
@@ -750,11 +838,13 @@ export async function disableSsn(
 export async function duplicatePerson(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/person/${request.personId}/duplicate`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -766,11 +856,13 @@ export async function duplicatePerson(
 export async function getOrCreatePersonBySsn(
   request: {
     body: GetOrCreatePersonBySsnRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PersonJSON> {
   const { data: json } = await client.request<JsonOf<PersonJSON>>({
     url: uri`/employee/person/details/ssn`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<GetOrCreatePersonBySsnRequest>
   })
   return deserializeJsonPersonJSON(json)
@@ -783,11 +875,13 @@ export async function getOrCreatePersonBySsn(
 export async function getPerson(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PersonResponse> {
   const { data: json } = await client.request<JsonOf<PersonResponse>>({
     url: uri`/employee/person/${request.personId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonPersonResponse(json)
 }
@@ -799,11 +893,13 @@ export async function getPerson(
 export async function getPersonDependants(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PersonWithChildrenDTO[]> {
   const { data: json } = await client.request<JsonOf<PersonWithChildrenDTO[]>>({
     url: uri`/employee/person/dependants/${request.personId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPersonWithChildrenDTO(e))
 }
@@ -815,11 +911,13 @@ export async function getPersonDependants(
 export async function getPersonGuardians(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<GuardiansResponse> {
   const { data: json } = await client.request<JsonOf<GuardiansResponse>>({
     url: uri`/employee/person/guardians/${request.personId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonGuardiansResponse(json)
 }
@@ -831,11 +929,13 @@ export async function getPersonGuardians(
 export async function getPersonIdentity(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PersonJSON> {
   const { data: json } = await client.request<JsonOf<PersonJSON>>({
     url: uri`/employee/person/details/${request.personId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonPersonJSON(json)
 }
@@ -847,11 +947,13 @@ export async function getPersonIdentity(
 export async function mergePeople(
   request: {
     body: MergeRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/person/merge`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<MergeRequest>
   })
   return json
@@ -864,11 +966,13 @@ export async function mergePeople(
 export async function safeDeletePerson(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/person/${request.personId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -880,11 +984,13 @@ export async function safeDeletePerson(
 export async function searchPerson(
   request: {
     body: SearchPersonBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PersonSummary[]> {
   const { data: json } = await client.request<JsonOf<PersonSummary[]>>({
     url: uri`/employee/person/search`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<SearchPersonBody>
   })
   return json.map(e => deserializeJsonPersonSummary(e))
@@ -898,11 +1004,13 @@ export async function updateGuardianEvakaRights(
   request: {
     childId: UUID,
     body: EvakaRightsRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/person/${request.childId}/evaka-rights`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<EvakaRightsRequest>
   })
   return json
@@ -915,11 +1023,13 @@ export async function updateGuardianEvakaRights(
 export async function updatePersonAndFamilyFromVtj(
   request: {
     personId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/person/${request.personId}/vtj-update`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -932,11 +1042,13 @@ export async function updatePersonDetails(
   request: {
     personId: UUID,
     body: PersonPatch
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PersonJSON> {
   const { data: json } = await client.request<JsonOf<PersonJSON>>({
     url: uri`/employee/person/${request.personId}`.toString(),
     method: 'PATCH',
+    headers,
     data: request.body satisfies JsonCompatible<PersonPatch>
   })
   return deserializeJsonPersonJSON(json)

--- a/frontend/src/employee-frontend/generated/api-clients/placement.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/placement.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { AxiosHeaders } from 'axios'
 import { GroupPlacementRequestBody } from 'lib-common/generated/api-types/placement'
 import { GroupTransferRequestBody } from 'lib-common/generated/api-types/placement'
 import { JsonCompatible } from 'lib-common/json'
@@ -25,11 +26,13 @@ export async function createGroupPlacement(
   request: {
     placementId: UUID,
     body: GroupPlacementRequestBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee/placements/${request.placementId}/group-placements`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<GroupPlacementRequestBody>
   })
   return json
@@ -42,11 +45,13 @@ export async function createGroupPlacement(
 export async function createPlacement(
   request: {
     body: PlacementCreateRequestBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/placements`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PlacementCreateRequestBody>
   })
   return json
@@ -59,11 +64,13 @@ export async function createPlacement(
 export async function deleteGroupPlacement(
   request: {
     groupPlacementId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/group-placements/${request.groupPlacementId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -75,11 +82,13 @@ export async function deleteGroupPlacement(
 export async function deletePlacement(
   request: {
     placementId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/placements/${request.placementId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -91,11 +100,13 @@ export async function deletePlacement(
 export async function getChildPlacementPeriods(
   request: {
     adultId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FiniteDateRange[]> {
   const { data: json } = await client.request<JsonOf<FiniteDateRange[]>>({
     url: uri`/employee/placements/child-placement-periods/${request.adultId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => FiniteDateRange.parseJson(e))
 }
@@ -107,11 +118,13 @@ export async function getChildPlacementPeriods(
 export async function getChildPlacements(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PlacementResponse> {
   const { data: json } = await client.request<JsonOf<PlacementResponse>>({
     url: uri`/employee/children/${request.childId}/placements`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonPlacementResponse(json)
 }
@@ -124,11 +137,13 @@ export async function transferGroupPlacement(
   request: {
     groupPlacementId: UUID,
     body: GroupTransferRequestBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/group-placements/${request.groupPlacementId}/transfer`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<GroupTransferRequestBody>
   })
   return json
@@ -142,11 +157,13 @@ export async function updatePlacementById(
   request: {
     placementId: UUID,
     body: PlacementUpdateRequestBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/placements/${request.placementId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<PlacementUpdateRequestBody>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/process.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/process.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { ProcessMetadataResponse } from 'lib-common/generated/api-types/process'
 import { UUID } from 'lib-common/types'
@@ -18,11 +19,13 @@ import { uri } from 'lib-common/uri'
 export async function getApplicationMetadata(
   request: {
     applicationId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ProcessMetadataResponse> {
   const { data: json } = await client.request<JsonOf<ProcessMetadataResponse>>({
     url: uri`/employee/process-metadata/applications/${request.applicationId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonProcessMetadataResponse(json)
 }
@@ -34,11 +37,13 @@ export async function getApplicationMetadata(
 export async function getAssistanceNeedDecisionMetadata(
   request: {
     decisionId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ProcessMetadataResponse> {
   const { data: json } = await client.request<JsonOf<ProcessMetadataResponse>>({
     url: uri`/employee/process-metadata/assistance-need-decisions/${request.decisionId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonProcessMetadataResponse(json)
 }
@@ -50,11 +55,13 @@ export async function getAssistanceNeedDecisionMetadata(
 export async function getAssistanceNeedPreschoolDecisionMetadata(
   request: {
     decisionId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ProcessMetadataResponse> {
   const { data: json } = await client.request<JsonOf<ProcessMetadataResponse>>({
     url: uri`/employee/process-metadata/assistance-need-preschool-decisions/${request.decisionId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonProcessMetadataResponse(json)
 }
@@ -66,11 +73,13 @@ export async function getAssistanceNeedPreschoolDecisionMetadata(
 export async function getChildDocumentMetadata(
   request: {
     childDocumentId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ProcessMetadataResponse> {
   const { data: json } = await client.request<JsonOf<ProcessMetadataResponse>>({
     url: uri`/employee/process-metadata/child-documents/${request.childDocumentId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonProcessMetadataResponse(json)
 }

--- a/frontend/src/employee-frontend/generated/api-clients/reports.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reports.ts
@@ -13,6 +13,7 @@ import { AssistanceNeedsAndActionsReportByChild } from 'lib-common/generated/api
 import { AttendanceReservationReportByChildBody } from 'lib-common/generated/api-types/reports'
 import { AttendanceReservationReportByChildGroup } from 'lib-common/generated/api-types/reports'
 import { AttendanceReservationReportRow } from 'lib-common/generated/api-types/reports'
+import { AxiosHeaders } from 'axios'
 import { CareType } from 'lib-common/generated/api-types/daycare'
 import { ChildAgeLanguageReportRow } from 'lib-common/generated/api-types/reports'
 import { ChildAttendanceReportRow } from 'lib-common/generated/api-types/reports'
@@ -101,7 +102,8 @@ export async function getApplicationsReport(
   request: {
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ApplicationsReportRow[]> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -110,6 +112,7 @@ export async function getApplicationsReport(
   const { data: json } = await client.request<JsonOf<ApplicationsReportRow[]>>({
     url: uri`/employee/reports/applications`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -119,10 +122,13 @@ export async function getApplicationsReport(
 /**
 * Generated from fi.espoo.evaka.reports.AssistanceNeedDecisionsReport.getAssistanceNeedDecisionsReport
 */
-export async function getAssistanceNeedDecisionsReport(): Promise<AssistanceNeedDecisionsReportRow[]> {
+export async function getAssistanceNeedDecisionsReport(
+  headers?: AxiosHeaders
+): Promise<AssistanceNeedDecisionsReportRow[]> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedDecisionsReportRow[]>>({
     url: uri`/employee/reports/assistance-need-decisions`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonAssistanceNeedDecisionsReportRow(e))
 }
@@ -131,10 +137,13 @@ export async function getAssistanceNeedDecisionsReport(): Promise<AssistanceNeed
 /**
 * Generated from fi.espoo.evaka.reports.AssistanceNeedDecisionsReport.getAssistanceNeedDecisionsReportUnreadCount
 */
-export async function getAssistanceNeedDecisionsReportUnreadCount(): Promise<number> {
+export async function getAssistanceNeedDecisionsReportUnreadCount(
+  headers?: AxiosHeaders
+): Promise<number> {
   const { data: json } = await client.request<JsonOf<number>>({
     url: uri`/employee/reports/assistance-need-decisions/unread-count`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -146,7 +155,8 @@ export async function getAssistanceNeedDecisionsReportUnreadCount(): Promise<num
 export async function getAssistanceNeedsAndActionsReport(
   request: {
     date: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedsAndActionsReport> {
   const params = createUrlSearchParams(
     ['date', request.date.formatIso()]
@@ -154,6 +164,7 @@ export async function getAssistanceNeedsAndActionsReport(
   const { data: json } = await client.request<JsonOf<AssistanceNeedsAndActionsReport>>({
     url: uri`/employee/reports/assistance-needs-and-actions`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -166,7 +177,8 @@ export async function getAssistanceNeedsAndActionsReport(
 export async function getAssistanceNeedsAndActionsReportByChild(
   request: {
     date: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AssistanceNeedsAndActionsReportByChild> {
   const params = createUrlSearchParams(
     ['date', request.date.formatIso()]
@@ -174,6 +186,7 @@ export async function getAssistanceNeedsAndActionsReportByChild(
   const { data: json } = await client.request<JsonOf<AssistanceNeedsAndActionsReportByChild>>({
     url: uri`/employee/reports/assistance-needs-and-actions/by-child`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -186,11 +199,13 @@ export async function getAssistanceNeedsAndActionsReportByChild(
 export async function getAttendanceReservationReportByChild(
   request: {
     body: AttendanceReservationReportByChildBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AttendanceReservationReportByChildGroup[]> {
   const { data: json } = await client.request<JsonOf<AttendanceReservationReportByChildGroup[]>>({
     url: uri`/employee/reports/attendance-reservation/by-child`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AttendanceReservationReportByChildBody>
   })
   return json.map(e => deserializeJsonAttendanceReservationReportByChildGroup(e))
@@ -206,7 +221,8 @@ export async function getAttendanceReservationReportByUnit(
     start: LocalDate,
     end: LocalDate,
     groupIds?: UUID[] | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AttendanceReservationReportRow[]> {
   const params = createUrlSearchParams(
     ['start', request.start.formatIso()],
@@ -216,6 +232,7 @@ export async function getAttendanceReservationReportByUnit(
   const { data: json } = await client.request<JsonOf<AttendanceReservationReportRow[]>>({
     url: uri`/employee/reports/attendance-reservation/${request.unitId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonAttendanceReservationReportRow(e))
@@ -228,7 +245,8 @@ export async function getAttendanceReservationReportByUnit(
 export async function getChildAgeLanguageReport(
   request: {
     date: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildAgeLanguageReportRow[]> {
   const params = createUrlSearchParams(
     ['date', request.date.formatIso()]
@@ -236,6 +254,7 @@ export async function getChildAgeLanguageReport(
   const { data: json } = await client.request<JsonOf<ChildAgeLanguageReportRow[]>>({
     url: uri`/employee/reports/child-age-language`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -250,7 +269,8 @@ export async function getChildAttendanceReport(
     childId: UUID,
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildAttendanceReportRow[]> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -259,6 +279,7 @@ export async function getChildAttendanceReport(
   const { data: json } = await client.request<JsonOf<ChildAttendanceReportRow[]>>({
     url: uri`/employee/reports/child-attendance/${request.childId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonChildAttendanceReportRow(e))
@@ -268,10 +289,13 @@ export async function getChildAttendanceReport(
 /**
 * Generated from fi.espoo.evaka.reports.ChildrenInDifferentAddressReportController.getChildrenInDifferentAddressReport
 */
-export async function getChildrenInDifferentAddressReport(): Promise<ChildrenInDifferentAddressReportRow[]> {
+export async function getChildrenInDifferentAddressReport(
+  headers?: AxiosHeaders
+): Promise<ChildrenInDifferentAddressReportRow[]> {
   const { data: json } = await client.request<JsonOf<ChildrenInDifferentAddressReportRow[]>>({
     url: uri`/employee/reports/children-in-different-address`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -286,7 +310,8 @@ export async function getCustomerFeesReport(
     areaId?: UUID | null,
     unitId?: UUID | null,
     decisionType: FinanceDecisionType
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CustomerFeesReportRow[]> {
   const params = createUrlSearchParams(
     ['date', request.date.formatIso()],
@@ -297,6 +322,7 @@ export async function getCustomerFeesReport(
   const { data: json } = await client.request<JsonOf<CustomerFeesReportRow[]>>({
     url: uri`/employee/reports/customer-fees`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -310,7 +336,8 @@ export async function getDecisionsReport(
   request: {
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DecisionsReportRow[]> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -319,6 +346,7 @@ export async function getDecisionsReport(
   const { data: json } = await client.request<JsonOf<DecisionsReportRow[]>>({
     url: uri`/employee/reports/decisions`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -331,7 +359,8 @@ export async function getDecisionsReport(
 export async function getDuplicatePeopleReport(
   request: {
     showIntentionalDuplicates?: boolean | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DuplicatePeopleReportRow[]> {
   const params = createUrlSearchParams(
     ['showIntentionalDuplicates', request.showIntentionalDuplicates?.toString()]
@@ -339,6 +368,7 @@ export async function getDuplicatePeopleReport(
   const { data: json } = await client.request<JsonOf<DuplicatePeopleReportRow[]>>({
     url: uri`/employee/reports/duplicate-people`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonDuplicatePeopleReportRow(e))
@@ -352,7 +382,8 @@ export async function getEndedPlacementsReport(
   request: {
     year: number,
     month: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<EndedPlacementsReportRow[]> {
   const params = createUrlSearchParams(
     ['year', request.year.toString()],
@@ -361,6 +392,7 @@ export async function getEndedPlacementsReport(
   const { data: json } = await client.request<JsonOf<EndedPlacementsReportRow[]>>({
     url: uri`/employee/reports/ended-placements`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonEndedPlacementsReportRow(e))
@@ -375,7 +407,8 @@ export async function getExceededServiceNeedReportRows(
     unitId: UUID,
     year: number,
     month: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ExceededServiceNeedReportRow[]> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId],
@@ -385,6 +418,7 @@ export async function getExceededServiceNeedReportRows(
   const { data: json } = await client.request<JsonOf<ExceededServiceNeedReportRow[]>>({
     url: uri`/employee/reports/exceeded-service-need/rows`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -394,10 +428,13 @@ export async function getExceededServiceNeedReportRows(
 /**
 * Generated from fi.espoo.evaka.reports.ExceededServiceNeedsReportController.getExceededServiceNeedReportUnits
 */
-export async function getExceededServiceNeedReportUnits(): Promise<ExceededServiceNeedReportUnit[]> {
+export async function getExceededServiceNeedReportUnits(
+  headers?: AxiosHeaders
+): Promise<ExceededServiceNeedReportUnit[]> {
   const { data: json } = await client.request<JsonOf<ExceededServiceNeedReportUnit[]>>({
     url: uri`/employee/reports/exceeded-service-need/units`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -406,10 +443,13 @@ export async function getExceededServiceNeedReportUnits(): Promise<ExceededServi
 /**
 * Generated from fi.espoo.evaka.reports.FamilyConflictReportController.getFamilyConflictsReport
 */
-export async function getFamilyConflictsReport(): Promise<FamilyConflictReportRow[]> {
+export async function getFamilyConflictsReport(
+  headers?: AxiosHeaders
+): Promise<FamilyConflictReportRow[]> {
   const { data: json } = await client.request<JsonOf<FamilyConflictReportRow[]>>({
     url: uri`/employee/reports/family-conflicts`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -422,7 +462,8 @@ export async function getFamilyContactsReport(
   request: {
     unitId: UUID,
     date: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FamilyContactReportRow[]> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId],
@@ -431,6 +472,7 @@ export async function getFamilyContactsReport(
   const { data: json } = await client.request<JsonOf<FamilyContactReportRow[]>>({
     url: uri`/employee/reports/family-contacts`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -444,7 +486,8 @@ export async function getFamilyDaycareMealReport(
   request: {
     startDate: LocalDate,
     endDate: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<FamilyDaycareMealReportResult> {
   const params = createUrlSearchParams(
     ['startDate', request.startDate.formatIso()],
@@ -453,6 +496,7 @@ export async function getFamilyDaycareMealReport(
   const { data: json } = await client.request<JsonOf<FamilyDaycareMealReportResult>>({
     url: uri`/employee/reports/family-daycare-meal-count`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -462,10 +506,13 @@ export async function getFamilyDaycareMealReport(
 /**
 * Generated from fi.espoo.evaka.reports.FuturePreschoolersReport.getFuturePreschoolersReport
 */
-export async function getFuturePreschoolersReport(): Promise<FuturePreschoolersReportRow[]> {
+export async function getFuturePreschoolersReport(
+  headers?: AxiosHeaders
+): Promise<FuturePreschoolersReportRow[]> {
   const { data: json } = await client.request<JsonOf<FuturePreschoolersReportRow[]>>({
     url: uri`/employee/reports/future-preschoolers`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonFuturePreschoolersReportRow(e))
 }
@@ -474,10 +521,13 @@ export async function getFuturePreschoolersReport(): Promise<FuturePreschoolersR
 /**
 * Generated from fi.espoo.evaka.reports.FuturePreschoolersReport.getFuturePreschoolersSourceUnitsReport
 */
-export async function getFuturePreschoolersSourceUnitsReport(): Promise<SourceUnitsReportRow[]> {
+export async function getFuturePreschoolersSourceUnitsReport(
+  headers?: AxiosHeaders
+): Promise<SourceUnitsReportRow[]> {
   const { data: json } = await client.request<JsonOf<SourceUnitsReportRow[]>>({
     url: uri`/employee/reports/future-preschoolers/source-units`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -486,10 +536,13 @@ export async function getFuturePreschoolersSourceUnitsReport(): Promise<SourceUn
 /**
 * Generated from fi.espoo.evaka.reports.FuturePreschoolersReport.getFuturePreschoolersUnitsReport
 */
-export async function getFuturePreschoolersUnitsReport(): Promise<PreschoolUnitsReportRow[]> {
+export async function getFuturePreschoolersUnitsReport(
+  headers?: AxiosHeaders
+): Promise<PreschoolUnitsReportRow[]> {
   const { data: json } = await client.request<JsonOf<PreschoolUnitsReportRow[]>>({
     url: uri`/employee/reports/future-preschoolers/units`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -502,7 +555,8 @@ export async function getHolidayPeriodAttendanceReport(
   request: {
     unitId: UUID,
     periodId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<HolidayPeriodAttendanceReportRow[]> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId],
@@ -511,6 +565,7 @@ export async function getHolidayPeriodAttendanceReport(
   const { data: json } = await client.request<JsonOf<HolidayPeriodAttendanceReportRow[]>>({
     url: uri`/employee/reports/holiday-period-attendance`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonHolidayPeriodAttendanceReportRow(e))
@@ -520,10 +575,13 @@ export async function getHolidayPeriodAttendanceReport(
 /**
 * Generated from fi.espoo.evaka.reports.IncompleteIncomeReport.getIncompleteIncomeReport
 */
-export async function getIncompleteIncomeReport(): Promise<IncompleteIncomeDbRow[]> {
+export async function getIncompleteIncomeReport(
+  headers?: AxiosHeaders
+): Promise<IncompleteIncomeDbRow[]> {
   const { data: json } = await client.request<JsonOf<IncompleteIncomeDbRow[]>>({
     url: uri`/employee/reports/incomplete-income`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonIncompleteIncomeDbRow(e))
 }
@@ -535,7 +593,8 @@ export async function getIncompleteIncomeReport(): Promise<IncompleteIncomeDbRow
 export async function getInvoiceReport(
   request: {
     date: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<InvoiceReport> {
   const params = createUrlSearchParams(
     ['date', request.date.formatIso()]
@@ -543,6 +602,7 @@ export async function getInvoiceReport(
   const { data: json } = await client.request<JsonOf<InvoiceReport>>({
     url: uri`/employee/reports/invoices`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -555,7 +615,8 @@ export async function getInvoiceReport(
 export async function getManualDuplicationReport(
   request: {
     viewMode?: ManualDuplicationReportViewMode | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ManualDuplicationReportRow[]> {
   const params = createUrlSearchParams(
     ['viewMode', request.viewMode?.toString()]
@@ -563,6 +624,7 @@ export async function getManualDuplicationReport(
   const { data: json } = await client.request<JsonOf<ManualDuplicationReportRow[]>>({
     url: uri`/employee/reports/manual-duplication`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonManualDuplicationReportRow(e))
@@ -576,7 +638,8 @@ export async function getMealReportByUnit(
   request: {
     unitId: UUID,
     date: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<MealReportData> {
   const params = createUrlSearchParams(
     ['date', request.date.formatIso()]
@@ -584,6 +647,7 @@ export async function getMealReportByUnit(
   const { data: json } = await client.request<JsonOf<MealReportData>>({
     url: uri`/employee/reports/meal/${request.unitId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonMealReportData(json)
@@ -598,7 +662,8 @@ export async function getMissingHeadOfFamilyReport(
     from: LocalDate,
     to?: LocalDate | null,
     showIntentionalDuplicates?: boolean | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<MissingHeadOfFamilyReportRow[]> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -608,6 +673,7 @@ export async function getMissingHeadOfFamilyReport(
   const { data: json } = await client.request<JsonOf<MissingHeadOfFamilyReportRow[]>>({
     url: uri`/employee/reports/missing-head-of-family`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonMissingHeadOfFamilyReportRow(e))
@@ -621,7 +687,8 @@ export async function getMissingServiceNeedReport(
   request: {
     from: LocalDate,
     to?: LocalDate | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<MissingServiceNeedReportRow[]> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -630,6 +697,7 @@ export async function getMissingServiceNeedReport(
   const { data: json } = await client.request<JsonOf<MissingServiceNeedReportRow[]>>({
     url: uri`/employee/reports/missing-service-need`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -639,10 +707,13 @@ export async function getMissingServiceNeedReport(
 /**
 * Generated from fi.espoo.evaka.reports.NonSsnChildrenReportController.getNonSsnChildrenReportRows
 */
-export async function getNonSsnChildrenReportRows(): Promise<NonSsnChildrenReportRow[]> {
+export async function getNonSsnChildrenReportRows(
+  headers?: AxiosHeaders
+): Promise<NonSsnChildrenReportRow[]> {
   const { data: json } = await client.request<JsonOf<NonSsnChildrenReportRow[]>>({
     url: uri`/employee/reports/non-ssn-children`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonNonSsnChildrenReportRow(e))
 }
@@ -659,7 +730,8 @@ export async function getOccupancyGroupReport(
     unitTypes?: CareType[] | null,
     year: number,
     month: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<OccupancyGroupReportResultRow[]> {
   const params = createUrlSearchParams(
     ['type', request.type.toString()],
@@ -672,6 +744,7 @@ export async function getOccupancyGroupReport(
   const { data: json } = await client.request<JsonOf<OccupancyGroupReportResultRow[]>>({
     url: uri`/employee/reports/occupancy-by-group`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -689,7 +762,8 @@ export async function getOccupancyUnitReport(
     unitTypes?: CareType[] | null,
     year: number,
     month: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<OccupancyUnitReportResultRow[]> {
   const params = createUrlSearchParams(
     ['type', request.type.toString()],
@@ -702,6 +776,7 @@ export async function getOccupancyUnitReport(
   const { data: json } = await client.request<JsonOf<OccupancyUnitReportResultRow[]>>({
     url: uri`/employee/reports/occupancy-by-unit`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -711,10 +786,13 @@ export async function getOccupancyUnitReport(
 /**
 * Generated from fi.espoo.evaka.reports.PartnersInDifferentAddressReportController.getPartnersInDifferentAddressReport
 */
-export async function getPartnersInDifferentAddressReport(): Promise<PartnersInDifferentAddressReportRow[]> {
+export async function getPartnersInDifferentAddressReport(
+  headers?: AxiosHeaders
+): Promise<PartnersInDifferentAddressReportRow[]> {
   const { data: json } = await client.request<JsonOf<PartnersInDifferentAddressReportRow[]>>({
     url: uri`/employee/reports/partners-in-different-address`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -728,7 +806,8 @@ export async function getPlacementCountReport(
     examinationDate: LocalDate,
     providerTypes?: ProviderType[] | null,
     placementTypes?: PlacementType[] | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PlacementCountReportResult> {
   const params = createUrlSearchParams(
     ['examinationDate', request.examinationDate.formatIso()],
@@ -738,6 +817,7 @@ export async function getPlacementCountReport(
   const { data: json } = await client.request<JsonOf<PlacementCountReportResult>>({
     url: uri`/employee/reports/placement-count`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -751,7 +831,8 @@ export async function getPlacementGuaranteeReport(
   request: {
     date: LocalDate,
     unitId?: UUID | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PlacementGuaranteeReportRow[]> {
   const params = createUrlSearchParams(
     ['date', request.date.formatIso()],
@@ -760,6 +841,7 @@ export async function getPlacementGuaranteeReport(
   const { data: json } = await client.request<JsonOf<PlacementGuaranteeReportRow[]>>({
     url: uri`/employee/reports/placement-guarantee`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonPlacementGuaranteeReportRow(e))
@@ -776,7 +858,8 @@ export async function getPlacementSketchingReport(
     applicationStatus?: ApplicationStatus[] | null,
     earliestApplicationSentDate?: LocalDate | null,
     latestApplicationSentDate?: LocalDate | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PlacementSketchingReportRow[]> {
   const params = createUrlSearchParams(
     ['placementStartDate', request.placementStartDate.formatIso()],
@@ -788,6 +871,7 @@ export async function getPlacementSketchingReport(
   const { data: json } = await client.request<JsonOf<PlacementSketchingReportRow[]>>({
     url: uri`/employee/reports/placement-sketching`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonPlacementSketchingReportRow(e))
@@ -803,7 +887,8 @@ export async function getPreschoolAbsenceReport(
     groupId?: UUID | null,
     termStart: LocalDate,
     termEnd: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildPreschoolAbsenceRow[]> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId],
@@ -814,6 +899,7 @@ export async function getPreschoolAbsenceReport(
   const { data: json } = await client.request<JsonOf<ChildPreschoolAbsenceRow[]>>({
     url: uri`/employee/reports/preschool-absence`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -823,10 +909,13 @@ export async function getPreschoolAbsenceReport(
 /**
 * Generated from fi.espoo.evaka.reports.PreschoolApplicationReport.getPreschoolApplicationReport
 */
-export async function getPreschoolApplicationReport(): Promise<PreschoolApplicationReportRow[]> {
+export async function getPreschoolApplicationReport(
+  headers?: AxiosHeaders
+): Promise<PreschoolApplicationReportRow[]> {
   const { data: json } = await client.request<JsonOf<PreschoolApplicationReportRow[]>>({
     url: uri`/employee/reports/preschool-application`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonPreschoolApplicationReportRow(e))
 }
@@ -839,7 +928,8 @@ export async function getPresenceReport(
   request: {
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PresenceReportRow[]> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -848,6 +938,7 @@ export async function getPresenceReport(
   const { data: json } = await client.request<JsonOf<PresenceReportRow[]>>({
     url: uri`/employee/reports/presences`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonPresenceReportRow(e))
@@ -861,7 +952,8 @@ export async function getRawReport(
   request: {
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<RawReportRow[]> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -870,6 +962,7 @@ export async function getRawReport(
   const { data: json } = await client.request<JsonOf<RawReportRow[]>>({
     url: uri`/employee/reports/raw`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonRawReportRow(e))
@@ -879,10 +972,13 @@ export async function getRawReport(
 /**
 * Generated from fi.espoo.evaka.reports.ReportPermissions.getPermittedReports
 */
-export async function getPermittedReports(): Promise<Report[]> {
+export async function getPermittedReports(
+  headers?: AxiosHeaders
+): Promise<Report[]> {
   const { data: json } = await client.request<JsonOf<Report[]>>({
     url: uri`/employee/reports`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -894,7 +990,8 @@ export async function getPermittedReports(): Promise<Report[]> {
 export async function getServiceNeedReport(
   request: {
     date: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ServiceNeedReportRow[]> {
   const params = createUrlSearchParams(
     ['date', request.date.formatIso()]
@@ -902,6 +999,7 @@ export async function getServiceNeedReport(
   const { data: json } = await client.request<JsonOf<ServiceNeedReportRow[]>>({
     url: uri`/employee/reports/service-need`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -916,7 +1014,8 @@ export async function getServiceVoucherReportForAllUnits(
     year: number,
     month: number,
     areaId?: UUID | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ServiceVoucherReport> {
   const params = createUrlSearchParams(
     ['year', request.year.toString()],
@@ -926,6 +1025,7 @@ export async function getServiceVoucherReportForAllUnits(
   const { data: json } = await client.request<JsonOf<ServiceVoucherReport>>({
     url: uri`/employee/reports/service-voucher-value/units`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonServiceVoucherReport(json)
@@ -940,7 +1040,8 @@ export async function getServiceVoucherReportForUnit(
     unitId: UUID,
     year: number,
     month: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ServiceVoucherUnitReport> {
   const params = createUrlSearchParams(
     ['year', request.year.toString()],
@@ -949,6 +1050,7 @@ export async function getServiceVoucherReportForUnit(
   const { data: json } = await client.request<JsonOf<ServiceVoucherUnitReport>>({
     url: uri`/employee/reports/service-voucher-value/units/${request.unitId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonServiceVoucherUnitReport(json)
@@ -962,7 +1064,8 @@ export async function getSextetReport(
   request: {
     year: number,
     placementType: PlacementType
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<SextetReportRow[]> {
   const params = createUrlSearchParams(
     ['year', request.year.toString()],
@@ -971,6 +1074,7 @@ export async function getSextetReport(
   const { data: json } = await client.request<JsonOf<SextetReportRow[]>>({
     url: uri`/employee/reports/sextet`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json
@@ -984,7 +1088,8 @@ export async function getStartingPlacementsReport(
   request: {
     year: number,
     month: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<StartingPlacementsRow[]> {
   const params = createUrlSearchParams(
     ['year', request.year.toString()],
@@ -993,6 +1098,7 @@ export async function getStartingPlacementsReport(
   const { data: json } = await client.request<JsonOf<StartingPlacementsRow[]>>({
     url: uri`/employee/reports/starting-placements`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonStartingPlacementsRow(e))
@@ -1002,10 +1108,13 @@ export async function getStartingPlacementsReport(
 /**
 * Generated from fi.espoo.evaka.reports.TitaniaErrorReport.getTitaniaErrorsReport
 */
-export async function getTitaniaErrorsReport(): Promise<TitaniaErrorReportRow[]> {
+export async function getTitaniaErrorsReport(
+  headers?: AxiosHeaders
+): Promise<TitaniaErrorReportRow[]> {
   const { data: json } = await client.request<JsonOf<TitaniaErrorReportRow[]>>({
     url: uri`/employee/reports/titania-errors`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonTitaniaErrorReportRow(e))
 }
@@ -1014,10 +1123,13 @@ export async function getTitaniaErrorsReport(): Promise<TitaniaErrorReportRow[]>
 /**
 * Generated from fi.espoo.evaka.reports.UnitsReportController.getUnitsReport
 */
-export async function getUnitsReport(): Promise<UnitsReportRow[]> {
+export async function getUnitsReport(
+  headers?: AxiosHeaders
+): Promise<UnitsReportRow[]> {
   const { data: json } = await client.request<JsonOf<UnitsReportRow[]>>({
     url: uri`/employee/reports/units`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -1026,10 +1138,13 @@ export async function getUnitsReport(): Promise<UnitsReportRow[]> {
 /**
 * Generated from fi.espoo.evaka.reports.VardaErrorReport.getVardaChildErrorsReport
 */
-export async function getVardaChildErrorsReport(): Promise<VardaChildErrorReportRow[]> {
+export async function getVardaChildErrorsReport(
+  headers?: AxiosHeaders
+): Promise<VardaChildErrorReportRow[]> {
   const { data: json } = await client.request<JsonOf<VardaChildErrorReportRow[]>>({
     url: uri`/employee/reports/varda-child-errors`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonVardaChildErrorReportRow(e))
 }
@@ -1038,10 +1153,13 @@ export async function getVardaChildErrorsReport(): Promise<VardaChildErrorReport
 /**
 * Generated from fi.espoo.evaka.reports.VardaErrorReport.getVardaUnitErrorsReport
 */
-export async function getVardaUnitErrorsReport(): Promise<VardaUnitErrorReportRow[]> {
+export async function getVardaUnitErrorsReport(
+  headers?: AxiosHeaders
+): Promise<VardaUnitErrorReportRow[]> {
   const { data: json } = await client.request<JsonOf<VardaUnitErrorReportRow[]>>({
     url: uri`/employee/reports/varda-unit-errors`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonVardaUnitErrorReportRow(e))
 }
@@ -1054,7 +1172,8 @@ export async function sendPatuReport(
   request: {
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -1063,6 +1182,7 @@ export async function sendPatuReport(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/patu-report`.toString(),
     method: 'POST',
+    headers,
     params
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/reservations.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reservations.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { ChildDatePresence } from 'lib-common/generated/api-types/reservations'
 import { DailyReservationRequest } from 'lib-common/generated/api-types/reservations'
 import { ExpectedAbsencesRequest } from 'lib-common/generated/api-types/reservations'
@@ -28,7 +29,8 @@ export async function getAttendanceReservations(
     from: LocalDate,
     to: LocalDate,
     includeNonOperationalDays?: boolean | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UnitAttendanceReservations> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId],
@@ -39,6 +41,7 @@ export async function getAttendanceReservations(
   const { data: json } = await client.request<JsonOf<UnitAttendanceReservations>>({
     url: uri`/employee/attendance-reservations`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonUnitAttendanceReservations(json)
@@ -51,11 +54,13 @@ export async function getAttendanceReservations(
 export async function getExpectedAbsences(
   request: {
     body: ExpectedAbsencesRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ExpectedAbsencesResponse> {
   const { data: json } = await client.request<JsonOf<ExpectedAbsencesResponse>>({
     url: uri`/employee/attendance-reservations/child-date/expected-absences`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ExpectedAbsencesRequest>
   })
   return json
@@ -68,11 +73,13 @@ export async function getExpectedAbsences(
 export async function postChildDatePresence(
   request: {
     body: ChildDatePresence
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/attendance-reservations/child-date`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ChildDatePresence>
   })
   return json
@@ -85,11 +92,13 @@ export async function postChildDatePresence(
 export async function postReservations(
   request: {
     body: DailyReservationRequest[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/attendance-reservations`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DailyReservationRequest[]>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/serviceneed.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/serviceneed.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import { AcceptServiceApplicationBody } from 'lib-common/generated/api-types/serviceneed'
+import { AxiosHeaders } from 'axios'
 import { EmployeeServiceApplication } from 'lib-common/generated/api-types/serviceneed'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
@@ -31,11 +32,13 @@ import { uri } from 'lib-common/uri'
 export async function deleteServiceNeed(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/service-needs/${request.id}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -47,7 +50,8 @@ export async function deleteServiceNeed(
 export async function getServiceNeedOptionPublicInfos(
   request: {
     placementTypes?: PlacementType[] | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ServiceNeedOptionPublicInfo[]> {
   const params = createUrlSearchParams(
     ...(request.placementTypes?.map((e): [string, string | null | undefined] => ['placementTypes', e.toString()]) ?? [])
@@ -55,6 +59,7 @@ export async function getServiceNeedOptionPublicInfos(
   const { data: json } = await client.request<JsonOf<ServiceNeedOptionPublicInfo[]>>({
     url: uri`/employee/public/service-needs/options`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonServiceNeedOptionPublicInfo(e))
@@ -64,10 +69,13 @@ export async function getServiceNeedOptionPublicInfos(
 /**
 * Generated from fi.espoo.evaka.serviceneed.ServiceNeedController.getServiceNeedOptions
 */
-export async function getServiceNeedOptions(): Promise<ServiceNeedOption[]> {
+export async function getServiceNeedOptions(
+  headers?: AxiosHeaders
+): Promise<ServiceNeedOption[]> {
   const { data: json } = await client.request<JsonOf<ServiceNeedOption[]>>({
     url: uri`/employee/service-needs/options`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonServiceNeedOption(e))
 }
@@ -79,11 +87,13 @@ export async function getServiceNeedOptions(): Promise<ServiceNeedOption[]> {
 export async function postServiceNeed(
   request: {
     body: ServiceNeedCreateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/service-needs`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ServiceNeedCreateRequest>
   })
   return json
@@ -97,11 +107,13 @@ export async function putServiceNeed(
   request: {
     id: UUID,
     body: ServiceNeedUpdateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/service-needs/${request.id}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ServiceNeedUpdateRequest>
   })
   return json
@@ -115,11 +127,13 @@ export async function acceptServiceApplication(
   request: {
     id: UUID,
     body: AcceptServiceApplicationBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/service-applications/${request.id}/accept`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<AcceptServiceApplicationBody>
   })
   return json
@@ -132,7 +146,8 @@ export async function acceptServiceApplication(
 export async function getChildServiceApplications(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<EmployeeServiceApplication[]> {
   const params = createUrlSearchParams(
     ['childId', request.childId]
@@ -140,6 +155,7 @@ export async function getChildServiceApplications(
   const { data: json } = await client.request<JsonOf<EmployeeServiceApplication[]>>({
     url: uri`/employee/service-applications`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonEmployeeServiceApplication(e))
@@ -152,7 +168,8 @@ export async function getChildServiceApplications(
 export async function getUndecidedServiceApplications(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UndecidedServiceApplicationSummary[]> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId]
@@ -160,6 +177,7 @@ export async function getUndecidedServiceApplications(
   const { data: json } = await client.request<JsonOf<UndecidedServiceApplicationSummary[]>>({
     url: uri`/employee/service-applications/undecided`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonUndecidedServiceApplicationSummary(e))
@@ -173,11 +191,13 @@ export async function rejectServiceApplication(
   request: {
     id: UUID,
     body: ServiceApplicationRejection
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/service-applications/${request.id}/reject`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ServiceApplicationRejection>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/setting.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/setting.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { SettingType } from 'lib-common/generated/api-types/setting'
@@ -14,10 +15,13 @@ import { uri } from 'lib-common/uri'
 /**
 * Generated from fi.espoo.evaka.setting.SettingController.getSettings
 */
-export async function getSettings(): Promise<Record<SettingType, string>> {
+export async function getSettings(
+  headers?: AxiosHeaders
+): Promise<Record<SettingType, string>> {
   const { data: json } = await client.request<JsonOf<Record<SettingType, string>>>({
     url: uri`/employee/settings`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -29,11 +33,13 @@ export async function getSettings(): Promise<Record<SettingType, string>> {
 export async function putSettings(
   request: {
     body: Record<SettingType, string>
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/settings`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<Record<SettingType, string>>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/specialdiet.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/specialdiet.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JamixSpecialDiet } from 'lib-common/generated/api-types/jamix'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
@@ -16,10 +17,13 @@ import { uri } from 'lib-common/uri'
 /**
 * Generated from fi.espoo.evaka.specialdiet.MealTexturesController.getMealTextures
 */
-export async function getMealTextures(): Promise<MealTexture[]> {
+export async function getMealTextures(
+  headers?: AxiosHeaders
+): Promise<MealTexture[]> {
   const { data: json } = await client.request<JsonOf<MealTexture[]>>({
     url: uri`/employee/meal-textures`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -28,10 +32,13 @@ export async function getMealTextures(): Promise<MealTexture[]> {
 /**
 * Generated from fi.espoo.evaka.specialdiet.SpecialDietController.getDiets
 */
-export async function getDiets(): Promise<SpecialDiet[]> {
+export async function getDiets(
+  headers?: AxiosHeaders
+): Promise<SpecialDiet[]> {
   const { data: json } = await client.request<JsonOf<SpecialDiet[]>>({
     url: uri`/employee/diets`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -43,11 +50,13 @@ export async function getDiets(): Promise<SpecialDiet[]> {
 export async function putDiets(
   request: {
     body: JamixSpecialDiet[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/diets`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<JamixSpecialDiet[]>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/systemnotifications.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/systemnotifications.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { SystemNotification } from 'lib-common/generated/api-types/systemnotifications'
@@ -19,11 +20,13 @@ import { uri } from 'lib-common/uri'
 export async function deleteSystemNotification(
   request: {
     targetGroup: SystemNotificationTargetGroup
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/system-notifications/${request.targetGroup}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -32,10 +35,13 @@ export async function deleteSystemNotification(
 /**
 * Generated from fi.espoo.evaka.systemnotifications.SystemNotificationsController.getAllSystemNotifications
 */
-export async function getAllSystemNotifications(): Promise<SystemNotification[]> {
+export async function getAllSystemNotifications(
+  headers?: AxiosHeaders
+): Promise<SystemNotification[]> {
   const { data: json } = await client.request<JsonOf<SystemNotification[]>>({
     url: uri`/employee/system-notifications`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonSystemNotification(e))
 }
@@ -47,11 +53,13 @@ export async function getAllSystemNotifications(): Promise<SystemNotification[]>
 export async function putSystemNotification(
   request: {
     body: SystemNotification
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/system-notifications`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<SystemNotification>
   })
   return json

--- a/frontend/src/employee-frontend/generated/api-clients/timeline.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/timeline.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { Timeline } from 'lib-common/generated/api-types/timeline'
 import { UUID } from 'lib-common/types'
@@ -22,7 +23,8 @@ export async function getTimeline(
     personId: UUID,
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Timeline> {
   const params = createUrlSearchParams(
     ['personId', request.personId],
@@ -32,6 +34,7 @@ export async function getTimeline(
   const { data: json } = await client.request<JsonOf<Timeline>>({
     url: uri`/employee/timeline`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonTimeline(json)

--- a/frontend/src/employee-frontend/generated/api-clients/varda.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/varda.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
@@ -16,11 +17,13 @@ import { uri } from 'lib-common/uri'
 export async function markChildForVardaReset(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/varda/child/reset/${request.childId}`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/absence.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/absence.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import { Absence } from 'lib-common/generated/api-types/absence'
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
 import { client } from '../../client'
@@ -18,11 +19,13 @@ import { uri } from 'lib-common/uri'
 export async function futureAbsencesOfChild(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Absence[]> {
   const { data: json } = await client.request<JsonOf<Absence[]>>({
     url: uri`/employee-mobile/absences/by-child/${request.childId}/future`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonAbsence(e))
 }

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/attendance.ts
@@ -8,6 +8,7 @@ import LocalDate from 'lib-common/local-date'
 import { AbsenceRangeRequest } from 'lib-common/generated/api-types/attendance'
 import { ArrivalsRequest } from 'lib-common/generated/api-types/attendance'
 import { AttendanceChild } from 'lib-common/generated/api-types/attendance'
+import { AxiosHeaders } from 'axios'
 import { ChildAttendanceStatusResponse } from 'lib-common/generated/api-types/attendance'
 import { CurrentDayStaffAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { DeparturesRequest } from 'lib-common/generated/api-types/attendance'
@@ -44,11 +45,13 @@ export async function cancelFullDayAbsence(
   request: {
     unitId: UUID,
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/children/${request.childId}/full-day-absence`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -63,7 +66,8 @@ export async function deleteAbsenceRange(
     childId: UUID,
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -72,6 +76,7 @@ export async function deleteAbsenceRange(
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/children/${request.childId}/absence-range`.toString(),
     method: 'DELETE',
+    headers,
     params
   })
   return json
@@ -84,11 +89,13 @@ export async function deleteAbsenceRange(
 export async function getAttendanceStatuses(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Record<UUID, ChildAttendanceStatusResponse>> {
   const { data: json } = await client.request<JsonOf<Record<UUID, ChildAttendanceStatusResponse>>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/attendances`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return Object.fromEntries(Object.entries(json).map(
     ([k, v]) => [k, deserializeJsonChildAttendanceStatusResponse(v)]
@@ -102,11 +109,13 @@ export async function getAttendanceStatuses(
 export async function getChildren(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AttendanceChild[]> {
   const { data: json } = await client.request<JsonOf<AttendanceChild[]>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/children`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonAttendanceChild(e))
 }
@@ -119,11 +128,13 @@ export async function getExpectedAbsencesOnDepartures(
   request: {
     unitId: UUID,
     body: ExpectedAbsencesOnDeparturesRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ExpectedAbsencesOnDeparturesResponse> {
   const { data: json } = await client.request<JsonOf<ExpectedAbsencesOnDeparturesResponse>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/departure/expected-absences`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ExpectedAbsencesOnDeparturesRequest>
   })
   return json
@@ -138,11 +149,13 @@ export async function postAbsenceRange(
     unitId: UUID,
     childId: UUID,
     body: AbsenceRangeRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/children/${request.childId}/absence-range`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<AbsenceRangeRequest>
   })
   return json
@@ -156,11 +169,13 @@ export async function postArrivals(
   request: {
     unitId: UUID,
     body: ArrivalsRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/arrivals`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ArrivalsRequest>
   })
   return json
@@ -174,11 +189,13 @@ export async function postDepartures(
   request: {
     unitId: UUID,
     body: DeparturesRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/departures`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<DeparturesRequest>
   })
   return json
@@ -193,11 +210,13 @@ export async function postFullDayAbsence(
     unitId: UUID,
     childId: UUID,
     body: FullDayAbsenceRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/children/${request.childId}/full-day-absence`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<FullDayAbsenceRequest>
   })
   return json
@@ -211,11 +230,13 @@ export async function returnToComing(
   request: {
     unitId: UUID,
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/children/${request.childId}/return-to-coming`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -228,11 +249,13 @@ export async function returnToPresent(
   request: {
     unitId: UUID,
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/children/${request.childId}/return-to-present`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -245,7 +268,8 @@ export async function getAttendancesByUnit(
   request: {
     unitId: UUID,
     date?: LocalDate | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CurrentDayStaffAttendanceResponse> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId],
@@ -254,6 +278,7 @@ export async function getAttendancesByUnit(
   const { data: json } = await client.request<JsonOf<CurrentDayStaffAttendanceResponse>>({
     url: uri`/employee-mobile/realtime-staff-attendances`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonCurrentDayStaffAttendanceResponse(json)
@@ -269,7 +294,8 @@ export async function getEmployeeAttendances(
     employeeId: UUID,
     from: LocalDate,
     to: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<StaffMember> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId],
@@ -280,6 +306,7 @@ export async function getEmployeeAttendances(
   const { data: json } = await client.request<JsonOf<StaffMember>>({
     url: uri`/employee-mobile/realtime-staff-attendances/employee`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonStaffMember(json)
@@ -292,7 +319,8 @@ export async function getEmployeeAttendances(
 export async function getOpenGroupAttendance(
   request: {
     userId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<OpenGroupAttendanceResponse> {
   const params = createUrlSearchParams(
     ['userId', request.userId]
@@ -300,6 +328,7 @@ export async function getOpenGroupAttendance(
   const { data: json } = await client.request<JsonOf<OpenGroupAttendanceResponse>>({
     url: uri`/employee-mobile/realtime-staff-attendances/open-attendance`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonOpenGroupAttendanceResponse(json)
@@ -312,11 +341,13 @@ export async function getOpenGroupAttendance(
 export async function markArrival(
   request: {
     body: StaffArrivalRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/realtime-staff-attendances/arrival`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<StaffArrivalRequest>
   })
   return json
@@ -329,11 +360,13 @@ export async function markArrival(
 export async function markDeparture(
   request: {
     body: StaffDepartureRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/realtime-staff-attendances/departure`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<StaffDepartureRequest>
   })
   return json
@@ -346,11 +379,13 @@ export async function markDeparture(
 export async function markExternalArrival(
   request: {
     body: ExternalStaffArrivalRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee-mobile/realtime-staff-attendances/arrival-external`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ExternalStaffArrivalRequest>
   })
   return json
@@ -363,11 +398,13 @@ export async function markExternalArrival(
 export async function markExternalDeparture(
   request: {
     body: ExternalStaffDepartureRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/realtime-staff-attendances/departure-external`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ExternalStaffDepartureRequest>
   })
   return json
@@ -381,7 +418,8 @@ export async function setAttendances(
   request: {
     unitId: UUID,
     body: StaffAttendanceUpdateRequest
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<StaffAttendanceUpdateResponse> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId]
@@ -389,6 +427,7 @@ export async function setAttendances(
   const { data: json } = await client.request<JsonOf<StaffAttendanceUpdateResponse>>({
     url: uri`/employee-mobile/realtime-staff-attendances`.toString(),
     method: 'PUT',
+    headers,
     params,
     data: request.body satisfies JsonCompatible<StaffAttendanceUpdateRequest>
   })
@@ -402,11 +441,13 @@ export async function setAttendances(
 export async function getUnitInfo(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UnitInfo> {
   const { data: json } = await client.request<JsonOf<UnitInfo>>({
     url: uri`/employee-mobile/units/${request.unitId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -418,7 +459,8 @@ export async function getUnitInfo(
 export async function getUnitStats(
   request: {
     unitIds?: UUID[] | null
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UnitStats[]> {
   const params = createUrlSearchParams(
     ...(request.unitIds?.map((e): [string, string | null | undefined] => ['unitIds', e]) ?? [])
@@ -426,6 +468,7 @@ export async function getUnitStats(
   const { data: json } = await client.request<JsonOf<UnitStats[]>>({
     url: uri`/employee-mobile/units/stats`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/childimages.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/childimages.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
 import { client } from '../../client'
@@ -16,11 +17,13 @@ import { uri } from 'lib-common/uri'
 export async function deleteImage(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/children/${request.childId}/image`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/daycare.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/daycare.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { StaffAttendanceUpdate } from 'lib-common/generated/api-types/daycare'
@@ -20,11 +21,13 @@ import { uri } from 'lib-common/uri'
 export async function getAttendancesByUnit(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UnitStaffAttendance> {
   const { data: json } = await client.request<JsonOf<UnitStaffAttendance>>({
     url: uri`/employee-mobile/staff-attendances/unit/${request.unitId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonUnitStaffAttendance(json)
 }
@@ -37,11 +40,13 @@ export async function upsertStaffAttendance(
   request: {
     groupId: UUID,
     body: StaffAttendanceUpdate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/staff-attendances/group/${request.groupId}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<StaffAttendanceUpdate>
   })
   return json

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/messaging.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import { AuthorizedMessageAccount } from 'lib-common/generated/api-types/messaging'
+import { AxiosHeaders } from 'axios'
 import { CreateMessageResponse } from 'lib-common/generated/api-types/messaging'
 import { DraftContent } from 'lib-common/generated/api-types/messaging'
 import { JsonCompatible } from 'lib-common/json'
@@ -38,11 +39,13 @@ export async function createMessage(
   request: {
     accountId: UUID,
     body: PostMessageBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<CreateMessageResponse> {
   const { data: json } = await client.request<JsonOf<CreateMessageResponse>>({
     url: uri`/employee-mobile/messages/${request.accountId}`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PostMessageBody>
   })
   return json
@@ -56,11 +59,13 @@ export async function createMessagePreflightCheck(
   request: {
     accountId: UUID,
     body: PostMessagePreflightBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PostMessagePreflightResponse> {
   const { data: json } = await client.request<JsonOf<PostMessagePreflightResponse>>({
     url: uri`/employee-mobile/messages/${request.accountId}/preflight-check`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PostMessagePreflightBody>
   })
   return json
@@ -74,11 +79,13 @@ export async function deleteDraftMessage(
   request: {
     accountId: UUID,
     draftId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/messages/${request.accountId}/drafts/${request.draftId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -90,11 +97,13 @@ export async function deleteDraftMessage(
 export async function getAccountsByDevice(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<AuthorizedMessageAccount[]> {
   const { data: json } = await client.request<JsonOf<AuthorizedMessageAccount[]>>({
     url: uri`/employee-mobile/messages/my-accounts/${request.unitId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -106,11 +115,13 @@ export async function getAccountsByDevice(
 export async function getDraftMessages(
   request: {
     accountId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DraftContent[]> {
   const { data: json } = await client.request<JsonOf<DraftContent[]>>({
     url: uri`/employee-mobile/messages/${request.accountId}/drafts`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonDraftContent(e))
 }
@@ -123,7 +134,8 @@ export async function getReceivedMessages(
   request: {
     accountId: UUID,
     page: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedMessageThreads> {
   const params = createUrlSearchParams(
     ['page', request.page.toString()]
@@ -131,6 +143,7 @@ export async function getReceivedMessages(
   const { data: json } = await client.request<JsonOf<PagedMessageThreads>>({
     url: uri`/employee-mobile/messages/${request.accountId}/received`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonPagedMessageThreads(json)
@@ -140,10 +153,13 @@ export async function getReceivedMessages(
 /**
 * Generated from fi.espoo.evaka.messaging.MessageController.getReceiversForNewMessage
 */
-export async function getReceiversForNewMessage(): Promise<MessageReceiversResponse[]> {
+export async function getReceiversForNewMessage(
+  headers?: AxiosHeaders
+): Promise<MessageReceiversResponse[]> {
   const { data: json } = await client.request<JsonOf<MessageReceiversResponse[]>>({
     url: uri`/employee-mobile/messages/receivers`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -156,7 +172,8 @@ export async function getSentMessages(
   request: {
     accountId: UUID,
     page: number
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PagedSentMessages> {
   const params = createUrlSearchParams(
     ['page', request.page.toString()]
@@ -164,6 +181,7 @@ export async function getSentMessages(
   const { data: json } = await client.request<JsonOf<PagedSentMessages>>({
     url: uri`/employee-mobile/messages/${request.accountId}/sent`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonPagedSentMessages(json)
@@ -177,11 +195,13 @@ export async function getThread(
   request: {
     accountId: UUID,
     threadId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<MessageThread> {
   const { data: json } = await client.request<JsonOf<MessageThread>>({
     url: uri`/employee-mobile/messages/${request.accountId}/thread/${request.threadId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonMessageThread(json)
 }
@@ -193,11 +213,13 @@ export async function getThread(
 export async function getUnreadMessagesByUnit(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UnreadCountByAccountAndGroup[]> {
   const { data: json } = await client.request<JsonOf<UnreadCountByAccountAndGroup[]>>({
     url: uri`/employee-mobile/messages/unread/${request.unitId}`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -209,11 +231,13 @@ export async function getUnreadMessagesByUnit(
 export async function initDraftMessage(
   request: {
     accountId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee-mobile/messages/${request.accountId}/drafts`.toString(),
-    method: 'POST'
+    method: 'POST',
+    headers
   })
   return json
 }
@@ -226,11 +250,13 @@ export async function markThreadRead(
   request: {
     accountId: UUID,
     threadId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/messages/${request.accountId}/threads/${request.threadId}/read`.toString(),
-    method: 'PUT'
+    method: 'PUT',
+    headers
   })
   return json
 }
@@ -244,11 +270,13 @@ export async function replyToThread(
     accountId: UUID,
     messageId: UUID,
     body: ReplyToMessageBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ThreadReply> {
   const { data: json } = await client.request<JsonOf<ThreadReply>>({
     url: uri`/employee-mobile/messages/${request.accountId}/${request.messageId}/reply`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ReplyToMessageBody>
   })
   return deserializeJsonThreadReply(json)
@@ -263,11 +291,13 @@ export async function updateDraftMessage(
     accountId: UUID,
     draftId: UUID,
     body: UpdatableDraftContent
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/messages/${request.accountId}/drafts/${request.draftId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<UpdatableDraftContent>
   })
   return json

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/note.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/note.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { ChildDailyNote } from 'lib-common/generated/api-types/note'
 import { ChildDailyNoteBody } from 'lib-common/generated/api-types/note'
 import { ChildStickyNote } from 'lib-common/generated/api-types/note'
@@ -27,11 +28,13 @@ export async function createChildDailyNote(
   request: {
     childId: UUID,
     body: ChildDailyNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee-mobile/children/${request.childId}/child-daily-notes`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ChildDailyNoteBody>
   })
   return json
@@ -44,11 +47,13 @@ export async function createChildDailyNote(
 export async function deleteChildDailyNote(
   request: {
     noteId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/child-daily-notes/${request.noteId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -61,11 +66,13 @@ export async function updateChildDailyNote(
   request: {
     noteId: UUID,
     body: ChildDailyNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildDailyNote> {
   const { data: json } = await client.request<JsonOf<ChildDailyNote>>({
     url: uri`/employee-mobile/child-daily-notes/${request.noteId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ChildDailyNoteBody>
   })
   return deserializeJsonChildDailyNote(json)
@@ -79,11 +86,13 @@ export async function createChildStickyNote(
   request: {
     childId: UUID,
     body: ChildStickyNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee-mobile/children/${request.childId}/child-sticky-notes`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<ChildStickyNoteBody>
   })
   return json
@@ -96,11 +105,13 @@ export async function createChildStickyNote(
 export async function deleteChildStickyNote(
   request: {
     noteId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/child-sticky-notes/${request.noteId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -113,11 +124,13 @@ export async function updateChildStickyNote(
   request: {
     noteId: UUID,
     body: ChildStickyNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildStickyNote> {
   const { data: json } = await client.request<JsonOf<ChildStickyNote>>({
     url: uri`/employee-mobile/child-sticky-notes/${request.noteId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ChildStickyNoteBody>
   })
   return deserializeJsonChildStickyNote(json)
@@ -131,11 +144,13 @@ export async function createGroupNote(
   request: {
     groupId: UUID,
     body: GroupNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<UUID> {
   const { data: json } = await client.request<JsonOf<UUID>>({
     url: uri`/employee-mobile/daycare-groups/${request.groupId}/group-notes`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<GroupNoteBody>
   })
   return json
@@ -148,11 +163,13 @@ export async function createGroupNote(
 export async function deleteGroupNote(
   request: {
     noteId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/group-notes/${request.noteId}`.toString(),
-    method: 'DELETE'
+    method: 'DELETE',
+    headers
   })
   return json
 }
@@ -164,11 +181,13 @@ export async function deleteGroupNote(
 export async function getGroupNotes(
   request: {
     groupId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<GroupNote[]> {
   const { data: json } = await client.request<JsonOf<GroupNote[]>>({
     url: uri`/employee-mobile/daycare-groups/${request.groupId}/group-notes`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonGroupNote(e))
 }
@@ -181,11 +200,13 @@ export async function updateGroupNote(
   request: {
     noteId: UUID,
     body: GroupNoteBody
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<GroupNote> {
   const { data: json } = await client.request<JsonOf<GroupNote>>({
     url: uri`/employee-mobile/group-notes/${request.noteId}`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<GroupNoteBody>
   })
   return deserializeJsonGroupNote(json)

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/occupancy.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/occupancy.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { JsonOf } from 'lib-common/json'
 import { OccupancyResponse } from 'lib-common/generated/api-types/occupancy'
 import { OccupancyResponseGroupLevel } from 'lib-common/generated/api-types/occupancy'
@@ -26,7 +27,8 @@ export async function getOccupancyPeriods(
     from: LocalDate,
     to: LocalDate,
     type: OccupancyType
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<OccupancyResponse> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -36,6 +38,7 @@ export async function getOccupancyPeriods(
   const { data: json } = await client.request<JsonOf<OccupancyResponse>>({
     url: uri`/employee-mobile/occupancy/by-unit/${request.unitId}`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonOccupancyResponse(json)
@@ -51,7 +54,8 @@ export async function getOccupancyPeriodsOnGroups(
     from: LocalDate,
     to: LocalDate,
     type: OccupancyType
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<OccupancyResponseGroupLevel[]> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
@@ -61,6 +65,7 @@ export async function getOccupancyPeriodsOnGroups(
   const { data: json } = await client.request<JsonOf<OccupancyResponseGroupLevel[]>>({
     url: uri`/employee-mobile/occupancy/by-unit/${request.unitId}/groups`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonOccupancyResponseGroupLevel(e))

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/pairing.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/pairing.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { Pairing } from 'lib-common/generated/api-types/pairing'
@@ -21,11 +22,13 @@ import { uri } from 'lib-common/uri'
 export async function getPairingStatus(
   request: {
     id: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<PairingStatusRes> {
   const { data: json } = await client.request<JsonOf<PairingStatusRes>>({
     url: uri`/employee-mobile/public/pairings/${request.id}/status`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -37,11 +40,13 @@ export async function getPairingStatus(
 export async function postPairingChallenge(
   request: {
     body: PostPairingChallengeReq
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<Pairing> {
   const { data: json } = await client.request<JsonOf<Pairing>>({
     url: uri`/employee-mobile/public/pairings/challenge`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<PostPairingChallengeReq>
   })
   return deserializeJsonPairing(json)

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/reservations.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/reservations.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { AxiosHeaders } from 'axios'
 import { ConfirmedRangeDate } from 'lib-common/generated/api-types/reservations'
 import { ConfirmedRangeDateUpdate } from 'lib-common/generated/api-types/reservations'
 import { DailyChildReservationResult } from 'lib-common/generated/api-types/reservations'
@@ -27,7 +28,8 @@ export async function getChildReservationsForDay(
   request: {
     unitId: UUID,
     examinationDate: LocalDate
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DailyChildReservationResult> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId],
@@ -36,6 +38,7 @@ export async function getChildReservationsForDay(
   const { data: json } = await client.request<JsonOf<DailyChildReservationResult>>({
     url: uri`/employee-mobile/attendance-reservations/confirmed-days/daily`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return deserializeJsonDailyChildReservationResult(json)
@@ -48,11 +51,13 @@ export async function getChildReservationsForDay(
 export async function getConfirmedRangeData(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ConfirmedRangeDate[]> {
   const { data: json } = await client.request<JsonOf<ConfirmedRangeDate[]>>({
     url: uri`/employee-mobile/attendance-reservations/by-child/${request.childId}/confirmed-range`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json.map(e => deserializeJsonConfirmedRangeDate(e))
 }
@@ -64,7 +69,8 @@ export async function getConfirmedRangeData(
 export async function getReservationStatisticsForConfirmedDays(
   request: {
     unitId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<DayReservationStatisticsResult[]> {
   const params = createUrlSearchParams(
     ['unitId', request.unitId]
@@ -72,6 +78,7 @@ export async function getReservationStatisticsForConfirmedDays(
   const { data: json } = await client.request<JsonOf<DayReservationStatisticsResult[]>>({
     url: uri`/employee-mobile/attendance-reservations/confirmed-days/stats`.toString(),
     method: 'GET',
+    headers,
     params
   })
   return json.map(e => deserializeJsonDayReservationStatisticsResult(e))
@@ -85,11 +92,13 @@ export async function setConfirmedRangeReservations(
   request: {
     childId: UUID,
     body: ConfirmedRangeDateUpdate[]
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/attendance-reservations/by-child/${request.childId}/confirmed-range`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<ConfirmedRangeDateUpdate[]>
   })
   return json

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/sensitive.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/sensitive.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { ChildBasicInformation } from 'lib-common/generated/api-types/sensitive'
 import { ChildSensitiveInformation } from 'lib-common/generated/api-types/sensitive'
 import { JsonOf } from 'lib-common/json'
@@ -19,11 +20,13 @@ import { uri } from 'lib-common/uri'
 export async function getBasicInfo(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildBasicInformation> {
   const { data: json } = await client.request<JsonOf<ChildBasicInformation>>({
     url: uri`/employee-mobile/children/${request.childId}/basic-info`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonChildBasicInformation(json)
 }
@@ -35,11 +38,13 @@ export async function getBasicInfo(
 export async function getSensitiveInfo(
   request: {
     childId: UUID
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<ChildSensitiveInformation> {
   const { data: json } = await client.request<JsonOf<ChildSensitiveInformation>>({
     url: uri`/employee-mobile/children/${request.childId}/sensitive-info`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/systemnotifications.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/systemnotifications.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { CurrentNotificationResponse } from 'lib-common/generated/api-types/systemnotifications'
 import { JsonOf } from 'lib-common/json'
 import { client } from '../../client'
@@ -14,10 +15,13 @@ import { uri } from 'lib-common/uri'
 /**
 * Generated from fi.espoo.evaka.systemnotifications.SystemNotificationsController.getCurrentSystemNotificationEmployeeMobile
 */
-export async function getCurrentSystemNotificationEmployeeMobile(): Promise<CurrentNotificationResponse> {
+export async function getCurrentSystemNotificationEmployeeMobile(
+  headers?: AxiosHeaders
+): Promise<CurrentNotificationResponse> {
   const { data: json } = await client.request<JsonOf<CurrentNotificationResponse>>({
     url: uri`/employee-mobile/system-notifications/current`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return deserializeJsonCurrentNotificationResponse(json)
 }

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/webpush.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/webpush.ts
@@ -4,6 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AxiosHeaders } from 'axios'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { PushSettings } from 'lib-common/generated/api-types/webpush'
@@ -15,10 +16,13 @@ import { uri } from 'lib-common/uri'
 /**
 * Generated from fi.espoo.evaka.webpush.WebPushController.getPushSettings
 */
-export async function getPushSettings(): Promise<PushSettings> {
+export async function getPushSettings(
+  headers?: AxiosHeaders
+): Promise<PushSettings> {
   const { data: json } = await client.request<JsonOf<PushSettings>>({
     url: uri`/employee-mobile/push-settings`.toString(),
-    method: 'GET'
+    method: 'GET',
+    headers
   })
   return json
 }
@@ -30,11 +34,13 @@ export async function getPushSettings(): Promise<PushSettings> {
 export async function setPushSettings(
   request: {
     body: PushSettings
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/push-settings`.toString(),
     method: 'PUT',
+    headers,
     data: request.body satisfies JsonCompatible<PushSettings>
   })
   return json
@@ -47,11 +53,13 @@ export async function setPushSettings(
 export async function upsertPushSubscription(
   request: {
     body: WebPushSubscription
-  }
+  },
+  headers?: AxiosHeaders
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee-mobile/push-subscription`.toString(),
     method: 'POST',
+    headers,
     data: request.body satisfies JsonCompatible<WebPushSubscription>
   })
   return json

--- a/service/codegen/src/main/kotlin/evaka/codegen/Codegen.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/Codegen.kt
@@ -83,6 +83,7 @@ private fun locateFrontendSrcDirectory(): Path {
 
 private fun absolutePath(srcPath: Path, file: TsFile): Path =
     when (file.project) {
+        TsProject.NodeModules -> file.path
         TsProject.LibCommon -> srcPath / "lib-common" / file.path
         TsProject.CitizenFrontend -> srcPath / "citizen-frontend" / file.path
         TsProject.EmployeeFrontend -> srcPath / "employee-frontend" / file.path

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/TsCode.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/TsCode.kt
@@ -9,6 +9,7 @@ import kotlin.io.path.div
 import kotlin.io.path.relativeTo
 
 enum class TsProject {
+    NodeModules,
     LibCommon,
     CitizenFrontend,
     EmployeeFrontend,
@@ -19,6 +20,7 @@ enum class TsProject {
 
     fun absoluteImportPath(path: Path): Path =
         when (this) {
+            NodeModules -> path
             LibCommon -> Path.of("lib-common") / path
             CitizenFrontend -> Path.of("citizen-frontend") / path
             EmployeeFrontend -> Path.of("employee-frontend") / path
@@ -31,6 +33,7 @@ enum class TsProject {
 data class TsFile(val project: TsProject, val path: Path) {
     fun importFrom(other: TsFile): String =
         when {
+                this.project == TsProject.NodeModules -> path.toString()
                 this.project == other.project ->
                     path.relativeTo(other.path.parent).let {
                         if (it.fileName == it) Path.of("./$it") else it


### PR DESCRIPTION
Toistaiseksi lähinnä dev-apia varten jotta voidaan halutessa antaa mocked time, mutta mahdollistaa muidenkin headerien lisäykset. Iso diff johtuu clientien uudelleen generoinnista (commit 2).