### PR TITLE
Poistetaan Titania-rajapinnasta uusien työntekijöiden luonti

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/titania/TitaniaServiceTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/titania/TitaniaServiceTest.kt
@@ -18,7 +18,6 @@ import java.time.LocalDate
 import java.time.LocalTime
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
-import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest
@@ -526,28 +525,15 @@ internal class TitaniaServiceTest : FullApplicationTest(resetDbBeforeEach = true
             db.transaction { tx -> titaniaService.updateWorkingTimeEventsInternal(tx, request) }
 
         assertThat(response.deleted).isEmpty()
-        assertThat(response.inserted)
-            .extracting({ it.type }, { it.startTime }, { it.endTime }, { it.description })
-            .containsExactly(
-                Tuple(
-                    StaffAttendanceType.PRESENT,
-                    HelsinkiDateTime.of(LocalDate.of(2022, 6, 15), LocalTime.of(9, 6)),
-                    HelsinkiDateTime.of(LocalDate.of(2022, 6, 15), LocalTime.of(15, 22)),
-                    null,
-                )
-            )
+        assertThat(response.inserted).isEmpty()
 
         val employees = db.transaction { tx -> tx.getEmployees() }
 
-        assertThat(employees)
-            .extracting({ it.firstName }, { it.lastName })
-            .containsExactly(Tuple("1", "Employee"))
+        assertThat(employees).isEmpty()
 
         val numbers = db.transaction { tx -> tx.getEmployeeIdsByNumbers(listOf("1234")) }
 
-        assertThat(numbers).containsOnlyKeys("1234")
-
-        assertThat(response.createdEmployees).containsExactly(employees[0].id)
+        assertThat(numbers).isEmpty()
     }
 
     @Test
@@ -700,7 +686,6 @@ internal class TitaniaServiceTest : FullApplicationTest(resetDbBeforeEach = true
 
         assertThat(response.inserted).isEmpty()
         assertThat(response.deleted).isEmpty()
-        assertThat(response.createdEmployees).isEmpty()
         assertThat(response.overLappingShifts)
             .containsExactlyInAnyOrder(
                 TitaniaOverLappingShifts(

--- a/service/src/main/kotlin/fi/espoo/evaka/titania/Titania.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/titania/Titania.kt
@@ -186,7 +186,6 @@ data class UpdateWorkingTimeEventsResponse(val message: String) {
 
 data class UpdateWorkingTimeEventsServiceResponse(
     val updateWorkingTimeEventsResponse: UpdateWorkingTimeEventsResponse,
-    val createdEmployees: List<EmployeeId>,
     val overlappingShifts: List<TitaniaOverLappingShifts>,
 )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/titania/TitaniaController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/titania/TitaniaController.kt
@@ -4,8 +4,6 @@
 
 package fi.espoo.evaka.titania
 
-import fi.espoo.evaka.Audit
-import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import jakarta.servlet.http.HttpServletRequest
@@ -34,7 +32,6 @@ class TitaniaController(private val titaniaService: TitaniaService) {
         return db.connect { dbc ->
             lateinit var result: UpdateWorkingTimeEventsServiceResponse
             dbc.transaction { tx -> result = titaniaService.updateWorkingTimeEvents(tx, request) }
-            result.createdEmployees.forEach { Audit.EmployeeCreate.log(targetId = AuditId(it)) }
             if (result.overlappingShifts.isNotEmpty()) {
                 throw TitaniaException(
                     TitaniaErrorDetail(

--- a/service/src/main/kotlin/fi/espoo/evaka/titania/TitaniaQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/titania/TitaniaQueries.kt
@@ -5,7 +5,6 @@
 package fi.espoo.evaka.titania
 
 import fi.espoo.evaka.attendance.RawAttendance
-import fi.espoo.evaka.pis.NewEmployee
 import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.Predicate
@@ -27,19 +26,6 @@ fun Database.Read.employeeNumbersQuery(employeeNumbers: Collection<String>): Dat
 fun Database.Read.getEmployeeIdsByNumbers(employeeNumbers: List<String>): Map<String, EmployeeId> {
     return employeeNumbersQuery(employeeNumbers).toMap { columnPair("employee_number", "id") }
 }
-
-fun Database.Transaction.createEmployees(employees: List<NewEmployee>): Map<String, EmployeeId> =
-    prepareBatch(employees) {
-            sql(
-                """
-INSERT INTO employee (first_name, last_name, email, external_id, employee_number, roles, active)
-VALUES (${bind { it.firstName }}, ${bind { it.lastName }}, ${bind { it.email }}, ${bind { it.externalId }}, ${bind { it.employeeNumber }}, ${bind { it.roles }}, true)
-RETURNING id, employee_number
-"""
-            )
-        }
-        .executeAndReturn()
-        .toMap { columnPair("employee_number", "id") }
 
 fun Database.Read.getEmployeeIdsByNumbersMapById(
     employeeNumbers: Collection<String>


### PR DESCRIPTION
Tuntemattomista henkilönumeroista on aiemmin luotu uusi `employee`-rivi tietokantaan. Tämä aiheuttaa toisinaan ylimääräisiä duplikaatteja, koska järjestelmien välillä tuntuu olevan epäsynkkaa henkilönumeroiden osalta. Ja lisäksi uusi rivi pahimmassa tapauksessa estää AD-kirjautumisen kyseiselle käyttäjälle, eikä tilannetta pysty korjaamaan eVakan käyttöliittymän kautta.

Tämän muutoksen myötä tuntemattomat henkilönumerot hylätään eli näiden osalta työvuorosuunnitelmat jää tallentumatta.