### PR TITLE
Päivämääräkentän saavutettavuus

### DIFF
--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -37,6 +37,8 @@ export interface Translations {
       dateTooEarly: string
       dateTooLate: string
     }
+    open: string
+    close: string
   }
   documentTemplates: {
     templateQuestions: {

--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.spec.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.spec.tsx
@@ -26,7 +26,9 @@ const translations: Translations = {
       validDate: 'Invalid date',
       dateTooEarly: 'Date too early',
       dateTooLate: 'Date too late'
-    }
+    },
+    open: 'Open date picker',
+    close: 'Close date picker'
   }
 }
 
@@ -38,7 +40,7 @@ describe('DatePicker', () => {
       </TestContextProvider>
     )
     const get = () =>
-      screen.getByRole('textbox', { description: 'Date picker description' })
+      screen.getByRole('textbox', { name: 'Date picker description' })
 
     it('attributes', () => {
       render(

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
@@ -44,6 +44,7 @@ export default React.memo(function DatePickerDay({
   return (
     <DayPicker
       mode="single"
+      autoFocus
       onDayClick={handleDayClick}
       locale={localeData}
       selected={date?.toSystemTzDate()}

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerInput.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerInput.tsx
@@ -6,7 +6,6 @@ import React, { useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 
 import LocalDate from 'lib-common/local-date'
-import { useUniqueId } from 'lib-common/utils/useUniqueId'
 
 import InputField, { InputInfo } from '../../atoms/form/InputField'
 import { useTranslations } from '../../i18n'
@@ -37,27 +36,20 @@ const DateInputField = styled(InputField)`
 `
 
 export default React.memo(function DatePickerInput(props: Props) {
-  const i18n = useTranslations()
   const { locale, useBrowserPicker, ...rest } = props
-  const ariaId = useUniqueId('date-picker-input')
 
   return (
     <>
       {useBrowserPicker ? (
-        <DateInputNative {...rest} locale={locale} ariaId={ariaId} />
+        <DateInputNative locale={locale} {...rest} />
       ) : (
-        <DateInputText {...rest} locale={locale} ariaId={ariaId} />
+        <DateInputText locale={locale} {...rest} />
       )}
-      <HelpTextForScreenReader lang={locale} id={ariaId}>
-        {i18n.datePicker.description}
-      </HelpTextForScreenReader>
     </>
   )
 })
 
-interface InternalProps extends Omit<Props, 'useBrowserPicker'> {
-  ariaId: string
-}
+type InternalProps = Omit<Props, 'useBrowserPicker'>
 
 const DateInputText = React.memo(function DateInputText({
   value,
@@ -69,8 +61,7 @@ const DateInputText = React.memo(function DateInputText({
   disabled,
   'data-qa': dataQa,
   id,
-  required,
-  ariaId
+  required
 }: InternalProps) {
   const i18n = useTranslations()
 
@@ -88,7 +79,7 @@ const DateInputText = React.memo(function DateInputText({
       onChange={handleChange}
       onFocus={onFocus}
       onBlur={onBlur}
-      aria-describedby={ariaId}
+      aria-label={i18n.datePicker.description}
       info={info}
       hideErrorsBeforeTouched={hideErrorsBeforeTouched}
       readonly={disabled}
@@ -112,8 +103,7 @@ const DateInputNative = React.memo(function DateInputNative({
   id,
   required,
   minDate,
-  maxDate,
-  ariaId
+  maxDate
 }: InternalProps) {
   const i18n = useTranslations()
 
@@ -140,7 +130,7 @@ const DateInputNative = React.memo(function DateInputNative({
       onChangeTarget={handleChange}
       onFocus={onFocus}
       onBlur={onBlur}
-      aria-describedby={ariaId}
+      aria-label={i18n.datePicker.description}
       info={info}
       hideErrorsBeforeTouched={hideErrorsBeforeTouched}
       readonly={disabled}
@@ -154,14 +144,3 @@ const DateInputNative = React.memo(function DateInputNative({
     />
   )
 })
-
-const HelpTextForScreenReader = styled.p`
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  position: absolute;
-`

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePicker.spec.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePicker.spec.tsx
@@ -26,7 +26,9 @@ const translations: Translations = {
       validDate: 'Invalid date',
       dateTooEarly: 'Date too early',
       dateTooLate: 'Date too late'
-    }
+    },
+    open: 'Open date picker',
+    close: 'Close date picker'
   }
 }
 
@@ -44,7 +46,7 @@ describe('DateRangePicker', () => {
     )
 
     const [start, end] = screen.getAllByRole('textbox', {
-      description: 'Date picker description'
+      name: 'Date picker description'
     })
     expect(start).toHaveAttribute('placeholder', 'Placeholder')
     expect(end).toHaveAttribute('placeholder', 'Placeholder')

--- a/frontend/src/lib-components/utils/TestContextProvider.tsx
+++ b/frontend/src/lib-components/utils/TestContextProvider.tsx
@@ -43,7 +43,9 @@ export const testTranslations: Translations = {
       validDate: '',
       dateTooEarly: '',
       dateTooLate: ''
-    }
+    },
+    open: '',
+    close: ''
   },
   documentTemplates: {
     templateQuestions: {

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -28,12 +28,14 @@ const components: Translations = {
   datePicker: {
     placeholder: 'dd.mm.yyyy',
     description:
-      'Type the date in dd.mm.yyyy format. You can get to month picker with the tab key.',
+      'Type the date in dd.mm.yyyy format. You can get to month picker with the Down Arrow key.',
     validationErrors: {
       validDate: 'Valid date format is dd.mm.yyyy',
       dateTooEarly: 'Pick a later date',
       dateTooLate: 'Pick an earlier date'
-    }
+    },
+    open: 'Open date picker',
+    close: 'Close date picker'
   },
   documentTemplates: {
     // only on employee frontend

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -28,12 +28,14 @@ const components: Translations = {
   datePicker: {
     placeholder: 'pp.kk.vvvv',
     description:
-      'Kirjoita päivämäärä kenttään muodossa pp.kk.vvvv. Tab-näppäimellä pääset kuukausivalitsimeen.',
+      'Kirjoita päivämäärä kenttään muodossa pp.kk.vvvv. Nuoli alas -näppäimellä pääset kuukausivalitsimeen.',
     validationErrors: {
       validDate: 'Anna muodossa pp.kk.vvvv',
       dateTooEarly: 'Valitse myöhäisempi päivä',
       dateTooLate: 'Valitse aikaisempi päivä'
-    }
+    },
+    open: 'Avaa päivämäärävalitsin',
+    close: 'Sulje päivämäärävalitsin'
   },
   documentTemplates: {
     templateQuestions: {

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -28,12 +28,14 @@ const components: Translations = {
   datePicker: {
     placeholder: 'dd.mm.åååå',
     description:
-      'Skriv in datumet i formatet dd.mm.åååå. Du kan komma till månadsväljaren med tabbtangenten.',
+      'Skriv in datumet i formatet dd.mm.åååå. Du kan komma till månadsväljaren med pil ned-tangenten.',
     validationErrors: {
       validDate: 'Ange i format dd.mm.åååå',
       dateTooEarly: 'Välj ett senare datum',
       dateTooLate: 'Välj ett tidigare datum'
-    }
+    },
+    open: 'Öppna datumväljaren',
+    close: 'Stäng datumväljaren'
   },
   documentTemplates: {
     // only on employee frontend


### PR DESCRIPTION
_Ennen muutosta_

Päivämäärävalitsin oli vaikeasti navigoitavissa ruudunlukijan/avusteisen kanssa. 

_Muutoksen jälkeen_

Lisätty erillinen ikoni valitsimen avaamiseen ja asetettu sille aria-haspopup- ja aria-expanded -attribuutit.
Input-kentästä pääsee myös valitsimeen painamalla nuoli alas -näppäintä.
Korvattu erillinen ruudunlukijan ohjeteksti asettamalla se inputin aria-labeliin suoraan.

Videolla käyttöä ensin hiirellä ja sitten näppäimistöllä:

https://github.com/user-attachments/assets/972d33a4-0247-403a-a46e-f2805d239e76


