### PR TITLE
Poistetaan vanhat turhat käytöstä poistuneet roolit

### DIFF
--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -16,16 +16,17 @@ export const client = axios.create({
 export type UUID = string
 
 export type UserRole =
-  | 'CITIZEN_WEAK'
   | 'ADMIN'
-  | 'DIRECTOR'
   | 'REPORT_VIEWER'
+  | 'DIRECTOR'
   | 'FINANCE_ADMIN'
   | 'FINANCE_STAFF'
   | 'SERVICE_WORKER'
-  | 'STAFF'
+  | 'MESSAGING'
   | 'UNIT_SUPERVISOR'
-  | 'MOBILE'
+  | 'STAFF'
+  | 'SPECIAL_EDUCATION_TEACHER'
+  | 'EARLY_CHILDHOOD_EDUCATION_SECRETARY'
 
 export type ServiceRequestHeader =
   | 'Authorization'

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -265,8 +265,6 @@ export interface Translatable {
 * Generated from fi.espoo.evaka.shared.auth.UserRole
 */
 export type UserRole =
-  | 'END_USER'
-  | 'CITIZEN_WEAK'
   | 'ADMIN'
   | 'REPORT_VIEWER'
   | 'DIRECTOR'
@@ -278,8 +276,6 @@ export type UserRole =
   | 'STAFF'
   | 'SPECIAL_EDUCATION_TEACHER'
   | 'EARLY_CHILDHOOD_EDUCATION_SECRETARY'
-  | 'MOBILE'
-  | 'GROUP_STAFF'
 
 export type VoucherValueDecisionId = string
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4823,11 +4823,7 @@ export const fi = {
       SPECIAL_EDUCATION_TEACHER: 'Erityisopettaja',
       EARLY_CHILDHOOD_EDUCATION_SECRETARY: 'Varhaiskasvatussihteeri',
       STAFF: 'Henkilökunta',
-      GROUP_STAFF: 'Ryhmän henkilökunta',
-      UNIT_SUPERVISOR: 'Johtaja',
-      MOBILE: 'Mobiili',
-      END_USER: 'Kuntalainen',
-      CITIZEN_WEAK: 'Kuntalainen (heikko)'
+      UNIT_SUPERVISOR: 'Johtaja'
     }
   },
   welcomePage: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/decision/DecisionCreationIntegrationTest.kt
@@ -313,12 +313,7 @@ WHERE id = ${bind(testDaycare.id)}
         val period = FiniteDateRange(LocalDate.of(2020, 3, 17), LocalDate.of(2023, 7, 31))
         val applicationId = insertInitialData(type = PlacementType.DAYCARE, period = period)
         val invalidRoleLists =
-            listOf(
-                setOf(UserRole.UNIT_SUPERVISOR),
-                setOf(UserRole.FINANCE_ADMIN),
-                setOf(UserRole.END_USER),
-                setOf(),
-            )
+            listOf(setOf(UserRole.UNIT_SUPERVISOR), setOf(UserRole.FINANCE_ADMIN), setOf())
         invalidRoleLists.forEach { roles ->
             assertThrows<Forbidden> {
                 applicationController.getDecisionDrafts(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementPlanIntegrationTest.kt
@@ -339,12 +339,7 @@ class PlacementPlanIntegrationTest : FullApplicationTest(resetDbBeforeEach = tru
                 preferredStartDate = LocalDate.of(2020, 3, 17),
             )
         val invalidRoleLists =
-            listOf(
-                setOf(UserRole.UNIT_SUPERVISOR),
-                setOf(UserRole.FINANCE_ADMIN),
-                setOf(UserRole.END_USER),
-                setOf(),
-            )
+            listOf(setOf(UserRole.UNIT_SUPERVISOR), setOf(UserRole.FINANCE_ADMIN), setOf())
         invalidRoleLists.forEach { roles ->
             assertThrows<Forbidden> {
                 applicationController.getPlacementPlanDraft(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/auth/UserRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/auth/UserRole.kt
@@ -7,8 +7,6 @@ package fi.espoo.evaka.shared.auth
 import fi.espoo.evaka.shared.db.DatabaseEnum
 
 enum class UserRole : DatabaseEnum {
-    END_USER,
-    CITIZEN_WEAK,
     ADMIN,
     REPORT_VIEWER,
     DIRECTOR,
@@ -21,9 +19,7 @@ enum class UserRole : DatabaseEnum {
     SPECIAL_EDUCATION_TEACHER,
 
     /** Varhaiskasvatussihteeri */
-    EARLY_CHILDHOOD_EDUCATION_SECRETARY,
-    MOBILE,
-    @Deprecated("Exists only for backwards compatibility") GROUP_STAFF;
+    EARLY_CHILDHOOD_EDUCATION_SECRETARY;
 
     fun isGlobalRole(): Boolean =
         when (this) {
@@ -49,15 +45,12 @@ enum class UserRole : DatabaseEnum {
     override val sqlType: String = "user_role"
 
     companion object {
-        @Suppress("DEPRECATION")
         val SCOPED_ROLES =
             setOf(
                 UNIT_SUPERVISOR,
                 STAFF,
                 SPECIAL_EDUCATION_TEACHER,
                 EARLY_CHILDHOOD_EDUCATION_SECRETARY,
-                MOBILE,
-                GROUP_STAFF,
             )
     }
 }


### PR DESCRIPTION
- `END_USER`, `CITIZEN_WEAK`, `MOBILE` on käyttäjätyyppejä eikä rooleja
- `GROUP_STAFF` on nykyään `STAFF` yksikkötasolla + erillinen ryhmäluvitus
- nämä on yhä tietokannan `user_role`-enumissa: `MOBILE`, `GROUP_STAFF`. Enumista poistaminen on hankalaa
- `employee.roles` ja `daycare_acl.role` -sarakkeissa on check constraintit jotka on jo nyt ajan tasalla eikä nyt poistettavia rooleja ole sallittu niissä pitkään aikaan