### PR TITLE
Lisätään "jatkava lapsi"-huomio hakemushakuun

### DIFF
--- a/frontend/src/employee-frontend/components/applications/ApplicationsFilters.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsFilters.tsx
@@ -6,6 +6,7 @@ import React, { Fragment, useContext, useEffect } from 'react'
 
 import { Loading, wrapResult } from 'lib-common/api'
 import {
+  ApplicationBasis,
   ApplicationStatusOption,
   applicationStatusOptions,
   ApplicationTypeToggle
@@ -31,7 +32,6 @@ import {
   ApplicationDateFilter,
   ApplicationDateType,
   ApplicationBasisFilter,
-  ApplicationBasis,
   ApplicationSummaryStatusOptions,
   PreschoolType,
   preschoolTypes,

--- a/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsList.tsx
@@ -381,6 +381,13 @@ const ApplicationsList = React.memo(function Applications({
                 size="s"
               />
             )}
+            {application.continuation && (
+              <RoundIcon
+                content="="
+                color={applicationBasisColors.CONTINUATION}
+                size="s"
+              />
+            )}
             {application.extendedCare && (
               <RoundIcon
                 content="V"

--- a/frontend/src/employee-frontend/components/common/Filters.tsx
+++ b/frontend/src/employee-frontend/components/common/Filters.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 
 import { UserContext } from 'employee-frontend/state/user'
 import {
+  ApplicationBasis,
   ApplicationStatusOption,
   applicationStatusOptions,
   ApplicationTypeToggle,
@@ -1088,17 +1089,6 @@ export function ApplicationDateFilter({
   )
 }
 
-export type ApplicationBasis =
-  | 'ADDITIONAL_INFO'
-  | 'SIBLING_BASIS'
-  | 'ASSISTANCE_NEED'
-  | 'CLUB_CARE'
-  | 'DAYCARE'
-  | 'EXTENDED_CARE'
-  | 'DUPLICATE_APPLICATION'
-  | 'URGENT'
-  | 'HAS_ATTACHMENTS'
-
 interface ApplicationBasisFilterProps {
   toggled: ApplicationBasis[]
   toggle: (applicationDateType: ApplicationBasis) => () => void
@@ -1172,6 +1162,18 @@ export function ApplicationBasisFilter({
             size="m"
             onClick={toggle('DAYCARE')}
             active={toggled.includes('DAYCARE')}
+          />
+        </Tooltip>
+        <Tooltip
+          tooltip={i18n.applications.basisTooltip.CONTINUATION}
+          position="top"
+        >
+          <RoundIcon
+            content="="
+            color={applicationBasisColors.CONTINUATION}
+            size="m"
+            onClick={toggle('CONTINUATION')}
+            active={toggled.includes('CONTINUATION')}
           />
         </Tooltip>
         <Tooltip

--- a/frontend/src/employee-frontend/state/application-ui.tsx
+++ b/frontend/src/employee-frontend/state/application-ui.tsx
@@ -14,6 +14,7 @@ import React, {
 
 import { Result, Loading } from 'lib-common/api'
 import {
+  ApplicationBasis,
   ApplicationStatusOption,
   ApplicationTypeToggle,
   PagedApplicationSummaries,
@@ -34,7 +35,6 @@ import { useDebounce } from 'lib-common/utils/useDebounce'
 
 import {
   ApplicationDateType,
-  ApplicationBasis,
   ApplicationSummaryStatusOptions,
   PreschoolType,
   ApplicationDistinctions

--- a/frontend/src/lib-common/generated/api-types/application.ts
+++ b/frontend/src/lib-common/generated/api-types/application.ts
@@ -88,6 +88,7 @@ export type ApplicationBasis =
   | 'SIBLING_BASIS'
   | 'ASSISTANCE_NEED'
   | 'CLUB_CARE'
+  | 'CONTINUATION'
   | 'DAYCARE'
   | 'EXTENDED_CARE'
   | 'DUPLICATE_APPLICATION'
@@ -291,6 +292,7 @@ export interface ApplicationSummary {
   attachmentCount: number
   checkedByAdmin: boolean
   confidential: boolean | null
+  continuation: boolean
   currentPlacementUnit: PreferredUnit | null
   dateOfBirth: LocalDate | null
   dueDate: LocalDate | null

--- a/frontend/src/lib-customizations/common.tsx
+++ b/frontend/src/lib-customizations/common.tsx
@@ -99,6 +99,7 @@ export const applicationBasisColors = {
   ADDITIONAL_INFO: main.m1,
   ASSISTANCE_NEED: accents.a6turquoise,
   CLUB_CARE: accents.a2orangeDark,
+  CONTINUATION: accents.a5orangeLight,
   DAYCARE: status.warning,
   DUPLICATE_APPLICATION: accents.a3emerald,
   EXTENDED_CARE: main.m3,

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -364,6 +364,7 @@ export const fi = {
       SIBLING_BASIS: 'Käyttää sisarusperustetta',
       ASSISTANCE_NEED: 'Tuen tarve',
       CLUB_CARE: 'Edellisenä toimintakautena ollut kerhopaikka',
+      CONTINUATION: 'Jatkava lapsi',
       DAYCARE: 'On ilmoittanut luopuvansa varhaiskasvatuspaikasta',
       EXTENDED_CARE: 'Vuorotyö',
       DUPLICATE_APPLICATION: 'Tuplahakemus',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationSearchIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationSearchIntegrationTest.kt
@@ -285,6 +285,42 @@ class ApplicationSearchIntegrationTest : FullApplicationTest(resetDbBeforeEach =
         assertEquals(applicationId_1, summary.data[1].id)
     }
 
+    @Test
+    fun `application summary can be be filtered by children with existing placement to the preferred unit`() {
+        db.transaction {
+            // Active placement
+            it.insert(
+                DevPlacement(
+                    type = PlacementType.DAYCARE,
+                    childId = testChild_1.id,
+                    unitId = testDaycare.id,
+                    startDate = now.today().minusMonths(12),
+                    endDate = now.today().plusMonths(6),
+                )
+            )
+
+            // Past placement (not included)
+            it.insert(
+                DevPlacement(
+                    type = PlacementType.DAYCARE,
+                    childId = testChild_2.id,
+                    unitId = testDaycare.id,
+                    startDate = now.today().minusMonths(12),
+                    endDate = now.today().minusDays(1),
+                )
+            )
+        }
+
+        val summary =
+            getApplicationSummaries(
+                type = ApplicationTypeToggle.ALL,
+                status = setOf(ApplicationStatusOption.SENT),
+                basis = setOf(ApplicationBasis.CONTINUATION),
+            )
+        assertEquals(1, summary.total)
+        assertEquals(applicationId_1, summary.data[0].id)
+    }
+
     private fun getApplicationSummaries(
         page: Int? = null,
         sortBy: ApplicationSortColumn? = null,

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -60,6 +60,7 @@ data class ApplicationSummary(
     val assistanceNeed: Boolean,
     val wasOnClubCare: Boolean? = null,
     val wasOnDaycare: Boolean? = null,
+    val continuation: Boolean,
     val extendedCare: Boolean,
     val duplicateApplication: Boolean = false,
     val transferApplication: Boolean,


### PR DESCRIPTION
Jatkava lapsi -ehto täyttyy jos hakemuksen ensimmäinen hakutoive on sama yksikkö, jossa lapsella on voimassaoleva sijoitus tänään.

Dokumentaatio: https://github.com/espoon-voltti/evaka/wiki/Hakemukset

<img width="308" alt="image" src="https://github.com/user-attachments/assets/5780f475-df0e-49c7-9dbc-5c9cb008fd59">
