### PR TITLE
Korjaus läsnäolon näkyvyyteen mobiilissa

### DIFF
--- a/frontend/src/e2e-test/specs/6_mobile/reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/reservations.spec.ts
@@ -230,7 +230,11 @@ describe('when child is in preschool only', () => {
   })
 
   test('absence can be removed from fixed schedule day', async () => {
-    await Fixture.absence({ childId: child.id, date: mockedTomorrow }).save()
+    await Fixture.absence({
+      childId: child.id,
+      date: mockedTomorrow,
+      absenceCategory: 'NONBILLABLE'
+    }).save()
 
     const page = await loginToMobile(mockedToday, unit.id)
     const reservationsPage = await navigateToReservations(page, child.id)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/AttendanceReservationsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/AttendanceReservationsControllerIntegrationTest.kt
@@ -862,6 +862,23 @@ class AttendanceReservationsControllerIntegrationTest :
                         unitId = testDaycare.id,
                         startDate = mon,
                         endDate = fri,
+                        type = PlacementType.PRESCHOOL_DAYCARE,
+                    )
+                )
+                tx.insert(
+                    DevReservation(
+                        childId = testChild_1.id,
+                        date = tue,
+                        startTime = LocalTime.of(9, 0),
+                        endTime = LocalTime.of(11, 0),
+                        createdBy = EvakaUserId(employeeId.raw),
+                    )
+                )
+                tx.insert(
+                    DevAbsence(
+                        childId = testChild_1.id,
+                        date = tue,
+                        absenceCategory = AbsenceCategory.BILLABLE,
                     )
                 )
                 tx.insert(DevMobileDevice(unitId = testDaycare.id))
@@ -878,7 +895,13 @@ class AttendanceReservationsControllerIntegrationTest :
                 ConfirmedRangeDate(
                     date = tue,
                     scheduleType = ScheduleType.RESERVATION_REQUIRED,
-                    reservations = emptyList(),
+                    reservations =
+                        listOf(
+                            ReservationResponse.Times(
+                                TimeRange(LocalTime.of(9, 0), LocalTime.of(11, 0)),
+                                true,
+                            )
+                        ),
                     absenceType = null,
                     dailyServiceTimes = null,
                 ),

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -367,17 +367,23 @@ class AttendanceReservationController(
                                     FiniteDateRange(it.startDate, it.endDate).includes(date)
                                 } ?: return@mapNotNull null
                             val reservationTimes = reservations[date] ?: emptyList()
-                            val absence = absences.firstOrNull { it.date == date }
+                            val daysAbsences = absences.filter { it.date == date }
                             val dailyServiceTime =
                                 dailyServiceTimes.firstOrNull {
                                     it.times.validityPeriod.includes(date)
                                 }
+                            val absenceCategories = placement.type.absenceCategories()
+                            val isFullDayAbsent =
+                                daysAbsences.map { it.category }.toSet() == absenceCategories
+
                             ConfirmedRangeDate(
                                 date = date,
                                 scheduleType =
                                     placement.type.scheduleType(date, clubTerms, preschoolTerms),
                                 reservations = reservationTimes,
-                                absenceType = absence?.absenceType,
+                                absenceType =
+                                    if (isFullDayAbsent) daysAbsences.firstOrNull()?.absenceType
+                                    else null,
                                 dailyServiceTimes = dailyServiceTime?.times,
                             )
                         }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/AttendanceReservationController.kt
@@ -382,7 +382,11 @@ class AttendanceReservationController(
                                     placement.type.scheduleType(date, clubTerms, preschoolTerms),
                                 reservations = reservationTimes,
                                 absenceType =
-                                    if (isFullDayAbsent) daysAbsences.firstOrNull()?.absenceType
+                                    if (isFullDayAbsent)
+                                        (daysAbsences.firstOrNull {
+                                                it.category == AbsenceCategory.BILLABLE
+                                            } ?: absences.firstOrNull())
+                                            ?.absenceType
                                     else null,
                                 dailyServiceTimes = dailyServiceTime?.times,
                             )


### PR DESCRIPTION
Kun lapselle, jolla on esiopetus + täydentävä vaka -sijoitus, ilmoitetaan läsnäoloajaksi kokonaan esiopetuksen ajalle sijoittuva aikaväli, näkyi tämä "Tulevat varaukset ja poissaolot"-sivulla virheellisesti poissaolona. Korjauksen jälkeen kyseinen tapaus näytetään oikein, ja näkyvillä on ilmoitettu läsnäolon aikaväli.