### PR TITLE
Oikaisulaskujen generointijobi oletuksena päälle

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -213,7 +213,7 @@ enum class ScheduledJob(
     ),
     GenerateReplacementInvoices(
         ScheduledJobs::generateReplacementDraftInvoices,
-        ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(4, 15))),
+        ScheduledJobSettings(enabled = true, schedule = JobSchedule.daily(LocalTime.of(4, 15))),
     ),
 }
 


### PR DESCRIPTION
Oikaisulaskuja ei generoida jos niitä ei ole otettu käyttöön, joten jobi on turvallista ajaa.