### PR TITLE
Siirron saaneiden lasten näkyminen irtisanottujen listalla

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-groups/TerminatedPlacements.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/TerminatedPlacements.tsx
@@ -3,17 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import sortBy from 'lodash/sortBy'
-import React, { useCallback, useState } from 'react'
+import React from 'react'
 import { Link } from 'react-router'
 
 import { TerminatedPlacement } from 'lib-common/generated/api-types/placement'
 import Title from 'lib-components/atoms/Title'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
-import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
-import {
-  ExpandingInfoBox,
-  InfoButton
-} from 'lib-components/molecules/ExpandingInfo'
+import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 
 import { useTranslation } from '../../../state/i18n'
 import { formatName } from '../../../utils'
@@ -64,8 +60,6 @@ export default React.memo(function TerminatedPlacements({
   recentlyTerminatedPlacements
 }: Props) {
   const { i18n } = useTranslation()
-  const [isInfoOpen, setIsInfoOpen] = useState(false)
-  const toggleInfo = useCallback(() => setIsInfoOpen((prev) => !prev), [])
 
   const sortedRows = sortBy(recentlyTerminatedPlacements, [
     (p: TerminatedPlacement) => p.terminationRequestedDate,
@@ -75,20 +69,9 @@ export default React.memo(function TerminatedPlacements({
 
   return (
     <>
-      <FixedSpaceRow alignItems="center">
+      <ExpandingInfo info={i18n.unit.termination.info}>
         <Title size={2}>{i18n.unit.termination.title}</Title>
-        <InfoButton
-          aria-label={i18n.common.openExpandingInfo}
-          open={isInfoOpen}
-          onClick={toggleInfo}
-        />
-      </FixedSpaceRow>
-      {isInfoOpen && (
-        <ExpandingInfoBox
-          info={i18n.unit.termination.info}
-          close={toggleInfo}
-        />
-      )}
+      </ExpandingInfo>
       <div>
         <Table data-qa="table-of-terminated-placements">
           <Thead>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/TerminatedPlacements.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/TerminatedPlacements.tsx
@@ -3,12 +3,17 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import sortBy from 'lodash/sortBy'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import { Link } from 'react-router'
 
 import { TerminatedPlacement } from 'lib-common/generated/api-types/placement'
 import Title from 'lib-components/atoms/Title'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
+import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
+import {
+  ExpandingInfoBox,
+  InfoButton
+} from 'lib-components/molecules/ExpandingInfo'
 
 import { useTranslation } from '../../../state/i18n'
 import { formatName } from '../../../utils'
@@ -59,6 +64,8 @@ export default React.memo(function TerminatedPlacements({
   recentlyTerminatedPlacements
 }: Props) {
   const { i18n } = useTranslation()
+  const [isInfoOpen, setIsInfoOpen] = useState(false)
+  const toggleInfo = useCallback(() => setIsInfoOpen((prev) => !prev), [])
 
   const sortedRows = sortBy(recentlyTerminatedPlacements, [
     (p: TerminatedPlacement) => p.terminationRequestedDate,
@@ -68,7 +75,20 @@ export default React.memo(function TerminatedPlacements({
 
   return (
     <>
-      <Title size={2}>{i18n.unit.termination.title}</Title>
+      <FixedSpaceRow alignItems="center">
+        <Title size={2}>{i18n.unit.termination.title}</Title>
+        <InfoButton
+          aria-label={i18n.common.openExpandingInfo}
+          open={isInfoOpen}
+          onClick={toggleInfo}
+        />
+      </FixedSpaceRow>
+      {isInfoOpen && (
+        <ExpandingInfoBox
+          info={i18n.unit.termination.info}
+          close={toggleInfo}
+        />
+      )}
       <div>
         <Table data-qa="table-of-terminated-placements">
           <Thead>

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2310,7 +2310,8 @@ export const fi = {
       }
     },
     termination: {
-      title: 'Irtisanotut paikat',
+      title: 'Päättyvät sijoitukset',
+      info: 'Listalla näkyvät ne lapset, joilla huoltaja on tehnyt irtisanomisilmoituksen edellisen kahden viikon aikana, tai joilla on huoltajan hyväksymä siirtohakemus toiseen yksikköön. Lapsia, joilla on muusta syystä päättyvä sijoitus, ei näytetä tällä listalla.',
       terminationRequestedDate: 'Irtisanomispäivä',
       endDate: 'Päättymispäivämäärä',
       groupName: 'Ryhmä'

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -6,6 +6,7 @@ package fi.espoo.evaka.daycare.controllers
 
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
+import fi.espoo.evaka.application.getActiveTransferApplicationsFromUnit
 import fi.espoo.evaka.backupcare.UnitBackupCare
 import fi.espoo.evaka.backupcare.getBackupCaresForDaycare
 import fi.espoo.evaka.daycare.CaretakerAmount
@@ -519,12 +520,17 @@ class DaycareController(
                                 unitId,
                             )
                         ) {
-                            tx.getTerminatedPlacements(
-                                clock.today(),
-                                unitId,
-                                clock.today().minusWeeks(terminatedPlacementsViewWeeks),
-                                clock.today(),
-                            )
+                            val terminatedPlacements =
+                                tx.getTerminatedPlacements(
+                                    clock.today(),
+                                    unitId,
+                                    clock.today().minusWeeks(terminatedPlacementsViewWeeks),
+                                    clock.today(),
+                                )
+                            val transferApplications =
+                                tx.getActiveTransferApplicationsFromUnit(unitId, clock.today())
+
+                            terminatedPlacements + transferApplications
                         } else {
                             emptyList()
                         }


### PR DESCRIPTION
Aikaisemmin irtisanottujen listalla näytettiin lapset kahden viikon ajan irtisanoutumisilmoituksen tekemisestä alkaen. Näiden lisäksi listalla näytetään nyt siirron saaneet lapset alkaen siitä hetkestä, kun huoltaja on ottanut uuden paikan vastaan, siihen asti, kunnes uusi sijoitus alkaa.

<img width="1345" alt="image" src="https://github.com/user-attachments/assets/5884ba26-0ddf-412f-a21c-df35bb7de675" />