### PR TITLE
Korjataan päivämäärävalitsimen virheviestit

### DIFF
--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
@@ -109,7 +109,7 @@ export const DatePickerF = React.memo(function DatePickerF({
       onChange={value.set}
       minDate={config.state?.minDate}
       maxDate={config.state?.maxDate}
-      info={'info' in props ? props.info : value.inputInfo()}
+      info={'info' in props ? props.info : bind.inputInfo()}
     />
   )
 })


### PR DESCRIPTION
Oletustoteutus ei tuntuisi tällä hetkellä toimivan, esim. Kerhon lukukausi -sivun Haku lukukaudelle alkaa -kenttä.
