### PR TITLE
Piilota pedagogisten asiakirjojen luonti käyttäjiltä, joilla vain lukuoikeus

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/ChildDocuments.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildDocuments.tsx
@@ -14,7 +14,11 @@ import {
   ChildDocumentSummaryWithPermittedActions,
   DocumentTemplateSummary
 } from 'lib-common/generated/api-types/document'
-import { useMutationResult, useQueryResult } from 'lib-common/query'
+import {
+  constantQuery,
+  useMutationResult,
+  useQueryResult
+} from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -156,14 +160,18 @@ const CreationModal = React.memo(function CreationModal({
 })
 
 export default React.memo(function ChildDocumentsList({
-  childId
+  childId,
+  hasCreatePermission
 }: {
   childId: UUID
+  hasCreatePermission: boolean
 }) {
   const { i18n } = useTranslation()
   const documentsResult = useQueryResult(childDocumentsQuery({ childId }))
   const documentTemplatesResult = useQueryResult(
-    activeDocumentTemplateSummariesQuery({ childId })
+    hasCreatePermission
+      ? activeDocumentTemplateSummariesQuery({ childId })
+      : constantQuery([])
   )
   const [creationModalOpen, setCreationModalOpen] = useState(false)
 
@@ -180,19 +188,23 @@ export default React.memo(function ChildDocumentsList({
 
       return (
         <FixedSpaceColumn>
-          <AddButtonRow
-            text={i18n.childInformation.childDocuments.addNew}
-            onClick={() => setCreationModalOpen(true)}
-            disabled={validTemplates.length < 1}
-            data-qa="create-document"
-          />
+          {hasCreatePermission && (
+            <>
+              <AddButtonRow
+                text={i18n.childInformation.childDocuments.addNew}
+                onClick={() => setCreationModalOpen(true)}
+                disabled={validTemplates.length < 1}
+                data-qa="create-document"
+              />
 
-          {creationModalOpen && (
-            <CreationModal
-              childId={childId}
-              templates={validTemplates}
-              onClose={() => setCreationModalOpen(false)}
-            />
+              {creationModalOpen && (
+                <CreationModal
+                  childId={childId}
+                  templates={validTemplates}
+                  onClose={() => setCreationModalOpen(false)}
+                />
+              )}
+            </>
           )}
 
           <ChildDocuments childId={childId} documents={documents} />

--- a/frontend/src/employee-frontend/components/child-information/ChildDocumentsSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildDocumentsSection.tsx
@@ -27,12 +27,17 @@ export default React.memo(function ChildDocumentsSection({
 
   const [open, setOpen] = useState(startOpen)
 
-  const hasChildDocumentsPermission = useMemo(
+  const hasChildDocumentsReadPermission = useMemo(
     () => permittedActions.has('READ_CHILD_DOCUMENT'),
     [permittedActions]
   )
 
-  if (!hasChildDocumentsPermission) {
+  const hasChildDocumentsCreatePermission = useMemo(
+    () => permittedActions.has('CREATE_CHILD_DOCUMENT'),
+    [permittedActions]
+  )
+
+  if (!hasChildDocumentsReadPermission) {
     return null
   }
 
@@ -48,7 +53,12 @@ export default React.memo(function ChildDocumentsSection({
         paddingVertical="L"
         data-qa="child-documents-collapsible"
       >
-        {hasChildDocumentsPermission && <ChildDocuments childId={childId} />}
+        {hasChildDocumentsReadPermission && (
+          <ChildDocuments
+            hasCreatePermission={hasChildDocumentsCreatePermission}
+            childId={childId}
+          />
+        )}
       </CollapsibleContentArea>
     </div>
   )


### PR DESCRIPTION
Käyttöliittymä näyttää turhaan luontikontrollit, vaikka käyttäjällä olisi vain lukuoikeus. Asiakirjan lisääminen ei voi onnistua ilman luonnin käyttöoikeutta.