### PR TITLE
Generoidaan vahvat ID-tyypit fronttiin

### DIFF
--- a/frontend/src/citizen-frontend/applications/ChildApplicationsBlock.tsx
+++ b/frontend/src/citizen-frontend/applications/ChildApplicationsBlock.tsx
@@ -12,6 +12,7 @@ import {
   ApplicationsOfChild,
   ApplicationStatus
 } from 'lib-common/generated/api-types/application'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { useMutation } from 'lib-common/query'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
@@ -104,7 +105,7 @@ export default React.memo(function ChildApplicationsBlock({
   )
 
   const onDeleteApplication = (
-    applicationId: string,
+    applicationId: ApplicationId,
     applicationStatus: ApplicationStatus
   ) => {
     setInfoMessage({

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationEditor.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationEditor.tsx
@@ -18,9 +18,10 @@ import {
   ApplicationDetails as ApplicationDetailsGen,
   CitizenChildren
 } from 'lib-common/generated/api-types/application'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useMutation, useQuery, useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { scrollToTop } from 'lib-common/utils/scrolling'
 import Main from 'lib-components/atoms/Main'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -470,7 +471,7 @@ const ApplicationEditorContent = React.memo(function DaycareApplicationEditor({
 })
 
 export default React.memo(function ApplicationEditor() {
-  const { applicationId } = useRouteParams(['applicationId'])
+  const applicationId = useIdRouteParam<ApplicationId>('applicationId')
   const t = useTranslation()
   const application = useQueryResult(applicationQuery({ applicationId }))
   const children = useQueryResult(applicationChildrenQuery())

--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -5,10 +5,13 @@
 import React from 'react'
 
 import { Result, wrapResult } from 'lib-common/api'
+import {
+  ApplicationId,
+  AttachmentId
+} from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useUniqueId } from 'lib-common/utils/useUniqueId'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
@@ -44,7 +47,7 @@ export default React.memo(function PreferredStartSubSection({
   verificationRequested,
   terms
 }: ServiceNeedSectionProps) {
-  const { applicationId } = useRouteParams(['applicationId'])
+  const applicationId = useIdRouteParam<ApplicationId>('applicationId')
   const t = useTranslation()
   const [lang] = useLang()
   const labelId = useUniqueId()
@@ -52,7 +55,7 @@ export default React.memo(function PreferredStartSubSection({
   const uploadUrgencyAttachment = (
     file: File,
     onUploadProgress: (percentage: number) => void
-  ): Promise<Result<UUID>> =>
+  ): Promise<Result<AttachmentId>> =>
     saveApplicationAttachment(
       applicationId,
       file,
@@ -79,7 +82,7 @@ export default React.memo(function PreferredStartSubSection({
       return result
     })
 
-  const deleteUrgencyAttachment = (id: UUID) =>
+  const deleteUrgencyAttachment = (id: AttachmentId) =>
     deleteAttachmentResult({ attachmentId: id }).then((result) => {
       if (result.isSuccess) {
         updateFormData({

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -7,9 +7,12 @@ import styled from 'styled-components'
 
 import { Result, wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
+import {
+  ApplicationId,
+  AttachmentId
+} from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import Radio from 'lib-components/atoms/form/Radio'
 import TimeInput from 'lib-components/atoms/form/TimeInput'
@@ -54,7 +57,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
 }: ServiceTimeSubSectionProps) {
   const [lang] = useLang()
   const t = useTranslation()
-  const { applicationId } = useRouteParams(['applicationId'])
+  const applicationId = useIdRouteParam<ApplicationId>('applicationId')
 
   const preferredStartDate = formData.preferredStartDate
   const optionsValidAtTime = useMemo(
@@ -119,7 +122,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
   const uploadExtendedCareAttachment = (
     file: File,
     onUploadProgress: (percentage: number) => void
-  ): Promise<Result<UUID>> =>
+  ): Promise<Result<AttachmentId>> =>
     saveApplicationAttachment(
       applicationId,
       file,
@@ -146,7 +149,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
       return result
     })
 
-  const deleteExtendedCareAttachment = (id: UUID) =>
+  const deleteExtendedCareAttachment = (id: AttachmentId) =>
     deleteAttachmentResult({ attachmentId: id }).then((result) => {
       if (result.isSuccess) {
         updateFormData({

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -9,10 +9,13 @@ import { Result, wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import { ServiceNeedOptionPublicInfo } from 'lib-common/generated/api-types/serviceneed'
+import {
+  ApplicationId,
+  AttachmentId
+} from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useUniqueId } from 'lib-common/utils/useUniqueId'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import Radio from 'lib-components/atoms/form/Radio'
@@ -63,7 +66,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
 }: ServiceTimeSubSectionProps) {
   const [lang] = useLang()
   const t = useTranslation()
-  const { applicationId } = useRouteParams(['applicationId'])
+  const applicationId = useIdRouteParam<ApplicationId>('applicationId')
   const labelId = useUniqueId()
 
   const serviceNeedOptionsByType = useMemo(
@@ -84,7 +87,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
   const uploadExtendedCareAttachment = (
     file: File,
     onUploadProgress: (percentage: number) => void
-  ): Promise<Result<UUID>> =>
+  ): Promise<Result<AttachmentId>> =>
     saveApplicationAttachment(
       applicationId,
       file,
@@ -111,7 +114,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
       return result
     })
 
-  const deleteExtendedCareAttachment = (id: UUID) =>
+  const deleteExtendedCareAttachment = (id: AttachmentId) =>
     deleteAttachmentResult({ attachmentId: id }).then((result) => {
       if (result.isSuccess) {
         updateFormData({

--- a/frontend/src/citizen-frontend/applications/read-view/ApplicationReadView.tsx
+++ b/frontend/src/citizen-frontend/applications/read-view/ApplicationReadView.tsx
@@ -6,8 +6,9 @@ import React from 'react'
 
 import { combine } from 'lib-common/api'
 import { apiDataToFormData } from 'lib-common/api-types/application/ApplicationFormData'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Container from 'lib-components/layout/Container'
 
 import Footer from '../../Footer'
@@ -18,7 +19,7 @@ import useTitle from '../../useTitle'
 import { applicationChildrenQuery, applicationQuery } from '../queries'
 
 export default React.memo(function ApplicationReadView() {
-  const { applicationId } = useRouteParams(['applicationId'])
+  const applicationId = useIdRouteParam<ApplicationId>('applicationId')
   const t = useTranslation()
   const application = useQueryResult(applicationQuery({ applicationId }))
   const children = useQueryResult(applicationChildrenQuery())

--- a/frontend/src/citizen-frontend/attachments.ts
+++ b/frontend/src/citizen-frontend/attachments.ts
@@ -4,6 +4,10 @@
 
 import { Failure, Result, Success } from 'lib-common/api'
 import { AttachmentType } from 'lib-common/generated/api-types/attachment'
+import {
+  ApplicationId,
+  AttachmentId
+} from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 
 import { API_URL, client } from './api-client'
@@ -12,12 +16,12 @@ async function doSaveAttachment(
   url: string,
   file: File,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> {
+): Promise<Result<AttachmentId>> {
   const formData = new FormData()
   formData.append('file', file)
 
   try {
-    const { data } = await client.post<string>(url, formData, {
+    const { data } = await client.post<AttachmentId>(url, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
       onUploadProgress: ({ loaded, total }) =>
         onUploadProgress(
@@ -36,7 +40,7 @@ export async function saveIncomeStatementAttachment(
   incomeStatementId: UUID | undefined,
   file: File,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> {
+): Promise<Result<AttachmentId>> {
   return doSaveAttachment(
     incomeStatementId
       ? `/citizen/attachments/income-statements/${incomeStatementId}`
@@ -49,7 +53,7 @@ export async function saveIncomeStatementAttachment(
 export async function saveMessageAttachment(
   file: File,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> {
+): Promise<Result<AttachmentId>> {
   return doSaveAttachment(
     '/citizen/attachments/messages',
     file,
@@ -58,11 +62,11 @@ export async function saveMessageAttachment(
 }
 
 export async function saveApplicationAttachment(
-  applicationId: UUID,
+  applicationId: ApplicationId,
   file: File,
   attachmentType: AttachmentType,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> {
+): Promise<Result<AttachmentId>> {
   return doSaveAttachment(
     `/citizen/attachments/applications/${applicationId}?type=${attachmentType}`,
     file,

--- a/frontend/src/citizen-frontend/calendar/DailyServiceTimeNotifications.tsx
+++ b/frontend/src/citizen-frontend/calendar/DailyServiceTimeNotifications.tsx
@@ -5,8 +5,8 @@
 import React, { useEffect, useState } from 'react'
 
 import { useTranslation } from 'citizen-frontend/localization'
+import { DailyServiceTimeNotificationId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { faExclamation } from 'lib-icons'
 
@@ -23,7 +23,9 @@ export default React.memo(function DailyServiceTimeNotification() {
 
   const notifications = dailyServiceTimeNotifications.getOrElse([])
 
-  const [notificationIds, setNotificationIds] = useState<UUID[]>([])
+  const [notificationIds, setNotificationIds] = useState<
+    DailyServiceTimeNotificationId[]
+  >([])
 
   useEffect(() => {
     if (notifications.length === 0) return

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -39,6 +39,7 @@ import {
   ReservationsResponse,
   UsedServiceResult
 } from 'lib-common/generated/api-types/reservations'
+import { CalendarEventTimeId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatFirstName } from 'lib-common/names'
 import { reservationHasTimes } from 'lib-common/reservations'
@@ -374,7 +375,7 @@ const DayModal = React.memo(function DayModal({
       eventTimeId: null
     })
   const onCancelClick = useCallback(
-    (childId: UUID, eventTimeId: UUID) => {
+    (childId: UUID, eventTimeId: CalendarEventTimeId) => {
       setConfirmationModalState({ visible: true, childId, eventTimeId })
     },
     [setConfirmationModalState]

--- a/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionReservationModal.tsx
@@ -19,6 +19,7 @@ import {
   CitizenCalendarEvent
 } from 'lib-common/generated/api-types/calendarevent'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
+import { CalendarEventTimeId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatFirstName } from 'lib-common/names'
 import { capitalizeFirstLetter } from 'lib-common/string'
@@ -64,11 +65,11 @@ import { showModalEventTime } from './discussion-survey'
 const discussionTimeReservationForm = mapped(
   object({
     selectedChild: required(value<UUID | undefined>()),
-    eventTimeId: required(value<UUID | null>())
+    eventTimeId: required(value<CalendarEventTimeId | undefined>())
   }),
   (output): CalendarEventTimeCitizenReservationForm => ({
     childId: output.selectedChild,
-    calendarEventTimeId: output.eventTimeId ?? ''
+    calendarEventTimeId: output.eventTimeId
   })
 )
 
@@ -77,7 +78,7 @@ function initialFormState(
 ): StateOf<typeof discussionTimeReservationForm> {
   return {
     selectedChild: selectedChild?.id,
-    eventTimeId: null
+    eventTimeId: undefined
   }
 }
 
@@ -268,7 +269,7 @@ export default React.memo(function DiscussionReservationModal({
               <MutateButton
                 primary
                 text={i18n.common.confirm}
-                disabled={eventTimeId.state === null}
+                disabled={eventTimeId.state === undefined}
                 mutation={addCalendarEventTimeReservationMutation}
                 onClick={() => {
                   if (!form.isValid()) {
@@ -282,7 +283,7 @@ export default React.memo(function DiscussionReservationModal({
                   setTimeAlreadyReserved(
                     failure.errorCode === 'TIME_ALREADY_RESERVED'
                   )
-                  eventTimeId.set(null)
+                  eventTimeId.set(undefined)
                   invalidateEvents()
                 }}
               />
@@ -301,7 +302,7 @@ export default React.memo(function DiscussionReservationModal({
 
 interface ReservationGridItemProps {
   itemData: CalendarEventTime
-  bind: BoundFormState<string>
+  bind: BoundFormState<CalendarEventTimeId>
   showDate: boolean
 }
 

--- a/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
@@ -11,6 +11,7 @@ import {
   CitizenCalendarEventTime
 } from 'lib-common/generated/api-types/calendarevent'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
+import { CalendarEventTimeId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatFirstName } from 'lib-common/names'
 import { UUID } from 'lib-common/types'
@@ -71,7 +72,7 @@ export const DiscussionHeader = styled.div`
 export interface ConfirmModalState {
   visible: boolean
   childId: UUID | null
-  eventTimeId: UUID | null
+  eventTimeId: CalendarEventTimeId | null
 }
 export default React.memo(function DiscussionSurveyModal({
   close,
@@ -115,7 +116,7 @@ export default React.memo(function DiscussionSurveyModal({
       eventTimeId: null
     })
   const onCancelClick = useCallback(
-    (childId: UUID, eventTimeId: UUID) => {
+    (childId: UUID, eventTimeId: CalendarEventTimeId) => {
       setConfirmationModalState({ visible: true, childId, eventTimeId })
     },
     [setConfirmationModalState]
@@ -238,7 +239,7 @@ export default React.memo(function DiscussionSurveyModal({
 
 interface DiscussionChildElementProps {
   childWithSurveys: ChildWithSurveys
-  onCancelClick: (childId: UUID, eventTimeId: UUID) => void
+  onCancelClick: (childId: UUID, eventTimeId: CalendarEventTimeId) => void
   openDiscussionReservations: (
     selectedChildId: UUID,
     selectedEventId: UUID
@@ -286,7 +287,7 @@ interface ChildSurveyElementProps {
   reservations: CitizenCalendarEventTime[]
   childId: UUID
   openDiscussionReservations: () => void
-  onCancelClick: (childId: UUID, eventTimeId: UUID) => void
+  onCancelClick: (childId: UUID, eventTimeId: CalendarEventTimeId) => void
 }
 const ChildSurveyElement = React.memo(function ChildSurveyElement({
   survey,

--- a/frontend/src/citizen-frontend/child-documents/ChildDocumentPage.tsx
+++ b/frontend/src/citizen-frontend/child-documents/ChildDocumentPage.tsx
@@ -13,8 +13,9 @@ import {
   ChildDocumentCitizenDetails,
   ChildDocumentDetails
 } from 'lib-common/generated/api-types/document'
+import { ChildDocumentId } from 'lib-common/generated/api-types/shared'
 import { useMutation, useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { tabletMin } from 'lib-components/breakpoints'
@@ -51,7 +52,7 @@ const TopButtonRow = styled(FixedSpaceRow)`
 `
 
 export default React.memo(function ChildDocumentPage() {
-  const { id } = useRouteParams(['id'])
+  const id = useIdRouteParam<ChildDocumentId>('id')
 
   const childDocument = useQueryResult(
     childDocumentDetailsQuery({ documentId: id })

--- a/frontend/src/citizen-frontend/children/sections/placement-termination/utils.spec.ts
+++ b/frontend/src/citizen-frontend/children/sections/placement-termination/utils.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { TerminatablePlacementGroup } from 'lib-common/generated/api-types/placement'
+import { fromUuid } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import { terminatedPlacementInfo } from './utils'
@@ -11,7 +12,7 @@ describe('Terminated placement info', () => {
   it('terminated daycare placement', () => {
     const data: TerminatablePlacementGroup = {
       type: 'DAYCARE',
-      unitId: 'b53d80e0-319b-4d2b-950c-f5c3c9f834bc',
+      unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
       unitName: 'Alkuräjähdyksen eskari',
       startDate: LocalDate.of(2021, 1, 1),
       endDate: LocalDate.of(2021, 1, 31),
@@ -21,7 +22,7 @@ describe('Terminated placement info', () => {
           id: 'd4e1cf34-72d5-4fad-b40c-5b1b4cb36883',
           type: 'DAYCARE',
           childId: '5a4f3ccc-5270-4d28-bd93-d355182b6768',
-          unitId: 'b53d80e0-319b-4d2b-950c-f5c3c9f834bc',
+          unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
           unitName: 'Alkuräjähdyksen eskari',
           startDate: LocalDate.of(2021, 1, 1),
           endDate: LocalDate.of(2021, 1, 31),
@@ -47,7 +48,7 @@ describe('Terminated placement info', () => {
   it('terminated additional connected daycare placement', () => {
     const data: TerminatablePlacementGroup = {
       type: 'PRESCHOOL',
-      unitId: 'b53d80e0-319b-4d2b-950c-f5c3c9f834bc',
+      unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
       unitName: 'Alkuräjähdyksen eskari',
       terminatable: true,
       startDate: LocalDate.of(2022, 1, 1),
@@ -57,7 +58,7 @@ describe('Terminated placement info', () => {
           id: 'd4e1cf34-72d5-4fad-b40c-5b1b4cb36883',
           type: 'PRESCHOOL_DAYCARE',
           childId: '5a4f3ccc-5270-4d28-bd93-d355182b6768',
-          unitId: 'b53d80e0-319b-4d2b-950c-f5c3c9f834bc',
+          unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
           unitName: 'Alkuräjähdyksen eskari',
           startDate: LocalDate.of(2022, 1, 1),
           endDate: LocalDate.of(2022, 6, 1),
@@ -71,7 +72,7 @@ describe('Terminated placement info', () => {
           id: '08e9e908-03d2-48a2-9634-5468b2165945',
           type: 'DAYCARE',
           childId: '5a4f3ccc-5270-4d28-bd93-d355182b6768',
-          unitId: 'b53d80e0-319b-4d2b-950c-f5c3c9f834bc',
+          unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
           unitName: 'Alkuräjähdyksen eskari',
           startDate: LocalDate.of(2022, 2, 2),
           endDate: LocalDate.of(2022, 11, 1),
@@ -96,7 +97,7 @@ describe('Terminated placement info', () => {
   it('terminated connected daycare before preschool placement', () => {
     const data: TerminatablePlacementGroup = {
       type: 'PRESCHOOL',
-      unitId: 'b53d80e0-319b-4d2b-950c-f5c3c9f834bc',
+      unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
       unitName: 'Alkuräjähdyksen eskari',
       startDate: LocalDate.of(2022, 1, 1),
       endDate: LocalDate.of(2022, 2, 28),
@@ -106,7 +107,7 @@ describe('Terminated placement info', () => {
           id: '8920e598-8b3a-11ed-bf51-4f02a3804b0b',
           type: 'PRESCHOOL_DAYCARE',
           childId: '5a4f3ccc-5270-4d28-bd93-d355182b6768',
-          unitId: 'b53d80e0-319b-4d2b-950c-f5c3c9f834bc',
+          unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
           unitName: 'Alkuräjähdyksen eskari',
           startDate: LocalDate.of(2022, 1, 1),
           endDate: LocalDate.of(2022, 2, 10),
@@ -122,7 +123,7 @@ describe('Terminated placement info', () => {
           id: '94e520b0-8b3a-11ed-b202-df238eb02b71',
           type: 'PRESCHOOL',
           childId: '5a4f3ccc-5270-4d28-bd93-d355182b6768',
-          unitId: 'b53d80e0-319b-4d2b-950c-f5c3c9f834bc',
+          unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
           unitName: 'Alkuräjähdyksen eskari',
           startDate: LocalDate.of(2022, 2, 11),
           endDate: LocalDate.of(2022, 2, 28),

--- a/frontend/src/citizen-frontend/children/sections/service-need-and-daily-service-time/NewServiceApplicationPage.tsx
+++ b/frontend/src/citizen-frontend/children/sections/service-need-and-daily-service-time/NewServiceApplicationPage.tsx
@@ -15,9 +15,9 @@ import {
 } from 'lib-common/form/form'
 import { useForm, useFormFields } from 'lib-common/form/hooks'
 import { ValidationError, ValidationSuccess } from 'lib-common/form/types'
+import { ServiceNeedOptionId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { constantQuery, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import useRouteParams from 'lib-common/useRouteParams'
 import Main from 'lib-components/atoms/Main'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -47,7 +47,7 @@ import {
 const form = transformed(
   object({
     startDate: required(localDate()),
-    serviceNeed: required(oneOf<UUID>()),
+    serviceNeed: required(oneOf<ServiceNeedOptionId>()),
     additionalInfo: value<string>()
   }),
   (res) => {

--- a/frontend/src/citizen-frontend/decisions/assistance-decision-page/AssistanceDecisionPage.tsx
+++ b/frontend/src/citizen-frontend/decisions/assistance-decision-page/AssistanceDecisionPage.tsx
@@ -9,8 +9,9 @@ import { renderResult } from 'citizen-frontend/async-rendering'
 import { useTranslation } from 'citizen-frontend/localization'
 import { LocalizationContext } from 'citizen-frontend/localization/state'
 import { AssistanceNeedDecision } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import AssistanceNeedDecisionReadOnly from 'lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly'
 import LegacyInlineButton from 'lib-components/atoms/buttons/LegacyInlineButton'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
@@ -28,7 +29,7 @@ import {
 } from './queries'
 
 export default React.memo(function AssistanceNeedDecisionPage() {
-  const { id } = useRouteParams(['id'])
+  const id = useIdRouteParam<AssistanceNeedDecisionId>('id')
 
   const assistanceNeedDecision = useQueryResult(assistanceDecisionQuery({ id }))
   const i18n = useTranslation()

--- a/frontend/src/citizen-frontend/decisions/assistance-decision-page/AssistancePreschoolDecisionPage.tsx
+++ b/frontend/src/citizen-frontend/decisions/assistance-decision-page/AssistancePreschoolDecisionPage.tsx
@@ -7,8 +7,9 @@ import React, { useEffect } from 'react'
 import Footer from 'citizen-frontend/Footer'
 import { renderResult } from 'citizen-frontend/async-rendering'
 import { useTranslation } from 'citizen-frontend/localization'
+import { AssistanceNeedPreschoolDecisionId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import AssistanceNeedPreschoolDecisionReadOnly from 'lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly'
 import LegacyInlineButton from 'lib-components/atoms/buttons/LegacyInlineButton'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
@@ -27,7 +28,7 @@ import {
 } from './queries-preschool'
 
 export default React.memo(function AssistanceNeedPreschoolDecisionPage() {
-  const { id } = useRouteParams(['id'])
+  const id = useIdRouteParam<AssistanceNeedPreschoolDecisionId>('id')
 
   const decision = useQueryResult(assistanceNeedPreschoolDecisionQuery({ id }))
   const i18n = useTranslation()

--- a/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponseList.tsx
+++ b/frontend/src/citizen-frontend/decisions/decision-response-page/DecisionResponseList.tsx
@@ -7,8 +7,9 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { DecisionWithValidStartDatePeriod } from 'lib-common/generated/api-types/application'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Main from 'lib-components/atoms/Main'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -28,7 +29,7 @@ import { decisionsOfApplicationQuery } from '../queries'
 import DecisionResponse from './DecisionResponse'
 
 export default React.memo(function DecisionResponseList() {
-  const { applicationId } = useRouteParams(['applicationId'])
+  const applicationId = useIdRouteParam<ApplicationId>('applicationId')
   const t = useTranslation()
   const navigate = useNavigate()
 

--- a/frontend/src/citizen-frontend/generated/api-clients/application.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/application.ts
@@ -8,6 +8,7 @@ import { AcceptDecisionRequest } from 'lib-common/generated/api-types/applicatio
 import { ApplicationDecisions } from 'lib-common/generated/api-types/application'
 import { ApplicationDetails } from 'lib-common/generated/api-types/application'
 import { ApplicationFormUpdate } from 'lib-common/generated/api-types/application'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { ApplicationType } from 'lib-common/generated/api-types/application'
 import { ApplicationsOfChild } from 'lib-common/generated/api-types/application'
 import { CitizenApplicationUpdate } from 'lib-common/generated/api-types/application'
@@ -17,8 +18,8 @@ import { DecisionWithValidStartDatePeriod } from 'lib-common/generated/api-types
 import { FinanceDecisionCitizenInfo } from 'lib-common/generated/api-types/application'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { RejectDecisionRequest } from 'lib-common/generated/api-types/application'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api-client'
 import { deserializeJsonApplicationDecisions } from 'lib-common/generated/api-types/application'
 import { deserializeJsonApplicationDetails } from 'lib-common/generated/api-types/application'
@@ -34,7 +35,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function acceptDecision(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: AcceptDecisionRequest
   }
 ): Promise<void> {
@@ -54,8 +55,8 @@ export async function createApplication(
   request: {
     body: CreateApplicationBody
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<ApplicationId> {
+  const { data: json } = await client.request<JsonOf<ApplicationId>>({
     url: uri`/citizen/applications`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<CreateApplicationBody>
@@ -69,7 +70,7 @@ export async function createApplication(
 */
 export async function deleteOrCancelUnprocessedApplication(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -85,7 +86,7 @@ export async function deleteOrCancelUnprocessedApplication(
 */
 export async function getApplication(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<ApplicationDetails> {
   const { data: json } = await client.request<JsonOf<ApplicationDetails>>({
@@ -113,7 +114,7 @@ export async function getApplicationChildren(): Promise<CitizenChildren[]> {
 */
 export async function getApplicationDecisions(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<DecisionWithValidStartDatePeriod[]> {
   const { data: json } = await client.request<JsonOf<DecisionWithValidStartDatePeriod[]>>({
@@ -129,7 +130,7 @@ export async function getApplicationDecisions(
 */
 export async function getChildDuplicateApplications(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<Partial<Record<ApplicationType, boolean>>> {
   const { data: json } = await client.request<JsonOf<Partial<Record<ApplicationType, boolean>>>>({
@@ -145,7 +146,7 @@ export async function getChildDuplicateApplications(
 */
 export async function getChildPlacementStatusByApplicationType(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<Partial<Record<ApplicationType, boolean>>> {
   const { data: json } = await client.request<JsonOf<Partial<Record<ApplicationType, boolean>>>>({
@@ -209,7 +210,7 @@ export async function getLiableCitizenFinanceDecisions(): Promise<FinanceDecisio
 */
 export async function rejectDecision(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: RejectDecisionRequest
   }
 ): Promise<void> {
@@ -227,7 +228,7 @@ export async function rejectDecision(
 */
 export async function saveApplicationAsDraft(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: ApplicationFormUpdate
   }
 ): Promise<void> {
@@ -245,7 +246,7 @@ export async function saveApplicationAsDraft(
 */
 export async function sendApplication(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -261,7 +262,7 @@ export async function sendApplication(
 */
 export async function updateApplication(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: CitizenApplicationUpdate
   }
 ): Promise<void> {

--- a/frontend/src/citizen-frontend/generated/api-clients/assistanceneed.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/assistanceneed.ts
@@ -6,10 +6,11 @@
 
 import { AssistanceNeedDecision } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedDecisionCitizenListItem } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
 import { AssistanceNeedPreschoolDecision } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedPreschoolDecisionCitizenListItem } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedPreschoolDecisionId } from 'lib-common/generated/api-types/shared'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
 import { UnreadAssistanceNeedDecisionItem } from 'lib-common/generated/api-types/assistanceneed'
 import { client } from '../../api-client'
 import { deserializeJsonAssistanceNeedDecision } from 'lib-common/generated/api-types/assistanceneed'
@@ -24,7 +25,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getAssistanceNeedDecision(
   request: {
-    id: UUID
+    id: AssistanceNeedDecisionId
   }
 ): Promise<AssistanceNeedDecision> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedDecision>>({
@@ -64,7 +65,7 @@ export async function getAssistanceNeedDecisions(): Promise<AssistanceNeedDecisi
 */
 export async function markAssistanceNeedDecisionAsRead(
   request: {
-    id: UUID
+    id: AssistanceNeedDecisionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -80,7 +81,7 @@ export async function markAssistanceNeedDecisionAsRead(
 */
 export async function getAssistanceNeedPreschoolDecision(
   request: {
-    id: UUID
+    id: AssistanceNeedPreschoolDecisionId
   }
 ): Promise<AssistanceNeedPreschoolDecision> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedPreschoolDecision>>({
@@ -120,7 +121,7 @@ export async function getAssistanceNeedPreschoolDecisions(): Promise<AssistanceN
 */
 export async function markAssistanceNeedPreschoolDecisionAsRead(
   request: {
-    id: UUID
+    id: AssistanceNeedPreschoolDecisionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({

--- a/frontend/src/citizen-frontend/generated/api-clients/attachment.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/attachment.ts
@@ -4,8 +4,8 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api-client'
 import { uri } from 'lib-common/uri'
 
@@ -15,7 +15,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function deleteAttachment(
   request: {
-    attachmentId: UUID
+    attachmentId: AttachmentId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({

--- a/frontend/src/citizen-frontend/generated/api-clients/calendarevent.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/calendarevent.ts
@@ -5,7 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
-import { CalendarEventAttendeeId } from 'lib-common/generated/api-types/shared'
+import { CalendarEventId } from 'lib-common/generated/api-types/shared'
 import { CalendarEventTime } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeCitizenReservationForm } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeId } from 'lib-common/generated/api-types/shared'
@@ -86,7 +86,7 @@ export async function getCitizenCalendarEvents(
 */
 export async function getReservableCalendarEventTimes(
   request: {
-    eventId: CalendarEventAttendeeId,
+    eventId: CalendarEventId,
     childId: PersonId
   }
 ): Promise<CalendarEventTime[]> {

--- a/frontend/src/citizen-frontend/generated/api-clients/calendarevent.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/calendarevent.ts
@@ -5,12 +5,14 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { CalendarEventAttendeeId } from 'lib-common/generated/api-types/shared'
 import { CalendarEventTime } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeCitizenReservationForm } from 'lib-common/generated/api-types/calendarevent'
+import { CalendarEventTimeId } from 'lib-common/generated/api-types/shared'
 import { CitizenCalendarEvent } from 'lib-common/generated/api-types/calendarevent'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api-client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonCalendarEventTime } from 'lib-common/generated/api-types/calendarevent'
@@ -40,8 +42,8 @@ export async function addCalendarEventTimeReservation(
 */
 export async function deleteCalendarEventTimeReservation(
   request: {
-    calendarEventTimeId: UUID,
-    childId: UUID
+    calendarEventTimeId: CalendarEventTimeId,
+    childId: PersonId
   }
 ): Promise<void> {
   const params = createUrlSearchParams(
@@ -84,8 +86,8 @@ export async function getCitizenCalendarEvents(
 */
 export async function getReservableCalendarEventTimes(
   request: {
-    eventId: UUID,
-    childId: UUID
+    eventId: CalendarEventAttendeeId,
+    childId: PersonId
   }
 ): Promise<CalendarEventTime[]> {
   const params = createUrlSearchParams(

--- a/frontend/src/citizen-frontend/generated/api-clients/children.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/children.ts
@@ -9,8 +9,8 @@ import { AttendanceSummary } from 'lib-common/generated/api-types/children'
 import { ChildAndPermittedActions } from 'lib-common/generated/api-types/children'
 import { DailyServiceTimes } from 'lib-common/generated/api-types/dailyservicetimes'
 import { JsonOf } from 'lib-common/json'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { ServiceNeedSummary } from 'lib-common/generated/api-types/serviceneed'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api-client'
 import { deserializeJsonDailyServiceTimes } from 'lib-common/generated/api-types/dailyservicetimes'
 import { deserializeJsonServiceNeedSummary } from 'lib-common/generated/api-types/serviceneed'
@@ -22,7 +22,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getChildAttendanceSummary(
   request: {
-    childId: UUID,
+    childId: PersonId,
     yearMonth: YearMonth
   }
 ): Promise<AttendanceSummary> {
@@ -39,7 +39,7 @@ export async function getChildAttendanceSummary(
 */
 export async function getChildDailyServiceTimes(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<DailyServiceTimes[]> {
   const { data: json } = await client.request<JsonOf<DailyServiceTimes[]>>({
@@ -55,7 +55,7 @@ export async function getChildDailyServiceTimes(
 */
 export async function getChildServiceNeeds(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<ServiceNeedSummary[]> {
   const { data: json } = await client.request<JsonOf<ServiceNeedSummary[]>>({

--- a/frontend/src/citizen-frontend/generated/api-clients/dailyservicetimes.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/dailyservicetimes.ts
@@ -4,7 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
-import { DailyServicesTimeNotificationId } from 'lib-common/generated/api-types/shared'
+import { DailyServiceTimeNotificationId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { client } from '../../api-client'
@@ -16,13 +16,13 @@ import { uri } from 'lib-common/uri'
 */
 export async function dismissDailyServiceTimeNotification(
   request: {
-    body: DailyServicesTimeNotificationId[]
+    body: DailyServiceTimeNotificationId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/daily-service-time-notifications/dismiss`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<DailyServicesTimeNotificationId[]>
+    data: request.body satisfies JsonCompatible<DailyServiceTimeNotificationId[]>
   })
   return json
 }
@@ -31,8 +31,8 @@ export async function dismissDailyServiceTimeNotification(
 /**
 * Generated from fi.espoo.evaka.dailyservicetimes.DailyServiceTimesCitizenController.getDailyServiceTimeNotifications
 */
-export async function getDailyServiceTimeNotifications(): Promise<DailyServicesTimeNotificationId[]> {
-  const { data: json } = await client.request<JsonOf<DailyServicesTimeNotificationId[]>>({
+export async function getDailyServiceTimeNotifications(): Promise<DailyServiceTimeNotificationId[]> {
+  const { data: json } = await client.request<JsonOf<DailyServiceTimeNotificationId[]>>({
     url: uri`/citizen/daily-service-time-notifications`.toString(),
     method: 'GET'
   })

--- a/frontend/src/citizen-frontend/generated/api-clients/dailyservicetimes.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/dailyservicetimes.ts
@@ -4,9 +4,9 @@
 
 // GENERATED FILE: no manual modifications
 
+import { DailyServicesTimeNotificationId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api-client'
 import { uri } from 'lib-common/uri'
 
@@ -16,13 +16,13 @@ import { uri } from 'lib-common/uri'
 */
 export async function dismissDailyServiceTimeNotification(
   request: {
-    body: UUID[]
+    body: DailyServicesTimeNotificationId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/citizen/daily-service-time-notifications/dismiss`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<DailyServicesTimeNotificationId[]>
   })
   return json
 }
@@ -31,8 +31,8 @@ export async function dismissDailyServiceTimeNotification(
 /**
 * Generated from fi.espoo.evaka.dailyservicetimes.DailyServiceTimesCitizenController.getDailyServiceTimeNotifications
 */
-export async function getDailyServiceTimeNotifications(): Promise<UUID[]> {
-  const { data: json } = await client.request<JsonOf<UUID[]>>({
+export async function getDailyServiceTimeNotifications(): Promise<DailyServicesTimeNotificationId[]> {
+  const { data: json } = await client.request<JsonOf<DailyServicesTimeNotificationId[]>>({
     url: uri`/citizen/daily-service-time-notifications`.toString(),
     method: 'GET'
   })

--- a/frontend/src/citizen-frontend/generated/api-clients/document.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/document.ts
@@ -6,8 +6,9 @@
 
 import { ChildDocumentCitizenDetails } from 'lib-common/generated/api-types/document'
 import { ChildDocumentCitizenSummary } from 'lib-common/generated/api-types/document'
+import { ChildDocumentId } from 'lib-common/generated/api-types/shared'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api-client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonChildDocumentCitizenDetails } from 'lib-common/generated/api-types/document'
@@ -20,7 +21,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getDocument(
   request: {
-    documentId: UUID
+    documentId: ChildDocumentId
   }
 ): Promise<ChildDocumentCitizenDetails> {
   const { data: json } = await client.request<JsonOf<ChildDocumentCitizenDetails>>({
@@ -36,7 +37,7 @@ export async function getDocument(
 */
 export async function getDocuments(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<ChildDocumentCitizenSummary[]> {
   const params = createUrlSearchParams(
@@ -54,8 +55,8 @@ export async function getDocuments(
 /**
 * Generated from fi.espoo.evaka.document.childdocument.ChildDocumentControllerCitizen.getUnreadDocumentsCount
 */
-export async function getUnreadDocumentsCount(): Promise<Partial<Record<UUID, number>>> {
-  const { data: json } = await client.request<JsonOf<Partial<Record<UUID, number>>>>({
+export async function getUnreadDocumentsCount(): Promise<Partial<Record<PersonId, number>>> {
+  const { data: json } = await client.request<JsonOf<Partial<Record<PersonId, number>>>>({
     url: uri`/citizen/child-documents/unread-count`.toString(),
     method: 'GET'
   })
@@ -68,7 +69,7 @@ export async function getUnreadDocumentsCount(): Promise<Partial<Record<UUID, nu
 */
 export async function putDocumentRead(
   request: {
-    documentId: UUID
+    documentId: ChildDocumentId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({

--- a/frontend/src/citizen-frontend/generated/api-clients/holidayperiod.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/holidayperiod.ts
@@ -7,9 +7,9 @@
 import { ActiveQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
 import { FixedPeriodsBody } from 'lib-common/generated/api-types/holidayperiod'
 import { HolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
+import { HolidayQuestionnaireId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api-client'
 import { deserializeJsonActiveQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
 import { deserializeJsonHolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
@@ -21,7 +21,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function answerFixedPeriodQuestionnaire(
   request: {
-    id: UUID,
+    id: HolidayQuestionnaireId,
     body: FixedPeriodsBody
   }
 ): Promise<void> {

--- a/frontend/src/citizen-frontend/generated/api-clients/incomestatement.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/incomestatement.ts
@@ -8,10 +8,11 @@ import LocalDate from 'lib-common/local-date'
 import { ChildBasicInfo } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeStatement } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeStatementBody } from 'lib-common/generated/api-types/incomestatement'
+import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { PagedIncomeStatements } from 'lib-common/generated/api-types/incomestatement'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api-client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonIncomeStatement } from 'lib-common/generated/api-types/incomestatement'
@@ -24,7 +25,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function createChildIncomeStatement(
   request: {
-    childId: UUID,
+    childId: PersonId,
     draft?: boolean | null,
     body: IncomeStatementBody
   }
@@ -69,7 +70,7 @@ export async function createIncomeStatement(
 */
 export async function deleteIncomeStatement(
   request: {
-    id: UUID
+    id: IncomeStatementId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -85,8 +86,8 @@ export async function deleteIncomeStatement(
 */
 export async function getChildIncomeStatement(
   request: {
-    childId: UUID,
-    incomeStatementId: UUID
+    childId: PersonId,
+    incomeStatementId: IncomeStatementId
   }
 ): Promise<IncomeStatement> {
   const { data: json } = await client.request<JsonOf<IncomeStatement>>({
@@ -102,7 +103,7 @@ export async function getChildIncomeStatement(
 */
 export async function getChildIncomeStatementStartDates(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<LocalDate[]> {
   const { data: json } = await client.request<JsonOf<LocalDate[]>>({
@@ -118,7 +119,7 @@ export async function getChildIncomeStatementStartDates(
 */
 export async function getChildIncomeStatements(
   request: {
-    childId: UUID,
+    childId: PersonId,
     page: number
   }
 ): Promise<PagedIncomeStatements> {
@@ -139,7 +140,7 @@ export async function getChildIncomeStatements(
 */
 export async function getIncomeStatement(
   request: {
-    incomeStatementId: UUID
+    incomeStatementId: IncomeStatementId
   }
 ): Promise<IncomeStatement> {
   const { data: json } = await client.request<JsonOf<IncomeStatement>>({
@@ -199,8 +200,8 @@ export async function getIncomeStatements(
 */
 export async function removeChildIncomeStatement(
   request: {
-    childId: UUID,
-    id: UUID
+    childId: PersonId,
+    id: IncomeStatementId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -216,8 +217,8 @@ export async function removeChildIncomeStatement(
 */
 export async function updateChildIncomeStatement(
   request: {
-    childId: UUID,
-    incomeStatementId: UUID,
+    childId: PersonId,
+    incomeStatementId: IncomeStatementId,
     draft: boolean,
     body: IncomeStatementBody
   }
@@ -240,7 +241,7 @@ export async function updateChildIncomeStatement(
 */
 export async function updateIncomeStatement(
   request: {
-    incomeStatementId: UUID,
+    incomeStatementId: IncomeStatementId,
     draft: boolean,
     body: IncomeStatementBody
   }

--- a/frontend/src/citizen-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/messaging.ts
@@ -8,11 +8,12 @@ import { CitizenMessageBody } from 'lib-common/generated/api-types/messaging'
 import { GetReceiversResponse } from 'lib-common/generated/api-types/messaging'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { MessageId } from 'lib-common/generated/api-types/shared'
+import { MessageThreadId } from 'lib-common/generated/api-types/shared'
 import { MyAccountResponse } from 'lib-common/generated/api-types/messaging'
 import { PagedCitizenMessageThreads } from 'lib-common/generated/api-types/messaging'
 import { ReplyToMessageBody } from 'lib-common/generated/api-types/messaging'
 import { ThreadReply } from 'lib-common/generated/api-types/messaging'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api-client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonPagedCitizenMessageThreads } from 'lib-common/generated/api-types/messaging'
@@ -25,7 +26,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function archiveThread(
   request: {
-    threadId: UUID
+    threadId: MessageThreadId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -97,7 +98,7 @@ export async function getUnreadMessages(): Promise<number> {
 */
 export async function markThreadRead(
   request: {
-    threadId: UUID
+    threadId: MessageThreadId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -115,8 +116,8 @@ export async function newMessage(
   request: {
     body: CitizenMessageBody
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<MessageThreadId> {
+  const { data: json } = await client.request<JsonOf<MessageThreadId>>({
     url: uri`/citizen/messages`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<CitizenMessageBody>
@@ -130,7 +131,7 @@ export async function newMessage(
 */
 export async function replyToThread(
   request: {
-    messageId: UUID,
+    messageId: MessageId,
     body: ReplyToMessageBody
   }
 ): Promise<ThreadReply> {

--- a/frontend/src/citizen-frontend/generated/api-clients/pedagogicaldocument.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/pedagogicaldocument.ts
@@ -6,7 +6,8 @@
 
 import { JsonOf } from 'lib-common/json'
 import { PedagogicalDocumentCitizen } from 'lib-common/generated/api-types/pedagogicaldocument'
-import { UUID } from 'lib-common/types'
+import { PedagogicalDocumentId } from 'lib-common/generated/api-types/shared'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api-client'
 import { deserializeJsonPedagogicalDocumentCitizen } from 'lib-common/generated/api-types/pedagogicaldocument'
 import { uri } from 'lib-common/uri'
@@ -17,7 +18,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getPedagogicalDocumentsForChild(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<PedagogicalDocumentCitizen[]> {
   const { data: json } = await client.request<JsonOf<PedagogicalDocumentCitizen[]>>({
@@ -31,8 +32,8 @@ export async function getPedagogicalDocumentsForChild(
 /**
 * Generated from fi.espoo.evaka.pedagogicaldocument.PedagogicalDocumentControllerCitizen.getUnreadPedagogicalDocumentCount
 */
-export async function getUnreadPedagogicalDocumentCount(): Promise<Partial<Record<UUID, number>>> {
-  const { data: json } = await client.request<JsonOf<Partial<Record<UUID, number>>>>({
+export async function getUnreadPedagogicalDocumentCount(): Promise<Partial<Record<PersonId, number>>> {
+  const { data: json } = await client.request<JsonOf<Partial<Record<PersonId, number>>>>({
     url: uri`/citizen/pedagogical-documents/unread-count`.toString(),
     method: 'GET'
   })
@@ -45,7 +46,7 @@ export async function getUnreadPedagogicalDocumentCount(): Promise<Partial<Recor
 */
 export async function markPedagogicalDocumentRead(
   request: {
-    documentId: UUID
+    documentId: PedagogicalDocumentId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({

--- a/frontend/src/citizen-frontend/generated/api-clients/placement.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/placement.ts
@@ -7,8 +7,8 @@
 import { ChildPlacementResponse } from 'lib-common/generated/api-types/placement'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { PlacementTerminationRequestBody } from 'lib-common/generated/api-types/placement'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api-client'
 import { deserializeJsonChildPlacementResponse } from 'lib-common/generated/api-types/placement'
 import { uri } from 'lib-common/uri'
@@ -19,7 +19,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getPlacements(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<ChildPlacementResponse> {
   const { data: json } = await client.request<JsonOf<ChildPlacementResponse>>({
@@ -35,7 +35,7 @@ export async function getPlacements(
 */
 export async function postPlacementTermination(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: PlacementTerminationRequestBody
   }
 ): Promise<void> {

--- a/frontend/src/citizen-frontend/generated/api-clients/serviceneed.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/serviceneed.ts
@@ -8,11 +8,12 @@ import LocalDate from 'lib-common/local-date'
 import { CitizenServiceApplication } from 'lib-common/generated/api-types/serviceneed'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import { ServiceApplicationCreateRequest } from 'lib-common/generated/api-types/serviceneed'
+import { ServiceApplicationId } from 'lib-common/generated/api-types/shared'
 import { ServiceNeedOptionBasics } from 'lib-common/generated/api-types/serviceneed'
 import { ServiceNeedOptionPublicInfo } from 'lib-common/generated/api-types/serviceneed'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api-client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonCitizenServiceApplication } from 'lib-common/generated/api-types/serviceneed'
@@ -63,7 +64,7 @@ export async function createServiceApplication(
 */
 export async function deleteServiceApplication(
   request: {
-    id: UUID
+    id: ServiceApplicationId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -79,7 +80,7 @@ export async function deleteServiceApplication(
 */
 export async function getChildServiceApplications(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<CitizenServiceApplication[]> {
   const params = createUrlSearchParams(
@@ -99,7 +100,7 @@ export async function getChildServiceApplications(
 */
 export async function getChildServiceNeedOptions(
   request: {
-    childId: UUID,
+    childId: PersonId,
     date: LocalDate
   }
 ): Promise<ServiceNeedOptionBasics[]> {

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
@@ -6,6 +6,7 @@ import React, { useCallback } from 'react'
 
 import { wrapResult } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import FileUpload from 'lib-components/molecules/FileUpload'
@@ -46,7 +47,7 @@ export default React.memo(function Attachments({
   )
 
   const handleDelete = useCallback(
-    async (id: UUID) =>
+    async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() => {
         onDeleted(id)
       }),

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
@@ -6,6 +6,7 @@ import React, { useCallback } from 'react'
 
 import { wrapResult } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 import UnorderedList from 'lib-components/atoms/UnorderedList'
 import { ContentArea } from 'lib-components/layout/Container'
@@ -57,7 +58,7 @@ export default React.memo(function Attachments({
   )
 
   const handleDelete = useCallback(
-    async (id: UUID) =>
+    async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() => {
         onDeleted(id)
       }),

--- a/frontend/src/citizen-frontend/income-statements/types/body.ts
+++ b/frontend/src/citizen-frontend/income-statements/types/body.ts
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import * as ApiTypes from 'lib-common/generated/api-types/incomestatement'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import { stringToInt } from 'lib-common/utils/number'
 
 import * as Form from './form'
@@ -27,7 +27,7 @@ export interface ChildIncomeBody
     ApiTypes.IncomeStatementBody.ChildIncome,
     ReadOnlyFields | 'attachments'
   > {
-  attachmentIds: UUID[]
+  attachmentIds: AttachmentId[]
 }
 
 export interface IncomeBody
@@ -35,7 +35,7 @@ export interface IncomeBody
     ApiTypes.IncomeStatementBody.Income,
     ReadOnlyFields | 'attachments'
   > {
-  attachmentIds: UUID[]
+  attachmentIds: AttachmentId[]
 }
 
 export type IncomeStatementBody = HighestFeeBody | IncomeBody | ChildIncomeBody

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -19,8 +19,8 @@ import {
   GetReceiversResponse,
   MessageAccount
 } from 'lib-common/generated/api-types/messaging'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { formatFirstName } from 'lib-common/names'
-import { UUID } from 'lib-common/types'
 import { SelectionChip } from 'lib-components/atoms/Chip'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
@@ -118,7 +118,7 @@ export default React.memo(function MessageEditor({
   )
 
   const handleAttachmentDelete = useCallback(
-    async (id: UUID) =>
+    async (id: AttachmentId) =>
       deleteAttachment({ attachmentId: id })
         .then(() => {
           setAttachments((prev) => prev.filter((a) => a.id !== id))

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -562,7 +562,7 @@ export class Fixture {
     initial: SemiPartial<DevAssistanceNeedDecision, 'childId'>
   ): AssistanceNeedDecisionBuilder {
     return new AssistanceNeedDecisionBuilder({
-      id: uuidv4(),
+      id: randomId(),
       assistanceLevels: ['SPECIAL_ASSISTANCE'],
       careMotivation: null,
       decisionMade: null,
@@ -626,7 +626,7 @@ export class Fixture {
     initial: SemiPartial<DevAssistanceNeedDecision, 'childId'>
   ): AssistanceNeedDecisionBuilder {
     return new AssistanceNeedDecisionBuilder({
-      id: uuidv4(),
+      id: randomId(),
       assistanceLevels: ['ENHANCED_ASSISTANCE'],
       careMotivation: 'Care motivation text',
       decisionMade: null,

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1026,7 +1026,7 @@ export class Fixture {
     initial: SemiPartial<DevCalendarEventAttendee, 'calendarEventId' | 'unitId'>
   ): CalendarEventAttendeeBuilder {
     return new CalendarEventAttendeeBuilder({
-      id: uuidv4(),
+      id: randomId(),
       groupId: null,
       childId: null,
       ...initial

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -498,7 +498,7 @@ export class Fixture {
     initial: SemiPartial<AssistanceFactor, 'childId'>
   ): AssistanceFactorBuilder {
     return new AssistanceFactorBuilder({
-      id: uuidv4(),
+      id: randomId(),
       capacityFactor: 1.0,
       validDuring: new FiniteDateRange(
         LocalDate.todayInSystemTz(),

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1155,7 +1155,7 @@ export class Fixture {
     initial: SemiPartial<DevChildDocument, 'childId' | 'templateId'>
   ): ChildDocumentBuilder {
     return new ChildDocumentBuilder({
-      id: uuidv4(),
+      id: randomId(),
       status: 'DRAFT',
       modifiedAt: HelsinkiDateTime.now(),
       contentModifiedAt: HelsinkiDateTime.now(),

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -262,7 +262,7 @@ export class Fixture {
   static careArea(initial?: Partial<DevCareArea>): CareAreaBuilder {
     const id = uniqueLabel()
     return new CareAreaBuilder({
-      id: uuidv4(),
+      id: randomId(),
       name: `Care Area ${id}`,
       shortName: `careArea_${id}`,
       areaCode: 2230,
@@ -2046,7 +2046,7 @@ export const clubTerms = [
 ]
 
 export const testCareArea: DevCareArea = {
-  id: '674dfb66-8849-489e-b094-e6a0ebfb3c71',
+  id: fromUuid('674dfb66-8849-489e-b094-e6a0ebfb3c71'),
   name: 'Superkeskus',
   shortName: 'super-keskus',
   areaCode: 299,
@@ -2054,7 +2054,7 @@ export const testCareArea: DevCareArea = {
 }
 
 export const testCareArea2: DevCareArea = {
-  id: '7a5b42db-451b-4394-b6a6-86993ea0ed45',
+  id: fromUuid('7a5b42db-451b-4394-b6a6-86993ea0ed45'),
   name: 'Hyperkeskus',
   shortName: 'hyper-keskus',
   areaCode: 298,

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1037,7 +1037,7 @@ export class Fixture {
     initial: SemiPartial<DevCalendarEventTime, 'calendarEventId'>
   ): CalendarEventTimeBuilder {
     return new CalendarEventTimeBuilder({
-      id: uuidv4(),
+      id: randomId(),
       date: LocalDate.of(2020, 1, 1),
       childId: null,
       modifiedBy: systemInternalUser.id,

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1179,7 +1179,7 @@ export class Fixture {
     initial: SemiPartial<AssistanceNeedVoucherCoefficient, 'childId'>
   ): AssistanceNeedVoucherCoefficientBuilder {
     return new AssistanceNeedVoucherCoefficientBuilder({
-      id: uuidv4(),
+      id: randomId(),
       validityPeriod: new FiniteDateRange(
         LocalDate.todayInSystemTz(),
         LocalDate.todayInSystemTz()

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1582,7 +1582,7 @@ export class AssistanceNeedPreschoolDecisionBuilder extends FixtureBuilder<DevAs
 
   withGuardian(guardianId: UUID) {
     this.data.form.guardianInfo.push({
-      id: uuidv4(),
+      id: randomId(),
       personId: guardianId,
       name: '',
       isHeard: false,

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -690,7 +690,7 @@ export class Fixture {
     initial: SemiPartial<DevAssistanceNeedPreschoolDecision, 'childId'>
   ): AssistanceNeedPreschoolDecisionBuilder {
     return new AssistanceNeedPreschoolDecisionBuilder({
-      id: uuidv4(),
+      id: randomId(),
       decisionNumber: 1000,
       status: 'DRAFT',
       annulmentReason: '',

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -39,6 +39,7 @@ import { DailyReservationRequest } from 'lib-common/generated/api-types/reservat
 import { ServiceNeedOption } from 'lib-common/generated/api-types/serviceneed'
 import { EvakaUser } from 'lib-common/generated/api-types/user'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
@@ -1058,7 +1059,7 @@ export class Fixture {
 
   static absence(initial: SemiPartial<DevAbsence, 'childId'>): AbsenceBuilder {
     return new AbsenceBuilder({
-      id: uuidv4(),
+      id: randomId(),
       date: LocalDate.todayInHelsinkiTz(),
       absenceType: 'OTHER_ABSENCE',
       modifiedAt: HelsinkiDateTime.now(),

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -37,9 +37,10 @@ import {
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import { DailyReservationRequest } from 'lib-common/generated/api-types/reservations'
 import { ServiceNeedOption } from 'lib-common/generated/api-types/serviceneed'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { EvakaUser } from 'lib-common/generated/api-types/user'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { randomId } from 'lib-common/id-type'
+import { fromUuid, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
@@ -848,7 +849,9 @@ export class Fixture {
   }
 
   static placementPlan(
-    initial: SemiPartial<PlacementPlan, 'unitId'> & { applicationId: UUID }
+    initial: SemiPartial<PlacementPlan, 'unitId'> & {
+      applicationId: ApplicationId
+    }
   ): PlacementPlanBuilder {
     return new PlacementPlanBuilder({
       periodStart: LocalDate.todayInSystemTz(),
@@ -1668,7 +1671,7 @@ export class FeeThresholdBuilder extends FixtureBuilder<FeeThresholds> {
 }
 
 export class PlacementPlanBuilder extends FixtureBuilder<
-  PlacementPlan & { applicationId: UUID }
+  PlacementPlan & { applicationId: ApplicationId }
 > {
   async save() {
     const { applicationId, ...body } = this.data
@@ -2901,7 +2904,9 @@ const applicationForm = (
   }
 }
 
-export const applicationFixtureId = '9dd0e1ba-9b3b-11ea-bb37-0242ac130002'
+export const applicationFixtureId = fromUuid<ApplicationId>(
+  '9dd0e1ba-9b3b-11ea-bb37-0242ac130002'
+)
 export const applicationFixture = (
   child: DevPerson,
   guardian: DevPerson,
@@ -2957,7 +2962,7 @@ const feeThresholds = {
 }
 
 export const decisionFixture = (
-  applicationId: string,
+  applicationId: ApplicationId,
   startDate: LocalDate,
   endDate: LocalDate
 ): DecisionRequest => ({

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -418,7 +418,7 @@ export class Fixture {
     initial: SemiPartial<DevBackupCare, 'childId' | 'unitId'>
   ): BackupCareBuilder {
     return new BackupCareBuilder({
-      id: uuidv4(),
+      id: randomId(),
       groupId: null,
       period: new FiniteDateRange(
         LocalDate.todayInSystemTz(),

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -949,7 +949,7 @@ export class Fixture {
     initial: SemiPartial<DevDailyServiceTimeNotification, 'guardianId'>
   ): DailyServiceTimeNotificationBuilder {
     return new DailyServiceTimeNotificationBuilder({
-      id: uuidv4(),
+      id: randomId(),
       ...initial
     })
   }

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -451,7 +451,7 @@ export class Fixture {
     const id = uniqueLabel()
 
     return new ServiceNeedOptionBuilder({
-      id: uuidv4(),
+      id: randomId(),
       daycareHoursPerWeek: 0,
       contractDaysPerMonth: null,
       daycareHoursPerMonth: null,

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -930,7 +930,7 @@ export class Fixture {
     initial: SemiPartial<DevDailyServiceTimes, 'childId'>
   ): DailyServiceTimeBuilder {
     return new DailyServiceTimeBuilder({
-      id: uuidv4(),
+      id: randomId(),
       validityPeriod: new DateRange(LocalDate.of(2020, 1, 1), null),
       type: 'REGULAR',
       regularTimes: new TimeRange(LocalTime.of(1, 0), LocalTime.of(15, 0)),

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1143,7 +1143,7 @@ export class Fixture {
     initial?: Partial<DevAssistanceActionOption>
   ): AssistanceActionOptionBuilder {
     return new AssistanceActionOptionBuilder({
-      id: uuidv4(),
+      id: randomId(),
       descriptionFi: 'a description',
       nameFi: 'a test assistance action option',
       value: 'TEST_ASSISTANCE_ACTION_OPTION',

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -37,7 +37,7 @@ import {
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import { DailyReservationRequest } from 'lib-common/generated/api-types/reservations'
 import { ServiceNeedOption } from 'lib-common/generated/api-types/serviceneed'
-import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { ApplicationId, DaycareId } from 'lib-common/generated/api-types/shared'
 import { EvakaUser } from 'lib-common/generated/api-types/user'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { fromUuid, randomId } from 'lib-common/id-type'
@@ -165,7 +165,7 @@ export class Fixture {
   static daycare(initial: SemiPartial<DevDaycare, 'areaId'>): DaycareBuilder {
     const id = uniqueLabel()
     return new DaycareBuilder({
-      id: uuidv4(),
+      id: randomId(),
       name: `daycare_${id}`,
       type: ['CENTRE'],
       dailyPreschoolTime: new TimeRange(
@@ -708,7 +708,7 @@ export class Fixture {
         grantedInterpretationService: false,
         grantedAssistiveDevices: false,
         grantedServicesBasis: '',
-        selectedUnit: '',
+        selectedUnit: null,
         primaryGroup: '',
         decisionBasis: '',
         basisDocumentPedagogicalReport: false,
@@ -918,7 +918,7 @@ export class Fixture {
     })
   }
 
-  static staffOccupancyCoefficient(unitId: string, employeeId: string) {
+  static staffOccupancyCoefficient(unitId: DaycareId, employeeId: string) {
     return new StaffOccupancyCoefficientBuilder({
       coefficient: 7,
       employeeId,
@@ -1231,7 +1231,7 @@ abstract class FixtureBuilder<T> {
 }
 
 export class DaycareBuilder extends FixtureBuilder<DevDaycare> {
-  id(id: string): DaycareBuilder {
+  id(id: DaycareId): DaycareBuilder {
     this.data.id = id
     return this
   }
@@ -1356,7 +1356,7 @@ export class FamilyBuilder extends FixtureBuilder<Family> {
 }
 
 export class EmployeeBuilder extends FixtureBuilder<DevEmployee> {
-  daycareAcl: { unitId: string; role: ScopedRole }[]
+  daycareAcl: { unitId: DaycareId; role: ScopedRole }[]
   groupAcl: {
     groupId: string
     created?: HelsinkiDateTime
@@ -1393,25 +1393,25 @@ export class EmployeeBuilder extends FixtureBuilder<DevEmployee> {
     return new EmployeeBuilder({ ...this.data, roles: ['MESSAGING'] })
   }
 
-  unitSupervisor(unitId: string): EmployeeBuilder {
+  unitSupervisor(unitId: DaycareId): EmployeeBuilder {
     return new EmployeeBuilder(this.data).withDaycareAcl(
       unitId,
       'UNIT_SUPERVISOR'
     )
   }
 
-  specialEducationTeacher(unitId: string): EmployeeBuilder {
+  specialEducationTeacher(unitId: DaycareId): EmployeeBuilder {
     return new EmployeeBuilder(this.data).withDaycareAcl(
       unitId,
       'SPECIAL_EDUCATION_TEACHER'
     )
   }
 
-  staff(unitId: string): EmployeeBuilder {
+  staff(unitId: DaycareId): EmployeeBuilder {
     return new EmployeeBuilder(this.data).withDaycareAcl(unitId, 'STAFF')
   }
 
-  withDaycareAcl(unitId: string, role: ScopedRole): this {
+  withDaycareAcl(unitId: DaycareId, role: ScopedRole): this {
     this.daycareAcl.push({ unitId, role })
     return this
   }
@@ -1600,7 +1600,7 @@ export class AssistanceNeedPreschoolDecisionBuilder extends FixtureBuilder<DevAs
   }
 
   withRequiredFieldsFilled(
-    unitId: UUID,
+    unitId: DaycareId,
     preparerId: UUID,
     decisionMakerId: UUID
   ) {
@@ -2062,7 +2062,7 @@ export const testCareArea2: DevCareArea = {
 }
 
 export const testClub: DevDaycare = {
-  id: '0b5ffd40-2f1a-476a-ad06-2861f433b0d1',
+  id: fromUuid('0b5ffd40-2f1a-476a-ad06-2861f433b0d1'),
   areaId: testCareArea.id,
   name: 'Alkuräjähdyksen kerho',
   type: ['CLUB'],
@@ -2136,7 +2136,7 @@ export const testClub: DevDaycare = {
 }
 
 export const testDaycare: DevDaycare = {
-  id: '4f3a32f5-d1bd-4b8b-aa4e-4fd78b18354b',
+  id: fromUuid('4f3a32f5-d1bd-4b8b-aa4e-4fd78b18354b'),
   areaId: testCareArea.id,
   name: 'Alkuräjähdyksen päiväkoti',
   type: ['CENTRE', 'PRESCHOOL', 'PREPARATORY_EDUCATION'],
@@ -2229,7 +2229,7 @@ export const testDaycare: DevDaycare = {
 }
 
 export const testDaycare2: DevDaycare = {
-  id: '6f540c39-e7f6-4222-a004-c527403378ec',
+  id: fromUuid('6f540c39-e7f6-4222-a004-c527403378ec'),
   areaId: testCareArea2.id,
   name: 'Mustan aukon päiväkoti',
   type: ['CENTRE'],
@@ -2314,7 +2314,7 @@ export const testDaycare2: DevDaycare = {
 }
 
 export const testDaycarePrivateVoucher: DevDaycare = {
-  id: '572adb7e-9b3d-11ea-bb37-0242ac130002',
+  id: fromUuid('572adb7e-9b3d-11ea-bb37-0242ac130002'),
   areaId: testCareArea.id,
   name: 'PS-yksikkö',
   type: ['CENTRE'],
@@ -2398,7 +2398,7 @@ export const testDaycarePrivateVoucher: DevDaycare = {
 }
 
 export const testPreschool: DevDaycare = {
-  id: 'b53d80e0-319b-4d2b-950c-f5c3c9f834bc',
+  id: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
   areaId: testCareArea.id,
   name: 'Alkuräjähdyksen eskari',
   type: ['CENTRE', 'PRESCHOOL', 'PREPARATORY_EDUCATION'],
@@ -2825,7 +2825,7 @@ const applicationForm = (
   guardian2Email: string,
   otherGuardianAgreementStatus: OtherGuardianAgreementStatus | null,
   preferredStartDate: LocalDate,
-  preferredUnits: string[],
+  preferredUnits: DaycareId[],
   connectedDaycare = false,
   assistanceNeeded = false
 ): ApplicationForm => {
@@ -2913,7 +2913,7 @@ export const applicationFixture = (
   otherGuardian: DevPerson | undefined = undefined,
   type: 'DAYCARE' | 'PRESCHOOL' | 'CLUB' = 'DAYCARE',
   otherGuardianAgreementStatus: OtherGuardianAgreementStatus | null = null,
-  preferredUnits: string[] = [testDaycare.id],
+  preferredUnits: DaycareId[] = [testDaycare.id],
   connectedDaycare = false,
   status: ApplicationStatus = 'SENT',
   preferredStartDate: LocalDate = LocalDate.of(2021, 8, 16),
@@ -2980,7 +2980,7 @@ export const feeDecisionsFixture = (
   status: FeeDecisionStatus,
   adult: DevPerson,
   child: DevPerson,
-  daycareId: UUID,
+  daycareId: DaycareId,
   partner: DevPerson | null,
   validDuring: FiniteDateRange = new FiniteDateRange(
     LocalDate.todayInSystemTz().subYears(1),
@@ -3044,7 +3044,7 @@ export const voucherValueDecisionsFixture = (
   id: UUID,
   adultId: UUID,
   childId: UUID,
-  daycareId: UUID,
+  daycareId: DaycareId,
   partner: DevPerson | null = null,
   status: 'DRAFT' | 'SENT' = 'DRAFT',
   validFrom = LocalDate.todayInSystemTz().subYears(1),
@@ -3111,7 +3111,7 @@ export const testDaycareGroup: DevDaycareGroup = {
 export function createDaycarePlacementFixture(
   id: string,
   childId: string,
-  unitId: string,
+  unitId: DaycareId,
   startDate = LocalDate.of(2022, 5, 1),
   endDate = LocalDate.of(2023, 8, 31),
   type: PlacementType = 'DAYCARE',

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -282,7 +282,7 @@ export class Fixture {
     >
   ): PreschoolTermBuilder {
     return new PreschoolTermBuilder({
-      id: uuidv4(),
+      id: randomId(),
       ...initial
     })
   }
@@ -1888,7 +1888,7 @@ export const nonFullDayTimeRange: TimeRange = new TimeRange(
 )
 
 export const preschoolTerm2020: DevPreschoolTerm = {
-  id: uuidv4(),
+  id: randomId(),
   finnishPreschool: new FiniteDateRange(
     LocalDate.of(2020, 8, 13),
     LocalDate.of(2021, 6, 4)
@@ -1909,7 +1909,7 @@ export const preschoolTerm2020: DevPreschoolTerm = {
 }
 
 export const preschoolTerm2021: DevPreschoolTerm = {
-  id: uuidv4(),
+  id: randomId(),
   finnishPreschool: new FiniteDateRange(
     LocalDate.of(2021, 8, 11),
     LocalDate.of(2022, 6, 3)
@@ -1930,7 +1930,7 @@ export const preschoolTerm2021: DevPreschoolTerm = {
 }
 
 export const preschoolTerm2022: DevPreschoolTerm = {
-  id: uuidv4(),
+  id: randomId(),
   finnishPreschool: new FiniteDateRange(
     LocalDate.of(2022, 8, 11),
     LocalDate.of(2023, 6, 2)
@@ -1951,7 +1951,7 @@ export const preschoolTerm2022: DevPreschoolTerm = {
 }
 
 export const preschoolTerm2023: DevPreschoolTerm = {
-  id: uuidv4(),
+  id: randomId(),
   finnishPreschool: new FiniteDateRange(
     LocalDate.of(2023, 8, 11),
     LocalDate.of(2024, 6, 3)
@@ -1983,7 +1983,7 @@ export const preschoolTerms = [
 ]
 
 export const clubTerm2020: ClubTerm = {
-  id: uuidv4(),
+  id: randomId(),
   term: new FiniteDateRange(
     LocalDate.of(2020, 8, 13),
     LocalDate.of(2021, 6, 4)
@@ -1996,7 +1996,7 @@ export const clubTerm2020: ClubTerm = {
 }
 
 export const clubTerm2021: ClubTerm = {
-  id: uuidv4(),
+  id: randomId(),
   term: new FiniteDateRange(
     LocalDate.of(2021, 8, 11),
     LocalDate.of(2022, 6, 3)
@@ -2009,7 +2009,7 @@ export const clubTerm2021: ClubTerm = {
 }
 
 export const clubTerm2022: ClubTerm = {
-  id: uuidv4(),
+  id: randomId(),
   term: new FiniteDateRange(
     LocalDate.of(2022, 8, 10),
     LocalDate.of(2023, 6, 3)
@@ -2022,7 +2022,7 @@ export const clubTerm2022: ClubTerm = {
 }
 
 export const clubTerm2023: ClubTerm = {
-  id: uuidv4(),
+  id: randomId(),
   term: new FiniteDateRange(
     LocalDate.of(2023, 8, 10),
     LocalDate.of(2024, 6, 3)

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1008,7 +1008,7 @@ export class Fixture {
     initial?: Partial<DevCalendarEvent>
   ): CalendarEventBuilder {
     return new CalendarEventBuilder({
-      id: uuidv4(),
+      id: randomId(),
       title: '',
       description: '',
       period: new FiniteDateRange(

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1130,7 +1130,7 @@ export class Fixture {
     initial: SemiPartial<DevAssistanceAction, 'childId' | 'updatedBy'>
   ): AssistanceActionBuilder {
     return new AssistanceActionBuilder({
-      id: uuidv4(),
+      id: randomId(),
       actions: ['ASSISTANCE_SERVICE_CHILD'],
       endDate: LocalDate.todayInSystemTz(),
       startDate: LocalDate.todayInSystemTz(),

--- a/frontend/src/e2e-test/dev-api/index.ts
+++ b/frontend/src/e2e-test/dev-api/index.ts
@@ -9,6 +9,7 @@ import FormData from 'form-data'
 import { BaseError } from 'make-error-cause'
 
 import { SimpleApplicationAction } from 'lib-common/generated/api-types/application'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 
 import config from '../config'
@@ -56,7 +57,7 @@ type DevApplicationAction =
   | 'CREATE_DEFAULT_PLACEMENT_PLAN'
 
 export async function execSimpleApplicationAction(
-  applicationId: string,
+  applicationId: ApplicationId,
   action: DevApplicationAction,
   mockedTime: HelsinkiDateTime
 ): Promise<void> {
@@ -72,7 +73,7 @@ export async function execSimpleApplicationAction(
 }
 
 export async function execSimpleApplicationActions(
-  applicationId: string,
+  applicationId: ApplicationId,
   actions: DevApplicationAction[],
   mockedTime: HelsinkiDateTime
 ): Promise<void> {

--- a/frontend/src/e2e-test/generated/api-clients.ts
+++ b/frontend/src/e2e-test/generated/api-clients.ts
@@ -22,7 +22,7 @@ import { ChildStickyNoteBody } from 'lib-common/generated/api-types/note'
 import { ChildStickyNoteId } from 'lib-common/generated/api-types/shared'
 import { Citizen } from './api-types'
 import { DailyReservationRequest } from 'lib-common/generated/api-types/reservations'
-import { DailyServicesTimeId } from 'lib-common/generated/api-types/shared'
+import { DailyServiceTimeId } from 'lib-common/generated/api-types/shared'
 import { DaycareAclInsert } from './api-types'
 import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { DaycarePlacementPlan } from 'lib-common/generated/api-types/application'
@@ -255,9 +255,9 @@ export async function addDailyServiceTime(
     body: DevDailyServiceTimes
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<DailyServicesTimeId> {
+): Promise<DailyServiceTimeId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<DailyServicesTimeId>>({
+    const { data: json } = await devClient.request<JsonOf<DailyServiceTimeId>>({
       url: uri`/daily-service-time`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },

--- a/frontend/src/e2e-test/generated/api-clients.ts
+++ b/frontend/src/e2e-test/generated/api-clients.ts
@@ -11,8 +11,8 @@ import { AbsenceId } from './api-types'
 import { ApplicationDetails } from 'lib-common/generated/api-types/application'
 import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { Autocomplete } from './api-types'
-import { CalendarEventAttendeeId } from 'lib-common/generated/api-types/shared'
-import { CalendarEventId } from './api-types'
+import { CalendarEventAttendeeId } from './api-types'
+import { CalendarEventId } from 'lib-common/generated/api-types/shared'
 import { CalendarEventTimeId } from 'lib-common/generated/api-types/shared'
 import { Caretaker } from './api-types'
 import { ChildDailyNoteBody } from 'lib-common/generated/api-types/note'
@@ -186,9 +186,9 @@ export async function addCalendarEvent(
     body: DevCalendarEvent
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<CalendarEventAttendeeId> {
+): Promise<CalendarEventId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<CalendarEventAttendeeId>>({
+    const { data: json } = await devClient.request<JsonOf<CalendarEventId>>({
       url: uri`/calendar-event`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -209,9 +209,9 @@ export async function addCalendarEventAttendee(
     body: DevCalendarEventAttendee
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<CalendarEventId> {
+): Promise<CalendarEventAttendeeId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<CalendarEventId>>({
+    const { data: json } = await devClient.request<JsonOf<CalendarEventAttendeeId>>({
       url: uri`/calendar-event-attendee`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },

--- a/frontend/src/e2e-test/generated/api-clients.ts
+++ b/frontend/src/e2e-test/generated/api-clients.ts
@@ -7,16 +7,27 @@
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import { Absence } from 'lib-common/generated/api-types/absence'
+import { AbsenceId } from './api-types'
 import { ApplicationDetails } from 'lib-common/generated/api-types/application'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { Autocomplete } from './api-types'
+import { CalendarEventAttendeeId } from 'lib-common/generated/api-types/shared'
+import { CalendarEventId } from './api-types'
+import { CalendarEventTimeId } from 'lib-common/generated/api-types/shared'
 import { Caretaker } from './api-types'
 import { ChildDailyNoteBody } from 'lib-common/generated/api-types/note'
+import { ChildDailyNoteId } from 'lib-common/generated/api-types/shared'
+import { ChildDocumentId } from 'lib-common/generated/api-types/shared'
 import { ChildStickyNoteBody } from 'lib-common/generated/api-types/note'
+import { ChildStickyNoteId } from 'lib-common/generated/api-types/shared'
 import { Citizen } from './api-types'
 import { DailyReservationRequest } from 'lib-common/generated/api-types/reservations'
+import { DailyServicesTimeId } from 'lib-common/generated/api-types/shared'
 import { DaycareAclInsert } from './api-types'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { DaycarePlacementPlan } from 'lib-common/generated/api-types/application'
 import { Decision } from 'lib-common/generated/api-types/decision'
+import { DecisionId } from 'lib-common/generated/api-types/shared'
 import { DecisionRequest } from './api-types'
 import { DevAbsence } from './api-types'
 import { DevApiError } from '../dev-api'
@@ -73,18 +84,29 @@ import { DevStaffAttendance } from './api-types'
 import { DevStaffAttendancePlan } from './api-types'
 import { DevTerminatePlacementRequest } from './api-types'
 import { DevUpsertStaffOccupancyCoefficient } from './api-types'
+import { DocumentTemplateId } from 'lib-common/generated/api-types/shared'
 import { Email } from './api-types'
 import { Employee } from 'lib-common/generated/api-types/pis'
+import { EmployeeId } from 'lib-common/generated/api-types/shared'
 import { FeeDecision } from 'lib-common/generated/api-types/invoicing'
 import { FeeThresholds } from 'lib-common/generated/api-types/invoicing'
+import { FeeThresholdsId } from 'lib-common/generated/api-types/shared'
 import { FixedPeriodQuestionnaireBody } from 'lib-common/generated/api-types/holidayperiod'
+import { GroupId } from 'lib-common/generated/api-types/shared'
 import { GroupNoteBody } from 'lib-common/generated/api-types/note'
+import { GroupNoteId } from 'lib-common/generated/api-types/shared'
 import { HolidayPeriodCreate } from 'lib-common/generated/api-types/holidayperiod'
+import { HolidayPeriodId } from 'lib-common/generated/api-types/shared'
+import { HolidayQuestionnaireId } from 'lib-common/generated/api-types/shared'
 import { IncomeNotification } from 'lib-common/generated/api-types/invoicing'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { MockVtjDataset } from './api-types'
 import { Pairing } from 'lib-common/generated/api-types/pairing'
+import { PairingId } from 'lib-common/generated/api-types/shared'
+import { PaymentId } from 'lib-common/generated/api-types/shared'
+import { PersonId } from 'lib-common/generated/api-types/shared'
+import { PlacementId } from 'lib-common/generated/api-types/shared'
 import { PlacementPlan } from './api-types'
 import { PostPairingChallengeReq } from 'lib-common/generated/api-types/pairing'
 import { PostPairingReq } from 'lib-common/generated/api-types/pairing'
@@ -94,8 +116,9 @@ import { ServiceNeedOption } from 'lib-common/generated/api-types/serviceneed'
 import { SfiMessage } from './api-types'
 import { SimpleApplicationAction } from 'lib-common/generated/api-types/application'
 import { SpecialDiet } from 'lib-common/generated/api-types/specialdiet'
+import { StaffAttendancePlanId } from './api-types'
+import { StaffAttendanceRealtimeId } from 'lib-common/generated/api-types/shared'
 import { StaffMemberAttendance } from 'lib-common/generated/api-types/attendance'
-import { UUID } from 'lib-common/types'
 import { VoucherValueDecision } from './api-types'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonAbsence } from 'lib-common/generated/api-types/absence'
@@ -116,9 +139,9 @@ export async function addAbsence(
     body: DevAbsence
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<AbsenceId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<AbsenceId>>({
       url: uri`/absence`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -136,7 +159,7 @@ export async function addAbsence(
 */
 export async function addAclRoleForDaycare(
   request: {
-    daycareId: UUID,
+    daycareId: DaycareId,
     body: DaycareAclInsert
   },
   options?: { mockedTime?: HelsinkiDateTime }
@@ -163,9 +186,9 @@ export async function addCalendarEvent(
     body: DevCalendarEvent
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<CalendarEventAttendeeId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<CalendarEventAttendeeId>>({
       url: uri`/calendar-event`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -186,9 +209,9 @@ export async function addCalendarEventAttendee(
     body: DevCalendarEventAttendee
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<CalendarEventId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<CalendarEventId>>({
       url: uri`/calendar-event-attendee`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -209,9 +232,9 @@ export async function addCalendarEventTime(
     body: DevCalendarEventTime
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<CalendarEventTimeId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<CalendarEventTimeId>>({
       url: uri`/calendar-event-time`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -232,9 +255,9 @@ export async function addDailyServiceTime(
     body: DevDailyServiceTimes
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<DailyServicesTimeId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<DailyServicesTimeId>>({
       url: uri`/daily-service-time`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -278,9 +301,9 @@ export async function addPayment(
     body: DevPayment
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<PaymentId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<PaymentId>>({
       url: uri`/payments`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -301,9 +324,9 @@ export async function addStaffAttendance(
     body: DevStaffAttendance
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<StaffAttendanceRealtimeId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<StaffAttendanceRealtimeId>>({
       url: uri`/realtime-staff-attendance`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -324,9 +347,9 @@ export async function addStaffAttendancePlan(
     body: DevStaffAttendancePlan
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<StaffAttendancePlanId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<StaffAttendancePlanId>>({
       url: uri`/staff-attendance-plan`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -363,7 +386,7 @@ export async function cleanUpMessages(
 */
 export async function createApplicationPlacementPlan(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: DaycarePlacementPlan
   },
   options?: { mockedTime?: HelsinkiDateTime }
@@ -390,9 +413,9 @@ export async function createApplications(
     body: DevApplicationWithForm[]
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID[]> {
+): Promise<ApplicationId[]> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID[]>>({
+    const { data: json } = await devClient.request<JsonOf<ApplicationId[]>>({
       url: uri`/applications`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -620,9 +643,9 @@ export async function createChildDocument(
     body: DevChildDocument
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<ChildDocumentId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<ChildDocumentId>>({
       url: uri`/child-documents`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -847,7 +870,7 @@ export async function createDaycares(
 */
 export async function createDecisionPdf(
   request: {
-    id: UUID
+    id: DecisionId
   },
   options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<void> {
@@ -892,7 +915,7 @@ export async function createDecisions(
 */
 export async function createDefaultPlacementPlan(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   },
   options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<void> {
@@ -936,9 +959,9 @@ export async function createDocumentTemplate(
     body: DevDocumentTemplate
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<DocumentTemplateId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<DocumentTemplateId>>({
       url: uri`/document-templates`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -959,9 +982,9 @@ export async function createEmployee(
     body: DevEmployee
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<EmployeeId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<EmployeeId>>({
       url: uri`/employee`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -1051,9 +1074,9 @@ export async function createFeeThresholds(
     body: FeeThresholds
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<FeeThresholdsId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<FeeThresholdsId>>({
       url: uri`/fee-thresholds`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -1140,7 +1163,7 @@ export async function createFridgePartner(
 */
 export async function createHolidayPeriod(
   request: {
-    id: UUID,
+    id: HolidayPeriodId,
     body: HolidayPeriodCreate
   },
   options?: { mockedTime?: HelsinkiDateTime }
@@ -1164,7 +1187,7 @@ export async function createHolidayPeriod(
 */
 export async function createHolidayQuestionnaire(
   request: {
-    id: UUID,
+    id: HolidayQuestionnaireId,
     body: FixedPeriodQuestionnaireBody
   },
   options?: { mockedTime?: HelsinkiDateTime }
@@ -1372,12 +1395,12 @@ export async function createPerson(
     body: DevPerson
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<PersonId> {
   try {
     const params = createUrlSearchParams(
       ['type', request.type.toString()]
     )
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<PersonId>>({
       url: uri`/person/create`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -1396,7 +1419,7 @@ export async function createPerson(
 */
 export async function createPlacementPlan(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: PlacementPlan
   },
   options?: { mockedTime?: HelsinkiDateTime }
@@ -1577,7 +1600,7 @@ export async function createVoucherValues(
 */
 export async function deleteDaycareCostCenter(
   request: {
-    daycareId: UUID
+    daycareId: DaycareId
   },
   options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<void> {
@@ -1599,7 +1622,7 @@ export async function deleteDaycareCostCenter(
 */
 export async function deletePlacement(
   request: {
-    placementId: UUID
+    placementId: PlacementId
   },
   options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<void> {
@@ -1640,7 +1663,7 @@ export async function digitransitAutocomplete(
 */
 export async function forceFullVtjRefresh(
   request: {
-    person: UUID
+    person: PersonId
   },
   options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<void> {
@@ -1681,7 +1704,7 @@ export async function generateReplacementDraftInvoices(
 */
 export async function getAbsences(
   request: {
-    childId: UUID,
+    childId: PersonId,
     date: LocalDate
   },
   options?: { mockedTime?: HelsinkiDateTime }
@@ -1709,7 +1732,7 @@ export async function getAbsences(
 */
 export async function getApplication(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   },
   options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<ApplicationDetails> {
@@ -1731,7 +1754,7 @@ export async function getApplication(
 */
 export async function getApplicationDecisions(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   },
   options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<Decision[]> {
@@ -1892,9 +1915,9 @@ export async function insertChild(
     body: DevPerson
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<PersonId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<PersonId>>({
       url: uri`/child`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -1958,13 +1981,13 @@ export async function postAttendances(
 */
 export async function postChildDailyNote(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: ChildDailyNoteBody
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<ChildDailyNoteId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<ChildDailyNoteId>>({
       url: uri`/children/${request.childId}/child-daily-notes`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -1982,13 +2005,13 @@ export async function postChildDailyNote(
 */
 export async function postChildStickyNote(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: ChildStickyNoteBody
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<ChildStickyNoteId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<ChildStickyNoteId>>({
       url: uri`/children/${request.childId}/child-sticky-notes`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -2029,13 +2052,13 @@ export async function postDigitransitQuery(
 */
 export async function postGroupNote(
   request: {
-    groupId: UUID,
+    groupId: GroupId,
     body: GroupNoteBody
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<GroupNoteId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<GroupNoteId>>({
       url: uri`/daycare-groups/${request.groupId}/group-notes`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
@@ -2122,7 +2145,7 @@ export async function postPairingChallenge(
 */
 export async function postPairingResponse(
   request: {
-    id: UUID,
+    id: PairingId,
     body: PostPairingResponseReq
   },
   options?: { mockedTime?: HelsinkiDateTime }
@@ -2261,7 +2284,7 @@ export async function putDigitransitAutocomplete(
 */
 export async function rejectDecisionByCitizen(
   request: {
-    id: UUID
+    id: DecisionId
   },
   options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<void> {
@@ -2370,7 +2393,7 @@ export async function setTestMode(
 */
 export async function simpleAction(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     action: SimpleApplicationAction
   },
   options?: { mockedTime?: HelsinkiDateTime }
@@ -2419,9 +2442,9 @@ export async function upsertPerson(
     body: DevPerson
   },
   options?: { mockedTime?: HelsinkiDateTime }
-): Promise<UUID> {
+): Promise<PersonId> {
   try {
-    const { data: json } = await devClient.request<JsonOf<UUID>>({
+    const { data: json } = await devClient.request<JsonOf<PersonId>>({
       url: uri`/person`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -30,7 +30,7 @@ import { AssistanceNeedPreschoolDecisionId } from 'lib-common/generated/api-type
 import { AssistanceNeedVoucherCoefficientId } from 'lib-common/generated/api-types/shared'
 import { BackupCareId } from 'lib-common/generated/api-types/shared'
 import { BackupPickupId } from 'lib-common/generated/api-types/shared'
-import { CalendarEventAttendeeId } from 'lib-common/generated/api-types/shared'
+import { CalendarEventId } from 'lib-common/generated/api-types/shared'
 import { CalendarEventTimeId } from 'lib-common/generated/api-types/shared'
 import { CalendarEventType } from 'lib-common/generated/api-types/calendarevent'
 import { CareType } from 'lib-common/generated/api-types/daycare'
@@ -133,7 +133,7 @@ export interface Autocomplete {
   features: Feature[]
 }
 
-export type CalendarEventId = string
+export type CalendarEventAttendeeId = string
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.Caretaker
@@ -339,7 +339,7 @@ export interface DevBackupPickup {
 export interface DevCalendarEvent {
   description: string
   eventType: CalendarEventType
-  id: CalendarEventAttendeeId
+  id: CalendarEventId
   modifiedAt: HelsinkiDateTime
   modifiedBy: EvakaUserId
   period: FiniteDateRange
@@ -350,10 +350,10 @@ export interface DevCalendarEvent {
 * Generated from fi.espoo.evaka.shared.dev.DevCalendarEventAttendee
 */
 export interface DevCalendarEventAttendee {
-  calendarEventId: CalendarEventAttendeeId
+  calendarEventId: CalendarEventId
   childId: PersonId | null
   groupId: GroupId | null
-  id: CalendarEventId
+  id: CalendarEventAttendeeId
   unitId: DaycareId
 }
 
@@ -361,7 +361,7 @@ export interface DevCalendarEventAttendee {
 * Generated from fi.espoo.evaka.shared.dev.DevCalendarEventTime
 */
 export interface DevCalendarEventTime {
-  calendarEventId: CalendarEventAttendeeId
+  calendarEventId: CalendarEventId
   childId: PersonId | null
   date: LocalDate
   end: LocalTime

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -13,53 +13,97 @@ import TimeRange from 'lib-common/time-range'
 import { AbsenceCategory } from 'lib-common/generated/api-types/absence'
 import { AbsenceType } from 'lib-common/generated/api-types/absence'
 import { ApplicationForm } from 'lib-common/generated/api-types/application'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { ApplicationOrigin } from 'lib-common/generated/api-types/application'
 import { ApplicationStatus } from 'lib-common/generated/api-types/application'
 import { ApplicationType } from 'lib-common/generated/api-types/application'
+import { AreaId } from 'lib-common/generated/api-types/shared'
+import { AssistanceActionId } from 'lib-common/generated/api-types/shared'
+import { AssistanceFactorId } from 'lib-common/generated/api-types/shared'
 import { AssistanceLevel } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedDecisionEmployee } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedDecisionGuardian } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
 import { AssistanceNeedDecisionStatus } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedPreschoolDecisionForm } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedPreschoolDecisionId } from 'lib-common/generated/api-types/shared'
+import { AssistanceNeedVoucherCoefficientId } from 'lib-common/generated/api-types/shared'
+import { BackupCareId } from 'lib-common/generated/api-types/shared'
+import { BackupPickupId } from 'lib-common/generated/api-types/shared'
+import { CalendarEventAttendeeId } from 'lib-common/generated/api-types/shared'
+import { CalendarEventTimeId } from 'lib-common/generated/api-types/shared'
 import { CalendarEventType } from 'lib-common/generated/api-types/calendarevent'
 import { CareType } from 'lib-common/generated/api-types/daycare'
+import { ChildDocumentId } from 'lib-common/generated/api-types/shared'
 import { ChildWithDateOfBirth } from 'lib-common/generated/api-types/invoicing'
+import { ClubTermId } from 'lib-common/generated/api-types/shared'
 import { Coordinate } from 'lib-common/generated/api-types/shared'
 import { DailyServiceTimesType } from 'lib-common/generated/api-types/dailyservicetimes'
+import { DailyServicesTimeId } from 'lib-common/generated/api-types/shared'
+import { DailyServicesTimeNotificationId } from 'lib-common/generated/api-types/shared'
+import { DaycareAssistanceId } from 'lib-common/generated/api-types/shared'
 import { DaycareAssistanceLevel } from 'lib-common/generated/api-types/assistance'
 import { DaycareDecisionCustomization } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
+import { DecisionId } from 'lib-common/generated/api-types/shared'
 import { DecisionIncome } from 'lib-common/generated/api-types/invoicing'
 import { DecisionStatus } from 'lib-common/generated/api-types/decision'
 import { DecisionType } from 'lib-common/generated/api-types/decision'
 import { DocumentContent } from 'lib-common/generated/api-types/document'
 import { DocumentStatus } from 'lib-common/generated/api-types/document'
 import { DocumentTemplateContent } from 'lib-common/generated/api-types/document'
+import { DocumentTemplateId } from 'lib-common/generated/api-types/shared'
 import { DocumentType } from 'lib-common/generated/api-types/document'
 import { EmailMessageType } from 'lib-common/generated/api-types/pis'
+import { EmployeeId } from 'lib-common/generated/api-types/shared'
 import { EvakaUser } from 'lib-common/generated/api-types/user'
+import { EvakaUserId } from 'lib-common/generated/api-types/shared'
 import { FeeAlterationWithEffect } from 'lib-common/generated/api-types/invoicing'
 import { FeeDecisionThresholds } from 'lib-common/generated/api-types/invoicing'
+import { FosterParentId } from 'lib-common/generated/api-types/shared'
+import { GroupId } from 'lib-common/generated/api-types/shared'
+import { GroupPlacementId } from 'lib-common/generated/api-types/shared'
+import { HolidayQuestionnaireId } from 'lib-common/generated/api-types/shared'
 import { IncomeEffect } from 'lib-common/generated/api-types/invoicing'
+import { IncomeId } from 'lib-common/generated/api-types/shared'
 import { IncomeStatementBody } from 'lib-common/generated/api-types/incomestatement'
+import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
 import { IncomeStatementStatus } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeValue } from 'lib-common/generated/api-types/invoicing'
+import { InvoiceCorrectionId } from 'lib-common/generated/api-types/shared'
+import { InvoiceId } from 'lib-common/generated/api-types/shared'
+import { InvoiceRowId } from 'lib-common/generated/api-types/shared'
 import { InvoiceStatus } from 'lib-common/generated/api-types/invoicing'
 import { JsonOf } from 'lib-common/json'
 import { Language } from 'lib-common/generated/api-types/daycare'
 import { MailingAddress } from 'lib-common/generated/api-types/daycare'
+import { MobileDeviceId } from 'lib-common/generated/api-types/shared'
 import { Nationality } from 'lib-common/generated/api-types/vtjclient'
 import { NativeLanguage } from 'lib-common/generated/api-types/vtjclient'
 import { OfficialLanguage } from 'lib-common/generated/api-types/shared'
+import { OtherAssistanceMeasureId } from 'lib-common/generated/api-types/shared'
 import { OtherAssistanceMeasureType } from 'lib-common/generated/api-types/assistance'
+import { ParentshipId } from 'lib-common/generated/api-types/shared'
+import { PartnershipId } from 'lib-common/generated/api-types/shared'
+import { PaymentId } from 'lib-common/generated/api-types/shared'
 import { PaymentStatus } from 'lib-common/generated/api-types/invoicing'
+import { PedagogicalDocumentId } from 'lib-common/generated/api-types/shared'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { PilotFeature } from 'lib-common/generated/api-types/shared'
+import { PlacementId } from 'lib-common/generated/api-types/shared'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
+import { PreschoolAssistanceId } from 'lib-common/generated/api-types/shared'
 import { PreschoolAssistanceLevel } from 'lib-common/generated/api-types/assistance'
+import { PreschoolTermId } from 'lib-common/generated/api-types/shared'
 import { ProviderType } from 'lib-common/generated/api-types/daycare'
 import { PushNotificationCategory } from 'lib-common/generated/api-types/webpush'
 import { ServiceApplicationDecisionStatus } from 'lib-common/generated/api-types/serviceneed'
+import { ServiceApplicationId } from 'lib-common/generated/api-types/shared'
+import { ServiceNeedId } from 'lib-common/generated/api-types/shared'
+import { ServiceNeedOptionId } from 'lib-common/generated/api-types/shared'
 import { ServiceOptions } from 'lib-common/generated/api-types/assistanceneed'
 import { ShiftCareType } from 'lib-common/generated/api-types/serviceneed'
+import { StaffAttendanceRealtimeId } from 'lib-common/generated/api-types/shared'
 import { StaffAttendanceType } from 'lib-common/generated/api-types/attendance'
 import { StructuralMotivationOptions } from 'lib-common/generated/api-types/assistanceneed'
 import { UUID } from 'lib-common/types'
@@ -67,6 +111,7 @@ import { UnitManager } from 'lib-common/generated/api-types/daycare'
 import { UserRole } from 'lib-common/generated/api-types/shared'
 import { VisitingAddress } from 'lib-common/generated/api-types/daycare'
 import { VoucherValueDecisionDifference } from 'lib-common/generated/api-types/invoicing'
+import { VoucherValueDecisionId } from 'lib-common/generated/api-types/shared'
 import { VoucherValueDecisionServiceNeed } from 'lib-common/generated/api-types/invoicing'
 import { VoucherValueDecisionStatus } from 'lib-common/generated/api-types/invoicing'
 import { VoucherValueDecisionType } from 'lib-common/generated/api-types/invoicing'
@@ -76,6 +121,10 @@ import { deserializeJsonChildWithDateOfBirth } from 'lib-common/generated/api-ty
 import { deserializeJsonDocumentContent } from 'lib-common/generated/api-types/document'
 import { deserializeJsonIncomeStatementBody } from 'lib-common/generated/api-types/incomestatement'
 
+export type AbsenceId = string
+
+export type AssistanceActionOptionId = string
+
 /**
 * Generated from fi.espoo.evaka.shared.dev.MockDigitransit.Autocomplete
 */
@@ -83,13 +132,15 @@ export interface Autocomplete {
   features: Feature[]
 }
 
+export type CalendarEventId = string
+
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.Caretaker
 */
 export interface Caretaker {
   amount: number
   endDate: LocalDate | null
-  groupId: UUID
+  groupId: GroupId
   startDate: LocalDate
 }
 
@@ -115,14 +166,14 @@ export interface DaycareAclInsert {
 * Generated from fi.espoo.evaka.shared.dev.DevApi.DecisionRequest
 */
 export interface DecisionRequest {
-  applicationId: UUID
-  employeeId: UUID
+  applicationId: ApplicationId
+  employeeId: EmployeeId
   endDate: LocalDate
-  id: UUID
+  id: DecisionId
   startDate: LocalDate
   status: DecisionStatus
   type: DecisionType
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -131,12 +182,12 @@ export interface DecisionRequest {
 export interface DevAbsence {
   absenceCategory: AbsenceCategory
   absenceType: AbsenceType
-  childId: UUID
+  childId: PersonId
   date: LocalDate
-  id: UUID
+  id: AbsenceId
   modifiedAt: HelsinkiDateTime
-  modifiedBy: UUID
-  questionnaireId: UUID | null
+  modifiedBy: EvakaUserId
+  questionnaireId: HolidayQuestionnaireId | null
 }
 
 /**
@@ -145,18 +196,18 @@ export interface DevAbsence {
 export interface DevApplicationWithForm {
   allowOtherGuardianAccess: boolean
   checkedByAdmin: boolean
-  childId: UUID
+  childId: PersonId
   confidential: boolean | null
   createdDate: HelsinkiDateTime | null
   dueDate: LocalDate | null
   form: ApplicationForm
   formModified: HelsinkiDateTime
-  guardianId: UUID
+  guardianId: PersonId
   hideFromGuardian: boolean
-  id: UUID
+  id: ApplicationId
   modifiedDate: HelsinkiDateTime | null
   origin: ApplicationOrigin
-  otherGuardians: UUID[]
+  otherGuardians: PersonId[]
   sentDate: LocalDate | null
   status: ApplicationStatus
   transferApplication: boolean
@@ -168,12 +219,12 @@ export interface DevApplicationWithForm {
 */
 export interface DevAssistanceAction {
   actions: string[]
-  childId: UUID
+  childId: PersonId
   endDate: LocalDate
-  id: UUID
+  id: AssistanceActionId
   otherAction: string
   startDate: LocalDate
-  updatedBy: UUID
+  updatedBy: EvakaUserId
 }
 
 /**
@@ -181,7 +232,7 @@ export interface DevAssistanceAction {
 */
 export interface DevAssistanceActionOption {
   descriptionFi: string | null
-  id: UUID
+  id: AssistanceActionOptionId
   nameFi: string
   value: string
 }
@@ -191,8 +242,8 @@ export interface DevAssistanceActionOption {
 */
 export interface DevAssistanceFactor {
   capacityFactor: number
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: AssistanceFactorId
   modified: HelsinkiDateTime
   modifiedBy: EvakaUser
   validDuring: FiniteDateRange
@@ -205,7 +256,7 @@ export interface DevAssistanceNeedDecision {
   annulmentReason: string
   assistanceLevels: AssistanceLevel[]
   careMotivation: string | null
-  childId: UUID
+  childId: PersonId
   decisionMade: LocalDate | null
   decisionMaker: AssistanceNeedDecisionEmployee | null
   decisionNumber: number | null
@@ -213,7 +264,7 @@ export interface DevAssistanceNeedDecision {
   expertResponsibilities: string | null
   guardianInfo: AssistanceNeedDecisionGuardian[]
   guardiansHeardOn: LocalDate | null
-  id: UUID
+  id: AssistanceNeedDecisionId
   language: OfficialLanguage
   motivationForDecision: string | null
   otherRepresentativeDetails: string | null
@@ -221,14 +272,14 @@ export interface DevAssistanceNeedDecision {
   pedagogicalMotivation: string | null
   preparedBy1: AssistanceNeedDecisionEmployee | null
   preparedBy2: AssistanceNeedDecisionEmployee | null
-  selectedUnit: UUID | null
+  selectedUnit: DaycareId | null
   sentForDecision: LocalDate | null
   serviceOptions: ServiceOptions
   servicesMotivation: string | null
   status: AssistanceNeedDecisionStatus
   structuralMotivationDescription: string | null
   structuralMotivationOptions: StructuralMotivationOptions
-  unreadGuardianIds: UUID[] | null
+  unreadGuardianIds: PersonId[] | null
   validityPeriod: DateRange
   viewOfGuardians: string | null
 }
@@ -238,23 +289,23 @@ export interface DevAssistanceNeedDecision {
 */
 export interface DevAssistanceNeedPreschoolDecision {
   annulmentReason: string
-  childId: UUID
+  childId: PersonId
   decisionMade: LocalDate | null
   decisionNumber: number
   form: AssistanceNeedPreschoolDecisionForm
-  id: UUID
+  id: AssistanceNeedPreschoolDecisionId
   sentForDecision: LocalDate | null
   status: AssistanceNeedDecisionStatus
-  unreadGuardianIds: UUID[] | null
+  unreadGuardianIds: PersonId[] | null
 }
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevAssistanceNeedVoucherCoefficient
 */
 export interface DevAssistanceNeedVoucherCoefficient {
-  childId: UUID
+  childId: PersonId
   coefficient: number
-  id: UUID
+  id: AssistanceNeedVoucherCoefficientId
   modifiedAt: HelsinkiDateTime
   modifiedBy: EvakaUser | null
   validityPeriod: FiniteDateRange
@@ -264,19 +315,19 @@ export interface DevAssistanceNeedVoucherCoefficient {
 * Generated from fi.espoo.evaka.shared.dev.DevBackupCare
 */
 export interface DevBackupCare {
-  childId: UUID
-  groupId: UUID | null
-  id: UUID
+  childId: PersonId
+  groupId: GroupId | null
+  id: BackupCareId
   period: FiniteDateRange
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevBackupPickup
 */
 export interface DevBackupPickup {
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: BackupPickupId
   name: string
   phone: string
 }
@@ -287,9 +338,9 @@ export interface DevBackupPickup {
 export interface DevCalendarEvent {
   description: string
   eventType: CalendarEventType
-  id: UUID
+  id: CalendarEventAttendeeId
   modifiedAt: HelsinkiDateTime
-  modifiedBy: UUID
+  modifiedBy: EvakaUserId
   period: FiniteDateRange
   title: string
 }
@@ -298,24 +349,24 @@ export interface DevCalendarEvent {
 * Generated from fi.espoo.evaka.shared.dev.DevCalendarEventAttendee
 */
 export interface DevCalendarEventAttendee {
-  calendarEventId: UUID
-  childId: UUID | null
-  groupId: UUID | null
-  id: UUID
-  unitId: UUID
+  calendarEventId: CalendarEventAttendeeId
+  childId: PersonId | null
+  groupId: GroupId | null
+  id: CalendarEventId
+  unitId: DaycareId
 }
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevCalendarEventTime
 */
 export interface DevCalendarEventTime {
-  calendarEventId: UUID
-  childId: UUID | null
+  calendarEventId: CalendarEventAttendeeId
+  childId: PersonId | null
   date: LocalDate
   end: LocalTime
-  id: UUID
+  id: CalendarEventTimeId
   modifiedAt: HelsinkiDateTime
-  modifiedBy: UUID
+  modifiedBy: EvakaUserId
   start: LocalTime
 }
 
@@ -324,7 +375,7 @@ export interface DevCalendarEventTime {
 */
 export interface DevCareArea {
   areaCode: number | null
-  id: UUID
+  id: AreaId
   name: string
   shortName: string
   subCostCenter: string | null
@@ -338,7 +389,7 @@ export interface DevChild {
   allergies: string
   diet: string
   dietId: number | null
-  id: UUID
+  id: PersonId
   languageAtHome: string
   languageAtHomeDetails: string
   mealTextureId: number | null
@@ -350,26 +401,26 @@ export interface DevChild {
 */
 export interface DevChildAttendance {
   arrived: LocalTime
-  childId: UUID
+  childId: PersonId
   date: LocalDate
   departed: LocalTime | null
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevChildDocument
 */
 export interface DevChildDocument {
-  childId: UUID
+  childId: PersonId
   content: DocumentContent
   contentModifiedAt: HelsinkiDateTime
-  contentModifiedBy: UUID | null
-  id: UUID
+  contentModifiedBy: EmployeeId | null
+  id: ChildDocumentId
   modifiedAt: HelsinkiDateTime
   publishedAt: HelsinkiDateTime | null
   publishedContent: DocumentContent | null
   status: DocumentStatus
-  templateId: UUID
+  templateId: DocumentTemplateId
 }
 
 /**
@@ -377,7 +428,7 @@ export interface DevChildDocument {
 */
 export interface DevClubTerm {
   applicationPeriod: FiniteDateRange
-  id: UUID
+  id: ClubTermId
   term: FiniteDateRange
   termBreaks: FiniteDateRange[]
 }
@@ -386,17 +437,17 @@ export interface DevClubTerm {
 * Generated from fi.espoo.evaka.shared.dev.DevDailyServiceTimeNotification
 */
 export interface DevDailyServiceTimeNotification {
-  guardianId: UUID
-  id: UUID
+  guardianId: PersonId
+  id: DailyServicesTimeNotificationId
 }
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevDailyServiceTimes
 */
 export interface DevDailyServiceTimes {
-  childId: UUID
+  childId: PersonId
   fridayTimes: TimeRange | null
-  id: UUID
+  id: DailyServicesTimeId
   mondayTimes: TimeRange | null
   regularTimes: TimeRange | null
   saturdayTimes: TimeRange | null
@@ -413,7 +464,7 @@ export interface DevDailyServiceTimes {
 */
 export interface DevDaycare {
   additionalInfo: string | null
-  areaId: UUID
+  areaId: AreaId
   businessId: string
   capacity: number
   closingDate: LocalDate | null
@@ -426,10 +477,10 @@ export interface DevDaycare {
   dwCostCenter: string | null
   email: string | null
   enabledPilotFeatures: PilotFeature[]
-  financeDecisionHandler: UUID | null
+  financeDecisionHandler: EmployeeId | null
   ghostUnit: boolean
   iban: string
-  id: UUID
+  id: DaycareId
   invoicedByMunicipality: boolean
   language: Language
   location: Coordinate | null
@@ -463,8 +514,8 @@ export interface DevDaycare {
 * Generated from fi.espoo.evaka.shared.dev.DevDaycareAssistance
 */
 export interface DevDaycareAssistance {
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: DaycareAssistanceId
   level: DaycareAssistanceLevel
   modified: HelsinkiDateTime
   modifiedBy: EvakaUser
@@ -475,9 +526,9 @@ export interface DevDaycareAssistance {
 * Generated from fi.espoo.evaka.shared.dev.DevDaycareGroup
 */
 export interface DevDaycareGroup {
-  daycareId: UUID
+  daycareId: DaycareId
   endDate: LocalDate | null
-  id: UUID
+  id: GroupId
   jamixCustomerNumber: number | null
   name: string
   startDate: LocalDate
@@ -488,8 +539,8 @@ export interface DevDaycareGroup {
 */
 export interface DevDaycareGroupAcl {
   created: HelsinkiDateTime
-  employeeId: UUID
-  groupId: UUID
+  employeeId: EmployeeId
+  groupId: GroupId
   updated: HelsinkiDateTime
 }
 
@@ -497,10 +548,10 @@ export interface DevDaycareGroupAcl {
 * Generated from fi.espoo.evaka.shared.dev.DevDaycareGroupPlacement
 */
 export interface DevDaycareGroupPlacement {
-  daycareGroupId: UUID
-  daycarePlacementId: UUID
+  daycareGroupId: GroupId
+  daycarePlacementId: PlacementId
   endDate: LocalDate
-  id: UUID
+  id: GroupPlacementId
   startDate: LocalDate
 }
 
@@ -511,7 +562,7 @@ export interface DevDocumentTemplate {
   archiveDurationMonths: number | null
   confidential: boolean
   content: DocumentTemplateContent
-  id: UUID
+  id: DocumentTemplateId
   language: OfficialLanguage
   legalBasis: string
   name: string
@@ -531,7 +582,7 @@ export interface DevEmployee {
   employeeNumber: string | null
   externalId: string | null
   firstName: string
-  id: UUID
+  id: EmployeeId
   lastLogin: HelsinkiDateTime
   lastName: string
   preferredFirstName: string | null
@@ -546,15 +597,15 @@ export interface DevEmployeePin {
   id: UUID
   locked: boolean
   pin: string
-  userId: UUID | null
+  userId: EmployeeId | null
 }
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevFamilyContact
 */
 export interface DevFamilyContact {
-  childId: UUID
-  contactPersonId: UUID
+  childId: PersonId
+  contactPersonId: PersonId
   id: UUID
   priority: number
 }
@@ -563,11 +614,11 @@ export interface DevFamilyContact {
 * Generated from fi.espoo.evaka.shared.dev.DevFosterParent
 */
 export interface DevFosterParent {
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: FosterParentId
   modifiedAt: HelsinkiDateTime
-  modifiedBy: UUID
-  parentId: UUID
+  modifiedBy: EvakaUserId
+  parentId: PersonId
   validDuring: DateRange
 }
 
@@ -575,11 +626,11 @@ export interface DevFosterParent {
 * Generated from fi.espoo.evaka.shared.dev.DevFridgeChild
 */
 export interface DevFridgeChild {
-  childId: UUID
+  childId: PersonId
   conflict: boolean
   endDate: LocalDate
-  headOfChild: UUID
-  id: UUID
+  headOfChild: PersonId
+  id: ParentshipId
   startDate: LocalDate
 }
 
@@ -592,8 +643,8 @@ export interface DevFridgePartner {
   endDate: LocalDate | null
   indx: number
   otherIndx: number
-  partnershipId: UUID
-  personId: UUID
+  partnershipId: PartnershipId
+  personId: PersonId
   startDate: LocalDate
 }
 
@@ -601,8 +652,8 @@ export interface DevFridgePartner {
 * Generated from fi.espoo.evaka.shared.dev.DevGuardian
 */
 export interface DevGuardian {
-  childId: UUID
-  guardianId: UUID
+  childId: PersonId
+  guardianId: PersonId
 }
 
 /**
@@ -611,11 +662,11 @@ export interface DevGuardian {
 export interface DevIncome {
   data: Partial<Record<string, IncomeValue>>
   effect: IncomeEffect
-  id: UUID
+  id: IncomeId
   isEntrepreneur: boolean
   modifiedAt: HelsinkiDateTime
-  modifiedBy: UUID
-  personId: UUID
+  modifiedBy: EvakaUserId
+  personId: PersonId
   validFrom: LocalDate
   validTo: LocalDate | null
   worksAtEcha: boolean
@@ -626,14 +677,14 @@ export interface DevIncome {
 */
 export interface DevIncomeStatement {
   createdAt: HelsinkiDateTime
-  createdBy: UUID
+  createdBy: EvakaUserId
   data: IncomeStatementBody
   handledAt: HelsinkiDateTime | null
-  handlerId: UUID | null
-  id: UUID
+  handlerId: EmployeeId | null
+  id: IncomeStatementId
   modifiedAt: HelsinkiDateTime
-  modifiedBy: UUID
-  personId: UUID
+  modifiedBy: EvakaUserId
+  personId: PersonId
   sentAt: HelsinkiDateTime | null
   status: IncomeStatementStatus
 }
@@ -642,21 +693,21 @@ export interface DevIncomeStatement {
 * Generated from fi.espoo.evaka.shared.dev.DevInvoice
 */
 export interface DevInvoice {
-  areaId: UUID
-  codebtor: UUID | null
+  areaId: AreaId
+  codebtor: PersonId | null
   createdAt: HelsinkiDateTime | null
   dueDate: LocalDate
-  headOfFamilyId: UUID
-  id: UUID
+  headOfFamilyId: PersonId
+  id: InvoiceId
   invoiceDate: LocalDate
   number: number | null
   periodEnd: LocalDate
   periodStart: LocalDate
-  replacedInvoiceId: UUID | null
+  replacedInvoiceId: InvoiceId | null
   revisionNumber: number
   rows: DevInvoiceRow[]
   sentAt: HelsinkiDateTime | null
-  sentBy: UUID | null
+  sentBy: EvakaUserId | null
   status: InvoiceStatus
 }
 
@@ -665,15 +716,15 @@ export interface DevInvoice {
 */
 export interface DevInvoiceRow {
   amount: number
-  childId: UUID
-  correctionId: UUID | null
+  childId: PersonId
+  correctionId: InvoiceCorrectionId | null
   description: string
-  id: UUID
+  id: InvoiceRowId
   idx: number | null
   periodEnd: LocalDate
   periodStart: LocalDate
   product: string
-  unitId: UUID
+  unitId: DaycareId
   unitPrice: number
 }
 
@@ -681,19 +732,19 @@ export interface DevInvoiceRow {
 * Generated from fi.espoo.evaka.shared.dev.DevMobileDevice
 */
 export interface DevMobileDevice {
-  id: UUID
+  id: MobileDeviceId
   longTermToken: UUID | null
   name: string
   pushNotificationCategories: PushNotificationCategory[]
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevOtherAssistanceMeasure
 */
 export interface DevOtherAssistanceMeasure {
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: OtherAssistanceMeasureId
   modified: HelsinkiDateTime
   modifiedBy: EvakaUser
   type: OtherAssistanceMeasureType
@@ -704,11 +755,11 @@ export interface DevOtherAssistanceMeasure {
 * Generated from fi.espoo.evaka.shared.dev.DevParentship
 */
 export interface DevParentship {
-  childId: UUID
+  childId: PersonId
   createdAt: HelsinkiDateTime
   endDate: LocalDate
-  headOfChildId: UUID
-  id: UUID
+  headOfChildId: PersonId
+  id: ParentshipId
   startDate: LocalDate
 }
 
@@ -718,16 +769,16 @@ export interface DevParentship {
 export interface DevPayment {
   amount: number
   dueDate: LocalDate | null
-  id: UUID
+  id: PaymentId
   number: number
   paymentDate: LocalDate | null
   period: FiniteDateRange
   sentAt: HelsinkiDateTime | null
-  sentBy: UUID | null
+  sentBy: EmployeeId | null
   status: PaymentStatus
   unitBusinessId: string | null
   unitIban: string | null
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
   unitProviderId: string | null
 }
@@ -736,12 +787,12 @@ export interface DevPayment {
 * Generated from fi.espoo.evaka.shared.dev.DevPedagogicalDocument
 */
 export interface DevPedagogicalDocument {
-  childId: UUID
-  createdBy: UUID
+  childId: PersonId
+  createdBy: EvakaUserId
   description: string
-  id: UUID
+  id: PedagogicalDocumentId
   modifiedAt: HelsinkiDateTime
-  modifiedBy: UUID
+  modifiedBy: EvakaUserId
 }
 
 /**
@@ -752,11 +803,11 @@ export interface DevPerson {
   dateOfBirth: LocalDate
   dateOfDeath: LocalDate | null
   disabledEmailTypes: EmailMessageType[]
-  duplicateOf: UUID | null
+  duplicateOf: PersonId | null
   email: string | null
   firstName: string
   forceManualFeeDecisions: boolean
-  id: UUID
+  id: PersonId
   invoiceRecipientName: string
   invoicingPostOffice: string
   invoicingPostalCode: string
@@ -783,7 +834,7 @@ export interface DevPerson {
 */
 export interface DevPersonEmail {
   email: string | null
-  personId: UUID
+  personId: PersonId
 }
 
 /**
@@ -798,8 +849,8 @@ export type DevPersonType =
 * Generated from fi.espoo.evaka.shared.dev.DevPersonalMobileDevice
 */
 export interface DevPersonalMobileDevice {
-  employeeId: UUID
-  id: UUID
+  employeeId: EmployeeId
+  id: MobileDeviceId
   longTermToken: UUID | null
   name: string
 }
@@ -808,23 +859,23 @@ export interface DevPersonalMobileDevice {
 * Generated from fi.espoo.evaka.shared.dev.DevPlacement
 */
 export interface DevPlacement {
-  childId: UUID
+  childId: PersonId
   endDate: LocalDate
-  id: UUID
+  id: PlacementId
   placeGuarantee: boolean
   startDate: LocalDate
-  terminatedBy: UUID | null
+  terminatedBy: EvakaUserId | null
   terminationRequestedDate: LocalDate | null
   type: PlacementType
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevPreschoolAssistance
 */
 export interface DevPreschoolAssistance {
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: PreschoolAssistanceId
   level: PreschoolAssistanceLevel
   modified: HelsinkiDateTime
   modifiedBy: EvakaUser
@@ -838,7 +889,7 @@ export interface DevPreschoolTerm {
   applicationPeriod: FiniteDateRange
   extendedTerm: FiniteDateRange
   finnishPreschool: FiniteDateRange
-  id: UUID
+  id: PreschoolTermId
   swedishPreschool: FiniteDateRange
   termBreaks: FiniteDateRange[]
 }
@@ -848,15 +899,15 @@ export interface DevPreschoolTerm {
 */
 export interface DevServiceApplication {
   additionalInfo: string
-  childId: UUID
+  childId: PersonId
   decidedAt: HelsinkiDateTime | null
-  decidedBy: UUID | null
+  decidedBy: EmployeeId | null
   decisionStatus: ServiceApplicationDecisionStatus | null
-  id: UUID
-  personId: UUID
+  id: ServiceApplicationId
+  personId: PersonId
   rejectedReason: string | null
   sentAt: HelsinkiDateTime
-  serviceNeedOptionId: UUID
+  serviceNeedOptionId: ServiceNeedOptionId
   startDate: LocalDate
 }
 
@@ -865,12 +916,12 @@ export interface DevServiceApplication {
 */
 export interface DevServiceNeed {
   confirmedAt: HelsinkiDateTime | null
-  confirmedBy: UUID
+  confirmedBy: EvakaUserId
   endDate: LocalDate
-  id: UUID
-  optionId: UUID
+  id: ServiceNeedId
+  optionId: ServiceNeedOptionId
   partWeek: boolean
-  placementId: UUID
+  placementId: PlacementId
   shiftCare: ShiftCareType
   startDate: LocalDate
 }
@@ -882,9 +933,9 @@ export interface DevStaffAttendance {
   arrived: HelsinkiDateTime
   departed: HelsinkiDateTime | null
   departedAutomatically: boolean
-  employeeId: UUID
-  groupId: UUID | null
-  id: UUID
+  employeeId: EmployeeId
+  groupId: GroupId | null
+  id: StaffAttendanceRealtimeId
   occupancyCoefficient: number
   type: StaffAttendanceType
 }
@@ -894,9 +945,9 @@ export interface DevStaffAttendance {
 */
 export interface DevStaffAttendancePlan {
   description: string | null
-  employeeId: UUID
+  employeeId: EmployeeId
   endTime: HelsinkiDateTime
-  id: UUID
+  id: StaffAttendancePlanId
   startTime: HelsinkiDateTime
   type: StaffAttendanceType
 }
@@ -906,8 +957,8 @@ export interface DevStaffAttendancePlan {
 */
 export interface DevTerminatePlacementRequest {
   endDate: LocalDate
-  placementId: UUID
-  terminatedBy: UUID | null
+  placementId: PlacementId
+  terminatedBy: EvakaUserId | null
   terminationRequestedDate: LocalDate | null
 }
 
@@ -916,8 +967,8 @@ export interface DevTerminatePlacementRequest {
 */
 export interface DevUpsertStaffOccupancyCoefficient {
   coefficient: number
-  employeeId: UUID
-  unitId: UUID
+  employeeId: EmployeeId
+  unitId: DaycareId
 }
 
 /**
@@ -1006,14 +1057,14 @@ export interface PlacementPlan {
   periodStart: LocalDate
   preschoolDaycarePeriodEnd: LocalDate | null
   preschoolDaycarePeriodStart: LocalDate | null
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
 * Generated from fi.espoo.evaka.reservations.ReservationInsert
 */
 export interface ReservationInsert {
-  childId: UUID
+  childId: PersonId
   date: LocalDate
   range: TimeRange | null
 }
@@ -1048,12 +1099,14 @@ export interface SfiMessage {
   streetAddress: string
 }
 
+export type StaffAttendancePlanId = string
+
 /**
 * Generated from fi.espoo.evaka.invoicing.domain.VoucherValueDecision
 */
 export interface VoucherValueDecision {
   approvedAt: HelsinkiDateTime | null
-  approvedById: UUID | null
+  approvedById: EmployeeId | null
   assistanceNeedCoefficient: number
   baseCoPayment: number
   baseValue: number
@@ -1070,10 +1123,10 @@ export interface VoucherValueDecision {
   feeAlterations: FeeAlterationWithEffect[]
   feeThresholds: FeeDecisionThresholds
   finalCoPayment: number
-  headOfFamilyId: UUID
+  headOfFamilyId: PersonId
   headOfFamilyIncome: DecisionIncome | null
-  id: UUID
-  partnerId: UUID | null
+  id: VoucherValueDecisionId
+  partnerId: PersonId | null
   partnerIncome: DecisionIncome | null
   placement: VoucherValueDecisionPlacement | null
   sentAt: HelsinkiDateTime | null
@@ -1090,7 +1143,7 @@ export interface VoucherValueDecision {
 */
 export interface VoucherValueDecisionPlacement {
   type: PlacementType
-  unitId: UUID
+  unitId: DaycareId
 }
 
 

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -124,7 +124,7 @@ import { deserializeJsonIncomeStatementBody } from 'lib-common/generated/api-typ
 
 export type AbsenceId = Id<'Absence'>
 
-export type AssistanceActionOptionId = string
+export type AssistanceActionOptionId = Id<'AssistanceActionOption'>
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.MockDigitransit.Autocomplete

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -38,9 +38,9 @@ import { ChildDocumentId } from 'lib-common/generated/api-types/shared'
 import { ChildWithDateOfBirth } from 'lib-common/generated/api-types/invoicing'
 import { ClubTermId } from 'lib-common/generated/api-types/shared'
 import { Coordinate } from 'lib-common/generated/api-types/shared'
+import { DailyServiceTimeId } from 'lib-common/generated/api-types/shared'
+import { DailyServiceTimeNotificationId } from 'lib-common/generated/api-types/shared'
 import { DailyServiceTimesType } from 'lib-common/generated/api-types/dailyservicetimes'
-import { DailyServicesTimeId } from 'lib-common/generated/api-types/shared'
-import { DailyServicesTimeNotificationId } from 'lib-common/generated/api-types/shared'
 import { DaycareAssistanceId } from 'lib-common/generated/api-types/shared'
 import { DaycareAssistanceLevel } from 'lib-common/generated/api-types/assistance'
 import { DaycareDecisionCustomization } from 'lib-common/generated/api-types/daycare'
@@ -439,7 +439,7 @@ export interface DevClubTerm {
 */
 export interface DevDailyServiceTimeNotification {
   guardianId: PersonId
-  id: DailyServicesTimeNotificationId
+  id: DailyServiceTimeNotificationId
 }
 
 /**
@@ -448,7 +448,7 @@ export interface DevDailyServiceTimeNotification {
 export interface DevDailyServiceTimes {
   childId: PersonId
   fridayTimes: TimeRange | null
-  id: DailyServicesTimeId
+  id: DailyServiceTimeId
   mondayTimes: TimeRange | null
   regularTimes: TimeRange | null
   saturdayTimes: TimeRange | null

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -133,7 +133,7 @@ export interface Autocomplete {
   features: Feature[]
 }
 
-export type CalendarEventAttendeeId = string
+export type CalendarEventAttendeeId = Id<'CalendarEventAttendee'>
 
 /**
 * Generated from fi.espoo.evaka.shared.dev.DevApi.Caretaker

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -64,6 +64,7 @@ import { FosterParentId } from 'lib-common/generated/api-types/shared'
 import { GroupId } from 'lib-common/generated/api-types/shared'
 import { GroupPlacementId } from 'lib-common/generated/api-types/shared'
 import { HolidayQuestionnaireId } from 'lib-common/generated/api-types/shared'
+import { Id } from 'lib-common/id-type'
 import { IncomeEffect } from 'lib-common/generated/api-types/invoicing'
 import { IncomeId } from 'lib-common/generated/api-types/shared'
 import { IncomeStatementBody } from 'lib-common/generated/api-types/incomestatement'
@@ -121,7 +122,7 @@ import { deserializeJsonChildWithDateOfBirth } from 'lib-common/generated/api-ty
 import { deserializeJsonDocumentContent } from 'lib-common/generated/api-types/document'
 import { deserializeJsonIncomeStatementBody } from 'lib-common/generated/api-types/incomestatement'
 
-export type AbsenceId = string
+export type AbsenceId = Id<'Absence'>
 
 export type AssistanceActionOptionId = string
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -5,6 +5,8 @@
 import { ApplicationFormData } from 'lib-common/api-types/application/ApplicationFormData'
 import { ServiceNeedOption } from 'lib-common/generated/api-types/application'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { fromUuid } from 'lib-common/id-type'
 import { JsonOf } from 'lib-common/json'
 import { UUID } from 'lib-common/types'
 
@@ -215,7 +217,7 @@ class CitizenApplicationEditor {
 
   getNewApplicationId() {
     const urlParts = this.page.url.split('/')
-    return urlParts[urlParts.length - 2]
+    return fromUuid<ApplicationId>(urlParts[urlParts.length - 2])
   }
 
   async goToVerification() {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { CalendarEventId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
@@ -37,9 +39,9 @@ let calendarPage: CitizenCalendarPage
 let children: DevPerson[]
 const today = LocalDate.of(2022, 1, 12)
 
-const groupEventId = uuidv4()
-const unitEventId = uuidv4()
-const individualEventId = uuidv4()
+const groupEventId = randomId<CalendarEventId>()
+const unitEventId = randomId<CalendarEventId>()
+const individualEventId = randomId<CalendarEventId>()
 
 let jariId: UUID
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
@@ -4,7 +4,9 @@
 
 import { DevCalendarEventTime, DevPerson } from 'e2e-test/generated/api-types'
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { CalendarEventId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -39,12 +41,12 @@ let children: DevPerson[]
 const today = LocalDate.of(2022, 1, 10)
 
 const groupId = uuidv4()
-const groupEventId = uuidv4()
-const unitEventId = uuidv4()
-const individualEventId = uuidv4()
+const groupEventId = randomId<CalendarEventId>()
+const unitEventId = randomId<CalendarEventId>()
+const individualEventId = randomId<CalendarEventId>()
 const reservationId = uuidv4()
 const groupReservationId = uuidv4()
-const restrictedEventId = uuidv4()
+const restrictedEventId = randomId<CalendarEventId>()
 const restrictedEventTimeId = uuidv4()
 const noncancellableEventTimeId = uuidv4()
 
@@ -398,7 +400,7 @@ describe.each(e)('Citizen calendar discussion surveys (%s)', (env) => {
 const visibleEventTimeId = uuidv4()
 const unavailableEventTimeId = uuidv4()
 const visibleLaterEventTimeId = uuidv4()
-const multiPlacementEventId = uuidv4()
+const multiPlacementEventId = randomId<CalendarEventId>()
 
 describe.each(e)('Citizen calendar event time visibility (%s)', (env) => {
   beforeEach(async () => {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
@@ -4,7 +4,10 @@
 
 import { DevCalendarEventTime, DevPerson } from 'e2e-test/generated/api-types'
 import FiniteDateRange from 'lib-common/finite-date-range'
-import { CalendarEventId } from 'lib-common/generated/api-types/shared'
+import {
+  CalendarEventId,
+  CalendarEventTimeId
+} from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
@@ -44,11 +47,11 @@ const groupId = uuidv4()
 const groupEventId = randomId<CalendarEventId>()
 const unitEventId = randomId<CalendarEventId>()
 const individualEventId = randomId<CalendarEventId>()
-const reservationId = uuidv4()
-const groupReservationId = uuidv4()
+const reservationId = randomId<CalendarEventTimeId>()
+const groupReservationId = randomId<CalendarEventTimeId>()
 const restrictedEventId = randomId<CalendarEventId>()
-const restrictedEventTimeId = uuidv4()
-const noncancellableEventTimeId = uuidv4()
+const restrictedEventTimeId = randomId<CalendarEventTimeId>()
+const noncancellableEventTimeId = randomId<CalendarEventTimeId>()
 
 let reservationData: DevCalendarEventTime
 
@@ -397,9 +400,9 @@ describe.each(e)('Citizen calendar discussion surveys (%s)', (env) => {
   })
 })
 
-const visibleEventTimeId = uuidv4()
-const unavailableEventTimeId = uuidv4()
-const visibleLaterEventTimeId = uuidv4()
+const visibleEventTimeId = randomId<CalendarEventTimeId>()
+const unavailableEventTimeId = randomId<CalendarEventTimeId>()
+const visibleLaterEventTimeId = randomId<CalendarEventTimeId>()
 const multiPlacementEventId = randomId<CalendarEventId>()
 
 describe.each(e)('Citizen calendar event time visibility (%s)', (env) => {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-map.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-map.spec.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { fromUuid } from 'lib-common/id-type'
+
 import config from '../../config'
 import {
   testCareArea,
@@ -25,7 +27,7 @@ import { Page } from '../../utils/page'
 const swedishDaycare: DevDaycare = {
   ...testDaycare2,
   name: 'Svart hål svenska daghem',
-  id: '9db9e8f7-2091-4be1-b091-fe107906e1b9',
+  id: fromUuid('9db9e8f7-2091-4be1-b091-fe107906e1b9'),
   language: 'sv',
   location: {
     lat: 60.200745762705296,
@@ -48,7 +50,7 @@ const testStreet: DigitransitFeature = {
 const privateDaycareWithoutPeriods: DevDaycare = {
   ...testDaycare2,
   name: 'Private daycare',
-  id: '9db9e8f7-2091-4be1-b091-fe10790e107a',
+  id: fromUuid('9db9e8f7-2091-4be1-b091-fe10790e107a'),
   location: { lat: 60.1601417, lon: 24.7830233 },
   daycareApplyPeriod: null,
   preschoolApplyPeriod: null,

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -6,6 +6,7 @@ import zip from 'lodash/zip'
 
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -1436,7 +1437,7 @@ describe('Citizen calendar visibility', () => {
   let page: Page
   const today = LocalDate.todayInSystemTz()
   let child: DevPerson
-  let daycareId: string
+  let daycareId: DaycareId
 
   beforeEach(async () => {
     await resetServiceState()

--- a/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
@@ -4,7 +4,9 @@
 
 import DateRange from 'lib-common/date-range'
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { CalendarEventId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -430,7 +432,7 @@ test('Foster parent can see calendar events for foster children', async () => {
     daycareGroupId: daycareGroup.id,
     daycarePlacementId: placement.id
   }).save()
-  const groupEventId = uuidv4()
+  const groupEventId = randomId<CalendarEventId>()
   await Fixture.calendarEvent({
     id: groupEventId,
     title: 'Group-wide event',

--- a/frontend/src/e2e-test/specs/5_employee/application-attachments.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-attachments.spec.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { ApplicationId, DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { randomId } from 'lib-common/id-type'
 
@@ -15,7 +15,6 @@ import {
   testChild2,
   testAdult,
   Fixture,
-  uuidv4,
   testChild,
   testCareArea
 } from '../../dev-api/fixtures'
@@ -122,7 +121,7 @@ describe('Employee application attachments', () => {
   })
 
   test('Extended care attachment is not visible to non-around-the-clock unit supervisor', async () => {
-    const daycareId = uuidv4()
+    const daycareId = randomId<DaycareId>()
     await Fixture.daycare({
       ...testDaycare,
       shiftCareOperationTimes: null,

--- a/frontend/src/e2e-test/specs/5_employee/application-attachments.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-attachments.spec.ts
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 
 import config from '../../config'
 import { execSimpleApplicationActions } from '../../dev-api'
@@ -128,7 +130,7 @@ describe('Employee application attachments', () => {
       id: daycareId
     }).save()
 
-    const applicationId = uuidv4()
+    const applicationId = randomId<ApplicationId>()
     await createApplications({
       body: [
         {

--- a/frontend/src/e2e-test/specs/5_employee/application-details.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-details.spec.ts
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { fromUuid } from 'lib-common/id-type'
 
 import config from '../../config'
 import { execSimpleApplicationAction, runPendingAsyncJobs } from '../../dev-api'
@@ -61,7 +63,7 @@ beforeEach(async () => {
       familyWithTwoGuardians.guardian,
       familyWithTwoGuardians.otherGuardian
     ),
-    id: '8634e2b9-200b-4a68-b956-66c5126f86a0'
+    id: fromUuid<ApplicationId>('8634e2b9-200b-4a68-b956-66c5126f86a0')
   }
   separatedFamilyApplication = {
     ...applicationFixture(
@@ -71,7 +73,7 @@ beforeEach(async () => {
       'DAYCARE',
       'NOT_AGREED'
     ),
-    id: '0c8b9ad3-d283-460d-a5d4-77bdcbc69374'
+    id: fromUuid<ApplicationId>('0c8b9ad3-d283-460d-a5d4-77bdcbc69374')
   }
   restrictedDetailsGuardianApplication = {
     ...applicationFixture(
@@ -81,7 +83,7 @@ beforeEach(async () => {
       'DAYCARE',
       'NOT_AGREED'
     ),
-    id: '6a9b1b1e-3fdf-11eb-b378-0242ac130002'
+    id: fromUuid<ApplicationId>('6a9b1b1e-3fdf-11eb-b378-0242ac130002')
   }
   await cleanUpMessages()
 

--- a/frontend/src/e2e-test/specs/5_employee/application-search.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-search.spec.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { fromUuid, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import config from '../../config'
@@ -13,8 +15,7 @@ import {
   testCareArea,
   testChild,
   testChild2,
-  testDaycare,
-  uuidv4
+  testDaycare
 } from '../../dev-api/fixtures'
 import {
   createApplications,
@@ -51,12 +52,12 @@ describe('Employee searches applications', () => {
 
     const duplicateFixture = {
       ...applicationFixture(testChild, testAdult),
-      id: '9dd0e1ba-9b3b-11ea-bb37-0242ac130222'
+      id: fromUuid<ApplicationId>('9dd0e1ba-9b3b-11ea-bb37-0242ac130222')
     }
 
     const nonDuplicateFixture = {
       ...applicationFixture(testChild2, testAdult),
-      id: '9dd0e1ba-9b3b-11ea-bb37-0242ac130224'
+      id: fromUuid<ApplicationId>('9dd0e1ba-9b3b-11ea-bb37-0242ac130224')
     }
 
     await createApplications({
@@ -82,7 +83,7 @@ describe('Employee searches applications', () => {
       ...applicationFixture(testChild, testAdult, undefined, 'DAYCARE', null, [
         unitId
       ]),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     })
 
     const app1 = createApplicationForUnit(daycare1.id)
@@ -113,7 +114,7 @@ describe('Employee searches applications', () => {
       ...applicationFixture(testChild, testAdult, undefined, 'DAYCARE', null, [
         unitId
       ]),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     })
 
     const app1 = createApplicationForUnit(daycare1.id)
@@ -155,7 +156,7 @@ describe('Employee searches applications', () => {
         false,
         assistanceNeeded
       ),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     })
 
     const appWithAssistanceNeeded = createApplicationForUnit(daycare1.id, true)
@@ -194,20 +195,20 @@ describe('Employee searches applications', () => {
       ...applicationFixture(testChild, testAdult, undefined, 'DAYCARE', null, [
         voucherUnit.id
       ]),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
     const applicationWithVoucherUnitSecond = {
       ...applicationFixture(testChild, testAdult, undefined, 'DAYCARE', null, [
         municipalUnit.id,
         voucherUnit.id
       ]),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
     const applicationWithNoVoucherUnit = {
       ...applicationFixture(testChild, testAdult, undefined, 'DAYCARE', null, [
         municipalUnit.id
       ]),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
 
     await createApplications({
@@ -261,13 +262,13 @@ describe('Employee searches applications', () => {
       ...applicationFixture(testChild, testAdult, undefined, 'CLUB', null, [
         club.id
       ]),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
     const daycareApplication = {
       ...applicationFixture(testChild, testAdult, undefined, 'DAYCARE', null, [
         daycare.id
       ]),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
     const preschoolApplication = {
       ...applicationFixture(
@@ -278,7 +279,7 @@ describe('Employee searches applications', () => {
         null,
         [preschool.id]
       ),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
     await createApplications({
       body: [clubApplication, daycareApplication, preschoolApplication]

--- a/frontend/src/e2e-test/specs/5_employee/application-search.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-search.spec.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { ApplicationId, DaycareId } from 'lib-common/generated/api-types/shared'
 import { fromUuid, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
@@ -79,7 +79,7 @@ describe('Employee searches applications', () => {
     const careArea3 = await Fixture.careArea().save()
     const daycare3 = await Fixture.daycare({ areaId: careArea3.id }).save()
 
-    const createApplicationForUnit = (unitId: string) => ({
+    const createApplicationForUnit = (unitId: DaycareId) => ({
       ...applicationFixture(testChild, testAdult, undefined, 'DAYCARE', null, [
         unitId
       ]),
@@ -110,7 +110,7 @@ describe('Employee searches applications', () => {
     const daycare1 = await Fixture.daycare({ areaId: careArea1.id }).save()
     const daycare2 = await Fixture.daycare({ areaId: careArea1.id }).save()
 
-    const createApplicationForUnit = (unitId: string) => ({
+    const createApplicationForUnit = (unitId: DaycareId) => ({
       ...applicationFixture(testChild, testAdult, undefined, 'DAYCARE', null, [
         unitId
       ]),
@@ -140,7 +140,7 @@ describe('Employee searches applications', () => {
       .save()
 
     const createApplicationForUnit = (
-      unitId: string,
+      unitId: DaycareId,
       assistanceNeeded: boolean
     ) => ({
       ...applicationFixture(

--- a/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { fromUuid, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -13,7 +15,6 @@ import {
   decisionFixture,
   Fixture,
   testPreschool,
-  uuidv4,
   familyWithRestrictedDetailsGuardian,
   familyWithSeparatedGuardians,
   familyWithTwoGuardians,
@@ -48,7 +49,7 @@ let applicationWorkbench: ApplicationWorkbenchPage
 let applicationReadView: ApplicationReadView
 
 let serviceWorker: DevEmployee
-let applicationId: string
+let applicationId: ApplicationId
 
 beforeEach(async () => {
   await resetServiceState()
@@ -396,7 +397,7 @@ describe('Application transitions', () => {
         'SENT',
         preferredStartDate
       ),
-      id: '6a9b1b1e-3fdf-11eb-b378-0242ac130002'
+      id: fromUuid<ApplicationId>('6a9b1b1e-3fdf-11eb-b378-0242ac130002')
     }
     const applicationId = fixture.id
 
@@ -452,7 +453,7 @@ describe('Application transitions', () => {
         'DAYCARE',
         'NOT_AGREED'
       ),
-      id: '6a9b1b1e-3fdf-11eb-b378-0242ac130002'
+      id: fromUuid<ApplicationId>('6a9b1b1e-3fdf-11eb-b378-0242ac130002')
     }
     const applicationId = restrictedDetailsGuardianApplication.id
 
@@ -489,7 +490,7 @@ describe('Application transitions', () => {
         'SENT',
         mockedTime
       ),
-      id: '6a9b1b1e-3fdf-11eb-b378-0242ac130002'
+      id: fromUuid<ApplicationId>('6a9b1b1e-3fdf-11eb-b378-0242ac130002')
     }
     const applicationId = fixture.id
     await createApplications({ body: [fixture] })
@@ -551,7 +552,7 @@ describe('Application transitions', () => {
         'SENT',
         mockedTime
       ),
-      id: '6a9b1b1e-3fdf-11eb-b378-0242ac130002'
+      id: fromUuid<ApplicationId>('6a9b1b1e-3fdf-11eb-b378-0242ac130002')
     }
     const applicationId = fixture.id
     await createApplications({ body: [fixture] })
@@ -608,7 +609,9 @@ describe('Application transitions', () => {
     }
     applicationId = fixture1.id
 
-    const applicationId2 = 'dd54782e-231c-4014-abaf-a63eed4e2627'
+    const applicationId2 = fromUuid<ApplicationId>(
+      'dd54782e-231c-4014-abaf-a63eed4e2627'
+    )
     const fixture2 = {
       ...applicationFixture(testChild2, familyWithSeparatedGuardians.guardian),
       status: 'SENT' as const,
@@ -809,12 +812,12 @@ describe('Application transitions', () => {
   test('Application rejected by citizen is shown for 2 weeks', async () => {
     const application1: DevApplicationWithForm = {
       ...applicationFixture(testChild, testAdult),
-      id: uuidv4(),
+      id: randomId<ApplicationId>(),
       status: 'WAITING_CONFIRMATION'
     }
     const application2: DevApplicationWithForm = {
       ...applicationFixture(testChild2, testAdult),
-      id: uuidv4(),
+      id: randomId<ApplicationId>(),
       status: 'WAITING_CONFIRMATION'
     }
     const placementStartDate = LocalDate.of(2021, 8, 16)

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-and-actions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-and-actions-report.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
@@ -27,7 +28,7 @@ import { employeeLogin } from '../../utils/user'
 
 let page: Page
 let childId: UUID
-let unitId: UUID
+let unitId: DaycareId
 let admin: DevEmployee
 
 const mockedTime = LocalDate.of(2024, 2, 19)

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
+import {
+  AssistanceNeedDecisionId,
+  DaycareId
+} from 'lib-common/generated/api-types/shared'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -39,7 +42,7 @@ let page: Page
 let decisionMaker: DevEmployee
 let director: DevEmployee
 
-let unitId: UUID
+let unitId: DaycareId
 let childId: UUID
 
 const mockedTime = LocalDate.of(2021, 8, 16)

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
@@ -82,7 +84,7 @@ describe('Assistance need decisions report', () => {
 
   test('Lists correct decisions', async () => {
     await Fixture.assistanceNeedDecision({
-      id: uuidv4(),
+      id: randomId<AssistanceNeedDecisionId>(),
       childId,
       decisionMaker: {
         employeeId: decisionMaker.id,
@@ -94,7 +96,7 @@ describe('Assistance need decisions report', () => {
       selectedUnit: unitId
     }).save()
     await Fixture.assistanceNeedDecision({
-      id: uuidv4(),
+      id: randomId<AssistanceNeedDecisionId>(),
       childId,
       decisionMaker: {
         employeeId: decisionMaker.id,
@@ -117,7 +119,7 @@ describe('Assistance need decisions report', () => {
       selectedUnit: unitId
     }).save()
     await Fixture.assistanceNeedDecision({
-      id: uuidv4(),
+      id: randomId<AssistanceNeedDecisionId>(),
       childId,
       decisionMaker: {
         employeeId: decisionMaker.id,
@@ -159,7 +161,7 @@ describe('Assistance need decisions report', () => {
   })
 
   test('Removes unopened indicator from decision after opening decision', async () => {
-    const decisionId = uuidv4()
+    const decisionId = randomId<AssistanceNeedDecisionId>()
     await Fixture.assistanceNeedDecision({
       id: decisionId,
       childId,
@@ -200,7 +202,7 @@ describe('Assistance need decisions report', () => {
   })
 
   test('Returns decision for editing', async () => {
-    const decisionId = uuidv4()
+    const decisionId = randomId<AssistanceNeedDecisionId>()
     await Fixture.assistanceNeedDecision({
       id: decisionId,
       childId,
@@ -228,7 +230,7 @@ describe('Assistance need decisions report', () => {
   })
 
   test('Decision can be rejected', async () => {
-    const decisionId = uuidv4()
+    const decisionId = randomId<AssistanceNeedDecisionId>()
     await Fixture.assistanceNeedDecision({
       id: decisionId,
       childId,
@@ -255,7 +257,7 @@ describe('Assistance need decisions report', () => {
   })
 
   test('Decision can be accepted', async () => {
-    const decisionId = uuidv4()
+    const decisionId = randomId<AssistanceNeedDecisionId>()
     await Fixture.assistanceNeedDecision({
       id: decisionId,
       childId,
@@ -282,7 +284,7 @@ describe('Assistance need decisions report', () => {
   })
 
   test('Accepted decision can be annulled', async () => {
-    const decisionId = uuidv4()
+    const decisionId = randomId<AssistanceNeedDecisionId>()
     await Fixture.assistanceNeedDecision({
       id: decisionId,
       childId,
@@ -319,7 +321,7 @@ describe('Assistance need decisions report', () => {
       .admin()
       .save()
 
-    const decisionId = uuidv4()
+    const decisionId = randomId<AssistanceNeedDecisionId>()
     await Fixture.assistanceNeedDecision({
       id: decisionId,
       childId,
@@ -358,7 +360,7 @@ describe('Assistance need decisions report', () => {
   })
 
   test('Special education teacher on child s unit can open the decision', async () => {
-    const decisionId = uuidv4()
+    const decisionId = randomId<AssistanceNeedDecisionId>()
     await Fixture.assistanceNeedDecision({
       id: decisionId,
       childId,
@@ -389,7 +391,7 @@ describe('Assistance need decisions report', () => {
     await createDaycarePlacements({ body: [daycarePlacementFixture2] })
 
     await Fixture.assistanceNeedDecision({
-      id: uuidv4(),
+      id: randomId<AssistanceNeedDecisionId>(),
       childId: anotherChildId,
       decisionMaker: {
         employeeId: decisionMaker.id,

--- a/frontend/src/e2e-test/specs/5_employee/child-attendance-reservation-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-attendance-reservation-report.spec.ts
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
-import { UUID } from 'lib-common/types'
 
 import config from '../../config'
 import {
@@ -27,7 +27,7 @@ import { employeeLogin } from '../../utils/user'
 
 let page: Page
 let child: DevPerson
-let unitId: UUID
+let unitId: DaycareId
 let admin: DevEmployee
 
 const mockedTime = LocalDate.of(2024, 2, 19)

--- a/frontend/src/e2e-test/specs/5_employee/child-information-assistance.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information-assistance.spec.ts
@@ -6,6 +6,7 @@ import DateRange from 'lib-common/date-range'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { AssistanceNeedDecisionStatus } from 'lib-common/generated/api-types/assistanceneed'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
@@ -36,8 +37,8 @@ let page: Page
 let childInformationPage: ChildInformationPage
 let assistance: AssistanceSection
 let childId: UUID
-let unitId: UUID
-let voucherUnitId: UUID
+let unitId: DaycareId
+let voucherUnitId: DaycareId
 let admin: DevEmployee
 
 beforeEach(async () => {

--- a/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { PlacementType } from 'lib-common/generated/api-types/placement'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -34,7 +35,7 @@ beforeEach(async (): Promise<void> => resetServiceState())
 const setupPlacement = async (
   placementId: string,
   childId: UUID,
-  unitId: UUID,
+  unitId: DaycareId,
   childPlacementType: PlacementType
 ) => {
   await createDaycarePlacements({
@@ -61,7 +62,7 @@ async function openChildPlacements(page: Page, childId: UUID) {
 describe('Child Information placement info', () => {
   let page: Page
   let childId: UUID
-  let unitId: UUID
+  let unitId: DaycareId
 
   beforeEach(async () => {
     await Fixture.careArea(testCareArea).save()

--- a/frontend/src/e2e-test/specs/5_employee/feature-flag-decision-draft-multiple-units.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/feature-flag-decision-draft-multiple-units.spec.ts
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { fromUuid } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -73,7 +75,7 @@ describe('Application transitions', () => {
         'SENT',
         mockedTime
       ),
-      id: '6a9b1b1e-3fdf-11eb-b378-0242ac130002'
+      id: fromUuid<ApplicationId>('6a9b1b1e-3fdf-11eb-b378-0242ac130002')
     }
     const applicationId = fixture.id
     await createApplications({ body: [fixture] })
@@ -135,7 +137,7 @@ describe('Application transitions', () => {
         'SENT',
         mockedTime
       ),
-      id: '6a9b1b1e-3fdf-11eb-b378-0242ac130002'
+      id: fromUuid<ApplicationId>('6a9b1b1e-3fdf-11eb-b378-0242ac130002')
     }
     const applicationId = fixture.id
     await createApplications({ body: [fixture] })

--- a/frontend/src/e2e-test/specs/5_employee/guardian-information-page.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/guardian-information-page.spec.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import {
@@ -15,7 +17,6 @@ import {
   testAdult,
   familyWithTwoGuardians,
   Fixture,
-  uuidv4,
   testCareArea
 } from '../../dev-api/fixtures'
 import {
@@ -46,7 +47,7 @@ beforeEach(async () => {
   const admin = await Fixture.employee().admin().save()
 
   const daycarePlacementFixture = createDaycarePlacementFixture(
-    uuidv4(),
+    randomId<ApplicationId>(),
     testChild.id,
     testDaycare.id
   )
@@ -58,7 +59,7 @@ beforeEach(async () => {
       familyWithTwoGuardians.guardian,
       testAdult
     ),
-    id: uuidv4()
+    id: randomId<ApplicationId>()
   }
 
   const startDate = LocalDate.of(2021, 8, 16)
@@ -73,7 +74,7 @@ beforeEach(async () => {
       {
         ...decisionFixture(application2.id, startDate, startDate),
         employeeId: admin.id,
-        id: uuidv4()
+        id: randomId<ApplicationId>()
       }
     ]
   })

--- a/frontend/src/e2e-test/specs/5_employee/manual-duplication-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/manual-duplication-report.spec.ts
@@ -2,11 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
 import config from '../../config'
-import { applicationFixture, Fixture, uuidv4 } from '../../dev-api/fixtures'
+import { applicationFixture, Fixture } from '../../dev-api/fixtures'
 import {
   createApplications,
   resetServiceState
@@ -40,7 +42,7 @@ describe('Manual duplication report', () => {
       mockedTime: mockedToday.toHelsinkiDateTime(LocalTime.of(8, 0))
     })
 
-    const application1Id = uuidv4()
+    const application1Id = randomId<ApplicationId>()
     await createApplications({
       body: [
         {
@@ -78,7 +80,7 @@ describe('Manual duplication report', () => {
       status: 'ACCEPTED'
     }).save()
 
-    const application2Id = uuidv4()
+    const application2Id = randomId<ApplicationId>()
     await createApplications({
       body: [
         {

--- a/frontend/src/e2e-test/specs/5_employee/placement-sketching-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/placement-sketching-report.spec.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -11,7 +13,6 @@ import {
   createDaycarePlacementFixture,
   testDaycare,
   Fixture,
-  uuidv4,
   testAdult,
   testChild,
   testChild2,
@@ -66,7 +67,7 @@ describe('Placement sketching report', () => {
 
     const preferredStartDate = LocalDate.of(2021, 8, 13)
     const sentDate = preferredStartDate.subMonths(4)
-    const applicationId = uuidv4()
+    const applicationId = randomId<ApplicationId>()
 
     const createdApplication: DevApplicationWithForm = {
       ...fixture,
@@ -105,7 +106,7 @@ describe('Placement sketching report', () => {
 
     const preferredStartDate = LocalDate.of(2021, 8, 13)
     const sentDate = preferredStartDate.subMonths(4)
-    const applicationId = uuidv4()
+    const applicationId = randomId<ApplicationId>()
 
     const createdApplication: DevApplicationWithForm = {
       ...fixture,
@@ -128,7 +129,7 @@ describe('Placement sketching report', () => {
     const currentUnit = preferredUnit
 
     const daycarePlacementFixture = createDaycarePlacementFixture(
-      uuidv4(),
+      randomId<ApplicationId>(),
       createdApplication.childId,
       preferredUnit.id,
       placementStartDate
@@ -166,7 +167,7 @@ describe('Placement sketching report', () => {
       },
       sentDate: sentDate,
       status: 'SENT',
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
 
     const fixtureForStatusWaitingPlacement = applicationFixture(
@@ -187,7 +188,7 @@ describe('Placement sketching report', () => {
       },
       sentDate: sentDate,
       status: 'WAITING_PLACEMENT',
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
 
     const fixtureForStatusActive = applicationFixture(
@@ -208,7 +209,7 @@ describe('Placement sketching report', () => {
       },
       sentDate: sentDate,
       status: 'ACTIVE',
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
 
     await createApplications({

--- a/frontend/src/e2e-test/specs/5_employee/preschool-application-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/preschool-application-report.spec.ts
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
 import config from '../../config'
-import { applicationFixture, Fixture, uuidv4 } from '../../dev-api/fixtures'
+import { applicationFixture, Fixture } from '../../dev-api/fixtures'
 import {
   createApplications,
   resetServiceState
@@ -81,7 +83,7 @@ xdescribe('Preschool application report', () => {
         'WAITING_UNIT_CONFIRMATION',
         nextTermStart
       ),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
 
     const child2 = await Fixture.person({
@@ -103,7 +105,7 @@ xdescribe('Preschool application report', () => {
         'WAITING_UNIT_CONFIRMATION',
         nextTermStart
       ),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
 
     await createApplications({ body: [application1, application2] })

--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar-child-date-modal.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar-child-date-modal.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { PlacementType } from 'lib-common/generated/api-types/placement'
+import { ServiceNeedOptionId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
@@ -25,7 +26,7 @@ let groupId: UUID
 let childId: UUID
 let placementId: UUID
 let unitSupervisor: DevEmployee
-let daycareServiceNeedOptionId: UUID
+let daycareServiceNeedOptionId: ServiceNeedOptionId
 
 let page: Page
 

--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
@@ -5,6 +5,8 @@
 import DateRange from 'lib-common/date-range'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { ShiftCareType } from 'lib-common/generated/api-types/serviceneed'
+import { BackupCareId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
@@ -98,7 +100,7 @@ const insertTestDataAndLogin = async ({
     shiftCare: childShiftCare
   }).save()
   await Fixture.backupCare({
-    id: uuidv4(),
+    id: randomId<BackupCareId>(),
     childId: child1Fixture.id,
     unitId: testDaycare.id,
     groupId: groupId2,
@@ -145,7 +147,7 @@ describe('Unit group calendar', () => {
       name: 'Varasijoitusryhmä samassa'
     }).save()
     await Fixture.backupCare({
-      id: uuidv4(),
+      id: randomId<BackupCareId>(),
       childId: child1Fixture.id,
       unitId: daycare.id,
       groupId: groupId3,
@@ -175,7 +177,7 @@ describe('Unit group calendar', () => {
       name: 'Varasijoitusryhmä samassa'
     }).save()
     await Fixture.backupCare({
-      id: uuidv4(),
+      id: randomId<BackupCareId>(),
       childId: child1Fixture.id,
       unitId: daycare.id,
       groupId: groupId3,

--- a/frontend/src/e2e-test/specs/5_employee/search-person.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/search-person.spec.ts
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import config from '../../config'
@@ -13,8 +15,7 @@ import {
   testCareArea,
   testChild,
   testChild2,
-  testDaycare,
-  uuidv4
+  testDaycare
 } from '../../dev-api/fixtures'
 import {
   createApplicationPlacementPlan,
@@ -77,7 +78,7 @@ describe('Search person', () => {
         true,
         true
       ),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
 
     const appWithoutAssistanceNeeded = {
@@ -96,7 +97,7 @@ describe('Search person', () => {
         true,
         false
       ),
-      id: uuidv4()
+      id: randomId<ApplicationId>()
     }
 
     await createApplications({

--- a/frontend/src/e2e-test/specs/5_employee/unit-acl.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-acl.spec.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 
 import {
@@ -21,7 +22,7 @@ import { Page } from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
 
 let page: Page
-let daycareId: UUID
+let daycareId: DaycareId
 const groupId: UUID = uuidv4()
 
 const eskoId = uuidv4()

--- a/frontend/src/e2e-test/specs/5_employee/unit-application-process.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-application-process.spec.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
@@ -12,7 +14,6 @@ import {
   testChild2,
   testAdult,
   Fixture,
-  uuidv4,
   familyWithTwoGuardians,
   testCareArea
 } from '../../dev-api/fixtures'
@@ -36,7 +37,7 @@ import { employeeLogin } from '../../utils/user'
 
 let page: Page
 let unitPage: UnitPage
-const groupId: UUID = uuidv4()
+const groupId: UUID = randomId<ApplicationId>()
 let child1Fixture: DevPerson
 let child2Fixture: DevPerson
 let child1DaycarePlacementId: UUID
@@ -66,7 +67,7 @@ beforeEach(async () => {
   }).save()
 
   child1Fixture = familyWithTwoGuardians.children[0]
-  child1DaycarePlacementId = uuidv4()
+  child1DaycarePlacementId = randomId<ApplicationId>()
   await Fixture.placement({
     id: child1DaycarePlacementId,
     childId: child1Fixture.id,
@@ -80,7 +81,7 @@ beforeEach(async () => {
     children: [testChild, testChild2]
   }).save()
   child2Fixture = testChild2
-  child2DaycarePlacementId = uuidv4()
+  child2DaycarePlacementId = randomId<ApplicationId>()
   await Fixture.placement({
     id: child2DaycarePlacementId,
     childId: child2Fixture.id,
@@ -110,12 +111,12 @@ describe('Unit groups - placement plans / proposals', () => {
 
     const application1: DevApplicationWithForm = {
       ...applicationFixture(testChild, testAdult),
-      id: uuidv4(),
+      id: randomId<ApplicationId>(),
       status: 'WAITING_UNIT_CONFIRMATION'
     }
     const application2: DevApplicationWithForm = {
       ...applicationFixture(testChild2, testAdult),
-      id: uuidv4(),
+      id: randomId<ApplicationId>(),
       status: 'WAITING_UNIT_CONFIRMATION'
     }
 

--- a/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { CalendarEventId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
@@ -41,7 +43,7 @@ const placementStartDate = mockedToday.subWeeks(4)
 const placementEndDate = mockedToday.addWeeks(4)
 const groupId: UUID = uuidv4()
 const groupId2 = uuidv4()
-const testSurveyId = uuidv4()
+const testSurveyId = randomId<CalendarEventId>()
 const eventTimeId = uuidv4()
 const eventTimeId2 = uuidv4()
 const child1DaycarePlacementId = uuidv4()

--- a/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
-import { CalendarEventId } from 'lib-common/generated/api-types/shared'
+import {
+  CalendarEventId,
+  CalendarEventTimeId
+} from 'lib-common/generated/api-types/shared'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -44,8 +47,8 @@ const placementEndDate = mockedToday.addWeeks(4)
 const groupId: UUID = uuidv4()
 const groupId2 = uuidv4()
 const testSurveyId = randomId<CalendarEventId>()
-const eventTimeId = uuidv4()
-const eventTimeId2 = uuidv4()
+const eventTimeId = randomId<CalendarEventTimeId>()
+const eventTimeId2 = randomId<CalendarEventTimeId>()
 const child1DaycarePlacementId = uuidv4()
 const child1DaycarePlacementId2 = uuidv4()
 

--- a/frontend/src/e2e-test/specs/6_mobile/pin-login.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/pin-login.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 
 import { mobileViewport } from '../../browser'
 import {
@@ -149,7 +150,7 @@ describe('Mobile PIN login', () => {
 
     await createBackupPickup({
       body: backupPickups.map(({ name, phone }) => ({
-        id: uuidv4(),
+        id: randomId(),
         childId: child.id,
         name,
         phone

--- a/frontend/src/e2e-test/specs/6_mobile/reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/reservations.spec.ts
@@ -4,6 +4,7 @@
 
 import DateRange from 'lib-common/date-range'
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -361,7 +362,7 @@ describe('when unit is open every day for shift care child', () => {
   })
 })
 
-const loginToMobile = async (today: LocalDate, unitId: UUID) => {
+const loginToMobile = async (today: LocalDate, unitId: DaycareId) => {
   const page = await Page.open({
     mockedTime: HelsinkiDateTime.fromLocal(today, LocalTime.of(14, 50))
   })

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -4,6 +4,7 @@
 
 import FiniteDateRange from 'lib-common/finite-date-range'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
@@ -221,7 +222,7 @@ describe('Sending and receiving messages', () => {
         await createBackupCares({
           body: [
             {
-              id: uuidv4(),
+              id: randomId(),
               childId: testChild2.id,
               unitId: testDaycare.id,
               groupId: testDaycareGroup.id,
@@ -276,7 +277,7 @@ describe('Sending and receiving messages', () => {
         await createBackupCares({
           body: [
             {
-              id: uuidv4(),
+              id: randomId(),
               childId,
               unitId: backupDaycareId,
               groupId: backupGroupFixtureId,

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
@@ -56,7 +57,7 @@ let unitSupervisor: DevEmployee
 let account: CitizenWeakAccount
 let careArea: DevCareArea
 let daycarePlacementFixture: DevPlacement
-let backupDaycareId: UUID
+let backupDaycareId: DaycareId
 let backupGroupFixtureId: UUID
 
 const mockedDate = LocalDate.of(2022, 5, 21)

--- a/frontend/src/e2e-test/utils/mobile.ts
+++ b/frontend/src/e2e-test/utils/mobile.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 
 import config from '../config'
@@ -15,7 +16,7 @@ import {
  *
  * @return An URL that completes the pairing in the browser
  */
-export async function pairMobileDevice(unitId: UUID): Promise<string> {
+export async function pairMobileDevice(unitId: DaycareId): Promise<string> {
   const longTermToken = uuidv4()
   await postMobileDevice({
     body: {

--- a/frontend/src/employee-frontend/api/attachments.ts
+++ b/frontend/src/employee-frontend/api/attachments.ts
@@ -4,6 +4,7 @@
 
 import { Failure, Result, Success } from 'lib-common/api'
 import { AttachmentType } from 'lib-common/generated/api-types/attachment'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 
 import { API_URL, client } from './client'
@@ -12,12 +13,12 @@ async function doSaveAttachment(
   config: { path: string; params?: unknown },
   file: File,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> {
+): Promise<Result<AttachmentId>> {
   const formData = new FormData()
   formData.append('file', file)
 
   try {
-    const { data } = await client.post<UUID>(config.path, formData, {
+    const { data } = await client.post<AttachmentId>(config.path, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
       params: config.params,
       onUploadProgress: ({ loaded, total }) =>
@@ -38,7 +39,7 @@ export async function saveApplicationAttachment(
   file: File,
   type: AttachmentType,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> {
+): Promise<Result<AttachmentId>> {
   return await doSaveAttachment(
     {
       path: `/employee/attachments/applications/${applicationId}`,
@@ -53,7 +54,7 @@ export async function saveIncomeStatementAttachment(
   incomeStatementId: UUID,
   file: File,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> {
+): Promise<Result<AttachmentId>> {
   return await doSaveAttachment(
     { path: `/employee/attachments/income-statements/${incomeStatementId}` },
     file,
@@ -65,7 +66,7 @@ export async function saveIncomeAttachment(
   incomeId: UUID | null,
   file: File,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> {
+): Promise<Result<AttachmentId>> {
   return await doSaveAttachment(
     {
       path: incomeId
@@ -81,7 +82,7 @@ export async function saveFeeAlterationAttachment(
   feeAlterationId: UUID | null,
   file: File,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> {
+): Promise<Result<AttachmentId>> {
   return await doSaveAttachment(
     {
       path: feeAlterationId
@@ -97,7 +98,7 @@ export const saveMessageAttachment = (
   draftId: UUID,
   file: File,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> =>
+): Promise<Result<AttachmentId>> =>
   doSaveAttachment(
     { path: `/employee/attachments/messages/${draftId}` },
     file,
@@ -108,7 +109,7 @@ export const savePedagogicalDocumentAttachment = (
   documentId: UUID,
   file: File,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> =>
+): Promise<Result<AttachmentId>> =>
   doSaveAttachment(
     { path: `/employee/attachments/pedagogical-documents/${documentId}` },
     file,

--- a/frontend/src/employee-frontend/components/ApplicationPage.tsx
+++ b/frontend/src/employee-frontend/components/ApplicationPage.tsx
@@ -15,10 +15,10 @@ import {
 import { PublicUnit } from 'lib-common/generated/api-types/daycare'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import { ServiceNeedOptionPublicInfo } from 'lib-common/generated/api-types/serviceneed'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { scrollToPos } from 'lib-common/utils/scrolling'
 import { useDebounce } from 'lib-common/utils/useDebounce'
 import { useApiState, useRestApi } from 'lib-common/utils/useRestApi'
@@ -89,7 +89,7 @@ const ApplicationMetadataSection = React.memo(
   function ApplicationMetadataSection({
     applicationId
   }: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }) {
     const result = useQueryResult(applicationMetadataQuery({ applicationId }))
     return <MetadataSection metadataResult={result} />
@@ -97,7 +97,7 @@ const ApplicationMetadataSection = React.memo(
 )
 
 export default React.memo(function ApplicationPage() {
-  const { id: applicationId } = useRouteParams(['id'])
+  const applicationId = useIdRouteParam<ApplicationId>('id')
 
   const { i18n } = useTranslation()
   const { setTitle, formatTitleName } = useContext<TitleState>(TitleContext)

--- a/frontend/src/employee-frontend/components/GroupCaretakers.tsx
+++ b/frontend/src/employee-frontend/components/GroupCaretakers.tsx
@@ -10,9 +10,10 @@ import {
   CaretakerAmount,
   CaretakersResponse
 } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { capitalizeFirstLetter } from 'lib-common/string'
 import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import useRouteParams, { useIdRouteParam } from 'lib-common/useRouteParams'
 import Loader from 'lib-components/atoms/Loader'
 import Title from 'lib-components/atoms/Title'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
@@ -67,7 +68,8 @@ const FlexRowRightAlign = styled(FlexRow)`
 `
 
 export default React.memo(function GroupCaretakers() {
-  const { unitId, groupId } = useRouteParams(['unitId', 'groupId'])
+  const { groupId } = useRouteParams(['groupId'])
+  const unitId = useIdRouteParam<DaycareId>('unitId')
   const { i18n } = useTranslation()
   const { setTitle } = useContext<TitleState>(TitleContext)
   const [caretakers, setCaretakers] = useState<Result<CaretakersResponse>>(

--- a/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
+++ b/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
@@ -17,6 +17,7 @@ import {
   IncomeStatement,
   SetIncomeStatementHandledBody
 } from 'lib-common/generated/api-types/incomestatement'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 import useRouteParams from 'lib-common/useRouteParams'
 import { useApiState } from 'lib-common/utils/useRestApi'
@@ -463,7 +464,7 @@ function EmployeeAttachments({
   )
 
   const handleDelete = useCallback(
-    async (id: UUID) =>
+    async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() => {
         onDeleted(id)
       }),

--- a/frontend/src/employee-frontend/components/MobilePairingModal.tsx
+++ b/frontend/src/employee-frontend/components/MobilePairingModal.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 
 import { Loading, Result, wrapResult } from 'lib-common/api'
 import { Pairing } from 'lib-common/generated/api-types/pairing'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 import InputField from 'lib-components/atoms/form/InputField'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
@@ -29,7 +30,7 @@ const postPairingResult = wrapResult(postPairing)
 const postPairingResponseResult = wrapResult(postPairingResponse)
 const putMobileDeviceNameResult = wrapResult(putMobileDeviceName)
 
-type IdProps = { unitId: UUID } | { employeeId: UUID }
+type IdProps = { unitId: DaycareId } | { employeeId: UUID }
 
 type Props = IdProps & { closeModal: () => void }
 

--- a/frontend/src/employee-frontend/components/UnitFeaturesPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitFeaturesPage.tsx
@@ -15,10 +15,10 @@ import {
   ProviderType
 } from 'lib-common/generated/api-types/daycare'
 import {
+  DaycareId,
   PilotFeature,
   pilotFeatures
 } from 'lib-common/generated/api-types/shared'
-import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -59,11 +59,11 @@ export default React.memo(function UnitFeaturesPage() {
   const [submitting, setSubmitting] = useState(false)
 
   const [undoAction, setUndoAction] =
-    useState<[UUID[], PilotFeature[], boolean]>()
+    useState<[DaycareId[], PilotFeature[], boolean]>()
 
   const updateFeatures = useCallback(
     async (
-      unitIds: UUID[],
+      unitIds: DaycareId[],
       features: PilotFeature[],
       enable: boolean,
       isUndoAction = false

--- a/frontend/src/employee-frontend/components/UnitPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitPage.tsx
@@ -19,10 +19,10 @@ import {
 import styled from 'styled-components'
 
 import { DaycareResponse } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Spinner from 'lib-components/atoms/state/Spinner'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { TabLinks } from 'lib-components/molecules/Tabs'
@@ -46,7 +46,7 @@ const defaultTab = (unit: DaycareResponse) => {
   return 'unit-info'
 }
 
-const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
+const UnitPage = React.memo(function UnitPage({ id }: { id: DaycareId }) {
   const { i18n } = useTranslation()
   const { setTitle } = useContext<TitleState>(TitleContext)
   const { unitInformation, filters, setFilters } = useContext(UnitContext)
@@ -239,7 +239,7 @@ const UnitPage = React.memo(function UnitPage({ id }: { id: UUID }) {
 })
 
 export default React.memo(function UnitPageWrapper() {
-  const { id } = useRouteParams(['id'])
+  const id = useIdRouteParam<DaycareId>('id')
   return (
     <UnitContextProvider id={id}>
       <UnitPage id={id} />

--- a/frontend/src/employee-frontend/components/application-page/ApplicationDecisionsSection.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationDecisionsSection.tsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router'
 
 import { ApplicationStatus } from 'lib-common/generated/api-types/application'
 import { Decision } from 'lib-common/generated/api-types/decision'
-import { UUID } from 'lib-common/types'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import ListGrid from 'lib-components/layout/ListGrid'
 import {
   FixedSpaceColumn,
@@ -43,7 +43,7 @@ const isDownloadAvailable = (decision: Decision) =>
   decision.documentKey !== null
 
 type Props = {
-  applicationId: UUID
+  applicationId: ApplicationId
   decisions: Decision[]
   reloadApplication: () => void
   applicationStatus: ApplicationStatus

--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -21,9 +21,9 @@ import { PublicUnit } from 'lib-common/generated/api-types/daycare'
 import { PersonJSON } from 'lib-common/generated/api-types/pis'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import { ServiceNeedOptionPublicInfo } from 'lib-common/generated/api-types/serviceneed'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
@@ -183,7 +183,7 @@ export default React.memo(function ApplicationEditView({
     (
       file: File,
       onUploadProgress: (percentage: number) => void
-    ): Promise<Result<UUID>> =>
+    ): Promise<Result<AttachmentId>> =>
       saveApplicationAttachment(
         application.id,
         file,
@@ -214,7 +214,7 @@ export default React.memo(function ApplicationEditView({
         return res
       })
 
-  const onDeleteAttachment = (id: UUID) =>
+  const onDeleteAttachment = (id: AttachmentId) =>
     deleteAttachmentResult({ attachmentId: id }).then((res) => {
       if (res.isSuccess) {
         setApplication(

--- a/frontend/src/employee-frontend/components/application-page/ApplicationNoteBox.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationNoteBox.tsx
@@ -13,8 +13,8 @@ import {
   updateApplicationNote
 } from 'employee-frontend/components/application-page/applications-queries'
 import { ApplicationNote } from 'lib-common/generated/api-types/application'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { useMutation } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import TextArea from 'lib-components/atoms/form/TextArea'
@@ -82,7 +82,7 @@ interface EditProps extends InputProps {
 }
 
 interface CreateProps extends InputProps {
-  applicationId: UUID
+  applicationId: ApplicationId
   onSave: () => void
   onCancel: () => void
 }

--- a/frontend/src/employee-frontend/components/application-page/ApplicationNotes.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationNotes.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
@@ -23,7 +24,7 @@ const Sticky = styled.div`
 `
 
 type Props = {
-  applicationId: UUID
+  applicationId: ApplicationId
   allowCreate: boolean
 }
 

--- a/frontend/src/employee-frontend/components/application-page/DecisionResponse.tsx
+++ b/frontend/src/employee-frontend/components/application-page/DecisionResponse.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useState } from 'react'
 
 import { wrapResult } from 'lib-common/api'
 import { Decision } from 'lib-common/generated/api-types/decision'
-import { UUID } from 'lib-common/types'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import Radio from 'lib-components/atoms/form/Radio'
 import {
@@ -25,7 +25,7 @@ const acceptDecisionResult = wrapResult(acceptDecision)
 const rejectDecisionResult = wrapResult(rejectDecision)
 
 interface Props {
-  applicationId: UUID
+  applicationId: ApplicationId
   decision: Decision
   reloadApplication: () => void
 }

--- a/frontend/src/employee-frontend/components/applications/ActionCheckbox.tsx
+++ b/frontend/src/employee-frontend/components/applications/ActionCheckbox.tsx
@@ -5,18 +5,19 @@
 import React, { useContext } from 'react'
 import styled from 'styled-components'
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 
 import { ApplicationUIContext } from '../../state/application-ui'
 
 type Props = {
-  applicationId: string
+  applicationId: ApplicationId
 }
 
 export default React.memo(function ActionCheckbox({ applicationId }: Props) {
   const { checkedIds, setCheckedIds, showCheckboxes } =
     useContext(ApplicationUIContext)
-  const updateCheckedIds = (applicationId: string, checked: boolean) => {
+  const updateCheckedIds = (applicationId: ApplicationId, checked: boolean) => {
     if (checked) {
       setCheckedIds(checkedIds.concat(applicationId))
     } else {

--- a/frontend/src/employee-frontend/components/applications/ApplicationsFilters.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsFilters.tsx
@@ -11,7 +11,7 @@ import {
   ApplicationTypeToggle
 } from 'lib-common/generated/api-types/application'
 import { DaycareCareArea } from 'lib-common/generated/api-types/daycare'
-import { UUID } from 'lib-common/types'
+import { AreaId } from 'lib-common/generated/api-types/shared'
 import MultiSelect from 'lib-components/atoms/form/MultiSelect'
 import Radio from 'lib-components/atoms/form/Radio'
 import { Label } from 'lib-components/typography'
@@ -304,8 +304,8 @@ export default React.memo(function ApplicationFilters() {
 
 type AreaMultiSelectProps = {
   areas: DaycareCareArea[]
-  selected: UUID[]
-  onSelect: (areaIds: UUID[]) => void
+  selected: AreaId[]
+  onSelect: (areaIds: AreaId[]) => void
 }
 
 const AreaMultiSelect = React.memo(function AreaMultiSelect({

--- a/frontend/src/employee-frontend/components/applications/ApplicationsFilters.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsFilters.tsx
@@ -11,7 +11,7 @@ import {
   ApplicationTypeToggle
 } from 'lib-common/generated/api-types/application'
 import { DaycareCareArea } from 'lib-common/generated/api-types/daycare'
-import { AreaId } from 'lib-common/generated/api-types/shared'
+import { AreaId, DaycareId } from 'lib-common/generated/api-types/shared'
 import MultiSelect from 'lib-components/atoms/form/MultiSelect'
 import Radio from 'lib-components/atoms/form/Radio'
 import { Label } from 'lib-components/typography'
@@ -169,7 +169,7 @@ export default React.memo(function ApplicationFilters() {
     })
   }
 
-  const changeUnits = (selectedUnits: string[]) => {
+  const changeUnits = (selectedUnits: DaycareId[]) => {
     setApplicationsResult(Loading.of())
     setApplicationSearchFilters({
       ...applicationSearchFilters,

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -12,7 +12,7 @@ import {
   ApplicationSummary,
   PagedApplicationSummaries
 } from 'lib-common/generated/api-types/application'
-import { UUID } from 'lib-common/types'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import Pagination from 'lib-components/Pagination'
 import PlacementCircle from 'lib-components/atoms/PlacementCircle'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
@@ -195,7 +195,7 @@ const ApplicationsList = React.memo(function Applications({
     hasRole(roles, 'FINANCE_ADMIN') ||
     hasRole(roles, 'ADMIN')
 
-  const [editedNote, setEditedNote] = useState<UUID | null>(null)
+  const [editedNote, setEditedNote] = useState<ApplicationId | null>(null)
   const [editedNoteText, setEditedNoteText] = useState<string>('')
 
   const isSorted = (column: ApplicationSortColumn) =>

--- a/frontend/src/employee-frontend/components/applications/ApplicationsPage.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsPage.tsx
@@ -68,9 +68,8 @@ export default React.memo(function ApplicationsPage() {
       page,
       sortBy,
       sortDir: sortDirection,
-      areas: debouncedApplicationSearchFilters.area.includes('All')
-        ? null
-        : debouncedApplicationSearchFilters.area.length > 0
+      areas:
+        debouncedApplicationSearchFilters.area.length > 0
           ? debouncedApplicationSearchFilters.area
           : null,
       units:

--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
@@ -23,10 +23,11 @@ import {
   DocumentContent,
   DocumentWriteLock
 } from 'lib-common/generated/api-types/document'
+import { ChildDocumentId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useDebounce } from 'lib-common/utils/useDebounce'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import Spinner from 'lib-components/atoms/state/Spinner'
@@ -328,7 +329,7 @@ const ChildDocumentEditViewInner = React.memo(
 
 export const ChildDocumentEditView = React.memo(
   function ChildDocumentEditView() {
-    const { documentId } = useRouteParams(['documentId'])
+    const documentId = useIdRouteParam<ChildDocumentId>('documentId')
     const [searchParams] = useSearchParams()
     const childIdFromUrl = searchParams.get('childId') // duplicate child workaround
 
@@ -365,7 +366,11 @@ export const ChildDocumentEditView = React.memo(
 )
 
 const ChildDocumentMetadataSection = React.memo(
-  function ChildDocumentMetadataSection({ documentId }: { documentId: UUID }) {
+  function ChildDocumentMetadataSection({
+    documentId
+  }: {
+    documentId: ChildDocumentId
+  }) {
     const result = useQueryResult(
       childDocumentMetadataQuery({ childDocumentId: documentId })
     )
@@ -596,7 +601,7 @@ const ChildDocumentReadViewInner = React.memo(
 
 export const ChildDocumentReadView = React.memo(
   function ChildDocumentReadView() {
-    const { documentId } = useRouteParams(['documentId'])
+    const documentId = useIdRouteParam<ChildDocumentId>('documentId')
     const [searchParams] = useSearchParams()
     const childIdFromUrl = searchParams.get('childId') // duplicate child workaround
 

--- a/frontend/src/employee-frontend/components/child-information/AssistanceNeedDecisionSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/AssistanceNeedDecisionSection.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components'
 import { ChildState, ChildContext } from 'employee-frontend/state/child'
 import { wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
@@ -69,7 +70,8 @@ export default React.memo(function AssistanceNeedDecisionSection({
 
   const [isCreatingDecision, setIsCreatingDecision] = useState(false)
 
-  const [removingDecision, setRemovingDecision] = useState<UUID>()
+  const [removingDecision, setRemovingDecision] =
+    useState<AssistanceNeedDecisionId>()
 
   return (
     <div ref={refSectionTop}>
@@ -229,7 +231,7 @@ const DeleteDecisionModal = React.memo(function DeleteDecisionModal({
   onClose
 }: {
   childId: UUID
-  decisionId: UUID
+  decisionId: AssistanceNeedDecisionId
   onClose: (shouldRefresh: boolean) => void
 }) {
   const { i18n } = useTranslation()

--- a/frontend/src/employee-frontend/components/child-information/AssistanceNeedPreschoolDecisionSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/AssistanceNeedPreschoolDecisionSection.tsx
@@ -7,6 +7,7 @@ import React, { useContext, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { ChildState, ChildContext } from 'employee-frontend/state/child'
+import { AssistanceNeedPreschoolDecisionId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import Title from 'lib-components/atoms/Title'
@@ -47,7 +48,8 @@ export default React.memo(function AssistanceNeedPreschoolDecisionSection({
     assistanceNeedPreschoolDecisionBasicsQuery({ childId })
   )
 
-  const [removingDecision, setRemovingDecision] = useState<UUID>()
+  const [removingDecision, setRemovingDecision] =
+    useState<AssistanceNeedPreschoolDecisionId>()
 
   return (
     <div ref={refSectionTop}>
@@ -139,7 +141,7 @@ const DeleteDecisionModal = React.memo(function DeleteDecisionModal({
   onClose
 }: {
   childId: UUID
-  decisionId: UUID
+  decisionId: AssistanceNeedPreschoolDecisionId
   onClose: () => void
 }) {
   const { i18n } = useTranslation()

--- a/frontend/src/employee-frontend/components/child-information/AssistanceNeedVoucherCoefficientSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/AssistanceNeedVoucherCoefficientSection.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components'
 import { ChildContext, ChildState } from 'employee-frontend/state/child'
 import { UIContext } from 'employee-frontend/state/ui'
 import { AssistanceNeedVoucherCoefficient } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedVoucherCoefficientId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { scrollToRef } from 'lib-common/utils/scrolling'
@@ -156,7 +157,7 @@ const DeleteAssistanceNeedVoucherCoefficientModal = React.memo(
     onClose
   }: {
     childId: UUID
-    coefficientId: UUID
+    coefficientId: AssistanceNeedVoucherCoefficientId
     onClose: () => void
   }) {
     const { mutateAsync: deleteAssistanceNeedVoucherCoefficient } =

--- a/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/DailyServiceTimesSection.tsx
@@ -6,6 +6,7 @@ import orderBy from 'lodash/orderBy'
 import React, { useContext, useState } from 'react'
 
 import { ChildContext, ChildState } from 'employee-frontend/state/child'
+import { DailyServiceTimeId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
@@ -48,7 +49,7 @@ export default React.memo(function DailyServiceTimesSection({
 
   const [uiMode, setUIMode] = useState<{
     type: 'delete' | 'modify'
-    id: UUID
+    id: DailyServiceTimeId
   }>()
 
   return (
@@ -148,7 +149,7 @@ const DeleteDailyServiceTimesModal = React.memo(
     onClose
   }: {
     childId: UUID
-    dailyServiceTimesId: UUID
+    dailyServiceTimesId: DailyServiceTimeId
     onClose: () => void
   }) {
     const { i18n } = useTranslation()

--- a/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
@@ -10,6 +10,7 @@ import {
   Attachment,
   PedagogicalDocument
 } from 'lib-common/generated/api-types/pedagogicaldocument'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { EvakaUser } from 'lib-common/generated/api-types/user'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { UUID } from 'lib-common/types'
@@ -124,7 +125,7 @@ const PedagogicalDocumentRow = React.memo(function PedagogicalDocument({
   )
 
   const handleAttachmentDelete = useCallback(
-    async (id: UUID) =>
+    async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() =>
         setPedagogicalDocument(({ ...rest }) => ({
           ...rest,

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionEditPage.tsx
@@ -16,8 +16,11 @@ import { AutosaveStatus } from 'employee-frontend/utils/use-autosave'
 import { Failure, Result, wrapResult } from 'lib-common/api'
 import { AssistanceNeedDecisionForm } from 'lib-common/generated/api-types/assistanceneed'
 import { Employee, PersonJSON } from 'lib-common/generated/api-types/pis'
-import { OfficialLanguage } from 'lib-common/generated/api-types/shared'
-import useRouteParams from 'lib-common/useRouteParams'
+import {
+  AssistanceNeedDecisionId,
+  OfficialLanguage
+} from 'lib-common/generated/api-types/shared'
+import useRouteParams, { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import AssistanceNeedDecisionInfoHeader from 'lib-components/assistance-need-decision/AssistanceNeedDecisionInfoHeader'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
@@ -87,7 +90,8 @@ const HorizontalLineWithoutBottomMargin = styled(HorizontalLine)`
 `
 
 export default React.memo(function AssistanceNeedDecisionEditPage() {
-  const { childId, id } = useRouteParams(['childId', 'id'])
+  const { childId } = useRouteParams(['childId'])
+  const id = useIdRouteParam<AssistanceNeedDecisionId>('id')
   const [child] = useApiState(
     () => getPersonIdentityResult({ personId: childId }),
     [childId]

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionPage.tsx
@@ -10,9 +10,9 @@ import { renderResult } from 'employee-frontend/components/async-rendering'
 import { I18nContext, Lang, useTranslation } from 'employee-frontend/state/i18n'
 import { wrapResult } from 'lib-common/api'
 import { AssistanceNeedDecision } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import useRouteParams, { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import AssistanceNeedDecisionReadOnly from 'lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -52,7 +52,7 @@ const canBeEdited = (decision: AssistanceNeedDecision) =>
 const DecisionMetadataSection = React.memo(function DecisionMetadataSection({
   decisionId
 }: {
-  decisionId: UUID
+  decisionId: AssistanceNeedDecisionId
 }) {
   const result = useQueryResult(
     assistanceNeedDecisionMetadataQuery({ decisionId })
@@ -61,7 +61,8 @@ const DecisionMetadataSection = React.memo(function DecisionMetadataSection({
 })
 
 export default React.memo(function AssistanceNeedDecisionPage() {
-  const { childId, id } = useRouteParams(['childId', 'id'])
+  const { childId } = useRouteParams(['childId'])
+  const id = useIdRouteParam<AssistanceNeedDecisionId>('id')
   const navigate = useNavigate()
 
   const [assistanceNeedDecision, reloadDecision] = useApiState(

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
@@ -32,12 +32,15 @@ import {
 } from 'lib-common/generated/api-types/assistanceneed'
 import { UnitStub } from 'lib-common/generated/api-types/daycare'
 import { Employee } from 'lib-common/generated/api-types/pis'
-import { OfficialLanguage } from 'lib-common/generated/api-types/shared'
+import {
+  AssistanceNeedPreschoolDecisionId,
+  OfficialLanguage
+} from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import useRouteParams, { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useDebounce } from 'lib-common/utils/useDebounce'
 import { AssistanceNeedDecisionStatusChip } from 'lib-components/assistance-need-decision/AssistanceNeedDecisionStatusChip'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
@@ -997,7 +1000,9 @@ const DecisionEditor = React.memo(function DecisionEditor({
 })
 
 export default React.memo(function AssistanceNeedPreschoolDecisionEditPage() {
-  const { childId, decisionId } = useRouteParams(['childId', 'decisionId'])
+  const { childId } = useRouteParams(['childId'])
+  const decisionId =
+    useIdRouteParam<AssistanceNeedPreschoolDecisionId>('decisionId')
   const decisionResult = useQueryResult(
     assistanceNeedPreschoolDecisionQuery({ id: decisionId })
   )

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
@@ -35,6 +35,7 @@ import { Employee } from 'lib-common/generated/api-types/pis'
 import {
   AssistanceNeedPreschoolDecisionGuardianId,
   AssistanceNeedPreschoolDecisionId,
+  DaycareId,
   OfficialLanguage
 } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
@@ -114,7 +115,7 @@ const form = mapped(
     grantedAssistiveDevices: boolean(),
     grantedServicesBasis: string(),
 
-    selectedUnit: value<UUID | null>(),
+    selectedUnit: value<DaycareId | null>(),
     primaryGroup: string(),
     decisionBasis: string(),
 

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
@@ -33,6 +33,7 @@ import {
 import { UnitStub } from 'lib-common/generated/api-types/daycare'
 import { Employee } from 'lib-common/generated/api-types/pis'
 import {
+  AssistanceNeedPreschoolDecisionGuardianId,
   AssistanceNeedPreschoolDecisionId,
   OfficialLanguage
 } from 'lib-common/generated/api-types/shared'
@@ -90,7 +91,7 @@ const SectionSpacer = styled(FixedSpaceColumn).attrs({ spacing: 'L' })``
 const LabeledValue = styled(FixedSpaceColumn).attrs({ spacing: 'xs' })``
 
 const guardianForm = object({
-  id: string(),
+  id: value<AssistanceNeedPreschoolDecisionGuardianId>(),
   name: string(),
   personId: string(),
   isHeard: boolean(),

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionReadPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionReadPage.tsx
@@ -6,9 +6,9 @@ import React from 'react'
 import { useNavigate } from 'react-router'
 
 import { AssistanceNeedPreschoolDecisionResponse } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedPreschoolDecisionId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import AssistanceNeedPreschoolDecisionReadOnly from 'lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
@@ -34,7 +34,7 @@ import {
 const DecisionMetadataSection = React.memo(function DecisionMetadataSection({
   decisionId
 }: {
-  decisionId: UUID
+  decisionId: AssistanceNeedPreschoolDecisionId
 }) {
   const result = useQueryResult(
     assistanceNeedPreschoolDecisionMetadataQuery({ decisionId })
@@ -158,7 +158,8 @@ const DecisionReadView = React.memo(function DecisionReadView({
 })
 
 export default React.memo(function AssistanceNeedPreschoolDecisionReadPage() {
-  const { decisionId } = useRouteParams(['decisionId'])
+  const decisionId =
+    useIdRouteParam<AssistanceNeedPreschoolDecisionId>('decisionId')
   const decisionResult = useQueryResult(
     assistanceNeedPreschoolDecisionQuery({ id: decisionId })
   )

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/assistance-need-decision-form.ts
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/assistance-need-decision-form.ts
@@ -11,7 +11,7 @@ import {
 import { Result, wrapResult } from 'lib-common/api'
 import { AssistanceNeedDecisionForm } from 'lib-common/generated/api-types/assistanceneed'
 import { Employee } from 'lib-common/generated/api-types/pis'
-import { UUID } from 'lib-common/types'
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
 import { useApiState } from 'lib-common/utils/useRestApi'
 
 import {
@@ -39,12 +39,15 @@ export type AssistanceNeedDecisionInfo = {
 }
 
 export function useAssistanceNeedDecision(
-  id: UUID
+  id: AssistanceNeedDecisionId
 ): AssistanceNeedDecisionInfo {
   const [formState, setFormState] = useState<AssistanceNeedDecisionForm>()
 
   const getSaveParameters = useCallback(
-    () => [id, formState] as [id: string, data: AssistanceNeedDecisionForm],
+    (): [AssistanceNeedDecisionId, AssistanceNeedDecisionForm] => [
+      id,
+      formState!
+    ],
     [id, formState]
   )
 
@@ -67,7 +70,10 @@ export function useAssistanceNeedDecision(
   const { status, setDirty, forceSave } = useAutosave({
     load: loadDecision,
     onLoaded: setFormState,
-    save: (id: UUID, decision: AssistanceNeedDecisionForm) =>
+    save: (
+      id: AssistanceNeedDecisionId,
+      decision: AssistanceNeedDecisionForm
+    ) =>
       updateAssistanceNeedDecisionResult({ id, body: { decision } }).then(
         (result) =>
           reloadDecisionMakerOptions()

--- a/frontend/src/employee-frontend/components/child-information/daily-service-times/DailyServiceTimesForms.tsx
+++ b/frontend/src/employee-frontend/components/child-information/daily-service-times/DailyServiceTimesForms.tsx
@@ -14,6 +14,7 @@ import {
   DailyServiceTimesType,
   DailyServiceTimesValue
 } from 'lib-common/generated/api-types/dailyservicetimes'
+import { DailyServiceTimeId } from 'lib-common/generated/api-types/shared'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -315,7 +316,7 @@ export const DailyServiceTimesCreationForm = React.memo(
 export interface EditProps {
   onClose: (shouldRefresh: boolean) => void
   childId: UUID
-  id: UUID
+  id: DailyServiceTimeId
   initialData: DailyServiceTimesValue
 }
 

--- a/frontend/src/employee-frontend/components/child-information/daily-service-times/DailyServiceTimesRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/daily-service-times/DailyServiceTimesRow.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 import { useTranslation } from 'employee-frontend/state/i18n'
 import { Action } from 'lib-common/generated/action'
 import { DailyServiceTimesValue } from 'lib-common/generated/api-types/dailyservicetimes'
+import { DailyServiceTimeId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
@@ -36,7 +37,7 @@ export default React.memo(function DailyServiceTimesRow({
   onDelete: () => void
   onEdit: (open: boolean) => void
   isEditing: boolean
-  id: UUID
+  id: DailyServiceTimeId
 }) {
   const { i18n } = useTranslation()
 

--- a/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationEditor.tsx
@@ -11,6 +11,7 @@ import {
 import { Result, Success, wrapResult } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
 import { FeeAlteration } from 'lib-common/generated/api-types/invoicing'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import Title from 'lib-components/atoms/Title'
@@ -218,7 +219,7 @@ function FeeAlterationAttachments({
   )
 
   const handleDelete = useCallback(
-    async (id: UUID) =>
+    async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() => {
         onDeleted(id)
       }),

--- a/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
@@ -9,6 +9,7 @@ import { wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -44,7 +45,7 @@ interface Form {
   type: PlacementType
   startDate: LocalDate
   endDate: LocalDate | null
-  unit: { id: string; name: string; ghostUnit: boolean } | null
+  unit: { id: DaycareId; name: string; ghostUnit: boolean } | null
   placeGuarantee: boolean
 }
 

--- a/frontend/src/employee-frontend/components/child-information/placements/service-needs/ServiceNeedEditorRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/service-needs/ServiceNeedEditorRow.tsx
@@ -18,8 +18,8 @@ import {
   ShiftCareType,
   shiftCareType
 } from 'lib-common/generated/api-types/serviceneed'
+import { ServiceNeedOptionId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { SelectF } from 'lib-components/atoms/dropdowns/Select'
 import Checkbox, { CheckboxF } from 'lib-components/atoms/form/Checkbox'
@@ -50,7 +50,7 @@ const putServiceNeedResult = wrapResult(putServiceNeed)
 
 const serviceNeedForm = object({
   range: required(localDateRange()),
-  option: required(oneOf<UUID>()),
+  option: required(oneOf<ServiceNeedOptionId>()),
   shiftCare: required(oneOf<ShiftCareType>()),
   partWeek: required(boolean())
 })

--- a/frontend/src/employee-frontend/components/common/Filters.tsx
+++ b/frontend/src/employee-frontend/components/common/Filters.tsx
@@ -31,6 +31,7 @@ import {
   VoucherValueDecisionDistinctiveParams,
   VoucherValueDecisionStatus
 } from 'lib-common/generated/api-types/invoicing'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import Tooltip from 'lib-components/atoms/Tooltip'
@@ -300,9 +301,9 @@ export function AreaFilter({
 }
 
 interface UnitFilterProps {
-  units: { id: string; name: string }[]
-  selected?: { id: string; name: string }
-  select: (unit?: string) => void
+  units: { id: DaycareId; name: string }[]
+  selected?: { id: DaycareId; name: string }
+  select: (unit?: DaycareId) => void
 }
 
 export const UnitFilter = React.memo(function UnitFilter({
@@ -1225,7 +1226,7 @@ export function ApplicationBasisFilter({
 }
 
 interface Option {
-  id: string
+  id: DaycareId
   name: string
 }
 
@@ -1239,8 +1240,8 @@ function getOptionLabel(option: Option) {
 
 interface MultiUnitsProps {
   units: Option[]
-  selectedUnits: string[]
-  onChange: (v: string[]) => void
+  selectedUnits: DaycareId[]
+  onChange: (v: DaycareId[]) => void
   'data-qa': string
 }
 

--- a/frontend/src/employee-frontend/components/decision-draft/DecisionDraft.tsx
+++ b/frontend/src/employee-frontend/components/decision-draft/DecisionDraft.tsx
@@ -22,7 +22,8 @@ import {
   DecisionType,
   DecisionUnit
 } from 'lib-common/generated/api-types/decision'
-import useRouteParams from 'lib-common/useRouteParams'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Loader from 'lib-components/atoms/Loader'
 import Title from 'lib-components/atoms/Title'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -160,7 +161,7 @@ function redirectToMainPage(navigate: NavigateFunction) {
 }
 
 export default React.memo(function Decision() {
-  const { id: applicationId } = useRouteParams(['id'])
+  const applicationId = useIdRouteParam<ApplicationId>('id')
   const { i18n } = useTranslation()
   const navigate = useNavigate()
   const [decisionDraftGroup, setDecisionDraftGroup] = useState<

--- a/frontend/src/employee-frontend/components/fee-decisions/FeeDecisionFilters.tsx
+++ b/frontend/src/employee-frontend/components/fee-decisions/FeeDecisionFilters.tsx
@@ -11,6 +11,7 @@ import {
   FeeDecisionDifference,
   FeeDecisionStatus
 } from 'lib-common/generated/api-types/invoicing'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { Gap } from 'lib-components/white-space'
 
@@ -97,7 +98,7 @@ function FeeDecisionFilters() {
     }
   }
 
-  const selectUnit = (id?: string) =>
+  const selectUnit = (id?: DaycareId) =>
     setSearchFilters((filters) => ({ ...filters, unit: id }))
 
   const selectFinanceDecisionHandler = (id?: string) =>

--- a/frontend/src/employee-frontend/components/finance-basics/ServiceNeedItem.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/ServiceNeedItem.tsx
@@ -11,8 +11,8 @@ import {
   ServiceNeedOptionVoucherValueRange,
   ServiceNeedOptionVoucherValueRangeWithId
 } from 'lib-common/generated/api-types/invoicing'
+import { ServiceNeedOptionId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
@@ -32,7 +32,7 @@ import VoucherValueEditor from './VoucherValueEditor'
 import { deleteVoucherValueMutation } from './queries'
 
 export type ServiceNeedItemProps = {
-  serviceNeedId: UUID
+  serviceNeedId: ServiceNeedOptionId
   serviceNeedName: string
   serviceNeedValidityStart: LocalDate
   serviceNeedValidityEnd: LocalDate | null
@@ -271,14 +271,18 @@ type EditorState =
     }
 
 export type FormState = {
-  [k in keyof Omit<ServiceNeedOptionVoucherValueRange, 'range'>]: string
+  [k in keyof Omit<
+    ServiceNeedOptionVoucherValueRange,
+    'range' | 'serviceNeedOptionId'
+  >]: string
 } & {
+  serviceNeedOptionId: ServiceNeedOptionId
   validFrom: LocalDate | null
   validTo: LocalDate | null
 }
 
 const emptyForm = (
-  serviceNeedOptionId: UUID,
+  serviceNeedOptionId: ServiceNeedOptionId,
   validFrom: LocalDate | null,
   coefficient: number,
   coefficientUnder3y: number

--- a/frontend/src/employee-frontend/components/group-caretakers/GroupCaretakersModal.tsx
+++ b/frontend/src/employee-frontend/components/group-caretakers/GroupCaretakersModal.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 
 import { wrapResult } from 'lib-common/api'
 import { CaretakerAmount } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import InputField from 'lib-components/atoms/form/InputField'
@@ -40,7 +41,7 @@ interface FormState {
 }
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   groupId: UUID
   existing: CaretakerAmount | null
   onSuccess: () => undefined | void

--- a/frontend/src/employee-frontend/components/income-statements/IncomeStatementFilters.tsx
+++ b/frontend/src/employee-frontend/components/income-statements/IncomeStatementFilters.tsx
@@ -5,6 +5,7 @@
 import React, { Fragment, useCallback, useContext } from 'react'
 
 import { ProviderType } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { DatePickerClearableDeprecated } from 'lib-components/molecules/DatePickerDeprecated'
@@ -56,7 +57,8 @@ export default React.memo(function IncomeStatementsFilters({
   )
 
   const setUnit = useCallback(
-    (unit: string | undefined) => setSearchFilters((old) => ({ ...old, unit })),
+    (unit: DaycareId | undefined) =>
+      setSearchFilters((old) => ({ ...old, unit })),
     [setSearchFilters]
   )
 

--- a/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
+++ b/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
@@ -14,6 +14,7 @@ import {
   IncomeStatementSortParam
 } from 'lib-common/generated/api-types/incomestatement'
 import { SortDirection } from 'lib-common/generated/api-types/invoicing'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { constantQuery, useQueryResult } from 'lib-common/query'
 import Pagination from 'lib-components/Pagination'
@@ -168,7 +169,7 @@ export default React.memo(function IncomeStatementsPage() {
   const [sortDirection, setSortDirection] = useState<SortDirection>('ASC')
   const [searchParams, setSearchParams] = useState<{
     areas: string[] | null
-    unit: string | null
+    unit: DaycareId | null
     providerTypes: ProviderType[] | null
     sentStartDate: LocalDate | null
     sentEndDate: LocalDate | null

--- a/frontend/src/employee-frontend/components/invoices/InvoiceFilters.tsx
+++ b/frontend/src/employee-frontend/components/invoices/InvoiceFilters.tsx
@@ -9,6 +9,7 @@ import {
   InvoiceDistinctiveParams,
   InvoiceStatus
 } from 'lib-common/generated/api-types/invoicing'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { Gap } from 'lib-components/white-space'
 
@@ -75,7 +76,7 @@ export default React.memo(function InvoiceFilters() {
   )
 
   const selectUnit = useCallback(
-    (unit?: string) => setSearchFilters((old) => ({ ...old, unit })),
+    (unit?: DaycareId) => setSearchFilters((old) => ({ ...old, unit })),
     [setSearchFilters]
   )
 

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -27,7 +27,9 @@ import {
   PagedSentMessages,
   PagedMessageCopies
 } from 'lib-common/generated/api-types/messaging'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { fromNullableUuid } from 'lib-common/id-type'
 import { UUID } from 'lib-common/types'
 import { usePeriodicRefresh } from 'lib-common/utils/usePeriodicRefresh'
 import { useApiState, useRestApi } from 'lib-common/utils/useRestApi'
@@ -109,7 +111,7 @@ export interface MessagesState {
   messageCopiesAsThreads: Result<MessageThread[]>
   prefilledRecipient: string | null
   prefilledTitle: string | null
-  relatedApplicationId: UUID | null
+  relatedApplicationId: ApplicationId | null
   accountAllowsNewMessage: () => boolean
 }
 
@@ -182,7 +184,9 @@ export const MessageContextProvider = React.memo(
     const threadId = searchParams.get('threadId')
     const prefilledTitle = searchParams.get('title')
     const prefilledRecipient = searchParams.get('recipient')
-    const relatedApplicationId = searchParams.get('applicationId')
+    const relatedApplicationId = fromNullableUuid<ApplicationId>(
+      searchParams.get('applicationId')
+    )
     const replyBoxActive = searchParams.get('reply')
 
     const setParams = useCallback(

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -19,6 +19,7 @@ import {
   PostMessageFilters,
   UpdatableDraftContent
 } from 'lib-common/generated/api-types/messaging'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -174,7 +175,9 @@ const FlagsInfoContent = React.memo(function FlagsInfoContent({
 interface Props {
   availableReceivers: MessageReceiversResponse[]
   defaultSender: SelectOption
-  deleteAttachment: (arg: { attachmentId: UUID }) => Promise<Result<void>>
+  deleteAttachment: (arg: {
+    attachmentId: AttachmentId
+  }) => Promise<Result<void>>
   draftContent?: DraftContent
   getAttachmentUrl: (attachmentId: UUID, fileName: string) => string
   initDraftRaw: (accountId: string) => Promise<Result<string>>
@@ -187,7 +190,7 @@ interface Props {
     draftId: UUID,
     file: File,
     onUploadProgress: (percentage: number) => void
-  ) => Promise<Result<UUID>>
+  ) => Promise<Result<AttachmentId>>
   sending: boolean
   defaultTitle?: string
 }
@@ -419,12 +422,12 @@ export default React.memo(function MessageEditor({
               return id
             }
           )
-        : Failure.of<UUID>({ message: 'Should not happen' }),
+        : Failure.of<AttachmentId>({ message: 'Should not happen' }),
     [draftId, message.attachments, saveMessageAttachment, updateMessage]
   )
 
   const handleAttachmentDelete = useCallback(
-    async (id: UUID) =>
+    async (id: AttachmentId) =>
       (await deleteAttachment({ attachmentId: id })).map(() =>
         setMessage(({ attachments, ...rest }) => ({
           ...rest,

--- a/frontend/src/employee-frontend/components/payments/PaymentFilters.tsx
+++ b/frontend/src/employee-frontend/components/payments/PaymentFilters.tsx
@@ -10,6 +10,7 @@ import {
   PaymentDistinctiveParams,
   PaymentStatus
 } from 'lib-common/generated/api-types/invoicing'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import Radio from 'lib-components/atoms/form/Radio'
@@ -77,7 +78,7 @@ export default React.memo(function PaymentFilters() {
   )
 
   const selectUnit = useCallback(
-    (unit: string | undefined) =>
+    (unit: DaycareId | undefined) =>
       setSearchFilters((old) => ({ ...old, unit: unit ?? null })),
     [setSearchFilters]
   )

--- a/frontend/src/employee-frontend/components/person-profile/PersonInvoiceCorrections.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonInvoiceCorrections.tsx
@@ -28,6 +28,7 @@ import {
   ProductWithName
 } from 'lib-common/generated/api-types/invoicing'
 import { PersonJSON } from 'lib-common/generated/api-types/pis'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { formatCents, parseCents } from 'lib-common/money'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -381,7 +382,7 @@ const correctionForm = object({
   targetMonth: localDate(),
   product: required(oneOf<string>()),
   description: required(value<string>()),
-  unit: required(oneOf<string>()),
+  unit: required(oneOf<DaycareId>()),
   period: required(localDateRange()),
   amount: transformed(value<string>(), (value) => {
     if (value.trim() === '') return ValidationError.of('required')
@@ -415,7 +416,7 @@ const InvoiceCorrectionEditModal = React.memo(
     personId: UUID
     childId: UUID
     row: InvoiceCorrection | null
-    units: Record<string, InvoiceDaycare | undefined>
+    units: Record<DaycareId, InvoiceDaycare | undefined>
     products: ProductWithName[]
     onEditorClose: () => void
   }) {
@@ -440,11 +441,13 @@ const InvoiceCorrectionEditModal = React.memo(
         description: row?.description ?? '',
         unit: {
           domValue: row?.unitId ?? '',
-          options: Object.entries(units).map(([id, unit]) => ({
-            value: id,
-            domValue: id,
-            label: unit?.name ?? ''
-          }))
+          options: Object.values(units)
+            .filter((unit) => !!unit)
+            .map((unit) => ({
+              value: unit.id,
+              domValue: unit.id,
+              label: unit.name
+            }))
         },
         period: row
           ? localDateRange.fromRange(row.period)

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
@@ -19,6 +19,7 @@ import {
   IncomeTypeOptions,
   IncomeValue
 } from 'lib-common/generated/api-types/invoicing'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { parseCents } from 'lib-common/money'
 import { UUID } from 'lib-common/types'
@@ -460,7 +461,7 @@ function IncomeAttachments({
   )
 
   const handleDelete = useCallback(
-    async (id: UUID) =>
+    async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() => {
         onDeleted(id)
       }),

--- a/frontend/src/employee-frontend/components/placement-draft/PlacementDraft.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/PlacementDraft.tsx
@@ -23,9 +23,10 @@ import {
   PlacementPlanDraft,
   PlacementSummary
 } from 'lib-common/generated/api-types/placement'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
@@ -114,7 +115,7 @@ export interface DaycarePlacementPlanForm {
 }
 
 export default React.memo(function PlacementDraft() {
-  const { id: applicationId } = useRouteParams(['id'])
+  const applicationId = useIdRouteParam<ApplicationId>('id')
   const { i18n } = useTranslation()
   const navigate = useNavigate()
   const [placementDraft, setPlacementDraft] = useState<

--- a/frontend/src/employee-frontend/components/placement-draft/PlacementDraft.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/PlacementDraft.tsx
@@ -23,9 +23,8 @@ import {
   PlacementPlanDraft,
   PlacementSummary
 } from 'lib-common/generated/api-types/placement'
-import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { ApplicationId, DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -109,7 +108,7 @@ function hasOverlap(
 }
 
 export interface DaycarePlacementPlanForm {
-  unitId: UUID | null
+  unitId: DaycareId | null
   period: FiniteDateRange | null
   preschoolDaycarePeriod: FiniteDateRange | null
 }
@@ -252,7 +251,7 @@ export default React.memo(function PlacementDraft() {
       }
     }
 
-  function addUnit(unitId: UUID) {
+  function addUnit(unitId: DaycareId) {
     return (
       units.isSuccess &&
       placementDraft.isSuccess &&

--- a/frontend/src/employee-frontend/components/placement-draft/UnitCard.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/UnitCard.tsx
@@ -11,10 +11,9 @@ import { isLoading, Result } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { PublicUnit } from 'lib-common/generated/api-types/daycare'
 import { OccupancyResponseSpeculated } from 'lib-common/generated/api-types/occupancy'
-import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { ApplicationId, DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { SelectionChip } from 'lib-components/atoms/Chip'
 import CrossIconButton from 'lib-components/atoms/buttons/CrossIconButton'
 import { Bold, H1, InformationText, Title } from 'lib-components/typography'
@@ -110,7 +109,7 @@ const OccupancyContainer = styled.div`
 
 function useSpeculatedOccupancies(
   applicationId: ApplicationId,
-  unitId: UUID,
+  unitId: DaycareId,
   period: FiniteDateRange,
   preschoolDaycarePeriod: FiniteDateRange | undefined
 ): Result<OccupancyResponseSpeculated> {
@@ -136,7 +135,7 @@ function useSpeculatedOccupancies(
 
 interface Props {
   applicationId: ApplicationId
-  unitId: string
+  unitId: DaycareId
   unitName: string
   period: FiniteDateRange
   preschoolDaycarePeriod?: FiniteDateRange
@@ -172,13 +171,13 @@ export default React.memo(function UnitCard({
 
   const removeUnit = useCallback(() => {
     setPlacement((prev) =>
-      prev.unitId === unitId ? { ...prev, unitId: '' } : prev
+      prev.unitId === unitId ? { ...prev, unitId: null } : prev
     )
     setAdditionalUnits((prev) => prev.filter((unit) => unit.id !== unitId))
   }, [setAdditionalUnits, setPlacement, unitId])
 
   const selectUnit = useCallback(
-    (unitId: UUID) => setPlacement((prev) => ({ ...prev, unitId })),
+    (unitId: DaycareId | null) => setPlacement((prev) => ({ ...prev, unitId })),
     [setPlacement]
   )
 
@@ -237,7 +236,7 @@ export default React.memo(function UnitCard({
       )}
       <SelectionChip
         data-qa="select-placement-unit"
-        onChange={(checked) => selectUnit(checked ? unitId : '')}
+        onChange={(checked) => selectUnit(checked ? unitId : null)}
         selected={isSelectedUnit}
         text={
           isSelectedUnit

--- a/frontend/src/employee-frontend/components/placement-draft/UnitCard.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/UnitCard.tsx
@@ -11,6 +11,7 @@ import { isLoading, Result } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { PublicUnit } from 'lib-common/generated/api-types/daycare'
 import { OccupancyResponseSpeculated } from 'lib-common/generated/api-types/occupancy'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -108,7 +109,7 @@ const OccupancyContainer = styled.div`
 `
 
 function useSpeculatedOccupancies(
-  applicationId: UUID,
+  applicationId: ApplicationId,
   unitId: UUID,
   period: FiniteDateRange,
   preschoolDaycarePeriod: FiniteDateRange | undefined
@@ -134,7 +135,7 @@ function useSpeculatedOccupancies(
 }
 
 interface Props {
-  applicationId: UUID
+  applicationId: ApplicationId
   unitId: string
   unitName: string
   period: FiniteDateRange

--- a/frontend/src/employee-frontend/components/placement-draft/UnitCards.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/UnitCards.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components'
 
 import { PublicUnit } from 'lib-common/generated/api-types/daycare'
 import { PlacementPlanDraft } from 'lib-common/generated/api-types/placement'
-import { UUID } from 'lib-common/types'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { defaultMargins } from 'lib-components/white-space'
 
 import { DaycarePlacementPlanForm } from './PlacementDraft'
@@ -22,7 +22,7 @@ const FlexContainer = styled.div`
 interface Props {
   additionalUnits: PublicUnit[]
   setAdditionalUnits: Dispatch<SetStateAction<PublicUnit[]>>
-  applicationId: UUID
+  applicationId: ApplicationId
   placement: DaycarePlacementPlanForm
   setPlacement: Dispatch<SetStateAction<DaycarePlacementPlanForm>>
   placementDraft: PlacementPlanDraft

--- a/frontend/src/employee-frontend/components/placement-tool/api.ts
+++ b/frontend/src/employee-frontend/components/placement-tool/api.ts
@@ -3,19 +3,19 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { Failure, Result, Success } from 'lib-common/api'
-import { UUID } from 'lib-common/types'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 
 import { client } from '../../api/client'
 
 export async function uploadPlacementFile(
   file: File,
   onUploadProgress: (percentage: number) => void
-): Promise<Result<UUID>> {
+): Promise<Result<AttachmentId>> {
   const formData = new FormData()
   formData.append('file', file)
 
   try {
-    const { data } = await client.post<string>(
+    const { data } = await client.post<AttachmentId>(
       '/employee/placement-tool',
       formData,
       {

--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReportDecision.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReportDecision.tsx
@@ -15,8 +15,8 @@ import {
   AssistanceNeedDecision,
   AssistanceNeedDecisionStatus
 } from 'lib-common/generated/api-types/assistanceneed'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import AssistanceNeedDecisionReadOnly from 'lib-components/assistance-need-decision/AssistanceNeedDecisionReadOnly'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -81,7 +81,7 @@ const DangerAsyncButton = styled(AsyncButton)`
 `
 
 export default React.memo(function AssistanceNeedDecisionsReportDecision() {
-  const { id } = useRouteParams(['id'])
+  const id = useIdRouteParam<AssistanceNeedDecisionId>('id')
   const navigate = useNavigate()
 
   const [assistanceNeedDecision, reloadDecision] = useApiState(
@@ -303,7 +303,7 @@ const DecisionModal = React.memo(function DecisionModal({
   onFailed,
   decisionStatus
 }: {
-  decisionId: UUID
+  decisionId: AssistanceNeedDecisionId
   onClose: (shouldRefresh: boolean) => void
   onFailed: () => void
   decisionStatus: DecisionStatus
@@ -378,7 +378,7 @@ const AnnulModal = React.memo(function AnnulModal({
   decisionId,
   onClose
 }: {
-  decisionId: UUID
+  decisionId: AssistanceNeedDecisionId
   onClose: (shouldRefresh: boolean) => void
 }) {
   const { i18n } = useTranslation()
@@ -423,7 +423,7 @@ const MismatchDecisionMakerModal = React.memo(
     decisionId,
     onClose
   }: {
-    decisionId: UUID
+    decisionId: AssistanceNeedDecisionId
     onClose: () => void
   }) {
     const { i18n } = useTranslation()

--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReportPreschoolDecision.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedDecisionsReportPreschoolDecision.tsx
@@ -15,8 +15,9 @@ import {
   AssistanceNeedPreschoolDecision,
   AssistanceNeedPreschoolDecisionResponse
 } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedPreschoolDecisionId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import AssistanceNeedPreschoolDecisionReadOnly from 'lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import { InputFieldF } from 'lib-components/atoms/form/InputField'
@@ -246,7 +247,8 @@ const DecisionView = React.memo(function DecisionView({
 
 export default React.memo(
   function AssistanceNeedDecisionsReportPreschoolDecision() {
-    const { decisionId } = useRouteParams(['decisionId'])
+    const decisionId =
+      useIdRouteParam<AssistanceNeedPreschoolDecisionId>('decisionId')
     const decisionResult = useQueryResult(
       assistanceNeedPreschoolDecisionQuery({ id: decisionId })
     )

--- a/frontend/src/employee-frontend/components/reports/AttendanceReservation.tsx
+++ b/frontend/src/employee-frontend/components/reports/AttendanceReservation.tsx
@@ -15,6 +15,7 @@ import styled from 'styled-components'
 import { Failure, Loading, Result, Success, wrapResult } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { AttendanceReservationReportRow } from 'lib-common/generated/api-types/reports'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import { constantQuery, useQueryResult } from 'lib-common/query'
@@ -65,7 +66,7 @@ interface AttendanceReservationReportUiRow {
 export default React.memo(function AttendanceReservation() {
   const { lang, i18n } = useTranslation()
 
-  const [unitId, setUnitId] = useState<UUID | null>(null)
+  const [unitId, setUnitId] = useState<DaycareId | null>(null)
   const [filters, setFilters] = useState<AttendanceReservationReportFilters>(
     () => {
       const defaultDate = LocalDate.todayInSystemTz().addWeeks(1)

--- a/frontend/src/employee-frontend/components/reports/AttendanceReservationByChild.tsx
+++ b/frontend/src/employee-frontend/components/reports/AttendanceReservationByChild.tsx
@@ -15,6 +15,7 @@ import {
   AttendanceReservationReportByChildGroup,
   AttendanceReservationReportByChildItem
 } from 'lib-common/generated/api-types/reports'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { constantQuery, useQueryResult } from 'lib-common/query'
@@ -61,7 +62,7 @@ export default React.memo(function AttendanceReservationByChild() {
   const { lang, i18n } = useTranslation()
   const { roles } = useContext(UserContext)
 
-  const [unitId, setUnitId] = useState<UUID | null>(null)
+  const [unitId, setUnitId] = useState<DaycareId | null>(null)
   const [range, setRange] = useState(() => {
     const defaultDate = LocalDate.todayInSystemTz().addWeeks(1)
     return new FiniteDateRange(

--- a/frontend/src/employee-frontend/components/reports/CustomerFees.tsx
+++ b/frontend/src/employee-frontend/components/reports/CustomerFees.tsx
@@ -14,11 +14,10 @@ import {
   FinanceDecisionType,
   financeDecisionTypes
 } from 'lib-common/generated/api-types/invoicing'
-import { AreaId } from 'lib-common/generated/api-types/shared'
+import { AreaId, DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatCents } from 'lib-common/money'
 import { constantQuery, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import Title from 'lib-components/atoms/Title'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { SelectF } from 'lib-components/atoms/dropdowns/Select'
@@ -37,7 +36,7 @@ import { customerFeesReportQuery } from './queries'
 const filterForm = object({
   date: required(localDate()),
   areaId: oneOf<AreaId>(),
-  unitId: oneOf<UUID>(),
+  unitId: oneOf<DaycareId>(),
   decisionType: required(oneOf<FinanceDecisionType>())
 })
 
@@ -45,7 +44,7 @@ const CustomerFeesInner = React.memo(function CustomerFeesInner({
   unitOptions,
   areaOptions
 }: {
-  unitOptions: { id: UUID; name: string }[]
+  unitOptions: { id: DaycareId; name: string }[]
   areaOptions: { id: AreaId; name: string }[]
 }) {
   const { i18n, lang } = useTranslation()

--- a/frontend/src/employee-frontend/components/reports/CustomerFees.tsx
+++ b/frontend/src/employee-frontend/components/reports/CustomerFees.tsx
@@ -14,6 +14,7 @@ import {
   FinanceDecisionType,
   financeDecisionTypes
 } from 'lib-common/generated/api-types/invoicing'
+import { AreaId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatCents } from 'lib-common/money'
 import { constantQuery, useQueryResult } from 'lib-common/query'
@@ -35,7 +36,7 @@ import { customerFeesReportQuery } from './queries'
 
 const filterForm = object({
   date: required(localDate()),
-  areaId: oneOf<UUID>(),
+  areaId: oneOf<AreaId>(),
   unitId: oneOf<UUID>(),
   decisionType: required(oneOf<FinanceDecisionType>())
 })
@@ -45,7 +46,7 @@ const CustomerFeesInner = React.memo(function CustomerFeesInner({
   areaOptions
 }: {
   unitOptions: { id: UUID; name: string }[]
-  areaOptions: { id: UUID; name: string }[]
+  areaOptions: { id: AreaId; name: string }[]
 }) {
   const { i18n, lang } = useTranslation()
 

--- a/frontend/src/employee-frontend/components/reports/ExceededServiceNeeds.tsx
+++ b/frontend/src/employee-frontend/components/reports/ExceededServiceNeeds.tsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router'
 import { object, oneOf, required } from 'lib-common/form/form'
 import { useForm, useFormFields } from 'lib-common/form/hooks'
 import { ExceededServiceNeedReportUnit } from 'lib-common/generated/api-types/reports'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { constantQuery, useQueryResult } from 'lib-common/query'
 import Title from 'lib-components/atoms/Title'
@@ -45,7 +46,7 @@ export default React.memo(function ReportExceededServiceNeeds() {
 })
 
 const filtersForm = object({
-  unitId: required(oneOf<string>()),
+  unitId: required(oneOf<DaycareId>()),
   year: required(oneOf<number>()),
   month: required(oneOf<number>())
 })

--- a/frontend/src/employee-frontend/components/reports/FamilyContacts.tsx
+++ b/frontend/src/employee-frontend/components/reports/FamilyContacts.tsx
@@ -8,9 +8,10 @@ import { Link } from 'react-router'
 import { localDate } from 'lib-common/form/fields'
 import { object, required } from 'lib-common/form/form'
 import { useForm, useFormFields } from 'lib-common/form/hooks'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { constantQuery, useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Title from 'lib-components/atoms/Title'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
@@ -30,7 +31,7 @@ const filterForm = object({
 })
 
 export default React.memo(function FamilyContacts() {
-  const { unitId } = useRouteParams(['unitId'])
+  const unitId = useIdRouteParam<DaycareId>('unitId')
   const { i18n, lang } = useTranslation()
 
   const filters = useForm(

--- a/frontend/src/employee-frontend/components/reports/HolidayPeriodAttendanceReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/HolidayPeriodAttendanceReport.tsx
@@ -14,6 +14,7 @@ import {
   ChildWithName,
   HolidayPeriodAttendanceReportRow
 } from 'lib-common/generated/api-types/reports'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatFirstName } from 'lib-common/names'
 import { constantQuery, useQueryResult } from 'lib-common/query'
@@ -44,7 +45,7 @@ import { FilterLabel, FilterRow, TableScrollable } from './common'
 import { holidayPeriodAttendanceReportQuery } from './queries'
 
 interface ReportQueryParams {
-  unitId: UUID
+  unitId: DaycareId
   periodId: UUID
   groupIds: UUID[] | null
 }

--- a/frontend/src/employee-frontend/components/reports/MealReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/MealReport.tsx
@@ -7,6 +7,7 @@ import React, { useContext, useState } from 'react'
 import { Action } from 'lib-common/generated/action'
 import { Daycare } from 'lib-common/generated/api-types/daycare'
 import { MealReportData } from 'lib-common/generated/api-types/reports'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import Title from 'lib-components/atoms/Title'
@@ -109,7 +110,7 @@ const MealReportData = ({
   permittedGlobalActions
 }: {
   date: LocalDate
-  unitId: string
+  unitId: DaycareId
   permittedGlobalActions: Action.Global[]
 }) => {
   const { i18n } = useTranslation()

--- a/frontend/src/employee-frontend/components/reports/PlacementGuarantee.tsx
+++ b/frontend/src/employee-frontend/components/reports/PlacementGuarantee.tsx
@@ -10,9 +10,9 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'employee-frontend/state/i18n'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { PlacementGuaranteeReportRow } from 'lib-common/generated/api-types/reports'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import Loader from 'lib-components/atoms/Loader'
 import Title from 'lib-components/atoms/Title'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
@@ -30,7 +30,7 @@ import { placementGuaranteeReportQuery } from './queries'
 
 interface PlacementGuaranteeReportFilters {
   date: LocalDate
-  unitId: UUID | null
+  unitId: DaycareId | null
 }
 
 const initialFilters: PlacementGuaranteeReportFilters = {

--- a/frontend/src/employee-frontend/components/reports/VoucherServiceProviderUnit.tsx
+++ b/frontend/src/employee-frontend/components/reports/VoucherServiceProviderUnit.tsx
@@ -15,10 +15,11 @@ import {
   ServiceVoucherUnitReport,
   ServiceVoucherValueRow
 } from 'lib-common/generated/api-types/reports'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { formatCents } from 'lib-common/money'
 import { Arg0 } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { formatDecimal } from 'lib-common/utils/number'
 import { useSyncQueryParams } from 'lib-common/utils/useSyncQueryParams'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
@@ -127,7 +128,7 @@ const yearOptions = range(maxYear, minYear - 1, -1)
 export default React.memo(function VoucherServiceProviderUnit() {
   const location = useLocation()
   const { i18n } = useTranslation()
-  const { unitId } = useRouteParams(['unitId'])
+  const unitId = useIdRouteParam<DaycareId>('unitId')
   const [report, setReport] = useState<Result<ServiceVoucherUnitReport>>(
     Loading.of()
   )

--- a/frontend/src/employee-frontend/components/unit/TabApplicationProcess.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabApplicationProcess.tsx
@@ -4,8 +4,8 @@
 
 import React, { useContext } from 'react'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import Title from 'lib-components/atoms/Title'
 import { ContentArea } from 'lib-components/layout/Container'
 import { Gap } from 'lib-components/white-space'
@@ -22,7 +22,7 @@ import TabWaitingConfirmation from './TabWaitingConfirmation'
 import { unitApplicationsQuery } from './queries'
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
 }
 
 export default React.memo(function TabApplicationProcess({ unitId }: Props) {

--- a/frontend/src/employee-frontend/components/unit/TabCalendar.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabCalendar.tsx
@@ -11,10 +11,11 @@ import {
   DaycareGroup,
   DaycareResponse
 } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useSyncQueryParams } from 'lib-common/utils/useSyncQueryParams'
 import { SelectionChip } from 'lib-components/atoms/Chip'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
@@ -106,7 +107,7 @@ function attendanceGroupToString(group: AttendanceGroupFilter): string {
 }
 
 export default React.memo(function TabCalendar() {
-  const { id: unitId } = useRouteParams(['id'])
+  const unitId = useIdRouteParam<DaycareId>('id')
   const { unitInformation, filters, setFilters } = useContext(UnitContext)
 
   return renderResult(unitInformation, (unitInformation) => (
@@ -139,7 +140,7 @@ const Calendar = React.memo(function Calendar({
   unitId,
   unitInformation
 }: {
-  unitId: string
+  unitId: DaycareId
   unitInformation: DaycareResponse
 }) {
   const groups = useQueryResult(unitGroupsQuery({ daycareId: unitId }))

--- a/frontend/src/employee-frontend/components/unit/TabGroups.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabGroups.tsx
@@ -66,12 +66,17 @@ export default React.memo(function TabGroups({
           </ContentArea>
         )}
 
-        {groupData.missingGroupPlacements.length > 0 && (
+        {groupData.missingGroupPlacements.length +
+          groupData.missingBackupGroupPlacements.length >
+          0 && (
           <ContentArea opaque data-qa="missing-placements-section">
             <MissingGroupPlacements
               unitId={unitId}
               groups={groupData.groups}
               missingGroupPlacements={groupData.missingGroupPlacements}
+              missingBackupGroupPlacements={
+                groupData.missingBackupGroupPlacements
+              }
               backupCares={groupData.backupCares}
               permittedPlacementActions={groupData.permittedPlacementActions}
               permittedBackupCareActions={groupData.permittedBackupCareActions}

--- a/frontend/src/employee-frontend/components/unit/TabPlacementProposals.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabPlacementProposals.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react'
 
 import { useTranslation } from 'employee-frontend/state/i18n'
 import { PlacementPlanDetails } from 'lib-common/generated/api-types/placement'
-import { UUID } from 'lib-common/types'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import Title from 'lib-components/atoms/Title'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 
@@ -14,7 +14,7 @@ import PlacementProposals from '../../components/unit/tab-placement-proposals/Pl
 import { NotificationCounter } from '../UnitPage'
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   placementProposals: PlacementPlanDetails[]
 }
 

--- a/frontend/src/employee-frontend/components/unit/TabServiceApplications.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabServiceApplications.tsx
@@ -5,8 +5,8 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import Title from 'lib-components/atoms/Title'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
@@ -18,7 +18,7 @@ import { renderResult } from '../async-rendering'
 import { unitServiceApplicationsQuery } from './queries'
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
 }
 
 export default React.memo(function TabServiceApplications({ unitId }: Props) {

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
@@ -28,6 +28,7 @@ import {
   IndividualChild
 } from 'lib-common/generated/api-types/calendarevent'
 import { DaycarePlacementWithDetails } from 'lib-common/generated/api-types/placement'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -201,7 +202,7 @@ export default React.memo(function CalendarEventsSection({
   operationalDays,
   groupId
 }: {
-  unitId: UUID
+  unitId: DaycareId
   selectedDate: LocalDate
   dateRange: FiniteDateRange
   operationalDays: DayOfWeek[]
@@ -496,7 +497,7 @@ const CreateEventModal = React.memo(function CreateEventModal({
   onClose,
   groupId
 }: {
-  unitId: UUID
+  unitId: DaycareId
   onClose: (shouldRefresh: boolean) => void
   groupId: UUID | null
 }) {

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyView.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyView.tsx
@@ -31,6 +31,7 @@ import {
   ChildBasics,
   DaycarePlacementWithDetails
 } from 'lib-common/generated/api-types/placement'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useMutation, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -214,7 +215,7 @@ export default React.memo(function DiscussionReservationSurveyView({
   groupId,
   eventData
 }: {
-  unitId: UUID
+  unitId: DaycareId
   groupId: UUID
   eventData: CalendarEvent
 }) {

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyWrapper.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyWrapper.tsx
@@ -5,10 +5,13 @@
 import React from 'react'
 
 import { renderResult } from 'employee-frontend/components/async-rendering'
-import { CalendarEventId } from 'lib-common/generated/api-types/shared'
+import {
+  CalendarEventId,
+  DaycareId
+} from 'lib-common/generated/api-types/shared'
 import { fromUuid } from 'lib-common/id-type'
 import { constantQuery, useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import useRouteParams, { useIdRouteParam } from 'lib-common/useRouteParams'
 
 import { discussionSurveyQuery } from '../queries'
 
@@ -22,11 +25,11 @@ export default React.memo(function DiscussionReservationSurveyWrapper({
 }: {
   mode: DiscussionReservationSurveyViewMode
 }) {
-  const {
-    groupId,
-    unitId,
-    eventId: eventIdOrNew
-  } = useRouteParams(['groupId', 'unitId', 'eventId'])
+  const { groupId, eventId: eventIdOrNew } = useRouteParams([
+    'groupId',
+    'eventId'
+  ])
+  const unitId = useIdRouteParam<DaycareId>('unitId')
   const eventId =
     eventIdOrNew && eventIdOrNew !== 'new'
       ? fromUuid<CalendarEventId>(eventIdOrNew)

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveysPage.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveysPage.tsx
@@ -9,8 +9,9 @@ import styled from 'styled-components'
 
 import { isLoading } from 'lib-common/api'
 import { CalendarEvent } from 'lib-common/generated/api-types/calendarevent'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import useRouteParams, { useIdRouteParam } from 'lib-common/useRouteParams'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
@@ -37,7 +38,8 @@ const ClickableSurvey = styled.div`
 
 export default React.memo(function DiscussionReservationSurveysPage() {
   const { i18n } = useTranslation()
-  const { groupId, unitId } = useRouteParams(['groupId', 'unitId'])
+  const { groupId } = useRouteParams(['groupId'])
+  const unitId = useIdRouteParam<DaycareId>('unitId')
   const unitInformation = useQueryResult(unitQuery({ daycareId: unitId }))
 
   const discussionSurveys = useQueryResult(

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/InviteeSection.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/InviteeSection.tsx
@@ -15,7 +15,7 @@ import {
   CalendarEventTime
 } from 'lib-common/generated/api-types/calendarevent'
 import { ChildBasics } from 'lib-common/generated/api-types/placement'
-import { UUID } from 'lib-common/types'
+import { CalendarEventId } from 'lib-common/generated/api-types/shared'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import {
   FixedSpaceColumn,
@@ -40,7 +40,7 @@ const ChildNameList = React.memo(function ChildNameList({
   childList,
   'data-qa': dataQa
 }: {
-  eventId: UUID
+  eventId: CalendarEventId
   childList: InviteeInfo[]
   'data-qa'?: string
 }) {

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/survey-editor/DiscussionSurveyEditor.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/survey-editor/DiscussionSurveyEditor.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'employee-frontend/state/i18n'
 import { combine } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { CalendarEvent } from 'lib-common/generated/api-types/calendarevent'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -40,7 +41,7 @@ export default React.memo(function DiscussionSurveyEditor({
   groupId,
   eventData
 }: {
-  unitId: UUID
+  unitId: DaycareId
   groupId: UUID
   eventData: CalendarEvent | null
 }) {

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/survey-editor/DiscussionSurveyForm.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/survey-editor/DiscussionSurveyForm.tsx
@@ -12,6 +12,7 @@ import {
   CalendarEvent,
   CalendarEventType
 } from 'lib-common/generated/api-types/calendarevent'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { cancelMutation } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
@@ -70,7 +71,7 @@ export default React.memo(function DiscussionSurveyForm({
   form: BoundForm<typeof surveyForm>
   eventData: CalendarEvent | null
   groupId: UUID
-  unitId: UUID
+  unitId: DaycareId
 }) {
   const { i18n } = useTranslation()
   const t = i18n.unit.calendar.events

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/survey-editor/DiscussionTimesForm.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/survey-editor/DiscussionTimesForm.tsx
@@ -15,6 +15,7 @@ import {
   DiscussionReservationDay
 } from 'lib-common/generated/api-types/calendarevent'
 import { UnitGroupDetails } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
@@ -71,7 +72,7 @@ export default React.memo(function DiscussionTimesForm({
 }: {
   eventData: CalendarEvent | null
   groupId: UUID
-  unitId: UUID
+  unitId: DaycareId
   groupData: UnitGroupDetails
   horizonRef: MutableRefObject<HTMLDivElement | null>
   calendarRange: FiniteDateRange

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
@@ -5,6 +5,7 @@
 import React, { useContext, useEffect, useState } from 'react'
 
 import { UpdateStateFn } from 'lib-common/form-state'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import InputField from 'lib-components/atoms/form/InputField'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
@@ -19,7 +20,7 @@ import { allPropertiesTrue } from '../../../../utils/validation/validations'
 import { createGroupMutation } from '../../queries'
 
 interface Props {
-  unitId: string
+  unitId: DaycareId
 }
 
 interface FormValidationResult {

--- a/frontend/src/employee-frontend/components/unit/tab-groups/notes/NotesModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/notes/NotesModal.tsx
@@ -7,6 +7,10 @@ import styled from 'styled-components'
 
 import { Result, wrapResult } from 'lib-common/api'
 import { NotesByGroupResponse } from 'lib-common/generated/api-types/note'
+import {
+  ChildStickyNoteId,
+  GroupNoteId
+} from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
@@ -162,7 +166,7 @@ export default React.memo(function NotesModal({
     [reload]
   )
   const saveGroupNote = useCallback(
-    ({ id, ...body }: EditedNote) =>
+    ({ id, ...body }: EditedNote<GroupNoteId>) =>
       (id
         ? updateGroupNoteResult({ noteId: id, body })
         : createGroupNoteResult({ groupId: group.id, body })
@@ -170,11 +174,12 @@ export default React.memo(function NotesModal({
     [group.id, reloadOnSuccess]
   )
   const removeGroupNote = useCallback(
-    (id: string) => deleteGroupNoteResult({ noteId: id }).then(reloadOnSuccess),
+    (id: GroupNoteId) =>
+      deleteGroupNoteResult({ noteId: id }).then(reloadOnSuccess),
     [reloadOnSuccess]
   )
   const saveStickyNote = useCallback(
-    ({ id, ...body }: EditedNote) => {
+    ({ id, ...body }: EditedNote<ChildStickyNoteId>) => {
       if (!child?.id) {
         return Promise.reject('invalid usage: childId was not provided')
       }
@@ -186,7 +191,7 @@ export default React.memo(function NotesModal({
     [child, reloadOnSuccess]
   )
   const removeStickyNote = useCallback(
-    (id: string) =>
+    (id: ChildStickyNoteId) =>
       deleteChildStickyNoteResult({ noteId: id }).then(reloadOnSuccess),
     [reloadOnSuccess]
   )

--- a/frontend/src/employee-frontend/components/unit/tab-groups/types.ts
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/types.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import {
+  MissingBackupGroupPlacement,
+  MissingGroupPlacement
+} from 'lib-common/generated/api-types/placement'
+
+export type MissingPlacement =
+  | { type: 'group'; data: MissingGroupPlacement }
+  | { type: 'backup'; data: MissingBackupGroupPlacement }
+
+export function toMissingPlacements(
+  missingGroupPlacements: MissingGroupPlacement[],
+  missingBackupGroupPlacements: MissingBackupGroupPlacement[]
+) {
+  return [
+    ...missingGroupPlacements.map((data) => ({
+      type: 'group' as const,
+      data
+    })),
+    ...missingBackupGroupPlacements.map((data) => ({
+      type: 'backup' as const,
+      data
+    }))
+  ]
+}

--- a/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposals.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposals.tsx
@@ -18,7 +18,7 @@ import {
   PlacementPlanDetails,
   PlacementPlanRejectReason
 } from 'lib-common/generated/api-types/placement'
-import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { ApplicationId, DaycareId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import {
@@ -54,7 +54,7 @@ interface DynamicState {
 }
 
 type Props = {
-  unitId: UUID
+  unitId: DaycareId
   placementPlans: PlacementPlanDetails[]
 }
 

--- a/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposals.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-placement-proposals/PlacementProposals.tsx
@@ -18,6 +18,7 @@ import {
   PlacementPlanDetails,
   PlacementPlanRejectReason
 } from 'lib-common/generated/api-types/placement'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import {
@@ -67,9 +68,8 @@ export default React.memo(function PlacementProposals({
   const [modalOpen, setModalOpen] = useState(false)
   const [reason, setReason] = useState<PlacementPlanRejectReason | null>(null)
   const [otherReason, setOtherReason] = useState<string>('')
-  const [currentApplicationId, setCurrentApplicationId] = useState<
-    string | null
-  >(null)
+  const [currentApplicationId, setCurrentApplicationId] =
+    useState<ApplicationId | null>(null)
 
   const isMounted = useRef(true)
   useEffect(
@@ -103,7 +103,7 @@ export default React.memo(function PlacementProposals({
   )
 
   const sendConfirmation = async (
-    applicationId: UUID,
+    applicationId: ApplicationId,
     status: PlacementPlanConfirmationStatus
   ) => {
     setConfirmationStates((state) => ({

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/DaycareAclAdditionModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/DaycareAclAdditionModal.tsx
@@ -15,8 +15,8 @@ import {
   DaycareGroupResponse
 } from 'lib-common/generated/api-types/daycare'
 import { Employee, TemporaryEmployee } from 'lib-common/generated/api-types/pis'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import { SelectionChip } from 'lib-components/atoms/Chip'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
@@ -62,7 +62,7 @@ type DaycareAclAdditionModalProps = {
   onClose: () => void
   onSuccess: () => void
   role?: DaycareAclRole
-  unitId: UUID
+  unitId: DaycareId
   groups: Record<string, DaycareGroupResponse>
   employees: Employee[]
   permittedActions: Action.Unit[]

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/EmployeeAclRowEditModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/EmployeeAclRowEditModal.tsx
@@ -14,6 +14,7 @@ import {
   DaycareGroupResponse
 } from 'lib-common/generated/api-types/daycare'
 import { TemporaryEmployee } from 'lib-common/generated/api-types/pis'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
@@ -53,12 +54,12 @@ interface Props {
   onClose: () => void
   onSuccess: () => void
   updatesGroupAcl: (arg: {
-    daycareId: UUID
+    daycareId: DaycareId
     employeeId: UUID
     body: AclUpdate
   }) => Promise<Result<unknown>>
   permittedActions: Action.Unit[]
-  unitId: UUID
+  unitId: DaycareId
   groups: Record<string, DaycareGroupResponse>
   employeeRow: FormattedRow
 }

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/Occupancy.tsx
@@ -12,6 +12,7 @@ import React, {
 import styled from 'styled-components'
 
 import { DaycareGroupResponse } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 import Select from 'lib-components/atoms/dropdowns/Select'
 import TreeDropdown, {
@@ -39,7 +40,7 @@ const Container = styled.div`
 `
 
 type Props = {
-  unitId: UUID
+  unitId: DaycareId
   filters: UnitFilters
   setFilters: Dispatch<SetStateAction<UnitFilters>>
   realtimeStaffAttendanceEnabled: boolean

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitAccessControl.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitAccessControl.tsx
@@ -10,7 +10,11 @@ import styled, { useTheme } from 'styled-components'
 import { combine, isLoading, Success, wrapResult } from 'lib-common/api'
 import { Action } from 'lib-common/generated/action'
 import { DaycareGroupResponse } from 'lib-common/generated/api-types/daycare'
-import { DaycareAclRow, UserRole } from 'lib-common/generated/api-types/shared'
+import {
+  DaycareAclRow,
+  DaycareId,
+  UserRole
+} from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
@@ -277,7 +281,7 @@ function AclTable({
 
 interface RemoveState {
   employee: FormattedRow
-  removeFn: (unitId: UUID, employeeId: UUID) => Promise<unknown>
+  removeFn: (unitId: DaycareId, employeeId: UUID) => Promise<unknown>
 }
 
 export interface UpdateState {

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupanciesForDateRange.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupanciesForDateRange.tsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import { Caretakers } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -74,7 +75,7 @@ export default React.memo(function OccupanciesForDateRange({
   from,
   to
 }: {
-  unitId: UUID
+  unitId: DaycareId
   groupId: UUID | null
   from: LocalDate
   to: LocalDate

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupanciesForSingleDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupanciesForSingleDay.tsx
@@ -5,6 +5,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -46,7 +47,7 @@ export const RealtimeRealizedOccupanciesForSingleDay = React.memo(
     date,
     shiftCareUnit
   }: {
-    unitId: UUID
+    unitId: DaycareId
     groupIds: UUID[] | null
     date: LocalDate
     shiftCareUnit: boolean
@@ -73,7 +74,7 @@ export const RealtimePlannedOccupanciesForSingleDay = React.memo(
     groupIds,
     date
   }: {
-    unitId: UUID
+    unitId: DaycareId
     groupIds: UUID[] | null
     date: LocalDate
   }) {
@@ -95,7 +96,7 @@ export const SimpleOccupanciesForSingleDay = React.memo(
     groupId,
     date
   }: {
-    unitId: UUID
+    unitId: DaycareId
     groupId: UUID | null
     date: LocalDate
   }) {

--- a/frontend/src/employee-frontend/components/unit/unit-details/UnitDetailsPage.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-details/UnitDetailsPage.tsx
@@ -6,8 +6,9 @@ import React, { useContext, useEffect, useState } from 'react'
 
 import { combine, Loading, Result } from 'lib-common/api'
 import { useBoolean } from 'lib-common/form/hooks'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import {
   MutateButton,
@@ -25,7 +26,7 @@ import { renderResult } from '../../async-rendering'
 import { areaQuery, unitQuery, updateUnitMutation } from '../queries'
 
 export default React.memo(function UnitDetailsPage() {
-  const { id } = useRouteParams(['id'])
+  const id = useIdRouteParam<DaycareId>('id')
   const { i18n } = useTranslation()
   const { setTitle } = useContext<TitleState>(TitleContext)
   const unit = useQueryResult(unitQuery({ daycareId: id }))

--- a/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
@@ -21,7 +21,7 @@ import {
   Language,
   ProviderType
 } from 'lib-common/generated/api-types/daycare'
-import { Coordinate } from 'lib-common/generated/api-types/shared'
+import { AreaId, Coordinate } from 'lib-common/generated/api-types/shared'
 import { JsonOf } from 'lib-common/json'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -66,7 +66,7 @@ type FormData = {
   name: string
   openingDate: LocalDate | null
   closingDate: LocalDate | null
-  areaId: string
+  areaId: AreaId | null
   careTypes: Record<OnlyCareType, boolean>
   dailyPreschoolTime: EditableTimeRange
   dailyPreparatoryTime: EditableTimeRange
@@ -410,7 +410,7 @@ function validateForm(
   if (!name) {
     errors.push({ text: i18n.unitEditor.error.name, key: 'unit-name' })
   }
-  if (!form.areaId) {
+  if (form.areaId == null) {
     errors.push({ text: i18n.unitEditor.error.area, key: 'unit-area' })
   }
   if (Object.values(form.careTypes).every((v) => !v)) {
@@ -681,6 +681,7 @@ function validateForm(
 
   if (
     name &&
+    areaId &&
     visitingAddress.streetAddress &&
     visitingAddress.postalCode &&
     visitingAddress.postOffice
@@ -784,7 +785,7 @@ function toFormData(unit: Daycare | undefined): FormData {
     name: unit?.name ?? '',
     openingDate: unit?.openingDate ?? null,
     closingDate: unit?.closingDate ?? null,
-    areaId: unit?.area?.id ?? '',
+    areaId: unit?.area?.id ?? null,
     careTypes: {
       DAYCARE:
         type?.some(

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDateModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDateModal.tsx
@@ -18,7 +18,8 @@ import {
   object,
   oneOf,
   required,
-  transformed
+  transformed,
+  value
 } from 'lib-common/form/form'
 import {
   BoundForm,
@@ -38,9 +39,9 @@ import {
   ReservationResponse,
   UnitDateInfo
 } from 'lib-common/generated/api-types/reservations'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { constantQuery, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import { SelectF } from 'lib-components/atoms/dropdowns/Select'
@@ -88,7 +89,7 @@ const form = transformed(
   object({
     date: required(localDate()),
     childId: required(string()),
-    unitId: required(string()),
+    unitId: required(value<DaycareId>()),
     reservations: array(reservationForm),
     reservationNoTimes: boolean(),
     attendances: array(attendanceForm),
@@ -163,7 +164,7 @@ export default React.memo(function ChildDateModal({
   onClose
 }: {
   target: ChildDateEditorTarget
-  unitId: UUID
+  unitId: DaycareId
   onClose: () => void
 }) {
   const { i18n } = useTranslation()

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lib-common/form/types'
 import { ExternalAttendanceBody } from 'lib-common/generated/api-types/attendance'
 import { DaycareGroup } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -60,14 +61,14 @@ const upsertDailyExternalRealtimeAttendancesResult = wrapResult(
 type ExternalPersonModalProps = {
   onClose: () => void
   onSave: () => void
-  unitId: UUID
+  unitId: DaycareId
   groups: DaycareGroup[]
   defaultGroupId: UUID
 }
 
 const externalPersonForm = transformed(
   object({
-    unitId: value<string>(),
+    unitId: value<DaycareId>(),
     date: validated(required(localDate()), (value) =>
       value.isAfter(LocalDate.todayInHelsinkiTz()) ? 'dateTooLate' : undefined
     ),
@@ -120,7 +121,7 @@ const externalPersonForm = transformed(
 )
 
 function initialFormState(
-  unitId: UUID,
+  unitId: DaycareId,
   groups: DaycareGroup[],
   defaultGroupId: UUID
 ): StateOf<typeof externalPersonForm> {

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lib-common/generated/api-types/attendance'
 import { DaycareGroup } from 'lib-common/generated/api-types/daycare'
 import { OperationalDay } from 'lib-common/generated/api-types/reservations'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -48,13 +49,6 @@ import {
 import { Translations, useTranslation } from '../../../state/i18n'
 import { formatName } from '../../../utils'
 
-const upsertDailyStaffRealtimeAttendancesResult = wrapResult(
-  upsertDailyStaffRealtimeAttendances
-)
-const upsertDailyExternalRealtimeAttendancesResult = wrapResult(
-  upsertDailyExternalRealtimeAttendances
-)
-
 import StaffAttendanceDetailsModal, {
   EditedAttendance,
   ModalAttendance,
@@ -70,10 +64,17 @@ import {
   NameWrapper
 } from './attendance-elements'
 
+const upsertDailyStaffRealtimeAttendancesResult = wrapResult(
+  upsertDailyStaffRealtimeAttendances
+)
+const upsertDailyExternalRealtimeAttendancesResult = wrapResult(
+  upsertDailyExternalRealtimeAttendances
+)
+
 type GroupFilter = (ids: UUID[]) => boolean
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   operationalDays: OperationalDay[]
   staffAttendances: EmployeeAttendance[]
   externalAttendances: ExternalAttendance[]
@@ -273,7 +274,7 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
     attendances: ModalAttendance[]
     plannedAttendances: ModalPlannedAttendance[]
   }
-  unitId: string
+  unitId: DaycareId
   groups: DaycareGroup[]
   defaultGroupId: string | null
   reloadStaffAttendances: () => Promise<Result<unknown>>

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -9,6 +9,7 @@ import { combine, isLoading, wrapResult } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { DaycareGroup } from 'lib-common/generated/api-types/daycare'
 import { Child } from 'lib-common/generated/api-types/reservations'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -55,7 +56,7 @@ const AttendanceTime = styled(Time)`
 `
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   selectedGroup: AttendanceGroupFilter
   selectedDate: LocalDate
   setSelectedDate: (date: LocalDate) => void

--- a/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionFilters.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionFilters.tsx
@@ -11,6 +11,7 @@ import {
   VoucherValueDecisionDistinctiveParams,
   VoucherValueDecisionStatus
 } from 'lib-common/generated/api-types/invoicing'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { Gap } from 'lib-components/white-space'
 
@@ -100,7 +101,7 @@ export default React.memo(function VoucherValueDecisionFilters() {
   )
 
   const selectUnit = useCallback(
-    (unit?: string) => setSearchFilters((filters) => ({ ...filters, unit })),
+    (unit?: DaycareId) => setSearchFilters((filters) => ({ ...filters, unit })),
     [setSearchFilters]
   )
 

--- a/frontend/src/employee-frontend/generated/api-clients/absence.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/absence.ts
@@ -6,12 +6,13 @@
 
 import { Absence } from 'lib-common/generated/api-types/absence'
 import { AbsenceUpsert } from 'lib-common/generated/api-types/absence'
+import { GroupId } from 'lib-common/generated/api-types/shared'
 import { GroupMonthCalendar } from 'lib-common/generated/api-types/absence'
 import { HolidayReservationsDelete } from 'lib-common/generated/api-types/absence'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { Presence } from 'lib-common/generated/api-types/absence'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonAbsence } from 'lib-common/generated/api-types/absence'
@@ -24,7 +25,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function addPresences(
   request: {
-    groupId: UUID,
+    groupId: GroupId,
     body: Presence[]
   }
 ): Promise<void> {
@@ -42,7 +43,7 @@ export async function addPresences(
 */
 export async function deleteHolidayReservations(
   request: {
-    groupId: UUID,
+    groupId: GroupId,
     body: HolidayReservationsDelete[]
   }
 ): Promise<void> {
@@ -60,7 +61,7 @@ export async function deleteHolidayReservations(
 */
 export async function getAbsencesOfChild(
   request: {
-    childId: UUID,
+    childId: PersonId,
     year: number,
     month: number
   }
@@ -83,7 +84,7 @@ export async function getAbsencesOfChild(
 */
 export async function groupMonthCalendar(
   request: {
-    groupId: UUID,
+    groupId: GroupId,
     year: number,
     month: number
   }
@@ -106,7 +107,7 @@ export async function groupMonthCalendar(
 */
 export async function upsertAbsences(
   request: {
-    groupId: UUID,
+    groupId: GroupId,
     body: AbsenceUpsert[]
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/application.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/application.ts
@@ -6,10 +6,13 @@
 
 import { AcceptDecisionRequest } from 'lib-common/generated/api-types/application'
 import { AcceptPlacementProposalRequest } from 'lib-common/generated/api-types/application'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { ApplicationNote } from 'lib-common/generated/api-types/application'
+import { ApplicationNoteId } from 'lib-common/generated/api-types/shared'
 import { ApplicationNoteResponse } from 'lib-common/generated/api-types/application'
 import { ApplicationResponse } from 'lib-common/generated/api-types/application'
 import { ApplicationUpdate } from 'lib-common/generated/api-types/application'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { DaycarePlacementPlan } from 'lib-common/generated/api-types/application'
 import { DecisionDraftGroup } from 'lib-common/generated/api-types/application'
 import { DecisionDraftUpdate } from 'lib-common/generated/api-types/decision'
@@ -19,6 +22,7 @@ import { NoteRequest } from 'lib-common/generated/api-types/application'
 import { PagedApplicationSummaries } from 'lib-common/generated/api-types/application'
 import { PaperApplicationCreateRequest } from 'lib-common/generated/api-types/application'
 import { PersonApplicationSummary } from 'lib-common/generated/api-types/application'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { PlacementPlanDraft } from 'lib-common/generated/api-types/placement'
 import { PlacementProposalConfirmationUpdate } from 'lib-common/generated/api-types/application'
 import { PreschoolTerm } from 'lib-common/generated/api-types/daycare'
@@ -26,7 +30,6 @@ import { RejectDecisionRequest } from 'lib-common/generated/api-types/applicatio
 import { SearchApplicationRequest } from 'lib-common/generated/api-types/application'
 import { SimpleApplicationAction } from 'lib-common/generated/api-types/application'
 import { SimpleBatchRequest } from 'lib-common/generated/api-types/application'
-import { UUID } from 'lib-common/types'
 import { UnitApplications } from 'lib-common/generated/api-types/application'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
@@ -47,7 +50,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function acceptDecision(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: AcceptDecisionRequest
   }
 ): Promise<void> {
@@ -65,7 +68,7 @@ export async function acceptDecision(
 */
 export async function acceptPlacementProposal(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     body: AcceptPlacementProposalRequest
   }
 ): Promise<void> {
@@ -83,7 +86,7 @@ export async function acceptPlacementProposal(
 */
 export async function cancelApplication(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     confidential?: boolean | null
   }
 ): Promise<void> {
@@ -106,8 +109,8 @@ export async function createPaperApplication(
   request: {
     body: PaperApplicationCreateRequest
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<ApplicationId> {
+  const { data: json } = await client.request<JsonOf<ApplicationId>>({
     url: uri`/employee/applications`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<PaperApplicationCreateRequest>
@@ -121,7 +124,7 @@ export async function createPaperApplication(
 */
 export async function createPlacementPlan(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: DaycarePlacementPlan
   }
 ): Promise<void> {
@@ -139,7 +142,7 @@ export async function createPlacementPlan(
 */
 export async function getApplicationDetails(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<ApplicationResponse> {
   const { data: json } = await client.request<JsonOf<ApplicationResponse>>({
@@ -172,7 +175,7 @@ export async function getApplicationSummaries(
 */
 export async function getChildApplicationSummaries(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<PersonApplicationSummary[]> {
   const { data: json } = await client.request<JsonOf<PersonApplicationSummary[]>>({
@@ -188,7 +191,7 @@ export async function getChildApplicationSummaries(
 */
 export async function getDecisionDrafts(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<DecisionDraftGroup> {
   const { data: json } = await client.request<JsonOf<DecisionDraftGroup>>({
@@ -204,7 +207,7 @@ export async function getDecisionDrafts(
 */
 export async function getGuardianApplicationSummaries(
   request: {
-    guardianId: UUID
+    guardianId: PersonId
   }
 ): Promise<PersonApplicationSummary[]> {
   const { data: json } = await client.request<JsonOf<PersonApplicationSummary[]>>({
@@ -220,7 +223,7 @@ export async function getGuardianApplicationSummaries(
 */
 export async function getPlacementPlanDraft(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<PlacementPlanDraft> {
   const { data: json } = await client.request<JsonOf<PlacementPlanDraft>>({
@@ -236,7 +239,7 @@ export async function getPlacementPlanDraft(
 */
 export async function getUnitApplications(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
 ): Promise<UnitApplications> {
   const { data: json } = await client.request<JsonOf<UnitApplications>>({
@@ -252,7 +255,7 @@ export async function getUnitApplications(
 */
 export async function rejectDecision(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: RejectDecisionRequest
   }
 ): Promise<void> {
@@ -270,7 +273,7 @@ export async function rejectDecision(
 */
 export async function respondToPlacementProposal(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: PlacementProposalConfirmationUpdate
   }
 ): Promise<void> {
@@ -288,7 +291,7 @@ export async function respondToPlacementProposal(
 */
 export async function sendApplication(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -304,7 +307,7 @@ export async function sendApplication(
 */
 export async function setApplicationVerified(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     confidential?: boolean | null
   }
 ): Promise<void> {
@@ -325,7 +328,7 @@ export async function setApplicationVerified(
 */
 export async function simpleApplicationAction(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     action: SimpleApplicationAction
   }
 ): Promise<void> {
@@ -360,7 +363,7 @@ export async function simpleBatchAction(
 */
 export async function updateApplication(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: ApplicationUpdate
   }
 ): Promise<void> {
@@ -378,7 +381,7 @@ export async function updateApplication(
 */
 export async function updateDecisionDrafts(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: DecisionDraftUpdate[]
   }
 ): Promise<void> {
@@ -408,7 +411,7 @@ export async function getNextPreschoolTerm(): Promise<PreschoolTerm[]> {
 */
 export async function createNote(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: NoteRequest
   }
 ): Promise<ApplicationNote> {
@@ -426,7 +429,7 @@ export async function createNote(
 */
 export async function deleteNote(
   request: {
-    noteId: UUID
+    noteId: ApplicationNoteId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -442,7 +445,7 @@ export async function deleteNote(
 */
 export async function getNotes(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<ApplicationNoteResponse[]> {
   const { data: json } = await client.request<JsonOf<ApplicationNoteResponse[]>>({
@@ -458,7 +461,7 @@ export async function getNotes(
 */
 export async function updateNote(
   request: {
-    noteId: UUID,
+    noteId: ApplicationNoteId,
     body: NoteRequest
   }
 ): Promise<void> {
@@ -476,7 +479,7 @@ export async function updateNote(
 */
 export async function updateServiceWorkerNote(
   request: {
-    applicationId: UUID,
+    applicationId: ApplicationId,
     body: NoteRequest
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/assistance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/assistance.ts
@@ -5,16 +5,21 @@
 // GENERATED FILE: no manual modifications
 
 import { AssistanceAction } from 'lib-common/generated/api-types/assistanceaction'
+import { AssistanceActionId } from 'lib-common/generated/api-types/shared'
 import { AssistanceActionOption } from 'lib-common/generated/api-types/assistanceaction'
 import { AssistanceActionRequest } from 'lib-common/generated/api-types/assistanceaction'
+import { AssistanceFactorId } from 'lib-common/generated/api-types/shared'
 import { AssistanceFactorUpdate } from 'lib-common/generated/api-types/assistance'
 import { AssistanceResponse } from 'lib-common/generated/api-types/assistance'
+import { DaycareAssistanceId } from 'lib-common/generated/api-types/shared'
 import { DaycareAssistanceUpdate } from 'lib-common/generated/api-types/assistance'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { OtherAssistanceMeasureId } from 'lib-common/generated/api-types/shared'
 import { OtherAssistanceMeasureUpdate } from 'lib-common/generated/api-types/assistance'
+import { PersonId } from 'lib-common/generated/api-types/shared'
+import { PreschoolAssistanceId } from 'lib-common/generated/api-types/shared'
 import { PreschoolAssistanceUpdate } from 'lib-common/generated/api-types/assistance'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { deserializeJsonAssistanceAction } from 'lib-common/generated/api-types/assistanceaction'
 import { deserializeJsonAssistanceResponse } from 'lib-common/generated/api-types/assistance'
@@ -26,7 +31,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function createAssistanceAction(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: AssistanceActionRequest
   }
 ): Promise<AssistanceAction> {
@@ -44,11 +49,11 @@ export async function createAssistanceAction(
 */
 export async function createAssistanceFactor(
   request: {
-    child: UUID,
+    child: PersonId,
     body: AssistanceFactorUpdate
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<AssistanceFactorId> {
+  const { data: json } = await client.request<JsonOf<AssistanceFactorId>>({
     url: uri`/employee/children/${request.child}/assistance-factors`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<AssistanceFactorUpdate>
@@ -62,11 +67,11 @@ export async function createAssistanceFactor(
 */
 export async function createDaycareAssistance(
   request: {
-    child: UUID,
+    child: PersonId,
     body: DaycareAssistanceUpdate
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<DaycareAssistanceId> {
+  const { data: json } = await client.request<JsonOf<DaycareAssistanceId>>({
     url: uri`/employee/children/${request.child}/daycare-assistances`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<DaycareAssistanceUpdate>
@@ -80,11 +85,11 @@ export async function createDaycareAssistance(
 */
 export async function createOtherAssistanceMeasure(
   request: {
-    child: UUID,
+    child: PersonId,
     body: OtherAssistanceMeasureUpdate
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<OtherAssistanceMeasureId> {
+  const { data: json } = await client.request<JsonOf<OtherAssistanceMeasureId>>({
     url: uri`/employee/children/${request.child}/other-assistance-measures`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<OtherAssistanceMeasureUpdate>
@@ -98,11 +103,11 @@ export async function createOtherAssistanceMeasure(
 */
 export async function createPreschoolAssistance(
   request: {
-    child: UUID,
+    child: PersonId,
     body: PreschoolAssistanceUpdate
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<PreschoolAssistanceId> {
+  const { data: json } = await client.request<JsonOf<PreschoolAssistanceId>>({
     url: uri`/employee/children/${request.child}/preschool-assistances`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<PreschoolAssistanceUpdate>
@@ -116,7 +121,7 @@ export async function createPreschoolAssistance(
 */
 export async function deleteAssistanceAction(
   request: {
-    id: UUID
+    id: AssistanceActionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -132,7 +137,7 @@ export async function deleteAssistanceAction(
 */
 export async function deleteAssistanceFactor(
   request: {
-    id: UUID
+    id: AssistanceFactorId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -148,7 +153,7 @@ export async function deleteAssistanceFactor(
 */
 export async function deleteDaycareAssistance(
   request: {
-    id: UUID
+    id: DaycareAssistanceId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -164,7 +169,7 @@ export async function deleteDaycareAssistance(
 */
 export async function deleteOtherAssistanceMeasure(
   request: {
-    id: UUID
+    id: OtherAssistanceMeasureId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -180,7 +185,7 @@ export async function deleteOtherAssistanceMeasure(
 */
 export async function deletePreschoolAssistance(
   request: {
-    id: UUID
+    id: PreschoolAssistanceId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -208,7 +213,7 @@ export async function getAssistanceActionOptions(): Promise<AssistanceActionOpti
 */
 export async function getChildAssistance(
   request: {
-    child: UUID
+    child: PersonId
   }
 ): Promise<AssistanceResponse> {
   const { data: json } = await client.request<JsonOf<AssistanceResponse>>({
@@ -224,7 +229,7 @@ export async function getChildAssistance(
 */
 export async function updateAssistanceAction(
   request: {
-    id: UUID,
+    id: AssistanceActionId,
     body: AssistanceActionRequest
   }
 ): Promise<AssistanceAction> {
@@ -242,7 +247,7 @@ export async function updateAssistanceAction(
 */
 export async function updateAssistanceFactor(
   request: {
-    id: UUID,
+    id: AssistanceFactorId,
     body: AssistanceFactorUpdate
   }
 ): Promise<void> {
@@ -260,7 +265,7 @@ export async function updateAssistanceFactor(
 */
 export async function updateDaycareAssistance(
   request: {
-    id: UUID,
+    id: DaycareAssistanceId,
     body: DaycareAssistanceUpdate
   }
 ): Promise<void> {
@@ -278,7 +283,7 @@ export async function updateDaycareAssistance(
 */
 export async function updateOtherAssistanceMeasure(
   request: {
-    id: UUID,
+    id: OtherAssistanceMeasureId,
     body: OtherAssistanceMeasureUpdate
   }
 ): Promise<void> {
@@ -296,7 +301,7 @@ export async function updateOtherAssistanceMeasure(
 */
 export async function updatePreschoolAssistance(
   request: {
-    id: UUID,
+    id: PreschoolAssistanceId,
     body: PreschoolAssistanceUpdate
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/assistanceneed.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/assistanceneed.ts
@@ -8,13 +8,16 @@ import { AnnulAssistanceNeedDecisionRequest } from 'lib-common/generated/api-typ
 import { AnnulAssistanceNeedPreschoolDecisionRequest } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedDecision } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedDecisionBasicsResponse } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
 import { AssistanceNeedDecisionRequest } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedDecisionResponse } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedPreschoolDecision } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedPreschoolDecisionBasicsResponse } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedPreschoolDecisionForm } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedPreschoolDecisionId } from 'lib-common/generated/api-types/shared'
 import { AssistanceNeedPreschoolDecisionResponse } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedVoucherCoefficient } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedVoucherCoefficientId } from 'lib-common/generated/api-types/shared'
 import { AssistanceNeedVoucherCoefficientRequest } from 'lib-common/generated/api-types/assistanceneed'
 import { AssistanceNeedVoucherCoefficientResponse } from 'lib-common/generated/api-types/assistanceneed'
 import { DecideAssistanceNeedDecisionRequest } from 'lib-common/generated/api-types/assistanceneed'
@@ -22,7 +25,7 @@ import { DecideAssistanceNeedPreschoolDecisionRequest } from 'lib-common/generat
 import { Employee } from 'lib-common/generated/api-types/pis'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { UpdateDecisionMakerForAssistanceNeedDecisionRequest } from 'lib-common/generated/api-types/assistanceneed'
 import { UpdateDecisionMakerForAssistanceNeedPreschoolDecisionRequest } from 'lib-common/generated/api-types/assistanceneed'
 import { client } from '../../api/client'
@@ -43,7 +46,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function annulAssistanceNeedDecision(
   request: {
-    id: UUID,
+    id: AssistanceNeedDecisionId,
     body: AnnulAssistanceNeedDecisionRequest
   }
 ): Promise<void> {
@@ -61,7 +64,7 @@ export async function annulAssistanceNeedDecision(
 */
 export async function createAssistanceNeedDecision(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: AssistanceNeedDecisionRequest
   }
 ): Promise<AssistanceNeedDecision> {
@@ -79,7 +82,7 @@ export async function createAssistanceNeedDecision(
 */
 export async function decideAssistanceNeedDecision(
   request: {
-    id: UUID,
+    id: AssistanceNeedDecisionId,
     body: DecideAssistanceNeedDecisionRequest
   }
 ): Promise<void> {
@@ -97,7 +100,7 @@ export async function decideAssistanceNeedDecision(
 */
 export async function deleteAssistanceNeedDecision(
   request: {
-    id: UUID
+    id: AssistanceNeedDecisionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -113,7 +116,7 @@ export async function deleteAssistanceNeedDecision(
 */
 export async function getAssistanceDecisionMakerOptions(
   request: {
-    id: UUID
+    id: AssistanceNeedDecisionId
   }
 ): Promise<Employee[]> {
   const { data: json } = await client.request<JsonOf<Employee[]>>({
@@ -129,7 +132,7 @@ export async function getAssistanceDecisionMakerOptions(
 */
 export async function getAssistanceNeedDecision(
   request: {
-    id: UUID
+    id: AssistanceNeedDecisionId
   }
 ): Promise<AssistanceNeedDecisionResponse> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedDecisionResponse>>({
@@ -145,7 +148,7 @@ export async function getAssistanceNeedDecision(
 */
 export async function getAssistanceNeedDecisions(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<AssistanceNeedDecisionBasicsResponse[]> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedDecisionBasicsResponse[]>>({
@@ -161,7 +164,7 @@ export async function getAssistanceNeedDecisions(
 */
 export async function markAssistanceNeedDecisionAsOpened(
   request: {
-    id: UUID
+    id: AssistanceNeedDecisionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -177,7 +180,7 @@ export async function markAssistanceNeedDecisionAsOpened(
 */
 export async function revertToUnsentAssistanceNeedDecision(
   request: {
-    id: UUID
+    id: AssistanceNeedDecisionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -193,7 +196,7 @@ export async function revertToUnsentAssistanceNeedDecision(
 */
 export async function sendAssistanceNeedDecision(
   request: {
-    id: UUID
+    id: AssistanceNeedDecisionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -209,7 +212,7 @@ export async function sendAssistanceNeedDecision(
 */
 export async function updateAssistanceNeedDecision(
   request: {
-    id: UUID,
+    id: AssistanceNeedDecisionId,
     body: AssistanceNeedDecisionRequest
   }
 ): Promise<void> {
@@ -227,7 +230,7 @@ export async function updateAssistanceNeedDecision(
 */
 export async function updateAssistanceNeedDecisionDecisionMaker(
   request: {
-    id: UUID,
+    id: AssistanceNeedDecisionId,
     body: UpdateDecisionMakerForAssistanceNeedDecisionRequest
   }
 ): Promise<void> {
@@ -245,7 +248,7 @@ export async function updateAssistanceNeedDecisionDecisionMaker(
 */
 export async function annulAssistanceNeedPreschoolDecision(
   request: {
-    id: UUID,
+    id: AssistanceNeedPreschoolDecisionId,
     body: AnnulAssistanceNeedPreschoolDecisionRequest
   }
 ): Promise<void> {
@@ -263,7 +266,7 @@ export async function annulAssistanceNeedPreschoolDecision(
 */
 export async function createAssistanceNeedPreschoolDecision(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<AssistanceNeedPreschoolDecision> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedPreschoolDecision>>({
@@ -279,7 +282,7 @@ export async function createAssistanceNeedPreschoolDecision(
 */
 export async function decideAssistanceNeedPreschoolDecision(
   request: {
-    id: UUID,
+    id: AssistanceNeedPreschoolDecisionId,
     body: DecideAssistanceNeedPreschoolDecisionRequest
   }
 ): Promise<void> {
@@ -297,7 +300,7 @@ export async function decideAssistanceNeedPreschoolDecision(
 */
 export async function deleteAssistanceNeedPreschoolDecision(
   request: {
-    id: UUID
+    id: AssistanceNeedPreschoolDecisionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -313,7 +316,7 @@ export async function deleteAssistanceNeedPreschoolDecision(
 */
 export async function getAssistanceNeedPreschoolDecision(
   request: {
-    id: UUID
+    id: AssistanceNeedPreschoolDecisionId
   }
 ): Promise<AssistanceNeedPreschoolDecisionResponse> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedPreschoolDecisionResponse>>({
@@ -329,7 +332,7 @@ export async function getAssistanceNeedPreschoolDecision(
 */
 export async function getAssistanceNeedPreschoolDecisions(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<AssistanceNeedPreschoolDecisionBasicsResponse[]> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedPreschoolDecisionBasicsResponse[]>>({
@@ -345,7 +348,7 @@ export async function getAssistanceNeedPreschoolDecisions(
 */
 export async function getAssistancePreschoolDecisionMakerOptions(
   request: {
-    id: UUID
+    id: AssistanceNeedPreschoolDecisionId
   }
 ): Promise<Employee[]> {
   const { data: json } = await client.request<JsonOf<Employee[]>>({
@@ -361,7 +364,7 @@ export async function getAssistancePreschoolDecisionMakerOptions(
 */
 export async function markAssistanceNeedPreschoolDecisionAsOpened(
   request: {
-    id: UUID
+    id: AssistanceNeedPreschoolDecisionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -377,7 +380,7 @@ export async function markAssistanceNeedPreschoolDecisionAsOpened(
 */
 export async function revertAssistanceNeedPreschoolDecisionToUnsent(
   request: {
-    id: UUID
+    id: AssistanceNeedPreschoolDecisionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -393,7 +396,7 @@ export async function revertAssistanceNeedPreschoolDecisionToUnsent(
 */
 export async function sendAssistanceNeedPreschoolDecisionForDecision(
   request: {
-    id: UUID
+    id: AssistanceNeedPreschoolDecisionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -409,7 +412,7 @@ export async function sendAssistanceNeedPreschoolDecisionForDecision(
 */
 export async function updateAssistanceNeedPreschoolDecision(
   request: {
-    id: UUID,
+    id: AssistanceNeedPreschoolDecisionId,
     body: AssistanceNeedPreschoolDecisionForm
   }
 ): Promise<void> {
@@ -427,7 +430,7 @@ export async function updateAssistanceNeedPreschoolDecision(
 */
 export async function updateAssistanceNeedPreschoolDecisionDecisionMaker(
   request: {
-    id: UUID,
+    id: AssistanceNeedPreschoolDecisionId,
     body: UpdateDecisionMakerForAssistanceNeedPreschoolDecisionRequest
   }
 ): Promise<void> {
@@ -445,7 +448,7 @@ export async function updateAssistanceNeedPreschoolDecisionDecisionMaker(
 */
 export async function createAssistanceNeedVoucherCoefficient(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: AssistanceNeedVoucherCoefficientRequest
   }
 ): Promise<AssistanceNeedVoucherCoefficient> {
@@ -463,7 +466,7 @@ export async function createAssistanceNeedVoucherCoefficient(
 */
 export async function deleteAssistanceNeedVoucherCoefficient(
   request: {
-    id: UUID
+    id: AssistanceNeedVoucherCoefficientId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -479,7 +482,7 @@ export async function deleteAssistanceNeedVoucherCoefficient(
 */
 export async function getAssistanceNeedVoucherCoefficients(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<AssistanceNeedVoucherCoefficientResponse[]> {
   const { data: json } = await client.request<JsonOf<AssistanceNeedVoucherCoefficientResponse[]>>({
@@ -495,7 +498,7 @@ export async function getAssistanceNeedVoucherCoefficients(
 */
 export async function updateAssistanceNeedVoucherCoefficient(
   request: {
-    id: UUID,
+    id: AssistanceNeedVoucherCoefficientId,
     body: AssistanceNeedVoucherCoefficientRequest
   }
 ): Promise<AssistanceNeedVoucherCoefficient> {

--- a/frontend/src/employee-frontend/generated/api-clients/attachment.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attachment.ts
@@ -4,8 +4,8 @@
 
 // GENERATED FILE: no manual modifications
 
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { uri } from 'lib-common/uri'
 
@@ -15,7 +15,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function deleteAttachment(
   request: {
-    attachmentId: UUID
+    attachmentId: AttachmentId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({

--- a/frontend/src/employee-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/attendance.ts
@@ -5,13 +5,14 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
+import { EmployeeId } from 'lib-common/generated/api-types/shared'
 import { ExternalAttendanceBody } from 'lib-common/generated/api-types/attendance'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { OpenGroupAttendanceResponse } from 'lib-common/generated/api-types/attendance'
 import { StaffAttendanceBody } from 'lib-common/generated/api-types/attendance'
 import { StaffAttendanceResponse } from 'lib-common/generated/api-types/attendance'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonOpenGroupAttendanceResponse } from 'lib-common/generated/api-types/attendance'
@@ -24,7 +25,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getOpenGroupAttendance(
   request: {
-    userId: UUID
+    userId: EmployeeId
   }
 ): Promise<OpenGroupAttendanceResponse> {
   const params = createUrlSearchParams(
@@ -44,7 +45,7 @@ export async function getOpenGroupAttendance(
 */
 export async function getRealtimeStaffAttendances(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     start: LocalDate,
     end: LocalDate
   }

--- a/frontend/src/employee-frontend/generated/api-clients/backupcare.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/backupcare.ts
@@ -5,12 +5,13 @@
 // GENERATED FILE: no manual modifications
 
 import { BackupCareCreateResponse } from 'lib-common/generated/api-types/backupcare'
+import { BackupCareId } from 'lib-common/generated/api-types/shared'
 import { BackupCareUpdateRequest } from 'lib-common/generated/api-types/backupcare'
 import { ChildBackupCaresResponse } from 'lib-common/generated/api-types/backupcare'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { NewBackupCare } from 'lib-common/generated/api-types/backupcare'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api/client'
 import { deserializeJsonChildBackupCaresResponse } from 'lib-common/generated/api-types/backupcare'
 import { uri } from 'lib-common/uri'
@@ -21,7 +22,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function createBackupCare(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: NewBackupCare
   }
 ): Promise<BackupCareCreateResponse> {
@@ -39,7 +40,7 @@ export async function createBackupCare(
 */
 export async function deleteBackupCare(
   request: {
-    id: UUID
+    id: BackupCareId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -55,7 +56,7 @@ export async function deleteBackupCare(
 */
 export async function getChildBackupCares(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<ChildBackupCaresResponse> {
   const { data: json } = await client.request<JsonOf<ChildBackupCaresResponse>>({
@@ -71,7 +72,7 @@ export async function getChildBackupCares(
 */
 export async function updateBackupCare(
   request: {
-    id: UUID,
+    id: BackupCareId,
     body: BackupCareUpdateRequest
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/backuppickup.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/backuppickup.ts
@@ -4,12 +4,13 @@
 
 // GENERATED FILE: no manual modifications
 
+import { BackupPickupId } from 'lib-common/generated/api-types/shared'
 import { ChildBackupPickup } from 'lib-common/generated/api-types/backuppickup'
 import { ChildBackupPickupContent } from 'lib-common/generated/api-types/backuppickup'
 import { ChildBackupPickupCreateResponse } from 'lib-common/generated/api-types/backuppickup'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api/client'
 import { uri } from 'lib-common/uri'
 
@@ -19,7 +20,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function createBackupPickup(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: ChildBackupPickupContent
   }
 ): Promise<ChildBackupPickupCreateResponse> {
@@ -37,7 +38,7 @@ export async function createBackupPickup(
 */
 export async function deleteBackupPickup(
   request: {
-    id: UUID
+    id: BackupPickupId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -53,7 +54,7 @@ export async function deleteBackupPickup(
 */
 export async function getBackupPickups(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<ChildBackupPickup[]> {
   const { data: json } = await client.request<JsonOf<ChildBackupPickup[]>>({
@@ -69,7 +70,7 @@ export async function getBackupPickups(
 */
 export async function updateBackupPickup(
   request: {
-    id: UUID,
+    id: BackupPickupId,
     body: ChildBackupPickupContent
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/calendarevent.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/calendarevent.ts
@@ -6,8 +6,8 @@
 
 import LocalDate from 'lib-common/local-date'
 import { CalendarEvent } from 'lib-common/generated/api-types/calendarevent'
-import { CalendarEventAttendeeId } from 'lib-common/generated/api-types/shared'
 import { CalendarEventForm } from 'lib-common/generated/api-types/calendarevent'
+import { CalendarEventId } from 'lib-common/generated/api-types/shared'
 import { CalendarEventTimeClearingForm } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeEmployeeReservationForm } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeForm } from 'lib-common/generated/api-types/calendarevent'
@@ -30,7 +30,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function addCalendarEventTime(
   request: {
-    id: CalendarEventAttendeeId,
+    id: CalendarEventId,
     body: CalendarEventTimeForm
   }
 ): Promise<CalendarEventTimeId> {
@@ -67,8 +67,8 @@ export async function createCalendarEvent(
   request: {
     body: CalendarEventForm
   }
-): Promise<CalendarEventAttendeeId> {
-  const { data: json } = await client.request<JsonOf<CalendarEventAttendeeId>>({
+): Promise<CalendarEventId> {
+  const { data: json } = await client.request<JsonOf<CalendarEventId>>({
     url: uri`/employee/calendar-event`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<CalendarEventForm>
@@ -82,7 +82,7 @@ export async function createCalendarEvent(
 */
 export async function deleteCalendarEvent(
   request: {
-    id: CalendarEventAttendeeId
+    id: CalendarEventId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -114,7 +114,7 @@ export async function deleteCalendarEventTime(
 */
 export async function getCalendarEvent(
   request: {
-    id: CalendarEventAttendeeId
+    id: CalendarEventId
   }
 ): Promise<CalendarEvent> {
   const { data: json } = await client.request<JsonOf<CalendarEvent>>({
@@ -194,7 +194,7 @@ export async function getUnitCalendarEvents(
 */
 export async function modifyCalendarEvent(
   request: {
-    id: CalendarEventAttendeeId,
+    id: CalendarEventId,
     body: CalendarEventUpdateForm
   }
 ): Promise<void> {
@@ -229,7 +229,7 @@ export async function setCalendarEventTimeReservation(
 */
 export async function updateCalendarEvent(
   request: {
-    id: CalendarEventAttendeeId,
+    id: CalendarEventId,
     body: CalendarEventUpdateForm
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/calendarevent.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/calendarevent.ts
@@ -6,15 +6,18 @@
 
 import LocalDate from 'lib-common/local-date'
 import { CalendarEvent } from 'lib-common/generated/api-types/calendarevent'
+import { CalendarEventAttendeeId } from 'lib-common/generated/api-types/shared'
 import { CalendarEventForm } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeClearingForm } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeEmployeeReservationForm } from 'lib-common/generated/api-types/calendarevent'
 import { CalendarEventTimeForm } from 'lib-common/generated/api-types/calendarevent'
+import { CalendarEventTimeId } from 'lib-common/generated/api-types/shared'
 import { CalendarEventUpdateForm } from 'lib-common/generated/api-types/calendarevent'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { DiscussionReservationDay } from 'lib-common/generated/api-types/calendarevent'
+import { GroupId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonCalendarEvent } from 'lib-common/generated/api-types/calendarevent'
@@ -27,11 +30,11 @@ import { uri } from 'lib-common/uri'
 */
 export async function addCalendarEventTime(
   request: {
-    id: UUID,
+    id: CalendarEventAttendeeId,
     body: CalendarEventTimeForm
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<CalendarEventTimeId> {
+  const { data: json } = await client.request<JsonOf<CalendarEventTimeId>>({
     url: uri`/employee/calendar-event/${request.id}/time`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<CalendarEventTimeForm>
@@ -64,8 +67,8 @@ export async function createCalendarEvent(
   request: {
     body: CalendarEventForm
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<CalendarEventAttendeeId> {
+  const { data: json } = await client.request<JsonOf<CalendarEventAttendeeId>>({
     url: uri`/employee/calendar-event`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<CalendarEventForm>
@@ -79,7 +82,7 @@ export async function createCalendarEvent(
 */
 export async function deleteCalendarEvent(
   request: {
-    id: UUID
+    id: CalendarEventAttendeeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -95,7 +98,7 @@ export async function deleteCalendarEvent(
 */
 export async function deleteCalendarEventTime(
   request: {
-    id: UUID
+    id: CalendarEventTimeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -111,7 +114,7 @@ export async function deleteCalendarEventTime(
 */
 export async function getCalendarEvent(
   request: {
-    id: UUID
+    id: CalendarEventAttendeeId
   }
 ): Promise<CalendarEvent> {
   const { data: json } = await client.request<JsonOf<CalendarEvent>>({
@@ -127,8 +130,8 @@ export async function getCalendarEvent(
 */
 export async function getGroupDiscussionReservationDays(
   request: {
-    unitId: UUID,
-    groupId: UUID,
+    unitId: DaycareId,
+    groupId: GroupId,
     start: LocalDate,
     end: LocalDate
   }
@@ -151,8 +154,8 @@ export async function getGroupDiscussionReservationDays(
 */
 export async function getGroupDiscussionSurveys(
   request: {
-    unitId: UUID,
-    groupId: UUID
+    unitId: DaycareId,
+    groupId: GroupId
   }
 ): Promise<CalendarEvent[]> {
   const { data: json } = await client.request<JsonOf<CalendarEvent[]>>({
@@ -168,7 +171,7 @@ export async function getGroupDiscussionSurveys(
 */
 export async function getUnitCalendarEvents(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     start: LocalDate,
     end: LocalDate
   }
@@ -191,7 +194,7 @@ export async function getUnitCalendarEvents(
 */
 export async function modifyCalendarEvent(
   request: {
-    id: UUID,
+    id: CalendarEventAttendeeId,
     body: CalendarEventUpdateForm
   }
 ): Promise<void> {
@@ -226,7 +229,7 @@ export async function setCalendarEventTimeReservation(
 */
 export async function updateCalendarEvent(
   request: {
-    id: UUID,
+    id: CalendarEventAttendeeId,
     body: CalendarEventUpdateForm
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/dailyservicetimes.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/dailyservicetimes.ts
@@ -7,9 +7,10 @@
 import { DailyServiceTimesEndDate } from 'lib-common/generated/api-types/dailyservicetimes'
 import { DailyServiceTimesResponse } from 'lib-common/generated/api-types/dailyservicetimes'
 import { DailyServiceTimesValue } from 'lib-common/generated/api-types/dailyservicetimes'
+import { DailyServicesTimeId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api/client'
 import { deserializeJsonDailyServiceTimesResponse } from 'lib-common/generated/api-types/dailyservicetimes'
 import { uri } from 'lib-common/uri'
@@ -20,7 +21,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function deleteDailyServiceTimes(
   request: {
-    id: UUID
+    id: DailyServicesTimeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -36,7 +37,7 @@ export async function deleteDailyServiceTimes(
 */
 export async function getDailyServiceTimes(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<DailyServiceTimesResponse[]> {
   const { data: json } = await client.request<JsonOf<DailyServiceTimesResponse[]>>({
@@ -52,7 +53,7 @@ export async function getDailyServiceTimes(
 */
 export async function postDailyServiceTimes(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: DailyServiceTimesValue
   }
 ): Promise<void> {
@@ -70,7 +71,7 @@ export async function postDailyServiceTimes(
 */
 export async function putDailyServiceTimes(
   request: {
-    id: UUID,
+    id: DailyServicesTimeId,
     body: DailyServiceTimesValue
   }
 ): Promise<void> {
@@ -88,7 +89,7 @@ export async function putDailyServiceTimes(
 */
 export async function putDailyServiceTimesEnd(
   request: {
-    id: UUID,
+    id: DailyServicesTimeId,
     body: DailyServiceTimesEndDate
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/dailyservicetimes.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/dailyservicetimes.ts
@@ -4,10 +4,10 @@
 
 // GENERATED FILE: no manual modifications
 
+import { DailyServiceTimeId } from 'lib-common/generated/api-types/shared'
 import { DailyServiceTimesEndDate } from 'lib-common/generated/api-types/dailyservicetimes'
 import { DailyServiceTimesResponse } from 'lib-common/generated/api-types/dailyservicetimes'
 import { DailyServiceTimesValue } from 'lib-common/generated/api-types/dailyservicetimes'
-import { DailyServicesTimeId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { PersonId } from 'lib-common/generated/api-types/shared'
@@ -21,7 +21,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function deleteDailyServiceTimes(
   request: {
-    id: DailyServicesTimeId
+    id: DailyServiceTimeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -71,7 +71,7 @@ export async function postDailyServiceTimes(
 */
 export async function putDailyServiceTimes(
   request: {
-    id: DailyServicesTimeId,
+    id: DailyServiceTimeId,
     body: DailyServiceTimesValue
   }
 ): Promise<void> {
@@ -89,7 +89,7 @@ export async function putDailyServiceTimes(
 */
 export async function putDailyServiceTimesEnd(
   request: {
-    id: DailyServicesTimeId,
+    id: DailyServiceTimeId,
     body: DailyServiceTimesEndDate
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/daycare.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/daycare.ts
@@ -9,31 +9,38 @@ import { AclUpdate } from 'lib-common/generated/api-types/daycare'
 import { AdditionalInformation } from 'lib-common/generated/api-types/daycare'
 import { ApplicationType } from 'lib-common/generated/api-types/application'
 import { ApplicationUnitType } from 'lib-common/generated/api-types/daycare'
+import { AreaId } from 'lib-common/generated/api-types/shared'
 import { AreaJSON } from 'lib-common/generated/api-types/daycare'
 import { CaretakerRequest } from 'lib-common/generated/api-types/daycare'
 import { CaretakersResponse } from 'lib-common/generated/api-types/daycare'
 import { ChildResponse } from 'lib-common/generated/api-types/daycare'
 import { ClubTerm } from 'lib-common/generated/api-types/daycare'
+import { ClubTermId } from 'lib-common/generated/api-types/shared'
 import { ClubTermRequest } from 'lib-common/generated/api-types/daycare'
 import { CreateDaycareResponse } from 'lib-common/generated/api-types/daycare'
 import { CreateGroupRequest } from 'lib-common/generated/api-types/daycare'
 import { Daycare } from 'lib-common/generated/api-types/daycare'
 import { DaycareAclRow } from 'lib-common/generated/api-types/shared'
+import { DaycareCaretakerId } from 'lib-common/generated/api-types/shared'
 import { DaycareFields } from 'lib-common/generated/api-types/daycare'
 import { DaycareGroup } from 'lib-common/generated/api-types/daycare'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { DaycareResponse } from 'lib-common/generated/api-types/daycare'
 import { Employee } from 'lib-common/generated/api-types/pis'
+import { EmployeeId } from 'lib-common/generated/api-types/shared'
 import { FullAclInfo } from 'lib-common/generated/api-types/daycare'
+import { GroupId } from 'lib-common/generated/api-types/shared'
 import { GroupUpdateRequest } from 'lib-common/generated/api-types/daycare'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { PreschoolTerm } from 'lib-common/generated/api-types/daycare'
+import { PreschoolTermId } from 'lib-common/generated/api-types/shared'
 import { PreschoolTermRequest } from 'lib-common/generated/api-types/daycare'
 import { PublicUnit } from 'lib-common/generated/api-types/daycare'
 import { StaffAttendanceForDates } from 'lib-common/generated/api-types/daycare'
 import { StaffAttendanceUpdate } from 'lib-common/generated/api-types/daycare'
 import { TemporaryEmployee } from 'lib-common/generated/api-types/pis'
-import { UUID } from 'lib-common/types'
 import { UnitFeatures } from 'lib-common/generated/api-types/daycare'
 import { UnitGroupDetails } from 'lib-common/generated/api-types/daycare'
 import { UnitNotifications } from 'lib-common/generated/api-types/daycare'
@@ -61,7 +68,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getAdditionalInfo(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<AdditionalInformation> {
   const { data: json } = await client.request<JsonOf<AdditionalInformation>>({
@@ -77,7 +84,7 @@ export async function getAdditionalInfo(
 */
 export async function getChild(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<ChildResponse> {
   const { data: json } = await client.request<JsonOf<ChildResponse>>({
@@ -93,7 +100,7 @@ export async function getChild(
 */
 export async function updateAdditionalInfo(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: AdditionalInformation
   }
 ): Promise<void> {
@@ -111,8 +118,8 @@ export async function updateAdditionalInfo(
 */
 export async function createCaretakers(
   request: {
-    daycareId: UUID,
-    groupId: UUID,
+    daycareId: DaycareId,
+    groupId: GroupId,
     body: CaretakerRequest
   }
 ): Promise<void> {
@@ -147,7 +154,7 @@ export async function createDaycare(
 */
 export async function createGroup(
   request: {
-    daycareId: UUID,
+    daycareId: DaycareId,
     body: CreateGroupRequest
   }
 ): Promise<DaycareGroup> {
@@ -165,8 +172,8 @@ export async function createGroup(
 */
 export async function deleteGroup(
   request: {
-    daycareId: UUID,
-    groupId: UUID
+    daycareId: DaycareId,
+    groupId: GroupId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -182,8 +189,8 @@ export async function deleteGroup(
 */
 export async function getCaretakers(
   request: {
-    daycareId: UUID,
-    groupId: UUID
+    daycareId: DaycareId,
+    groupId: GroupId
   }
 ): Promise<CaretakersResponse> {
   const { data: json } = await client.request<JsonOf<CaretakersResponse>>({
@@ -199,7 +206,7 @@ export async function getCaretakers(
 */
 export async function getDaycare(
   request: {
-    daycareId: UUID
+    daycareId: DaycareId
   }
 ): Promise<DaycareResponse> {
   const { data: json } = await client.request<JsonOf<DaycareResponse>>({
@@ -235,7 +242,7 @@ export async function getDaycares(
 */
 export async function getGroups(
   request: {
-    daycareId: UUID,
+    daycareId: DaycareId,
     from?: LocalDate | null,
     to?: LocalDate | null
   }
@@ -270,7 +277,7 @@ export async function getUnitFeatures(): Promise<UnitFeatures[]> {
 */
 export async function getUnitGroupDetails(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     from: LocalDate,
     to: LocalDate
   }
@@ -293,7 +300,7 @@ export async function getUnitGroupDetails(
 */
 export async function getUnitNotifications(
   request: {
-    daycareId: UUID
+    daycareId: DaycareId
   }
 ): Promise<UnitNotifications> {
   const { data: json } = await client.request<JsonOf<UnitNotifications>>({
@@ -309,9 +316,9 @@ export async function getUnitNotifications(
 */
 export async function removeCaretakers(
   request: {
-    daycareId: UUID,
-    groupId: UUID,
-    id: UUID
+    daycareId: DaycareId,
+    groupId: GroupId,
+    id: DaycareCaretakerId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -327,9 +334,9 @@ export async function removeCaretakers(
 */
 export async function updateCaretakers(
   request: {
-    daycareId: UUID,
-    groupId: UUID,
-    id: UUID,
+    daycareId: DaycareId,
+    groupId: GroupId,
+    id: DaycareCaretakerId,
     body: CaretakerRequest
   }
 ): Promise<void> {
@@ -347,7 +354,7 @@ export async function updateCaretakers(
 */
 export async function updateDaycare(
   request: {
-    daycareId: UUID,
+    daycareId: DaycareId,
     body: DaycareFields
   }
 ): Promise<void> {
@@ -365,8 +372,8 @@ export async function updateDaycare(
 */
 export async function updateGroup(
   request: {
-    daycareId: UUID,
-    groupId: UUID,
+    daycareId: DaycareId,
+    groupId: GroupId,
     body: GroupUpdateRequest
   }
 ): Promise<void> {
@@ -454,7 +461,7 @@ export async function getAreas(): Promise<AreaJSON[]> {
 export async function getUnits(
   request: {
     type: UnitTypeFilter,
-    areaIds?: UUID[] | null,
+    areaIds?: AreaId[] | null,
     from?: LocalDate | null
   }
 ): Promise<UnitStub[]> {
@@ -477,7 +484,7 @@ export async function getUnits(
 */
 export async function getStaffAttendancesByGroup(
   request: {
-    groupId: UUID,
+    groupId: GroupId,
     year: number,
     month: number
   }
@@ -500,7 +507,7 @@ export async function getStaffAttendancesByGroup(
 */
 export async function upsertStaffAttendance(
   request: {
-    groupId: UUID,
+    groupId: GroupId,
     body: StaffAttendanceUpdate
   }
 ): Promise<void> {
@@ -552,7 +559,7 @@ export async function createPreschoolTerm(
 */
 export async function deleteClubTerm(
   request: {
-    id: UUID
+    id: ClubTermId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -568,7 +575,7 @@ export async function deleteClubTerm(
 */
 export async function deletePreschoolTerm(
   request: {
-    id: UUID
+    id: PreschoolTermId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -608,7 +615,7 @@ export async function getPreschoolTerms(): Promise<PreschoolTerm[]> {
 */
 export async function updateClubTerm(
   request: {
-    id: UUID,
+    id: ClubTermId,
     body: ClubTermRequest
   }
 ): Promise<void> {
@@ -626,7 +633,7 @@ export async function updateClubTerm(
 */
 export async function updatePreschoolTerm(
   request: {
-    id: UUID,
+    id: PreschoolTermId,
     body: PreschoolTermRequest
   }
 ): Promise<void> {
@@ -644,8 +651,8 @@ export async function updatePreschoolTerm(
 */
 export async function addFullAclForRole(
   request: {
-    daycareId: UUID,
-    employeeId: UUID,
+    daycareId: DaycareId,
+    employeeId: EmployeeId,
     body: FullAclInfo
   }
 ): Promise<void> {
@@ -663,11 +670,11 @@ export async function addFullAclForRole(
 */
 export async function createTemporaryEmployee(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     body: TemporaryEmployee
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<EmployeeId> {
+  const { data: json } = await client.request<JsonOf<EmployeeId>>({
     url: uri`/employee/daycares/${request.unitId}/temporary`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<TemporaryEmployee>
@@ -681,8 +688,8 @@ export async function createTemporaryEmployee(
 */
 export async function deleteEarlyChildhoodEducationSecretary(
   request: {
-    daycareId: UUID,
-    employeeId: UUID
+    daycareId: DaycareId,
+    employeeId: EmployeeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -698,8 +705,8 @@ export async function deleteEarlyChildhoodEducationSecretary(
 */
 export async function deleteSpecialEducationTeacher(
   request: {
-    daycareId: UUID,
-    employeeId: UUID
+    daycareId: DaycareId,
+    employeeId: EmployeeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -715,8 +722,8 @@ export async function deleteSpecialEducationTeacher(
 */
 export async function deleteStaff(
   request: {
-    daycareId: UUID,
-    employeeId: UUID
+    daycareId: DaycareId,
+    employeeId: EmployeeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -732,8 +739,8 @@ export async function deleteStaff(
 */
 export async function deleteTemporaryEmployee(
   request: {
-    unitId: UUID,
-    employeeId: UUID
+    unitId: DaycareId,
+    employeeId: EmployeeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -749,8 +756,8 @@ export async function deleteTemporaryEmployee(
 */
 export async function deleteTemporaryEmployeeAcl(
   request: {
-    unitId: UUID,
-    employeeId: UUID
+    unitId: DaycareId,
+    employeeId: EmployeeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -766,8 +773,8 @@ export async function deleteTemporaryEmployeeAcl(
 */
 export async function deleteUnitSupervisor(
   request: {
-    daycareId: UUID,
-    employeeId: UUID
+    daycareId: DaycareId,
+    employeeId: EmployeeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -783,7 +790,7 @@ export async function deleteUnitSupervisor(
 */
 export async function getDaycareAcl(
   request: {
-    daycareId: UUID
+    daycareId: DaycareId
   }
 ): Promise<DaycareAclRow[]> {
   const { data: json } = await client.request<JsonOf<DaycareAclRow[]>>({
@@ -799,8 +806,8 @@ export async function getDaycareAcl(
 */
 export async function getTemporaryEmployee(
   request: {
-    unitId: UUID,
-    employeeId: UUID
+    unitId: DaycareId,
+    employeeId: EmployeeId
   }
 ): Promise<TemporaryEmployee> {
   const { data: json } = await client.request<JsonOf<TemporaryEmployee>>({
@@ -816,7 +823,7 @@ export async function getTemporaryEmployee(
 */
 export async function getTemporaryEmployees(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
 ): Promise<Employee[]> {
   const { data: json } = await client.request<JsonOf<Employee[]>>({
@@ -832,8 +839,8 @@ export async function getTemporaryEmployees(
 */
 export async function updateGroupAclWithOccupancyCoefficient(
   request: {
-    daycareId: UUID,
-    employeeId: UUID,
+    daycareId: DaycareId,
+    employeeId: EmployeeId,
     body: AclUpdate
   }
 ): Promise<void> {
@@ -851,8 +858,8 @@ export async function updateGroupAclWithOccupancyCoefficient(
 */
 export async function updateTemporaryEmployee(
   request: {
-    unitId: UUID,
-    employeeId: UUID,
+    unitId: DaycareId,
+    employeeId: EmployeeId,
     body: TemporaryEmployee
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/decision.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/decision.ts
@@ -7,7 +7,7 @@
 import { DecisionListResponse } from 'lib-common/generated/api-types/decision'
 import { DecisionUnit } from 'lib-common/generated/api-types/decision'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonDecisionListResponse } from 'lib-common/generated/api-types/decision'
@@ -31,7 +31,7 @@ export async function getDecisionUnits(): Promise<DecisionUnit[]> {
 */
 export async function getDecisionsByGuardian(
   request: {
-    id: UUID
+    id: PersonId
   }
 ): Promise<DecisionListResponse> {
   const params = createUrlSearchParams(

--- a/frontend/src/employee-frontend/generated/api-clients/document.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/document.ts
@@ -6,6 +6,7 @@
 
 import DateRange from 'lib-common/date-range'
 import { ChildDocumentCreateRequest } from 'lib-common/generated/api-types/document'
+import { ChildDocumentId } from 'lib-common/generated/api-types/shared'
 import { ChildDocumentSummaryWithPermittedActions } from 'lib-common/generated/api-types/document'
 import { ChildDocumentWithPermittedActions } from 'lib-common/generated/api-types/document'
 import { DocumentContent } from 'lib-common/generated/api-types/document'
@@ -13,12 +14,13 @@ import { DocumentLockResponse } from 'lib-common/generated/api-types/document'
 import { DocumentTemplate } from 'lib-common/generated/api-types/document'
 import { DocumentTemplateBasicsRequest } from 'lib-common/generated/api-types/document'
 import { DocumentTemplateContent } from 'lib-common/generated/api-types/document'
+import { DocumentTemplateId } from 'lib-common/generated/api-types/shared'
 import { DocumentTemplateSummary } from 'lib-common/generated/api-types/document'
 import { ExportedDocumentTemplate } from 'lib-common/generated/api-types/document'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { StatusChangeRequest } from 'lib-common/generated/api-types/document'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonChildDocumentSummaryWithPermittedActions } from 'lib-common/generated/api-types/document'
@@ -52,7 +54,7 @@ export async function createTemplate(
 */
 export async function deleteDraftTemplate(
   request: {
-    templateId: UUID
+    templateId: DocumentTemplateId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -68,7 +70,7 @@ export async function deleteDraftTemplate(
 */
 export async function duplicateTemplate(
   request: {
-    templateId: UUID,
+    templateId: DocumentTemplateId,
     body: DocumentTemplateBasicsRequest
   }
 ): Promise<DocumentTemplate> {
@@ -86,7 +88,7 @@ export async function duplicateTemplate(
 */
 export async function exportTemplate(
   request: {
-    templateId: UUID
+    templateId: DocumentTemplateId
   }
 ): Promise<ExportedDocumentTemplate> {
   const { data: json } = await client.request<JsonOf<ExportedDocumentTemplate>>({
@@ -102,7 +104,7 @@ export async function exportTemplate(
 */
 export async function forceUnpublishTemplate(
   request: {
-    templateId: UUID
+    templateId: DocumentTemplateId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -118,7 +120,7 @@ export async function forceUnpublishTemplate(
 */
 export async function getActiveTemplates(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<DocumentTemplateSummary[]> {
   const params = createUrlSearchParams(
@@ -138,7 +140,7 @@ export async function getActiveTemplates(
 */
 export async function getTemplate(
   request: {
-    templateId: UUID
+    templateId: DocumentTemplateId
   }
 ): Promise<DocumentTemplate> {
   const { data: json } = await client.request<JsonOf<DocumentTemplate>>({
@@ -183,7 +185,7 @@ export async function importTemplate(
 */
 export async function publishTemplate(
   request: {
-    templateId: UUID
+    templateId: DocumentTemplateId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -199,7 +201,7 @@ export async function publishTemplate(
 */
 export async function updateDraftTemplateBasics(
   request: {
-    templateId: UUID,
+    templateId: DocumentTemplateId,
     body: DocumentTemplateBasicsRequest
   }
 ): Promise<void> {
@@ -217,7 +219,7 @@ export async function updateDraftTemplateBasics(
 */
 export async function updateDraftTemplateContent(
   request: {
-    templateId: UUID,
+    templateId: DocumentTemplateId,
     body: DocumentTemplateContent
   }
 ): Promise<void> {
@@ -235,7 +237,7 @@ export async function updateDraftTemplateContent(
 */
 export async function updateTemplateValidity(
   request: {
-    templateId: UUID,
+    templateId: DocumentTemplateId,
     body: DateRange
   }
 ): Promise<void> {
@@ -255,8 +257,8 @@ export async function createDocument(
   request: {
     body: ChildDocumentCreateRequest
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<ChildDocumentId> {
+  const { data: json } = await client.request<JsonOf<ChildDocumentId>>({
     url: uri`/employee/child-documents`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<ChildDocumentCreateRequest>
@@ -270,7 +272,7 @@ export async function createDocument(
 */
 export async function deleteDraftDocument(
   request: {
-    documentId: UUID
+    documentId: ChildDocumentId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -286,7 +288,7 @@ export async function deleteDraftDocument(
 */
 export async function getDocument(
   request: {
-    documentId: UUID
+    documentId: ChildDocumentId
   }
 ): Promise<ChildDocumentWithPermittedActions> {
   const { data: json } = await client.request<JsonOf<ChildDocumentWithPermittedActions>>({
@@ -302,7 +304,7 @@ export async function getDocument(
 */
 export async function getDocuments(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<ChildDocumentSummaryWithPermittedActions[]> {
   const params = createUrlSearchParams(
@@ -322,7 +324,7 @@ export async function getDocuments(
 */
 export async function nextDocumentStatus(
   request: {
-    documentId: UUID,
+    documentId: ChildDocumentId,
     body: StatusChangeRequest
   }
 ): Promise<void> {
@@ -340,7 +342,7 @@ export async function nextDocumentStatus(
 */
 export async function prevDocumentStatus(
   request: {
-    documentId: UUID,
+    documentId: ChildDocumentId,
     body: StatusChangeRequest
   }
 ): Promise<void> {
@@ -358,7 +360,7 @@ export async function prevDocumentStatus(
 */
 export async function publishDocument(
   request: {
-    documentId: UUID
+    documentId: ChildDocumentId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -374,7 +376,7 @@ export async function publishDocument(
 */
 export async function takeDocumentWriteLock(
   request: {
-    documentId: UUID
+    documentId: ChildDocumentId
   }
 ): Promise<DocumentLockResponse> {
   const { data: json } = await client.request<JsonOf<DocumentLockResponse>>({
@@ -390,7 +392,7 @@ export async function takeDocumentWriteLock(
 */
 export async function updateDocumentContent(
   request: {
-    documentId: UUID,
+    documentId: ChildDocumentId,
     body: DocumentContent
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/holidayperiod.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/holidayperiod.ts
@@ -8,10 +8,11 @@ import { FixedPeriodQuestionnaire } from 'lib-common/generated/api-types/holiday
 import { FixedPeriodQuestionnaireBody } from 'lib-common/generated/api-types/holidayperiod'
 import { HolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
 import { HolidayPeriodCreate } from 'lib-common/generated/api-types/holidayperiod'
+import { HolidayPeriodId } from 'lib-common/generated/api-types/shared'
 import { HolidayPeriodUpdate } from 'lib-common/generated/api-types/holidayperiod'
+import { HolidayQuestionnaireId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { deserializeJsonFixedPeriodQuestionnaire } from 'lib-common/generated/api-types/holidayperiod'
 import { deserializeJsonHolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
@@ -40,7 +41,7 @@ export async function createHolidayPeriod(
 */
 export async function deleteHolidayPeriod(
   request: {
-    id: UUID
+    id: HolidayPeriodId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -56,7 +57,7 @@ export async function deleteHolidayPeriod(
 */
 export async function getHolidayPeriod(
   request: {
-    id: UUID
+    id: HolidayPeriodId
   }
 ): Promise<HolidayPeriod> {
   const { data: json } = await client.request<JsonOf<HolidayPeriod>>({
@@ -84,7 +85,7 @@ export async function getHolidayPeriods(): Promise<HolidayPeriod[]> {
 */
 export async function updateHolidayPeriod(
   request: {
-    id: UUID,
+    id: HolidayPeriodId,
     body: HolidayPeriodUpdate
   }
 ): Promise<void> {
@@ -119,7 +120,7 @@ export async function createHolidayQuestionnaire(
 */
 export async function deleteHolidayQuestionnaire(
   request: {
-    id: UUID
+    id: HolidayQuestionnaireId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -135,7 +136,7 @@ export async function deleteHolidayQuestionnaire(
 */
 export async function getQuestionnaire(
   request: {
-    id: UUID
+    id: HolidayQuestionnaireId
   }
 ): Promise<FixedPeriodQuestionnaire> {
   const { data: json } = await client.request<JsonOf<FixedPeriodQuestionnaire>>({
@@ -163,7 +164,7 @@ export async function getQuestionnaires(): Promise<FixedPeriodQuestionnaire[]> {
 */
 export async function updateHolidayQuestionnaire(
   request: {
-    id: UUID,
+    id: HolidayQuestionnaireId,
     body: FixedPeriodQuestionnaireBody
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/incomestatement.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/incomestatement.ts
@@ -6,13 +6,14 @@
 
 import { ChildBasicInfo } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeStatement } from 'lib-common/generated/api-types/incomestatement'
+import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { PagedIncomeStatements } from 'lib-common/generated/api-types/incomestatement'
 import { PagedIncomeStatementsAwaitingHandler } from 'lib-common/generated/api-types/incomestatement'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { SearchIncomeStatementsRequest } from 'lib-common/generated/api-types/incomestatement'
 import { SetIncomeStatementHandledBody } from 'lib-common/generated/api-types/incomestatement'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonIncomeStatement } from 'lib-common/generated/api-types/incomestatement'
@@ -26,8 +27,8 @@ import { uri } from 'lib-common/uri'
 */
 export async function getIncomeStatement(
   request: {
-    personId: UUID,
-    incomeStatementId: UUID
+    personId: PersonId,
+    incomeStatementId: IncomeStatementId
   }
 ): Promise<IncomeStatement> {
   const { data: json } = await client.request<JsonOf<IncomeStatement>>({
@@ -43,7 +44,7 @@ export async function getIncomeStatement(
 */
 export async function getIncomeStatementChildren(
   request: {
-    guardianId: UUID
+    guardianId: PersonId
   }
 ): Promise<ChildBasicInfo[]> {
   const { data: json } = await client.request<JsonOf<ChildBasicInfo[]>>({
@@ -59,7 +60,7 @@ export async function getIncomeStatementChildren(
 */
 export async function getIncomeStatements(
   request: {
-    personId: UUID,
+    personId: PersonId,
     page: number
   }
 ): Promise<PagedIncomeStatements> {
@@ -97,7 +98,7 @@ export async function getIncomeStatementsAwaitingHandler(
 */
 export async function setIncomeStatementHandled(
   request: {
-    incomeStatementId: UUID,
+    incomeStatementId: IncomeStatementId,
     body: SetIncomeStatementHandledBody
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/invoicing.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/invoicing.ts
@@ -7,24 +7,31 @@
 import LocalDate from 'lib-common/local-date'
 import { CreateRetroactiveFeeDecisionsBody } from 'lib-common/generated/api-types/invoicing'
 import { Employee } from 'lib-common/generated/api-types/pis'
+import { EmployeeId } from 'lib-common/generated/api-types/shared'
 import { FeeAlteration } from 'lib-common/generated/api-types/invoicing'
+import { FeeAlterationId } from 'lib-common/generated/api-types/shared'
 import { FeeAlterationWithPermittedActions } from 'lib-common/generated/api-types/invoicing'
 import { FeeDecision } from 'lib-common/generated/api-types/invoicing'
 import { FeeDecisionDetailed } from 'lib-common/generated/api-types/invoicing'
+import { FeeDecisionId } from 'lib-common/generated/api-types/shared'
 import { FeeDecisionTypeRequest } from 'lib-common/generated/api-types/invoicing'
 import { FeeThresholds } from 'lib-common/generated/api-types/invoicing'
+import { FeeThresholdsId } from 'lib-common/generated/api-types/shared'
 import { FeeThresholdsWithId } from 'lib-common/generated/api-types/invoicing'
 import { GenerateDecisionsBody } from 'lib-common/generated/api-types/invoicing'
 import { IncomeCoefficient } from 'lib-common/generated/api-types/invoicing'
+import { IncomeId } from 'lib-common/generated/api-types/shared'
 import { IncomeNotification } from 'lib-common/generated/api-types/invoicing'
 import { IncomeRequest } from 'lib-common/generated/api-types/invoicing'
 import { IncomeTypeOptions } from 'lib-common/generated/api-types/invoicing'
 import { IncomeWithPermittedActions } from 'lib-common/generated/api-types/invoicing'
 import { InvoiceCodes } from 'lib-common/generated/api-types/invoicing'
+import { InvoiceCorrectionId } from 'lib-common/generated/api-types/shared'
 import { InvoiceCorrectionInsert } from 'lib-common/generated/api-types/invoicing'
 import { InvoiceCorrectionWithPermittedActions } from 'lib-common/generated/api-types/invoicing'
 import { InvoiceDetailed } from 'lib-common/generated/api-types/invoicing'
 import { InvoiceDetailedResponse } from 'lib-common/generated/api-types/invoicing'
+import { InvoiceId } from 'lib-common/generated/api-types/shared'
 import { InvoicePayload } from 'lib-common/generated/api-types/invoicing'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
@@ -34,15 +41,19 @@ import { PagedFeeDecisionSummaries } from 'lib-common/generated/api-types/invoic
 import { PagedInvoiceSummaryResponses } from 'lib-common/generated/api-types/invoicing'
 import { PagedPayments } from 'lib-common/generated/api-types/invoicing'
 import { PagedVoucherValueDecisionSummaries } from 'lib-common/generated/api-types/invoicing'
+import { PaymentId } from 'lib-common/generated/api-types/shared'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { SearchFeeDecisionRequest } from 'lib-common/generated/api-types/invoicing'
 import { SearchInvoicesRequest } from 'lib-common/generated/api-types/invoicing'
 import { SearchPaymentsRequest } from 'lib-common/generated/api-types/invoicing'
 import { SearchVoucherValueDecisionRequest } from 'lib-common/generated/api-types/invoicing'
 import { SendPaymentsRequest } from 'lib-common/generated/api-types/invoicing'
+import { ServiceNeedOptionId } from 'lib-common/generated/api-types/shared'
+import { ServiceNeedOptionVoucherValueId } from 'lib-common/generated/api-types/shared'
 import { ServiceNeedOptionVoucherValueRange } from 'lib-common/generated/api-types/invoicing'
 import { ServiceNeedOptionVoucherValueRangeWithId } from 'lib-common/generated/api-types/invoicing'
-import { UUID } from 'lib-common/types'
 import { VoucherValueDecisionDetailed } from 'lib-common/generated/api-types/invoicing'
+import { VoucherValueDecisionId } from 'lib-common/generated/api-types/shared'
 import { VoucherValueDecisionSummary } from 'lib-common/generated/api-types/invoicing'
 import { VoucherValueDecisionTypeRequest } from 'lib-common/generated/api-types/invoicing'
 import { client } from '../../api/client'
@@ -89,7 +100,7 @@ export async function createFeeAlteration(
 */
 export async function deleteFeeAlteration(
   request: {
-    feeAlterationId: UUID
+    feeAlterationId: FeeAlterationId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -105,7 +116,7 @@ export async function deleteFeeAlteration(
 */
 export async function getFeeAlterations(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<FeeAlterationWithPermittedActions[]> {
   const params = createUrlSearchParams(
@@ -125,7 +136,7 @@ export async function getFeeAlterations(
 */
 export async function updateFeeAlteration(
   request: {
-    feeAlterationId: UUID,
+    feeAlterationId: FeeAlterationId,
     body: FeeAlteration
   }
 ): Promise<void> {
@@ -143,8 +154,8 @@ export async function updateFeeAlteration(
 */
 export async function confirmFeeDecisionDrafts(
   request: {
-    decisionHandlerId?: UUID | null,
-    body: UUID[]
+    decisionHandlerId?: EmployeeId | null,
+    body: FeeDecisionId[]
   }
 ): Promise<void> {
   const params = createUrlSearchParams(
@@ -154,7 +165,7 @@ export async function confirmFeeDecisionDrafts(
     url: uri`/employee/fee-decisions/confirm`.toString(),
     method: 'POST',
     params,
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<FeeDecisionId[]>
   })
   return json
 }
@@ -165,7 +176,7 @@ export async function confirmFeeDecisionDrafts(
 */
 export async function generateRetroactiveFeeDecisions(
   request: {
-    id: UUID,
+    id: PersonId,
     body: CreateRetroactiveFeeDecisionsBody
   }
 ): Promise<void> {
@@ -183,7 +194,7 @@ export async function generateRetroactiveFeeDecisions(
 */
 export async function getFeeDecision(
   request: {
-    id: UUID
+    id: FeeDecisionId
   }
 ): Promise<FeeDecisionDetailed> {
   const { data: json } = await client.request<JsonOf<FeeDecisionDetailed>>({
@@ -199,7 +210,7 @@ export async function getFeeDecision(
 */
 export async function getHeadOfFamilyFeeDecisions(
   request: {
-    id: UUID
+    id: PersonId
   }
 ): Promise<FeeDecision[]> {
   const { data: json } = await client.request<JsonOf<FeeDecision[]>>({
@@ -215,13 +226,13 @@ export async function getHeadOfFamilyFeeDecisions(
 */
 export async function ignoreFeeDecisionDrafts(
   request: {
-    body: UUID[]
+    body: FeeDecisionId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-decisions/ignore`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<FeeDecisionId[]>
   })
   return json
 }
@@ -249,13 +260,13 @@ export async function searchFeeDecisions(
 */
 export async function setFeeDecisionSent(
   request: {
-    body: UUID[]
+    body: FeeDecisionId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-decisions/mark-sent`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<FeeDecisionId[]>
   })
   return json
 }
@@ -266,7 +277,7 @@ export async function setFeeDecisionSent(
 */
 export async function setFeeDecisionType(
   request: {
-    id: UUID,
+    id: FeeDecisionId,
     body: FeeDecisionTypeRequest
   }
 ): Promise<void> {
@@ -284,13 +295,13 @@ export async function setFeeDecisionType(
 */
 export async function unignoreFeeDecisionDrafts(
   request: {
-    body: UUID[]
+    body: FeeDecisionId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/fee-decisions/unignore`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<FeeDecisionId[]>
   })
   return json
 }
@@ -352,7 +363,7 @@ export async function createVoucherValue(
 */
 export async function deleteVoucherValue(
   request: {
-    id: UUID
+    id: ServiceNeedOptionVoucherValueId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -378,8 +389,8 @@ export async function getFeeThresholds(): Promise<FeeThresholdsWithId[]> {
 /**
 * Generated from fi.espoo.evaka.invoicing.controller.FinanceBasicsController.getVoucherValues
 */
-export async function getVoucherValues(): Promise<Partial<Record<UUID, ServiceNeedOptionVoucherValueRangeWithId[]>>> {
-  const { data: json } = await client.request<JsonOf<Partial<Record<UUID, ServiceNeedOptionVoucherValueRangeWithId[]>>>>({
+export async function getVoucherValues(): Promise<Partial<Record<ServiceNeedOptionId, ServiceNeedOptionVoucherValueRangeWithId[]>>> {
+  const { data: json } = await client.request<JsonOf<Partial<Record<ServiceNeedOptionId, ServiceNeedOptionVoucherValueRangeWithId[]>>>>({
     url: uri`/employee/finance-basics/voucher-values`.toString(),
     method: 'GET'
   })
@@ -394,7 +405,7 @@ export async function getVoucherValues(): Promise<Partial<Record<UUID, ServiceNe
 */
 export async function updateFeeThresholds(
   request: {
-    id: UUID,
+    id: FeeThresholdsId,
     body: FeeThresholds
   }
 ): Promise<void> {
@@ -412,7 +423,7 @@ export async function updateFeeThresholds(
 */
 export async function updateVoucherValue(
   request: {
-    id: UUID,
+    id: ServiceNeedOptionVoucherValueId,
     body: ServiceNeedOptionVoucherValueRange
   }
 ): Promise<void> {
@@ -444,8 +455,8 @@ export async function createIncome(
   request: {
     body: IncomeRequest
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<IncomeId> {
+  const { data: json } = await client.request<JsonOf<IncomeId>>({
     url: uri`/employee/incomes`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<IncomeRequest>
@@ -459,7 +470,7 @@ export async function createIncome(
 */
 export async function deleteIncome(
   request: {
-    incomeId: UUID
+    incomeId: IncomeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -487,7 +498,7 @@ export async function getIncomeMultipliers(): Promise<Partial<Record<IncomeCoeff
 */
 export async function getIncomeNotifications(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<IncomeNotification[]> {
   const params = createUrlSearchParams(
@@ -519,7 +530,7 @@ export async function getIncomeTypeOptions(): Promise<IncomeTypeOptions> {
 */
 export async function getPersonIncomes(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<IncomeWithPermittedActions[]> {
   const params = createUrlSearchParams(
@@ -539,7 +550,7 @@ export async function getPersonIncomes(
 */
 export async function updateIncome(
   request: {
-    incomeId: UUID,
+    incomeId: IncomeId,
     body: IncomeRequest
   }
 ): Promise<void> {
@@ -569,7 +580,7 @@ export async function createDraftInvoices(): Promise<void> {
 */
 export async function createReplacementDraftsForHeadOfFamily(
   request: {
-    headOfFamilyId: UUID
+    headOfFamilyId: PersonId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -585,13 +596,13 @@ export async function createReplacementDraftsForHeadOfFamily(
 */
 export async function deleteDraftInvoices(
   request: {
-    body: UUID[]
+    body: InvoiceId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoices/delete-drafts`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<InvoiceId[]>
   })
   return json
 }
@@ -602,7 +613,7 @@ export async function deleteDraftInvoices(
 */
 export async function getHeadOfFamilyInvoices(
   request: {
-    id: UUID
+    id: PersonId
   }
 ): Promise<InvoiceDetailed[]> {
   const { data: json } = await client.request<JsonOf<InvoiceDetailed[]>>({
@@ -618,7 +629,7 @@ export async function getHeadOfFamilyInvoices(
 */
 export async function getInvoice(
   request: {
-    id: UUID
+    id: InvoiceId
   }
 ): Promise<InvoiceDetailedResponse> {
   const { data: json } = await client.request<JsonOf<InvoiceDetailedResponse>>({
@@ -646,13 +657,13 @@ export async function getInvoiceCodes(): Promise<InvoiceCodes> {
 */
 export async function markInvoicesSent(
   request: {
-    body: UUID[]
+    body: InvoiceId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/invoices/mark-sent`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<InvoiceId[]>
   })
   return json
 }
@@ -663,7 +674,7 @@ export async function markInvoicesSent(
 */
 export async function markReplacementDraftSent(
   request: {
-    invoiceId: UUID,
+    invoiceId: InvoiceId,
     body: MarkReplacementDraftSentRequest
   }
 ): Promise<void> {
@@ -700,7 +711,7 @@ export async function sendInvoices(
   request: {
     invoiceDate?: LocalDate | null,
     dueDate?: LocalDate | null,
-    body: UUID[]
+    body: InvoiceId[]
   }
 ): Promise<void> {
   const params = createUrlSearchParams(
@@ -711,7 +722,7 @@ export async function sendInvoices(
     url: uri`/employee/invoices/send`.toString(),
     method: 'POST',
     params,
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<InvoiceId[]>
   })
   return json
 }
@@ -756,7 +767,7 @@ export async function createInvoiceCorrection(
 */
 export async function deleteInvoiceCorrection(
   request: {
-    id: UUID
+    id: InvoiceCorrectionId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -772,7 +783,7 @@ export async function deleteInvoiceCorrection(
 */
 export async function getPersonInvoiceCorrections(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<InvoiceCorrectionWithPermittedActions[]> {
   const { data: json } = await client.request<JsonOf<InvoiceCorrectionWithPermittedActions[]>>({
@@ -788,7 +799,7 @@ export async function getPersonInvoiceCorrections(
 */
 export async function updateInvoiceCorrectionNote(
   request: {
-    id: UUID,
+    id: InvoiceCorrectionId,
     body: NoteUpdateBody
   }
 ): Promise<void> {
@@ -806,13 +817,13 @@ export async function updateInvoiceCorrectionNote(
 */
 export async function confirmDraftPayments(
   request: {
-    body: UUID[]
+    body: PaymentId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/payments/confirm`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<PaymentId[]>
   })
   return json
 }
@@ -835,13 +846,13 @@ export async function createPaymentDrafts(): Promise<void> {
 */
 export async function deleteDraftPayments(
   request: {
-    body: UUID[]
+    body: PaymentId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/payments/delete-drafts`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<PaymentId[]>
   })
   return json
 }
@@ -852,13 +863,13 @@ export async function deleteDraftPayments(
 */
 export async function revertPaymentsToDrafts(
   request: {
-    body: UUID[]
+    body: PaymentId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/payments/revert-to-draft`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<PaymentId[]>
   })
   return json
 }
@@ -903,7 +914,7 @@ export async function sendPayments(
 */
 export async function generateRetroactiveVoucherValueDecisions(
   request: {
-    id: UUID,
+    id: PersonId,
     body: CreateRetroactiveFeeDecisionsBody
   }
 ): Promise<void> {
@@ -921,7 +932,7 @@ export async function generateRetroactiveVoucherValueDecisions(
 */
 export async function getHeadOfFamilyVoucherValueDecisions(
   request: {
-    headOfFamilyId: UUID
+    headOfFamilyId: PersonId
   }
 ): Promise<VoucherValueDecisionSummary[]> {
   const { data: json } = await client.request<JsonOf<VoucherValueDecisionSummary[]>>({
@@ -937,7 +948,7 @@ export async function getHeadOfFamilyVoucherValueDecisions(
 */
 export async function getVoucherValueDecision(
   request: {
-    id: UUID
+    id: VoucherValueDecisionId
   }
 ): Promise<VoucherValueDecisionDetailed> {
   const { data: json } = await client.request<JsonOf<VoucherValueDecisionDetailed>>({
@@ -953,13 +964,13 @@ export async function getVoucherValueDecision(
 */
 export async function ignoreVoucherValueDecisionDrafts(
   request: {
-    body: UUID[]
+    body: VoucherValueDecisionId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/value-decisions/ignore`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<VoucherValueDecisionId[]>
   })
   return json
 }
@@ -970,13 +981,13 @@ export async function ignoreVoucherValueDecisionDrafts(
 */
 export async function markVoucherValueDecisionSent(
   request: {
-    body: UUID[]
+    body: VoucherValueDecisionId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/value-decisions/mark-sent`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<VoucherValueDecisionId[]>
   })
   return json
 }
@@ -1004,8 +1015,8 @@ export async function searchVoucherValueDecisions(
 */
 export async function sendVoucherValueDecisionDrafts(
   request: {
-    decisionHandlerId?: UUID | null,
-    body: UUID[]
+    decisionHandlerId?: EmployeeId | null,
+    body: VoucherValueDecisionId[]
   }
 ): Promise<void> {
   const params = createUrlSearchParams(
@@ -1015,7 +1026,7 @@ export async function sendVoucherValueDecisionDrafts(
     url: uri`/employee/value-decisions/send`.toString(),
     method: 'POST',
     params,
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<VoucherValueDecisionId[]>
   })
   return json
 }
@@ -1026,7 +1037,7 @@ export async function sendVoucherValueDecisionDrafts(
 */
 export async function setVoucherValueDecisionType(
   request: {
-    id: UUID,
+    id: VoucherValueDecisionId,
     body: VoucherValueDecisionTypeRequest
   }
 ): Promise<void> {
@@ -1044,13 +1055,13 @@ export async function setVoucherValueDecisionType(
 */
 export async function unignoreVoucherValueDecisionDrafts(
   request: {
-    body: UUID[]
+    body: VoucherValueDecisionId[]
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
     url: uri`/employee/value-decisions/unignore`.toString(),
     method: 'POST',
-    data: request.body satisfies JsonCompatible<UUID[]>
+    data: request.body satisfies JsonCompatible<VoucherValueDecisionId[]>
   })
   return json
 }

--- a/frontend/src/employee-frontend/generated/api-clients/jamix.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/jamix.ts
@@ -5,8 +5,8 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { uri } from 'lib-common/uri'
@@ -17,7 +17,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function sendJamixOrders(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     date: LocalDate
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/messaging.ts
@@ -4,13 +4,18 @@
 
 // GENERATED FILE: no manual modifications
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { AuthorizedMessageAccount } from 'lib-common/generated/api-types/messaging'
 import { CreateMessageResponse } from 'lib-common/generated/api-types/messaging'
 import { DraftContent } from 'lib-common/generated/api-types/messaging'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { MessageAccountId } from 'lib-common/generated/api-types/shared'
+import { MessageDraftId } from 'lib-common/generated/api-types/shared'
+import { MessageId } from 'lib-common/generated/api-types/shared'
 import { MessageReceiversResponse } from 'lib-common/generated/api-types/messaging'
 import { MessageThread } from 'lib-common/generated/api-types/messaging'
+import { MessageThreadId } from 'lib-common/generated/api-types/shared'
 import { PagedMessageCopies } from 'lib-common/generated/api-types/messaging'
 import { PagedMessageThreads } from 'lib-common/generated/api-types/messaging'
 import { PagedSentMessages } from 'lib-common/generated/api-types/messaging'
@@ -20,7 +25,6 @@ import { PostMessagePreflightResponse } from 'lib-common/generated/api-types/mes
 import { ReplyToMessageBody } from 'lib-common/generated/api-types/messaging'
 import { ThreadByApplicationResponse } from 'lib-common/generated/api-types/messaging'
 import { ThreadReply } from 'lib-common/generated/api-types/messaging'
-import { UUID } from 'lib-common/types'
 import { UnreadCountByAccount } from 'lib-common/generated/api-types/messaging'
 import { UpdatableDraftContent } from 'lib-common/generated/api-types/messaging'
 import { client } from '../../api/client'
@@ -40,8 +44,8 @@ import { uri } from 'lib-common/uri'
 */
 export async function archiveThread(
   request: {
-    accountId: UUID,
-    threadId: UUID
+    accountId: MessageAccountId,
+    threadId: MessageThreadId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -57,7 +61,7 @@ export async function archiveThread(
 */
 export async function createMessage(
   request: {
-    accountId: UUID,
+    accountId: MessageAccountId,
     body: PostMessageBody
   }
 ): Promise<CreateMessageResponse> {
@@ -75,7 +79,7 @@ export async function createMessage(
 */
 export async function createMessagePreflightCheck(
   request: {
-    accountId: UUID,
+    accountId: MessageAccountId,
     body: PostMessagePreflightBody
   }
 ): Promise<PostMessagePreflightResponse> {
@@ -93,8 +97,8 @@ export async function createMessagePreflightCheck(
 */
 export async function deleteDraftMessage(
   request: {
-    accountId: UUID,
-    draftId: UUID
+    accountId: MessageAccountId,
+    draftId: MessageDraftId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -122,7 +126,7 @@ export async function getAccountsByUser(): Promise<AuthorizedMessageAccount[]> {
 */
 export async function getArchivedMessages(
   request: {
-    accountId: UUID,
+    accountId: MessageAccountId,
     page: number
   }
 ): Promise<PagedMessageThreads> {
@@ -143,7 +147,7 @@ export async function getArchivedMessages(
 */
 export async function getDraftMessages(
   request: {
-    accountId: UUID
+    accountId: MessageAccountId
   }
 ): Promise<DraftContent[]> {
   const { data: json } = await client.request<JsonOf<DraftContent[]>>({
@@ -159,7 +163,7 @@ export async function getDraftMessages(
 */
 export async function getMessageCopies(
   request: {
-    accountId: UUID,
+    accountId: MessageAccountId,
     page: number
   }
 ): Promise<PagedMessageCopies> {
@@ -180,7 +184,7 @@ export async function getMessageCopies(
 */
 export async function getReceivedMessages(
   request: {
-    accountId: UUID,
+    accountId: MessageAccountId,
     page: number
   }
 ): Promise<PagedMessageThreads> {
@@ -213,7 +217,7 @@ export async function getReceiversForNewMessage(): Promise<MessageReceiversRespo
 */
 export async function getSentMessages(
   request: {
-    accountId: UUID,
+    accountId: MessageAccountId,
     page: number
   }
 ): Promise<PagedSentMessages> {
@@ -234,8 +238,8 @@ export async function getSentMessages(
 */
 export async function getThread(
   request: {
-    accountId: UUID,
-    threadId: UUID
+    accountId: MessageAccountId,
+    threadId: MessageThreadId
   }
 ): Promise<MessageThread> {
   const { data: json } = await client.request<JsonOf<MessageThread>>({
@@ -251,7 +255,7 @@ export async function getThread(
 */
 export async function getThreadByApplicationId(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<ThreadByApplicationResponse> {
   const { data: json } = await client.request<JsonOf<ThreadByApplicationResponse>>({
@@ -279,10 +283,10 @@ export async function getUnreadMessages(): Promise<UnreadCountByAccount[]> {
 */
 export async function initDraftMessage(
   request: {
-    accountId: UUID
+    accountId: MessageAccountId
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<MessageDraftId> {
+  const { data: json } = await client.request<JsonOf<MessageDraftId>>({
     url: uri`/employee/messages/${request.accountId}/drafts`.toString(),
     method: 'POST'
   })
@@ -295,8 +299,8 @@ export async function initDraftMessage(
 */
 export async function markThreadRead(
   request: {
-    accountId: UUID,
-    threadId: UUID
+    accountId: MessageAccountId,
+    threadId: MessageThreadId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -312,8 +316,8 @@ export async function markThreadRead(
 */
 export async function replyToThread(
   request: {
-    accountId: UUID,
-    messageId: UUID,
+    accountId: MessageAccountId,
+    messageId: MessageId,
     body: ReplyToMessageBody
   }
 ): Promise<ThreadReply> {
@@ -331,8 +335,8 @@ export async function replyToThread(
 */
 export async function updateDraftMessage(
   request: {
-    accountId: UUID,
-    draftId: UUID,
+    accountId: MessageAccountId,
+    draftId: MessageDraftId,
     body: UpdatableDraftContent
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/note.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/note.ts
@@ -6,14 +6,18 @@
 
 import { ChildDailyNote } from 'lib-common/generated/api-types/note'
 import { ChildDailyNoteBody } from 'lib-common/generated/api-types/note'
+import { ChildDailyNoteId } from 'lib-common/generated/api-types/shared'
 import { ChildStickyNote } from 'lib-common/generated/api-types/note'
 import { ChildStickyNoteBody } from 'lib-common/generated/api-types/note'
+import { ChildStickyNoteId } from 'lib-common/generated/api-types/shared'
+import { GroupId } from 'lib-common/generated/api-types/shared'
 import { GroupNote } from 'lib-common/generated/api-types/note'
 import { GroupNoteBody } from 'lib-common/generated/api-types/note'
+import { GroupNoteId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { NotesByGroupResponse } from 'lib-common/generated/api-types/note'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api/client'
 import { deserializeJsonChildDailyNote } from 'lib-common/generated/api-types/note'
 import { deserializeJsonChildStickyNote } from 'lib-common/generated/api-types/note'
@@ -27,7 +31,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getNotesByGroup(
   request: {
-    groupId: UUID
+    groupId: GroupId
   }
 ): Promise<NotesByGroupResponse> {
   const { data: json } = await client.request<JsonOf<NotesByGroupResponse>>({
@@ -43,11 +47,11 @@ export async function getNotesByGroup(
 */
 export async function createChildDailyNote(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: ChildDailyNoteBody
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<ChildDailyNoteId> {
+  const { data: json } = await client.request<JsonOf<ChildDailyNoteId>>({
     url: uri`/employee/children/${request.childId}/child-daily-notes`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<ChildDailyNoteBody>
@@ -61,7 +65,7 @@ export async function createChildDailyNote(
 */
 export async function deleteChildDailyNote(
   request: {
-    noteId: UUID
+    noteId: ChildDailyNoteId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -77,7 +81,7 @@ export async function deleteChildDailyNote(
 */
 export async function updateChildDailyNote(
   request: {
-    noteId: UUID,
+    noteId: ChildDailyNoteId,
     body: ChildDailyNoteBody
   }
 ): Promise<ChildDailyNote> {
@@ -95,11 +99,11 @@ export async function updateChildDailyNote(
 */
 export async function createChildStickyNote(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: ChildStickyNoteBody
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<ChildStickyNoteId> {
+  const { data: json } = await client.request<JsonOf<ChildStickyNoteId>>({
     url: uri`/employee/children/${request.childId}/child-sticky-notes`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<ChildStickyNoteBody>
@@ -113,7 +117,7 @@ export async function createChildStickyNote(
 */
 export async function deleteChildStickyNote(
   request: {
-    noteId: UUID
+    noteId: ChildStickyNoteId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -129,7 +133,7 @@ export async function deleteChildStickyNote(
 */
 export async function updateChildStickyNote(
   request: {
-    noteId: UUID,
+    noteId: ChildStickyNoteId,
     body: ChildStickyNoteBody
   }
 ): Promise<ChildStickyNote> {
@@ -147,11 +151,11 @@ export async function updateChildStickyNote(
 */
 export async function createGroupNote(
   request: {
-    groupId: UUID,
+    groupId: GroupId,
     body: GroupNoteBody
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<GroupNoteId> {
+  const { data: json } = await client.request<JsonOf<GroupNoteId>>({
     url: uri`/employee/daycare-groups/${request.groupId}/group-notes`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<GroupNoteBody>
@@ -165,7 +169,7 @@ export async function createGroupNote(
 */
 export async function deleteGroupNote(
   request: {
-    noteId: UUID
+    noteId: GroupNoteId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -181,7 +185,7 @@ export async function deleteGroupNote(
 */
 export async function updateGroupNote(
   request: {
-    noteId: UUID,
+    noteId: GroupNoteId,
     body: GroupNoteBody
   }
 ): Promise<GroupNote> {

--- a/frontend/src/employee-frontend/generated/api-clients/occupancy.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/occupancy.ts
@@ -5,13 +5,15 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { AttendanceReservationReportRow } from 'lib-common/generated/api-types/reports'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { GetUnitOccupanciesForDayBody } from 'lib-common/generated/api-types/occupancy'
+import { GroupId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { OccupancyResponseSpeculated } from 'lib-common/generated/api-types/occupancy'
 import { RealtimeOccupancy } from 'lib-common/generated/api-types/occupancy'
-import { UUID } from 'lib-common/types'
 import { UnitOccupancies } from 'lib-common/generated/api-types/occupancy'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
@@ -26,8 +28,8 @@ import { uri } from 'lib-common/uri'
 */
 export async function getOccupancyPeriodsSpeculated(
   request: {
-    unitId: UUID,
-    applicationId: UUID,
+    unitId: DaycareId,
+    applicationId: ApplicationId,
     from: LocalDate,
     to: LocalDate,
     preschoolDaycareFrom?: LocalDate | null,
@@ -54,10 +56,10 @@ export async function getOccupancyPeriodsSpeculated(
 */
 export async function getUnitOccupancies(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     from: LocalDate,
     to: LocalDate,
-    groupId?: UUID | null
+    groupId?: GroupId | null
   }
 ): Promise<UnitOccupancies> {
   const params = createUrlSearchParams(
@@ -79,7 +81,7 @@ export async function getUnitOccupancies(
 */
 export async function getUnitPlannedOccupanciesForDay(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     body: GetUnitOccupanciesForDayBody
   }
 ): Promise<AttendanceReservationReportRow[]> {
@@ -97,7 +99,7 @@ export async function getUnitPlannedOccupanciesForDay(
 */
 export async function getUnitRealizedOccupanciesForDay(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     body: GetUnitOccupanciesForDayBody
   }
 ): Promise<RealtimeOccupancy> {

--- a/frontend/src/employee-frontend/generated/api-clients/pairing.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/pairing.ts
@@ -4,15 +4,17 @@
 
 // GENERATED FILE: no manual modifications
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { MobileDevice } from 'lib-common/generated/api-types/pairing'
+import { MobileDeviceId } from 'lib-common/generated/api-types/shared'
 import { Pairing } from 'lib-common/generated/api-types/pairing'
+import { PairingId } from 'lib-common/generated/api-types/shared'
 import { PairingStatusRes } from 'lib-common/generated/api-types/pairing'
 import { PostPairingReq } from 'lib-common/generated/api-types/pairing'
 import { PostPairingResponseReq } from 'lib-common/generated/api-types/pairing'
 import { RenameRequest } from 'lib-common/generated/api-types/pairing'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonPairing } from 'lib-common/generated/api-types/pairing'
@@ -24,7 +26,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function deleteMobileDevice(
   request: {
-    id: UUID
+    id: MobileDeviceId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -40,7 +42,7 @@ export async function deleteMobileDevice(
 */
 export async function getMobileDevices(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
 ): Promise<MobileDevice[]> {
   const params = createUrlSearchParams(
@@ -72,7 +74,7 @@ export async function getPersonalMobileDevices(): Promise<MobileDevice[]> {
 */
 export async function putMobileDeviceName(
   request: {
-    id: UUID,
+    id: MobileDeviceId,
     body: RenameRequest
   }
 ): Promise<void> {
@@ -90,7 +92,7 @@ export async function putMobileDeviceName(
 */
 export async function getPairingStatus(
   request: {
-    id: UUID
+    id: PairingId
   }
 ): Promise<PairingStatusRes> {
   const { data: json } = await client.request<JsonOf<PairingStatusRes>>({
@@ -123,7 +125,7 @@ export async function postPairing(
 */
 export async function postPairingResponse(
   request: {
-    id: UUID,
+    id: PairingId,
     body: PostPairingResponseReq
   }
 ): Promise<Pairing> {

--- a/frontend/src/employee-frontend/generated/api-clients/pedagogicaldocument.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/pedagogicaldocument.ts
@@ -7,8 +7,9 @@
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { PedagogicalDocument } from 'lib-common/generated/api-types/pedagogicaldocument'
+import { PedagogicalDocumentId } from 'lib-common/generated/api-types/shared'
 import { PedagogicalDocumentPostBody } from 'lib-common/generated/api-types/pedagogicaldocument'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api/client'
 import { deserializeJsonPedagogicalDocument } from 'lib-common/generated/api-types/pedagogicaldocument'
 import { uri } from 'lib-common/uri'
@@ -36,7 +37,7 @@ export async function createPedagogicalDocument(
 */
 export async function deletePedagogicalDocument(
   request: {
-    documentId: UUID
+    documentId: PedagogicalDocumentId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -52,7 +53,7 @@ export async function deletePedagogicalDocument(
 */
 export async function getChildPedagogicalDocuments(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<PedagogicalDocument[]> {
   const { data: json } = await client.request<JsonOf<PedagogicalDocument[]>>({
@@ -68,7 +69,7 @@ export async function getChildPedagogicalDocuments(
 */
 export async function updatePedagogicalDocument(
   request: {
-    documentId: UUID,
+    documentId: PedagogicalDocumentId,
     body: PedagogicalDocumentPostBody
   }
 ): Promise<PedagogicalDocument> {

--- a/frontend/src/employee-frontend/generated/api-clients/pis.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/pis.ts
@@ -8,8 +8,10 @@ import DateRange from 'lib-common/date-range'
 import { AddSsnRequest } from 'lib-common/generated/api-types/pis'
 import { CreateFosterParentRelationshipBody } from 'lib-common/generated/api-types/pis'
 import { CreatePersonBody } from 'lib-common/generated/api-types/pis'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { DisableSsnRequest } from 'lib-common/generated/api-types/pis'
 import { Employee } from 'lib-common/generated/api-types/pis'
+import { EmployeeId } from 'lib-common/generated/api-types/shared'
 import { EmployeePreferredFirstName } from 'lib-common/generated/api-types/pis'
 import { EmployeeSetPreferredFirstNameUpdateRequest } from 'lib-common/generated/api-types/pis'
 import { EmployeeWithDaycareRoles } from 'lib-common/generated/api-types/pis'
@@ -18,6 +20,7 @@ import { FamilyContact } from 'lib-common/generated/api-types/pis'
 import { FamilyContactPriorityUpdate } from 'lib-common/generated/api-types/pis'
 import { FamilyContactUpdate } from 'lib-common/generated/api-types/pis'
 import { FamilyOverview } from 'lib-common/generated/api-types/pis'
+import { FosterParentId } from 'lib-common/generated/api-types/shared'
 import { FosterParentRelationship } from 'lib-common/generated/api-types/pis'
 import { GetOrCreatePersonBySsnRequest } from 'lib-common/generated/api-types/pis'
 import { GuardiansResponse } from 'lib-common/generated/api-types/pis'
@@ -27,13 +30,16 @@ import { MergeRequest } from 'lib-common/generated/api-types/pis'
 import { NewEmployee } from 'lib-common/generated/api-types/pis'
 import { PagedEmployeesWithDaycareRoles } from 'lib-common/generated/api-types/pis'
 import { Parentship } from 'lib-common/generated/api-types/pis'
+import { ParentshipId } from 'lib-common/generated/api-types/shared'
 import { ParentshipRequest } from 'lib-common/generated/api-types/pis'
 import { ParentshipUpdateRequest } from 'lib-common/generated/api-types/pis'
 import { ParentshipWithPermittedActions } from 'lib-common/generated/api-types/pis'
 import { Partnership } from 'lib-common/generated/api-types/pis'
+import { PartnershipId } from 'lib-common/generated/api-types/shared'
 import { PartnershipRequest } from 'lib-common/generated/api-types/pis'
 import { PartnershipUpdateRequest } from 'lib-common/generated/api-types/pis'
 import { PartnershipWithPermittedActions } from 'lib-common/generated/api-types/pis'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { PersonIdentityResponseJSON } from 'lib-common/generated/api-types/pis'
 import { PersonJSON } from 'lib-common/generated/api-types/pis'
 import { PersonPatch } from 'lib-common/generated/api-types/pis'
@@ -43,7 +49,6 @@ import { PersonWithChildrenDTO } from 'lib-common/generated/api-types/pis'
 import { PinCode } from 'lib-common/generated/api-types/pis'
 import { SearchEmployeeRequest } from 'lib-common/generated/api-types/pis'
 import { SearchPersonBody } from 'lib-common/generated/api-types/pis'
-import { UUID } from 'lib-common/types'
 import { UpsertEmployeeDaycareRolesRequest } from 'lib-common/generated/api-types/pis'
 import { UserRole } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api/client'
@@ -70,7 +75,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function activateEmployee(
   request: {
-    id: UUID
+    id: EmployeeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -103,7 +108,7 @@ export async function createEmployee(
 */
 export async function deactivateEmployee(
   request: {
-    id: UUID
+    id: EmployeeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -119,7 +124,7 @@ export async function deactivateEmployee(
 */
 export async function deleteEmployee(
   request: {
-    id: UUID
+    id: EmployeeId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -135,8 +140,8 @@ export async function deleteEmployee(
 */
 export async function deleteEmployeeDaycareRoles(
   request: {
-    id: UUID,
-    daycareId?: UUID | null
+    id: EmployeeId,
+    daycareId?: DaycareId | null
   }
 ): Promise<void> {
   const params = createUrlSearchParams(
@@ -156,7 +161,7 @@ export async function deleteEmployeeDaycareRoles(
 */
 export async function getEmployee(
   request: {
-    id: UUID
+    id: EmployeeId
   }
 ): Promise<Employee> {
   const { data: json } = await client.request<JsonOf<Employee>>({
@@ -172,7 +177,7 @@ export async function getEmployee(
 */
 export async function getEmployeeDetails(
   request: {
-    id: UUID
+    id: EmployeeId
   }
 ): Promise<EmployeeWithDaycareRoles> {
   const { data: json } = await client.request<JsonOf<EmployeeWithDaycareRoles>>({
@@ -270,7 +275,7 @@ export async function setEmployeePreferredFirstName(
 */
 export async function updateEmployeeGlobalRoles(
   request: {
-    id: UUID,
+    id: EmployeeId,
     body: UserRole[]
   }
 ): Promise<void> {
@@ -288,7 +293,7 @@ export async function updateEmployeeGlobalRoles(
 */
 export async function upsertEmployeeDaycareRoles(
   request: {
-    id: UUID,
+    id: EmployeeId,
     body: UpsertEmployeeDaycareRolesRequest
   }
 ): Promise<void> {
@@ -323,7 +328,7 @@ export async function upsertPinCode(
 */
 export async function getFamilyByPerson(
   request: {
-    id: UUID
+    id: PersonId
   }
 ): Promise<FamilyOverview> {
   const { data: json } = await client.request<JsonOf<FamilyOverview>>({
@@ -339,7 +344,7 @@ export async function getFamilyByPerson(
 */
 export async function getFamilyContactSummary(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<FamilyContact[]> {
   const params = createUrlSearchParams(
@@ -410,7 +415,7 @@ export async function createFosterParentRelationship(
 */
 export async function deleteFosterParentRelationship(
   request: {
-    id: UUID
+    id: FosterParentId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -426,7 +431,7 @@ export async function deleteFosterParentRelationship(
 */
 export async function getFosterChildren(
   request: {
-    parentId: UUID
+    parentId: PersonId
   }
 ): Promise<FosterParentRelationship[]> {
   const { data: json } = await client.request<JsonOf<FosterParentRelationship[]>>({
@@ -442,7 +447,7 @@ export async function getFosterChildren(
 */
 export async function getFosterParents(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<FosterParentRelationship[]> {
   const { data: json } = await client.request<JsonOf<FosterParentRelationship[]>>({
@@ -458,7 +463,7 @@ export async function getFosterParents(
 */
 export async function updateFosterParentRelationshipValidity(
   request: {
-    id: UUID,
+    id: FosterParentId,
     body: DateRange
   }
 ): Promise<void> {
@@ -493,7 +498,7 @@ export async function createParentship(
 */
 export async function deleteParentship(
   request: {
-    id: UUID
+    id: ParentshipId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -509,7 +514,7 @@ export async function deleteParentship(
 */
 export async function getParentship(
   request: {
-    id: UUID
+    id: ParentshipId
   }
 ): Promise<Parentship> {
   const { data: json } = await client.request<JsonOf<Parentship>>({
@@ -525,8 +530,8 @@ export async function getParentship(
 */
 export async function getParentships(
   request: {
-    headOfChildId?: UUID | null,
-    childId?: UUID | null
+    headOfChildId?: PersonId | null,
+    childId?: PersonId | null
   }
 ): Promise<ParentshipWithPermittedActions[]> {
   const params = createUrlSearchParams(
@@ -547,7 +552,7 @@ export async function getParentships(
 */
 export async function retryParentship(
   request: {
-    id: UUID
+    id: ParentshipId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -563,7 +568,7 @@ export async function retryParentship(
 */
 export async function updateParentship(
   request: {
-    id: UUID,
+    id: ParentshipId,
     body: ParentshipUpdateRequest
   }
 ): Promise<void> {
@@ -598,7 +603,7 @@ export async function createPartnership(
 */
 export async function deletePartnership(
   request: {
-    partnershipId: UUID
+    partnershipId: PartnershipId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -614,7 +619,7 @@ export async function deletePartnership(
 */
 export async function getPartnership(
   request: {
-    partnershipId: UUID
+    partnershipId: PartnershipId
   }
 ): Promise<Partnership> {
   const { data: json } = await client.request<JsonOf<Partnership>>({
@@ -630,7 +635,7 @@ export async function getPartnership(
 */
 export async function getPartnerships(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<PartnershipWithPermittedActions[]> {
   const params = createUrlSearchParams(
@@ -650,7 +655,7 @@ export async function getPartnerships(
 */
 export async function retryPartnership(
   request: {
-    partnershipId: UUID
+    partnershipId: PartnershipId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -666,7 +671,7 @@ export async function retryPartnership(
 */
 export async function updatePartnership(
   request: {
-    partnershipId: UUID,
+    partnershipId: PartnershipId,
     body: PartnershipUpdateRequest
   }
 ): Promise<void> {
@@ -684,7 +689,7 @@ export async function updatePartnership(
 */
 export async function addSsn(
   request: {
-    personId: UUID,
+    personId: PersonId,
     body: AddSsnRequest
   }
 ): Promise<PersonJSON> {
@@ -716,8 +721,8 @@ export async function createPerson(
   request: {
     body: CreatePersonBody
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<PersonId> {
+  const { data: json } = await client.request<JsonOf<PersonId>>({
     url: uri`/employee/person/create`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<CreatePersonBody>
@@ -731,7 +736,7 @@ export async function createPerson(
 */
 export async function disableSsn(
   request: {
-    personId: UUID,
+    personId: PersonId,
     body: DisableSsnRequest
   }
 ): Promise<void> {
@@ -749,10 +754,10 @@ export async function disableSsn(
 */
 export async function duplicatePerson(
   request: {
-    personId: UUID
+    personId: PersonId
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<PersonId> {
+  const { data: json } = await client.request<JsonOf<PersonId>>({
     url: uri`/employee/person/${request.personId}/duplicate`.toString(),
     method: 'POST'
   })
@@ -782,7 +787,7 @@ export async function getOrCreatePersonBySsn(
 */
 export async function getPerson(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<PersonResponse> {
   const { data: json } = await client.request<JsonOf<PersonResponse>>({
@@ -798,7 +803,7 @@ export async function getPerson(
 */
 export async function getPersonDependants(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<PersonWithChildrenDTO[]> {
   const { data: json } = await client.request<JsonOf<PersonWithChildrenDTO[]>>({
@@ -814,7 +819,7 @@ export async function getPersonDependants(
 */
 export async function getPersonGuardians(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<GuardiansResponse> {
   const { data: json } = await client.request<JsonOf<GuardiansResponse>>({
@@ -830,7 +835,7 @@ export async function getPersonGuardians(
 */
 export async function getPersonIdentity(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<PersonJSON> {
   const { data: json } = await client.request<JsonOf<PersonJSON>>({
@@ -863,7 +868,7 @@ export async function mergePeople(
 */
 export async function safeDeletePerson(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -896,7 +901,7 @@ export async function searchPerson(
 */
 export async function updateGuardianEvakaRights(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: EvakaRightsRequest
   }
 ): Promise<void> {
@@ -914,7 +919,7 @@ export async function updateGuardianEvakaRights(
 */
 export async function updatePersonAndFamilyFromVtj(
   request: {
-    personId: UUID
+    personId: PersonId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -930,7 +935,7 @@ export async function updatePersonAndFamilyFromVtj(
 */
 export async function updatePersonDetails(
   request: {
-    personId: UUID,
+    personId: PersonId,
     body: PersonPatch
   }
 ): Promise<PersonJSON> {

--- a/frontend/src/employee-frontend/generated/api-clients/placement.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/placement.ts
@@ -5,14 +5,16 @@
 // GENERATED FILE: no manual modifications
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { GroupPlacementId } from 'lib-common/generated/api-types/shared'
 import { GroupPlacementRequestBody } from 'lib-common/generated/api-types/placement'
 import { GroupTransferRequestBody } from 'lib-common/generated/api-types/placement'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { PlacementCreateRequestBody } from 'lib-common/generated/api-types/placement'
+import { PlacementId } from 'lib-common/generated/api-types/shared'
 import { PlacementResponse } from 'lib-common/generated/api-types/placement'
 import { PlacementUpdateRequestBody } from 'lib-common/generated/api-types/placement'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { deserializeJsonPlacementResponse } from 'lib-common/generated/api-types/placement'
 import { uri } from 'lib-common/uri'
@@ -23,11 +25,11 @@ import { uri } from 'lib-common/uri'
 */
 export async function createGroupPlacement(
   request: {
-    placementId: UUID,
+    placementId: PlacementId,
     body: GroupPlacementRequestBody
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<GroupPlacementId> {
+  const { data: json } = await client.request<JsonOf<GroupPlacementId>>({
     url: uri`/employee/placements/${request.placementId}/group-placements`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<GroupPlacementRequestBody>
@@ -58,7 +60,7 @@ export async function createPlacement(
 */
 export async function deleteGroupPlacement(
   request: {
-    groupPlacementId: UUID
+    groupPlacementId: GroupPlacementId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -74,7 +76,7 @@ export async function deleteGroupPlacement(
 */
 export async function deletePlacement(
   request: {
-    placementId: UUID
+    placementId: PlacementId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -90,7 +92,7 @@ export async function deletePlacement(
 */
 export async function getChildPlacementPeriods(
   request: {
-    adultId: UUID
+    adultId: PersonId
   }
 ): Promise<FiniteDateRange[]> {
   const { data: json } = await client.request<JsonOf<FiniteDateRange[]>>({
@@ -106,7 +108,7 @@ export async function getChildPlacementPeriods(
 */
 export async function getChildPlacements(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<PlacementResponse> {
   const { data: json } = await client.request<JsonOf<PlacementResponse>>({
@@ -122,7 +124,7 @@ export async function getChildPlacements(
 */
 export async function transferGroupPlacement(
   request: {
-    groupPlacementId: UUID,
+    groupPlacementId: GroupPlacementId,
     body: GroupTransferRequestBody
   }
 ): Promise<void> {
@@ -140,7 +142,7 @@ export async function transferGroupPlacement(
 */
 export async function updatePlacementById(
   request: {
-    placementId: UUID,
+    placementId: PlacementId,
     body: PlacementUpdateRequestBody
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/process.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/process.ts
@@ -4,9 +4,12 @@
 
 // GENERATED FILE: no manual modifications
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
+import { AssistanceNeedPreschoolDecisionId } from 'lib-common/generated/api-types/shared'
+import { ChildDocumentId } from 'lib-common/generated/api-types/shared'
 import { JsonOf } from 'lib-common/json'
 import { ProcessMetadataResponse } from 'lib-common/generated/api-types/process'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { deserializeJsonProcessMetadataResponse } from 'lib-common/generated/api-types/process'
 import { uri } from 'lib-common/uri'
@@ -17,7 +20,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getApplicationMetadata(
   request: {
-    applicationId: UUID
+    applicationId: ApplicationId
   }
 ): Promise<ProcessMetadataResponse> {
   const { data: json } = await client.request<JsonOf<ProcessMetadataResponse>>({
@@ -33,7 +36,7 @@ export async function getApplicationMetadata(
 */
 export async function getAssistanceNeedDecisionMetadata(
   request: {
-    decisionId: UUID
+    decisionId: AssistanceNeedDecisionId
   }
 ): Promise<ProcessMetadataResponse> {
   const { data: json } = await client.request<JsonOf<ProcessMetadataResponse>>({
@@ -49,7 +52,7 @@ export async function getAssistanceNeedDecisionMetadata(
 */
 export async function getAssistanceNeedPreschoolDecisionMetadata(
   request: {
-    decisionId: UUID
+    decisionId: AssistanceNeedPreschoolDecisionId
   }
 ): Promise<ProcessMetadataResponse> {
   const { data: json } = await client.request<JsonOf<ProcessMetadataResponse>>({
@@ -65,7 +68,7 @@ export async function getAssistanceNeedPreschoolDecisionMetadata(
 */
 export async function getChildDocumentMetadata(
   request: {
-    childDocumentId: UUID
+    childDocumentId: ChildDocumentId
   }
 ): Promise<ProcessMetadataResponse> {
   const { data: json } = await client.request<JsonOf<ProcessMetadataResponse>>({

--- a/frontend/src/employee-frontend/generated/api-clients/reports.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reports.ts
@@ -7,6 +7,7 @@
 import LocalDate from 'lib-common/local-date'
 import { ApplicationStatus } from 'lib-common/generated/api-types/application'
 import { ApplicationsReportRow } from 'lib-common/generated/api-types/reports'
+import { AreaId } from 'lib-common/generated/api-types/shared'
 import { AssistanceNeedDecisionsReportRow } from 'lib-common/generated/api-types/reports'
 import { AssistanceNeedsAndActionsReport } from 'lib-common/generated/api-types/reports'
 import { AssistanceNeedsAndActionsReportByChild } from 'lib-common/generated/api-types/reports'
@@ -20,6 +21,7 @@ import { ChildPreschoolAbsenceRow } from 'lib-common/generated/api-types/reports
 import { ChildrenInDifferentAddressReportRow } from 'lib-common/generated/api-types/reports'
 import { CustomerFeesReportRow } from 'lib-common/generated/api-types/reports'
 import { DaycareAssistanceLevel } from 'lib-common/generated/api-types/assistance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { DecisionsReportRow } from 'lib-common/generated/api-types/reports'
 import { DuplicatePeopleReportRow } from 'lib-common/generated/api-types/reports'
 import { EndedPlacementsReportRow } from 'lib-common/generated/api-types/reports'
@@ -30,7 +32,9 @@ import { FamilyContactReportRow } from 'lib-common/generated/api-types/reports'
 import { FamilyDaycareMealReportResult } from 'lib-common/generated/api-types/reports'
 import { FinanceDecisionType } from 'lib-common/generated/api-types/invoicing'
 import { FuturePreschoolersReportRow } from 'lib-common/generated/api-types/reports'
+import { GroupId } from 'lib-common/generated/api-types/shared'
 import { HolidayPeriodAttendanceReportRow } from 'lib-common/generated/api-types/reports'
+import { HolidayPeriodId } from 'lib-common/generated/api-types/shared'
 import { IncompleteIncomeDbRow } from 'lib-common/generated/api-types/reports'
 import { InvoiceReport } from 'lib-common/generated/api-types/reports'
 import { JsonCompatible } from 'lib-common/json'
@@ -46,6 +50,7 @@ import { OccupancyType } from 'lib-common/generated/api-types/occupancy'
 import { OccupancyUnitReportResultRow } from 'lib-common/generated/api-types/reports'
 import { OtherAssistanceMeasureType } from 'lib-common/generated/api-types/assistance'
 import { PartnersInDifferentAddressReportRow } from 'lib-common/generated/api-types/reports'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { PlacementCountReportResult } from 'lib-common/generated/api-types/reports'
 import { PlacementGuaranteeReportRow } from 'lib-common/generated/api-types/reports'
 import { PlacementSketchingReportRow } from 'lib-common/generated/api-types/reports'
@@ -64,7 +69,6 @@ import { SextetReportRow } from 'lib-common/generated/api-types/reports'
 import { SourceUnitsReportRow } from 'lib-common/generated/api-types/reports'
 import { StartingPlacementsRow } from 'lib-common/generated/api-types/reports'
 import { TitaniaErrorReportRow } from 'lib-common/generated/api-types/reports'
-import { UUID } from 'lib-common/types'
 import { UnitsReportRow } from 'lib-common/generated/api-types/reports'
 import { VardaChildErrorReportRow } from 'lib-common/generated/api-types/reports'
 import { VardaUnitErrorReportRow } from 'lib-common/generated/api-types/reports'
@@ -217,10 +221,10 @@ export async function getAttendanceReservationReportByChild(
 */
 export async function getAttendanceReservationReportByUnit(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     start: LocalDate,
     end: LocalDate,
-    groupIds?: UUID[] | null
+    groupIds?: GroupId[] | null
   }
 ): Promise<AttendanceReservationReportRow[]> {
   const params = createUrlSearchParams(
@@ -262,7 +266,7 @@ export async function getChildAgeLanguageReport(
 */
 export async function getChildAttendanceReport(
   request: {
-    childId: UUID,
+    childId: PersonId,
     from: LocalDate,
     to: LocalDate
   }
@@ -298,8 +302,8 @@ export async function getChildrenInDifferentAddressReport(): Promise<ChildrenInD
 export async function getCustomerFeesReport(
   request: {
     date: LocalDate,
-    areaId?: UUID | null,
-    unitId?: UUID | null,
+    areaId?: AreaId | null,
+    unitId?: DaycareId | null,
     decisionType: FinanceDecisionType
   }
 ): Promise<CustomerFeesReportRow[]> {
@@ -387,7 +391,7 @@ export async function getEndedPlacementsReport(
 */
 export async function getExceededServiceNeedReportRows(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     year: number,
     month: number
   }
@@ -435,7 +439,7 @@ export async function getFamilyConflictsReport(): Promise<FamilyConflictReportRo
 */
 export async function getFamilyContactsReport(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     date: LocalDate
   }
 ): Promise<FamilyContactReportRow[]> {
@@ -515,9 +519,9 @@ export async function getFuturePreschoolersUnitsReport(): Promise<PreschoolUnits
 */
 export async function getHolidayPeriodAttendanceReport(
   request: {
-    groupIds?: UUID[] | null,
-    unitId: UUID,
-    periodId: UUID
+    groupIds?: GroupId[] | null,
+    unitId: DaycareId,
+    periodId: HolidayPeriodId
   }
 ): Promise<HolidayPeriodAttendanceReportRow[]> {
   const params = createUrlSearchParams(
@@ -591,7 +595,7 @@ export async function getManualDuplicationReport(
 */
 export async function getMealReportByUnit(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     date: LocalDate
   }
 ): Promise<MealReportData> {
@@ -671,7 +675,7 @@ export async function getNonSsnChildrenReportRows(): Promise<NonSsnChildrenRepor
 export async function getOccupancyGroupReport(
   request: {
     type: OccupancyType,
-    careAreaId?: UUID | null,
+    careAreaId?: AreaId | null,
     providerType?: ProviderType | null,
     unitTypes?: CareType[] | null,
     year: number,
@@ -701,7 +705,7 @@ export async function getOccupancyGroupReport(
 export async function getOccupancyUnitReport(
   request: {
     type: OccupancyType,
-    careAreaId?: UUID | null,
+    careAreaId?: AreaId | null,
     providerType?: ProviderType | null,
     unitTypes?: CareType[] | null,
     year: number,
@@ -767,7 +771,7 @@ export async function getPlacementCountReport(
 export async function getPlacementGuaranteeReport(
   request: {
     date: LocalDate,
-    unitId?: UUID | null
+    unitId?: DaycareId | null
   }
 ): Promise<PlacementGuaranteeReportRow[]> {
   const params = createUrlSearchParams(
@@ -816,8 +820,8 @@ export async function getPlacementSketchingReport(
 */
 export async function getPreschoolAbsenceReport(
   request: {
-    unitId: UUID,
-    groupId?: UUID | null,
+    unitId: DaycareId,
+    groupId?: GroupId | null,
     termStart: LocalDate,
     termEnd: LocalDate
   }
@@ -932,7 +936,7 @@ export async function getServiceVoucherReportForAllUnits(
   request: {
     year: number,
     month: number,
-    areaId?: UUID | null
+    areaId?: AreaId | null
   }
 ): Promise<ServiceVoucherReport> {
   const params = createUrlSearchParams(
@@ -954,7 +958,7 @@ export async function getServiceVoucherReportForAllUnits(
 */
 export async function getServiceVoucherReportForUnit(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     year: number,
     month: number
   }

--- a/frontend/src/employee-frontend/generated/api-clients/reservations.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reservations.ts
@@ -7,11 +7,11 @@
 import LocalDate from 'lib-common/local-date'
 import { ChildDatePresence } from 'lib-common/generated/api-types/reservations'
 import { DailyReservationRequest } from 'lib-common/generated/api-types/reservations'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { ExpectedAbsencesRequest } from 'lib-common/generated/api-types/reservations'
 import { ExpectedAbsencesResponse } from 'lib-common/generated/api-types/reservations'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
 import { UnitAttendanceReservations } from 'lib-common/generated/api-types/reservations'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
@@ -24,7 +24,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getAttendanceReservations(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     from: LocalDate,
     to: LocalDate,
     includeNonOperationalDays?: boolean | null

--- a/frontend/src/employee-frontend/generated/api-clients/serviceneed.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/serviceneed.ts
@@ -5,16 +5,19 @@
 // GENERATED FILE: no manual modifications
 
 import { AcceptServiceApplicationBody } from 'lib-common/generated/api-types/serviceneed'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { EmployeeServiceApplication } from 'lib-common/generated/api-types/serviceneed'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
+import { ServiceApplicationId } from 'lib-common/generated/api-types/shared'
 import { ServiceApplicationRejection } from 'lib-common/generated/api-types/serviceneed'
 import { ServiceNeedCreateRequest } from 'lib-common/generated/api-types/serviceneed'
+import { ServiceNeedId } from 'lib-common/generated/api-types/shared'
 import { ServiceNeedOption } from 'lib-common/generated/api-types/serviceneed'
 import { ServiceNeedOptionPublicInfo } from 'lib-common/generated/api-types/serviceneed'
 import { ServiceNeedUpdateRequest } from 'lib-common/generated/api-types/serviceneed'
-import { UUID } from 'lib-common/types'
 import { UndecidedServiceApplicationSummary } from 'lib-common/generated/api-types/serviceneed'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
@@ -30,7 +33,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function deleteServiceNeed(
   request: {
-    id: UUID
+    id: ServiceNeedId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -95,7 +98,7 @@ export async function postServiceNeed(
 */
 export async function putServiceNeed(
   request: {
-    id: UUID,
+    id: ServiceNeedId,
     body: ServiceNeedUpdateRequest
   }
 ): Promise<void> {
@@ -113,7 +116,7 @@ export async function putServiceNeed(
 */
 export async function acceptServiceApplication(
   request: {
-    id: UUID,
+    id: ServiceApplicationId,
     body: AcceptServiceApplicationBody
   }
 ): Promise<void> {
@@ -131,7 +134,7 @@ export async function acceptServiceApplication(
 */
 export async function getChildServiceApplications(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<EmployeeServiceApplication[]> {
   const params = createUrlSearchParams(
@@ -151,7 +154,7 @@ export async function getChildServiceApplications(
 */
 export async function getUndecidedServiceApplications(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
 ): Promise<UndecidedServiceApplicationSummary[]> {
   const params = createUrlSearchParams(
@@ -171,7 +174,7 @@ export async function getUndecidedServiceApplications(
 */
 export async function rejectServiceApplication(
   request: {
-    id: UUID,
+    id: ServiceApplicationId,
     body: ServiceApplicationRejection
   }
 ): Promise<void> {

--- a/frontend/src/employee-frontend/generated/api-clients/timeline.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/timeline.ts
@@ -6,8 +6,8 @@
 
 import LocalDate from 'lib-common/local-date'
 import { JsonOf } from 'lib-common/json'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { Timeline } from 'lib-common/generated/api-types/timeline'
-import { UUID } from 'lib-common/types'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonTimeline } from 'lib-common/generated/api-types/timeline'
@@ -19,7 +19,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getTimeline(
   request: {
-    personId: UUID,
+    personId: PersonId,
     from: LocalDate,
     to: LocalDate
   }

--- a/frontend/src/employee-frontend/generated/api-clients/varda.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/varda.ts
@@ -5,7 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../api/client'
 import { uri } from 'lib-common/uri'
 
@@ -15,7 +15,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function markChildForVardaReset(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({

--- a/frontend/src/employee-frontend/state/application-ui.tsx
+++ b/frontend/src/employee-frontend/state/application-ui.tsx
@@ -23,7 +23,7 @@ import {
   DaycareCareArea,
   UnitStub
 } from 'lib-common/generated/api-types/daycare'
-import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import { ApplicationId, AreaId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { useDebounce } from 'lib-common/utils/useDebounce'
@@ -57,7 +57,7 @@ interface UIState {
 }
 
 interface ApplicationSearchFilters {
-  area: string[]
+  area: AreaId[]
   units: string[]
   basis: ApplicationBasis[]
   status: ApplicationSummaryStatusOptions

--- a/frontend/src/employee-frontend/state/application-ui.tsx
+++ b/frontend/src/employee-frontend/state/application-ui.tsx
@@ -23,9 +23,9 @@ import {
   DaycareCareArea,
   UnitStub
 } from 'lib-common/generated/api-types/daycare'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { useDebounce } from 'lib-common/utils/useDebounce'
 
 import {
@@ -51,8 +51,8 @@ interface UIState {
   ) => void
   debouncedApplicationSearchFilters: ApplicationSearchFilters
   clearSearchFilters: () => void
-  checkedIds: string[]
-  setCheckedIds: (applicationIds: UUID[]) => void
+  checkedIds: ApplicationId[]
+  setCheckedIds: (applicationIds: ApplicationId[]) => void
   showCheckboxes: boolean
 }
 
@@ -139,7 +139,7 @@ export const ApplicationUIContextProvider = React.memo(
       500
     )
 
-    const [checkedIds, setCheckedIds] = useState<string[]>(
+    const [checkedIds, setCheckedIds] = useState<ApplicationId[]>(
       defaultState.checkedIds
     )
     const showCheckboxes = [

--- a/frontend/src/employee-frontend/state/application-ui.tsx
+++ b/frontend/src/employee-frontend/state/application-ui.tsx
@@ -23,7 +23,11 @@ import {
   DaycareCareArea,
   UnitStub
 } from 'lib-common/generated/api-types/daycare'
-import { ApplicationId, AreaId } from 'lib-common/generated/api-types/shared'
+import {
+  ApplicationId,
+  AreaId,
+  DaycareId
+} from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { useDebounce } from 'lib-common/utils/useDebounce'
@@ -58,7 +62,7 @@ interface UIState {
 
 interface ApplicationSearchFilters {
   area: AreaId[]
-  units: string[]
+  units: DaycareId[]
   basis: ApplicationBasis[]
   status: ApplicationSummaryStatusOptions
   type: ApplicationTypeToggle

--- a/frontend/src/employee-frontend/state/invoicing-ui.tsx
+++ b/frontend/src/employee-frontend/state/invoicing-ui.tsx
@@ -31,6 +31,7 @@ import {
   FeeDecisionDifference
 } from 'lib-common/generated/api-types/invoicing'
 import { Employee } from 'lib-common/generated/api-types/pis'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -44,7 +45,7 @@ export type Checked = Record<string, boolean>
 
 interface FeeDecisionSearchFilters {
   area: string[]
-  unit?: UUID
+  unit?: DaycareId
   statuses: FeeDecisionStatus[]
   distinctiveDetails: DistinctiveParams[]
   startDate: LocalDate | undefined
@@ -65,7 +66,7 @@ interface FeeDecisionSearchFilterState {
 
 interface ValueDecisionSearchFilters {
   area: string[]
-  unit?: UUID
+  unit?: DaycareId
   statuses: VoucherValueDecisionStatus[]
   distinctiveDetails: VoucherValueDecisionDistinctiveParams[]
   financeDecisionHandlerId?: UUID
@@ -86,7 +87,7 @@ interface ValueDecisionSearchFilterState {
 
 export interface InvoiceSearchFilters {
   area: string[]
-  unit?: string
+  unit?: DaycareId
   status: InvoiceStatus
   distinctiveDetails: InvoiceDistinctiveParams[]
   startDate: LocalDate | undefined
@@ -105,7 +106,7 @@ interface InvoiceSearchFilterState {
 
 export interface PaymentSearchFilters {
   area: string[]
-  unit: string | null
+  unit: DaycareId | null
   distinctions: PaymentDistinctiveParams[]
   status: PaymentStatus
   paymentDateStart: LocalDate | null
@@ -123,7 +124,7 @@ interface PaymentSearchFilterState {
 
 export interface IncomeStatementSearchFilters {
   area: string[]
-  unit: string | undefined
+  unit: DaycareId | undefined
   providerTypes: ProviderType[]
   sentStartDate: LocalDate | undefined
   sentEndDate: LocalDate | undefined

--- a/frontend/src/employee-frontend/state/ui.tsx
+++ b/frontend/src/employee-frontend/state/ui.tsx
@@ -4,6 +4,7 @@
 
 import React, { useMemo, useState, createContext, useCallback } from 'react'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 
 export type ErrorMessageType = 'warning' | 'error'
@@ -95,6 +96,6 @@ export const UIContextProvider = React.memo(function UIContextProvider({
 })
 
 interface PairingState {
-  id: { unitId: UUID } | { employeeId: UUID }
+  id: { unitId: DaycareId } | { employeeId: UUID }
   onClose?: () => void
 }

--- a/frontend/src/employee-frontend/state/unit.tsx
+++ b/frontend/src/employee-frontend/state/unit.tsx
@@ -12,10 +12,10 @@ import React, {
 
 import { Loading, Result, Success, wrapResult } from 'lib-common/api'
 import { DaycareResponse } from 'lib-common/generated/api-types/daycare'
-import { DaycareAclRow } from 'lib-common/generated/api-types/shared'
+import { DaycareAclRow, DaycareId } from 'lib-common/generated/api-types/shared'
+import { fromUuid } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 
 import { unitQuery } from '../components/unit/queries'
@@ -25,7 +25,7 @@ import { UnitFilters } from '../utils/UnitFilters'
 const getDaycareAclResult = wrapResult(getDaycareAcl)
 
 export interface UnitState {
-  unitId: UUID
+  unitId: DaycareId
   unitInformation: Result<DaycareResponse>
   filters: UnitFilters
   setFilters: Dispatch<SetStateAction<UnitFilters>>
@@ -34,7 +34,7 @@ export interface UnitState {
 }
 
 const defaultState: UnitState = {
-  unitId: '',
+  unitId: fromUuid('00000000-0000-0000-0000-000000000000'),
   unitInformation: Loading.of(),
   filters: new UnitFilters(LocalDate.todayInSystemTz(), '1 day'),
   setFilters: () => undefined,
@@ -48,7 +48,7 @@ export const UnitContextProvider = React.memo(function UnitContextProvider({
   id,
   children
 }: {
-  id: UUID
+  id: DaycareId
   children: React.JSX.Element
 }) {
   const [filters, setFilters] = useState(defaultState.filters)

--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -14,11 +14,12 @@ import {
 } from 'react-router'
 import { StyleSheetManager, ThemeProvider } from 'styled-components'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQuery, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { Uri, uri } from 'lib-common/uri'
-import useRouteParams from 'lib-common/useRouteParams'
+import useRouteParams, { useIdRouteParam } from 'lib-common/useRouteParams'
 import {
   Notifications,
   NotificationsContextProvider
@@ -150,7 +151,7 @@ function shouldForwardProp(propName: string, target: unknown) {
 }
 
 function UnitRouter() {
-  const { unitId } = useRouteParams(['unitId'])
+  const unitId = useIdRouteParam<DaycareId>('unitId')
 
   return (
     <Routes>
@@ -170,7 +171,7 @@ function UnitRouter() {
   )
 }
 
-function GroupRouter({ unitId }: { unitId: UUID }) {
+function GroupRouter({ unitId }: { unitId: DaycareId }) {
   const { groupId } = useRouteParams([], ['groupId'])
   const unitOrGroup: UnitOrGroup = useMemo(
     () => toUnitOrGroup(unitId, groupId),
@@ -258,7 +259,7 @@ function ChildAttendanceRouter({ unitOrGroup }: { unitOrGroup: UnitOrGroup }) {
   )
 }
 
-function ChildRouter({ unitId }: { unitId: UUID }) {
+function ChildRouter({ unitId }: { unitId: DaycareId }) {
   const { childId } = useRouteParams(['childId'])
 
   return (

--- a/frontend/src/employee-mobile-frontend/RequirePinAuth.tsx
+++ b/frontend/src/employee-mobile-frontend/RequirePinAuth.tsx
@@ -5,13 +5,13 @@
 import React, { useContext } from 'react'
 import { Navigate } from 'react-router'
 
-import { UUID } from 'lib-common/types'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 
 import { PinLogin } from './auth/PinLogin'
 import { UserContext } from './auth/state'
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   children?: React.ReactNode
 }
 

--- a/frontend/src/employee-mobile-frontend/auth/PinLogin.tsx
+++ b/frontend/src/employee-mobile-frontend/auth/PinLogin.tsx
@@ -12,6 +12,7 @@ import React, {
 } from 'react'
 import { useNavigate } from 'react-router'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
@@ -38,7 +39,7 @@ interface EmployeeOption {
 const PinLoginForm = React.memo(function PinLoginForm({
   unitId
 }: {
-  unitId: UUID
+  unitId: DaycareId
 }) {
   const { i18n } = useTranslation()
   const { user, refreshAuthStatus } = useContext(UserContext)
@@ -157,7 +158,7 @@ export const PinLogin = React.memo(function PinLogin({
   unitId,
   childId
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childId?: UUID
 }) {
   const unitInfoResponse = useQueryResult(unitInfoQuery({ unitId }))

--- a/frontend/src/employee-mobile-frontend/auth/renderPinRequiringResult.tsx
+++ b/frontend/src/employee-mobile-frontend/auth/renderPinRequiringResult.tsx
@@ -5,7 +5,7 @@
 import React from 'react'
 
 import { Result } from 'lib-common/api'
-import { UUID } from 'lib-common/types'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 
 import { renderResult, RenderResultFn } from '../async-rendering'
 
@@ -18,7 +18,7 @@ function isResultT<T>(res: Result<T | PinLoginRequired>): res is Result<T> {
 
 export function renderPinRequiringResult<T>(
   result: Result<T | PinLoginRequired>,
-  unitId: UUID,
+  unitId: DaycareId,
   renderer: RenderResultFn<T>
 ) {
   return isResultT(result) ? (

--- a/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkAbsent.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkAbsent.tsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router'
 import styled from 'styled-components'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -32,7 +33,7 @@ export default React.memo(function MarkAbsent({
   unitId,
   childId
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childId: UUID
 }) {
   const navigate = useNavigate()

--- a/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkAbsentBeforehand.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkAbsentBeforehand.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components'
 import { wrapResult } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { AbsenceType } from 'lib-common/generated/api-types/absence'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -55,7 +56,7 @@ export default React.memo(function MarkAbsentBeforehand({
   unitId,
   childId
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childId: UUID
 }) {
   const navigate = useNavigate()

--- a/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkDeparted.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkDeparted.tsx
@@ -14,6 +14,7 @@ import {
   AttendanceTimes,
   ChildAttendanceStatusResponse
 } from 'lib-common/generated/api-types/attendance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -109,7 +110,7 @@ const MarkDepartedInner = React.memo(function MarkDepartedWithChild({
   childList,
   multiselect
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childList: {
     child: AttendanceChild
     attendanceStatus: ChildAttendanceStatusResponse
@@ -427,7 +428,7 @@ const MarkDepartedWithParams = React.memo(function MarkDepartedWithParams({
   childIds,
   multiselect
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childIds: UUID[]
   multiselect: boolean
 }) {
@@ -452,7 +453,11 @@ const MarkDepartedWithParams = React.memo(function MarkDepartedWithParams({
   )
 })
 
-export default React.memo(function MarkDeparted({ unitId }: { unitId: UUID }) {
+export default React.memo(function MarkDeparted({
+  unitId
+}: {
+  unitId: DaycareId
+}) {
   const [searchParams] = useSearchParams()
   const children = searchParams.get('children') ?? ''
   const multiselect = searchParams.get('multiselect') === 'true'

--- a/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkPresent.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkPresent.tsx
@@ -12,6 +12,7 @@ import {
   AttendanceChild,
   ChildAttendanceStatusResponse
 } from 'lib-common/generated/api-types/attendance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalTime from 'lib-common/local-time'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
@@ -53,7 +54,7 @@ const MarkPresentInner = React.memo(function MarkPresentInner({
   childList,
   multiselect
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childList: {
     child: AttendanceChild
     attendanceStatus: ChildAttendanceStatusResponse
@@ -196,7 +197,7 @@ const MarkPresentWithParams = React.memo(function MarkPresentWithParams({
   childIds,
   multiselect
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childIds: UUID[]
   multiselect: boolean
 }) {
@@ -221,7 +222,11 @@ const MarkPresentWithParams = React.memo(function MarkPresentWithParams({
   )
 })
 
-export default React.memo(function MarkPresent({ unitId }: { unitId: UUID }) {
+export default React.memo(function MarkPresent({
+  unitId
+}: {
+  unitId: DaycareId
+}) {
   const [searchParams] = useSearchParams()
   const children = searchParams.get('children')
   const multiselect = searchParams.get('multiselect') === 'true'

--- a/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkReservations.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkReservations.tsx
@@ -37,6 +37,7 @@ import {
   ConfirmedRangeDateUpdate,
   Reservation
 } from 'lib-common/generated/api-types/reservations'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { useQueryResult } from 'lib-common/query'
@@ -217,7 +218,7 @@ export default React.memo(function MarkReservations({
   unitId,
   childId
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childId: UUID
 }) {
   const navigate = useNavigate()

--- a/frontend/src/employee-mobile-frontend/child-attendance/api.ts
+++ b/frontend/src/employee-mobile-frontend/child-attendance/api.ts
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { AttendanceChild } from 'lib-common/generated/api-types/attendance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 
 import { client } from '../client'
 import { getChildren } from '../generated/api-clients/attendance'
 
 export async function getUnitChildren(
-  unitId: string
+  unitId: DaycareId
 ): Promise<AttendanceChild[]> {
   return getChildren({ unitId }).then((data) =>
     data.sort((a, b) => compareByProperty(a, b, 'firstName'))

--- a/frontend/src/employee-mobile-frontend/child-attendance/queries.ts
+++ b/frontend/src/employee-mobile-frontend/child-attendance/queries.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { mutation, query } from 'lib-common/query'
@@ -164,12 +165,13 @@ export const cancelAbsenceMutation = mutation({
 })
 
 export const uploadChildImageMutation = mutation({
-  api: ({ childId, file }: { unitId: UUID; childId: UUID; file: File }) =>
+  api: ({ childId, file }: { unitId: DaycareId; childId: UUID; file: File }) =>
     uploadChildImage({ childId, file }),
   invalidateQueryKeys: ({ unitId }) => [childrenQuery(unitId).queryKey]
 })
 
 export const deleteChildImageMutation = mutation({
-  api: (arg: Arg0<typeof deleteImage> & { unitId: UUID }) => deleteImage(arg),
+  api: (arg: Arg0<typeof deleteImage> & { unitId: DaycareId }) =>
+    deleteImage(arg),
   invalidateQueryKeys: ({ unitId }) => [childrenQuery(unitId).queryKey]
 })

--- a/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 
 import { combine } from 'lib-common/api'
 import { AttendanceStatus } from 'lib-common/generated/api-types/attendance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import {
   constantQuery,
@@ -57,7 +58,7 @@ export default React.memo(function AttendanceChildPage({
   unitId,
   childId
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childId: UUID
 }) {
   const { i18n } = useTranslation()

--- a/frontend/src/employee-mobile-frontend/child-info/ChildButtons.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/ChildButtons.tsx
@@ -7,8 +7,8 @@ import { Link } from 'react-router'
 import styled, { useTheme } from 'styled-components'
 
 import { AttendanceChild } from 'lib-common/generated/api-types/attendance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { faChild, faComments, faPen } from 'lib-icons'
@@ -19,7 +19,7 @@ import { useTranslation } from '../common/i18n'
 import { unitInfoQuery } from '../units/queries'
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   groupHasNotes: boolean
   child: AttendanceChild
 }

--- a/frontend/src/employee-mobile-frontend/child-info/ChildInfoPage.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/ChildInfoPage.tsx
@@ -6,6 +6,7 @@ import React, { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 import styled from 'styled-components'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import Title from 'lib-components/atoms/Title'
@@ -27,7 +28,7 @@ export default React.memo(function ChildInfoPage({
   unitId,
   childId
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childId: UUID
 }) {
   const { i18n } = useTranslation()

--- a/frontend/src/employee-mobile-frontend/child-info/ChildSensitiveInfo.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/ChildSensitiveInfo.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 
 import { Result, Success } from 'lib-common/api'
 import { ChildSensitiveInformation } from 'lib-common/generated/api-types/sensitive'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { Arg0 } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import { ContentArea } from 'lib-components/layout/Container'
@@ -62,7 +63,7 @@ const renderKeyValue = (
 
 interface Props {
   childId: string
-  unitId: string
+  unitId: DaycareId
 }
 
 export default React.memo(function ChildSensitiveInfo({

--- a/frontend/src/employee-mobile-frontend/child-info/ImageEditor.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/ImageEditor.tsx
@@ -12,6 +12,7 @@ import ReactCrop, {
 import { useNavigate } from 'react-router'
 import styled from 'styled-components'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -27,7 +28,7 @@ import { useTranslation } from '../common/i18n'
 import 'react-image-crop/dist/ReactCrop.css'
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   childId: UUID
   image: string
   onReturn: () => void

--- a/frontend/src/employee-mobile-frontend/child-info/child-state-pages/AttendanceChildAbsent.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/child-state-pages/AttendanceChildAbsent.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 
@@ -13,7 +14,7 @@ import { useTranslation } from '../../common/i18n'
 
 interface Props {
   childId: UUID
-  unitId: UUID
+  unitId: DaycareId
 }
 
 export default React.memo(function AttendanceChildAbsent({

--- a/frontend/src/employee-mobile-frontend/child-notes/ChildNotes.tsx
+++ b/frontend/src/employee-mobile-frontend/child-notes/ChildNotes.tsx
@@ -10,6 +10,7 @@ import {
   ChildDailyNote,
   ChildStickyNote
 } from 'lib-common/generated/api-types/note'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import {
   constantQuery,
   useChainedQuery,
@@ -87,7 +88,7 @@ export default React.memo(function ChildNotes({
   unitId,
   childId
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childId: UUID
 }) {
   const { i18n } = useTranslation()

--- a/frontend/src/employee-mobile-frontend/child-notes/ChildStickyNotesTab.tsx
+++ b/frontend/src/employee-mobile-frontend/child-notes/ChildStickyNotesTab.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useMemo } from 'react'
 
 import { ChildStickyNote } from 'lib-common/generated/api-types/note'
+import { ChildStickyNoteId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import {
@@ -59,14 +60,14 @@ export const ChildStickyNotesTab = React.memo(function ChildStickyNotesTab({
     deleteChildStickyNoteMutation
   )
   const onSave = useCallback(
-    ({ id, ...body }: EditedNote) =>
+    ({ id, ...body }: EditedNote<ChildStickyNoteId>) =>
       id
         ? updateChildStickyNote({ unitId, noteId: id, body })
         : createChildStickyNote({ unitId, childId, body }),
     [updateChildStickyNote, createChildStickyNote, unitId, childId]
   )
   const onRemove = useCallback(
-    (noteId: UUID) => deleteChildStickyNote({ unitId, noteId }),
+    (noteId: ChildStickyNoteId) => deleteChildStickyNote({ unitId, noteId }),
     [deleteChildStickyNote, unitId]
   )
   const labels = useMemo<StickyNoteTabLabels>(

--- a/frontend/src/employee-mobile-frontend/child-notes/ChildStickyNotesTab.tsx
+++ b/frontend/src/employee-mobile-frontend/child-notes/ChildStickyNotesTab.tsx
@@ -5,7 +5,10 @@
 import React, { useCallback, useMemo } from 'react'
 
 import { ChildStickyNote } from 'lib-common/generated/api-types/note'
-import { ChildStickyNoteId } from 'lib-common/generated/api-types/shared'
+import {
+  ChildStickyNoteId,
+  DaycareId
+} from 'lib-common/generated/api-types/shared'
 import { useMutationResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import {
@@ -38,7 +41,7 @@ const getStickyNoteTabLabels = (i18n: Translations): StickyNoteTabLabels => ({
 })
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   childId: UUID
   notes: ChildStickyNote[]
 }

--- a/frontend/src/employee-mobile-frontend/child-notes/DailyNotesTab.tsx
+++ b/frontend/src/employee-mobile-frontend/child-notes/DailyNotesTab.tsx
@@ -12,6 +12,7 @@ import {
   childDailyNoteLevelValues,
   childDailyNoteReminderValues
 } from 'lib-common/generated/api-types/note'
+import { ChildDailyNoteId } from 'lib-common/generated/api-types/shared'
 import { useMutation, useMutationResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { ChipWrapper, SelectionChip } from 'lib-components/atoms/Chip'
@@ -107,7 +108,7 @@ interface Props {
   unitId: UUID
   childId: UUID
   formData?: ChildDailyNoteFormData
-  dailyNoteId: UUID | undefined
+  dailyNoteId: ChildDailyNoteId | undefined
 }
 
 export const DailyNotesTab = React.memo(function DailyNotesTab({

--- a/frontend/src/employee-mobile-frontend/child-notes/DailyNotesTab.tsx
+++ b/frontend/src/employee-mobile-frontend/child-notes/DailyNotesTab.tsx
@@ -12,7 +12,10 @@ import {
   childDailyNoteLevelValues,
   childDailyNoteReminderValues
 } from 'lib-common/generated/api-types/note'
-import { ChildDailyNoteId } from 'lib-common/generated/api-types/shared'
+import {
+  ChildDailyNoteId,
+  DaycareId
+} from 'lib-common/generated/api-types/shared'
 import { useMutation, useMutationResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { ChipWrapper, SelectionChip } from 'lib-components/atoms/Chip'
@@ -105,7 +108,7 @@ const emptyNote = () => ({
 })
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   childId: UUID
   formData?: ChildDailyNoteFormData
   dailyNoteId: ChildDailyNoteId | undefined

--- a/frontend/src/employee-mobile-frontend/child-notes/GroupNotesTab.tsx
+++ b/frontend/src/employee-mobile-frontend/child-notes/GroupNotesTab.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useMemo } from 'react'
 
 import { GroupNote } from 'lib-common/generated/api-types/note'
+import { GroupNoteId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import {
@@ -57,14 +58,14 @@ export const GroupNotesTab = React.memo(function GroupNotesTab({
   )
 
   const onSave = useCallback(
-    ({ id, ...body }: EditedNote) =>
+    ({ id, ...body }: EditedNote<GroupNoteId>) =>
       id
         ? updateGroupNote({ groupId, noteId: id, body })
         : createGroupNote({ groupId, body }),
     [createGroupNote, updateGroupNote, groupId]
   )
   const onRemove = useCallback(
-    (noteId: UUID) => deleteGroupNote({ groupId, noteId }),
+    (noteId: GroupNoteId) => deleteGroupNote({ groupId, noteId }),
     [deleteGroupNote, groupId]
   )
   const labels = useMemo<StickyNoteTabLabels>(

--- a/frontend/src/employee-mobile-frontend/child-notes/queries.ts
+++ b/frontend/src/employee-mobile-frontend/child-notes/queries.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { mutation, query } from 'lib-common/query'
 import { Arg0, UUID } from 'lib-common/types'
 
@@ -50,37 +51,37 @@ export const deleteGroupNoteMutation = mutation({
 })
 
 export const createChildDailyNoteMutation = mutation({
-  api: (arg: Arg0<typeof createChildDailyNote> & { unitId: UUID }) =>
+  api: (arg: Arg0<typeof createChildDailyNote> & { unitId: DaycareId }) =>
     createChildDailyNote(arg),
   invalidateQueryKeys: ({ unitId }) => [childrenQuery(unitId).queryKey]
 })
 
 export const updateChildDailyNoteMutation = mutation({
-  api: (arg: Arg0<typeof updateChildDailyNote> & { unitId: UUID }) =>
+  api: (arg: Arg0<typeof updateChildDailyNote> & { unitId: DaycareId }) =>
     updateChildDailyNote(arg).then(() => undefined),
   invalidateQueryKeys: ({ unitId }) => [childrenQuery(unitId).queryKey]
 })
 
 export const deleteChildDailyNoteMutation = mutation({
-  api: (arg: Arg0<typeof deleteChildDailyNote> & { unitId: UUID }) =>
+  api: (arg: Arg0<typeof deleteChildDailyNote> & { unitId: DaycareId }) =>
     deleteChildDailyNote(arg).then(() => undefined),
   invalidateQueryKeys: ({ unitId }) => [childrenQuery(unitId).queryKey]
 })
 
 export const createChildStickyNoteMutation = mutation({
-  api: (arg: Arg0<typeof createChildStickyNote> & { unitId: UUID }) =>
+  api: (arg: Arg0<typeof createChildStickyNote> & { unitId: DaycareId }) =>
     createChildStickyNote(arg),
   invalidateQueryKeys: ({ unitId }) => [childrenQuery(unitId).queryKey]
 })
 
 export const updateChildStickyNoteMutation = mutation({
-  api: (arg: Arg0<typeof updateChildStickyNote> & { unitId: UUID }) =>
+  api: (arg: Arg0<typeof updateChildStickyNote> & { unitId: DaycareId }) =>
     updateChildStickyNote(arg),
   invalidateQueryKeys: ({ unitId }) => [childrenQuery(unitId).queryKey]
 })
 
 export const deleteChildStickyNoteMutation = mutation({
-  api: (arg: Arg0<typeof deleteChildStickyNote> & { unitId: UUID }) =>
+  api: (arg: Arg0<typeof deleteChildStickyNote> & { unitId: DaycareId }) =>
     deleteChildStickyNote(arg),
   invalidateQueryKeys: ({ unitId }) => [childrenQuery(unitId).queryKey]
 })

--- a/frontend/src/employee-mobile-frontend/common/GroupSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/common/GroupSelector.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { GroupInfo } from 'lib-common/generated/api-types/attendance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
@@ -20,7 +21,7 @@ import { unitInfoQuery } from '../units/queries'
 import { useTranslation } from './i18n'
 
 interface GroupSelectorProps {
-  unitId: UUID
+  unitId: DaycareId
   selectedGroup: GroupInfo | undefined
   onChangeGroup: (group: GroupInfo | undefined) => void
   countInfo?: CountInfo

--- a/frontend/src/employee-mobile-frontend/common/GroupSelectorBar.tsx
+++ b/frontend/src/employee-mobile-frontend/common/GroupSelectorBar.tsx
@@ -7,7 +7,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import { GroupInfo } from 'lib-common/generated/api-types/attendance'
-import { UUID } from 'lib-common/types'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import LegacyInlineButton from 'lib-components/atoms/buttons/LegacyInlineButton'
@@ -56,7 +56,7 @@ const GroupSelectorWrapper = animated(styled.div`
 `)
 
 export interface Props {
-  unitId: UUID
+  unitId: DaycareId
   selectedGroup: GroupInfo | undefined
   onChangeGroup: (group: GroupInfo | undefined) => void
   onSearch?: () => void

--- a/frontend/src/employee-mobile-frontend/common/TopBar.tsx
+++ b/frontend/src/employee-mobile-frontend/common/TopBar.tsx
@@ -6,8 +6,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
@@ -56,7 +56,7 @@ const Title = styled.div`
 `
 
 interface Props {
-  unitId: UUID | undefined
+  unitId: DaycareId | undefined
   title: string
   onBack?: () => void
   onClose?: () => void

--- a/frontend/src/employee-mobile-frontend/common/TopBarWithGroupSelector.tsx
+++ b/frontend/src/employee-mobile-frontend/common/TopBarWithGroupSelector.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router'
 import { UserContext } from 'employee-mobile-frontend/auth/state'
 import { combine } from 'lib-common/api'
 import { GroupInfo } from 'lib-common/generated/api-types/attendance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { Gap } from 'lib-components/white-space'
@@ -19,7 +20,7 @@ import { GroupSelectorBar } from './GroupSelectorBar'
 import TopBar from './TopBar'
 
 export type TopBarWithGroupSelectorProps = {
-  unitId: UUID
+  unitId: DaycareId
   selectedGroup: GroupInfo | undefined
   onChangeGroup: (group: GroupInfo | undefined) => void
   includeSelectAll?: boolean

--- a/frontend/src/employee-mobile-frontend/common/top-bar/LoggedInUser.tsx
+++ b/frontend/src/employee-mobile-frontend/common/top-bar/LoggedInUser.tsx
@@ -8,8 +8,8 @@ import styled from 'styled-components'
 import { useTranslation } from 'employee-mobile-frontend/common/i18n'
 import { combine } from 'lib-common/api'
 import { Staff } from 'lib-common/generated/api-types/attendance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { constantQuery, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import { defaultMargins } from 'lib-components/white-space'
@@ -42,7 +42,7 @@ const getUserName = (u: Staff | undefined) => {
 export const LoggedInUser = React.memo(function LoggedInUser({
   unitId
 }: {
-  unitId: UUID | undefined
+  unitId: DaycareId | undefined
 }) {
   const { user, refreshAuthStatus } = useContext(UserContext)
 

--- a/frontend/src/employee-mobile-frontend/common/unit-or-group.ts
+++ b/frontend/src/employee-mobile-frontend/common/unit-or-group.ts
@@ -10,7 +10,7 @@ export type UnitOrGroup =
   | { type: 'group'; unitId: DaycareId; id: GroupId }
 
 export const toUnitOrGroup = (
-  unitId: UUID,
+  unitId: DaycareId,
   groupId?: UUID | null
 ): UnitOrGroup =>
   groupId && groupId !== 'all'

--- a/frontend/src/employee-mobile-frontend/common/unit-or-group.ts
+++ b/frontend/src/employee-mobile-frontend/common/unit-or-group.ts
@@ -2,11 +2,12 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { DaycareId, GroupId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 
 export type UnitOrGroup =
-  | { type: 'unit'; unitId: UUID }
-  | { type: 'group'; unitId: UUID; id: UUID }
+  | { type: 'unit'; unitId: DaycareId }
+  | { type: 'group'; unitId: DaycareId; id: GroupId }
 
 export const toUnitOrGroup = (
   unitId: UUID,

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/absence.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/absence.ts
@@ -6,7 +6,7 @@
 
 import { Absence } from 'lib-common/generated/api-types/absence'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../client'
 import { deserializeJsonAbsence } from 'lib-common/generated/api-types/absence'
 import { uri } from 'lib-common/uri'
@@ -17,7 +17,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function futureAbsencesOfChild(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<Absence[]> {
   const { data: json } = await client.request<JsonOf<Absence[]>>({

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/attendance.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/attendance.ts
@@ -10,7 +10,9 @@ import { ArrivalsRequest } from 'lib-common/generated/api-types/attendance'
 import { AttendanceChild } from 'lib-common/generated/api-types/attendance'
 import { ChildAttendanceStatusResponse } from 'lib-common/generated/api-types/attendance'
 import { CurrentDayStaffAttendanceResponse } from 'lib-common/generated/api-types/attendance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { DeparturesRequest } from 'lib-common/generated/api-types/attendance'
+import { EmployeeId } from 'lib-common/generated/api-types/shared'
 import { ExpectedAbsencesOnDeparturesRequest } from 'lib-common/generated/api-types/attendance'
 import { ExpectedAbsencesOnDeparturesResponse } from 'lib-common/generated/api-types/attendance'
 import { ExternalStaffArrivalRequest } from 'lib-common/generated/api-types/attendance'
@@ -19,12 +21,13 @@ import { FullDayAbsenceRequest } from 'lib-common/generated/api-types/attendance
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { OpenGroupAttendanceResponse } from 'lib-common/generated/api-types/attendance'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { StaffArrivalRequest } from 'lib-common/generated/api-types/attendance'
+import { StaffAttendanceExternalId } from 'lib-common/generated/api-types/shared'
 import { StaffAttendanceUpdateRequest } from 'lib-common/generated/api-types/attendance'
 import { StaffAttendanceUpdateResponse } from 'lib-common/generated/api-types/attendance'
 import { StaffDepartureRequest } from 'lib-common/generated/api-types/attendance'
 import { StaffMember } from 'lib-common/generated/api-types/attendance'
-import { UUID } from 'lib-common/types'
 import { UnitInfo } from 'lib-common/generated/api-types/attendance'
 import { UnitStats } from 'lib-common/generated/api-types/attendance'
 import { client } from '../../client'
@@ -42,8 +45,8 @@ import { uri } from 'lib-common/uri'
 */
 export async function cancelFullDayAbsence(
   request: {
-    unitId: UUID,
-    childId: UUID
+    unitId: DaycareId,
+    childId: PersonId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -59,8 +62,8 @@ export async function cancelFullDayAbsence(
 */
 export async function deleteAbsenceRange(
   request: {
-    unitId: UUID,
-    childId: UUID,
+    unitId: DaycareId,
+    childId: PersonId,
     from: LocalDate,
     to: LocalDate
   }
@@ -83,10 +86,10 @@ export async function deleteAbsenceRange(
 */
 export async function getAttendanceStatuses(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
-): Promise<Partial<Record<UUID, ChildAttendanceStatusResponse>>> {
-  const { data: json } = await client.request<JsonOf<Partial<Record<UUID, ChildAttendanceStatusResponse>>>>({
+): Promise<Partial<Record<PersonId, ChildAttendanceStatusResponse>>> {
+  const { data: json } = await client.request<JsonOf<Partial<Record<PersonId, ChildAttendanceStatusResponse>>>>({
     url: uri`/employee-mobile/attendances/units/${request.unitId}/attendances`.toString(),
     method: 'GET'
   })
@@ -101,7 +104,7 @@ export async function getAttendanceStatuses(
 */
 export async function getChildren(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
 ): Promise<AttendanceChild[]> {
   const { data: json } = await client.request<JsonOf<AttendanceChild[]>>({
@@ -117,7 +120,7 @@ export async function getChildren(
 */
 export async function getExpectedAbsencesOnDepartures(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     body: ExpectedAbsencesOnDeparturesRequest
   }
 ): Promise<ExpectedAbsencesOnDeparturesResponse> {
@@ -135,8 +138,8 @@ export async function getExpectedAbsencesOnDepartures(
 */
 export async function postAbsenceRange(
   request: {
-    unitId: UUID,
-    childId: UUID,
+    unitId: DaycareId,
+    childId: PersonId,
     body: AbsenceRangeRequest
   }
 ): Promise<void> {
@@ -154,7 +157,7 @@ export async function postAbsenceRange(
 */
 export async function postArrivals(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     body: ArrivalsRequest
   }
 ): Promise<void> {
@@ -172,7 +175,7 @@ export async function postArrivals(
 */
 export async function postDepartures(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     body: DeparturesRequest
   }
 ): Promise<void> {
@@ -190,8 +193,8 @@ export async function postDepartures(
 */
 export async function postFullDayAbsence(
   request: {
-    unitId: UUID,
-    childId: UUID,
+    unitId: DaycareId,
+    childId: PersonId,
     body: FullDayAbsenceRequest
   }
 ): Promise<void> {
@@ -209,8 +212,8 @@ export async function postFullDayAbsence(
 */
 export async function returnToComing(
   request: {
-    unitId: UUID,
-    childId: UUID
+    unitId: DaycareId,
+    childId: PersonId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -226,8 +229,8 @@ export async function returnToComing(
 */
 export async function returnToPresent(
   request: {
-    unitId: UUID,
-    childId: UUID
+    unitId: DaycareId,
+    childId: PersonId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -243,7 +246,7 @@ export async function returnToPresent(
 */
 export async function getAttendancesByUnit(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     date?: LocalDate | null
   }
 ): Promise<CurrentDayStaffAttendanceResponse> {
@@ -265,8 +268,8 @@ export async function getAttendancesByUnit(
 */
 export async function getEmployeeAttendances(
   request: {
-    unitId: UUID,
-    employeeId: UUID,
+    unitId: DaycareId,
+    employeeId: EmployeeId,
     from: LocalDate,
     to: LocalDate
   }
@@ -291,7 +294,7 @@ export async function getEmployeeAttendances(
 */
 export async function getOpenGroupAttendance(
   request: {
-    userId: UUID
+    userId: EmployeeId
   }
 ): Promise<OpenGroupAttendanceResponse> {
   const params = createUrlSearchParams(
@@ -347,8 +350,8 @@ export async function markExternalArrival(
   request: {
     body: ExternalStaffArrivalRequest
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<StaffAttendanceExternalId> {
+  const { data: json } = await client.request<JsonOf<StaffAttendanceExternalId>>({
     url: uri`/employee-mobile/realtime-staff-attendances/arrival-external`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<ExternalStaffArrivalRequest>
@@ -379,7 +382,7 @@ export async function markExternalDeparture(
 */
 export async function setAttendances(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     body: StaffAttendanceUpdateRequest
   }
 ): Promise<StaffAttendanceUpdateResponse> {
@@ -401,7 +404,7 @@ export async function setAttendances(
 */
 export async function getUnitInfo(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
 ): Promise<UnitInfo> {
   const { data: json } = await client.request<JsonOf<UnitInfo>>({
@@ -417,7 +420,7 @@ export async function getUnitInfo(
 */
 export async function getUnitStats(
   request: {
-    unitIds?: UUID[] | null
+    unitIds?: DaycareId[] | null
   }
 ): Promise<UnitStats[]> {
   const params = createUrlSearchParams(

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/childimages.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/childimages.ts
@@ -5,7 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../client'
 import { uri } from 'lib-common/uri'
 
@@ -15,7 +15,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function deleteImage(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/daycare.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/daycare.ts
@@ -4,10 +4,11 @@
 
 // GENERATED FILE: no manual modifications
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
+import { GroupId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { StaffAttendanceUpdate } from 'lib-common/generated/api-types/daycare'
-import { UUID } from 'lib-common/types'
 import { UnitStaffAttendance } from 'lib-common/generated/api-types/daycare'
 import { client } from '../../client'
 import { deserializeJsonUnitStaffAttendance } from 'lib-common/generated/api-types/daycare'
@@ -19,7 +20,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getAttendancesByUnit(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
 ): Promise<UnitStaffAttendance> {
   const { data: json } = await client.request<JsonOf<UnitStaffAttendance>>({
@@ -35,7 +36,7 @@ export async function getAttendancesByUnit(
 */
 export async function upsertStaffAttendance(
   request: {
-    groupId: UUID,
+    groupId: GroupId,
     body: StaffAttendanceUpdate
   }
 ): Promise<void> {

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/messaging.ts
@@ -6,11 +6,16 @@
 
 import { AuthorizedMessageAccount } from 'lib-common/generated/api-types/messaging'
 import { CreateMessageResponse } from 'lib-common/generated/api-types/messaging'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { DraftContent } from 'lib-common/generated/api-types/messaging'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
+import { MessageAccountId } from 'lib-common/generated/api-types/shared'
+import { MessageDraftId } from 'lib-common/generated/api-types/shared'
+import { MessageId } from 'lib-common/generated/api-types/shared'
 import { MessageReceiversResponse } from 'lib-common/generated/api-types/messaging'
 import { MessageThread } from 'lib-common/generated/api-types/messaging'
+import { MessageThreadId } from 'lib-common/generated/api-types/shared'
 import { PagedMessageThreads } from 'lib-common/generated/api-types/messaging'
 import { PagedSentMessages } from 'lib-common/generated/api-types/messaging'
 import { PostMessageBody } from 'lib-common/generated/api-types/messaging'
@@ -18,7 +23,6 @@ import { PostMessagePreflightBody } from 'lib-common/generated/api-types/messagi
 import { PostMessagePreflightResponse } from 'lib-common/generated/api-types/messaging'
 import { ReplyToMessageBody } from 'lib-common/generated/api-types/messaging'
 import { ThreadReply } from 'lib-common/generated/api-types/messaging'
-import { UUID } from 'lib-common/types'
 import { UnreadCountByAccountAndGroup } from 'lib-common/generated/api-types/messaging'
 import { UpdatableDraftContent } from 'lib-common/generated/api-types/messaging'
 import { client } from '../../client'
@@ -36,7 +40,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function createMessage(
   request: {
-    accountId: UUID,
+    accountId: MessageAccountId,
     body: PostMessageBody
   }
 ): Promise<CreateMessageResponse> {
@@ -54,7 +58,7 @@ export async function createMessage(
 */
 export async function createMessagePreflightCheck(
   request: {
-    accountId: UUID,
+    accountId: MessageAccountId,
     body: PostMessagePreflightBody
   }
 ): Promise<PostMessagePreflightResponse> {
@@ -72,8 +76,8 @@ export async function createMessagePreflightCheck(
 */
 export async function deleteDraftMessage(
   request: {
-    accountId: UUID,
-    draftId: UUID
+    accountId: MessageAccountId,
+    draftId: MessageDraftId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -89,7 +93,7 @@ export async function deleteDraftMessage(
 */
 export async function getAccountsByDevice(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
 ): Promise<AuthorizedMessageAccount[]> {
   const { data: json } = await client.request<JsonOf<AuthorizedMessageAccount[]>>({
@@ -105,7 +109,7 @@ export async function getAccountsByDevice(
 */
 export async function getDraftMessages(
   request: {
-    accountId: UUID
+    accountId: MessageAccountId
   }
 ): Promise<DraftContent[]> {
   const { data: json } = await client.request<JsonOf<DraftContent[]>>({
@@ -121,7 +125,7 @@ export async function getDraftMessages(
 */
 export async function getReceivedMessages(
   request: {
-    accountId: UUID,
+    accountId: MessageAccountId,
     page: number
   }
 ): Promise<PagedMessageThreads> {
@@ -154,7 +158,7 @@ export async function getReceiversForNewMessage(): Promise<MessageReceiversRespo
 */
 export async function getSentMessages(
   request: {
-    accountId: UUID,
+    accountId: MessageAccountId,
     page: number
   }
 ): Promise<PagedSentMessages> {
@@ -175,8 +179,8 @@ export async function getSentMessages(
 */
 export async function getThread(
   request: {
-    accountId: UUID,
-    threadId: UUID
+    accountId: MessageAccountId,
+    threadId: MessageThreadId
   }
 ): Promise<MessageThread> {
   const { data: json } = await client.request<JsonOf<MessageThread>>({
@@ -192,7 +196,7 @@ export async function getThread(
 */
 export async function getUnreadMessagesByUnit(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
 ): Promise<UnreadCountByAccountAndGroup[]> {
   const { data: json } = await client.request<JsonOf<UnreadCountByAccountAndGroup[]>>({
@@ -208,10 +212,10 @@ export async function getUnreadMessagesByUnit(
 */
 export async function initDraftMessage(
   request: {
-    accountId: UUID
+    accountId: MessageAccountId
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<MessageDraftId> {
+  const { data: json } = await client.request<JsonOf<MessageDraftId>>({
     url: uri`/employee-mobile/messages/${request.accountId}/drafts`.toString(),
     method: 'POST'
   })
@@ -224,8 +228,8 @@ export async function initDraftMessage(
 */
 export async function markThreadRead(
   request: {
-    accountId: UUID,
-    threadId: UUID
+    accountId: MessageAccountId,
+    threadId: MessageThreadId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -241,8 +245,8 @@ export async function markThreadRead(
 */
 export async function replyToThread(
   request: {
-    accountId: UUID,
-    messageId: UUID,
+    accountId: MessageAccountId,
+    messageId: MessageId,
     body: ReplyToMessageBody
   }
 ): Promise<ThreadReply> {
@@ -260,8 +264,8 @@ export async function replyToThread(
 */
 export async function updateDraftMessage(
   request: {
-    accountId: UUID,
-    draftId: UUID,
+    accountId: MessageAccountId,
+    draftId: MessageDraftId,
     body: UpdatableDraftContent
   }
 ): Promise<void> {

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/note.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/note.ts
@@ -6,13 +6,17 @@
 
 import { ChildDailyNote } from 'lib-common/generated/api-types/note'
 import { ChildDailyNoteBody } from 'lib-common/generated/api-types/note'
+import { ChildDailyNoteId } from 'lib-common/generated/api-types/shared'
 import { ChildStickyNote } from 'lib-common/generated/api-types/note'
 import { ChildStickyNoteBody } from 'lib-common/generated/api-types/note'
+import { ChildStickyNoteId } from 'lib-common/generated/api-types/shared'
+import { GroupId } from 'lib-common/generated/api-types/shared'
 import { GroupNote } from 'lib-common/generated/api-types/note'
 import { GroupNoteBody } from 'lib-common/generated/api-types/note'
+import { GroupNoteId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../client'
 import { deserializeJsonChildDailyNote } from 'lib-common/generated/api-types/note'
 import { deserializeJsonChildStickyNote } from 'lib-common/generated/api-types/note'
@@ -25,11 +29,11 @@ import { uri } from 'lib-common/uri'
 */
 export async function createChildDailyNote(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: ChildDailyNoteBody
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<ChildDailyNoteId> {
+  const { data: json } = await client.request<JsonOf<ChildDailyNoteId>>({
     url: uri`/employee-mobile/children/${request.childId}/child-daily-notes`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<ChildDailyNoteBody>
@@ -43,7 +47,7 @@ export async function createChildDailyNote(
 */
 export async function deleteChildDailyNote(
   request: {
-    noteId: UUID
+    noteId: ChildDailyNoteId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -59,7 +63,7 @@ export async function deleteChildDailyNote(
 */
 export async function updateChildDailyNote(
   request: {
-    noteId: UUID,
+    noteId: ChildDailyNoteId,
     body: ChildDailyNoteBody
   }
 ): Promise<ChildDailyNote> {
@@ -77,11 +81,11 @@ export async function updateChildDailyNote(
 */
 export async function createChildStickyNote(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: ChildStickyNoteBody
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<ChildStickyNoteId> {
+  const { data: json } = await client.request<JsonOf<ChildStickyNoteId>>({
     url: uri`/employee-mobile/children/${request.childId}/child-sticky-notes`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<ChildStickyNoteBody>
@@ -95,7 +99,7 @@ export async function createChildStickyNote(
 */
 export async function deleteChildStickyNote(
   request: {
-    noteId: UUID
+    noteId: ChildStickyNoteId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -111,7 +115,7 @@ export async function deleteChildStickyNote(
 */
 export async function updateChildStickyNote(
   request: {
-    noteId: UUID,
+    noteId: ChildStickyNoteId,
     body: ChildStickyNoteBody
   }
 ): Promise<ChildStickyNote> {
@@ -129,11 +133,11 @@ export async function updateChildStickyNote(
 */
 export async function createGroupNote(
   request: {
-    groupId: UUID,
+    groupId: GroupId,
     body: GroupNoteBody
   }
-): Promise<UUID> {
-  const { data: json } = await client.request<JsonOf<UUID>>({
+): Promise<GroupNoteId> {
+  const { data: json } = await client.request<JsonOf<GroupNoteId>>({
     url: uri`/employee-mobile/daycare-groups/${request.groupId}/group-notes`.toString(),
     method: 'POST',
     data: request.body satisfies JsonCompatible<GroupNoteBody>
@@ -147,7 +151,7 @@ export async function createGroupNote(
 */
 export async function deleteGroupNote(
   request: {
-    noteId: UUID
+    noteId: GroupNoteId
   }
 ): Promise<void> {
   const { data: json } = await client.request<JsonOf<void>>({
@@ -163,7 +167,7 @@ export async function deleteGroupNote(
 */
 export async function getGroupNotes(
   request: {
-    groupId: UUID
+    groupId: GroupId
   }
 ): Promise<GroupNote[]> {
   const { data: json } = await client.request<JsonOf<GroupNote[]>>({
@@ -179,7 +183,7 @@ export async function getGroupNotes(
 */
 export async function updateGroupNote(
   request: {
-    noteId: UUID,
+    noteId: GroupNoteId,
     body: GroupNoteBody
   }
 ): Promise<GroupNote> {

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/occupancy.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/occupancy.ts
@@ -5,11 +5,11 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { JsonOf } from 'lib-common/json'
 import { OccupancyResponse } from 'lib-common/generated/api-types/occupancy'
 import { OccupancyResponseGroupLevel } from 'lib-common/generated/api-types/occupancy'
 import { OccupancyType } from 'lib-common/generated/api-types/occupancy'
-import { UUID } from 'lib-common/types'
 import { client } from '../../client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonOccupancyResponse } from 'lib-common/generated/api-types/occupancy'
@@ -22,7 +22,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getOccupancyPeriods(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     from: LocalDate,
     to: LocalDate,
     type: OccupancyType
@@ -47,7 +47,7 @@ export async function getOccupancyPeriods(
 */
 export async function getOccupancyPeriodsOnGroups(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     from: LocalDate,
     to: LocalDate,
     type: OccupancyType

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/pairing.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/pairing.ts
@@ -7,9 +7,9 @@
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
 import { Pairing } from 'lib-common/generated/api-types/pairing'
+import { PairingId } from 'lib-common/generated/api-types/shared'
 import { PairingStatusRes } from 'lib-common/generated/api-types/pairing'
 import { PostPairingChallengeReq } from 'lib-common/generated/api-types/pairing'
-import { UUID } from 'lib-common/types'
 import { client } from '../../client'
 import { deserializeJsonPairing } from 'lib-common/generated/api-types/pairing'
 import { uri } from 'lib-common/uri'
@@ -20,7 +20,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getPairingStatus(
   request: {
-    id: UUID
+    id: PairingId
   }
 ): Promise<PairingStatusRes> {
   const { data: json } = await client.request<JsonOf<PairingStatusRes>>({

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/reservations.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/reservations.ts
@@ -9,9 +9,10 @@ import { ConfirmedRangeDate } from 'lib-common/generated/api-types/reservations'
 import { ConfirmedRangeDateUpdate } from 'lib-common/generated/api-types/reservations'
 import { DailyChildReservationResult } from 'lib-common/generated/api-types/reservations'
 import { DayReservationStatisticsResult } from 'lib-common/generated/api-types/reservations'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { JsonCompatible } from 'lib-common/json'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonConfirmedRangeDate } from 'lib-common/generated/api-types/reservations'
@@ -25,7 +26,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getChildReservationsForDay(
   request: {
-    unitId: UUID,
+    unitId: DaycareId,
     examinationDate: LocalDate
   }
 ): Promise<DailyChildReservationResult> {
@@ -47,7 +48,7 @@ export async function getChildReservationsForDay(
 */
 export async function getConfirmedRangeData(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<ConfirmedRangeDate[]> {
   const { data: json } = await client.request<JsonOf<ConfirmedRangeDate[]>>({
@@ -63,7 +64,7 @@ export async function getConfirmedRangeData(
 */
 export async function getReservationStatisticsForConfirmedDays(
   request: {
-    unitId: UUID
+    unitId: DaycareId
   }
 ): Promise<DayReservationStatisticsResult[]> {
   const params = createUrlSearchParams(
@@ -83,7 +84,7 @@ export async function getReservationStatisticsForConfirmedDays(
 */
 export async function setConfirmedRangeReservations(
   request: {
-    childId: UUID,
+    childId: PersonId,
     body: ConfirmedRangeDateUpdate[]
   }
 ): Promise<void> {

--- a/frontend/src/employee-mobile-frontend/generated/api-clients/sensitive.ts
+++ b/frontend/src/employee-mobile-frontend/generated/api-clients/sensitive.ts
@@ -7,7 +7,7 @@
 import { ChildBasicInformation } from 'lib-common/generated/api-types/sensitive'
 import { ChildSensitiveInformation } from 'lib-common/generated/api-types/sensitive'
 import { JsonOf } from 'lib-common/json'
-import { UUID } from 'lib-common/types'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import { client } from '../../client'
 import { deserializeJsonChildBasicInformation } from 'lib-common/generated/api-types/sensitive'
 import { uri } from 'lib-common/uri'
@@ -18,7 +18,7 @@ import { uri } from 'lib-common/uri'
 */
 export async function getBasicInfo(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<ChildBasicInformation> {
   const { data: json } = await client.request<JsonOf<ChildBasicInformation>>({
@@ -34,7 +34,7 @@ export async function getBasicInfo(
 */
 export async function getSensitiveInfo(
   request: {
-    childId: UUID
+    childId: PersonId
   }
 ): Promise<ChildSensitiveInformation> {
   const { data: json } = await client.request<JsonOf<ChildSensitiveInformation>>({

--- a/frontend/src/employee-mobile-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/MessageEditor.tsx
@@ -18,6 +18,7 @@ import {
   PostMessageBody,
   UpdatableDraftContent
 } from 'lib-common/generated/api-types/messaging'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { cancelMutation, useMutation, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { isAutomatedTest } from 'lib-common/utils/helpers'
@@ -104,7 +105,7 @@ const messageForm = mapped(
 )
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   account: MessageAccount
   availableRecipients: MessageReceiversResponse[]
   draft: DraftContent | undefined

--- a/frontend/src/employee-mobile-frontend/messages/NewChildMessagePage.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/NewChildMessagePage.tsx
@@ -10,6 +10,7 @@ import { combine } from 'lib-common/api'
 import { MessageReceiver } from 'lib-common/api-types/messaging'
 import { AttendanceChild } from 'lib-common/generated/api-types/attendance'
 import { AuthorizedMessageAccount } from 'lib-common/generated/api-types/messaging'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import {
   constantQuery,
   useChainedQuery,
@@ -32,7 +33,7 @@ import MessageEditor from './MessageEditor'
 import { messagingAccountsQuery, recipientsQuery } from './queries'
 
 interface Props {
-  unitId: UUID
+  unitId: DaycareId
   childGroupAccount: AuthorizedMessageAccount | undefined
   child: AttendanceChild
 }
@@ -112,7 +113,7 @@ export default React.memo(function MessageEditorPageWrapper({
   unitId,
   childId
 }: {
-  unitId: UUID
+  unitId: DaycareId
   childId: UUID
 }) {
   const child = useChild(useQueryResult(childrenQuery(unitId)), childId)

--- a/frontend/src/employee-mobile-frontend/messages/ThreadView.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/ThreadView.tsx
@@ -22,6 +22,7 @@ import {
   MessageThread,
   SentMessage
 } from 'lib-common/generated/api-types/messaging'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { formatAccountNames } from 'lib-common/messaging'
 import { constantQuery, useChainedQuery } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -99,7 +100,7 @@ export const ReceivedThreadPage = React.memo(function ReceivedThreadPage({
 })
 
 interface ReceivedThreadProps {
-  unitId: UUID
+  unitId: DaycareId
   accountId: UUID
   thread: MessageThread
   onBack: () => void
@@ -259,7 +260,7 @@ const SingleMessage = React.memo(
 )
 
 interface SentMessageViewProps {
-  unitId: UUID
+  unitId: DaycareId
   account: MessageAccount
   message: SentMessage
   onBack: () => void

--- a/frontend/src/employee-mobile-frontend/messages/queries.ts
+++ b/frontend/src/employee-mobile-frontend/messages/queries.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { mutation, pagedInfiniteQuery, query } from 'lib-common/query'
 import { Arg0, UUID } from 'lib-common/types'
 
@@ -50,7 +51,7 @@ const queryKeys = createQueryKeys('messages', {
 export const messagingAccountsQuery = query({
   // employeeId is not sent to api but is used to invalidate the query when it changes, so that there's no risk of
   // leaking account information from the previous logged-in employee
-  api: ({ unitId }: { unitId: string; employeeId: string | undefined }) =>
+  api: ({ unitId }: { unitId: DaycareId; employeeId: string | undefined }) =>
     getAccountsByDevice({ unitId }),
   queryKey: queryKeys.accounts
 })

--- a/frontend/src/employee-mobile-frontend/settings/NotificationSettings.tsx
+++ b/frontend/src/employee-mobile-frontend/settings/NotificationSettings.tsx
@@ -23,6 +23,7 @@ import {
   useFormField
 } from 'lib-common/form/hooks'
 import { GroupInfo } from 'lib-common/generated/api-types/attendance'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import {
   pushNotificationCategories,
   PushNotificationCategory,
@@ -63,7 +64,7 @@ const EditButton = styled(Button)`
 export const NotificationSettings = React.memo(function NotificationSettings({
   unitId
 }: {
-  unitId: UUID
+  unitId: DaycareId
 }) {
   const { i18n } = useTranslation()
   const t = i18n.settings.notifications

--- a/frontend/src/employee-mobile-frontend/settings/SettingsPage.tsx
+++ b/frontend/src/employee-mobile-frontend/settings/SettingsPage.tsx
@@ -6,8 +6,8 @@ import React, { useContext, useMemo } from 'react'
 import { useNavigate } from 'react-router'
 
 import { combine } from 'lib-common/api'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { ContentArea } from 'lib-components/layout/Container'
 import { H1 } from 'lib-components/typography'
 
@@ -26,7 +26,7 @@ import { NotificationSettings } from './NotificationSettings'
 export const SettingsPage = React.memo(function SettingsPage({
   unitId
 }: {
-  unitId: UUID
+  unitId: DaycareId
 }) {
   const navigate = useNavigate()
   const { i18n } = useTranslation()

--- a/frontend/src/employee-mobile-frontend/staff-attendance/ExternalStaffMemberPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/ExternalStaffMemberPage.tsx
@@ -5,10 +5,10 @@
 import React, { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalTime from 'lib-common/local-time'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import useRouteParams from 'lib-common/useRouteParams'
 import {
   MutateButton,
@@ -33,7 +33,7 @@ import { toStaff } from './utils'
 export default React.memo(function ExternalStaffMemberPage({
   unitId
 }: {
-  unitId: UUID
+  unitId: DaycareId
 }) {
   const navigate = useNavigate()
   const { attendanceId } = useRouteParams(['attendanceId'])

--- a/frontend/src/employee-mobile-frontend/staff/api.ts
+++ b/frontend/src/employee-mobile-frontend/staff/api.ts
@@ -7,6 +7,7 @@ import {
   getOccupancyPeriodsOnGroups
 } from 'employee-mobile-frontend/generated/api-clients/occupancy'
 import { Result, wrapResult } from 'lib-common/api'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 
 const getOccupancyPeriodsResult = wrapResult(getOccupancyPeriods)
@@ -14,7 +15,7 @@ const getOccupancyPeriodsOnGroupsResult = wrapResult(
   getOccupancyPeriodsOnGroups
 )
 export async function getRealizedOccupancyToday(
-  unitId: string,
+  unitId: DaycareId,
   groupId: string | undefined
 ): Promise<Result<number>> {
   const today = LocalDate.todayInSystemTz()

--- a/frontend/src/lib-common/api-types/application/ApplicationFormData.ts
+++ b/frontend/src/lib-common/api-types/application/ApplicationFormData.ts
@@ -15,6 +15,8 @@ import {
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import LocalDate from 'lib-common/local-date'
 
+import { DaycareId } from '../../generated/api-types/shared'
+
 export type ServiceNeedFormData = {
   preferredStartDate: LocalDate | null
   urgent: boolean
@@ -41,7 +43,7 @@ export type UnitPreferenceFormData = {
   siblingName: string
   siblingSsn: string
   siblingUnit: string
-  preferredUnits: { id: string; name: string }[]
+  preferredUnits: { id: DaycareId; name: string }[]
 }
 
 export type ContactInfoFormData = {

--- a/frontend/src/lib-common/api-types/attachment.ts
+++ b/frontend/src/lib-common/api-types/attachment.ts
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { UUID } from '../types'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 
 export interface Attachment {
-  id: UUID
+  id: AttachmentId
   name: string
   contentType: string
 }

--- a/frontend/src/lib-common/generated/api-types/absence.ts
+++ b/frontend/src/lib-common/generated/api-types/absence.ts
@@ -9,11 +9,12 @@ import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import TimeRange from '../../time-range'
 import { EvakaUserType } from './user'
+import { GroupId } from './shared'
 import { JsonOf } from '../../json'
+import { PersonId } from './shared'
 import { Reservation } from './reservations'
 import { ScheduleType } from './placement'
 import { ShiftCareType } from './serviceneed'
-import { UUID } from '../../types'
 import { deserializeJsonReservation } from './reservations'
 
 /**
@@ -22,7 +23,7 @@ import { deserializeJsonReservation } from './reservations'
 export interface Absence {
   absenceType: AbsenceType
   category: AbsenceCategory
-  childId: UUID
+  childId: PersonId
   date: LocalDate
   modifiedAt: HelsinkiDateTime
   modifiedByStaff: boolean
@@ -54,7 +55,7 @@ export type AbsenceType =
 export interface AbsenceUpsert {
   absenceType: AbsenceType
   category: AbsenceCategory
-  childId: UUID
+  childId: PersonId
   date: LocalDate
 }
 
@@ -81,7 +82,7 @@ export interface ChildReservation {
 * Generated from fi.espoo.evaka.absence.ChildServiceNeedInfo
 */
 export interface ChildServiceNeedInfo {
-  childId: UUID
+  childId: PersonId
   daycareHoursPerMonth: number | null
   hasContractDays: boolean
   optionName: string
@@ -98,7 +99,7 @@ export interface GroupMonthCalendar {
   daycareName: string
   daycareOperationTimes: (TimeRange | null)[]
   days: GroupMonthCalendarDay[]
-  groupId: UUID
+  groupId: GroupId
   groupName: string
   shiftCareOperationTimes: (TimeRange | null)[] | null
 }
@@ -111,7 +112,7 @@ export interface GroupMonthCalendarChild {
   attendanceTotalHours: number
   dateOfBirth: LocalDate
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   reservationTotalHours: number
   usedService: UsedServiceTotals | null
@@ -134,7 +135,7 @@ export interface GroupMonthCalendarDayChild {
   absenceCategories: AbsenceCategory[]
   absences: AbsenceWithModifierInfo[]
   backupCare: boolean
-  childId: UUID
+  childId: PersonId
   dailyServiceTimes: TimeRange | null
   missingHolidayReservation: boolean
   reservations: ChildReservation[]
@@ -146,7 +147,7 @@ export interface GroupMonthCalendarDayChild {
 * Generated from fi.espoo.evaka.absence.AbsenceController.HolidayReservationsDelete
 */
 export interface HolidayReservationsDelete {
-  childId: UUID
+  childId: PersonId
   date: LocalDate
 }
 
@@ -155,7 +156,7 @@ export interface HolidayReservationsDelete {
 */
 export interface Presence {
   category: AbsenceCategory
-  childId: UUID
+  childId: PersonId
   date: LocalDate
 }
 

--- a/frontend/src/lib-common/generated/api-types/application.ts
+++ b/frontend/src/lib-common/generated/api-types/application.ts
@@ -8,21 +8,33 @@ import FiniteDateRange from '../../finite-date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import { Action } from '../action'
+import { ApplicationId } from './shared'
+import { ApplicationNoteId } from './shared'
+import { AreaId } from './shared'
+import { AttachmentId } from './shared'
 import { AttachmentType } from './attachment'
 import { CreatePersonBody } from './pis'
+import { DaycareId } from './shared'
 import { Decision } from './decision'
 import { DecisionDraft } from './decision'
+import { DecisionId } from './shared'
 import { DecisionStatus } from './decision'
 import { DecisionType } from './decision'
 import { DecisionUnit } from './decision'
+import { EmployeeId } from './shared'
 import { EvakaUser } from './user'
+import { EvakaUserId } from './shared'
 import { FinanceDecisionType } from './invoicing'
 import { JsonOf } from '../../json'
+import { MessageContentId } from './shared'
+import { MessageThreadId } from './shared'
+import { PersonId } from './shared'
 import { PersonJSON } from './pis'
 import { PlacementPlanConfirmationStatus } from './placement'
 import { PlacementPlanDetails } from './placement'
 import { PlacementPlanRejectReason } from './placement'
 import { PlacementType } from './placement'
+import { ServiceNeedOptionId } from './shared'
 import { UUID } from '../../types'
 import { deserializeJsonCreatePersonBody } from './pis'
 import { deserializeJsonDecision } from './decision'
@@ -34,7 +46,7 @@ import { deserializeJsonPlacementPlanDetails } from './placement'
 * Generated from fi.espoo.evaka.application.AcceptDecisionRequest
 */
 export interface AcceptDecisionRequest {
-  decisionId: UUID
+  decisionId: DecisionId
   requestedStartDate: LocalDate
 }
 
@@ -59,13 +71,13 @@ export interface Address {
 */
 export interface ApplicationAttachment {
   contentType: string
-  id: UUID
+  id: AttachmentId
   name: string
   receivedAt: HelsinkiDateTime
   type: AttachmentType
   updated: HelsinkiDateTime
-  uploadedByEmployee: UUID | null
-  uploadedByPerson: UUID | null
+  uploadedByEmployee: EmployeeId | null
+  uploadedByPerson: PersonId | null
 }
 
 /**
@@ -94,9 +106,9 @@ export type ApplicationDateType =
 * Generated from fi.espoo.evaka.application.ApplicationDecisions
 */
 export interface ApplicationDecisions {
-  decidableApplications: UUID[]
+  decidableApplications: ApplicationId[]
   decisions: DecisionSummary[]
-  permittedActions: Partial<Record<UUID, Action.Citizen.Decision[]>>
+  permittedActions: Partial<Record<DecisionId, Action.Citizen.Decision[]>>
 }
 
 /**
@@ -107,7 +119,7 @@ export interface ApplicationDetails {
   allowOtherGuardianAccess: boolean
   attachments: ApplicationAttachment[]
   checkedByAdmin: boolean
-  childId: UUID
+  childId: PersonId
   childRestricted: boolean
   confidential: boolean | null
   createdDate: HelsinkiDateTime | null
@@ -115,11 +127,11 @@ export interface ApplicationDetails {
   dueDateSetManuallyAt: HelsinkiDateTime | null
   form: ApplicationForm
   guardianDateOfDeath: LocalDate | null
-  guardianId: UUID
+  guardianId: PersonId
   guardianRestricted: boolean
   hasOtherGuardian: boolean
   hideFromGuardian: boolean
-  id: UUID
+  id: ApplicationId
   modifiedDate: HelsinkiDateTime | null
   origin: ApplicationOrigin
   otherGuardianLivesInSameAddress: boolean | null
@@ -169,16 +181,16 @@ export interface ApplicationFormUpdate {
 * Generated from fi.espoo.evaka.application.ApplicationNote
 */
 export interface ApplicationNote {
-  applicationId: UUID
+  applicationId: ApplicationId
   content: string
   created: HelsinkiDateTime
-  createdBy: UUID
+  createdBy: EvakaUserId
   createdByName: string
-  id: UUID
-  messageContentId: UUID | null
-  messageThreadId: UUID | null
+  id: ApplicationNoteId
+  messageContentId: MessageContentId | null
+  messageThreadId: MessageThreadId | null
   updated: HelsinkiDateTime
-  updatedBy: UUID
+  updatedBy: EvakaUserId
   updatedByName: string
 }
 
@@ -285,7 +297,7 @@ export interface ApplicationSummary {
   duplicateApplication: boolean
   extendedCare: boolean
   firstName: string
-  id: UUID
+  id: ApplicationId
   lastName: string
   origin: ApplicationOrigin
   placementPlanStartDate: LocalDate | null
@@ -326,7 +338,7 @@ export type ApplicationTypeToggle =
 * Generated from fi.espoo.evaka.application.ApplicationUnitSummary
 */
 export interface ApplicationUnitSummary {
-  applicationId: UUID
+  applicationId: ApplicationId
   dateOfBirth: LocalDate
   extendedCare: boolean
   firstName: string
@@ -355,11 +367,11 @@ export interface ApplicationUpdate {
 */
 export interface ApplicationsOfChild {
   applicationSummaries: CitizenApplicationSummary[]
-  childId: UUID
+  childId: PersonId
   childName: string
-  decidableApplications: UUID[]
-  duplicateOf: UUID | null
-  permittedActions: Partial<Record<UUID, Action.Citizen.Application[]>>
+  decidableApplications: ApplicationId[]
+  duplicateOf: PersonId | null
+  permittedActions: Partial<Record<ApplicationId, Action.Citizen.Application[]>>
 }
 
 /**
@@ -403,9 +415,9 @@ export interface ChildInfo {
 */
 export interface CitizenApplicationSummary {
   allPreferredUnitNames: string[]
-  applicationId: UUID
+  applicationId: ApplicationId
   applicationStatus: ApplicationStatus
-  childId: UUID
+  childId: PersonId
   childName: string | null
   createdDate: HelsinkiDateTime
   modifiedDate: HelsinkiDateTime
@@ -429,9 +441,9 @@ export interface CitizenApplicationUpdate {
 */
 export interface CitizenChildren {
   dateOfBirth: LocalDate
-  duplicateOf: UUID | null
+  duplicateOf: PersonId | null
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   socialSecurityNumber: string | null
 }
@@ -448,7 +460,7 @@ export interface ClubDetails {
 * Generated from fi.espoo.evaka.application.CreateApplicationBody
 */
 export interface CreateApplicationBody {
-  childId: UUID
+  childId: PersonId
   type: ApplicationType
 }
 
@@ -458,7 +470,7 @@ export interface CreateApplicationBody {
 export interface DaycarePlacementPlan {
   period: FiniteDateRange
   preschoolDaycarePeriod: FiniteDateRange | null
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -477,9 +489,9 @@ export interface DecisionDraftGroup {
 * Generated from fi.espoo.evaka.application.DecisionSummary
 */
 export interface DecisionSummary {
-  applicationId: UUID
-  childId: UUID
-  id: UUID
+  applicationId: ApplicationId
+  childId: PersonId
+  id: DecisionId
   resolved: LocalDate | null
   sentDate: LocalDate
   status: DecisionStatus
@@ -501,7 +513,7 @@ export interface DecisionWithValidStartDatePeriod {
 */
 export interface FinanceDecisionChildInfo {
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
 }
 
@@ -544,7 +556,7 @@ export interface Guardian {
 */
 export interface GuardianInfo {
   firstName: string
-  id: UUID | null
+  id: PersonId | null
   isVtjGuardian: boolean
   lastName: string
   ssn: string | null
@@ -564,7 +576,7 @@ export interface GuardianUpdate {
 */
 export interface LiableCitizenInfo {
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
 }
 
@@ -596,8 +608,8 @@ export interface PagedApplicationSummaries {
 * Generated from fi.espoo.evaka.application.PaperApplicationCreateRequest
 */
 export interface PaperApplicationCreateRequest {
-  childId: UUID
-  guardianId: UUID | null
+  childId: PersonId
+  guardianId: PersonId | null
   guardianSsn: string | null
   guardianToBeCreated: CreatePersonBody | null
   hideFromGuardian: boolean
@@ -610,15 +622,15 @@ export interface PaperApplicationCreateRequest {
 * Generated from fi.espoo.evaka.application.PersonApplicationSummary
 */
 export interface PersonApplicationSummary {
-  applicationId: UUID
-  childId: UUID
+  applicationId: ApplicationId
+  childId: PersonId
   childName: string | null
   childSsn: string | null
   connectedDaycare: boolean
-  guardianId: UUID
+  guardianId: PersonId
   guardianName: string
   preferredStartDate: LocalDate | null
-  preferredUnitId: UUID | null
+  preferredUnitId: DaycareId | null
   preferredUnitName: string | null
   preparatoryEducation: boolean
   sentDate: LocalDate | null
@@ -672,7 +684,7 @@ export interface Preferences {
 * Generated from fi.espoo.evaka.application.PreferredUnit
 */
 export interface PreferredUnit {
-  id: UUID
+  id: DaycareId
   name: string
 }
 
@@ -680,14 +692,14 @@ export interface PreferredUnit {
 * Generated from fi.espoo.evaka.application.RejectDecisionRequest
 */
 export interface RejectDecisionRequest {
-  decisionId: UUID
+  decisionId: DecisionId
 }
 
 /**
 * Generated from fi.espoo.evaka.application.SearchApplicationRequest
 */
 export interface SearchApplicationRequest {
-  areas: UUID[] | null
+  areas: AreaId[] | null
   basis: ApplicationBasis[] | null
   dateType: ApplicationDateType[] | null
   distinctions: ApplicationDistinctions[] | null
@@ -701,7 +713,7 @@ export interface SearchApplicationRequest {
   statuses: ApplicationStatusOption[] | null
   transferApplications: TransferApplicationFilter | null
   type: ApplicationTypeToggle
-  units: UUID[] | null
+  units: DaycareId[] | null
   voucherApplications: VoucherApplicationFilter | null
 }
 
@@ -729,7 +741,7 @@ export interface ServiceNeed {
 * Generated from fi.espoo.evaka.application.ServiceNeedOption
 */
 export interface ServiceNeedOption {
-  id: UUID
+  id: ServiceNeedOptionId
   nameEn: string
   nameFi: string
   nameSv: string
@@ -761,7 +773,7 @@ export type SimpleApplicationAction =
 * Generated from fi.espoo.evaka.application.SimpleBatchRequest
 */
 export interface SimpleBatchRequest {
-  applicationIds: UUID[]
+  applicationIds: ApplicationId[]
 }
 
 /**

--- a/frontend/src/lib-common/generated/api-types/assistance.ts
+++ b/frontend/src/lib-common/generated/api-types/assistance.ts
@@ -8,9 +8,13 @@ import FiniteDateRange from '../../finite-date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
 import { Action } from '../action'
 import { AssistanceActionResponse } from './assistanceaction'
+import { AssistanceFactorId } from './shared'
+import { DaycareAssistanceId } from './shared'
 import { EvakaUser } from './user'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
+import { OtherAssistanceMeasureId } from './shared'
+import { PersonId } from './shared'
+import { PreschoolAssistanceId } from './shared'
 import { deserializeJsonAssistanceActionResponse } from './assistanceaction'
 
 /**
@@ -18,8 +22,8 @@ import { deserializeJsonAssistanceActionResponse } from './assistanceaction'
 */
 export interface AssistanceFactor {
   capacityFactor: number
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: AssistanceFactorId
   modified: HelsinkiDateTime
   modifiedBy: EvakaUser
   validDuring: FiniteDateRange
@@ -56,8 +60,8 @@ export interface AssistanceResponse {
 * Generated from fi.espoo.evaka.assistance.DaycareAssistance
 */
 export interface DaycareAssistance {
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: DaycareAssistanceId
   level: DaycareAssistanceLevel
   modified: HelsinkiDateTime
   modifiedBy: EvakaUser
@@ -96,8 +100,8 @@ export interface DaycareAssistanceUpdate {
 * Generated from fi.espoo.evaka.assistance.OtherAssistanceMeasure
 */
 export interface OtherAssistanceMeasure {
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: OtherAssistanceMeasureId
   modified: HelsinkiDateTime
   modifiedBy: EvakaUser
   type: OtherAssistanceMeasureType
@@ -138,8 +142,8 @@ export interface OtherAssistanceMeasureUpdate {
 * Generated from fi.espoo.evaka.assistance.PreschoolAssistance
 */
 export interface PreschoolAssistance {
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: PreschoolAssistanceId
   level: PreschoolAssistanceLevel
   modified: HelsinkiDateTime
   modifiedBy: EvakaUser

--- a/frontend/src/lib-common/generated/api-types/assistanceaction.ts
+++ b/frontend/src/lib-common/generated/api-types/assistanceaction.ts
@@ -6,17 +6,18 @@
 
 import LocalDate from '../../local-date'
 import { Action } from '../action'
+import { AssistanceActionId } from './shared'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
+import { PersonId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.assistanceaction.AssistanceAction
 */
 export interface AssistanceAction {
   actions: string[]
-  childId: UUID
+  childId: PersonId
   endDate: LocalDate
-  id: UUID
+  id: AssistanceActionId
   otherAction: string
   startDate: LocalDate
 }

--- a/frontend/src/lib-common/generated/api-types/assistanceneed.ts
+++ b/frontend/src/lib-common/generated/api-types/assistanceneed.ts
@@ -9,10 +9,17 @@ import FiniteDateRange from '../../finite-date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import { Action } from '../action'
+import { AssistanceNeedDecisionGuardianId } from './shared'
+import { AssistanceNeedDecisionId } from './shared'
+import { AssistanceNeedPreschoolDecisionGuardianId } from './shared'
+import { AssistanceNeedPreschoolDecisionId } from './shared'
+import { AssistanceNeedVoucherCoefficientId } from './shared'
+import { DaycareId } from './shared'
+import { EmployeeId } from './shared'
 import { EvakaUser } from './user'
 import { JsonOf } from '../../json'
 import { OfficialLanguage } from './shared'
-import { UUID } from '../../types'
+import { PersonId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionController.AnnulAssistanceNeedDecisionRequest
@@ -53,7 +60,7 @@ export interface AssistanceNeedDecision {
   guardianInfo: AssistanceNeedDecisionGuardian[]
   guardiansHeardOn: LocalDate | null
   hasDocument: boolean
-  id: UUID
+  id: AssistanceNeedDecisionId
   language: OfficialLanguage
   motivationForDecision: string | null
   otherRepresentativeDetails: string | null
@@ -78,7 +85,7 @@ export interface AssistanceNeedDecision {
 export interface AssistanceNeedDecisionBasics {
   created: HelsinkiDateTime
   decisionMade: LocalDate | null
-  id: UUID
+  id: AssistanceNeedDecisionId
   selectedUnit: UnitInfoBasics | null
   sentForDecision: LocalDate | null
   status: AssistanceNeedDecisionStatus
@@ -98,7 +105,7 @@ export interface AssistanceNeedDecisionBasicsResponse {
 */
 export interface AssistanceNeedDecisionChild {
   dateOfBirth: LocalDate | null
-  id: UUID | null
+  id: PersonId | null
   name: string | null
 }
 
@@ -108,9 +115,9 @@ export interface AssistanceNeedDecisionChild {
 export interface AssistanceNeedDecisionCitizenListItem {
   annulmentReason: string
   assistanceLevels: AssistanceLevel[]
-  childId: UUID
+  childId: PersonId
   decisionMade: LocalDate
-  id: UUID
+  id: AssistanceNeedDecisionId
   isUnread: boolean
   selectedUnit: UnitInfoBasics | null
   status: AssistanceNeedDecisionStatus
@@ -121,7 +128,7 @@ export interface AssistanceNeedDecisionCitizenListItem {
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionEmployee
 */
 export interface AssistanceNeedDecisionEmployee {
-  employeeId: UUID | null
+  employeeId: EmployeeId | null
   name: string | null
   phoneNumber: string | null
   title: string | null
@@ -131,7 +138,7 @@ export interface AssistanceNeedDecisionEmployee {
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionEmployeeForm
 */
 export interface AssistanceNeedDecisionEmployeeForm {
-  employeeId: UUID | null
+  employeeId: EmployeeId | null
   phoneNumber: string | null
   title: string | null
 }
@@ -172,17 +179,17 @@ export interface AssistanceNeedDecisionForm {
 */
 export interface AssistanceNeedDecisionGuardian {
   details: string | null
-  id: UUID | null
+  id: AssistanceNeedDecisionGuardianId | null
   isHeard: boolean
   name: string
-  personId: UUID | null
+  personId: PersonId | null
 }
 
 /**
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionMaker
 */
 export interface AssistanceNeedDecisionMaker {
-  employeeId: UUID | null
+  employeeId: EmployeeId | null
   name: string | null
   title: string | null
 }
@@ -191,7 +198,7 @@ export interface AssistanceNeedDecisionMaker {
 * Generated from fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionMakerForm
 */
 export interface AssistanceNeedDecisionMakerForm {
-  employeeId: UUID | null
+  employeeId: EmployeeId | null
   title: string | null
 }
 
@@ -233,7 +240,7 @@ export interface AssistanceNeedPreschoolDecision {
   decisionNumber: number
   form: AssistanceNeedPreschoolDecisionForm
   hasDocument: boolean
-  id: UUID
+  id: AssistanceNeedPreschoolDecisionId
   isValid: boolean
   preparer1Name: string | null
   preparer2Name: string | null
@@ -250,15 +257,15 @@ export interface AssistanceNeedPreschoolDecision {
 */
 export interface AssistanceNeedPreschoolDecisionBasics {
   annulmentReason: string
-  childId: UUID
+  childId: PersonId
   created: HelsinkiDateTime
   decisionMade: LocalDate | null
-  id: UUID
+  id: AssistanceNeedPreschoolDecisionId
   selectedUnit: UnitInfoBasics | null
   sentForDecision: LocalDate | null
   status: AssistanceNeedDecisionStatus
   type: AssistanceNeedPreschoolDecisionType | null
-  unreadGuardianIds: UUID[] | null
+  unreadGuardianIds: PersonId[] | null
   validFrom: LocalDate | null
   validTo: LocalDate | null
 }
@@ -276,7 +283,7 @@ export interface AssistanceNeedPreschoolDecisionBasicsResponse {
 */
 export interface AssistanceNeedPreschoolDecisionChild {
   dateOfBirth: LocalDate
-  id: UUID
+  id: PersonId
   name: string
 }
 
@@ -285,9 +292,9 @@ export interface AssistanceNeedPreschoolDecisionChild {
 */
 export interface AssistanceNeedPreschoolDecisionCitizenListItem {
   annulmentReason: string
-  childId: UUID
+  childId: PersonId
   decisionMade: LocalDate
-  id: UUID
+  id: AssistanceNeedPreschoolDecisionId
   isUnread: boolean
   status: AssistanceNeedDecisionStatus
   type: AssistanceNeedPreschoolDecisionType
@@ -311,7 +318,7 @@ export interface AssistanceNeedPreschoolDecisionForm {
   basisDocumentSocialReportDate: LocalDate | null
   basisDocumentsInfo: string
   decisionBasis: string
-  decisionMakerEmployeeId: UUID | null
+  decisionMakerEmployeeId: EmployeeId | null
   decisionMakerTitle: string
   extendedCompulsoryEducation: boolean
   extendedCompulsoryEducationInfo: string
@@ -324,14 +331,14 @@ export interface AssistanceNeedPreschoolDecisionForm {
   language: OfficialLanguage
   otherRepresentativeDetails: string
   otherRepresentativeHeard: boolean
-  preparer1EmployeeId: UUID | null
+  preparer1EmployeeId: EmployeeId | null
   preparer1PhoneNumber: string
   preparer1Title: string
-  preparer2EmployeeId: UUID | null
+  preparer2EmployeeId: EmployeeId | null
   preparer2PhoneNumber: string
   preparer2Title: string
   primaryGroup: string
-  selectedUnit: UUID | null
+  selectedUnit: DaycareId | null
   type: AssistanceNeedPreschoolDecisionType | null
   validFrom: LocalDate | null
   validTo: LocalDate | null
@@ -343,10 +350,10 @@ export interface AssistanceNeedPreschoolDecisionForm {
 */
 export interface AssistanceNeedPreschoolDecisionGuardian {
   details: string
-  id: UUID
+  id: AssistanceNeedPreschoolDecisionGuardianId
   isHeard: boolean
   name: string
-  personId: UUID
+  personId: PersonId
 }
 
 /**
@@ -369,9 +376,9 @@ export type AssistanceNeedPreschoolDecisionType =
 * Generated from fi.espoo.evaka.assistanceneed.vouchercoefficient.AssistanceNeedVoucherCoefficient
 */
 export interface AssistanceNeedVoucherCoefficient {
-  childId: UUID
+  childId: PersonId
   coefficient: number
-  id: UUID
+  id: AssistanceNeedVoucherCoefficientId
   modifiedAt: HelsinkiDateTime
   modifiedBy: EvakaUser | null
   validityPeriod: FiniteDateRange
@@ -434,14 +441,14 @@ export interface StructuralMotivationOptions {
 * Generated from fi.espoo.evaka.assistanceneed.decision.UnitIdInfo
 */
 export interface UnitIdInfo {
-  id: UUID | null
+  id: DaycareId | null
 }
 
 /**
 * Generated from fi.espoo.evaka.assistanceneed.decision.UnitInfo
 */
 export interface UnitInfo {
-  id: UUID | null
+  id: DaycareId | null
   name: string | null
   postOffice: string | null
   postalCode: string | null
@@ -452,7 +459,7 @@ export interface UnitInfo {
 * Generated from fi.espoo.evaka.assistanceneed.decision.UnitInfoBasics
 */
 export interface UnitInfoBasics {
-  id: UUID | null
+  id: DaycareId | null
   name: string | null
 }
 
@@ -460,7 +467,7 @@ export interface UnitInfoBasics {
 * Generated from fi.espoo.evaka.assistanceneed.decision.UnreadAssistanceNeedDecisionItem
 */
 export interface UnreadAssistanceNeedDecisionItem {
-  childId: UUID
+  childId: PersonId
   count: number
 }
 

--- a/frontend/src/lib-common/generated/api-types/attachment.ts
+++ b/frontend/src/lib-common/generated/api-types/attachment.ts
@@ -4,7 +4,7 @@
 
 // GENERATED FILE: no manual modifications
 
-import { UUID } from '../../types'
+import { AttachmentId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.attachment.AttachmentType
@@ -18,7 +18,7 @@ export type AttachmentType =
 */
 export interface IncomeAttachment {
   contentType: string
-  id: UUID
+  id: AttachmentId
   name: string
 }
 
@@ -27,6 +27,6 @@ export interface IncomeAttachment {
 */
 export interface MessageAttachment {
   contentType: string
-  id: UUID
+  id: AttachmentId
   name: string
 }

--- a/frontend/src/lib-common/generated/api-types/attendance.ts
+++ b/frontend/src/lib-common/generated/api-types/attendance.ts
@@ -13,13 +13,18 @@ import { AbsenceType } from './absence'
 import { ChildDailyNote } from './note'
 import { ChildStickyNote } from './note'
 import { DailyServiceTimesValue } from './dailyservicetimes'
+import { DaycareId } from './shared'
+import { EmployeeId } from './shared'
+import { GroupId } from './shared'
 import { HelsinkiDateTimeRange } from './shared'
 import { JsonOf } from '../../json'
+import { PersonId } from './shared'
 import { PilotFeature } from './shared'
 import { PlacementType } from './placement'
 import { ReservationResponse } from './reservations'
 import { ScheduleType } from './placement'
-import { UUID } from '../../types'
+import { StaffAttendanceExternalId } from './shared'
+import { StaffAttendanceRealtimeId } from './shared'
 import { deserializeJsonChildDailyNote } from './note'
 import { deserializeJsonChildStickyNote } from './note'
 import { deserializeJsonDailyServiceTimesValue } from './dailyservicetimes'
@@ -39,7 +44,7 @@ export interface AbsenceRangeRequest {
 */
 export interface ArrivalsRequest {
   arrived: LocalTime
-  children: UUID[]
+  children: PersonId[]
 }
 
 /**
@@ -49,8 +54,8 @@ export interface Attendance {
   arrived: HelsinkiDateTime
   departed: HelsinkiDateTime | null
   departedAutomatically: boolean
-  groupId: UUID | null
-  id: UUID
+  groupId: GroupId | null
+  id: StaffAttendanceRealtimeId
   occupancyCoefficient: number
   type: StaffAttendanceType
 }
@@ -64,8 +69,8 @@ export interface AttendanceChild {
   dailyServiceTimes: DailyServiceTimesValue | null
   dateOfBirth: LocalDate
   firstName: string
-  groupId: UUID | null
-  id: UUID
+  groupId: GroupId | null
+  id: PersonId
   imageUrl: string | null
   lastName: string
   operationalDates: LocalDate[]
@@ -116,7 +121,7 @@ export interface ChildAttendanceStatusResponse {
 export interface ChildDeparture {
   absenceTypeBillable: AbsenceType | null
   absenceTypeNonbillable: AbsenceType | null
-  childId: UUID
+  childId: PersonId
 }
 
 /**
@@ -155,9 +160,9 @@ export interface EmployeeAttendance {
   allowedToEdit: boolean
   attendances: Attendance[]
   currentOccupancyCoefficient: number
-  employeeId: UUID
+  employeeId: EmployeeId
   firstName: string
-  groups: UUID[]
+  groups: GroupId[]
   lastName: string
   plannedAttendances: PlannedStaffAttendance[]
 }
@@ -166,7 +171,7 @@ export interface EmployeeAttendance {
 * Generated from fi.espoo.evaka.attendance.ChildAttendanceController.ExpectedAbsencesOnDeparturesRequest
 */
 export interface ExpectedAbsencesOnDeparturesRequest {
-  childIds: UUID[]
+  childIds: PersonId[]
   departed: LocalTime
 }
 
@@ -174,7 +179,7 @@ export interface ExpectedAbsencesOnDeparturesRequest {
 * Generated from fi.espoo.evaka.attendance.ChildAttendanceController.ExpectedAbsencesOnDeparturesResponse
 */
 export interface ExpectedAbsencesOnDeparturesResponse {
-  categoriesByChild: Partial<Record<UUID, AbsenceCategory[] | null>>
+  categoriesByChild: Partial<Record<PersonId, AbsenceCategory[] | null>>
 }
 
 /**
@@ -184,8 +189,8 @@ export interface ExternalAttendance {
   arrived: HelsinkiDateTime
   departed: HelsinkiDateTime | null
   departedAutomatically: boolean
-  groupId: UUID
-  id: UUID
+  groupId: GroupId
+  id: StaffAttendanceExternalId
   name: string
   occupancyCoefficient: number
   type: StaffAttendanceType
@@ -198,7 +203,7 @@ export interface ExternalAttendanceBody {
   date: LocalDate
   entries: ExternalAttendanceUpsert[]
   name: string
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -207,9 +212,9 @@ export interface ExternalAttendanceBody {
 export interface ExternalAttendanceUpsert {
   arrived: HelsinkiDateTime
   departed: HelsinkiDateTime | null
-  groupId: UUID
+  groupId: GroupId
   hasStaffOccupancyEffect: boolean
-  id: UUID | null
+  id: StaffAttendanceExternalId | null
 }
 
 /**
@@ -217,7 +222,7 @@ export interface ExternalAttendanceUpsert {
 */
 export interface ExternalStaffArrivalRequest {
   arrived: LocalTime
-  groupId: UUID
+  groupId: GroupId
   hasStaffOccupancyEffect: boolean
   name: string
 }
@@ -226,7 +231,7 @@ export interface ExternalStaffArrivalRequest {
 * Generated from fi.espoo.evaka.attendance.MobileRealtimeStaffAttendanceController.ExternalStaffDepartureRequest
 */
 export interface ExternalStaffDepartureRequest {
-  attendanceId: UUID
+  attendanceId: StaffAttendanceExternalId
   time: LocalTime
 }
 
@@ -235,8 +240,8 @@ export interface ExternalStaffDepartureRequest {
 */
 export interface ExternalStaffMember {
   arrived: HelsinkiDateTime
-  groupId: UUID
-  id: UUID
+  groupId: GroupId
+  id: StaffAttendanceExternalId
   name: string
   occupancyEffect: boolean
 }
@@ -252,7 +257,7 @@ export interface FullDayAbsenceRequest {
 * Generated from fi.espoo.evaka.attendance.GroupInfo
 */
 export interface GroupInfo {
-  id: UUID
+  id: GroupId
   name: string
   utilization: number
 }
@@ -262,8 +267,8 @@ export interface GroupInfo {
 */
 export interface OpenGroupAttendance {
   date: LocalDate
-  groupId: UUID
-  unitId: UUID
+  groupId: GroupId
+  unitId: DaycareId
   unitName: string
 }
 
@@ -288,8 +293,8 @@ export interface PlannedStaffAttendance {
 */
 export interface Staff {
   firstName: string
-  groups: UUID[]
-  id: UUID
+  groups: GroupId[]
+  id: EmployeeId
   lastName: string
   pinLocked: boolean
   pinSet: boolean
@@ -299,8 +304,8 @@ export interface Staff {
 * Generated from fi.espoo.evaka.attendance.MobileRealtimeStaffAttendanceController.StaffArrivalRequest
 */
 export interface StaffArrivalRequest {
-  employeeId: UUID
-  groupId: UUID
+  employeeId: EmployeeId
+  groupId: GroupId
   hasStaffOccupancyEffect: boolean | null
   pinCode: string
   time: LocalTime
@@ -312,9 +317,9 @@ export interface StaffArrivalRequest {
 */
 export interface StaffAttendanceBody {
   date: LocalDate
-  employeeId: UUID
+  employeeId: EmployeeId
   entries: StaffAttendanceUpsert[]
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -343,7 +348,7 @@ export type StaffAttendanceType = typeof staffAttendanceTypes[number]
 */
 export interface StaffAttendanceUpdateRequest {
   date: LocalDate
-  employeeId: UUID
+  employeeId: EmployeeId
   pinCode: string
   rows: StaffAttendanceUpsert[]
 }
@@ -352,8 +357,8 @@ export interface StaffAttendanceUpdateRequest {
 * Generated from fi.espoo.evaka.attendance.MobileRealtimeStaffAttendanceController.StaffAttendanceUpdateResponse
 */
 export interface StaffAttendanceUpdateResponse {
-  deleted: UUID[]
-  inserted: UUID[]
+  deleted: StaffAttendanceRealtimeId[]
+  inserted: StaffAttendanceRealtimeId[]
 }
 
 /**
@@ -362,9 +367,9 @@ export interface StaffAttendanceUpdateResponse {
 export interface StaffAttendanceUpsert {
   arrived: HelsinkiDateTime
   departed: HelsinkiDateTime | null
-  groupId: UUID | null
+  groupId: GroupId | null
   hasStaffOccupancyEffect: boolean
-  id: UUID | null
+  id: StaffAttendanceRealtimeId | null
   type: StaffAttendanceType
 }
 
@@ -372,8 +377,8 @@ export interface StaffAttendanceUpsert {
 * Generated from fi.espoo.evaka.attendance.MobileRealtimeStaffAttendanceController.StaffDepartureRequest
 */
 export interface StaffDepartureRequest {
-  employeeId: UUID
-  groupId: UUID
+  employeeId: EmployeeId
+  groupId: GroupId
   pinCode: string
   time: LocalTime
   type: StaffAttendanceType | null
@@ -384,15 +389,15 @@ export interface StaffDepartureRequest {
 */
 export interface StaffMember {
   attendances: StaffMemberAttendance[]
-  employeeId: UUID
+  employeeId: EmployeeId
   firstName: string
-  groupIds: UUID[]
+  groupIds: GroupId[]
   hasFutureAttendances: boolean
   lastName: string
   latestCurrentDayAttendance: StaffMemberAttendance | null
   occupancyEffect: boolean
   plannedAttendances: PlannedStaffAttendance[]
-  present: UUID | null
+  present: GroupId | null
   spanningPlan: HelsinkiDateTimeRange | null
 }
 
@@ -403,9 +408,9 @@ export interface StaffMemberAttendance {
   arrived: HelsinkiDateTime
   departed: HelsinkiDateTime | null
   departedAutomatically: boolean
-  employeeId: UUID
-  groupId: UUID | null
-  id: UUID
+  employeeId: EmployeeId
+  groupId: GroupId | null
+  id: StaffAttendanceRealtimeId
   occupancyCoefficient: number
   type: StaffAttendanceType
 }
@@ -416,7 +421,7 @@ export interface StaffMemberAttendance {
 export interface UnitInfo {
   features: PilotFeature[]
   groups: GroupInfo[]
-  id: UUID
+  id: DaycareId
   isOperationalDate: boolean
   name: string
   staff: Staff[]
@@ -427,7 +432,7 @@ export interface UnitInfo {
 * Generated from fi.espoo.evaka.attendance.UnitStats
 */
 export interface UnitStats {
-  id: UUID
+  id: DaycareId
   name: string
   presentChildren: number
   presentStaff: number

--- a/frontend/src/lib-common/generated/api-types/backupcare.ts
+++ b/frontend/src/lib-common/generated/api-types/backupcare.ts
@@ -7,9 +7,12 @@
 import FiniteDateRange from '../../finite-date-range'
 import LocalDate from '../../local-date'
 import { Action } from '../action'
+import { BackupCareId } from './shared'
+import { DaycareId } from './shared'
+import { GroupId } from './shared'
 import { JsonOf } from '../../json'
+import { PersonId } from './shared'
 import { ServiceNeed } from './serviceneed'
-import { UUID } from '../../types'
 import { deserializeJsonServiceNeed } from './serviceneed'
 
 /**
@@ -18,7 +21,7 @@ import { deserializeJsonServiceNeed } from './serviceneed'
 export interface BackupCareChild {
   birthDate: LocalDate
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
 }
 
@@ -26,14 +29,14 @@ export interface BackupCareChild {
 * Generated from fi.espoo.evaka.backupcare.BackupCareCreateResponse
 */
 export interface BackupCareCreateResponse {
-  id: UUID
+  id: BackupCareId
 }
 
 /**
 * Generated from fi.espoo.evaka.backupcare.BackupCareGroup
 */
 export interface BackupCareGroup {
-  id: UUID
+  id: GroupId
   name: string
 }
 
@@ -41,7 +44,7 @@ export interface BackupCareGroup {
 * Generated from fi.espoo.evaka.backupcare.BackupCareUnit
 */
 export interface BackupCareUnit {
-  id: UUID
+  id: DaycareId
   name: string
 }
 
@@ -49,7 +52,7 @@ export interface BackupCareUnit {
 * Generated from fi.espoo.evaka.backupcare.BackupCareUpdateRequest
 */
 export interface BackupCareUpdateRequest {
-  groupId: UUID | null
+  groupId: GroupId | null
   period: FiniteDateRange
 }
 
@@ -58,7 +61,7 @@ export interface BackupCareUpdateRequest {
 */
 export interface ChildBackupCare {
   group: BackupCareGroup | null
-  id: UUID
+  id: BackupCareId
   period: FiniteDateRange
   unit: BackupCareUnit
 }
@@ -82,9 +85,9 @@ export interface ChildBackupCaresResponse {
 * Generated from fi.espoo.evaka.backupcare.NewBackupCare
 */
 export interface NewBackupCare {
-  groupId: UUID | null
+  groupId: GroupId | null
   period: FiniteDateRange
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -94,7 +97,7 @@ export interface UnitBackupCare {
   child: BackupCareChild
   fromUnits: string[]
   group: BackupCareGroup | null
-  id: UUID
+  id: BackupCareId
   missingServiceNeedDays: number
   period: FiniteDateRange
   serviceNeeds: ServiceNeed[]

--- a/frontend/src/lib-common/generated/api-types/backuppickup.ts
+++ b/frontend/src/lib-common/generated/api-types/backuppickup.ts
@@ -4,14 +4,15 @@
 
 // GENERATED FILE: no manual modifications
 
-import { UUID } from '../../types'
+import { BackupPickupId } from './shared'
+import { PersonId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.backuppickup.ChildBackupPickup
 */
 export interface ChildBackupPickup {
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: BackupPickupId
   name: string
   phone: string
 }
@@ -28,5 +29,5 @@ export interface ChildBackupPickupContent {
 * Generated from fi.espoo.evaka.backuppickup.ChildBackupPickupCreateResponse
 */
 export interface ChildBackupPickupCreateResponse {
-  id: UUID
+  id: BackupPickupId
 }

--- a/frontend/src/lib-common/generated/api-types/calendarevent.ts
+++ b/frontend/src/lib-common/generated/api-types/calendarevent.ts
@@ -9,9 +9,13 @@ import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import LocalTime from '../../local-time'
 import TimeRange from '../../time-range'
+import { CalendarEventAttendeeId } from './shared'
+import { CalendarEventTimeId } from './shared'
+import { DaycareId } from './shared'
 import { EvakaUser } from './user'
+import { GroupId } from './shared'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
+import { PersonId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.calendarevent.AttendanceType
@@ -40,12 +44,12 @@ export interface CalendarEvent {
   description: string
   eventType: CalendarEventType
   groups: GroupInfo[]
-  id: UUID
+  id: CalendarEventAttendeeId
   individualChildren: IndividualChild[]
   period: FiniteDateRange
   times: CalendarEventTime[]
   title: string
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -57,18 +61,18 @@ export interface CalendarEventForm {
   period: FiniteDateRange
   times: CalendarEventTimeForm[] | null
   title: string
-  tree: Partial<Record<UUID, UUID[] | null>> | null
-  unitId: UUID
+  tree: Partial<Record<GroupId, PersonId[] | null>> | null
+  unitId: DaycareId
 }
 
 /**
 * Generated from fi.espoo.evaka.calendarevent.CalendarEventTime
 */
 export interface CalendarEventTime {
-  childId: UUID | null
+  childId: PersonId | null
   date: LocalDate
   endTime: LocalTime
-  id: UUID
+  id: CalendarEventTimeId
   startTime: LocalTime
 }
 
@@ -76,24 +80,24 @@ export interface CalendarEventTime {
 * Generated from fi.espoo.evaka.calendarevent.CalendarEventTimeCitizenReservationForm
 */
 export interface CalendarEventTimeCitizenReservationForm {
-  calendarEventTimeId: UUID
-  childId: UUID
+  calendarEventTimeId: CalendarEventTimeId
+  childId: PersonId
 }
 
 /**
 * Generated from fi.espoo.evaka.calendarevent.CalendarEventTimeClearingForm
 */
 export interface CalendarEventTimeClearingForm {
-  calendarEventId: UUID
-  childId: UUID
+  calendarEventId: CalendarEventAttendeeId
+  childId: PersonId
 }
 
 /**
 * Generated from fi.espoo.evaka.calendarevent.CalendarEventTimeEmployeeReservationForm
 */
 export interface CalendarEventTimeEmployeeReservationForm {
-  calendarEventTimeId: UUID
-  childId: UUID | null
+  calendarEventTimeId: CalendarEventTimeId
+  childId: PersonId | null
 }
 
 /**
@@ -117,19 +121,19 @@ export type CalendarEventType =
 export interface CalendarEventUpdateForm {
   description: string
   title: string
-  tree: Partial<Record<UUID, UUID[] | null>> | null
+  tree: Partial<Record<GroupId, PersonId[] | null>> | null
 }
 
 /**
 * Generated from fi.espoo.evaka.calendarevent.CitizenCalendarEvent
 */
 export interface CitizenCalendarEvent {
-  attendingChildren: Partial<Record<UUID, AttendingChild[]>>
+  attendingChildren: Partial<Record<PersonId, AttendingChild[]>>
   description: string
   eventType: CalendarEventType
-  id: UUID
+  id: CalendarEventAttendeeId
   period: FiniteDateRange
-  timesByChild: Partial<Record<UUID, CitizenCalendarEventTime[]>>
+  timesByChild: Partial<Record<PersonId, CitizenCalendarEventTime[]>>
   title: string
 }
 
@@ -137,10 +141,10 @@ export interface CitizenCalendarEvent {
 * Generated from fi.espoo.evaka.calendarevent.CitizenCalendarEventTime
 */
 export interface CitizenCalendarEventTime {
-  childId: UUID | null
+  childId: PersonId | null
   date: LocalDate
   endTime: LocalTime
-  id: UUID
+  id: CalendarEventTimeId
   isEditable: boolean
   startTime: LocalTime
 }
@@ -159,7 +163,7 @@ export interface DiscussionReservationDay {
 * Generated from fi.espoo.evaka.calendarevent.GroupInfo
 */
 export interface GroupInfo {
-  id: UUID
+  id: GroupId
   name: string
 }
 
@@ -168,8 +172,8 @@ export interface GroupInfo {
 */
 export interface IndividualChild {
   firstName: string
-  groupId: UUID
-  id: UUID
+  groupId: GroupId
+  id: PersonId
   lastName: string
 }
 

--- a/frontend/src/lib-common/generated/api-types/calendarevent.ts
+++ b/frontend/src/lib-common/generated/api-types/calendarevent.ts
@@ -9,7 +9,7 @@ import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import LocalTime from '../../local-time'
 import TimeRange from '../../time-range'
-import { CalendarEventAttendeeId } from './shared'
+import { CalendarEventId } from './shared'
 import { CalendarEventTimeId } from './shared'
 import { DaycareId } from './shared'
 import { EvakaUser } from './user'
@@ -44,7 +44,7 @@ export interface CalendarEvent {
   description: string
   eventType: CalendarEventType
   groups: GroupInfo[]
-  id: CalendarEventAttendeeId
+  id: CalendarEventId
   individualChildren: IndividualChild[]
   period: FiniteDateRange
   times: CalendarEventTime[]
@@ -88,7 +88,7 @@ export interface CalendarEventTimeCitizenReservationForm {
 * Generated from fi.espoo.evaka.calendarevent.CalendarEventTimeClearingForm
 */
 export interface CalendarEventTimeClearingForm {
-  calendarEventId: CalendarEventAttendeeId
+  calendarEventId: CalendarEventId
   childId: PersonId
 }
 
@@ -131,7 +131,7 @@ export interface CitizenCalendarEvent {
   attendingChildren: Partial<Record<PersonId, AttendingChild[]>>
   description: string
   eventType: CalendarEventType
-  id: CalendarEventAttendeeId
+  id: CalendarEventId
   period: FiniteDateRange
   timesByChild: Partial<Record<PersonId, CitizenCalendarEventTime[]>>
   title: string

--- a/frontend/src/lib-common/generated/api-types/children.ts
+++ b/frontend/src/lib-common/generated/api-types/children.ts
@@ -5,8 +5,11 @@
 // GENERATED FILE: no manual modifications
 
 import { Action } from '../action'
+import { ChildImageId } from './shared'
+import { DaycareId } from './shared'
+import { GroupId } from './shared'
+import { PersonId } from './shared'
 import { PlacementType } from './placement'
-import { UUID } from '../../types'
 
 /**
 * Generated from fi.espoo.evaka.children.AttendanceSummary
@@ -19,12 +22,12 @@ export interface AttendanceSummary {
 * Generated from fi.espoo.evaka.children.ChildAndPermittedActions
 */
 export interface ChildAndPermittedActions {
-  duplicateOf: UUID | null
+  duplicateOf: PersonId | null
   firstName: string
   group: Group | null
   hasPedagogicalDocuments: boolean
-  id: UUID
-  imageId: UUID | null
+  id: PersonId
+  imageId: ChildImageId | null
   lastName: string
   permittedActions: Action.Citizen.Child[]
   preferredName: string
@@ -37,7 +40,7 @@ export interface ChildAndPermittedActions {
 * Generated from fi.espoo.evaka.children.Group
 */
 export interface Group {
-  id: UUID
+  id: GroupId
   name: string
 }
 
@@ -45,6 +48,6 @@ export interface Group {
 * Generated from fi.espoo.evaka.children.Unit
 */
 export interface Unit {
-  id: UUID
+  id: DaycareId
   name: string
 }

--- a/frontend/src/lib-common/generated/api-types/dailyservicetimes.ts
+++ b/frontend/src/lib-common/generated/api-types/dailyservicetimes.ts
@@ -8,15 +8,16 @@ import DateRange from '../../date-range'
 import LocalDate from '../../local-date'
 import TimeRange from '../../time-range'
 import { Action } from '../action'
+import { DailyServicesTimeId } from './shared'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
+import { PersonId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.dailyservicetimes.DailyServiceTimes
 */
 export interface DailyServiceTimes {
-  childId: UUID
-  id: UUID
+  childId: PersonId
+  id: DailyServicesTimeId
   times: DailyServiceTimesValue
 }
 

--- a/frontend/src/lib-common/generated/api-types/dailyservicetimes.ts
+++ b/frontend/src/lib-common/generated/api-types/dailyservicetimes.ts
@@ -8,7 +8,7 @@ import DateRange from '../../date-range'
 import LocalDate from '../../local-date'
 import TimeRange from '../../time-range'
 import { Action } from '../action'
-import { DailyServicesTimeId } from './shared'
+import { DailyServiceTimeId } from './shared'
 import { JsonOf } from '../../json'
 import { PersonId } from './shared'
 
@@ -17,7 +17,7 @@ import { PersonId } from './shared'
 */
 export interface DailyServiceTimes {
   childId: PersonId
-  id: DailyServicesTimeId
+  id: DailyServiceTimeId
   times: DailyServiceTimesValue
 }
 

--- a/frontend/src/lib-common/generated/api-types/daycare.ts
+++ b/frontend/src/lib-common/generated/api-types/daycare.ts
@@ -10,17 +10,26 @@ import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import TimeRange from '../../time-range'
 import { Action } from '../action'
+import { AreaId } from './shared'
+import { BackupCareId } from './shared'
+import { ClubTermId } from './shared'
 import { Coordinate } from './shared'
+import { DaycareCaretakerId } from './shared'
+import { DaycareId } from './shared'
 import { DaycarePlacementWithDetails } from './placement'
+import { EmployeeId } from './shared'
+import { GroupId } from './shared'
+import { GroupPlacementId } from './shared'
 import { JsonOf } from '../../json'
 import { MealTexture } from './specialdiet'
 import { MissingGroupPlacement } from './placement'
 import { OccupancyResponse } from './occupancy'
 import { PersonJSON } from './pis'
 import { PilotFeature } from './shared'
+import { PlacementId } from './shared'
+import { PreschoolTermId } from './shared'
 import { SpecialDiet } from './specialdiet'
 import { TerminatedPlacement } from './placement'
-import { UUID } from '../../types'
 import { UnitBackupCare } from './backupcare'
 import { UnitChildrenCapacityFactors } from './placement'
 import { UserRole } from './shared'
@@ -35,7 +44,7 @@ import { deserializeJsonUnitBackupCare } from './backupcare'
 * Generated from fi.espoo.evaka.daycare.controllers.UnitAclController.AclUpdate
 */
 export interface AclUpdate {
-  groupIds: UUID[] | null
+  groupIds: GroupId[] | null
   hasStaffOccupancyEffect: boolean | null
 }
 
@@ -67,7 +76,7 @@ export type ApplicationUnitType =
 * Generated from fi.espoo.evaka.daycare.controllers.AreaJSON
 */
 export interface AreaJSON {
-  id: UUID
+  id: AreaId
   name: string
   shortName: string
 }
@@ -92,8 +101,8 @@ export type CareType = typeof careTypes[number]
 export interface CaretakerAmount {
   amount: number
   endDate: LocalDate | null
-  groupId: UUID
-  id: UUID
+  groupId: GroupId
+  id: DaycareCaretakerId
   startDate: LocalDate
 }
 
@@ -138,7 +147,7 @@ export interface ChildResponse {
 */
 export interface ClubTerm {
   applicationPeriod: FiniteDateRange
-  id: UUID
+  id: ClubTermId
   term: FiniteDateRange
   termBreaks: FiniteDateRange[]
 }
@@ -156,7 +165,7 @@ export interface ClubTermRequest {
 * Generated from fi.espoo.evaka.daycare.controllers.DaycareController.CreateDaycareResponse
 */
 export interface CreateDaycareResponse {
-  id: UUID
+  id: DaycareId
 }
 
 /**
@@ -189,7 +198,7 @@ export interface Daycare {
   financeDecisionHandler: FinanceDecisionHandler | null
   ghostUnit: boolean
   iban: string
-  id: UUID
+  id: DaycareId
   invoicedByMunicipality: boolean
   language: Language
   location: Coordinate | null
@@ -222,7 +231,7 @@ export interface Daycare {
 * Generated from fi.espoo.evaka.daycare.DaycareCareArea
 */
 export interface DaycareCareArea {
-  id: UUID
+  id: AreaId
   name: string
   shortName: string
 }
@@ -242,7 +251,7 @@ export interface DaycareDecisionCustomization {
 */
 export interface DaycareFields {
   additionalInfo: string | null
-  areaId: UUID
+  areaId: AreaId
   businessId: string
   capacity: number
   closingDate: LocalDate | null
@@ -254,7 +263,7 @@ export interface DaycareFields {
   decisionCustomization: DaycareDecisionCustomization
   dwCostCenter: string | null
   email: string | null
-  financeDecisionHandlerId: UUID | null
+  financeDecisionHandlerId: EmployeeId | null
   ghostUnit: boolean
   iban: string
   invoicedByMunicipality: boolean
@@ -287,10 +296,10 @@ export interface DaycareFields {
 * Generated from fi.espoo.evaka.daycare.service.DaycareGroup
 */
 export interface DaycareGroup {
-  daycareId: UUID
+  daycareId: DaycareId
   deletable: boolean
   endDate: LocalDate | null
-  id: UUID
+  id: GroupId
   jamixCustomerNumber: number | null
   name: string
   startDate: LocalDate
@@ -301,7 +310,7 @@ export interface DaycareGroup {
 */
 export interface DaycareGroupResponse {
   endDate: LocalDate | null
-  id: UUID
+  id: GroupId
   name: string
   permittedActions: Action.Group[]
 }
@@ -332,7 +341,7 @@ export interface DaycareResponse {
 */
 export interface FinanceDecisionHandler {
   firstName: string
-  id: UUID
+  id: EmployeeId
   lastName: string
 }
 
@@ -348,8 +357,8 @@ export interface FullAclInfo {
 * Generated from fi.espoo.evaka.daycare.controllers.GroupOccupancies
 */
 export interface GroupOccupancies {
-  confirmed: Partial<Record<UUID, OccupancyResponse>>
-  realized: Partial<Record<UUID, OccupancyResponse>>
+  confirmed: Partial<Record<GroupId, OccupancyResponse>>
+  realized: Partial<Record<GroupId, OccupancyResponse>>
 }
 
 /**
@@ -359,7 +368,7 @@ export interface GroupStaffAttendance {
   count: number
   countOther: number
   date: LocalDate
-  groupId: UUID
+  groupId: GroupId
   updated: HelsinkiDateTime
 }
 
@@ -398,7 +407,7 @@ export interface PreschoolTerm {
   applicationPeriod: FiniteDateRange
   extendedTerm: FiniteDateRange
   finnishPreschool: FiniteDateRange
-  id: UUID
+  id: PreschoolTermId
   swedishPreschool: FiniteDateRange
   termBreaks: FiniteDateRange[]
 }
@@ -433,7 +442,7 @@ export interface PublicUnit {
   daycareApplyPeriod: DateRange | null
   email: string | null
   ghostUnit: boolean | null
-  id: UUID
+  id: DaycareId
   language: Language
   location: Coordinate | null
   name: string
@@ -454,7 +463,7 @@ export interface PublicUnit {
 export interface StaffAttendanceForDates {
   attendances: Partial<Record<string, GroupStaffAttendance>>
   endDate: LocalDate | null
-  groupId: UUID
+  groupId: GroupId
   groupName: string
   startDate: LocalDate
 }
@@ -466,7 +475,7 @@ export interface StaffAttendanceUpdate {
   count: number | null
   countOther: number | null
   date: LocalDate
-  groupId: UUID
+  groupId: GroupId
 }
 
 /**
@@ -474,7 +483,7 @@ export interface StaffAttendanceUpdate {
 */
 export interface UnitFeatures {
   features: PilotFeature[]
-  id: UUID
+  id: DaycareId
   name: string
   providerType: ProviderType
   type: CareType[]
@@ -485,13 +494,13 @@ export interface UnitFeatures {
 */
 export interface UnitGroupDetails {
   backupCares: UnitBackupCare[]
-  caretakers: Partial<Record<UUID, Caretakers>>
+  caretakers: Partial<Record<GroupId, Caretakers>>
   groupOccupancies: GroupOccupancies | null
   groups: DaycareGroup[]
   missingGroupPlacements: MissingGroupPlacement[]
-  permittedBackupCareActions: Partial<Record<UUID, Action.BackupCare[]>>
-  permittedGroupPlacementActions: Partial<Record<UUID, Action.GroupPlacement[]>>
-  permittedPlacementActions: Partial<Record<UUID, Action.Placement[]>>
+  permittedBackupCareActions: Partial<Record<BackupCareId, Action.BackupCare[]>>
+  permittedGroupPlacementActions: Partial<Record<GroupPlacementId, Action.GroupPlacement[]>>
+  permittedPlacementActions: Partial<Record<PlacementId, Action.Placement[]>>
   placements: DaycarePlacementWithDetails[]
   recentlyTerminatedPlacements: TerminatedPlacement[]
   unitChildrenCapacityFactors: UnitChildrenCapacityFactors[]
@@ -530,7 +539,7 @@ export interface UnitStaffAttendance {
 */
 export interface UnitStub {
   careTypes: CareType[]
-  id: UUID
+  id: DaycareId
   name: string
 }
 
@@ -549,7 +558,7 @@ export type UnitTypeFilter =
 export interface UpdateFeaturesRequest {
   enable: boolean
   features: PilotFeature[]
-  unitIds: UUID[]
+  unitIds: DaycareId[]
 }
 
 /**

--- a/frontend/src/lib-common/generated/api-types/daycare.ts
+++ b/frontend/src/lib-common/generated/api-types/daycare.ts
@@ -22,6 +22,7 @@ import { GroupId } from './shared'
 import { GroupPlacementId } from './shared'
 import { JsonOf } from '../../json'
 import { MealTexture } from './specialdiet'
+import { MissingBackupGroupPlacement } from './placement'
 import { MissingGroupPlacement } from './placement'
 import { OccupancyResponse } from './occupancy'
 import { PersonJSON } from './pis'
@@ -34,6 +35,7 @@ import { UnitBackupCare } from './backupcare'
 import { UnitChildrenCapacityFactors } from './placement'
 import { UserRole } from './shared'
 import { deserializeJsonDaycarePlacementWithDetails } from './placement'
+import { deserializeJsonMissingBackupGroupPlacement } from './placement'
 import { deserializeJsonMissingGroupPlacement } from './placement'
 import { deserializeJsonOccupancyResponse } from './occupancy'
 import { deserializeJsonPersonJSON } from './pis'
@@ -497,6 +499,7 @@ export interface UnitGroupDetails {
   caretakers: Partial<Record<GroupId, Caretakers>>
   groupOccupancies: GroupOccupancies | null
   groups: DaycareGroup[]
+  missingBackupGroupPlacements: MissingBackupGroupPlacement[]
   missingGroupPlacements: MissingGroupPlacement[]
   permittedBackupCareActions: Partial<Record<BackupCareId, Action.BackupCare[]>>
   permittedGroupPlacementActions: Partial<Record<GroupPlacementId, Action.GroupPlacement[]>>
@@ -797,6 +800,7 @@ export function deserializeJsonUnitGroupDetails(json: JsonOf<UnitGroupDetails>):
     backupCares: json.backupCares.map(e => deserializeJsonUnitBackupCare(e)),
     groupOccupancies: (json.groupOccupancies != null) ? deserializeJsonGroupOccupancies(json.groupOccupancies) : null,
     groups: json.groups.map(e => deserializeJsonDaycareGroup(e)),
+    missingBackupGroupPlacements: json.missingBackupGroupPlacements.map(e => deserializeJsonMissingBackupGroupPlacement(e)),
     missingGroupPlacements: json.missingGroupPlacements.map(e => deserializeJsonMissingGroupPlacement(e)),
     placements: json.placements.map(e => deserializeJsonDaycarePlacementWithDetails(e)),
     recentlyTerminatedPlacements: json.recentlyTerminatedPlacements.map(e => deserializeJsonTerminatedPlacement(e))

--- a/frontend/src/lib-common/generated/api-types/decision.ts
+++ b/frontend/src/lib-common/generated/api-types/decision.ts
@@ -5,23 +5,26 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from '../../local-date'
+import { ApplicationId } from './shared'
+import { DaycareId } from './shared'
+import { DecisionId } from './shared'
 import { JsonOf } from '../../json'
+import { PersonId } from './shared'
 import { ProviderType } from './daycare'
-import { UUID } from '../../types'
 
 /**
 * Generated from fi.espoo.evaka.decision.Decision
 */
 export interface Decision {
-  applicationId: UUID
-  childId: UUID
+  applicationId: ApplicationId
+  childId: PersonId
   childName: string
   createdBy: string
   decisionNumber: number
   documentContainsContactInfo: boolean
   documentKey: string | null
   endDate: LocalDate
-  id: UUID
+  id: DecisionId
   requestedStartDate: LocalDate | null
   resolved: LocalDate | null
   resolvedByName: string | null
@@ -37,11 +40,11 @@ export interface Decision {
 */
 export interface DecisionDraft {
   endDate: LocalDate
-  id: UUID
+  id: DecisionId
   planned: boolean
   startDate: LocalDate
   type: DecisionType
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -49,10 +52,10 @@ export interface DecisionDraft {
 */
 export interface DecisionDraftUpdate {
   endDate: LocalDate
-  id: UUID
+  id: DecisionId
   planned: boolean
   startDate: LocalDate
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -89,7 +92,7 @@ export interface DecisionUnit {
   daycareDecisionName: string
   decisionHandler: string
   decisionHandlerAddress: string
-  id: UUID
+  id: DaycareId
   manager: string | null
   name: string
   phone: string | null

--- a/frontend/src/lib-common/generated/api-types/document.ts
+++ b/frontend/src/lib-common/generated/api-types/document.ts
@@ -8,10 +8,13 @@ import DateRange from '../../date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import { Action } from '../action'
+import { ChildDocumentId } from './shared'
+import { DocumentTemplateId } from './shared'
+import { EmployeeId } from './shared'
 import { JsonOf } from '../../json'
 import { OfficialLanguage } from './shared'
+import { PersonId } from './shared'
 import { PlacementType } from './placement'
-import { UUID } from '../../types'
 
 
 export namespace AnsweredQuestion {
@@ -108,7 +111,7 @@ export interface CheckboxGroupQuestionOption {
 export interface ChildBasics {
   dateOfBirth: LocalDate | null
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
 }
 
@@ -119,7 +122,7 @@ export interface ChildDocumentCitizenDetails {
   child: ChildBasics
   content: DocumentContent
   downloadable: boolean
-  id: UUID
+  id: ChildDocumentId
   publishedAt: HelsinkiDateTime | null
   status: DocumentStatus
   template: DocumentTemplate
@@ -129,7 +132,7 @@ export interface ChildDocumentCitizenDetails {
 * Generated from fi.espoo.evaka.document.childdocument.ChildDocumentCitizenSummary
 */
 export interface ChildDocumentCitizenSummary {
-  id: UUID
+  id: ChildDocumentId
   publishedAt: HelsinkiDateTime
   status: DocumentStatus
   templateName: string
@@ -141,8 +144,8 @@ export interface ChildDocumentCitizenSummary {
 * Generated from fi.espoo.evaka.document.childdocument.ChildDocumentCreateRequest
 */
 export interface ChildDocumentCreateRequest {
-  childId: UUID
-  templateId: UUID
+  childId: PersonId
+  templateId: DocumentTemplateId
 }
 
 /**
@@ -151,7 +154,7 @@ export interface ChildDocumentCreateRequest {
 export interface ChildDocumentDetails {
   child: ChildBasics
   content: DocumentContent
-  id: UUID
+  id: ChildDocumentId
   publishedAt: HelsinkiDateTime | null
   publishedContent: DocumentContent | null
   status: DocumentStatus
@@ -162,11 +165,11 @@ export interface ChildDocumentDetails {
 * Generated from fi.espoo.evaka.document.childdocument.ChildDocumentSummary
 */
 export interface ChildDocumentSummary {
-  id: UUID
+  id: ChildDocumentId
   modifiedAt: HelsinkiDateTime
   publishedAt: HelsinkiDateTime | null
   status: DocumentStatus
-  templateId: UUID
+  templateId: DocumentTemplateId
   templateName: string
   type: DocumentType
 }
@@ -217,7 +220,7 @@ export interface DocumentTemplate {
   archiveDurationMonths: number | null
   confidential: boolean
   content: DocumentTemplateContent
-  id: UUID
+  id: DocumentTemplateId
   language: OfficialLanguage
   legalBasis: string
   name: string
@@ -255,7 +258,7 @@ export interface DocumentTemplateContent {
 */
 export interface DocumentTemplateSummary {
   documentCount: number
-  id: UUID
+  id: DocumentTemplateId
   language: OfficialLanguage
   name: string
   placementTypes: PlacementType[]
@@ -284,7 +287,7 @@ export type DocumentType = typeof documentTypes[number]
 * Generated from fi.espoo.evaka.document.childdocument.DocumentWriteLock
 */
 export interface DocumentWriteLock {
-  modifiedBy: UUID
+  modifiedBy: EmployeeId
   modifiedByName: string
   opensAt: HelsinkiDateTime
 }

--- a/frontend/src/lib-common/generated/api-types/holidayperiod.ts
+++ b/frontend/src/lib-common/generated/api-types/holidayperiod.ts
@@ -7,15 +7,17 @@
 import FiniteDateRange from '../../finite-date-range'
 import LocalDate from '../../local-date'
 import { AbsenceType } from './absence'
+import { HolidayPeriodId } from './shared'
+import { HolidayQuestionnaireId } from './shared'
 import { JsonOf } from '../../json'
+import { PersonId } from './shared'
 import { Translatable } from './shared'
-import { UUID } from '../../types'
 
 /**
 * Generated from fi.espoo.evaka.holidayperiod.ActiveQuestionnaire
 */
 export interface ActiveQuestionnaire {
-  eligibleChildren: UUID[]
+  eligibleChildren: PersonId[]
   previousAnswers: HolidayQuestionnaireAnswer[]
   questionnaire: FixedPeriodQuestionnaire
 }
@@ -29,7 +31,7 @@ export interface FixedPeriodQuestionnaire {
   conditions: QuestionnaireConditions
   description: Translatable
   descriptionLink: Translatable
-  id: UUID
+  id: HolidayQuestionnaireId
   periodOptionLabel: Translatable
   periodOptions: FiniteDateRange[]
   requiresStrongAuth: boolean
@@ -56,14 +58,14 @@ export interface FixedPeriodQuestionnaireBody {
 * Generated from fi.espoo.evaka.holidayperiod.FixedPeriodsBody
 */
 export interface FixedPeriodsBody {
-  fixedPeriods: Partial<Record<UUID, FiniteDateRange | null>>
+  fixedPeriods: Partial<Record<PersonId, FiniteDateRange | null>>
 }
 
 /**
 * Generated from fi.espoo.evaka.holidayperiod.HolidayPeriod
 */
 export interface HolidayPeriod {
-  id: UUID
+  id: HolidayPeriodId
   period: FiniteDateRange
   reservationDeadline: LocalDate
   reservationsOpenOn: LocalDate
@@ -122,9 +124,9 @@ export interface HolidayPeriodUpdate {
 * Generated from fi.espoo.evaka.holidayperiod.HolidayQuestionnaireAnswer
 */
 export interface HolidayQuestionnaireAnswer {
-  childId: UUID
+  childId: PersonId
   fixedPeriod: FiniteDateRange | null
-  questionnaireId: UUID
+  questionnaireId: HolidayQuestionnaireId
 }
 
 /**

--- a/frontend/src/lib-common/generated/api-types/incomestatement.ts
+++ b/frontend/src/lib-common/generated/api-types/incomestatement.ts
@@ -6,10 +6,13 @@
 
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
+import { AttachmentId } from './shared'
+import { DaycareId } from './shared'
+import { IncomeStatementId } from './shared'
 import { JsonOf } from '../../json'
+import { PersonId } from './shared'
 import { ProviderType } from './daycare'
 import { SortDirection } from './invoicing'
-import { UUID } from '../../types'
 
 /**
 * Generated from fi.espoo.evaka.incomestatement.Accountant
@@ -26,7 +29,7 @@ export interface Accountant {
 */
 export interface Attachment {
   contentType: string
-  id: UUID
+  id: AttachmentId
   name: string
   uploadedByEmployee: boolean
 }
@@ -36,7 +39,7 @@ export interface Attachment {
 */
 export interface ChildBasicInfo {
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
 }
 
@@ -95,11 +98,11 @@ export namespace IncomeStatement {
     firstName: string
     handledAt: HelsinkiDateTime | null
     handlerNote: string
-    id: UUID
+    id: IncomeStatementId
     lastName: string
     modifiedAt: HelsinkiDateTime
     otherInfo: string
-    personId: UUID
+    personId: PersonId
     sentAt: HelsinkiDateTime | null
     startDate: LocalDate
     status: IncomeStatementStatus
@@ -115,10 +118,10 @@ export namespace IncomeStatement {
     firstName: string
     handledAt: HelsinkiDateTime | null
     handlerNote: string
-    id: UUID
+    id: IncomeStatementId
     lastName: string
     modifiedAt: HelsinkiDateTime
-    personId: UUID
+    personId: PersonId
     sentAt: HelsinkiDateTime | null
     startDate: LocalDate
     status: IncomeStatementStatus
@@ -138,11 +141,11 @@ export namespace IncomeStatement {
     gross: Gross | null
     handledAt: HelsinkiDateTime | null
     handlerNote: string
-    id: UUID
+    id: IncomeStatementId
     lastName: string
     modifiedAt: HelsinkiDateTime
     otherInfo: string
-    personId: UUID
+    personId: PersonId
     sentAt: HelsinkiDateTime | null
     startDate: LocalDate
     status: IncomeStatementStatus
@@ -161,10 +164,10 @@ export type IncomeStatement = IncomeStatement.ChildIncome | IncomeStatement.High
 */
 export interface IncomeStatementAwaitingHandler {
   handlerNote: string
-  id: UUID
+  id: IncomeStatementId
   incomeEndDate: LocalDate | null
   personFirstName: string
-  personId: UUID
+  personId: PersonId
   personLastName: string
   personName: string
   primaryCareArea: string | null
@@ -180,7 +183,7 @@ export namespace IncomeStatementBody {
   */
   export interface ChildIncome {
     type: 'CHILD_INCOME'
-    attachmentIds: UUID[]
+    attachmentIds: AttachmentId[]
     endDate: LocalDate | null
     otherInfo: string
     startDate: LocalDate
@@ -201,7 +204,7 @@ export namespace IncomeStatementBody {
   export interface Income {
     type: 'INCOME'
     alimonyPayer: boolean
-    attachmentIds: UUID[]
+    attachmentIds: AttachmentId[]
     endDate: LocalDate | null
     entrepreneur: Entrepreneur | null
     gross: Gross | null
@@ -313,7 +316,7 @@ export interface SearchIncomeStatementsRequest {
   sentStartDate: LocalDate | null
   sortBy: IncomeStatementSortParam | null
   sortDirection: SortDirection | null
-  unit: UUID | null
+  unit: DaycareId | null
 }
 
 /**

--- a/frontend/src/lib-common/generated/api-types/invoicing.ts
+++ b/frontend/src/lib-common/generated/api-types/invoicing.ts
@@ -10,20 +10,37 @@ import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import YearMonth from '../../year-month'
 import { Action } from '../action'
+import { ApplicationId } from './shared'
+import { AreaId } from './shared'
+import { AttachmentId } from './shared'
 import { CareType } from './daycare'
+import { DaycareId } from './shared'
+import { EmployeeId } from './shared'
 import { EvakaUser } from './user'
+import { EvakaUserId } from './shared'
+import { FeeAlterationId } from './shared'
+import { FeeDecisionId } from './shared'
+import { FeeThresholdsId } from './shared'
 import { IncomeAttachment } from './attachment'
+import { IncomeId } from './shared'
+import { InvoiceCorrectionId } from './shared'
+import { InvoiceId } from './shared'
+import { InvoiceRowId } from './shared'
 import { JsonOf } from '../../json'
+import { PaymentId } from './shared'
+import { PersonId } from './shared'
 import { PlacementType } from './placement'
 import { ProviderType } from './daycare'
-import { UUID } from '../../types'
+import { ServiceNeedOptionId } from './shared'
+import { ServiceNeedOptionVoucherValueId } from './shared'
+import { VoucherValueDecisionId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.invoicing.domain.ChildWithDateOfBirth
 */
 export interface ChildWithDateOfBirth {
   dateOfBirth: LocalDate
-  id: UUID
+  id: PersonId
 }
 
 /**
@@ -65,7 +82,7 @@ export type DistinctiveParams = typeof feeDecisionDistinctiveParams[number]
 */
 export interface EmployeeWithName {
   firstName: string
-  id: UUID
+  id: EmployeeId
   lastName: string
 }
 
@@ -75,12 +92,12 @@ export interface EmployeeWithName {
 export interface FeeAlteration {
   amount: number
   attachments: FeeAlterationAttachment[]
-  id: UUID | null
+  id: FeeAlterationId | null
   isAbsolute: boolean
   modifiedAt: HelsinkiDateTime | null
   modifiedBy: EvakaUser | null
   notes: string
-  personId: UUID
+  personId: PersonId
   type: FeeAlterationType
   validFrom: LocalDate
   validTo: LocalDate | null
@@ -91,7 +108,7 @@ export interface FeeAlteration {
 */
 export interface FeeAlterationAttachment {
   contentType: string
-  id: UUID
+  id: AttachmentId
   name: string
 }
 
@@ -129,20 +146,20 @@ export interface FeeAlterationWithPermittedActions {
 */
 export interface FeeDecision {
   approvedAt: HelsinkiDateTime | null
-  approvedById: UUID | null
+  approvedById: EmployeeId | null
   children: FeeDecisionChild[]
   created: HelsinkiDateTime
-  decisionHandlerId: UUID | null
+  decisionHandlerId: EmployeeId | null
   decisionNumber: number | null
   decisionType: FeeDecisionType
   difference: FeeDecisionDifference[]
   documentKey: string | null
   familySize: number
   feeThresholds: FeeDecisionThresholds
-  headOfFamilyId: UUID
+  headOfFamilyId: PersonId
   headOfFamilyIncome: DecisionIncome | null
-  id: UUID
-  partnerId: UUID | null
+  id: FeeDecisionId
+  partnerId: PersonId | null
   partnerIncome: DecisionIncome | null
   sentAt: HelsinkiDateTime | null
   status: FeeDecisionStatus
@@ -183,7 +200,7 @@ export interface FeeDecisionChildDetailed {
   serviceNeedDescriptionSv: string
   serviceNeedFeeCoefficient: number
   serviceNeedMissing: boolean
-  serviceNeedOptionId: UUID | null
+  serviceNeedOptionId: ServiceNeedOptionId | null
   siblingDiscount: number
 }
 
@@ -205,7 +222,7 @@ export interface FeeDecisionDetailed {
   financeDecisionHandlerLastName: string | null
   headOfFamily: PersonDetailed
   headOfFamilyIncome: DecisionIncome | null
-  id: UUID
+  id: FeeDecisionId
   incomeEffect: IncomeEffect
   isRetroactive: boolean
   partner: PersonDetailed | null
@@ -241,7 +258,7 @@ export type FeeDecisionDifference = typeof feeDecisionDifferences[number]
 */
 export interface FeeDecisionPlacement {
   type: PlacementType
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -253,7 +270,7 @@ export interface FeeDecisionServiceNeed {
   descriptionSv: string
   feeCoefficient: number
   missing: boolean
-  optionId: UUID | null
+  optionId: ServiceNeedOptionId | null
 }
 
 /**
@@ -291,7 +308,7 @@ export interface FeeDecisionSummary {
   difference: FeeDecisionDifference[]
   finalPrice: number
   headOfFamily: PersonBasic
-  id: UUID
+  id: FeeDecisionId
   sentAt: HelsinkiDateTime | null
   status: FeeDecisionStatus
   validDuring: FiniteDateRange
@@ -359,7 +376,7 @@ export interface FeeThresholds {
 * Generated from fi.espoo.evaka.invoicing.controller.FeeThresholdsWithId
 */
 export interface FeeThresholdsWithId {
-  id: UUID
+  id: FeeThresholdsId
   thresholds: FeeThresholds
 }
 
@@ -378,23 +395,23 @@ export type FinanceDecisionType = typeof financeDecisionTypes[number]
 */
 export interface GenerateDecisionsBody {
   starting: string
-  targetHeads: (UUID | null)[]
+  targetHeads: (PersonId | null)[]
 }
 
 /**
 * Generated from fi.espoo.evaka.invoicing.domain.Income
 */
 export interface Income {
-  applicationId: UUID | null
+  applicationId: ApplicationId | null
   attachments: IncomeAttachment[]
   data: Partial<Record<string, IncomeValue>>
   effect: IncomeEffect
-  id: UUID
+  id: IncomeId
   isEntrepreneur: boolean
   modifiedAt: HelsinkiDateTime
   modifiedBy: EvakaUser
   notes: string
-  personId: UUID
+  personId: PersonId
   total: number
   totalExpenses: number
   totalIncome: number
@@ -433,7 +450,7 @@ export type IncomeEffect =
 export interface IncomeNotification {
   created: HelsinkiDateTime
   notificationType: IncomeNotificationType
-  receiverId: UUID
+  receiverId: PersonId
 }
 
 /**
@@ -465,7 +482,7 @@ export interface IncomeRequest {
   effect: IncomeEffect
   isEntrepreneur: boolean
   notes: string
-  personId: UUID
+  personId: PersonId
   validFrom: LocalDate
   validTo: LocalDate | null
   worksAtECHA: boolean
@@ -510,16 +527,16 @@ export interface InvoiceCodes {
 */
 export interface InvoiceCorrection {
   amount: number
-  childId: UUID
+  childId: PersonId
   description: string
-  headOfFamilyId: UUID
-  id: UUID
+  headOfFamilyId: PersonId
+  id: InvoiceCorrectionId
   invoice: InvoiceWithCorrection | null
   note: string
   period: FiniteDateRange
   product: string
   targetMonth: YearMonth | null
-  unitId: UUID
+  unitId: DaycareId
   unitPrice: number
 }
 
@@ -528,13 +545,13 @@ export interface InvoiceCorrection {
 */
 export interface InvoiceCorrectionInsert {
   amount: number
-  childId: UUID
+  childId: PersonId
   description: string
-  headOfFamilyId: UUID
+  headOfFamilyId: PersonId
   note: string
   period: FiniteDateRange
   product: string
-  unitId: UUID
+  unitId: DaycareId
   unitPrice: number
 }
 
@@ -551,7 +568,7 @@ export interface InvoiceCorrectionWithPermittedActions {
 */
 export interface InvoiceDaycare {
   costCenter: string | null
-  id: UUID
+  id: DaycareId
   name: string
 }
 
@@ -561,17 +578,17 @@ export interface InvoiceDaycare {
 export interface InvoiceDetailed {
   account: number
   agreementType: number | null
-  areaId: UUID
+  areaId: AreaId
   codebtor: PersonDetailed | null
   dueDate: LocalDate
   headOfFamily: PersonDetailed
-  id: UUID
+  id: InvoiceId
   invoiceDate: LocalDate
   number: number | null
   periodEnd: LocalDate
   periodStart: LocalDate
   relatedFeeDecisions: RelatedFeeDecision[]
-  replacedInvoiceId: UUID | null
+  replacedInvoiceId: InvoiceId | null
   replacementNotes: string | null
   replacementReason: InvoiceReplacementReason | null
   revisionNumber: number
@@ -629,11 +646,11 @@ export type InvoiceReplacementReason = typeof invoiceReplacementReasons[number]
 export interface InvoiceRowDetailed {
   amount: number
   child: PersonDetailed
-  correctionId: UUID | null
+  correctionId: InvoiceCorrectionId | null
   costCenter: string
   daycareType: CareType[]
   description: string
-  id: UUID
+  id: InvoiceRowId
   note: string | null
   periodEnd: LocalDate
   periodStart: LocalDate
@@ -641,7 +658,7 @@ export interface InvoiceRowDetailed {
   product: string
   savedCostCenter: string | null
   subCostCenter: string | null
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
   unitPrice: number
   unitProviderType: ProviderType
@@ -676,12 +693,12 @@ export interface InvoiceSummary {
   children: PersonBasic[]
   createdAt: HelsinkiDateTime | null
   headOfFamily: PersonDetailed
-  id: UUID
+  id: InvoiceId
   periodEnd: LocalDate
   periodStart: LocalDate
   revisionNumber: number
   sentAt: HelsinkiDateTime | null
-  sentBy: UUID | null
+  sentBy: EvakaUserId | null
   status: InvoiceStatus
   totalPrice: number
 }
@@ -698,7 +715,7 @@ export interface InvoiceSummaryResponse {
 * Generated from fi.espoo.evaka.invoicing.service.InvoiceWithCorrection
 */
 export interface InvoiceWithCorrection {
-  id: UUID
+  id: InvoiceId
   status: InvoiceStatus
 }
 
@@ -760,12 +777,12 @@ export interface Payment {
   amount: number
   created: HelsinkiDateTime
   dueDate: LocalDate | null
-  id: UUID
+  id: PaymentId
   number: number | null
   paymentDate: LocalDate | null
   period: DateRange
   sentAt: HelsinkiDateTime | null
-  sentBy: UUID | null
+  sentBy: EvakaUserId | null
   status: PaymentStatus
   unit: PaymentUnit
   updated: HelsinkiDateTime
@@ -802,7 +819,7 @@ export interface PaymentUnit {
   businessId: string | null
   careType: CareType[]
   iban: string | null
-  id: UUID
+  id: DaycareId
   name: string
   providerId: string | null
 }
@@ -813,7 +830,7 @@ export interface PaymentUnit {
 export interface PersonBasic {
   dateOfBirth: LocalDate
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   ssn: string | null
 }
@@ -827,7 +844,7 @@ export interface PersonDetailed {
   email: string | null
   firstName: string
   forceManualFeeDecisions: boolean
-  id: UUID
+  id: PersonId
   invoiceRecipientName: string
   invoicingPostOffice: string
   invoicingPostalCode: string
@@ -856,7 +873,7 @@ export interface ProductWithName {
 */
 export interface RelatedFeeDecision {
   decisionNumber: number
-  id: UUID
+  id: FeeDecisionId
 }
 
 /**
@@ -867,7 +884,7 @@ export interface SearchFeeDecisionRequest {
   difference: FeeDecisionDifference[] | null
   distinctions: DistinctiveParams[] | null
   endDate: LocalDate | null
-  financeDecisionHandlerId: UUID | null
+  financeDecisionHandlerId: EmployeeId | null
   page: number
   searchByStartDate: boolean
   searchTerms: string | null
@@ -875,7 +892,7 @@ export interface SearchFeeDecisionRequest {
   sortDirection: SortDirection | null
   startDate: LocalDate | null
   statuses: FeeDecisionStatus[] | null
-  unit: UUID | null
+  unit: DaycareId | null
 }
 
 /**
@@ -891,7 +908,7 @@ export interface SearchInvoicesRequest {
   sortBy: InvoiceSortParam | null
   sortDirection: SortDirection | null
   status: InvoiceStatus
-  unit: UUID | null
+  unit: DaycareId | null
 }
 
 /**
@@ -907,7 +924,7 @@ export interface SearchPaymentsRequest {
   sortBy: PaymentSortParam
   sortDirection: SortDirection
   status: PaymentStatus
-  unit: UUID | null
+  unit: DaycareId | null
 }
 
 /**
@@ -918,7 +935,7 @@ export interface SearchVoucherValueDecisionRequest {
   difference: VoucherValueDecisionDifference[] | null
   distinctions: VoucherValueDecisionDistinctiveParams[] | null
   endDate: LocalDate | null
-  financeDecisionHandlerId: UUID | null
+  financeDecisionHandlerId: EmployeeId | null
   page: number
   searchByStartDate: boolean
   searchTerms: string | null
@@ -926,7 +943,7 @@ export interface SearchVoucherValueDecisionRequest {
   sortDirection: SortDirection | null
   startDate: LocalDate | null
   statuses: VoucherValueDecisionStatus[]
-  unit: UUID | null
+  unit: DaycareId | null
 }
 
 /**
@@ -935,7 +952,7 @@ export interface SearchVoucherValueDecisionRequest {
 export interface SendPaymentsRequest {
   dueDate: LocalDate
   paymentDate: LocalDate
-  paymentIds: UUID[]
+  paymentIds: PaymentId[]
 }
 
 /**
@@ -947,7 +964,7 @@ export interface ServiceNeedOptionVoucherValueRange {
   coefficient: number
   coefficientUnder3y: number
   range: DateRange
-  serviceNeedOptionId: UUID
+  serviceNeedOptionId: ServiceNeedOptionId
   value: number
   valueUnder3y: number
 }
@@ -956,7 +973,7 @@ export interface ServiceNeedOptionVoucherValueRange {
 * Generated from fi.espoo.evaka.invoicing.controller.ServiceNeedOptionVoucherValueRangeWithId
 */
 export interface ServiceNeedOptionVoucherValueRangeWithId {
-  id: UUID
+  id: ServiceNeedOptionVoucherValueId
   voucherValues: ServiceNeedOptionVoucherValueRange
 }
 
@@ -971,9 +988,9 @@ export type SortDirection =
 * Generated from fi.espoo.evaka.invoicing.domain.UnitData
 */
 export interface UnitData {
-  areaId: UUID
+  areaId: AreaId
   areaName: string
-  id: UUID
+  id: DaycareId
   language: string
   name: string
 }
@@ -1004,7 +1021,7 @@ export interface VoucherValueDecisionDetailed {
   financeDecisionHandlerLastName: string | null
   headOfFamily: PersonDetailed
   headOfFamilyIncome: DecisionIncome | null
-  id: UUID
+  id: VoucherValueDecisionId
   incomeEffect: IncomeEffect
   isRetroactive: boolean
   partner: PersonDetailed | null
@@ -1113,7 +1130,7 @@ export interface VoucherValueDecisionSummary {
   difference: VoucherValueDecisionDifference[]
   finalCoPayment: number
   headOfFamily: PersonBasic
-  id: UUID
+  id: VoucherValueDecisionId
   sentAt: HelsinkiDateTime | null
   status: VoucherValueDecisionStatus
   validFrom: LocalDate

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -5,10 +5,19 @@
 // GENERATED FILE: no manual modifications
 
 import HelsinkiDateTime from '../../helsinki-date-time'
+import { ApplicationId } from './shared'
+import { AttachmentId } from './shared'
+import { DaycareId } from './shared'
+import { GroupId } from './shared'
 import { JsonOf } from '../../json'
+import { MessageAccountId } from './shared'
 import { MessageAttachment } from './attachment'
+import { MessageContentId } from './shared'
+import { MessageDraftId } from './shared'
+import { MessageId } from './shared'
 import { MessageReceiver } from '../../api-types/messaging'
-import { UUID } from '../../types'
+import { MessageThreadId } from './shared'
+import { PersonId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.messaging.AccountType
@@ -32,18 +41,18 @@ export interface AuthorizedMessageAccount {
 * Generated from fi.espoo.evaka.messaging.MessageControllerCitizen.ChildMessageAccountAccess
 */
 export interface ChildMessageAccountAccess {
-  newMessage: UUID[]
-  reply: UUID[]
+  newMessage: MessageAccountId[]
+  reply: MessageAccountId[]
 }
 
 /**
 * Generated from fi.espoo.evaka.messaging.CitizenMessageBody
 */
 export interface CitizenMessageBody {
-  attachmentIds: UUID[]
-  children: UUID[]
+  attachmentIds: AttachmentId[]
+  children: PersonId[]
   content: string
-  recipients: UUID[]
+  recipients: MessageAccountId[]
   title: string
 }
 
@@ -55,7 +64,7 @@ export namespace CitizenMessageThread {
   export interface Redacted {
     type: 'Redacted'
     hasUnreadMessages: boolean
-    id: UUID
+    id: MessageThreadId
     lastMessageSentAt: HelsinkiDateTime | null
     sender: MessageAccount | null
     urgent: boolean
@@ -67,7 +76,7 @@ export namespace CitizenMessageThread {
   export interface Regular {
     type: 'Regular'
     children: MessageChild[]
-    id: UUID
+    id: MessageThreadId
     isCopy: boolean
     messageType: MessageType
     messages: Message[]
@@ -87,7 +96,7 @@ export type CitizenMessageThread = CitizenMessageThread.Redacted | CitizenMessag
 * Generated from fi.espoo.evaka.messaging.MessageController.CreateMessageResponse
 */
 export interface CreateMessageResponse {
-  createdId: UUID | null
+  createdId: MessageContentId | null
 }
 
 /**
@@ -97,8 +106,8 @@ export interface DraftContent {
   attachments: MessageAttachment[]
   content: string
   createdAt: HelsinkiDateTime
-  id: UUID
-  recipientIds: UUID[]
+  id: MessageDraftId
+  recipientIds: string[]
   recipientNames: string[]
   sensitive: boolean
   title: string
@@ -110,7 +119,7 @@ export interface DraftContent {
 * Generated from fi.espoo.evaka.messaging.MessageControllerCitizen.GetReceiversResponse
 */
 export interface GetReceiversResponse {
-  childrenToMessageAccounts: Partial<Record<UUID, ChildMessageAccountAccess>>
+  childrenToMessageAccounts: Partial<Record<PersonId, ChildMessageAccountAccess>>
   messageAccounts: MessageAccount[]
 }
 
@@ -118,9 +127,9 @@ export interface GetReceiversResponse {
 * Generated from fi.espoo.evaka.messaging.Group
 */
 export interface Group {
-  id: UUID
+  id: GroupId
   name: string
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -130,20 +139,20 @@ export interface Group {
 export interface Message {
   attachments: MessageAttachment[]
   content: string
-  id: UUID
+  id: MessageId
   readAt: HelsinkiDateTime | null
   recipientNames: string[] | null
   recipients: MessageAccount[]
   sender: MessageAccount
   sentAt: HelsinkiDateTime
-  threadId: UUID
+  threadId: MessageThreadId
 }
 
 /**
 * Generated from fi.espoo.evaka.messaging.MessageAccount
 */
 export interface MessageAccount {
-  id: UUID
+  id: MessageAccountId
   name: string
   type: AccountType
 }
@@ -152,7 +161,7 @@ export interface MessageAccount {
 * Generated from fi.espoo.evaka.messaging.MessageChild
 */
 export interface MessageChild {
-  childId: UUID
+  childId: PersonId
   firstName: string
   lastName: string
   preferredName: string
@@ -164,18 +173,18 @@ export interface MessageChild {
 export interface MessageCopy {
   attachments: MessageAttachment[]
   content: string
-  messageId: UUID
+  messageId: MessageId
   readAt: HelsinkiDateTime | null
   recipientAccountType: AccountType
-  recipientId: UUID
+  recipientId: MessageAccountId
   recipientName: string
   recipientNames: string[]
   senderAccountType: AccountType
-  senderId: UUID
+  senderId: MessageAccountId
   senderName: string
   sensitive: boolean
   sentAt: HelsinkiDateTime
-  threadId: UUID
+  threadId: MessageThreadId
   title: string
   type: MessageType
   urgent: boolean
@@ -185,7 +194,7 @@ export interface MessageCopy {
 * Generated from fi.espoo.evaka.messaging.MessageReceiversResponse
 */
 export interface MessageReceiversResponse {
-  accountId: UUID
+  accountId: MessageAccountId
   receivers: MessageReceiver[]
 }
 
@@ -193,7 +202,7 @@ export interface MessageReceiversResponse {
 * Generated from fi.espoo.evaka.messaging.MessageRecipient
 */
 export interface MessageRecipient {
-  id: UUID
+  id: string
   type: MessageRecipientType
 }
 
@@ -212,7 +221,7 @@ export type MessageRecipientType =
 */
 export interface MessageThread {
   children: MessageChild[]
-  id: UUID
+  id: MessageThreadId
   isCopy: boolean
   messages: Message[]
   sensitive: boolean
@@ -232,7 +241,7 @@ export type MessageType =
 * Generated from fi.espoo.evaka.messaging.MessageControllerCitizen.MyAccountResponse
 */
 export interface MyAccountResponse {
-  accountId: UUID
+  accountId: MessageAccountId
   messageAttachmentsAllowed: boolean
 }
 
@@ -276,13 +285,13 @@ export interface PagedSentMessages {
 * Generated from fi.espoo.evaka.messaging.MessageController.PostMessageBody
 */
 export interface PostMessageBody {
-  attachmentIds: UUID[]
+  attachmentIds: AttachmentId[]
   content: string
-  draftId: UUID | null
+  draftId: MessageDraftId | null
   filters: PostMessageFilters | null
   recipientNames: string[]
   recipients: MessageRecipient[]
-  relatedApplicationId: UUID | null
+  relatedApplicationId: ApplicationId | null
   sensitive: boolean
   title: string
   type: MessageType
@@ -319,7 +328,7 @@ export interface PostMessagePreflightResponse {
 */
 export interface ReplyToMessageBody {
   content: string
-  recipientAccountIds: UUID[]
+  recipientAccountIds: MessageAccountId[]
 }
 
 /**
@@ -328,7 +337,7 @@ export interface ReplyToMessageBody {
 export interface SentMessage {
   attachments: MessageAttachment[]
   content: string
-  contentId: UUID
+  contentId: MessageContentId
   recipientNames: string[]
   sensitive: boolean
   sentAt: HelsinkiDateTime
@@ -349,14 +358,14 @@ export interface ThreadByApplicationResponse {
 */
 export interface ThreadReply {
   message: Message
-  threadId: UUID
+  threadId: MessageThreadId
 }
 
 /**
 * Generated from fi.espoo.evaka.messaging.UnreadCountByAccount
 */
 export interface UnreadCountByAccount {
-  accountId: UUID
+  accountId: MessageAccountId
   unreadCopyCount: number
   unreadCount: number
 }
@@ -365,8 +374,8 @@ export interface UnreadCountByAccount {
 * Generated from fi.espoo.evaka.messaging.UnreadCountByAccountAndGroup
 */
 export interface UnreadCountByAccountAndGroup {
-  accountId: UUID
-  groupId: UUID
+  accountId: MessageAccountId
+  groupId: GroupId
   unreadCopyCount: number
   unreadCount: number
 }
@@ -376,7 +385,7 @@ export interface UnreadCountByAccountAndGroup {
 */
 export interface UpdatableDraftContent {
   content: string
-  recipientIds: UUID[]
+  recipientIds: string[]
   recipientNames: string[]
   sensitive: boolean
   title: string

--- a/frontend/src/lib-common/generated/api-types/note.ts
+++ b/frontend/src/lib-common/generated/api-types/note.ts
@@ -6,16 +6,20 @@
 
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
+import { ChildDailyNoteId } from './shared'
+import { ChildStickyNoteId } from './shared'
+import { GroupId } from './shared'
+import { GroupNoteId } from './shared'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
+import { PersonId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.note.child.daily.ChildDailyNote
 */
 export interface ChildDailyNote {
-  childId: UUID
+  childId: PersonId
   feedingNote: ChildDailyNoteLevel | null
-  id: UUID
+  id: ChildDailyNoteId
   modifiedAt: HelsinkiDateTime
   note: string
   reminderNote: string
@@ -62,9 +66,9 @@ export type ChildDailyNoteReminder = typeof childDailyNoteReminderValues[number]
 * Generated from fi.espoo.evaka.note.child.sticky.ChildStickyNote
 */
 export interface ChildStickyNote {
-  childId: UUID
+  childId: PersonId
   expires: LocalDate
-  id: UUID
+  id: ChildStickyNoteId
   modifiedAt: HelsinkiDateTime
   note: string
 }
@@ -82,8 +86,8 @@ export interface ChildStickyNoteBody {
 */
 export interface GroupNote {
   expires: LocalDate
-  groupId: UUID
-  id: UUID
+  groupId: GroupId
+  id: GroupNoteId
   modifiedAt: HelsinkiDateTime
   note: string
 }

--- a/frontend/src/lib-common/generated/api-types/occupancy.ts
+++ b/frontend/src/lib-common/generated/api-types/occupancy.ts
@@ -8,8 +8,9 @@ import FiniteDateRange from '../../finite-date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import { Caretakers } from './daycare'
+import { GroupId } from './shared'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
+import { PersonId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.occupancy.ChildCapacityPoint
@@ -25,7 +26,7 @@ export interface ChildCapacityPoint {
 export interface ChildOccupancyAttendance {
   arrived: HelsinkiDateTime
   capacity: number
-  childId: UUID
+  childId: PersonId
   departed: HelsinkiDateTime | null
 }
 
@@ -34,7 +35,7 @@ export interface ChildOccupancyAttendance {
 */
 export interface GetUnitOccupanciesForDayBody {
   date: LocalDate
-  groupIds: UUID[] | null
+  groupIds: GroupId[] | null
 }
 
 /**
@@ -71,7 +72,7 @@ export interface OccupancyResponse {
 * Generated from fi.espoo.evaka.occupancy.OccupancyResponseGroupLevel
 */
 export interface OccupancyResponseGroupLevel {
-  groupId: UUID
+  groupId: GroupId
   occupancies: OccupancyResponse
 }
 

--- a/frontend/src/lib-common/generated/api-types/pairing.ts
+++ b/frontend/src/lib-common/generated/api-types/pairing.ts
@@ -5,14 +5,17 @@
 // GENERATED FILE: no manual modifications
 
 import HelsinkiDateTime from '../../helsinki-date-time'
+import { DaycareId } from './shared'
+import { EmployeeId } from './shared'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
+import { MobileDeviceId } from './shared'
+import { PairingId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.pairing.MobileDevice
 */
 export interface MobileDevice {
-  id: UUID
+  id: MobileDeviceId
   name: string
 }
 
@@ -20,12 +23,12 @@ export interface MobileDevice {
 * Generated from fi.espoo.evaka.pairing.MobileDeviceDetails
 */
 export interface MobileDeviceDetails {
-  employeeId: UUID | null
-  id: UUID
+  employeeId: EmployeeId | null
+  id: MobileDeviceId
   name: string
   personalDevice: boolean
   pushApplicationServerKey: string | null
-  unitIds: UUID[]
+  unitIds: DaycareId[]
 }
 
 /**
@@ -33,13 +36,13 @@ export interface MobileDeviceDetails {
 */
 export interface Pairing {
   challengeKey: string
-  employeeId: UUID | null
+  employeeId: EmployeeId | null
   expires: HelsinkiDateTime
-  id: UUID
-  mobileDeviceId: UUID | null
+  id: PairingId
+  mobileDeviceId: MobileDeviceId | null
   responseKey: string | null
   status: PairingStatus
-  unitId: UUID | null
+  unitId: DaycareId | null
 }
 
 /**
@@ -71,14 +74,14 @@ export namespace PostPairingReq {
   * Generated from fi.espoo.evaka.pairing.PairingsController.PostPairingReq.Employee
   */
   export interface Employee {
-    employeeId: UUID
+    employeeId: EmployeeId
   }
 
   /**
   * Generated from fi.espoo.evaka.pairing.PairingsController.PostPairingReq.Unit
   */
   export interface Unit {
-    unitId: UUID
+    unitId: DaycareId
   }
 }
 

--- a/frontend/src/lib-common/generated/api-types/pedagogicaldocument.ts
+++ b/frontend/src/lib-common/generated/api-types/pedagogicaldocument.ts
@@ -5,16 +5,18 @@
 // GENERATED FILE: no manual modifications
 
 import HelsinkiDateTime from '../../helsinki-date-time'
+import { AttachmentId } from './shared'
 import { EvakaUser } from './user'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
+import { PedagogicalDocumentId } from './shared'
+import { PersonId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.pedagogicaldocument.Attachment
 */
 export interface Attachment {
   contentType: string
-  id: UUID
+  id: AttachmentId
   name: string
 }
 
@@ -23,11 +25,11 @@ export interface Attachment {
 */
 export interface PedagogicalDocument {
   attachments: Attachment[]
-  childId: UUID
+  childId: PersonId
   createdAt: HelsinkiDateTime
   createdBy: EvakaUser
   description: string
-  id: UUID
+  id: PedagogicalDocumentId
   modifiedAt: HelsinkiDateTime
   modifiedBy: EvakaUser
 }
@@ -37,10 +39,10 @@ export interface PedagogicalDocument {
 */
 export interface PedagogicalDocumentCitizen {
   attachments: Attachment[]
-  childId: UUID
+  childId: PersonId
   createdAt: HelsinkiDateTime
   description: string
-  id: UUID
+  id: PedagogicalDocumentId
   isRead: boolean
 }
 
@@ -48,7 +50,7 @@ export interface PedagogicalDocumentCitizen {
 * Generated from fi.espoo.evaka.pedagogicaldocument.PedagogicalDocumentPostBody
 */
 export interface PedagogicalDocumentPostBody {
-  childId: UUID
+  childId: PersonId
   description: string
 }
 

--- a/frontend/src/lib-common/generated/api-types/pis.ts
+++ b/frontend/src/lib-common/generated/api-types/pis.ts
@@ -8,17 +8,25 @@ import DateRange from '../../date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import { Action } from '../action'
+import { ApplicationId } from './shared'
 import { ApplicationType } from './application'
 import { CitizenAuthLevel } from './shared'
 import { CitizenFeatures } from './shared'
+import { DaycareId } from './shared'
 import { EmployeeFeatures } from './shared'
+import { EmployeeId } from './shared'
 import { EvakaUser } from './user'
+import { EvakaUserId } from './shared'
+import { FosterParentId } from './shared'
+import { GroupId } from './shared'
 import { IncomeEffect } from './invoicing'
 import { JsonOf } from '../../json'
 import { MobileDevice } from './pairing'
 import { Nationality } from './vtjclient'
 import { NativeLanguage } from './vtjclient'
-import { UUID } from '../../types'
+import { ParentshipId } from './shared'
+import { PartnershipId } from './shared'
+import { PersonId } from './shared'
 import { UserRole } from './shared'
 
 /**
@@ -35,7 +43,7 @@ export interface CitizenUserDetails {
   backupPhone: string
   email: string | null
   firstName: string
-  id: UUID
+  id: PersonId
   keycloakEmail: string | null
   lastName: string
   phone: string
@@ -59,8 +67,8 @@ export interface CitizenUserResponse {
 * Generated from fi.espoo.evaka.pis.controllers.CreateFosterParentRelationshipBody
 */
 export interface CreateFosterParentRelationshipBody {
-  childId: UUID
-  parentId: UUID
+  childId: PersonId
+  parentId: PersonId
   validDuring: DateRange
 }
 
@@ -92,13 +100,13 @@ export type CreateSource =
 export interface CreationModificationMetadata {
   createSource: CreateSource | null
   createdAt: HelsinkiDateTime | null
-  createdBy: UUID | null
+  createdBy: EvakaUserId | null
   createdByName: string | null
-  createdFromApplication: UUID | null
+  createdFromApplication: ApplicationId | null
   createdFromApplicationCreated: HelsinkiDateTime | null
   createdFromApplicationType: ApplicationType | null
   modifiedAt: HelsinkiDateTime | null
-  modifiedBy: UUID | null
+  modifiedBy: EvakaUserId | null
   modifiedByName: string | null
   modifySource: ModifySource | null
 }
@@ -107,9 +115,9 @@ export interface CreationModificationMetadata {
 * Generated from fi.espoo.evaka.pis.DaycareGroupRole
 */
 export interface DaycareGroupRole {
-  daycareId: UUID
+  daycareId: DaycareId
   daycareName: string
-  groupId: UUID
+  groupId: GroupId
   groupName: string
 }
 
@@ -117,7 +125,7 @@ export interface DaycareGroupRole {
 * Generated from fi.espoo.evaka.pis.DaycareRole
 */
 export interface DaycareRole {
-  daycareId: UUID
+  daycareId: DaycareId
   daycareName: string
   role: UserRole
 }
@@ -156,10 +164,10 @@ export interface Employee {
   email: string | null
   externalId: string | null
   firstName: string
-  id: UUID
+  id: EmployeeId
   lastName: string
   preferredFirstName: string | null
-  temporaryInUnitId: UUID | null
+  temporaryInUnitId: DaycareId | null
   updated: HelsinkiDateTime | null
 }
 
@@ -186,7 +194,7 @@ export interface EmployeeUserResponse {
   allScopedRoles: UserRole[]
   firstName: string
   globalRoles: UserRole[]
-  id: UUID
+  id: EmployeeId
   lastName: string
   permittedGlobalActions: Action.Global[]
 }
@@ -204,7 +212,7 @@ export interface EmployeeWithDaycareRoles {
   externalId: string | null
   firstName: string
   globalRoles: UserRole[]
-  id: UUID
+  id: EmployeeId
   lastLogin: HelsinkiDateTime | null
   lastName: string
   personalMobileDevices: MobileDevice[]
@@ -217,7 +225,7 @@ export interface EmployeeWithDaycareRoles {
 */
 export interface EvakaRightsRequest {
   denied: boolean
-  guardianId: UUID
+  guardianId: PersonId
 }
 
 /**
@@ -227,7 +235,7 @@ export interface FamilyContact {
   backupPhone: string
   email: string | null
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   phone: string
   postOffice: string
@@ -241,8 +249,8 @@ export interface FamilyContact {
 * Generated from fi.espoo.evaka.pis.controllers.FamilyContactPriorityUpdate
 */
 export interface FamilyContactPriorityUpdate {
-  childId: UUID
-  contactPersonId: UUID
+  childId: PersonId
+  contactPersonId: PersonId
   priority: number | null
 }
 
@@ -262,8 +270,8 @@ export type FamilyContactRole =
 */
 export interface FamilyContactUpdate {
   backupPhone: string | null
-  childId: UUID
-  contactPersonId: UUID
+  childId: PersonId
+  contactPersonId: PersonId
   email: string | null
   phone: string | null
 }
@@ -292,10 +300,10 @@ export interface FamilyOverviewIncome {
 export interface FamilyOverviewPerson {
   dateOfBirth: LocalDate
   firstName: string
-  headOfChild: UUID | null
+  headOfChild: PersonId | null
   income: FamilyOverviewIncome | null
   lastName: string
-  personId: UUID
+  personId: PersonId
   postOffice: string
   postalCode: string
   restrictedDetailsEnabled: boolean
@@ -310,7 +318,7 @@ export interface FosterParentRelationship {
   modifiedAt: HelsinkiDateTime
   modifiedBy: EvakaUser
   parent: PersonSummary
-  relationshipId: UUID
+  relationshipId: FosterParentId
   validDuring: DateRange
 }
 
@@ -334,8 +342,8 @@ export interface GuardiansResponse {
 * Generated from fi.espoo.evaka.pis.controllers.PersonController.MergeRequest
 */
 export interface MergeRequest {
-  duplicate: UUID
-  master: UUID
+  duplicate: PersonId
+  master: PersonId
 }
 
 /**
@@ -356,7 +364,7 @@ export interface NewEmployee {
   firstName: string
   lastName: string
   roles: UserRole[]
-  temporaryInUnitId: UUID | null
+  temporaryInUnitId: DaycareId | null
 }
 
 /**
@@ -381,12 +389,12 @@ export interface PagedEmployeesWithDaycareRoles {
 */
 export interface Parentship {
   child: PersonJSON
-  childId: UUID
+  childId: PersonId
   conflict: boolean
   endDate: LocalDate
   headOfChild: PersonJSON
-  headOfChildId: UUID
-  id: UUID
+  headOfChildId: PersonId
+  id: ParentshipId
   startDate: LocalDate
 }
 
@@ -395,13 +403,13 @@ export interface Parentship {
 */
 export interface ParentshipDetailed {
   child: PersonJSON
-  childId: UUID
+  childId: PersonId
   conflict: boolean
   creationModificationMetadata: CreationModificationMetadata
   endDate: LocalDate
   headOfChild: PersonJSON
-  headOfChildId: UUID
-  id: UUID
+  headOfChildId: PersonId
+  id: ParentshipId
   startDate: LocalDate
 }
 
@@ -409,9 +417,9 @@ export interface ParentshipDetailed {
 * Generated from fi.espoo.evaka.pis.controllers.ParentshipController.ParentshipRequest
 */
 export interface ParentshipRequest {
-  childId: UUID
+  childId: PersonId
   endDate: LocalDate
-  headOfChildId: UUID
+  headOfChildId: PersonId
   startDate: LocalDate
 }
 
@@ -438,7 +446,7 @@ export interface Partnership {
   conflict: boolean
   creationModificationMetadata: CreationModificationMetadata
   endDate: LocalDate | null
-  id: UUID
+  id: PartnershipId
   partners: PersonJSON[]
   startDate: LocalDate
 }
@@ -448,8 +456,8 @@ export interface Partnership {
 */
 export interface PartnershipRequest {
   endDate: LocalDate | null
-  person1Id: UUID
-  person2Id: UUID
+  person1Id: PersonId
+  person2Id: PersonId
   startDate: LocalDate
 }
 
@@ -484,7 +492,7 @@ export interface PersonAddressDTO {
 * Generated from fi.espoo.evaka.pis.controllers.PersonController.PersonIdentityResponseJSON
 */
 export interface PersonIdentityResponseJSON {
-  id: UUID
+  id: PersonId
   socialSecurityNumber: string | null
 }
 
@@ -495,11 +503,11 @@ export interface PersonJSON {
   backupPhone: string
   dateOfBirth: LocalDate
   dateOfDeath: LocalDate | null
-  duplicateOf: UUID | null
+  duplicateOf: PersonId | null
   email: string | null
   firstName: string
   forceManualFeeDecisions: boolean
-  id: UUID
+  id: PersonId
   invoiceRecipientName: string
   invoicingPostOffice: string
   invoicingPostalCode: string
@@ -554,7 +562,7 @@ export interface PersonSummary {
   dateOfBirth: LocalDate
   dateOfDeath: LocalDate | null
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   restrictedDetailsEnabled: boolean
   socialSecurityNumber: string | null
@@ -570,10 +578,10 @@ export interface PersonWithChildrenDTO {
   children: PersonWithChildrenDTO[]
   dateOfBirth: LocalDate
   dateOfDeath: LocalDate | null
-  duplicateOf: UUID | null
+  duplicateOf: PersonId | null
   email: string | null
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   nationalities: Nationality[]
   nativeLanguage: NativeLanguage | null
@@ -656,7 +664,7 @@ export interface SearchPersonBody {
 */
 export interface TemporaryEmployee {
   firstName: string
-  groupIds: UUID[]
+  groupIds: GroupId[]
   hasStaffOccupancyEffect: boolean
   lastName: string
   pinCode: PinCode | null
@@ -673,7 +681,7 @@ export interface UpdatePasswordRequest {
 * Generated from fi.espoo.evaka.pis.controllers.EmployeeController.UpsertEmployeeDaycareRolesRequest
 */
 export interface UpsertEmployeeDaycareRolesRequest {
-  daycareIds: UUID[]
+  daycareIds: DaycareId[]
   role: UserRole
 }
 

--- a/frontend/src/lib-common/generated/api-types/placement.ts
+++ b/frontend/src/lib-common/generated/api-types/placement.ts
@@ -8,13 +8,20 @@ import FiniteDateRange from '../../finite-date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import { Action } from '../action'
+import { ApplicationId } from './shared'
+import { DaycareId } from './shared'
 import { EvakaUser } from './user'
+import { GroupId } from './shared'
+import { GroupPlacementId } from './shared'
 import { JsonOf } from '../../json'
 import { Language } from './daycare'
+import { PersonId } from './shared'
 import { PilotFeature } from './shared'
+import { PlacementId } from './shared'
+import { PlacementPlanId } from './shared'
 import { ProviderType } from './daycare'
 import { ServiceNeed } from './serviceneed'
-import { UUID } from '../../types'
+import { ServiceNeedId } from './shared'
 import { Unit } from './children'
 import { deserializeJsonServiceNeed } from './serviceneed'
 
@@ -24,7 +31,7 @@ import { deserializeJsonServiceNeed } from './serviceneed'
 export interface ChildBasics {
   dateOfBirth: LocalDate
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   socialSecurityNumber: string | null
 }
@@ -33,15 +40,15 @@ export interface ChildBasics {
 * Generated from fi.espoo.evaka.placement.ChildPlacement
 */
 export interface ChildPlacement {
-  childId: UUID
+  childId: PersonId
   endDate: LocalDate
-  id: UUID
+  id: PlacementId
   startDate: LocalDate
   terminatable: boolean
   terminatedBy: EvakaUser | null
   terminationRequestedDate: LocalDate | null
   type: PlacementType
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -58,7 +65,7 @@ export interface ChildPlacementResponse {
 export interface DaycareBasics {
   area: string
   enabledPilotFeatures: PilotFeature[]
-  id: UUID
+  id: DaycareId
   language: Language
   name: string
   providerType: ProviderType
@@ -68,11 +75,11 @@ export interface DaycareBasics {
 * Generated from fi.espoo.evaka.placement.DaycareGroupPlacement
 */
 export interface DaycareGroupPlacement {
-  daycarePlacementId: UUID
+  daycarePlacementId: PlacementId
   endDate: LocalDate
-  groupId: UUID | null
+  groupId: GroupId | null
   groupName: string | null
-  id: UUID | null
+  id: GroupPlacementId | null
   startDate: LocalDate
 }
 
@@ -85,7 +92,7 @@ export interface DaycarePlacementWithDetails {
   defaultServiceNeedOptionNameFi: string | null
   endDate: LocalDate
   groupPlacements: DaycareGroupPlacement[]
-  id: UUID
+  id: PlacementId
   isRestrictedFromUser: boolean
   missingServiceNeedDays: number
   modifiedAt: HelsinkiDateTime | null
@@ -103,7 +110,7 @@ export interface DaycarePlacementWithDetails {
 */
 export interface GroupPlacementRequestBody {
   endDate: LocalDate
-  groupId: UUID
+  groupId: GroupId
   startDate: LocalDate
 }
 
@@ -111,7 +118,7 @@ export interface GroupPlacementRequestBody {
 * Generated from fi.espoo.evaka.placement.GroupTransferRequestBody
 */
 export interface GroupTransferRequestBody {
-  groupId: UUID
+  groupId: GroupId
   startDate: LocalDate
 }
 
@@ -120,14 +127,14 @@ export interface GroupTransferRequestBody {
 */
 export interface MissingGroupPlacement {
   backup: boolean
-  childId: UUID
+  childId: PersonId
   dateOfBirth: LocalDate
   defaultServiceNeedOptionNameFi: string | null
   firstName: string
   fromUnits: string[]
   gap: FiniteDateRange
   lastName: string
-  placementId: UUID
+  placementId: PlacementId
   placementPeriod: FiniteDateRange
   placementType: PlacementType | null
   serviceNeeds: MissingGroupPlacementServiceNeed[]
@@ -146,12 +153,12 @@ export interface MissingGroupPlacementServiceNeed {
 * Generated from fi.espoo.evaka.placement.PlacementCreateRequestBody
 */
 export interface PlacementCreateRequestBody {
-  childId: UUID
+  childId: PersonId
   endDate: LocalDate
   placeGuarantee: boolean
   startDate: LocalDate
   type: PlacementType
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -160,7 +167,7 @@ export interface PlacementCreateRequestBody {
 export interface PlacementDraftChild {
   dob: LocalDate
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
 }
 
@@ -168,7 +175,7 @@ export interface PlacementDraftChild {
 * Generated from fi.espoo.evaka.placement.PlacementDraftUnit
 */
 export interface PlacementDraftUnit {
-  id: UUID
+  id: DaycareId
   name: string
 }
 
@@ -178,7 +185,7 @@ export interface PlacementDraftUnit {
 export interface PlacementPlanChild {
   dateOfBirth: LocalDate
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
 }
 
@@ -195,16 +202,16 @@ export type PlacementPlanConfirmationStatus =
 * Generated from fi.espoo.evaka.placement.PlacementPlanDetails
 */
 export interface PlacementPlanDetails {
-  applicationId: UUID
+  applicationId: ApplicationId
   child: PlacementPlanChild
-  id: UUID
+  id: PlacementPlanId
   period: FiniteDateRange
   preschoolDaycarePeriod: FiniteDateRange | null
   rejectedByCitizen: boolean
   type: PlacementType
   unitAcceptDisabled: boolean
   unitConfirmationStatus: PlacementPlanConfirmationStatus
-  unitId: UUID
+  unitId: DaycareId
   unitRejectOtherReason: string | null
   unitRejectReason: PlacementPlanRejectReason | null
 }
@@ -235,8 +242,8 @@ export type PlacementPlanRejectReason =
 * Generated from fi.espoo.evaka.placement.PlacementResponse
 */
 export interface PlacementResponse {
-  permittedPlacementActions: Partial<Record<UUID, Action.Placement[]>>
-  permittedServiceNeedActions: Partial<Record<UUID, Action.ServiceNeed[]>>
+  permittedPlacementActions: Partial<Record<PlacementId, Action.Placement[]>>
+  permittedServiceNeedActions: Partial<Record<ServiceNeedId, Action.ServiceNeed[]>>
   placements: DaycarePlacementWithDetails[]
 }
 
@@ -244,9 +251,9 @@ export interface PlacementResponse {
 * Generated from fi.espoo.evaka.placement.PlacementSummary
 */
 export interface PlacementSummary {
-  childId: UUID
+  childId: PersonId
   endDate: LocalDate
-  id: UUID
+  id: PlacementId
   startDate: LocalDate
   type: PlacementType
   unit: Unit
@@ -259,7 +266,7 @@ export interface PlacementTerminationRequestBody {
   terminateDaycareOnly: boolean | null
   terminationDate: LocalDate
   type: TerminatablePlacementType
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -308,7 +315,7 @@ export interface TerminatablePlacementGroup {
   startDate: LocalDate
   terminatable: boolean
   type: TerminatablePlacementType
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -329,7 +336,7 @@ export interface TerminatedPlacement {
   connectedDaycareOnly: boolean
   currentDaycareGroupName: string | null
   endDate: LocalDate
-  id: UUID
+  id: PlacementId
   terminatedBy: EvakaUser | null
   terminationRequestedDate: LocalDate | null
   type: PlacementType
@@ -340,7 +347,7 @@ export interface TerminatedPlacement {
 */
 export interface UnitChildrenCapacityFactors {
   assistanceNeedFactor: number
-  childId: UUID
+  childId: PersonId
   serviceNeedFactor: number
 }
 

--- a/frontend/src/lib-common/generated/api-types/placement.ts
+++ b/frontend/src/lib-common/generated/api-types/placement.ts
@@ -9,6 +9,7 @@ import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import { Action } from '../action'
 import { ApplicationId } from './shared'
+import { BackupCareId } from './shared'
 import { DaycareId } from './shared'
 import { EvakaUser } from './user'
 import { GroupId } from './shared'
@@ -123,20 +124,32 @@ export interface GroupTransferRequestBody {
 }
 
 /**
-* Generated from fi.espoo.evaka.placement.MissingGroupPlacement
+* Generated from fi.espoo.evaka.placement.MissingBackupGroupPlacement
 */
-export interface MissingGroupPlacement {
-  backup: boolean
+export interface MissingBackupGroupPlacement {
+  backupCareId: BackupCareId
   childId: PersonId
   dateOfBirth: LocalDate
-  defaultServiceNeedOptionNameFi: string | null
   firstName: string
   fromUnits: string[]
   gap: FiniteDateRange
   lastName: string
+  placementPeriod: FiniteDateRange
+}
+
+/**
+* Generated from fi.espoo.evaka.placement.MissingGroupPlacement
+*/
+export interface MissingGroupPlacement {
+  childId: PersonId
+  dateOfBirth: LocalDate
+  defaultServiceNeedOptionNameFi: string | null
+  firstName: string
+  gap: FiniteDateRange
+  lastName: string
   placementId: PlacementId
   placementPeriod: FiniteDateRange
-  placementType: PlacementType | null
+  placementType: PlacementType
   serviceNeeds: MissingGroupPlacementServiceNeed[]
 }
 
@@ -414,6 +427,16 @@ export function deserializeJsonGroupTransferRequestBody(json: JsonOf<GroupTransf
   return {
     ...json,
     startDate: LocalDate.parseIso(json.startDate)
+  }
+}
+
+
+export function deserializeJsonMissingBackupGroupPlacement(json: JsonOf<MissingBackupGroupPlacement>): MissingBackupGroupPlacement {
+  return {
+    ...json,
+    dateOfBirth: LocalDate.parseIso(json.dateOfBirth),
+    gap: FiniteDateRange.parseJson(json.gap),
+    placementPeriod: FiniteDateRange.parseJson(json.placementPeriod)
   }
 }
 

--- a/frontend/src/lib-common/generated/api-types/process.ts
+++ b/frontend/src/lib-common/generated/api-types/process.ts
@@ -5,9 +5,9 @@
 // GENERATED FILE: no manual modifications
 
 import HelsinkiDateTime from '../../helsinki-date-time'
+import { ArchivedProcessId } from './shared'
 import { EvakaUser } from './user'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
 
 /**
 * Generated from fi.espoo.evaka.process.ArchivedProcess
@@ -15,7 +15,7 @@ import { UUID } from '../../types'
 export interface ArchivedProcess {
   archiveDurationMonths: number
   history: ArchivedProcessHistoryRow[]
-  id: UUID
+  id: ArchivedProcessId
   number: number
   organization: string
   processDefinitionNumber: string

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -11,20 +11,28 @@ import LocalTime from '../../local-time'
 import TimeInterval from '../../time-interval'
 import TimeRange from '../../time-range'
 import { AbsenceType } from './absence'
+import { ApplicationId } from './shared'
 import { ApplicationStatus } from './application'
+import { AreaId } from './shared'
 import { AssistanceActionOption } from './assistanceaction'
 import { AssistanceNeedDecisionStatus } from './assistanceneed'
 import { DaycareAssistanceLevel } from './assistance'
+import { DaycareId } from './shared'
 import { DecisionType } from './decision'
+import { GroupId } from './shared'
 import { JsonOf } from '../../json'
 import { MealType } from './mealintegration'
 import { OccupancyValues } from './occupancy'
 import { OtherAssistanceMeasureType } from './assistance'
+import { PersonId } from './shared'
+import { PlacementId } from './shared'
 import { PlacementType } from './placement'
 import { PreschoolAssistanceLevel } from './assistance'
 import { ProviderType } from './daycare'
+import { ServiceNeedId } from './shared'
 import { ServiceNeedOption } from './application'
 import { UUID } from '../../types'
+import { VoucherValueDecisionId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.reports.ApplicationsReportRow
@@ -36,7 +44,7 @@ export interface ApplicationsReportRow {
   preschool: number
   total: number
   under3Years: number
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
   unitProviderType: ProviderType
 }
@@ -83,13 +91,13 @@ export interface AssistanceNeedsAndActionsReportRow {
   assistanceNeedVoucherCoefficientCount: number
   careAreaName: string
   daycareAssistanceCounts: Partial<Record<DaycareAssistanceLevel, number>>
-  groupId: UUID
+  groupId: GroupId
   groupName: string
   noActionCount: number
   otherActionCount: number
   otherAssistanceMeasureCounts: Partial<Record<OtherAssistanceMeasureType, number>>
   preschoolAssistanceCounts: Partial<Record<PreschoolAssistanceLevel, number>>
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -102,15 +110,15 @@ export interface AssistanceNeedsAndActionsReportRowByChild {
   careAreaName: string
   childAge: number
   childFirstName: string
-  childId: UUID
+  childId: PersonId
   childLastName: string
   daycareAssistanceCounts: Partial<Record<DaycareAssistanceLevel, number>>
-  groupId: UUID
+  groupId: GroupId
   groupName: string
   otherAction: string
   otherAssistanceMeasureCounts: Partial<Record<OtherAssistanceMeasureType, number>>
   preschoolAssistanceCounts: Partial<Record<PreschoolAssistanceLevel, number>>
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -118,16 +126,16 @@ export interface AssistanceNeedsAndActionsReportRowByChild {
 * Generated from fi.espoo.evaka.reports.AttendanceReservationReportController.AttendanceReservationReportByChildBody
 */
 export interface AttendanceReservationReportByChildBody {
-  groupIds: UUID[]
+  groupIds: GroupId[]
   range: FiniteDateRange
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
 * Generated from fi.espoo.evaka.reports.AttendanceReservationReportByChildGroup
 */
 export interface AttendanceReservationReportByChildGroup {
-  groupId: UUID | null
+  groupId: GroupId | null
   groupName: string | null
   items: AttendanceReservationReportByChildItem[]
 }
@@ -139,7 +147,7 @@ export interface AttendanceReservationReportByChildItem {
   backupCare: boolean
   childDateOfBirth: LocalDate
   childFirstName: string
-  childId: UUID
+  childId: PersonId
   childLastName: string
   date: LocalDate
   fullDayAbsence: boolean
@@ -155,7 +163,7 @@ export interface AttendanceReservationReportRow {
   childCountOver3: number
   childCountUnder3: number
   dateTime: HelsinkiDateTime
-  groupId: UUID | null
+  groupId: GroupId | null
   groupName: string | null
   staffCountRequired: number
 }
@@ -189,7 +197,7 @@ export interface ChildAgeLanguageReportRow {
   sv_5y: number
   sv_6y: number
   sv_7y: number
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
   unitProviderType: ProviderType
   unitType: UnitType
@@ -210,7 +218,7 @@ export interface ChildAttendanceReportRow {
 * Generated from fi.espoo.evaka.reports.ChildPreschoolAbsenceRow
 */
 export interface ChildPreschoolAbsenceRow {
-  childId: UUID
+  childId: PersonId
   firstName: string
   hourlyTypeResults: Partial<Record<AbsenceType, number>>
   lastName: string
@@ -221,7 +229,7 @@ export interface ChildPreschoolAbsenceRow {
 */
 export interface ChildWithName {
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
 }
 
@@ -232,13 +240,13 @@ export interface ChildrenInDifferentAddressReportRow {
   addressChild: string
   addressParent: string
   careAreaName: string
-  childId: UUID
+  childId: PersonId
   firstNameChild: string | null
   firstNameParent: string | null
   lastNameChild: string | null
   lastNameParent: string | null
-  parentId: UUID
-  unitId: UUID
+  parentId: PersonId
+  unitId: DaycareId
   unitName: string
 }
 
@@ -248,7 +256,7 @@ export interface ChildrenInDifferentAddressReportRow {
 export interface Contact {
   email: string | null
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   phone: string
 }
@@ -280,7 +288,7 @@ export interface DecisionsReportRow {
   preschoolDaycare: number
   providerType: ProviderType
   total: number
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -292,7 +300,7 @@ export interface DuplicatePeopleReportRow {
   duplicateNumber: number
   firstName: string | null
   groupIndex: number
-  id: UUID
+  id: PersonId
   lastName: string | null
   referenceCounts: ReferenceCount[]
   socialSecurityNumber: string | null
@@ -304,7 +312,7 @@ export interface DuplicatePeopleReportRow {
 */
 export interface EndedPlacementsReportRow {
   areaName: string
-  childId: UUID
+  childId: PersonId
   firstName: string | null
   lastName: string | null
   nextPlacementStart: LocalDate | null
@@ -317,13 +325,13 @@ export interface EndedPlacementsReportRow {
 */
 export interface ExceededServiceNeedReportRow {
   childFirstName: string
-  childId: UUID
+  childId: PersonId
   childLastName: string
   excessHours: number
-  groupId: UUID | null
+  groupId: GroupId | null
   groupName: string | null
   serviceNeedHoursPerMonth: number
-  unitId: UUID
+  unitId: DaycareId
   usedServiceHours: number
 }
 
@@ -331,7 +339,7 @@ export interface ExceededServiceNeedReportRow {
 * Generated from fi.espoo.evaka.reports.ExceededServiceNeedReportUnit
 */
 export interface ExceededServiceNeedReportUnit {
-  id: UUID
+  id: DaycareId
   name: string
 }
 
@@ -342,11 +350,11 @@ export interface FamilyConflictReportRow {
   careAreaName: string
   childConflictCount: number
   firstName: string | null
-  id: UUID
+  id: PersonId
   lastName: string | null
   partnerConflictCount: number
   socialSecurityNumber: string | null
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -359,7 +367,7 @@ export interface FamilyContactReportRow {
   guardian1: Contact | null
   guardian2: Contact | null
   headOfChild: Contact | null
-  id: UUID
+  id: PersonId
   lastName: string
   postOffice: string
   postalCode: string
@@ -371,7 +379,7 @@ export interface FamilyContactReportRow {
 * Generated from fi.espoo.evaka.reports.FamilyDaycareMealReport.FamilyDaycareMealAreaResult
 */
 export interface FamilyDaycareMealAreaResult {
-  areaId: UUID
+  areaId: AreaId
   areaName: string
   breakfastCount: number
   daycareResults: FamilyDaycareMealDaycareResult[]
@@ -384,7 +392,7 @@ export interface FamilyDaycareMealAreaResult {
 */
 export interface FamilyDaycareMealChildResult {
   breakfastCount: number
-  childId: UUID
+  childId: PersonId
   firstName: string
   lastName: string
   lunchCount: number
@@ -397,7 +405,7 @@ export interface FamilyDaycareMealChildResult {
 export interface FamilyDaycareMealDaycareResult {
   breakfastCount: number
   childResults: FamilyDaycareMealChildResult[]
-  daycareId: UUID
+  daycareId: DaycareId
   daycareName: string
   lunchCount: number
   snackCount: number
@@ -424,9 +432,9 @@ export interface FuturePreschoolersReportRow {
   childLastName: string
   childPostOffice: string
   childPostalCode: string
-  id: UUID
+  id: PersonId
   options: string[]
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -451,7 +459,7 @@ export interface IncompleteIncomeDbRow {
   daycareName: string
   firstName: string
   lastName: string
-  personId: UUID
+  personId: PersonId
   validFrom: LocalDate
 }
 
@@ -483,18 +491,18 @@ export interface InvoiceReportRow {
 * Generated from fi.espoo.evaka.reports.ManualDuplicationReportController.ManualDuplicationReportRow
 */
 export interface ManualDuplicationReportRow {
-  applicationId: UUID
+  applicationId: ApplicationId
   childFirstName: string
-  childId: UUID
+  childId: PersonId
   childLastName: string
-  connectedDaycareId: UUID
+  connectedDaycareId: DaycareId
   connectedDaycareName: string
   connectedDecisionType: DecisionType
   connectedEndDate: LocalDate
   connectedSnoName: string | null
   connectedStartDate: LocalDate
   dateOfBirth: LocalDate
-  preschoolDaycareId: UUID
+  preschoolDaycareId: DaycareId
   preschoolDaycareName: string
   preschoolDecisionType: DecisionType
   preschoolEndDate: LocalDate
@@ -535,7 +543,7 @@ export interface MealReportRow {
 * Generated from fi.espoo.evaka.reports.MissingHeadOfFamilyReportRow
 */
 export interface MissingHeadOfFamilyReportRow {
-  childId: UUID
+  childId: PersonId
   firstName: string
   lastName: string
   rangesWithoutHead: FiniteDateRange[]
@@ -546,11 +554,11 @@ export interface MissingHeadOfFamilyReportRow {
 */
 export interface MissingServiceNeedReportRow {
   careAreaName: string
-  childId: UUID
+  childId: PersonId
   daysWithoutServiceNeed: number
   firstName: string | null
   lastName: string | null
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -558,7 +566,7 @@ export interface MissingServiceNeedReportRow {
 * Generated from fi.espoo.evaka.reports.NonSsnChildrenReportRow
 */
 export interface NonSsnChildrenReportRow {
-  childId: UUID
+  childId: PersonId
   dateOfBirth: LocalDate
   firstName: string
   lastName: string
@@ -570,12 +578,12 @@ export interface NonSsnChildrenReportRow {
 * Generated from fi.espoo.evaka.reports.OccupancyGroupReportResultRow
 */
 export interface OccupancyGroupReportResultRow {
-  areaId: UUID
+  areaId: AreaId
   areaName: string
-  groupId: UUID
+  groupId: GroupId
   groupName: string
   occupancies: Partial<Record<string, OccupancyValues>>
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -583,10 +591,10 @@ export interface OccupancyGroupReportResultRow {
 * Generated from fi.espoo.evaka.reports.OccupancyUnitReportResultRow
 */
 export interface OccupancyUnitReportResultRow {
-  areaId: UUID
+  areaId: AreaId
   areaName: string
   occupancies: Partial<Record<string, OccupancyValues>>
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -601,9 +609,9 @@ export interface PartnersInDifferentAddressReportRow {
   firstName2: string | null
   lastName1: string | null
   lastName2: string | null
-  personId1: UUID
-  personId2: UUID
-  unitId: UUID
+  personId1: PersonId
+  personId2: PersonId
+  unitId: DaycareId
   unitName: string
 }
 
@@ -611,7 +619,7 @@ export interface PartnersInDifferentAddressReportRow {
 * Generated from fi.espoo.evaka.reports.PlacementCountReportController.PlacementCountAreaResult
 */
 export interface PlacementCountAreaResult {
-  areaId: UUID
+  areaId: AreaId
   areaName: string
   calculatedPlacements: number
   daycareResults: PlacementCountDaycareResult[]
@@ -625,7 +633,7 @@ export interface PlacementCountAreaResult {
 */
 export interface PlacementCountDaycareResult {
   calculatedPlacements: number
-  daycareId: UUID
+  daycareId: DaycareId
   daycareName: string
   placementCount: number
   placementCount3vAndOver: number
@@ -647,14 +655,14 @@ export interface PlacementCountReportResult {
 * Generated from fi.espoo.evaka.reports.PlacementGuaranteeReportRow
 */
 export interface PlacementGuaranteeReportRow {
-  areaId: UUID
+  areaId: AreaId
   areaName: string
   childFirstName: string
-  childId: UUID
+  childId: PersonId
   childLastName: string
   placementEndDate: LocalDate
   placementStartDate: LocalDate
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -663,7 +671,7 @@ export interface PlacementGuaranteeReportRow {
 */
 export interface PlacementSketchingReportRow {
   additionalInfo: string
-  applicationId: UUID
+  applicationId: ApplicationId
   applicationStatus: ApplicationStatus
   areaName: string
   assistanceNeeded: boolean | null
@@ -672,20 +680,20 @@ export interface PlacementSketchingReportRow {
   childCorrectedStreetAddress: string
   childDob: LocalDate
   childFirstName: string
-  childId: UUID
+  childId: PersonId
   childLastName: string
   childMovingDate: LocalDate | null
   childPostalCode: string | null
   childStreetAddr: string | null
   connectedDaycare: boolean | null
-  currentUnitId: UUID | null
+  currentUnitId: DaycareId | null
   currentUnitName: string | null
   guardianEmail: string | null
   guardianPhoneNumber: string | null
   otherPreferredUnits: string[]
   preferredStartDate: LocalDate
   preparatoryEducation: boolean | null
-  requestedUnitId: UUID
+  requestedUnitId: DaycareId
   requestedUnitName: string
   sentDate: LocalDate
   serviceNeedOption: ServiceNeedOption | null
@@ -696,16 +704,16 @@ export interface PlacementSketchingReportRow {
 * Generated from fi.espoo.evaka.reports.PreschoolApplicationReportRow
 */
 export interface PreschoolApplicationReportRow {
-  applicationId: UUID
-  applicationUnitId: UUID
+  applicationId: ApplicationId
+  applicationUnitId: DaycareId
   applicationUnitName: string
   childDateOfBirth: LocalDate
   childFirstName: string
-  childId: UUID
+  childId: PersonId
   childLastName: string
   childPostalCode: string
   childStreetAddress: string
-  currentUnitId: UUID | null
+  currentUnitId: DaycareId | null
   currentUnitName: string | null
   isDaycareAssistanceNeed: boolean
 }
@@ -715,7 +723,7 @@ export interface PreschoolApplicationReportRow {
 */
 export interface PreschoolUnitsReportRow {
   address: string
-  id: UUID
+  id: DaycareId
   options: string[]
   postOffice: string
   postalCode: string
@@ -729,7 +737,7 @@ export interface PreschoolUnitsReportRow {
 export interface PresenceReportRow {
   date: LocalDate
   daycareGroupName: string | null
-  daycareId: UUID | null
+  daycareId: DaycareId | null
   present: boolean | null
   socialSecurityNumber: string | null
 }
@@ -742,18 +750,18 @@ export interface RawReportRow {
   absencePaid: AbsenceType | null
   age: number
   assistanceNeedVoucherCoefficient: number | null
-  backupGroupId: UUID | null
-  backupUnitId: UUID | null
+  backupGroupId: GroupId | null
+  backupUnitId: DaycareId | null
   capacity: number
   capacityFactor: number
   careArea: string
   caretakersPlanned: number | null
   caretakersRealized: number | null
-  childId: UUID
+  childId: PersonId
   costCenter: string | null
   dateOfBirth: LocalDate
   day: LocalDate
-  daycareGroupId: UUID | null
+  daycareGroupId: GroupId | null
   firstName: string
   groupName: string | null
   hasAssistanceNeed: boolean
@@ -773,7 +781,7 @@ export interface RawReportRow {
   serviceNeed: string | null
   shiftCare: boolean
   staffDimensioning: number
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
   unitProviderType: ProviderType
   unitType: UnitType | null
@@ -872,13 +880,13 @@ export interface ServiceVoucherUnitReport {
 * Generated from fi.espoo.evaka.reports.ServiceVoucherValueRow
 */
 export interface ServiceVoucherValueRow {
-  areaId: UUID
+  areaId: AreaId
   areaName: string
   assistanceNeedCoefficient: number
   childDateOfBirth: LocalDate
   childFirstName: string
   childGroupName: string | null
-  childId: UUID
+  childId: PersonId
   childLastName: string
   isNew: boolean
   numberOfDays: number
@@ -886,11 +894,11 @@ export interface ServiceVoucherValueRow {
   realizedPeriod: FiniteDateRange
   serviceNeedDescription: string
   serviceVoucherCoPayment: number
-  serviceVoucherDecisionId: UUID
+  serviceVoucherDecisionId: VoucherValueDecisionId
   serviceVoucherFinalCoPayment: number
   serviceVoucherValue: number
   type: VoucherReportRowType
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -909,7 +917,7 @@ export interface ServiceVoucherValueUnitAggregate {
 export interface SextetReportRow {
   attendanceDays: number
   placementType: PlacementType
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 
@@ -918,7 +926,7 @@ export interface SextetReportRow {
 */
 export interface SourceUnitsReportRow {
   address: string
-  id: UUID
+  id: DaycareId
   postOffice: string
   postalCode: string
   unitName: string
@@ -929,11 +937,11 @@ export interface SourceUnitsReportRow {
 */
 export interface StartingPlacementsRow {
   careAreaName: string
-  childId: UUID
+  childId: PersonId
   dateOfBirth: LocalDate
   firstName: string
   lastName: string
-  placementId: UUID
+  placementId: PlacementId
   placementStart: LocalDate
   unitName: string
 }
@@ -978,9 +986,9 @@ export interface TitaniaErrorUnit {
 * Generated from fi.espoo.evaka.reports.ServiceVoucherValueUnitAggregate.UnitData
 */
 export interface UnitData {
-  areaId: UUID
+  areaId: AreaId
   areaName: string
-  id: UUID
+  id: DaycareId
   name: string
 }
 
@@ -1008,7 +1016,7 @@ export interface UnitsReportRow {
   clubApply: boolean
   costCenter: string
   daycareApply: boolean
-  id: UUID
+  id: DaycareId
   invoicedByMunicipality: boolean
   name: string
   ophOrganizerOid: string | null
@@ -1026,11 +1034,11 @@ export interface UnitsReportRow {
 * Generated from fi.espoo.evaka.reports.VardaChildErrorReportRow
 */
 export interface VardaChildErrorReportRow {
-  childId: UUID
+  childId: PersonId
   created: HelsinkiDateTime
   errors: string[]
   resetTimeStamp: HelsinkiDateTime | null
-  serviceNeedId: UUID | null
+  serviceNeedId: ServiceNeedId | null
   serviceNeedOptionName: string | null
   serviceNeedValidity: FiniteDateRange | null
   updated: HelsinkiDateTime
@@ -1043,7 +1051,7 @@ export interface VardaUnitErrorReportRow {
   createdAt: HelsinkiDateTime
   error: string
   erroredAt: HelsinkiDateTime
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
 }
 

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -10,13 +10,16 @@ import TimeInterval from '../../time-interval'
 import TimeRange from '../../time-range'
 import { AbsenceCategory } from './absence'
 import { AbsenceType } from './absence'
+import { ChildImageId } from './shared'
 import { ChildServiceNeedInfo } from './absence'
 import { DailyServiceTimesValue } from './dailyservicetimes'
+import { DaycareId } from './shared'
+import { GroupId } from './shared'
 import { HolidayPeriodEffect } from './holidayperiod'
 import { JsonOf } from '../../json'
+import { PersonId } from './shared'
 import { PlacementType } from './placement'
 import { ScheduleType } from './placement'
-import { UUID } from '../../types'
 import { deserializeJsonChildServiceNeedInfo } from './absence'
 import { deserializeJsonDailyServiceTimesValue } from './dailyservicetimes'
 import { deserializeJsonHolidayPeriodEffect } from './holidayperiod'
@@ -34,7 +37,7 @@ export interface AbsenceInfo {
 */
 export interface AbsenceRequest {
   absenceType: AbsenceType
-  childIds: UUID[]
+  childIds: PersonId[]
   dateRange: FiniteDateRange
 }
 
@@ -59,7 +62,7 @@ export type BackupPlacementType =
 export interface Child {
   dateOfBirth: LocalDate
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   preferredName: string
   serviceNeeds: ChildServiceNeedInfo[]
@@ -72,10 +75,10 @@ export interface ChildDatePresence {
   absenceBillable: AbsenceType | null
   absenceNonbillable: AbsenceType | null
   attendances: TimeInterval[]
-  childId: UUID
+  childId: PersonId
   date: LocalDate
   reservations: Reservation[]
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -85,10 +88,10 @@ export interface ChildRecordOfDay {
   absenceBillable: AbsenceTypeResponse | null
   absenceNonbillable: AbsenceTypeResponse | null
   attendances: TimeInterval[]
-  backupGroupId: UUID | null
-  childId: UUID
+  backupGroupId: GroupId | null
+  childId: PersonId
   dailyServiceTimes: DailyServiceTimesValue | null
-  groupId: UUID | null
+  groupId: GroupId | null
   inOtherUnit: boolean
   possibleAbsenceCategories: AbsenceCategory[]
   reservations: ReservationResponse[]
@@ -101,9 +104,9 @@ export interface ChildRecordOfDay {
 export interface ChildReservationInfo {
   absent: boolean
   backupPlacement: BackupPlacementType | null
-  childId: UUID
+  childId: PersonId
   dailyServiceTimes: DailyServiceTimesValue | null
-  groupId: UUID | null
+  groupId: GroupId | null
   isInHolidayPeriod: boolean
   reservations: ReservationResponse[]
   scheduleType: ScheduleType
@@ -134,7 +137,7 @@ export interface ConfirmedRangeDateUpdate {
 */
 export interface DailyChildReservationResult {
   childReservations: ChildReservationInfo[]
-  children: Partial<Record<UUID, ReservationChildInfo>>
+  children: Partial<Record<PersonId, ReservationChildInfo>>
 }
 
 
@@ -144,7 +147,7 @@ export namespace DailyReservationRequest {
   */
   export interface Absent {
     type: 'ABSENT'
-    childId: UUID
+    childId: PersonId
     date: LocalDate
   }
 
@@ -153,7 +156,7 @@ export namespace DailyReservationRequest {
   */
   export interface Nothing {
     type: 'NOTHING'
-    childId: UUID
+    childId: PersonId
     date: LocalDate
   }
 
@@ -162,7 +165,7 @@ export namespace DailyReservationRequest {
   */
   export interface Present {
     type: 'PRESENT'
-    childId: UUID
+    childId: PersonId
     date: LocalDate
   }
 
@@ -171,7 +174,7 @@ export namespace DailyReservationRequest {
   */
   export interface Reservations {
     type: 'RESERVATIONS'
-    childId: UUID
+    childId: PersonId
     date: LocalDate
     reservation: TimeRange
     secondReservation: TimeRange | null
@@ -197,7 +200,7 @@ export interface DayReservationStatisticsResult {
 */
 export interface ExpectedAbsencesRequest {
   attendances: TimeRange[]
-  childId: UUID
+  childId: PersonId
   date: LocalDate
 }
 
@@ -214,7 +217,7 @@ export interface ExpectedAbsencesResponse {
 export interface GroupReservationStatisticResult {
   absentCount: number
   calculatedPresent: number
-  groupId: UUID | null
+  groupId: GroupId | null
   presentCount: number
 }
 
@@ -299,10 +302,10 @@ export type Reservation = Reservation.NoTimes | Reservation.Times
 * Generated from fi.espoo.evaka.reservations.ReservationChild
 */
 export interface ReservationChild {
-  duplicateOf: UUID | null
+  duplicateOf: PersonId | null
   firstName: string
-  id: UUID
-  imageId: UUID | null
+  id: PersonId
+  imageId: ChildImageId | null
   lastName: string
   monthSummaries: MonthSummary[]
   preferredName: string
@@ -315,7 +318,7 @@ export interface ReservationChild {
 export interface ReservationChildInfo {
   dateOfBirth: LocalDate
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   preferredName: string
 }
@@ -324,7 +327,7 @@ export interface ReservationChildInfo {
 * Generated from fi.espoo.evaka.reservations.UnitAttendanceReservations.ReservationGroup
 */
 export interface ReservationGroup {
-  id: UUID
+  id: GroupId
   name: string
 }
 
@@ -369,7 +372,7 @@ export interface ReservationResponseDay {
 export interface ReservationResponseDayChild {
   absence: AbsenceInfo | null
   attendances: TimeInterval[]
-  childId: UUID
+  childId: PersonId
   holidayPeriodEffect: HolidayPeriodEffect | null
   reservableTimeRange: ReservableTimeRange
   reservations: ReservationResponse[]

--- a/frontend/src/lib-common/generated/api-types/sensitive.ts
+++ b/frontend/src/lib-common/generated/api-types/sensitive.ts
@@ -7,8 +7,8 @@
 import LocalDate from '../../local-date'
 import { ContactInfo } from './attendance'
 import { JsonOf } from '../../json'
+import { PersonId } from './shared'
 import { PlacementType } from './placement'
-import { UUID } from '../../types'
 
 /**
 * Generated from fi.espoo.evaka.sensitive.ChildBasicInformation
@@ -18,7 +18,7 @@ export interface ChildBasicInformation {
   contacts: ContactInfo[]
   dateOfBirth: LocalDate
   firstName: string
-  id: UUID
+  id: PersonId
   lastName: string
   placementType: PlacementType | null
   preferredName: string
@@ -32,7 +32,7 @@ export interface ChildSensitiveInformation {
   allergies: string
   childAddress: string
   diet: string
-  id: UUID
+  id: PersonId
   medication: string
   ssn: string
 }

--- a/frontend/src/lib-common/generated/api-types/serviceneed.ts
+++ b/frontend/src/lib-common/generated/api-types/serviceneed.ts
@@ -8,9 +8,16 @@ import DateRange from '../../date-range'
 import HelsinkiDateTime from '../../helsinki-date-time'
 import LocalDate from '../../local-date'
 import { Action } from '../action'
+import { DaycareId } from './shared'
+import { EmployeeId } from './shared'
+import { EvakaUserId } from './shared'
 import { JsonOf } from '../../json'
+import { PersonId } from './shared'
+import { PlacementId } from './shared'
 import { PlacementType } from './placement'
-import { UUID } from '../../types'
+import { ServiceApplicationId } from './shared'
+import { ServiceNeedId } from './shared'
+import { ServiceNeedOptionId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.serviceneed.application.ServiceApplicationController.AcceptServiceApplicationBody
@@ -41,12 +48,12 @@ export interface EmployeeServiceApplication {
 */
 export interface ServiceApplication {
   additionalInfo: string
-  childId: UUID
+  childId: PersonId
   childName: string
   currentPlacement: ServiceApplicationPlacement | null
   decision: ServiceApplicationDecision | null
-  id: UUID
-  personId: UUID
+  id: ServiceApplicationId
+  personId: PersonId
   personName: string
   sentAt: HelsinkiDateTime
   serviceNeedOption: ServiceNeedOptionBasics
@@ -58,8 +65,8 @@ export interface ServiceApplication {
 */
 export interface ServiceApplicationCreateRequest {
   additionalInfo: string
-  childId: UUID
-  serviceNeedOptionId: UUID
+  childId: PersonId
+  serviceNeedOptionId: ServiceNeedOptionId
   startDate: LocalDate
 }
 
@@ -68,7 +75,7 @@ export interface ServiceApplicationCreateRequest {
 */
 export interface ServiceApplicationDecision {
   decidedAt: HelsinkiDateTime
-  decidedBy: UUID
+  decidedBy: EmployeeId
   decidedByName: string
   rejectedReason: string | null
   status: ServiceApplicationDecisionStatus
@@ -86,9 +93,9 @@ export type ServiceApplicationDecisionStatus =
 */
 export interface ServiceApplicationPlacement {
   endDate: LocalDate
-  id: UUID
+  id: PlacementId
   type: PlacementType
-  unitId: UUID
+  unitId: DaycareId
 }
 
 /**
@@ -104,10 +111,10 @@ export interface ServiceApplicationRejection {
 export interface ServiceNeed {
   confirmed: ServiceNeedConfirmation | null
   endDate: LocalDate
-  id: UUID
+  id: ServiceNeedId
   option: ServiceNeedOptionSummary
   partWeek: boolean
-  placementId: UUID
+  placementId: PlacementId
   shiftCare: ShiftCareType
   startDate: LocalDate
   updated: HelsinkiDateTime
@@ -119,7 +126,7 @@ export interface ServiceNeed {
 export interface ServiceNeedConfirmation {
   at: HelsinkiDateTime | null
   name: string
-  userId: UUID
+  userId: EvakaUserId
 }
 
 /**
@@ -127,9 +134,9 @@ export interface ServiceNeedConfirmation {
 */
 export interface ServiceNeedCreateRequest {
   endDate: LocalDate
-  optionId: UUID
+  optionId: ServiceNeedOptionId
   partWeek: boolean
-  placementId: UUID
+  placementId: PlacementId
   shiftCare: ShiftCareType
   startDate: LocalDate
 }
@@ -145,7 +152,7 @@ export interface ServiceNeedOption {
   feeCoefficient: number
   feeDescriptionFi: string
   feeDescriptionSv: string
-  id: UUID
+  id: ServiceNeedOptionId
   nameEn: string
   nameFi: string
   nameSv: string
@@ -167,7 +174,7 @@ export interface ServiceNeedOption {
 * Generated from fi.espoo.evaka.serviceneed.application.ServiceNeedOptionBasics
 */
 export interface ServiceNeedOptionBasics {
-  id: UUID
+  id: ServiceNeedOptionId
   nameEn: string
   nameFi: string
   nameSv: string
@@ -180,7 +187,7 @@ export interface ServiceNeedOptionBasics {
 * Generated from fi.espoo.evaka.serviceneed.ServiceNeedOptionPublicInfo
 */
 export interface ServiceNeedOptionPublicInfo {
-  id: UUID
+  id: ServiceNeedOptionId
   nameEn: string
   nameFi: string
   nameSv: string
@@ -193,7 +200,7 @@ export interface ServiceNeedOptionPublicInfo {
 * Generated from fi.espoo.evaka.serviceneed.ServiceNeedOptionSummary
 */
 export interface ServiceNeedOptionSummary {
-  id: UUID
+  id: ServiceNeedOptionId
   nameEn: string
   nameFi: string
   nameSv: string
@@ -216,7 +223,7 @@ export interface ServiceNeedSummary {
 */
 export interface ServiceNeedUpdateRequest {
   endDate: LocalDate
-  optionId: UUID
+  optionId: ServiceNeedOptionId
   partWeek: boolean
   shiftCare: ShiftCareType
   startDate: LocalDate
@@ -237,10 +244,10 @@ export type ShiftCareType = typeof shiftCareType[number]
 * Generated from fi.espoo.evaka.serviceneed.application.UndecidedServiceApplicationSummary
 */
 export interface UndecidedServiceApplicationSummary {
-  childId: UUID
+  childId: PersonId
   childName: string
   currentNeed: string | null
-  id: UUID
+  id: ServiceApplicationId
   newNeed: string
   placementEndDate: LocalDate
   sentAt: HelsinkiDateTime

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -18,7 +18,7 @@ export type AreaId = Id<'Area'>
 
 export type AssistanceActionId = Id<'AssistanceAction'>
 
-export type AssistanceFactorId = string
+export type AssistanceFactorId = Id<'AssistanceFactor'>
 
 export type AssistanceNeedDecisionGuardianId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -244,7 +244,7 @@ export type ServiceApplicationId = string
 
 export type ServiceNeedId = string
 
-export type ServiceNeedOptionId = string
+export type ServiceNeedOptionId = Id<'ServiceNeedOption'>
 
 export type ServiceNeedOptionVoucherValueId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -36,7 +36,7 @@ export type BackupCareId = Id<'BackupCare'>
 
 export type BackupPickupId = Id<'BackupPickup'>
 
-export type CalendarEventAttendeeId = string
+export type CalendarEventId = Id<'CalendarEvent'>
 
 export type CalendarEventTimeId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -22,7 +22,7 @@ export type AssistanceFactorId = Id<'AssistanceFactor'>
 
 export type AssistanceNeedDecisionGuardianId = string
 
-export type AssistanceNeedDecisionId = string
+export type AssistanceNeedDecisionId = Id<'AssistanceNeedDecision'>
 
 export type AssistanceNeedPreschoolDecisionGuardianId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -20,7 +20,7 @@ export type AssistanceActionId = Id<'AssistanceAction'>
 
 export type AssistanceFactorId = Id<'AssistanceFactor'>
 
-export type AssistanceNeedDecisionGuardianId = string
+export type AssistanceNeedDecisionGuardianId = Id<'AssistanceNeedDecisionGuardian'>
 
 export type AssistanceNeedDecisionId = Id<'AssistanceNeedDecision'>
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -24,7 +24,7 @@ export type AssistanceNeedDecisionGuardianId = Id<'AssistanceNeedDecisionGuardia
 
 export type AssistanceNeedDecisionId = Id<'AssistanceNeedDecision'>
 
-export type AssistanceNeedPreschoolDecisionGuardianId = string
+export type AssistanceNeedPreschoolDecisionGuardianId = Id<'AssistanceNeedPreschoolDecisionGuardian'>
 
 export type AssistanceNeedPreschoolDecisionId = Id<'AssistanceNeedPreschoolDecision'>
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -30,7 +30,7 @@ export type AssistanceNeedPreschoolDecisionId = Id<'AssistanceNeedPreschoolDecis
 
 export type AssistanceNeedVoucherCoefficientId = Id<'AssistanceNeedVoucherCoefficient'>
 
-export type AttachmentId = string
+export type AttachmentId = Id<'Attachment'>
 
 export type BackupCareId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -44,7 +44,7 @@ export type ChildDailyNoteId = Id<'ChildDailyNote'>
 
 export type ChildDocumentId = Id<'ChildDocument'>
 
-export type ChildImageId = string
+export type ChildImageId = Id<'ChildImage'>
 
 export type ChildStickyNoteId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -34,7 +34,7 @@ export type AttachmentId = Id<'Attachment'>
 
 export type BackupCareId = Id<'BackupCare'>
 
-export type BackupPickupId = string
+export type BackupPickupId = Id<'BackupPickup'>
 
 export type CalendarEventAttendeeId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -12,7 +12,7 @@ export type ApplicationId = Id<'Application'>
 
 export type ApplicationNoteId = Id<'ApplicationNote'>
 
-export type ArchivedProcessId = string
+export type ArchivedProcessId = Id<'ArchivedProcess'>
 
 export type AreaId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -38,7 +38,7 @@ export type BackupPickupId = Id<'BackupPickup'>
 
 export type CalendarEventId = Id<'CalendarEvent'>
 
-export type CalendarEventTimeId = string
+export type CalendarEventTimeId = Id<'CalendarEventTime'>
 
 export type ChildDailyNoteId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -75,7 +75,7 @@ export interface Coordinate {
   lon: number
 }
 
-export type DailyServiceTimeId = string
+export type DailyServiceTimeId = Id<'DailyServiceTime'>
 
 export type DailyServiceTimeNotificationId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -10,7 +10,7 @@ import { JsonOf } from '../../json'
 
 export type ApplicationId = Id<'Application'>
 
-export type ApplicationNoteId = string
+export type ApplicationNoteId = Id<'ApplicationNote'>
 
 export type ArchivedProcessId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -16,7 +16,7 @@ export type ArchivedProcessId = Id<'ArchivedProcess'>
 
 export type AreaId = Id<'Area'>
 
-export type AssistanceActionId = string
+export type AssistanceActionId = Id<'AssistanceAction'>
 
 export type AssistanceFactorId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -26,7 +26,7 @@ export type AssistanceNeedDecisionId = Id<'AssistanceNeedDecision'>
 
 export type AssistanceNeedPreschoolDecisionGuardianId = string
 
-export type AssistanceNeedPreschoolDecisionId = string
+export type AssistanceNeedPreschoolDecisionId = Id<'AssistanceNeedPreschoolDecision'>
 
 export type AssistanceNeedVoucherCoefficientId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -32,7 +32,7 @@ export type AssistanceNeedVoucherCoefficientId = Id<'AssistanceNeedVoucherCoeffi
 
 export type AttachmentId = Id<'Attachment'>
 
-export type BackupCareId = string
+export type BackupCareId = Id<'BackupCare'>
 
 export type BackupPickupId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -75,9 +75,9 @@ export interface Coordinate {
   lon: number
 }
 
-export type DailyServicesTimeId = string
+export type DailyServiceTimeId = string
 
-export type DailyServicesTimeNotificationId = string
+export type DailyServiceTimeNotificationId = string
 
 /**
 * Generated from fi.espoo.evaka.shared.auth.DaycareAclRow

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -5,9 +5,10 @@
 // GENERATED FILE: no manual modifications
 
 import HelsinkiDateTime from '../../helsinki-date-time'
+import { Id } from '../../id-type'
 import { JsonOf } from '../../json'
 
-export type ApplicationId = string
+export type ApplicationId = Id<'Application'>
 
 export type ApplicationNoteId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -14,7 +14,7 @@ export type ApplicationNoteId = Id<'ApplicationNote'>
 
 export type ArchivedProcessId = Id<'ArchivedProcess'>
 
-export type AreaId = string
+export type AreaId = Id<'Area'>
 
 export type AssistanceActionId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -28,7 +28,7 @@ export type AssistanceNeedPreschoolDecisionGuardianId = Id<'AssistanceNeedPresch
 
 export type AssistanceNeedPreschoolDecisionId = Id<'AssistanceNeedPreschoolDecision'>
 
-export type AssistanceNeedVoucherCoefficientId = string
+export type AssistanceNeedVoucherCoefficientId = Id<'AssistanceNeedVoucherCoefficient'>
 
 export type AttachmentId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -105,7 +105,7 @@ export type DaycareAssistanceId = string
 
 export type DaycareCaretakerId = string
 
-export type DaycareId = string
+export type DaycareId = Id<'Daycare'>
 
 export type DecisionId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -77,7 +77,7 @@ export interface Coordinate {
 
 export type DailyServiceTimeId = Id<'DailyServiceTime'>
 
-export type DailyServiceTimeNotificationId = string
+export type DailyServiceTimeNotificationId = Id<'DailyServiceTimeNotification'>
 
 /**
 * Generated from fi.espoo.evaka.shared.auth.DaycareAclRow

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -46,7 +46,7 @@ export type ChildDocumentId = Id<'ChildDocument'>
 
 export type ChildImageId = Id<'ChildImage'>
 
-export type ChildStickyNoteId = string
+export type ChildStickyNoteId = Id<'ChildStickyNote'>
 
 /**
 * Generated from fi.espoo.evaka.shared.auth.CitizenAuthLevel
@@ -153,7 +153,7 @@ export type FosterParentId = string
 
 export type GroupId = string
 
-export type GroupNoteId = string
+export type GroupNoteId = Id<'GroupNote'>
 
 export type GroupPlacementId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -6,7 +6,46 @@
 
 import HelsinkiDateTime from '../../helsinki-date-time'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
+
+export type ApplicationId = string
+
+export type ApplicationNoteId = string
+
+export type ArchivedProcessId = string
+
+export type AreaId = string
+
+export type AssistanceActionId = string
+
+export type AssistanceFactorId = string
+
+export type AssistanceNeedDecisionGuardianId = string
+
+export type AssistanceNeedDecisionId = string
+
+export type AssistanceNeedPreschoolDecisionGuardianId = string
+
+export type AssistanceNeedPreschoolDecisionId = string
+
+export type AssistanceNeedVoucherCoefficientId = string
+
+export type AttachmentId = string
+
+export type BackupCareId = string
+
+export type BackupPickupId = string
+
+export type CalendarEventAttendeeId = string
+
+export type CalendarEventTimeId = string
+
+export type ChildDailyNoteId = string
+
+export type ChildDocumentId = string
+
+export type ChildImageId = string
+
+export type ChildStickyNoteId = string
 
 /**
 * Generated from fi.espoo.evaka.shared.auth.CitizenAuthLevel
@@ -25,6 +64,8 @@ export interface CitizenFeatures {
   reservations: boolean
 }
 
+export type ClubTermId = string
+
 /**
 * Generated from fi.espoo.evaka.shared.domain.Coordinate
 */
@@ -33,12 +74,16 @@ export interface Coordinate {
   lon: number
 }
 
+export type DailyServicesTimeId = string
+
+export type DailyServicesTimeNotificationId = string
+
 /**
 * Generated from fi.espoo.evaka.shared.auth.DaycareAclRow
 */
 export interface DaycareAclRow {
   employee: DaycareAclRowEmployee
-  groupIds: UUID[]
+  groupIds: GroupId[]
   role: UserRole
 }
 
@@ -50,10 +95,20 @@ export interface DaycareAclRowEmployee {
   email: string | null
   firstName: string
   hasStaffOccupancyEffect: boolean | null
-  id: UUID
+  id: EmployeeId
   lastName: string
   temporary: boolean
 }
+
+export type DaycareAssistanceId = string
+
+export type DaycareCaretakerId = string
+
+export type DaycareId = string
+
+export type DecisionId = string
+
+export type DocumentTemplateId = string
 
 /**
 * Generated from fi.espoo.evaka.shared.security.EmployeeFeatures
@@ -83,6 +138,24 @@ export interface EmployeeFeatures {
   units: boolean
 }
 
+export type EmployeeId = string
+
+export type EvakaUserId = string
+
+export type FeeAlterationId = string
+
+export type FeeDecisionId = string
+
+export type FeeThresholdsId = string
+
+export type FosterParentId = string
+
+export type GroupId = string
+
+export type GroupNoteId = string
+
+export type GroupPlacementId = string
+
 /**
 * Generated from fi.espoo.evaka.shared.domain.HelsinkiDateTimeRange
 */
@@ -90,6 +163,32 @@ export interface HelsinkiDateTimeRange {
   end: HelsinkiDateTime
   start: HelsinkiDateTime
 }
+
+export type HolidayPeriodId = string
+
+export type HolidayQuestionnaireId = string
+
+export type IncomeId = string
+
+export type IncomeStatementId = string
+
+export type InvoiceCorrectionId = string
+
+export type InvoiceId = string
+
+export type InvoiceRowId = string
+
+export type MessageAccountId = string
+
+export type MessageContentId = string
+
+export type MessageDraftId = string
+
+export type MessageId = string
+
+export type MessageThreadId = string
+
+export type MobileDeviceId = string
 
 /**
 * Generated from fi.espoo.evaka.shared.domain.OfficialLanguage
@@ -100,6 +199,20 @@ export const officialLanguages = [
 ] as const
 
 export type OfficialLanguage = typeof officialLanguages[number]
+
+export type OtherAssistanceMeasureId = string
+
+export type PairingId = string
+
+export type ParentshipId = string
+
+export type PartnershipId = string
+
+export type PaymentId = string
+
+export type PedagogicalDocumentId = string
+
+export type PersonId = string
 
 /**
 * Generated from fi.espoo.evaka.shared.security.PilotFeature
@@ -117,6 +230,26 @@ export const pilotFeatures = [
 ] as const
 
 export type PilotFeature = typeof pilotFeatures[number]
+
+export type PlacementId = string
+
+export type PlacementPlanId = string
+
+export type PreschoolAssistanceId = string
+
+export type PreschoolTermId = string
+
+export type ServiceApplicationId = string
+
+export type ServiceNeedId = string
+
+export type ServiceNeedOptionId = string
+
+export type ServiceNeedOptionVoucherValueId = string
+
+export type StaffAttendanceExternalId = string
+
+export type StaffAttendanceRealtimeId = string
 
 /**
 * Generated from fi.espoo.evaka.shared.domain.Translatable
@@ -146,6 +279,8 @@ export type UserRole =
   | 'EARLY_CHILDHOOD_EDUCATION_SECRETARY'
   | 'MOBILE'
   | 'GROUP_STAFF'
+
+export type VoucherValueDecisionId = string
 
 
 export function deserializeJsonHelsinkiDateTimeRange(json: JsonOf<HelsinkiDateTimeRange>): HelsinkiDateTimeRange {

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -65,7 +65,7 @@ export interface CitizenFeatures {
   reservations: boolean
 }
 
-export type ClubTermId = string
+export type ClubTermId = Id<'ClubTerm'>
 
 /**
 * Generated from fi.espoo.evaka.shared.domain.Coordinate
@@ -238,7 +238,7 @@ export type PlacementPlanId = string
 
 export type PreschoolAssistanceId = string
 
-export type PreschoolTermId = string
+export type PreschoolTermId = Id<'PreschoolTerm'>
 
 export type ServiceApplicationId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -40,7 +40,7 @@ export type CalendarEventId = Id<'CalendarEvent'>
 
 export type CalendarEventTimeId = Id<'CalendarEventTime'>
 
-export type ChildDailyNoteId = string
+export type ChildDailyNoteId = Id<'ChildDailyNote'>
 
 export type ChildDocumentId = string
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -42,7 +42,7 @@ export type CalendarEventTimeId = Id<'CalendarEventTime'>
 
 export type ChildDailyNoteId = Id<'ChildDailyNote'>
 
-export type ChildDocumentId = string
+export type ChildDocumentId = Id<'ChildDocument'>
 
 export type ChildImageId = string
 

--- a/frontend/src/lib-common/generated/api-types/timeline.ts
+++ b/frontend/src/lib-common/generated/api-types/timeline.ts
@@ -7,12 +7,21 @@
 import DateRange from '../../date-range'
 import LocalDate from '../../local-date'
 import { CreationModificationMetadata } from './pis'
+import { DaycareId } from './shared'
+import { FeeAlterationId } from './shared'
 import { FeeAlterationType } from './invoicing'
+import { FeeDecisionId } from './shared'
 import { FeeDecisionStatus } from './invoicing'
 import { IncomeEffect } from './invoicing'
+import { IncomeId } from './shared'
 import { JsonOf } from '../../json'
+import { ParentshipId } from './shared'
+import { PartnershipId } from './shared'
+import { PersonId } from './shared'
+import { PlacementId } from './shared'
 import { PlacementType } from './placement'
-import { UUID } from '../../types'
+import { ServiceNeedId } from './shared'
+import { VoucherValueDecisionId } from './shared'
 import { VoucherValueDecisionStatus } from './invoicing'
 import { deserializeJsonCreationModificationMetadata } from './pis'
 
@@ -26,7 +35,7 @@ export interface Timeline {
   incomes: TimelineIncome[]
   lastName: string
   partners: TimelinePartnerDetailed[]
-  personId: UUID
+  personId: PersonId
   valueDecisions: TimelineValueDecision[]
 }
 
@@ -34,12 +43,12 @@ export interface Timeline {
 * Generated from fi.espoo.evaka.timeline.TimelineChildDetailed
 */
 export interface TimelineChildDetailed {
-  childId: UUID
+  childId: PersonId
   creationModificationMetadata: CreationModificationMetadata
   dateOfBirth: LocalDate
   feeAlterations: TimelineFeeAlteration[]
   firstName: string
-  id: UUID
+  id: ParentshipId
   incomes: TimelineIncome[]
   lastName: string
   originApplicationAccessible: boolean
@@ -54,7 +63,7 @@ export interface TimelineChildDetailed {
 export interface TimelineFeeAlteration {
   absolute: boolean
   amount: number
-  id: UUID
+  id: FeeAlterationId
   notes: string
   range: DateRange
   type: FeeAlterationType
@@ -64,7 +73,7 @@ export interface TimelineFeeAlteration {
 * Generated from fi.espoo.evaka.timeline.TimelineFeeDecision
 */
 export interface TimelineFeeDecision {
-  id: UUID
+  id: FeeDecisionId
   range: DateRange
   status: FeeDecisionStatus
   totalFee: number
@@ -75,7 +84,7 @@ export interface TimelineFeeDecision {
 */
 export interface TimelineIncome {
   effect: IncomeEffect
-  id: UUID
+  id: IncomeId
   range: DateRange
 }
 
@@ -87,11 +96,11 @@ export interface TimelinePartnerDetailed {
   creationModificationMetadata: CreationModificationMetadata
   feeDecisions: TimelineFeeDecision[]
   firstName: string
-  id: UUID
+  id: PartnershipId
   incomes: TimelineIncome[]
   lastName: string
   originApplicationAccessible: boolean
-  partnerId: UUID
+  partnerId: PersonId
   range: DateRange
   valueDecisions: TimelineValueDecision[]
 }
@@ -100,7 +109,7 @@ export interface TimelinePartnerDetailed {
 * Generated from fi.espoo.evaka.timeline.TimelinePlacement
 */
 export interface TimelinePlacement {
-  id: UUID
+  id: PlacementId
   range: DateRange
   type: PlacementType
   unit: TimelinePlacementUnit
@@ -110,7 +119,7 @@ export interface TimelinePlacement {
 * Generated from fi.espoo.evaka.timeline.TimelinePlacementUnit
 */
 export interface TimelinePlacementUnit {
-  id: UUID
+  id: DaycareId
   name: string
 }
 
@@ -118,7 +127,7 @@ export interface TimelinePlacementUnit {
 * Generated from fi.espoo.evaka.timeline.TimelineServiceNeed
 */
 export interface TimelineServiceNeed {
-  id: UUID
+  id: ServiceNeedId
   name: string
   range: DateRange
 }
@@ -127,7 +136,7 @@ export interface TimelineServiceNeed {
 * Generated from fi.espoo.evaka.timeline.TimelineValueDecision
 */
 export interface TimelineValueDecision {
-  id: UUID
+  id: VoucherValueDecisionId
   range: DateRange
   status: VoucherValueDecisionStatus
 }

--- a/frontend/src/lib-common/generated/api-types/user.ts
+++ b/frontend/src/lib-common/generated/api-types/user.ts
@@ -4,13 +4,13 @@
 
 // GENERATED FILE: no manual modifications
 
-import { UUID } from '../../types'
+import { EvakaUserId } from './shared'
 
 /**
 * Generated from fi.espoo.evaka.user.EvakaUser
 */
 export interface EvakaUser {
-  id: UUID
+  id: EvakaUserId
   name: string
   type: EvakaUserType
 }

--- a/frontend/src/lib-common/generated/api-types/webpush.ts
+++ b/frontend/src/lib-common/generated/api-types/webpush.ts
@@ -5,8 +5,8 @@
 // GENERATED FILE: no manual modifications
 
 import HelsinkiDateTime from '../../helsinki-date-time'
+import { GroupId } from './shared'
 import { JsonOf } from '../../json'
-import { UUID } from '../../types'
 
 /**
 * Generated from fi.espoo.evaka.webpush.PushNotificationCategory
@@ -24,7 +24,7 @@ export type PushNotificationCategory = typeof pushNotificationCategories[number]
 */
 export interface PushSettings {
   categories: PushNotificationCategory[]
-  groups: UUID[]
+  groups: GroupId[]
 }
 
 /**

--- a/frontend/src/lib-common/id-type.ts
+++ b/frontend/src/lib-common/id-type.ts
@@ -1,0 +1,2 @@
+declare const id: unique symbol
+export type Id<B extends string> = string & { [id]: B }

--- a/frontend/src/lib-common/id-type.ts
+++ b/frontend/src/lib-common/id-type.ts
@@ -1,2 +1,26 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { validate, v4 as uuidv4 } from 'uuid'
+
 declare const id: unique symbol
 export type Id<B extends string> = string & { [id]: B }
+
+export function fromUuid<T extends Id<string>>(id: string): T {
+  if (!validate(id)) {
+    throw new Error(`Invalid UUID: ${id}`)
+  }
+  return id as T
+}
+
+export function fromNullableUuid<T extends Id<string>>(
+  id: string | null
+): T | null {
+  if (id === null) return null
+  return fromUuid<T>(id)
+}
+
+export function randomId<T extends Id<string>>(): T {
+  return uuidv4() as T
+}

--- a/frontend/src/lib-common/useRouteParams.ts
+++ b/frontend/src/lib-common/useRouteParams.ts
@@ -5,6 +5,8 @@
 import * as Sentry from '@sentry/browser'
 import { useParams } from 'react-router'
 
+import { fromUuid, Id } from './id-type'
+
 export default function useRouteParams<
   const Required extends string[],
   const Optional extends string[]
@@ -34,3 +36,8 @@ export default function useRouteParams<
 
 type RequiredObject<T extends string[]> = Record<T[number], string>
 type OptionalObject<T extends string[]> = Partial<Record<T[number], string>>
+
+export function useIdRouteParam<T extends Id<string>>(paramName: string): T {
+  const params = useRouteParams([paramName])
+  return fromUuid<T>(params[paramName])
+}

--- a/frontend/src/lib-components/atoms/dropdowns/TreeDropdown.tsx
+++ b/frontend/src/lib-components/atoms/dropdowns/TreeDropdown.tsx
@@ -154,7 +154,7 @@ export interface TreeNode {
   children: TreeNode[]
 }
 
-export const sortTreeByText = (tree: TreeNode[]): TreeNode[] =>
+export const sortTreeByText = <N extends TreeNode>(tree: N[]): N[] =>
   sortBy(
     tree.map((node) => ({
       ...node,

--- a/frontend/src/lib-components/employee/notes/StaticStickyNote.tsx
+++ b/frontend/src/lib-components/employee/notes/StaticStickyNote.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback } from 'react'
 
 import { Result } from 'lib-common/api'
-import { UUID } from 'lib-common/types'
+import { Id } from 'lib-common/id-type'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { ContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
@@ -21,21 +21,21 @@ export interface StaticLabels {
   validTo: (date: string) => string
 }
 
-interface Props {
-  note: Note
-  onRemove: (id: UUID) => Promise<Result<unknown>>
+interface Props<IdType extends Id<string>> {
+  note: Note<IdType>
+  onRemove: (id: IdType) => Promise<Result<unknown>>
   editable: boolean
   onEdit: () => void
   labels: StaticLabels
 }
 
-export const StaticStickyNote = React.memo(function StaticStickyNote({
+export function StaticStickyNote<IdType extends Id<string>>({
   note,
   editable,
   onEdit,
   onRemove,
   labels
-}: Props) {
+}: Props<IdType>) {
   const removeNote = useCallback(() => onRemove(note.id), [note.id, onRemove])
   return (
     <ContentArea opaque paddingHorizontal="s" data-qa="sticky-note">
@@ -64,4 +64,4 @@ export const StaticStickyNote = React.memo(function StaticStickyNote({
       </FixedSpaceRow>
     </ContentArea>
   )
-})
+}

--- a/frontend/src/lib-components/employee/notes/StickyNoteEditor.tsx
+++ b/frontend/src/lib-components/employee/notes/StickyNoteEditor.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useState } from 'react'
 
 import { Result } from 'lib-common/api'
+import { Id } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import TextArea from 'lib-components/atoms/form/TextArea'
@@ -13,7 +14,7 @@ import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { Gap } from 'lib-components/white-space'
 
 import { InlineAsyncButton } from './InlineAsyncButton'
-import { EditedNote, Note } from './notes'
+import { EditedNote } from './notes'
 
 export interface EditorLabels {
   cancel: string
@@ -21,19 +22,19 @@ export interface EditorLabels {
   placeholder: string
 }
 
-interface Props {
-  note: Note
-  onSave: (note: EditedNote) => Promise<Result<unknown>>
+interface Props<IdType extends Id<string>> {
+  note: EditedNote<IdType>
+  onSave: (note: EditedNote<IdType>) => Promise<Result<unknown>>
   onCancelEdit: () => void
   labels: EditorLabels
 }
 
-export const StickyNoteEditor = React.memo(function StickyNoteEditor({
+export function StickyNoteEditor<IdType extends Id<string>>({
   note,
   onCancelEdit,
   onSave,
   labels
-}: Props) {
+}: Props<IdType>) {
   const [text, setText] = useState(note.note)
 
   const saveNote = useCallback(
@@ -72,4 +73,4 @@ export const StickyNoteEditor = React.memo(function StickyNoteEditor({
       </FixedSpaceRow>
     </ContentArea>
   )
-})
+}

--- a/frontend/src/lib-components/employee/notes/StickyNoteTab.tsx
+++ b/frontend/src/lib-components/employee/notes/StickyNoteTab.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useState } from 'react'
 
 import { Result } from 'lib-common/api'
+import { Id } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -17,8 +18,7 @@ import { StaticLabels, StaticStickyNote } from './StaticStickyNote'
 import { EditorLabels, StickyNoteEditor } from './StickyNoteEditor'
 import { EditedNote, Note } from './notes'
 
-const newNote = () => ({
-  id: '',
+const newNote = (): EditedNote<never> => ({
   expires: LocalDate.todayInSystemTz().addDays(7),
   note: ''
 })
@@ -30,23 +30,23 @@ export interface StickyNoteTabLabels {
   static: StaticLabels
 }
 
-interface StickyNoteTabProps {
+interface StickyNoteTabProps<IdType extends Id<string>> {
   labels: StickyNoteTabLabels
-  notes: Note[]
-  onSave: (note: EditedNote) => Promise<Result<unknown>>
-  onRemove: (id: UUID) => Promise<Result<unknown>>
+  notes: Note<IdType>[]
+  onSave: (note: EditedNote<IdType>) => Promise<Result<unknown>>
+  onRemove: (id: IdType) => Promise<Result<unknown>>
   smallerHeading?: boolean
   subHeading?: string
 }
 
-export const StickyNoteTab = React.memo(function StickyNoteTab({
+export function StickyNoteTab<IdType extends Id<string>>({
   labels,
   notes,
   onSave,
   onRemove,
   smallerHeading = false,
   subHeading
-}: StickyNoteTabProps) {
+}: StickyNoteTabProps<IdType>) {
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   const [editing, setEditing] = useState<UUID | 'new' | null>(
     notes.length === 0 ? 'new' : null
@@ -117,4 +117,4 @@ export const StickyNoteTab = React.memo(function StickyNoteTab({
       )}
     </>
   )
-})
+}

--- a/frontend/src/lib-components/employee/notes/notes.d.ts
+++ b/frontend/src/lib-components/employee/notes/notes.d.ts
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { Id } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 
 export type StickyNoteBody = { note: string; expires: LocalDate }
-export type Note = StickyNoteBody & { id: UUID }
-export type EditedNote = StickyNoteBody & { id?: UUID }
+export type Note<IdType extends Id<string>> = StickyNoteBody & { id: IdType }
+export type EditedNote<IdType extends Id<string>> = StickyNoteBody & {
+  id?: IdType
+}

--- a/frontend/src/lib-components/molecules/FileUpload.tsx
+++ b/frontend/src/lib-components/molecules/FileUpload.tsx
@@ -9,6 +9,8 @@ import styled from 'styled-components'
 
 import { Failure, Result, Success } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import { UUID } from 'lib-common/types'
 import { useUniqueId } from 'lib-common/utils/useUniqueId'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
@@ -39,7 +41,7 @@ const fileUploadErrorKeys = {
 type FileUploadError = keyof typeof fileUploadErrorKeys
 
 interface FileObject extends Attachment {
-  key: number
+  key: string
   file: File | undefined
   error: FileUploadError | undefined
   /**
@@ -79,8 +81,8 @@ interface FileUploadProps {
   onUpload: (
     file: File,
     onUploadProgress: (percentage: number) => void
-  ) => Promise<Result<UUID>>
-  onDelete: (id: UUID) => Promise<Result<void>>
+  ) => Promise<Result<AttachmentId>>
+  onDelete: (id: AttachmentId) => Promise<Result<void>>
   onStateChange?: (status: UploadStatus) => void
   getDownloadUrl: (id: UUID, fileName: string) => string
   disabled?: boolean
@@ -252,7 +254,7 @@ const ProgressBarError = styled.div`
 const attachmentToFile = (attachment: Attachment): FileObject => ({
   id: attachment.id,
   file: undefined,
-  key: Math.random(),
+  key: attachment.id,
   name: attachment.name,
   contentType: attachment.contentType,
   progress: 100,
@@ -395,12 +397,12 @@ export default React.memo(function FileUpload({
     onUpload: (
       file: File,
       onUploadProgress: (percentage: number) => void
-    ) => Promise<Result<UUID>>
+    ) => Promise<Result<AttachmentId>>
   ) => {
     const error = file.size > MAX_ATTACHMENT_SIZE ? 'FILE_TOO_LARGE' : undefined
-    const pseudoId = Math.random()
+    const pseudoId = randomId<AttachmentId>()
     const fileObject: FileObject = {
-      id: pseudoId.toString(),
+      id: pseudoId,
       key: pseudoId,
       file,
       name: file.name,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.DailyServiceTimeNotification::class,
         DatabaseTable.Daycare::class,
         DatabaseTable.DaycareAssistance::class,
         DatabaseTable.DaycareCaretaker::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.ApplicationNote::class,
         DatabaseTable.ArchivedProcess::class,
         DatabaseTable.Area::class,
         DatabaseTable.AssistanceAction::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.AssistanceNeedDecisionGuardian::class,
         DatabaseTable.AssistanceNeedPreschoolDecision::class,
         DatabaseTable.AssistanceNeedPreschoolDecisionGuardian::class,
         DatabaseTable.AssistanceNeedVoucherCoefficient::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.DailyServiceTime::class,
         DatabaseTable.DailyServiceTimeNotification::class,
         DatabaseTable.Daycare::class,
         DatabaseTable.DaycareAssistance::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.invoicing.service.ProductKey
 import fi.espoo.evaka.messaging.MessageReceiver
 import fi.espoo.evaka.pairing.MobileDeviceDetails
 import fi.espoo.evaka.pis.SystemController
+import fi.espoo.evaka.shared.DatabaseTable
 import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.data.DateSet
 import fi.espoo.evaka.shared.domain.DateRange
@@ -48,6 +49,7 @@ private val plannedEndpoints: Set<String> = setOf()
 val endpointExcludes = plannedEndpoints + deprecatedEndpoints
 
 object Imports {
+    val id = TsImport.Named(LibCommon / "id-type.ts", "Id")
     val localDate = TsImport.Default(LibCommon / "local-date.ts", "LocalDate")
     val localTime = TsImport.Default(LibCommon / "local-time.ts", "LocalTime")
     val helsinkiDateTime =
@@ -68,6 +70,94 @@ object Imports {
     val createUrlSearchParams = TsImport.Named(LibCommon / "api.ts", "createUrlSearchParams")
     val devApiError = TsImport.Named(E2ETest / "dev-api", "DevApiError")
 }
+
+// For lenient id types, a string type alias is generated: `type FooId = string`.
+// For others, a strict type is generated: `type FooId = Id<'Foo'>`.
+val lenientIdTypes =
+    setOf(
+        DatabaseTable.Absence::class,
+        DatabaseTable.Application::class,
+        DatabaseTable.ApplicationNote::class,
+        DatabaseTable.ArchivedProcess::class,
+        DatabaseTable.Area::class,
+        DatabaseTable.AssistanceAction::class,
+        DatabaseTable.AssistanceActionOption::class,
+        DatabaseTable.AssistanceFactor::class,
+        DatabaseTable.AssistanceNeedDecision::class,
+        DatabaseTable.AssistanceNeedDecisionGuardian::class,
+        DatabaseTable.AssistanceNeedPreschoolDecision::class,
+        DatabaseTable.AssistanceNeedPreschoolDecisionGuardian::class,
+        DatabaseTable.AssistanceNeedVoucherCoefficient::class,
+        DatabaseTable.Attachment::class,
+        DatabaseTable.AttendanceReservation::class,
+        DatabaseTable.BackupCare::class,
+        DatabaseTable.BackupPickup::class,
+        DatabaseTable.CalendarEvent::class,
+        DatabaseTable.CalendarEventAttendee::class,
+        DatabaseTable.CalendarEventTime::class,
+        DatabaseTable.ChildAttendance::class,
+        DatabaseTable.ChildDailyNote::class,
+        DatabaseTable.ChildDocument::class,
+        DatabaseTable.ChildImage::class,
+        DatabaseTable.ChildStickyNote::class,
+        DatabaseTable.ClubTerm::class,
+        DatabaseTable.GroupNote::class,
+        DatabaseTable.DailyServicesTime::class,
+        DatabaseTable.DailyServicesTimeNotification::class,
+        DatabaseTable.Daycare::class,
+        DatabaseTable.DaycareAssistance::class,
+        DatabaseTable.DaycareCaretaker::class,
+        DatabaseTable.Decision::class,
+        DatabaseTable.DocumentTemplate::class,
+        DatabaseTable.Employee::class,
+        DatabaseTable.EmployeePin::class,
+        DatabaseTable.EvakaUser::class,
+        DatabaseTable.FamilyContact::class,
+        DatabaseTable.FeeAlteration::class,
+        DatabaseTable.FeeDecision::class,
+        DatabaseTable.FeeThresholds::class,
+        DatabaseTable.FosterParent::class,
+        DatabaseTable.Group::class,
+        DatabaseTable.GroupPlacement::class,
+        DatabaseTable.HolidayPeriod::class,
+        DatabaseTable.HolidayQuestionnaire::class,
+        DatabaseTable.Income::class,
+        DatabaseTable.IncomeNotification::class,
+        DatabaseTable.IncomeStatement::class,
+        DatabaseTable.Invoice::class,
+        DatabaseTable.InvoiceCorrection::class,
+        DatabaseTable.InvoiceRow::class,
+        DatabaseTable.KoskiStudyRight::class,
+        DatabaseTable.Message::class,
+        DatabaseTable.MessageAccount::class,
+        DatabaseTable.MessageContent::class,
+        DatabaseTable.MessageDraft::class,
+        DatabaseTable.MessageRecipients::class,
+        DatabaseTable.MessageThread::class,
+        DatabaseTable.MessageThreadFolder::class,
+        DatabaseTable.MobileDevice::class,
+        DatabaseTable.OtherAssistanceMeasure::class,
+        DatabaseTable.Pairing::class,
+        DatabaseTable.Parentship::class,
+        DatabaseTable.Partnership::class,
+        DatabaseTable.Payment::class,
+        DatabaseTable.PedagogicalDocument::class,
+        DatabaseTable.Person::class,
+        DatabaseTable.Placement::class,
+        DatabaseTable.PlacementPlan::class,
+        DatabaseTable.PreschoolAssistance::class,
+        DatabaseTable.PreschoolTerm::class,
+        DatabaseTable.ServiceApplication::class,
+        DatabaseTable.ServiceNeed::class,
+        DatabaseTable.ServiceNeedOption::class,
+        DatabaseTable.ServiceNeedOptionVoucherValue::class,
+        DatabaseTable.StaffAttendance::class,
+        DatabaseTable.StaffAttendanceRealtime::class,
+        DatabaseTable.StaffAttendanceExternal::class,
+        DatabaseTable.StaffAttendancePlan::class,
+        DatabaseTable.StaffOccupancyCoefficient::class,
+        DatabaseTable.VoucherValueDecision::class,
+    )
 
 val defaultMetadata =
     TypeMetadata(
@@ -195,21 +285,13 @@ val defaultMetadata =
                 serializeRequestParam = { value, _ -> value },
                 Imports.uuid,
             ),
-        Id::class to
-            TsExternalTypeRef(
-                "UUID",
-                keyRepresentation = TsCode(Imports.uuid),
-                deserializeJson = null,
-                serializePathVariable = { value -> value },
-                serializeRequestParam = { value, _ -> value },
-                Imports.uuid,
-            ),
+        Id::class to GenericWrapper(default = String::class),
         List::class to TsArray,
         Set::class to TsArray,
         Map::class to TsRecord,
         Pair::class to TsTuple(size = 2),
         Triple::class to TsTuple(size = 3),
-        Sensitive::class to GenericWrapper,
+        Sensitive::class to GenericWrapper(),
         Void::class to Excluded,
         ExternalId::class to TsPlain("string"),
         YearMonth::class to

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.AssistanceNeedVoucherCoefficient::class,
         DatabaseTable.Attachment::class,
         DatabaseTable.AttendanceReservation::class,
         DatabaseTable.BackupCare::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.Daycare::class,
         DatabaseTable.DaycareAssistance::class,
         DatabaseTable.DaycareCaretaker::class,
         DatabaseTable.Decision::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.AssistanceNeedPreschoolDecision::class,
         DatabaseTable.AssistanceNeedPreschoolDecisionGuardian::class,
         DatabaseTable.AssistanceNeedVoucherCoefficient::class,
         DatabaseTable.Attachment::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.AssistanceFactor::class,
         DatabaseTable.AssistanceNeedDecision::class,
         DatabaseTable.AssistanceNeedDecisionGuardian::class,
         DatabaseTable.AssistanceNeedPreschoolDecision::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.ChildImage::class,
         DatabaseTable.ChildStickyNote::class,
         DatabaseTable.ClubTerm::class,
         DatabaseTable.GroupNote::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.Absence::class,
         DatabaseTable.Application::class,
         DatabaseTable.ApplicationNote::class,
         DatabaseTable.ArchivedProcess::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.AssistanceNeedPreschoolDecisionGuardian::class,
         DatabaseTable.AssistanceNeedVoucherCoefficient::class,
         DatabaseTable.Attachment::class,
         DatabaseTable.AttendanceReservation::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.CalendarEventAttendee::class,
         DatabaseTable.CalendarEventTime::class,
         DatabaseTable.ChildAttendance::class,
         DatabaseTable.ChildDailyNote::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.BackupPickup::class,
         DatabaseTable.CalendarEvent::class,
         DatabaseTable.CalendarEventAttendee::class,
         DatabaseTable.CalendarEventTime::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,9 +75,7 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.ChildStickyNote::class,
         DatabaseTable.ClubTerm::class,
-        DatabaseTable.GroupNote::class,
         DatabaseTable.DailyServicesTime::class,
         DatabaseTable.DailyServicesTimeNotification::class,
         DatabaseTable.Daycare::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.CalendarEvent::class,
         DatabaseTable.CalendarEventAttendee::class,
         DatabaseTable.CalendarEventTime::class,
         DatabaseTable.ChildAttendance::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.AttendanceReservation::class,
         DatabaseTable.BackupCare::class,
         DatabaseTable.BackupPickup::class,
         DatabaseTable.CalendarEvent::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.ArchivedProcess::class,
         DatabaseTable.Area::class,
         DatabaseTable.AssistanceAction::class,
         DatabaseTable.AssistanceActionOption::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.ChildDocument::class,
         DatabaseTable.ChildImage::class,
         DatabaseTable.ChildStickyNote::class,
         DatabaseTable.ClubTerm::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,8 +75,8 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.DailyServicesTime::class,
-        DatabaseTable.DailyServicesTimeNotification::class,
+        DatabaseTable.DailyServiceTime::class,
+        DatabaseTable.DailyServiceTimeNotification::class,
         DatabaseTable.Daycare::class,
         DatabaseTable.DaycareAssistance::class,
         DatabaseTable.DaycareCaretaker::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.Attachment::class,
         DatabaseTable.AttendanceReservation::class,
         DatabaseTable.BackupCare::class,
         DatabaseTable.BackupPickup::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.Area::class,
         DatabaseTable.AssistanceAction::class,
         DatabaseTable.AssistanceActionOption::class,
         DatabaseTable.AssistanceFactor::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.AssistanceActionOption::class,
         DatabaseTable.AssistanceFactor::class,
         DatabaseTable.AssistanceNeedDecision::class,
         DatabaseTable.AssistanceNeedDecisionGuardian::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.ClubTerm::class,
         DatabaseTable.DailyServicesTime::class,
         DatabaseTable.DailyServicesTimeNotification::class,
         DatabaseTable.Daycare::class,
@@ -120,7 +119,6 @@ val lenientIdTypes =
         DatabaseTable.Placement::class,
         DatabaseTable.PlacementPlan::class,
         DatabaseTable.PreschoolAssistance::class,
-        DatabaseTable.PreschoolTerm::class,
         DatabaseTable.ServiceApplication::class,
         DatabaseTable.ServiceNeed::class,
         DatabaseTable.ServiceNeedOptionVoucherValue::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.AssistanceNeedDecision::class,
         DatabaseTable.AssistanceNeedDecisionGuardian::class,
         DatabaseTable.AssistanceNeedPreschoolDecision::class,
         DatabaseTable.AssistanceNeedPreschoolDecisionGuardian::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.BackupCare::class,
         DatabaseTable.BackupPickup::class,
         DatabaseTable.CalendarEvent::class,
         DatabaseTable.CalendarEventAttendee::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.ChildDailyNote::class,
         DatabaseTable.ChildDocument::class,
         DatabaseTable.ChildImage::class,
         DatabaseTable.ChildStickyNote::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.Application::class,
         DatabaseTable.ApplicationNote::class,
         DatabaseTable.ArchivedProcess::class,
         DatabaseTable.Area::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -147,7 +147,6 @@ val lenientIdTypes =
         DatabaseTable.PreschoolTerm::class,
         DatabaseTable.ServiceApplication::class,
         DatabaseTable.ServiceNeed::class,
-        DatabaseTable.ServiceNeedOption::class,
         DatabaseTable.ServiceNeedOptionVoucherValue::class,
         DatabaseTable.StaffAttendance::class,
         DatabaseTable.StaffAttendanceRealtime::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.AssistanceAction::class,
         DatabaseTable.AssistanceActionOption::class,
         DatabaseTable.AssistanceFactor::class,
         DatabaseTable.AssistanceNeedDecision::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.CalendarEventTime::class,
         DatabaseTable.ChildAttendance::class,
         DatabaseTable.ChildDailyNote::class,
         DatabaseTable.ChildDocument::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -75,7 +75,6 @@ object Imports {
 // For others, a strict type is generated: `type FooId = Id<'Foo'>`.
 val lenientIdTypes =
     setOf(
-        DatabaseTable.ChildAttendance::class,
         DatabaseTable.ChildDailyNote::class,
         DatabaseTable.ChildDocument::class,
         DatabaseTable.ChildImage::class,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
@@ -1472,26 +1472,25 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                 placement
             }
 
-        val result = db.read { tx -> getMissingGroupPlacements(tx, daycare1.id) }
+        val (group, backup) = db.read { tx -> getMissingGroupPlacements(tx, daycare1.id) }
         assertEquals(
             listOf(
                 MissingGroupPlacement(
                     placement.id,
                     placement.type,
-                    false,
                     FiniteDateRange(placement.startDate, placement.endDate),
                     testChild_1.id,
                     testChild_1.firstName,
                     testChild_1.lastName,
                     testChild_1.dateOfBirth,
                     listOf(),
-                    listOf(),
                     "Kokopäiväinen",
                     FiniteDateRange(evakaLaunch.plusMonths(6).plusDays(1), evakaLaunch.plusYears(1)),
                 )
             ),
-            result,
+            group,
         )
+        assertEquals(emptyList(), backup)
     }
 
     @Test
@@ -1535,25 +1534,22 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                 )
             }
 
-        val result = db.read { tx -> getMissingGroupPlacements(tx, daycare2.id) }
+        val (group, backup) = db.read { tx -> getMissingGroupPlacements(tx, daycare2.id) }
+        assertEquals(emptyList(), group)
         assertEquals(
             listOf(
-                MissingGroupPlacement(
-                    PlacementId(backupCareId.raw),
-                    null,
-                    true,
+                MissingBackupGroupPlacement(
+                    backupCareId,
                     FiniteDateRange(evakaLaunch, evakaLaunch.plusYears(1)),
                     testChild_1.id,
                     testChild_1.firstName,
                     testChild_1.lastName,
                     testChild_1.dateOfBirth,
                     listOf(daycare1.name),
-                    listOf(),
-                    "",
                     FiniteDateRange(evakaLaunch, evakaLaunch.plusYears(1)),
                 )
             ),
-            result,
+            backup,
         )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PlacementToolController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PlacementToolController.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.application
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.daycare.PreschoolTerm
+import fi.espoo.evaka.shared.AttachmentId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
@@ -33,7 +34,7 @@ class PlacementToolController(
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,
         @RequestPart("file") file: MultipartFile,
-    ): UUID {
+    ): AttachmentId {
         return db.connect { dbc ->
                 dbc.transaction { tx ->
                     accessControl.requirePermissionFor(
@@ -45,7 +46,7 @@ class PlacementToolController(
                     placementToolService.createPlacementToolApplications(tx, user, clock, file)
 
                     // this is needed for fileUpload component
-                    UUID.randomUUID()
+                    AttachmentId(UUID.randomUUID())
                 }
             }
             .also { Audit.PlacementTool.log() }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -66,9 +66,9 @@ sealed interface DatabaseTable {
 
     sealed class GroupNote : DatabaseTable
 
-    sealed class DailyServicesTime : DatabaseTable
+    sealed class DailyServiceTime : DatabaseTable
 
-    sealed class DailyServicesTimeNotification : DatabaseTable
+    sealed class DailyServiceTimeNotification : DatabaseTable
 
     sealed class Daycare : DatabaseTable
 
@@ -234,9 +234,9 @@ typealias ChildStickyNoteId = Id<DatabaseTable.ChildStickyNote>
 
 typealias ClubTermId = Id<DatabaseTable.ClubTerm>
 
-typealias DailyServiceTimeNotificationId = Id<DatabaseTable.DailyServicesTimeNotification>
+typealias DailyServiceTimeNotificationId = Id<DatabaseTable.DailyServiceTimeNotification>
 
-typealias DailyServiceTimesId = Id<DatabaseTable.DailyServicesTime>
+typealias DailyServiceTimesId = Id<DatabaseTable.DailyServiceTime>
 
 typealias DaycareAssistanceId = Id<DatabaseTable.DaycareAssistance>
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/Id.kt
@@ -214,9 +214,9 @@ typealias BackupCareId = Id<DatabaseTable.BackupCare>
 
 typealias BackupPickupId = Id<DatabaseTable.BackupPickup>
 
-typealias CalendarEventAttendeeId = Id<DatabaseTable.CalendarEvent>
+typealias CalendarEventAttendeeId = Id<DatabaseTable.CalendarEventAttendee>
 
-typealias CalendarEventId = Id<DatabaseTable.CalendarEventAttendee>
+typealias CalendarEventId = Id<DatabaseTable.CalendarEvent>
 
 typealias CalendarEventTimeId = Id<DatabaseTable.CalendarEventTime>
 


### PR DESCRIPTION
Generoidaan kaikki ID-tyypit fronttiin. Transitiovaiheessa osa tyypeistä generoidaan `string`-aliaksiksi, ja osa vahvoiksi tyypeiksi.

Vahva tyypitys perustuu "branded types" -tekniikkaan, jolloin ajon aikaisesti käsitellään stringejä, mutta tyyppitasolla eri ID:t eivät ole yhteensopivia keskenään.

ID-tyyppejä on yhteensä 82 ja tämän PR:n jälkeen niistä 32 (~39 %) on vahvasti tyypitettyjä ja loput string-aliaksia.
