### PR TITLE
Pieniä korjauksia oikaisulaskuihin

### DIFF
--- a/frontend/src/employee-frontend/components/invoice/ReplacementDraftInfo.tsx
+++ b/frontend/src/employee-frontend/components/invoice/ReplacementDraftInfo.tsx
@@ -6,8 +6,9 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { string } from 'lib-common/form/fields'
-import { object, oneOf, required } from 'lib-common/form/form'
+import { object, oneOf, required, validated } from 'lib-common/form/form'
 import { useForm, useFormFields } from 'lib-common/form/hooks'
+import { FieldErrors } from 'lib-common/form/types'
 import {
   InvoiceDetailedResponse,
   InvoiceReplacementReason,
@@ -26,10 +27,18 @@ import { H3, Label, P } from 'lib-components/typography'
 import { useTranslation } from '../../state/i18n'
 import { markReplacementDraftSentMutation } from '../invoices/queries'
 
-const replacementDraftForm = object({
-  reason: required(oneOf<InvoiceReplacementReason>()),
-  notes: string()
-})
+const replacementDraftForm = validated(
+  object({
+    reason: required(oneOf<InvoiceReplacementReason>()),
+    notes: string()
+  }),
+  (output): FieldErrors<'required'> | undefined => {
+    if (output.reason === 'OTHER' && !output.notes) {
+      return { notes: 'required' }
+    }
+    return undefined
+  }
+)
 
 export function ReplacementDraftForm({
   invoiceResponse

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/InvoiceController.kt
@@ -347,6 +347,10 @@ class InvoiceController(
         @PathVariable invoiceId: InvoiceId,
         @RequestBody body: MarkReplacementDraftSentRequest,
     ) {
+        if (body.reason == InvoiceReplacementReason.OTHER && body.notes.isBlank()) {
+            throw BadRequest("Notes are required when reason is OTHER")
+        }
+
         db.connect { dbc ->
             dbc.transaction { tx ->
                 accessControl.requirePermissionFor(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -1803,7 +1803,7 @@ sealed interface Action {
             HasGlobalRole(ADMIN, SERVICE_WORKER, FINANCE_ADMIN),
             HasUnitRole(UNIT_SUPERVISOR).inPlacementUnitOfChildOfPerson(),
         ),
-        CREATE_REPLACEMENT_DRAFT_INVOICES(HasGlobalRole(ADMIN, FINANCE_ADMIN)),
+        CREATE_REPLACEMENT_DRAFT_INVOICES(HasGlobalRole(ADMIN, FINANCE_ADMIN, FINANCE_STAFF)),
         DELETE(HasGlobalRole(ADMIN)),
         DOWNLOAD_ADDRESS_PAGE(HasGlobalRole(ADMIN, FINANCE_ADMIN, SERVICE_WORKER)),
         DUPLICATE(HasGlobalRole(ADMIN)),


### PR DESCRIPTION
- Annetaan Talouden työntekijä (ulkoinen) -roolille oikeus muodostaa päämiehen oikaisulaskut 
- Tehdään lisätiedot-kentästä pakollinen jos oikaisun syy on Muu