### PR TITLE
Korjaus tuloilmoitusluonnosten näkyvyyteen virkailijoille

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatement.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatement.kt
@@ -159,7 +159,7 @@ fun createValidatedIncomeStatement(
 ): IncomeStatementId {
     if (!draft && !validateIncomeStatementBody(body)) throw BadRequest("Invalid income statement")
 
-    if (tx.incomeStatementExistsForStartDate(user.id, body.startDate)) {
+    if (tx.unhandledIncomeStatementExistsForStartDate(personId, body.startDate)) {
         throw BadRequest("An income statement for this start date already exists")
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/incomestatement/IncomeStatementController.kt
@@ -47,8 +47,8 @@ class IncomeStatementController(private val accessControl: AccessControl) {
                         personId,
                     )
                     it.readIncomeStatementsForPerson(
+                        user = user,
                         personId = personId,
-                        includeEmployeeContent = true,
                         page = page,
                         pageSize = 10,
                     )
@@ -71,18 +71,18 @@ class IncomeStatementController(private val accessControl: AccessControl) {
         @PathVariable incomeStatementId: IncomeStatementId,
     ): IncomeStatement {
         return db.connect { dbc ->
-                dbc.read {
+                dbc.read { tx ->
                     accessControl.requirePermissionFor(
-                        it,
+                        tx,
                         user,
                         clock,
                         Action.Person.READ_INCOME_STATEMENTS,
                         personId,
                     )
-                    it.readIncomeStatementForPerson(
-                        personId,
-                        incomeStatementId,
-                        includeEmployeeContent = true,
+                    tx.readIncomeStatementForPerson(
+                        user = user,
+                        personId = personId,
+                        incomeStatementId = incomeStatementId,
                     )
                 } ?: throw NotFound("No such income statement")
             }


### PR DESCRIPTION
Tuloilmoitukset näkyivät asiakkaan sivujen kautta talouden käyttäjille jo luonnostilassa ollessaan. Lisäksi korjattu validointilogiikkaa joka estää luomasta useaa ilmoitusta jotka alkavat samana päivänä.