### PR TITLE
Muutetaan laskujen täsmäysraportin päivävalitsin kuukausivalitsimeen

### DIFF
--- a/frontend/src/employee-frontend/components/reports/queries.ts
+++ b/frontend/src/employee-frontend/components/reports/queries.ts
@@ -20,6 +20,7 @@ import {
   getFuturePreschoolersUnitsReport,
   getHolidayPeriodAttendanceReport,
   getIncompleteIncomeReport,
+  getInvoiceReport,
   getMealReportByUnit,
   getMissingHeadOfFamilyReport,
   getNonSsnChildrenReportRows,
@@ -70,6 +71,7 @@ const queryKeys = createQueryKeys('reports', {
     'familyContacts',
     filters
   ],
+  invoices: (filters: Arg0<typeof getInvoiceReport>) => ['invoices', filters],
   missingHeadOfFamily: (filters: Arg0<typeof getMissingHeadOfFamilyReport>) => [
     'missingHeadOfFamily',
     filters
@@ -149,6 +151,11 @@ export const exceededServiceNeedsReportRowsQuery = query({
 export const familyContactsReportQuery = query({
   api: getFamilyContactsReport,
   queryKey: queryKeys.familyContacts
+})
+
+export const invoicesReportQuery = query({
+  api: getInvoiceReport,
+  queryKey: queryKeys.invoices
 })
 
 export const missingHeadOfFamilyReportQuery = query({

--- a/frontend/src/employee-frontend/generated/api-clients/reports.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reports.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import LocalDate from 'lib-common/local-date'
+import YearMonth from 'lib-common/year-month'
 import { ApplicationStatus } from 'lib-common/generated/api-types/application'
 import { ApplicationsReportRow } from 'lib-common/generated/api-types/reports'
 import { AreaId } from 'lib-common/generated/api-types/shared'
@@ -555,11 +556,11 @@ export async function getIncompleteIncomeReport(): Promise<IncompleteIncomeDbRow
 */
 export async function getInvoiceReport(
   request: {
-    date: LocalDate
+    yearMonth: YearMonth
   }
 ): Promise<InvoiceReport> {
   const params = createUrlSearchParams(
-    ['date', request.date.formatIso()]
+    ['yearMonth', request.yearMonth.formatIso()]
   )
   const { data: json } = await client.request<JsonOf<InvoiceReport>>({
     url: uri`/employee/reports/invoices`.toString(),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/InvoicingReportTest.kt
@@ -21,6 +21,7 @@ import fi.espoo.evaka.testAdult_2
 import fi.espoo.evaka.testChild_1
 import fi.espoo.evaka.testChild_2
 import java.time.LocalDate
+import java.time.YearMonth
 import java.util.UUID
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -49,11 +50,11 @@ class InvoicingReportTest : FullApplicationTest(resetDbBeforeEach = true) {
 
     @Test
     fun `simple case of three invoices`() {
-        val date = LocalDate.of(2019, 1, 1)
-        insertInvoices(date)
+        val yearMonth = YearMonth.of(2019, 1)
+        insertInvoices(yearMonth.atDay(1))
 
         getAndAssert(
-            date,
+            yearMonth,
             InvoiceReport(
                 reportRows =
                     listOf(
@@ -81,13 +82,13 @@ class InvoicingReportTest : FullApplicationTest(resetDbBeforeEach = true) {
     private val testUser =
         AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.FINANCE_ADMIN))
 
-    private fun getAndAssert(date: LocalDate, expected: InvoiceReport) {
+    private fun getAndAssert(yearMonth: YearMonth, expected: InvoiceReport) {
         val result =
             invoiceReportController.getInvoiceReport(
                 dbInstance(),
                 testUser,
                 MockEvakaClock(2024, 10, 31, 12, 0, 0),
-                date,
+                yearMonth,
             )
         assertEquals(expected, result)
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
@@ -127,7 +127,7 @@ class ReportSmokeTests : FullApplicationTest(resetDbBeforeEach = false) {
 
     @Test
     fun `invoice report returns http 200`() {
-        assertOkResponse(http.get("/employee/reports/invoices", listOf("date" to "2020-08-01")))
+        assertOkResponse(http.get("/employee/reports/invoices", listOf("yearMonth" to "2020-08")))
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
@@ -15,8 +15,7 @@ import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
-import java.time.LocalDate
-import org.springframework.format.annotation.DateTimeFormat
+import java.time.YearMonth
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -28,7 +27,7 @@ class InvoiceReportController(private val accessControl: AccessControl) {
         db: Database,
         user: AuthenticatedUser.Employee,
         clock: EvakaClock,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+        @RequestParam yearMonth: YearMonth,
     ): InvoiceReport {
         return db.connect { dbc ->
                 dbc.read {
@@ -39,12 +38,12 @@ class InvoiceReportController(private val accessControl: AccessControl) {
                         Action.Global.READ_INVOICE_REPORT,
                     )
                     it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
-                    it.getInvoiceReportWithRows(FiniteDateRange.ofMonth(date))
+                    it.getInvoiceReportWithRows(FiniteDateRange.ofMonth(yearMonth))
                 }
             }
             .also {
                 Audit.InvoicesReportRead.log(
-                    meta = mapOf("date" to date, "count" to it.reportRows.size)
+                    meta = mapOf("yearMonth" to yearMonth, "count" to it.reportRows.size)
                 )
             }
     }


### PR DESCRIPTION
Laskujen täsmäytysraportin päivävalitsin on aiheuttanut kyselyitä mitä merkitystä valitulla päivällä on saman kuukauden sisällä. Ei mitään koska raportti toimii kuukausitasolla, joten vaihdetaan käyttöön kuukausivalitsin.