### PR TITLE
Tekstimuutoksia varhaiskasvatuksen tuen päätökselle Espoossa

### DIFF
--- a/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
@@ -467,7 +467,7 @@ describe('Citizen assistance decisions', () => {
     )
     await waitUntilEqual(
       () => assistanceNeedDecisionPage.selectedUnit(),
-      `${testDaycare.name}\n${testDaycare.visitingAddress.streetAddress}\n${testDaycare.visitingAddress.postalCode} ${testDaycare.visitingAddress.postOffice}\nLoma-aikoina tuen järjestämispaikka ja -tapa saattavat muuttua.`
+      `${testDaycare.name}\n${testDaycare.visitingAddress.streetAddress}\n${testDaycare.visitingAddress.postalCode} ${testDaycare.visitingAddress.postOffice}`
     )
     await waitUntilEqual(
       () => assistanceNeedDecisionPage.motivationForDecision(),

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
@@ -296,7 +296,7 @@ describe('Assistance Need Decisions - Preview page', () => {
       )
       await waitUntilEqual(
         () => assistanceNeedDecisionPreviewPage.selectedUnit,
-        `${testDaycare.name}\n${testDaycare.visitingAddress.streetAddress}\n${testDaycare.visitingAddress.postalCode} ${testDaycare.visitingAddress.postOffice}\nLoma-aikoina tuen järjestämispaikka ja -tapa saattavat muuttua.`
+        `${testDaycare.name}\n${testDaycare.visitingAddress.streetAddress}\n${testDaycare.visitingAddress.postalCode} ${testDaycare.visitingAddress.postOffice}`
       )
       await waitUntilEqual(
         () => assistanceNeedDecisionPreviewPage.motivationForDecision,
@@ -422,7 +422,7 @@ describe('Assistance Need Decisions - Preview page', () => {
       )
       await waitUntilEqual(
         () => assistanceNeedDecisionPreviewPage.selectedUnit,
-        `${testDaycare.name}\n${testDaycare.visitingAddress.streetAddress}\n${testDaycare.visitingAddress.postalCode} ${testDaycare.visitingAddress.postOffice}\nLoma-aikoina tuen järjestämispaikka ja -tapa saattavat muuttua.`
+        `${testDaycare.name}\n${testDaycare.visitingAddress.streetAddress}\n${testDaycare.visitingAddress.postalCode} ${testDaycare.visitingAddress.postOffice}`
       )
       await waitUntilEqual(
         () => assistanceNeedDecisionPreviewPage.motivationForDecision,

--- a/frontend/src/lib-customizations/espoo/citizen.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen.tsx
@@ -533,6 +533,15 @@ const customizations: CitizenCustomizations = {
           title: 'Tulotietojen täyttäminen',
           estimate: 'Arvio palkkatuloistani (ennen veroja)'
         }
+      },
+      decisions: {
+        assistanceDecisions: {
+          decision: {
+            motivationForDecision:
+              'Perustelut lapsen tuen tasolle ja tuen järjestelyt loma-aikoina',
+            unitMayChange: ''
+          }
+        }
       }
     },
     sv: {
@@ -1061,6 +1070,15 @@ const customizations: CitizenCustomizations = {
         grossIncome: {
           title: 'Att fylla i uppgifterna om inkomster',
           estimate: 'Uppskattning av mina bruttolön (före skatt)'
+        }
+      },
+      decisions: {
+        assistanceDecisions: {
+          decision: {
+            motivationForDecision:
+              'Motivering för barnets stödbehov och arrangemang för stöd under lovtider',
+            unitMayChange: ''
+          }
         }
       }
     },

--- a/frontend/src/lib-customizations/espoo/employee.tsx
+++ b/frontend/src/lib-customizations/espoo/employee.tsx
@@ -25,6 +25,11 @@ const customizations: EmployeeCustomizations = {
         }
       },
       childInformation: {
+        assistanceNeedDecision: {
+          motivationForDecision:
+            'Perustelut lapsen tuen tasolle ja tuen järjestelyt loma-aikoina',
+          unitMayChange: ''
+        },
         pedagogicalDocument: {
           explanation:
             'Pedagogisen dokumentoinnin ominaisuutta käytetään toiminnasta kertovien kuvien ja digitaalisten dokumenttien jakamiseen.',
@@ -37,7 +42,15 @@ const customizations: EmployeeCustomizations = {
         }
       }
     },
-    sv: {}
+    sv: {
+      childInformation: {
+        assistanceNeedDecision: {
+          motivationForDecision:
+            'Motivering för barnets stödbehov och arrangemang för stöd under lovtider',
+          unitMayChange: ''
+        }
+      }
+    }
   },
   cityLogo: <img src={Logo} alt="Espoo Logo" data-qa="footer-city-logo" />,
   featureFlags,


### PR DESCRIPTION
Espoolle varhaiskasvatuksen tuen päätökselle muutettu otsikko "Perustelut lapsen tuen tasolle" -> "Perustelut lapsen tuen tasolle ja tuen järjestelyt loma-aikoina".
Korvattu tyhjällä teksti "Loma-aikoina tuen järjestämisen tapa ja paikka voi muuttua".