### PR TITLE
Palvelutuottajien suomi.fi -kirjautuminen (ei vielä käytössä)

### DIFF
--- a/apigw/src/app.ts
+++ b/apigw/src/app.ts
@@ -17,6 +17,7 @@ import {
 } from './enduser/suomi-fi-saml.js'
 import { createSamlAdIntegration } from './internal/ad-saml.js'
 import { createDevAdRouter } from './internal/dev-ad-auth.js'
+import { createDevEmployeeSfiRouter } from './internal/dev-sfi-auth.js'
 import { createKeycloakEmployeeIntegration } from './internal/keycloak-employee-saml.js'
 import {
   checkMobileEmployeeIdToken,
@@ -191,7 +192,10 @@ export function apiRouter(config: Config, redisClient: RedisClient) {
 
   let employeeSfiIntegration: SamlIntegration | undefined
   if (config.sfi.type === 'mock') {
-    // TODO
+    router.use(
+      '/employee/auth/sfi',
+      createDevEmployeeSfiRouter(employeeSessions)
+    )
   } else if (config.sfi.type === 'saml') {
     employeeSfiIntegration = createEmployeeSuomiFiIntegration(
       employeeSessions,

--- a/apigw/src/app.ts
+++ b/apigw/src/app.ts
@@ -228,7 +228,7 @@ export function apiRouter(config: Config, redisClient: RedisClient) {
           return employeeSfiIntegration.router(req, res, next)
       } else {
         if (citizenSfiIntegration)
-          return citizenSfiIntegration?.router(req, res, next)
+          return citizenSfiIntegration.router(req, res, next)
       }
       res.sendStatus(404)
     }

--- a/apigw/src/enduser/suomi-fi-saml.ts
+++ b/apigw/src/enduser/suomi-fi-saml.ts
@@ -11,7 +11,7 @@ import { RedisClient } from '../shared/redis-client.js'
 import { createSamlIntegration } from '../shared/routes/saml.js'
 import { authenticateProfile, createSamlConfig } from '../shared/saml/index.js'
 import redisCacheProvider from '../shared/saml/node-saml-cache-redis.js'
-import { citizenLogin } from '../shared/service-client.js'
+import { citizenLogin, employeeSuomiFiLogin } from '../shared/service-client.js'
 import { Sessions } from '../shared/session.js'
 
 // Suomi.fi e-Identification – Attributes transmitted on an identified user:
@@ -29,7 +29,7 @@ const Profile = z.object({
 
 const ssnRegex = /^[0-9]{6}[-+ABCDEFUVWXY][0-9]{3}[0-9ABCDEFHJKLMNPRSTUVWXY]$/
 
-const authenticate = authenticateProfile(
+const authenticateCitizen = authenticateProfile(
   Profile,
   async (samlSession, profile) => {
     const socialSecurityNumber = profile[SUOMI_FI_SSN_KEY]?.trim()
@@ -51,7 +51,7 @@ const authenticate = authenticateProfile(
   }
 )
 
-export function createSuomiFiIntegration(
+export function createCitizenSuomiFiIntegration(
   sessions: Sessions<'citizen'>,
   config: EvakaSamlConfig,
   redisClient: RedisClient
@@ -65,7 +65,50 @@ export function createSuomiFiIntegration(
         redisCacheProvider(redisClient, { keyPrefix: 'suomifi-saml-resp:' })
       )
     ),
-    authenticate,
+    authenticate: authenticateCitizen,
     defaultPageUrl: '/'
+  })
+}
+
+const authenticateEmployee = authenticateProfile(
+  Profile,
+  async (samlSession, profile) => {
+    const socialSecurityNumber = profile[SUOMI_FI_SSN_KEY]?.trim()
+    if (!socialSecurityNumber) throw Error('No SSN in SAML data')
+    if (!ssnRegex.test(socialSecurityNumber)) {
+      logWarn('Invalid SSN received from Suomi.fi login')
+    }
+    const person = await employeeSuomiFiLogin({
+      ssn: profile[SUOMI_FI_SSN_KEY],
+      firstName: profile[SUOMI_FI_GIVEN_NAME_KEY],
+      lastName: profile[SUOMI_FI_SURNAME_KEY]
+    })
+    return {
+      id: person.id,
+      authType: 'sfi',
+      userType: 'EMPLOYEE',
+      globalRoles: person.globalRoles,
+      allScopedRoles: person.allScopedRoles,
+      samlSession
+    }
+  }
+)
+
+export function createEmployeeSuomiFiIntegration(
+  sessions: Sessions<'employee'>,
+  config: EvakaSamlConfig,
+  redisClient: RedisClient
+) {
+  return createSamlIntegration({
+    sessions,
+    strategyName: 'suomifi',
+    saml: new SAML(
+      createSamlConfig(
+        config,
+        redisCacheProvider(redisClient, { keyPrefix: 'employee-sfi:' })
+      )
+    ),
+    authenticate: authenticateEmployee,
+    defaultPageUrl: '/employee'
   })
 }

--- a/apigw/src/internal/ad-saml.ts
+++ b/apigw/src/internal/ad-saml.ts
@@ -2,14 +2,16 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { SAML } from '@node-saml/node-saml'
 import { z } from 'zod'
 
-import { Config } from '../shared/config.js'
-import {
-  authenticateProfile,
-  AuthenticateProfile
-} from '../shared/saml/index.js'
+import { EvakaSamlConfig } from '../shared/config.js'
+import { RedisClient } from '../shared/redis-client.js'
+import { createSamlIntegration } from '../shared/routes/saml.js'
+import { authenticateProfile, createSamlConfig } from '../shared/saml/index.js'
+import redisCacheProvider from '../shared/saml/node-saml-cache-redis.js'
 import { employeeLogin } from '../shared/service-client.js'
+import { Sessions } from '../shared/session.js'
 
 const AD_GIVEN_NAME_KEY =
   'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname'
@@ -29,23 +31,48 @@ const Profile = z
   })
   .passthrough()
 
-export const authenticateAd = (config: Config['ad']): AuthenticateProfile =>
-  authenticateProfile(Profile, async (samlSession, profile) => {
-    const aad = profile[config.userIdKey]
-    if (!aad || typeof aad !== 'string') throw Error('No user ID in SAML data')
-    const person = await employeeLogin({
-      externalId: `${config.externalIdPrefix}:${aad}`,
-      firstName: profile[AD_GIVEN_NAME_KEY] ?? '',
-      lastName: profile[AD_FAMILY_NAME_KEY] ?? '',
-      email: profile[AD_EMAIL_KEY],
-      employeeNumber: profile[AD_EMPLOYEE_NUMBER_KEY]
-    })
-    return {
-      id: person.id,
-      authType: 'ad',
-      userType: 'EMPLOYEE',
-      globalRoles: person.globalRoles,
-      allScopedRoles: person.allScopedRoles,
-      samlSession
+export function createSamlAdIntegration(
+  sessions: Sessions<'employee'>,
+  config: {
+    externalIdPrefix: string
+    userIdKey: string
+    saml: EvakaSamlConfig
+  },
+  redisClient: RedisClient
+) {
+  const authenticate = authenticateProfile(
+    Profile,
+    async (samlSession, profile) => {
+      const aad = profile[config.userIdKey]
+      if (!aad || typeof aad !== 'string')
+        throw Error('No user ID in SAML data')
+      const person = await employeeLogin({
+        externalId: `${config.externalIdPrefix}:${aad}`,
+        firstName: profile[AD_GIVEN_NAME_KEY] ?? '',
+        lastName: profile[AD_FAMILY_NAME_KEY] ?? '',
+        email: profile[AD_EMAIL_KEY],
+        employeeNumber: profile[AD_EMPLOYEE_NUMBER_KEY]
+      })
+      return {
+        id: person.id,
+        authType: 'ad',
+        userType: 'EMPLOYEE',
+        globalRoles: person.globalRoles,
+        allScopedRoles: person.allScopedRoles,
+        samlSession
+      }
     }
+  )
+  return createSamlIntegration({
+    sessions,
+    strategyName: 'ead',
+    saml: new SAML(
+      createSamlConfig(
+        config.saml,
+        redisCacheProvider(redisClient, { keyPrefix: 'ad-saml-resp:' })
+      )
+    ),
+    authenticate,
+    defaultPageUrl: '/employee'
   })
+}

--- a/apigw/src/internal/dev-sfi-auth.ts
+++ b/apigw/src/internal/dev-sfi-auth.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Router } from 'express'
+import _ from 'lodash'
+
+import { createDevAuthRouter } from '../shared/auth/dev-auth.js'
+import { getVtjPersons } from '../shared/dev-api.js'
+import { assertStringProp } from '../shared/express.js'
+import { employeeSuomiFiLogin } from '../shared/service-client.js'
+import { Sessions } from '../shared/session.js'
+
+export function createDevEmployeeSfiRouter(
+  sessions: Sessions<'employee'>
+): Router {
+  return createDevAuthRouter({
+    sessions,
+    root: '/employee',
+    loginFormHandler: async (req, res) => {
+      const defaultSsn = '070644-937X'
+
+      const persons = _.orderBy(
+        await getVtjPersons(),
+        [({ ssn }) => defaultSsn === ssn, ({ ssn }) => ssn],
+        ['desc', 'asc']
+      )
+      const inputs = persons
+        .map(({ ssn, firstName, lastName }) => {
+          if (!ssn) return ''
+          const checked = ssn === defaultSsn ? 'checked' : ''
+          return `<div><input type="radio" id="${ssn}" name="preset" value="${ssn}" required ${checked}/><label for="${ssn}"><span style="font-family: monospace; user-select: all">${ssn}</span>: ${firstName} ${lastName}</label></div>`
+        })
+        .filter((line) => !!line)
+
+      const formQuery =
+        typeof req.query.RelayState === 'string'
+          ? `?RelayState=${encodeURIComponent(req.query.RelayState)}`
+          : ''
+      const formUri = `${req.baseUrl}/login/callback${formQuery}`
+
+      res.contentType('text/html').send(`
+          <html>
+          <body>
+            <h1>Devausympäristön Suomi.fi-kirjautuminen</h1>
+            <form action="${formUri}" method="post">
+              <div style="margin-bottom: 20px">
+                <button type="submit">Kirjaudu</button>
+              </div>
+              ${inputs.join('\n')}
+            </form>
+          </body>
+          </html>
+        `)
+    },
+    verifyUser: async (req) => {
+      const ssn = assertStringProp(req.body, 'preset')
+      const persons = await getVtjPersons()
+      const person = persons.find((c) => c.ssn === ssn)
+      if (!person) throw new Error(`No VTJ person found with SSN ${ssn}`)
+      const employee = await employeeSuomiFiLogin({
+        ssn,
+        firstName: person.firstName,
+        lastName: person.lastName
+      })
+      return {
+        id: employee.id,
+        authType: 'dev',
+        userType: 'EMPLOYEE',
+        globalRoles: employee.globalRoles,
+        allScopedRoles: employee.allScopedRoles
+      }
+    }
+  })
+}

--- a/apigw/src/internal/dev-sfi-auth.ts
+++ b/apigw/src/internal/dev-sfi-auth.ts
@@ -18,7 +18,7 @@ export function createDevEmployeeSfiRouter(
     sessions,
     root: '/employee',
     loginFormHandler: async (req, res) => {
-      const defaultSsn = '070644-937X'
+      const defaultSsn = '060195-966B'
 
       const persons = _.orderBy(
         await getVtjPersons(),

--- a/apigw/src/shared/auth/dev-auth.ts
+++ b/apigw/src/shared/auth/dev-auth.ts
@@ -27,6 +27,7 @@ export function createDevAuthRouter<T extends SessionType>({
 }: DevAuthRouterOptions<T>): express.Router {
   const router = express.Router()
 
+  router.use(sessions.middleware)
   router.get('/login', toRequestHandler(loginFormHandler))
   router.post(
     `/login/callback`,

--- a/apigw/src/shared/auth/index.ts
+++ b/apigw/src/shared/auth/index.ts
@@ -25,7 +25,7 @@ export type CitizenSessionUser =
 export type EmployeeSessionUser =
   | {
       id: string
-      authType: 'ad' | 'keycloak-employee'
+      authType: 'ad' | 'keycloak-employee' | 'sfi'
       userType: 'EMPLOYEE'
       samlSession: SamlSession
       globalRoles: string[]

--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -458,16 +458,14 @@ function createLocalDevelopmentOverrides(): Partial<EnvVariables> {
 export interface Config {
   citizen: SessionConfig
   employee: SessionConfig
-  ad: {
-    externalIdPrefix: string
-    userIdKey: string
-  } & (
+  ad:
     | { type: 'mock' | 'disabled' }
     | {
         type: 'saml'
+        externalIdPrefix: string
+        userIdKey: string
         saml: EvakaSamlConfig
       }
-  )
   sfi: { type: 'mock' | 'disabled' } | { type: 'saml'; saml: EvakaSamlConfig }
   keycloakEmployee: EvakaSamlConfig | undefined
   keycloakCitizen: EvakaSamlConfig | undefined
@@ -626,12 +624,12 @@ export function configFromEnv(): Config {
     optional('DEV_LOGIN', parseBoolean) ?? required('AD_MOCK', parseBoolean)
   const adType = adMock ? 'mock' : 'saml'
   const ad: Config['ad'] = {
-    externalIdPrefix: required('AD_SAML_EXTERNAL_ID_PREFIX', unchanged),
-    userIdKey: required('AD_USER_ID_KEY', unchanged),
     ...(adType !== 'saml'
       ? { type: adType }
       : {
           type: adType,
+          externalIdPrefix: required('AD_SAML_EXTERNAL_ID_PREFIX', unchanged),
+          userIdKey: required('AD_USER_ID_KEY', unchanged),
           saml: {
             callbackUrl: required('AD_SAML_CALLBACK_URL', unchanged),
             entryPoint: required('AD_SAML_ENTRYPOINT_URL', unchanged),

--- a/apigw/src/shared/dev-api.ts
+++ b/apigw/src/shared/dev-api.ts
@@ -28,3 +28,14 @@ export async function getEmployees(): Promise<Employee[]> {
   const { data } = await client.get<Employee[]>(`/dev-api/employee`)
   return data
 }
+
+export async function getVtjPersons(): Promise<VtjPersonSummary[]> {
+  const { data } = await client.get<VtjPersonSummary[]>(`/dev-api/vtj-person`)
+  return data
+}
+
+export interface VtjPersonSummary {
+  ssn: string
+  firstName: string
+  lastName: string
+}

--- a/apigw/src/shared/routes/saml.ts
+++ b/apigw/src/shared/routes/saml.ts
@@ -10,7 +10,7 @@ import express from 'express'
 import _ from 'lodash'
 
 import { createLogoutToken } from '../auth/index.js'
-import { toRequestHandler } from '../express.js'
+import { AsyncRequestHandler, toRequestHandler } from '../express.js'
 import { logAuditEvent, logDebug } from '../logging.js'
 import {
   parseDescriptionFromSamlError,
@@ -54,15 +54,21 @@ export class SamlError extends Error {
   }
 }
 
-// Returns an Express router for handling SAML-related requests.
-//
-// We support two SAML "bindings", which define how data is passed by the
-// browser to the SP (us) and the IDP.
-// * HTTP redirect: the browser makes a GET request with query parameters
-// * HTTP POST: the browser makes a POST request with URI-encoded form body
-export default function createSamlRouter<T extends SessionType>(
+const samlRequestOptions = (req: express.Request): AuthOptions => {
+  const locale = req.query.locale
+  return typeof locale === 'string' ? { additionalParams: { locale } } : {}
+}
+
+const isSamlPostRequest = (req: express.Request) => 'SAMLRequest' in req.body
+
+export interface SamlIntegration {
+  router: express.Router
+  logout: AsyncRequestHandler
+}
+
+export function createSamlIntegration<T extends SessionType>(
   endpointConfig: SamlEndpointConfig<T>
-): express.Router {
+): SamlIntegration {
   const { sessions, strategyName, saml, defaultPageUrl, authenticate } =
     endpointConfig
 
@@ -77,12 +83,6 @@ export default function createSamlRouter<T extends SessionType>(
       ? `${defaultPageUrl}?loginError=true&errorCode=${encodeURIComponent(errorCode)}`
       : `${defaultPageUrl}?loginError=true`
   }
-  const samlRequestOptions = (req: express.Request): AuthOptions => {
-    const locale = req.query.locale
-    return typeof locale === 'string' ? { additionalParams: { locale } } : {}
-  }
-
-  const isSamlPostRequest = (req: express.Request) => 'SAMLRequest' in req.body
 
   const validateSamlLoginResponse = async (
     req: express.Request
@@ -95,237 +95,257 @@ export default function createSamlRouter<T extends SessionType>(
     return samlMessage.profile
   }
 
-  const router = express.Router()
+  const login: AsyncRequestHandler = async (req, res) => {
+    logAuditEvent(eventCode('sign_in_started'), req, 'Login endpoint called')
+    try {
+      const idpLoginUrl = await saml.getAuthorizeUrlAsync(
+        // no need for validation here, because the value only matters in the login callback request and is validated there
+        getRawUnvalidatedRelayState(req) ?? '',
+        undefined,
+        samlRequestOptions(req)
+      )
+      return res.redirect(idpLoginUrl)
+    } catch (err) {
+      logAuditEvent(
+        eventCode('sign_in_failed'),
+        req,
+        `Error logging user in. ${err?.toString()}`
+      )
+      throw new SamlError('Login failed', {
+        redirectUrl: errorRedirectUrl(err),
+        cause: err
+      })
+    }
+  }
+  const loginCallback: AsyncRequestHandler = async (req, res) => {
+    logAuditEvent(eventCode('sign_in'), req, 'Login callback endpoint called')
+    let profile: Profile
+    try {
+      profile = await validateSamlLoginResponse(req)
+    } catch (err) {
+      if (err instanceof Error && err.message === 'InResponseTo is not valid')
+        // These errors can happen for example when the user browses back to the login callback after login
+        throw new SamlError('Login failed', {
+          redirectUrl: sessions.isAuthenticated(req)
+            ? (validateRelayStateUrl(req)?.toString() ?? defaultPageUrl)
+            : errorRedirectUrl(err),
+          cause: err,
+          // just ignore without logging to reduce noise in logs
+          silent: true
+        })
 
-  // Our application directs the browser to this endpoint to start the login
-  // flow. We generate a LoginRequest.
-  router.get(
-    `/login`,
-    toRequestHandler(async (req, res) => {
-      logAuditEvent(eventCode('sign_in_started'), req, 'Login endpoint called')
-      try {
-        const idpLoginUrl = await saml.getAuthorizeUrlAsync(
-          // no need for validation here, because the value only matters in the login callback request and is validated there
-          getRawUnvalidatedRelayState(req) ?? '',
-          undefined,
-          samlRequestOptions(req)
-        )
-        return res.redirect(idpLoginUrl)
-      } catch (err) {
+      const samlError = samlErrorSchema.safeParse(err)
+      if (samlError.success) {
+        const description =
+          parseDescriptionFromSamlError(samlError.data, req) ??
+          'Could not parse SAML message'
         logAuditEvent(
           eventCode('sign_in_failed'),
           req,
-          `Error logging user in. ${err?.toString()}`
+          `Failed to authenticate user. Description: ${description}. ${err?.toString()}`
+        )
+        throw new SamlError('Login failed', {
+          redirectUrl: errorRedirectUrl(err),
+          cause: err,
+          // just ignore without logging to reduce noise in logs
+          silent: true
+        })
+      } else {
+        logAuditEvent(
+          eventCode('sign_in_failed'),
+          req,
+          `Failed to authenticate user. ${err?.toString()}`
         )
         throw new SamlError('Login failed', {
           redirectUrl: errorRedirectUrl(err),
           cause: err
         })
       }
-    })
-  )
+    }
+    try {
+      const user = await authenticate(profile)
+      await sessions.login(req, user)
+      logAuditEvent(
+        `evaka.saml.${strategyName}.sign_in`,
+        req,
+        'User logged in successfully'
+      )
+
+      // Persist in session to allow custom logic per strategy
+      req.session.idpProvider = strategyName
+      await sessions.saveLogoutToken(req, createLogoutToken(profile))
+
+      const redirectUrl =
+        validateRelayStateUrl(req)?.toString() ?? defaultPageUrl
+      logDebug(`Redirecting to ${redirectUrl}`, req, { redirectUrl })
+      return res.redirect(redirectUrl)
+    } catch (err) {
+      logAuditEvent(
+        eventCode('sign_in_failed'),
+        req,
+        `Error logging user in. ${err?.toString()}`
+      )
+      throw new SamlError('Login failed', {
+        redirectUrl: errorRedirectUrl(err),
+        cause: err
+      })
+    }
+  }
+
+  const logout: AsyncRequestHandler = async (req, res) => {
+    logAuditEvent(
+      eventCode('sign_out_requested'),
+      req,
+      'Logout endpoint called'
+    )
+    try {
+      const user = sessions.getUser(req)
+      const samlSession = SamlSessionSchema.safeParse(user)
+      let url: string
+      if (samlSession.success) {
+        url = await saml.getLogoutUrlAsync(
+          samlSession.data,
+          // no need for validation here, because the value only matters in the logout callback request and is validated there
+          getRawUnvalidatedRelayState(req) ?? '',
+          samlRequestOptions(req)
+        )
+      } else {
+        url = defaultPageUrl
+      }
+      await sessions.destroy(req, res)
+      return res.redirect(url)
+    } catch (err) {
+      logAuditEvent(
+        eventCode('sign_out_failed'),
+        req,
+        `Logout failed. ${err?.toString()}.`
+      )
+      throw new SamlError('Logout failed', {
+        redirectUrl: defaultPageUrl,
+        cause: err
+      })
+    }
+  }
+  const logoutCallback: AsyncRequestHandler = async (req, res) => {
+    logAuditEvent(eventCode('sign_out'), req, 'Logout callback called')
+
+    let samlMessage: { profile: Profile | null; loggedOut: boolean }
+    if (req.method === 'GET') {
+      const originalQuery = url.parse(req.url).query ?? ''
+      samlMessage = await saml.validateRedirectAsync(req.query, originalQuery)
+    } else if (req.method === 'POST') {
+      samlMessage = isSamlPostRequest(req)
+        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          await saml.validatePostRequestAsync(req.body)
+        : // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          await saml.validatePostResponseAsync(req.body)
+    } else {
+      throw new SamlError(`Unsupported HTTP method ${req.method}`)
+    }
+    if (!samlMessage.loggedOut) {
+      throw new SamlError(
+        'Invalid SAML message type: expected logout request/response'
+      )
+    }
+
+    try {
+      let url: string
+      // There are two scenarios:
+      // 1. IDP-initiated logout, and we've just received a logout request -> profile is not null, the SAML transaction
+      // is still in progress, and we should redirect the user back to the IDP
+      // 2. SP-initiated logout, and we've just received a logout response -> profile is null, the SAML transaction
+      // is complete, and we should redirect the user to some meaningful page
+      if (samlMessage.profile) {
+        let user: unknown
+        const sessionUser = sessions.getUser(req)
+        if (sessionUser) {
+          const userId = SamlProfileIdSchema.safeParse(sessionUser)
+          user = userId.success ? userId.data : undefined
+
+          await sessions.destroy(req, res)
+        } else {
+          // We're possibly doing SLO without a real session (e.g. browser has
+          // 3rd party cookies disabled)
+          const logoutToken = createLogoutToken(samlMessage.profile)
+          const sessionUser = await sessions.logoutWithToken(logoutToken)
+          const userId = SamlProfileIdSchema.safeParse(sessionUser)
+          user = userId.success ? userId.data : undefined
+        }
+        const profileId = SamlProfileIdSchema.safeParse(samlMessage.profile)
+        const success = profileId.success && _.isEqual(user, profileId.data)
+
+        url = await saml.getLogoutResponseUrlAsync(
+          samlMessage.profile,
+          // not validated, because the value and its format are specified by the IDP and we're supposed to
+          // just pass it back
+          getRawUnvalidatedRelayState(req) ?? '',
+          samlRequestOptions(req),
+          success
+        )
+      } else {
+        url = validateRelayStateUrl(req)?.toString() ?? defaultPageUrl
+      }
+      return res.redirect(url)
+    } catch (err) {
+      if (err instanceof Error && err.message === 'InResponseTo is not valid')
+        throw new SamlError('Logout failed', {
+          redirectUrl: validateRelayStateUrl(req)?.toString() ?? defaultPageUrl,
+          cause: err,
+          // just ignore without logging to reduce noise in logs
+          silent: true
+        })
+
+      const samlError = samlErrorSchema.safeParse(err)
+      if (samlError.success) {
+        const description =
+          parseDescriptionFromSamlError(samlError.data, req) ??
+          'Could not parse SAML message'
+        logAuditEvent(
+          eventCode('sign_out_failed'),
+          req,
+          `Logout failed. Description: ${description}. ${err?.toString()}`
+        )
+        throw new SamlError('Logout failed', {
+          redirectUrl: validateRelayStateUrl(req)?.toString() ?? defaultPageUrl,
+          cause: err,
+          // just ignore without logging to reduce noise in logs
+          silent: true
+        })
+      } else {
+        logAuditEvent(
+          eventCode('sign_out_failed'),
+          req,
+          `Logout failed. ${err?.toString()}`
+        )
+        throw new SamlError('Logout failed', {
+          redirectUrl: validateRelayStateUrl(req)?.toString() ?? defaultPageUrl,
+          cause: err
+        })
+      }
+    }
+  }
+
+  // Returns an Express router for handling SAML-related requests.
+  //
+  // We support two SAML "bindings", which define how data is passed by the
+  // browser to the SP (us) and the IDP.
+  // * HTTP redirect: the browser makes a GET request with query parameters
+  // * HTTP POST: the browser makes a POST request with URI-encoded form body
+  const router = express.Router()
+  router.use(sessions.middleware)
+  // Our application directs the browser to this endpoint to start the login
+  // flow. We generate a LoginRequest.
+  router.get(`/login`, toRequestHandler(login))
   // The IDP makes the browser POST to this callback during login flow, and
   // a SAML LoginResponse is included in the request.
   router.post(
     `/login/callback`,
     urlencodedParser,
-    toRequestHandler(async (req, res) => {
-      logAuditEvent(eventCode('sign_in'), req, 'Login callback endpoint called')
-      let profile: Profile
-      try {
-        profile = await validateSamlLoginResponse(req)
-      } catch (err) {
-        if (err instanceof Error && err.message === 'InResponseTo is not valid')
-          // These errors can happen for example when the user browses back to the login callback after login
-          throw new SamlError('Login failed', {
-            redirectUrl: sessions.isAuthenticated(req)
-              ? (validateRelayStateUrl(req)?.toString() ?? defaultPageUrl)
-              : errorRedirectUrl(err),
-            cause: err,
-            // just ignore without logging to reduce noise in logs
-            silent: true
-          })
-
-        const samlError = samlErrorSchema.safeParse(err)
-        if (samlError.success) {
-          const description =
-            parseDescriptionFromSamlError(samlError.data, req) ??
-            'Could not parse SAML message'
-          logAuditEvent(
-            eventCode('sign_in_failed'),
-            req,
-            `Failed to authenticate user. Description: ${description}. ${err?.toString()}`
-          )
-          throw new SamlError('Login failed', {
-            redirectUrl: errorRedirectUrl(err),
-            cause: err,
-            // just ignore without logging to reduce noise in logs
-            silent: true
-          })
-        } else {
-          logAuditEvent(
-            eventCode('sign_in_failed'),
-            req,
-            `Failed to authenticate user. ${err?.toString()}`
-          )
-          throw new SamlError('Login failed', {
-            redirectUrl: errorRedirectUrl(err),
-            cause: err
-          })
-        }
-      }
-      try {
-        const user = await authenticate(profile)
-        await sessions.login(req, user)
-        logAuditEvent(
-          `evaka.saml.${strategyName}.sign_in`,
-          req,
-          'User logged in successfully'
-        )
-
-        // Persist in session to allow custom logic per strategy
-        req.session.idpProvider = strategyName
-        await sessions.saveLogoutToken(req, createLogoutToken(profile))
-
-        const redirectUrl =
-          validateRelayStateUrl(req)?.toString() ?? defaultPageUrl
-        logDebug(`Redirecting to ${redirectUrl}`, req, { redirectUrl })
-        return res.redirect(redirectUrl)
-      } catch (err) {
-        logAuditEvent(
-          eventCode('sign_in_failed'),
-          req,
-          `Error logging user in. ${err?.toString()}`
-        )
-        throw new SamlError('Login failed', {
-          redirectUrl: errorRedirectUrl(err),
-          cause: err
-        })
-      }
-    })
+    toRequestHandler(loginCallback)
   )
-
   // Our application directs the browser to one of these endpoints to start
   // the logout flow. We generate a LogoutRequest.
-  router.get(
-    `/logout`,
-    toRequestHandler(async (req, res) => {
-      logAuditEvent(
-        eventCode('sign_out_requested'),
-        req,
-        'Logout endpoint called'
-      )
-      try {
-        const user = sessions.getUser(req)
-        const samlSession = SamlSessionSchema.safeParse(user)
-        let url: string
-        if (samlSession.success) {
-          url = await saml.getLogoutUrlAsync(
-            samlSession.data,
-            // no need for validation here, because the value only matters in the logout callback request and is validated there
-            getRawUnvalidatedRelayState(req) ?? '',
-            samlRequestOptions(req)
-          )
-        } else {
-          url = defaultPageUrl
-        }
-        await sessions.destroy(req, res)
-        return res.redirect(url)
-      } catch (err) {
-        logAuditEvent(
-          eventCode('sign_out_failed'),
-          req,
-          `Logout failed. ${err?.toString()}.`
-        )
-        throw new SamlError('Logout failed', {
-          redirectUrl: defaultPageUrl,
-          cause: err
-        })
-      }
-    })
-  )
-  const logoutCallback = (
-    parseLogoutMessage: (req: express.Request) => Promise<Profile | null>
-  ) =>
-    toRequestHandler(async (req, res) => {
-      logAuditEvent(eventCode('sign_out'), req, 'Logout callback called')
-      try {
-        const profile = await parseLogoutMessage(req)
-        let url: string
-        // There are two scenarios:
-        // 1. IDP-initiated logout, and we've just received a logout request -> profile is not null, the SAML transaction
-        // is still in progress, and we should redirect the user back to the IDP
-        // 2. SP-initiated logout, and we've just received a logout response -> profile is null, the SAML transaction
-        // is complete, and we should redirect the user to some meaningful page
-        if (profile) {
-          let user: unknown
-          const sessionUser = sessions.getUser(req)
-          if (sessionUser) {
-            const userId = SamlProfileIdSchema.safeParse(sessionUser)
-            user = userId.success ? userId.data : undefined
-
-            await sessions.destroy(req, res)
-          } else {
-            // We're possibly doing SLO without a real session (e.g. browser has
-            // 3rd party cookies disabled)
-            const logoutToken = createLogoutToken(profile)
-            const sessionUser = await sessions.logoutWithToken(logoutToken)
-            const userId = SamlProfileIdSchema.safeParse(sessionUser)
-            user = userId.success ? userId.data : undefined
-          }
-          const profileId = SamlProfileIdSchema.safeParse(profile)
-          const success = profileId.success && _.isEqual(user, profileId.data)
-
-          url = await saml.getLogoutResponseUrlAsync(
-            profile,
-            // not validated, because the value and its format are specified by the IDP and we're supposed to
-            // just pass it back
-            getRawUnvalidatedRelayState(req) ?? '',
-            samlRequestOptions(req),
-            success
-          )
-        } else {
-          url = validateRelayStateUrl(req)?.toString() ?? defaultPageUrl
-        }
-        return res.redirect(url)
-      } catch (err) {
-        if (err instanceof Error && err.message === 'InResponseTo is not valid')
-          throw new SamlError('Logout failed', {
-            redirectUrl: validateRelayStateUrl(req) ?? defaultPageUrl,
-            cause: err,
-            // just ignore without logging to reduce noise in logs
-            silent: true
-          })
-
-        const samlError = samlErrorSchema.safeParse(err)
-        if (samlError.success) {
-          const description =
-            parseDescriptionFromSamlError(samlError.data, req) ??
-            'Could not parse SAML message'
-          logAuditEvent(
-            eventCode('sign_out_failed'),
-            req,
-            `Logout failed. Description: ${description}. ${err?.toString()}`
-          )
-          throw new SamlError('Logout failed', {
-            redirectUrl: validateRelayStateUrl(req) ?? defaultPageUrl,
-            cause: err,
-            // just ignore without logging to reduce noise in logs
-            silent: true
-          })
-        } else {
-          logAuditEvent(
-            eventCode('sign_out_failed'),
-            req,
-            `Logout failed. ${err?.toString()}`
-          )
-          throw new SamlError('Logout failed', {
-            redirectUrl: validateRelayStateUrl(req) ?? defaultPageUrl,
-            cause: err
-          })
-        }
-      }
-    })
+  router.get(`/logout`, toRequestHandler(logout))
   // The IDP makes the browser either GET or POST one of these endpoints in two
   // separate logout flows.
   // 1. SP-initiated logout. In this case the logout flow started from us
@@ -334,39 +354,15 @@ export default function createSamlRouter<T extends SessionType>(
   // 2. IDP-initiated logout (= SAML single logout). In this case the logout
   //   flow started from the IDP, and a SAML LogoutRequest is included in the
   //   request.
-  router.get(
-    `/logout/callback`,
-    logoutCallback(async (req) => {
-      const originalQuery = url.parse(req.url).query ?? ''
-      const { profile, loggedOut } = await saml.validateRedirectAsync(
-        req.query,
-        originalQuery
-      )
-      if (!loggedOut) {
-        throw new SamlError(
-          'Invalid SAML message type: expected logout response'
-        )
-      }
-      return profile
-    })
-  )
+  router.get(`/logout/callback`, toRequestHandler(logoutCallback))
   router.post(
     `/logout/callback`,
     urlencodedParser,
-    logoutCallback(async (req) => {
-      const { profile, loggedOut } = isSamlPostRequest(req)
-        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          await saml.validatePostRequestAsync(req.body)
-        : // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          await saml.validatePostResponseAsync(req.body)
-      if (!loggedOut) {
-        throw new SamlError(
-          'Invalid SAML message type: expected logout request/response'
-        )
-      }
-      return profile
-    })
+    toRequestHandler(logoutCallback)
   )
 
-  return router
+  return {
+    router,
+    logout
+  }
 }

--- a/apigw/src/shared/saml/index.ts
+++ b/apigw/src/shared/saml/index.ts
@@ -110,13 +110,11 @@ export function getRawUnvalidatedRelayState(
 // redirected to after the SAML transaction is complete. Since the RelayState
 // is not signed or encrypted, we must make sure the URL points to our application
 // and not to some 3rd party domain
-export function validateRelayStateUrl(
-  req: express.Request
-): string | undefined {
+export function validateRelayStateUrl(req: express.Request): URL | undefined {
   const relayState = getRawUnvalidatedRelayState(req)
   if (relayState) {
     const url = parseUrlWithOrigin(evakaBaseUrl, relayState)
-    if (url) return url.toString()
+    if (url) return url
     logError('Invalid RelayState in request', req)
   }
   return undefined

--- a/apigw/src/shared/test/gateway-tester.ts
+++ b/apigw/src/shared/test/gateway-tester.ts
@@ -128,7 +128,7 @@ export class GatewayTester {
       postData = postData !== undefined ? postData : { preset: 'dummy' }
       this.nockScope.post('/system/citizen-login').reply(200, user)
       await this.client.post(
-        '/api/application/auth/saml/login/callback',
+        '/api/citizen/auth/sfi/login/callback',
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         new URLSearchParams(postData),
         {

--- a/frontend/src/citizen-frontend/navigation/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/DesktopNav.tsx
@@ -20,23 +20,23 @@ import { desktopMin, desktopSmall } from 'lib-components/breakpoints'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { fontWeights } from 'lib-components/typography'
 import useCloseOnOutsideClick from 'lib-components/utils/useCloseOnOutsideClick'
-import { Gap, defaultMargins } from 'lib-components/white-space'
+import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import {
   faLockAlt,
-  faSignIn,
   farBars,
   farSignOut,
   farXmark,
   fasChevronDown,
-  fasChevronUp
+  fasChevronUp,
+  faSignIn
 } from 'lib-icons'
 
 import { AuthContext, User } from '../auth/state'
 import { useTranslation } from '../localization'
 
 import AttentionIndicator from './AttentionIndicator'
-import { getLogoutUri } from './const'
+import { logoutUrl } from './const'
 import {
   CircledChar,
   DropDown,
@@ -417,10 +417,7 @@ const SubNavigationMenu = React.memo(function SubNavigationMenu({
               </CircledChar>
             )}
           </DropDownLink>
-          <DropDownLocalLink
-            data-qa="sub-nav-menu-logout"
-            href={getLogoutUri(user)}
-          >
+          <DropDownLocalLink data-qa="sub-nav-menu-logout" href={logoutUrl}>
             {t.header.logout}
             <FontAwesomeIcon icon={farSignOut} />
           </DropDownLocalLink>

--- a/frontend/src/citizen-frontend/navigation/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/MobileNav.tsx
@@ -38,11 +38,7 @@ import { langs, useLang, useTranslation } from '../localization'
 import { unreadMessagesCountQuery } from '../messages/queries'
 
 import AttentionIndicator from './AttentionIndicator'
-import {
-  getLogoutUri,
-  headerHeightMobile,
-  mobileBottomNavHeight
-} from './const'
+import { headerHeightMobile, logoutUrl, mobileBottomNavHeight } from './const'
 import {
   CircledChar,
   DropDownInfo,
@@ -411,7 +407,7 @@ const Menu = React.memo(function Menu({
             </CircledChar>
           )}
         </DropDownLink>
-        <DropDownLocalLink key="sub-nav-menu-logout" href={getLogoutUri(user)}>
+        <DropDownLocalLink key="sub-nav-menu-logout" href={logoutUrl}>
           {t.header.logout}
           <FontAwesomeIcon icon={farSignOut} />
         </DropDownLocalLink>

--- a/frontend/src/citizen-frontend/navigation/const.ts
+++ b/frontend/src/citizen-frontend/navigation/const.ts
@@ -6,12 +6,11 @@ export const logoutUrl = `/api/citizen/auth/logout?RelayState=/`
 
 export const getWeakLoginUri = (
   url = `${window.location.pathname}${window.location.search}${window.location.hash}`
-) =>
-  `/api/application/auth/evaka-customer/login?RelayState=${encodeURIComponent(url)}`
+) => `/api/citizen/auth/keycloak/login?RelayState=${encodeURIComponent(url)}`
 
 export const getStrongLoginUri = (
   url = `${window.location.pathname}${window.location.search}${window.location.hash}`
-) => `/api/application/auth/saml/login?RelayState=${encodeURIComponent(url)}`
+) => `/api/citizen/auth/sfi/login?RelayState=${encodeURIComponent(url)}`
 
 export const headerHeightDesktop = 80
 export const headerHeightMobile = 60

--- a/frontend/src/citizen-frontend/navigation/const.ts
+++ b/frontend/src/citizen-frontend/navigation/const.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { User } from '../auth/state'
+export const logoutUrl = `/api/citizen/auth/logout?RelayState=/`
 
 export const getWeakLoginUri = (
   url = `${window.location.pathname}${window.location.search}${window.location.hash}`
@@ -12,11 +12,6 @@ export const getWeakLoginUri = (
 export const getStrongLoginUri = (
   url = `${window.location.pathname}${window.location.search}${window.location.hash}`
 ) => `/api/application/auth/saml/login?RelayState=${encodeURIComponent(url)}`
-
-export const getLogoutUri = (user: User) =>
-  `/api/application/auth/${
-    user?.authLevel === 'WEAK' ? 'evaka-customer' : 'saml'
-  }/logout`
 
 export const headerHeightDesktop = 80
 export const headerHeightMobile = 60

--- a/frontend/src/e2e-test/config.ts
+++ b/frontend/src/e2e-test/config.ts
@@ -60,8 +60,7 @@ const config = {
       env('BROWSER', parseEnum(['chromium', 'firefox', 'webkit'] as const)) ??
       'chromium'
   },
-  apiUrl: `${browserUrl}/api/internal`,
-  citizenApiUrl: `${browserUrl}/api/application`,
+  apiUrl: `${browserUrl}/api`,
   adminUrl: `${browserUrl}/employee/applications`,
   employeeUrl: `${browserUrl}/employee`,
   employeeLoginUrl: `${browserUrl}/employee/login`,

--- a/frontend/src/e2e-test/generated/api-clients.ts
+++ b/frontend/src/e2e-test/generated/api-clients.ts
@@ -120,6 +120,7 @@ import { StaffAttendancePlanId } from './api-types'
 import { StaffAttendanceRealtimeId } from 'lib-common/generated/api-types/shared'
 import { StaffMemberAttendance } from 'lib-common/generated/api-types/attendance'
 import { VoucherValueDecision } from './api-types'
+import { VtjPersonSummary } from './api-types'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonAbsence } from 'lib-common/generated/api-types/absence'
 import { deserializeJsonApplicationDetails } from 'lib-common/generated/api-types/application'
@@ -1882,6 +1883,25 @@ export async function getStaffAttendances(
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() }
     })
     return json.map(e => deserializeJsonStaffMemberAttendance(e))
+  } catch (e) {
+    throw new DevApiError(e)
+  }
+}
+
+
+/**
+* Generated from fi.espoo.evaka.shared.dev.DevApi.getVtjPersons
+*/
+export async function getVtjPersons(
+  options?: { mockedTime?: HelsinkiDateTime }
+): Promise<VtjPersonSummary[]> {
+  try {
+    const { data: json } = await devClient.request<JsonOf<VtjPersonSummary[]>>({
+      url: uri`/vtj-person`.toString(),
+      method: 'GET',
+      headers: { EvakaMockedTime: options?.mockedTime?.formatIso() }
+    })
+    return json
   } catch (e) {
     throw new DevApiError(e)
   }

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -1150,6 +1150,15 @@ export interface VoucherValueDecisionPlacement {
   unitId: DaycareId
 }
 
+/**
+* Generated from fi.espoo.evaka.shared.dev.VtjPersonSummary
+*/
+export interface VtjPersonSummary {
+  firstName: string
+  lastName: string
+  ssn: string
+}
+
 
 export function deserializeJsonCaretaker(json: JsonOf<Caretaker>): Caretaker {
   return {

--- a/frontend/src/e2e-test/utils/user.ts
+++ b/frontend/src/e2e-test/utils/user.ts
@@ -12,7 +12,7 @@ export async function enduserLogin(page: Page, person: DevPerson) {
     throw new Error('Person does not have an SSN: cannot login')
   }
 
-  const authUrl = `${config.citizenApiUrl}/auth/saml/login/callback?RelayState=%2Fapplications`
+  const authUrl = `${config.apiUrl}/citizen/auth/sfi/login/callback?RelayState=%2Fapplications`
   if (!page.url.startsWith(config.enduserUrl)) {
     // We must be in the correct domain to be able to fetch()
     await page.goto(config.enduserLoginUrl)
@@ -85,7 +85,7 @@ export async function employeeLogin(
     email?: string | null
   }
 ) {
-  const authUrl = `${config.apiUrl}/auth/saml/login/callback?RelayState=%2Femployee`
+  const authUrl = `${config.apiUrl}/employee/auth/ad/login/callback?RelayState=%2Femployee`
   const preset = JSON.stringify({
     externalId,
     firstName,

--- a/frontend/src/employee-frontend/api/auth.ts
+++ b/frontend/src/employee-frontend/api/auth.ts
@@ -13,7 +13,7 @@ import { JsonOf } from 'lib-common/json'
 
 import { client } from './client'
 
-export const logoutUrl = `/api/internal/auth/saml/logout?RelayState=/employee/login`
+export const logoutUrl = `/api/employee/auth/logout?RelayState=/employee/login`
 
 const redirectUri = (() => {
   if (window.location.pathname === '/employee/login') {

--- a/frontend/src/employee-frontend/api/auth.ts
+++ b/frontend/src/employee-frontend/api/auth.ts
@@ -30,9 +30,9 @@ const redirectUri = (() => {
   }${searchParams}${window.location.hash}`
 })()
 
-export function getLoginUrl(type: 'evaka' | 'saml' = 'saml') {
+export function getLoginUrl(type: 'ad' | 'keycloak' = 'ad') {
   const relayState = encodeURIComponent(redirectUri)
-  return `/api/internal/auth/${type}/login?RelayState=${relayState}`
+  return `/api/employee/auth/${type}/login?RelayState=${relayState}`
 }
 
 export async function getAuthStatus(): Promise<AuthStatus<User>> {

--- a/frontend/src/employee-frontend/api/auth.ts
+++ b/frontend/src/employee-frontend/api/auth.ts
@@ -30,7 +30,7 @@ const redirectUri = (() => {
   }${searchParams}${window.location.hash}`
 })()
 
-export function getLoginUrl(type: 'ad' | 'keycloak' = 'ad') {
+export function getLoginUrl(type: 'ad' | 'keycloak' | 'sfi' = 'ad') {
   const relayState = encodeURIComponent(redirectUri)
   return `/api/employee/auth/${type}/login?RelayState=${relayState}`
 }

--- a/frontend/src/employee-frontend/components/login-page/Login.tsx
+++ b/frontend/src/employee-frontend/components/login-page/Login.tsx
@@ -39,11 +39,11 @@ function Login({ error }: Props) {
           {i18n.login.subtitle}
         </Title>
         <Center>
-          <LinkButton data-qa="login-btn" href={getLoginUrl('saml')}>
+          <LinkButton data-qa="login-btn" href={getLoginUrl('ad')}>
             <span>{i18n.login.loginAD}</span>
           </LinkButton>
           <Gap horizontal />
-          <LinkButton data-qa="login-btn" href={getLoginUrl('evaka')}>
+          <LinkButton data-qa="login-btn" href={getLoginUrl('keycloak')}>
             <span>{i18n.login.loginEvaka}</span>
           </LinkButton>
         </Center>

--- a/frontend/src/employee-frontend/components/login-page/Login.tsx
+++ b/frontend/src/employee-frontend/components/login-page/Login.tsx
@@ -9,6 +9,7 @@ import Title from 'lib-components/atoms/Title'
 import LinkButton from 'lib-components/atoms/buttons/LinkButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { Gap } from 'lib-components/white-space'
+import { featureFlags } from 'lib-customizations/employee'
 
 import { getLoginUrl } from '../../api/auth'
 import { useTranslation } from '../../state/i18n'
@@ -43,9 +44,23 @@ function Login({ error }: Props) {
             <span>{i18n.login.loginAD}</span>
           </LinkButton>
           <Gap horizontal />
-          <LinkButton data-qa="login-btn" href={getLoginUrl('keycloak')}>
-            <span>{i18n.login.loginEvaka}</span>
-          </LinkButton>
+          {featureFlags.employeeSfiLogin ? (
+            <>
+              <LinkButton data-qa="login-btn" href={getLoginUrl('keycloak')}>
+                <span>{i18n.login.loginEvaka} (Keycloak)</span>
+              </LinkButton>
+              <Gap horizontal />
+              <LinkButton data-qa="login-btn" href={getLoginUrl('sfi')}>
+                <span>{i18n.login.loginEvaka} (Suomi.fi)</span>
+              </LinkButton>
+            </>
+          ) : (
+            <>
+              <LinkButton data-qa="login-btn" href={getLoginUrl('keycloak')}>
+                <span>{i18n.login.loginEvaka}</span>
+              </LinkButton>
+            </>
+          )}
         </Center>
         <ErrorMessage error={error} />
       </ContentArea>

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -45,7 +45,8 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: true,
     multiSelectDeparture: true,
-    weakLogin: true
+    weakLogin: true,
+    employeeSfiLogin: true
   },
   staging: {
     environmentLabel: 'Staging',
@@ -81,7 +82,8 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: true,
     multiSelectDeparture: true,
-    weakLogin: true
+    weakLogin: true,
+    employeeSfiLogin: true
   },
   prod: {
     environmentLabel: null,
@@ -116,7 +118,8 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: false,
     multiSelectDeparture: false,
-    weakLogin: false
+    weakLogin: false,
+    employeeSfiLogin: false
   }
 }
 

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -284,6 +284,10 @@ interface BaseFeatureFlags {
    * Enable support for citizen weak login
    */
   weakLogin?: boolean
+  /**
+   * Enable support for employee Suomi.fi login
+   */
+  employeeSfiLogin?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -653,6 +653,12 @@ UPDATE placement SET end_date = ${bind(req.endDate)}, termination_requested_date
             .filter { it.guardians.isEmpty() }
             .map(Citizen::from)
 
+    @GetMapping("/vtj-person")
+    fun getVtjPersons(): List<VtjPersonSummary> =
+        MockPersonDetailsService.getAllPersons()
+            .filter { it.guardians.isEmpty() }
+            .map(VtjPersonSummary::from)
+
     @PostMapping("/guardian")
     fun insertGuardians(db: Database, @RequestBody guardians: List<DevGuardian>) {
         db.connect { dbc -> dbc.transaction { tx -> guardians.forEach { tx.insert(it) } } }
@@ -2316,6 +2322,17 @@ data class Citizen(
                 firstName = vtjPerson.firstNames,
                 lastName = vtjPerson.lastName,
                 dependantCount = vtjPerson.dependants.size,
+            )
+    }
+}
+
+data class VtjPersonSummary(val ssn: String, val firstName: String, val lastName: String) {
+    companion object {
+        fun from(vtjPerson: VtjPerson) =
+            VtjPersonSummary(
+                ssn = vtjPerson.socialSecurityNumber,
+                firstName = vtjPerson.firstNames,
+                lastName = vtjPerson.lastName,
             )
     }
 }

--- a/service/src/main/resources/dev-data/employees.sql
+++ b/service/src/main/resources/dev-data/employees.sql
@@ -16,6 +16,8 @@ INSERT INTO employee (id, first_name, last_name, email, external_id, active) VAL
     ('00000000-0000-4000-8005-000000000000', 'Kaisa', 'Kasvattaja', 'kaisa.kasvattaja@espoo.fi', 'espoo-ad:00000000-0000-4000-8005-000000000000', TRUE),
     ('00000000-0000-4000-8005-000000000001', 'Kalle', 'Kasvattaja', 'kalle.kasvattaja@espoo.fi', 'espoo-ad:00000000-0000-4000-8005-000000000001', TRUE),
     ('00000000-0000-4000-8006-000000000000', 'Erkki', 'Erityisopettaja', 'erkki.erityisopettaja@espoo.fi', 'espoo-ad:00000000-0000-4000-8006-000000000000', TRUE);
+INSERT INTO employee (id, first_name, last_name, social_security_number, active) VALUES
+    ('fdbf9276-c5a9-4092-87f8-6a27521d940a', 'Hannele', 'Finström', '060195-966B', true);
 
 INSERT INTO evaka_user (id, type, employee_id, name)
 SELECT id, 'EMPLOYEE', id, last_name || ' ' || first_name
@@ -27,7 +29,8 @@ INSERT INTO daycare_acl (daycare_id, employee_id, role) VALUES
     ('2dcf0fc0-788e-11e9-bd12-db78e886e666', '00000000-0000-4000-8006-000000000000', 'SPECIAL_EDUCATION_TEACHER'),
     ('2dd6e5f6-788e-11e9-bd72-9f1cfe2d8405', '00000000-0000-4000-8004-000000000001', 'UNIT_SUPERVISOR'),
     ('2dd6e5f6-788e-11e9-bd72-9f1cfe2d8405', '00000000-0000-4000-8005-000000000001', 'STAFF'),
-    ('2dd6e5f6-788e-11e9-bd72-9f1cfe2d8405', '00000000-0000-4000-8006-000000000000', 'SPECIAL_EDUCATION_TEACHER');
+    ('2dd6e5f6-788e-11e9-bd72-9f1cfe2d8405', '00000000-0000-4000-8006-000000000000', 'SPECIAL_EDUCATION_TEACHER'),
+    ('2dd6e5f6-788e-11e9-bd72-9f1cfe999999', 'fdbf9276-c5a9-4092-87f8-6a27521d940a', 'UNIT_SUPERVISOR');
 
 INSERT INTO message_account (employee_id, type)
 SELECT id, 'PERSONAL'::message_account_type AS type


### PR DESCRIPTION
- napin näkyvyys on feature flagin takana, eikä tuotannossa muutenkaan toimi vielä koska kellään työntekijällä ei ole hetua kannassa
- vanha Suomi.fi:lle metadatassa ilmoitettu `/api/application/auth/saml`-polku valitsee oikean toteutuksen RelayState-parametrin polun perusteella
- tulevaisuudessa voidaan ilmoittaa Suomi.fi:lle erilliset polut `/api/citizen/auth/sfi` ja `/api/employee/auth/sfi`