### PR TITLE
Generoidaan vahvat ID-tyypit fronttiin, osa 3

### DIFF
--- a/frontend/src/citizen-frontend/applications/queries.ts
+++ b/frontend/src/citizen-frontend/applications/queries.ts
@@ -5,9 +5,9 @@
 import { ApplicationType } from 'lib-common/generated/api-types/application'
 import { ApplicationUnitType } from 'lib-common/generated/api-types/daycare'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
+import { ApplicationId, ChildId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { mutation, query } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 
 import {
   createApplication,
@@ -44,11 +44,11 @@ const queryKeys = createQueryKeys('applications', {
       shiftCare
     }
   ],
-  application: (applicationId: UUID) => ['application', applicationId],
+  application: (applicationId: ApplicationId) => ['application', applicationId],
   guardianApplications: () => ['guardianApplications'],
   children: () => ['children'],
-  duplicates: (childId: UUID) => ['duplicates', childId],
-  activePlacementsByApplicationType: (childId: UUID) => [
+  duplicates: (childId: ChildId) => ['duplicates', childId],
+  activePlacementsByApplicationType: (childId: ChildId) => [
     'activePlacementsByApplicationType',
     childId
   ],

--- a/frontend/src/citizen-frontend/attachments.ts
+++ b/frontend/src/citizen-frontend/attachments.ts
@@ -6,9 +6,9 @@ import { Failure, Result, Success } from 'lib-common/api'
 import { AttachmentType } from 'lib-common/generated/api-types/attachment'
 import {
   ApplicationId,
-  AttachmentId
+  AttachmentId,
+  IncomeStatementId
 } from 'lib-common/generated/api-types/shared'
-import { UUID } from 'lib-common/types'
 
 import { API_URL, client } from './api-client'
 
@@ -37,7 +37,7 @@ async function doSaveAttachment(
 }
 
 export async function saveIncomeStatementAttachment(
-  incomeStatementId: UUID | undefined,
+  incomeStatementId: IncomeStatementId | undefined,
   file: File,
   onUploadProgress: (percentage: number) => void
 ): Promise<Result<AttachmentId>> {
@@ -75,7 +75,7 @@ export async function saveApplicationAttachment(
 }
 
 export function getAttachmentUrl(
-  attachmentId: UUID,
+  attachmentId: AttachmentId,
   requestedFilename: string
 ): string {
   const encodedFilename = encodeURIComponent(requestedFilename)

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -10,9 +10,10 @@ import { focusElementOnNextFrame } from 'citizen-frontend/utils/focus'
 import { combine, isLoading, Result } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { CitizenCalendarEvent } from 'lib-common/generated/api-types/calendarevent'
+import { CalendarEventId, ChildId } from 'lib-common/generated/api-types/shared'
+import { fromNullableUuid } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import { useQuery, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import Main from 'lib-components/atoms/Main'
 import { ContentArea } from 'lib-components/layout/Container'
 import { Desktop, RenderOnlyOn } from 'lib-components/layout/responsive-layout'
@@ -360,8 +361,8 @@ type URLModalState =
   | { type: 'discussions' }
   | {
       type: 'discussion-reservations'
-      selectedEventId: UUID | undefined
-      selectedChildId: UUID | undefined
+      selectedEventId: CalendarEventId | undefined
+      selectedChildId: ChildId | undefined
     }
 
 // Modal state not stored to the URL
@@ -382,8 +383,8 @@ interface UseModalStateResult {
   openHolidayModal: () => void
   openDiscussionSurveyModal: () => void
   openDiscussionReservationModal: (
-    selectedChildId: UUID | undefined,
-    selectedEventId: UUID | undefined
+    selectedChildId: ChildId | undefined,
+    selectedEventId: CalendarEventId | undefined
   ) => void
   closeModal: () => void
 }
@@ -430,7 +431,10 @@ export function useCalendarModalState(): UseModalStateResult {
     [openModal]
   )
   const openDiscussionReservationModal = useCallback(
-    (selectedChildId: UUID | undefined, selectedEventId: UUID | undefined) =>
+    (
+      selectedChildId: ChildId | undefined,
+      selectedEventId: CalendarEventId | undefined
+    ) =>
       openModal({
         type: 'discussion-reservations',
         selectedChildId,
@@ -467,8 +471,11 @@ function parseQueryString(qs: string): URLModalState | undefined {
   const modalParam = searchParams.get('modal')
   const startDateParam = searchParams.get('startDate')
   const endDateParam = searchParams.get('endDate')
-  const selectedChildId = searchParams.get('selectedChildId') ?? undefined
-  const selectedEventId = searchParams.get('selectedEventId') ?? undefined
+  const selectedChildId =
+    fromNullableUuid<ChildId>(searchParams.get('selectedChildId')) ?? undefined
+  const selectedEventId =
+    fromNullableUuid<CalendarEventId>(searchParams.get('selectedEventId')) ??
+    undefined
   const returnToDayModal = searchParams.has('returnToDayModal')
 
   const date = dateParam ? LocalDate.tryParseIso(dateParam) : undefined

--- a/frontend/src/citizen-frontend/calendar/RoundChildImages.tsx
+++ b/frontend/src/citizen-frontend/calendar/RoundChildImages.tsx
@@ -7,16 +7,16 @@ import React, { useMemo } from 'react'
 import styled, { css } from 'styled-components'
 
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
+import { ChildId, ChildImageId } from 'lib-common/generated/api-types/shared'
 import { formatFirstName } from 'lib-common/names'
-import { UUID } from 'lib-common/types'
 import { fontWeights } from 'lib-components/typography'
 import { theme } from 'lib-customizations/common'
 
 import { API_URL } from '../api-client'
 
 export interface ChildImageData {
-  childId: UUID
-  imageId: UUID | null
+  childId: ChildId
+  imageId: ChildImageId | null
   initialLetter: string
   colorIndex: number
 }
@@ -81,7 +81,7 @@ const Overlap = styled.div<{ overlap: number; index: number }>`
 `
 
 export interface RoundChildImageProps {
-  imageId: UUID | null
+  imageId: ChildImageId | null
   fallbackText: string
   colorIndex: number
   size: number

--- a/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
+++ b/frontend/src/citizen-frontend/calendar/calendar-elements.tsx
@@ -15,11 +15,11 @@ import {
   ReservationResponseDay,
   ReservationResponseDayChild
 } from 'lib-common/generated/api-types/reservations'
+import { ChildId } from 'lib-common/generated/api-types/shared'
 import {
   reservationHasTimes,
   reservationsAndAttendancesDiffer
 } from 'lib-common/reservations'
-import { UUID } from 'lib-common/types'
 import StatusIcon from 'lib-components/atoms/StatusIcon'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import {
@@ -156,13 +156,13 @@ export type BackgroundHighlightType =
 interface DailyChildGroupElement {
   type: DailyChildGroupElementType
   text: string
-  childId: UUID
+  childId: ChildId
 }
 
 interface GroupedDailyChildren {
   type: DailyChildGroupElementType
   text: string
-  childIds: UUID[]
+  childIds: ChildId[]
   key: string
 }
 

--- a/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
@@ -12,12 +12,12 @@ import {
 } from 'lib-common/generated/api-types/calendarevent'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
 import {
+  CalendarEventId,
   CalendarEventTimeId,
   ChildId
 } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatFirstName } from 'lib-common/names'
-import { UUID } from 'lib-common/types'
 import { StaticChip } from 'lib-components/atoms/Chip'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { cancelMutation } from 'lib-components/atoms/buttons/MutateButton'
@@ -58,8 +58,8 @@ interface Props {
   surveys: CitizenCalendarEvent[]
   childData: ReservationChild[]
   openDiscussionReservations: (
-    selectedChildId: UUID | undefined,
-    selectedEventId: UUID | undefined
+    selectedChildId: ChildId | undefined,
+    selectedEventId: CalendarEventId | undefined
   ) => void
 }
 
@@ -245,7 +245,7 @@ interface DiscussionChildElementProps {
   onCancelClick: (childId: ChildId, eventTimeId: CalendarEventTimeId) => void
   openDiscussionReservations: (
     selectedChildId: ChildId,
-    selectedEventId: UUID
+    selectedEventId: CalendarEventId
   ) => void
 }
 
@@ -288,7 +288,7 @@ const DiscussionChildElement = React.memo(function DiscussionChildElement({
 interface ChildSurveyElementProps {
   survey: CitizenCalendarEvent
   reservations: CitizenCalendarEventTime[]
-  childId: UUID
+  childId: ChildId
   openDiscussionReservations: () => void
   onCancelClick: (childId: ChildId, eventTimeId: CalendarEventTimeId) => void
 }

--- a/frontend/src/citizen-frontend/calendar/holiday-modal/FixedPeriodSelectionModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/holiday-modal/FixedPeriodSelectionModal.tsx
@@ -14,8 +14,8 @@ import {
   HolidayQuestionnaireAnswer
 } from 'lib-common/generated/api-types/holidayperiod'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
+import { ChildId } from 'lib-common/generated/api-types/shared'
 import { formatFirstName } from 'lib-common/names'
-import { UUID } from 'lib-common/types'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
@@ -45,7 +45,7 @@ interface Props {
   close: () => void
   questionnaire: HolidayQuestionnaire.FixedPeriodQuestionnaire
   availableChildren: ReservationChild[]
-  eligibleChildren: UUID[]
+  eligibleChildren: ChildId[]
   previousAnswers: HolidayQuestionnaireAnswer[]
 }
 

--- a/frontend/src/citizen-frontend/calendar/holiday-modal/OpenRangesSelectionModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/holiday-modal/OpenRangesSelectionModal.tsx
@@ -12,8 +12,8 @@ import {
   OpenRangesBody
 } from 'lib-common/generated/api-types/holidayperiod'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
+import { ChildId } from 'lib-common/generated/api-types/shared'
 import { formatFirstName } from 'lib-common/names'
-import { UUID } from 'lib-common/types'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
@@ -45,7 +45,7 @@ interface Props {
   close: () => void
   questionnaire: HolidayQuestionnaire.OpenRangesQuestionnaire
   availableChildren: ReservationChild[]
-  eligibleChildren: UUID[]
+  eligibleChildren: ChildId[]
   previousAnswers: HolidayQuestionnaireAnswer[]
 }
 

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/form.ts
@@ -41,7 +41,6 @@ import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { Repetition } from 'lib-common/reservations'
 import TimeRange from 'lib-common/time-range'
-import { UUID } from 'lib-common/types'
 import { Translations } from 'lib-customizations/citizen'
 
 export const MAX_TIME_RANGE = new TimeRange(
@@ -345,7 +344,7 @@ export function resetTimes(
   next: {
     repetition: Repetition
     selectedRange: FiniteDateRange
-    selectedChildren: UUID[]
+    selectedChildren: ChildId[]
   }
 ): StateOf<typeof timesUnion> {
   const { repetition, selectedRange, selectedChildren } = next
@@ -439,7 +438,7 @@ export function resetTimes(
 
 export function resetDay(
   calendarDays: ReservationResponseDay[],
-  selectedChildren: UUID[]
+  selectedChildren: ChildId[]
 ): StateOf<typeof day> {
   // Daily data for selected children on selected days
   const children = calendarDays.flatMap((day) =>
@@ -614,8 +613,14 @@ const getCommonTimeRanges = (
 }
 
 export class DayProperties {
-  private readonly reservableDaysByChild: Record<UUID, Set<string> | undefined>
-  private readonly operationDaysByChild: Record<UUID, Set<number> | undefined>
+  private readonly reservableDaysByChild: Record<
+    ChildId,
+    Set<string> | undefined
+  >
+  private readonly operationDaysByChild: Record<
+    ChildId,
+    Set<number> | undefined
+  >
 
   minDate: LocalDate | undefined
   maxDate: LocalDate | undefined
@@ -624,8 +629,8 @@ export class DayProperties {
     public readonly calendarDays: ReservationResponseDay[],
     reservableRange: FiniteDateRange
   ) {
-    const reservableDaysByChild: Record<UUID, Set<string> | undefined> = {}
-    const operationDaysByChild: Record<UUID, Set<number> | undefined> = {}
+    const reservableDaysByChild: Record<ChildId, Set<string> | undefined> = {}
+    const operationDaysByChild: Record<ChildId, Set<number> | undefined> = {}
     const holidays = new Set<string>()
 
     let minDate: LocalDate | undefined = undefined
@@ -671,14 +676,14 @@ export class DayProperties {
 
   isOperationalDayForAnyChild(
     dayOfWeek: number,
-    selectedChildren: string[]
+    selectedChildren: ChildId[]
   ): boolean {
     return selectedChildren.some((childId) =>
       this.operationDaysByChild[childId]?.has(dayOfWeek)
     )
   }
 
-  getReservableDatesInRangeForChild(range: FiniteDateRange, childId: UUID) {
+  getReservableDatesInRangeForChild(range: FiniteDateRange, childId: ChildId) {
     const reservableDays = this.reservableDaysByChild[childId]
     if (!reservableDays) return []
 

--- a/frontend/src/citizen-frontend/children/queries.ts
+++ b/frontend/src/citizen-frontend/children/queries.ts
@@ -2,9 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ChildId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { mutation, query } from 'lib-common/query'
-import { Arg0, UUID } from 'lib-common/types'
+import { Arg0 } from 'lib-common/types'
 
 import { getChildren } from '../generated/api-clients/children'
 import {
@@ -17,8 +18,8 @@ import { createQueryKeys } from '../query'
 
 const queryKeys = createQueryKeys('children', {
   all: () => null,
-  serviceApplications: (childId: UUID) => [childId, 'service-applications'],
-  serviceNeedOptions: (childId: UUID, date: LocalDate) => [
+  serviceApplications: (childId: ChildId) => [childId, 'service-applications'],
+  serviceNeedOptions: (childId: ChildId, date: LocalDate) => [
     childId,
     'service-need-options',
     date
@@ -50,6 +51,6 @@ export const createServiceApplicationsMutation = mutation({
 export const deleteServiceApplicationsMutation = mutation({
   api: deleteServiceApplication,
   invalidateQueryKeys: (
-    arg: Arg0<typeof deleteServiceApplication> & { childId: UUID }
+    arg: Arg0<typeof deleteServiceApplication> & { childId: ChildId }
   ) => [queryKeys.serviceApplications(arg.childId)]
 })

--- a/frontend/src/citizen-frontend/children/sections/pedagogical-documents/queries.ts
+++ b/frontend/src/citizen-frontend/children/sections/pedagogical-documents/queries.ts
@@ -4,7 +4,7 @@
 
 import { ChildId } from 'lib-common/generated/api-types/shared'
 import { mutation, query } from 'lib-common/query'
-import { Arg0, UUID } from 'lib-common/types'
+import { Arg0 } from 'lib-common/types'
 
 import {
   getPedagogicalDocumentsForChild,
@@ -14,7 +14,7 @@ import {
 import { createQueryKeys } from '../../../query'
 
 const queryKeys = createQueryKeys('pedagogicalDocuments', {
-  forChild: (childId: UUID) => ['documents', childId],
+  forChild: (childId: ChildId) => ['documents', childId],
   unreadCount: () => ['unreadCount']
 })
 

--- a/frontend/src/citizen-frontend/children/sections/placement-termination/utils.spec.ts
+++ b/frontend/src/citizen-frontend/children/sections/placement-termination/utils.spec.ts
@@ -19,7 +19,7 @@ describe('Terminated placement info', () => {
       terminatable: true,
       placements: [
         {
-          id: 'd4e1cf34-72d5-4fad-b40c-5b1b4cb36883',
+          id: fromUuid('d4e1cf34-72d5-4fad-b40c-5b1b4cb36883'),
           type: 'DAYCARE',
           childId: fromUuid('5a4f3ccc-5270-4d28-bd93-d355182b6768'),
           unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
@@ -55,7 +55,7 @@ describe('Terminated placement info', () => {
       endDate: LocalDate.of(2022, 6, 1),
       placements: [
         {
-          id: 'd4e1cf34-72d5-4fad-b40c-5b1b4cb36883',
+          id: fromUuid('d4e1cf34-72d5-4fad-b40c-5b1b4cb36883'),
           type: 'PRESCHOOL_DAYCARE',
           childId: fromUuid('5a4f3ccc-5270-4d28-bd93-d355182b6768'),
           unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
@@ -69,7 +69,7 @@ describe('Terminated placement info', () => {
       ],
       additionalPlacements: [
         {
-          id: '08e9e908-03d2-48a2-9634-5468b2165945',
+          id: fromUuid('08e9e908-03d2-48a2-9634-5468b2165945'),
           type: 'DAYCARE',
           childId: fromUuid('5a4f3ccc-5270-4d28-bd93-d355182b6768'),
           unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
@@ -104,7 +104,7 @@ describe('Terminated placement info', () => {
       terminatable: true,
       placements: [
         {
-          id: '8920e598-8b3a-11ed-bf51-4f02a3804b0b',
+          id: fromUuid('8920e598-8b3a-11ed-bf51-4f02a3804b0b'),
           type: 'PRESCHOOL_DAYCARE',
           childId: fromUuid('5a4f3ccc-5270-4d28-bd93-d355182b6768'),
           unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),
@@ -120,7 +120,7 @@ describe('Terminated placement info', () => {
           }
         },
         {
-          id: '94e520b0-8b3a-11ed-b202-df238eb02b71',
+          id: fromUuid('94e520b0-8b3a-11ed-b202-df238eb02b71'),
           type: 'PRESCHOOL',
           childId: fromUuid('5a4f3ccc-5270-4d28-bd93-d355182b6768'),
           unitId: fromUuid('b53d80e0-319b-4d2b-950c-f5c3c9f834bc'),

--- a/frontend/src/citizen-frontend/children/sections/placement-termination/utils.ts
+++ b/frontend/src/citizen-frontend/children/sections/placement-termination/utils.ts
@@ -6,8 +6,8 @@ import {
   PlacementType,
   TerminatablePlacementGroup
 } from 'lib-common/generated/api-types/placement'
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 
 type TerminatedPlacementInfoType =
   | { type: 'placement'; placementType: PlacementType }
@@ -17,7 +17,7 @@ export function terminatedPlacementInfo(
   placementGroup: TerminatablePlacementGroup
 ): {
   type: TerminatedPlacementInfoType
-  unitId: UUID
+  unitId: DaycareId
   unitName: string
   lastDay: LocalDate
 } {

--- a/frontend/src/citizen-frontend/children/sections/service-need-and-daily-service-time/ServiceApplications.tsx
+++ b/frontend/src/citizen-frontend/children/sections/service-need-and-daily-service-time/ServiceApplications.tsx
@@ -12,7 +12,7 @@ import {
   ServiceApplication,
   ServiceNeedOptionBasics
 } from 'lib-common/generated/api-types/serviceneed'
-import { UUID } from 'lib-common/types'
+import { ChildId } from 'lib-common/generated/api-types/shared'
 import { StaticChip } from 'lib-components/atoms/Chip'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
@@ -53,7 +53,7 @@ export default React.memo(function ServiceApplications({
   applications,
   canCreate
 }: {
-  childId: UUID
+  childId: ChildId
   applications: CitizenServiceApplication[]
   canCreate: boolean
 }) {

--- a/frontend/src/citizen-frontend/children/sections/service-need-and-daily-service-time/queries.ts
+++ b/frontend/src/citizen-frontend/children/sections/service-need-and-daily-service-time/queries.ts
@@ -2,15 +2,15 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ChildId } from 'lib-common/generated/api-types/shared'
 import { query } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import YearMonth from 'lib-common/year-month'
 
 import { getChildAttendanceSummary } from '../../../generated/api-clients/children'
 import { createQueryKeys } from '../../../query'
 
 const queryKeys = createQueryKeys('serviceNeedAndDailyServiceTime', {
-  attendanceSummary: (childId: UUID, month: YearMonth) => [
+  attendanceSummary: (childId: ChildId, month: YearMonth) => [
     'attendanceSummary',
     childId,
     month

--- a/frontend/src/citizen-frontend/decisions/assistance-decision-page/queries-preschool.ts
+++ b/frontend/src/citizen-frontend/decisions/assistance-decision-page/queries-preschool.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { AssistanceNeedPreschoolDecisionId } from 'lib-common/generated/api-types/shared'
 import { mutation, query } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 
 import {
   getAssistanceNeedPreschoolDecision,
@@ -15,7 +15,7 @@ import { createQueryKeys } from '../../query'
 
 const queryKeys = createQueryKeys('assistancePreschoolDecisions', {
   all: () => ['all'],
-  detail: (id: UUID) => ['preschoolDecisions', id],
+  detail: (id: AssistanceNeedPreschoolDecisionId) => ['preschoolDecisions', id],
   unreadCounts: () => ['unreadCounts']
 })
 

--- a/frontend/src/citizen-frontend/decisions/assistance-decision-page/queries.ts
+++ b/frontend/src/citizen-frontend/decisions/assistance-decision-page/queries.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
 import { mutation, query } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 
 import {
   getAssistanceNeedDecision,
@@ -15,7 +15,7 @@ import { createQueryKeys } from '../../query'
 
 const queryKeys = createQueryKeys('assistanceDecisions', {
   all: () => ['all'],
-  detail: (id: UUID) => ['decisions', id],
+  detail: (id: AssistanceNeedDecisionId) => ['decisions', id],
   unreadCounts: () => ['unreadCounts']
 })
 

--- a/frontend/src/citizen-frontend/decisions/decisions-page/ApplicationDecision.tsx
+++ b/frontend/src/citizen-frontend/decisions/decisions-page/ApplicationDecision.tsx
@@ -10,8 +10,11 @@ import {
   DecisionStatus,
   DecisionType
 } from 'lib-common/generated/api-types/decision'
+import {
+  ApplicationId,
+  DecisionId
+} from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import { StaticChip } from 'lib-components/atoms/Chip'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import ButtonContainer from 'lib-components/layout/ButtonContainer'
@@ -32,8 +35,8 @@ const preschoolInfoTypes: DecisionType[] = [
 ]
 
 interface Props {
-  id: UUID
-  applicationId: UUID
+  id: DecisionId
+  applicationId: ApplicationId
   type: DecisionType
   sentDate: LocalDate
   resolved: LocalDate | null

--- a/frontend/src/citizen-frontend/decisions/decisions-page/AssistanceDecision.tsx
+++ b/frontend/src/citizen-frontend/decisions/decisions-page/AssistanceDecision.tsx
@@ -12,8 +12,8 @@ import {
   AssistanceNeedDecisionStatus,
   UnitInfoBasics
 } from 'lib-common/generated/api-types/assistanceneed'
+import { AssistanceNeedDecisionId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import { AssistanceNeedDecisionStatusChip } from 'lib-components/assistance-need-decision/AssistanceNeedDecisionStatusChip'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
@@ -25,7 +25,7 @@ import { faFileAlt } from 'lib-icons'
 import { useTranslation } from '../../localization'
 
 interface Props {
-  id: UUID
+  id: AssistanceNeedDecisionId
   decisionMade: LocalDate
   assistanceLevels: AssistanceLevel[]
   validityPeriod: DateRange

--- a/frontend/src/citizen-frontend/decisions/decisions-page/Decisions.tsx
+++ b/frontend/src/citizen-frontend/decisions/decisions-page/Decisions.tsx
@@ -13,9 +13,9 @@ import {
   AssistanceNeedDecisionCitizenListItem,
   AssistanceNeedPreschoolDecisionCitizenListItem
 } from 'lib-common/generated/api-types/assistanceneed'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
@@ -54,13 +54,13 @@ export default React.memo(function Decisions() {
       | AssistanceNeedDecisionCitizenListItem
       | AssistanceNeedPreschoolDecisionCitizenListItem
       | {
-          applicationId: UUID
+          applicationId: ApplicationId
           resolved: LocalDate | null
         }
     )[]
     firstName: string
     lastName: string
-    decidableApplications: UUID[]
+    decidableApplications: ApplicationId[]
   }) => {
     const unconfirmedDecisionsCount = child.decisions.filter(
       (decision) =>

--- a/frontend/src/citizen-frontend/decisions/queries.ts
+++ b/frontend/src/citizen-frontend/decisions/queries.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { mutation, query } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 
 import {
   acceptDecision,
@@ -17,7 +17,7 @@ import { createQueryKeys } from '../query'
 
 const queryKeys = createQueryKeys('applicationDecisions', {
   all: () => ['all'],
-  byApplication: (applicationId: UUID) => ['decisions', applicationId],
+  byApplication: (applicationId: ApplicationId) => ['decisions', applicationId],
   notifications: () => ['notifications'],
   financeDecisions: () => ['financeDecisions']
 })

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
@@ -6,8 +6,10 @@ import React, { useCallback } from 'react'
 
 import { wrapResult } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
-import { AttachmentId } from 'lib-common/generated/api-types/shared'
-import { UUID } from 'lib-common/types'
+import {
+  AttachmentId,
+  IncomeStatementId
+} from 'lib-common/generated/api-types/shared'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import FileUpload from 'lib-components/molecules/FileUpload'
 
@@ -22,10 +24,10 @@ export default React.memo(function Attachments({
   onUploaded,
   onDeleted
 }: {
-  incomeStatementId: UUID | undefined
+  incomeStatementId: IncomeStatementId | undefined
   attachments: Attachment[]
   onUploaded: (attachment: Attachment) => void
-  onDeleted: (attachmentId: UUID) => void
+  onDeleted: (attachmentId: AttachmentId) => void
 }) {
   const handleUpload = useCallback(
     async (file: File, onUploadProgress: (percentage: number) => void) =>

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
@@ -7,14 +7,17 @@ import { useNavigate } from 'react-router'
 
 import { combine, Loading, Result } from 'lib-common/api'
 import { IncomeStatementStatus } from 'lib-common/generated/api-types/incomestatement'
-import { ChildId } from 'lib-common/generated/api-types/shared'
+import {
+  ChildId,
+  IncomeStatementId
+} from 'lib-common/generated/api-types/shared'
+import { fromUuid } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import {
   constantQuery,
   useMutationResult,
   useQueryResult
 } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import useRouteParams, { useIdRouteParam } from 'lib-common/useRouteParams'
 import Main from 'lib-components/atoms/Main'
 
@@ -41,7 +44,7 @@ interface EditorState {
 
 function useInitialEditorState(
   childId: ChildId,
-  id: UUID | undefined
+  id: IncomeStatementId | undefined
 ): Result<EditorState> {
   const incomeStatement = useQueryResult(
     id
@@ -74,7 +77,9 @@ export default React.memo(function ChildIncomeStatementEditor() {
   const childId = useIdRouteParam<ChildId>('childId')
   const navigate = useNavigate()
   const incomeStatementId =
-    params.incomeStatementId === 'new' ? undefined : params.incomeStatementId
+    params.incomeStatementId === 'new'
+      ? undefined
+      : fromUuid<IncomeStatementId>(params.incomeStatementId)
 
   const [state, setState] = useState<Result<EditorState>>(Loading.of())
   const initialEditorState = useInitialEditorState(childId, incomeStatementId)

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
@@ -8,8 +8,11 @@ import styled from 'styled-components'
 import { Result } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
 import { IncomeStatementStatus } from 'lib-common/generated/api-types/incomestatement'
+import {
+  AttachmentId,
+  IncomeStatementId
+} from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import { scrollToRef } from 'lib-common/utils/scrolling'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
@@ -40,7 +43,7 @@ import {
 import * as Form from './types/form'
 
 interface Props {
-  incomeStatementId: UUID | undefined
+  incomeStatementId: IncomeStatementId | undefined
   status: IncomeStatementStatus
   formData: Form.IncomeStatementForm
   showFormErrors: boolean
@@ -61,7 +64,7 @@ const ChildIncome = React.memo(function ChildIncome({
   formData,
   onChange
 }: {
-  incomeStatementId: UUID | undefined
+  incomeStatementId: IncomeStatementId | undefined
   formData: Form.IncomeStatementForm
   onChange: SetStateCallback<Form.IncomeStatementForm>
 }) {
@@ -77,7 +80,7 @@ const ChildIncome = React.memo(function ChildIncome({
   )
 
   const onAttachmentDeleted = useCallback(
-    (id: UUID) =>
+    (id: AttachmentId) =>
       onChange((prev) => ({
         ...prev,
         attachments: prev.attachments.filter((a) => a.id !== id)

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementView.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementView.tsx
@@ -9,9 +9,12 @@ import styled from 'styled-components'
 
 import { Attachment } from 'lib-common/api-types/attachment'
 import { IncomeStatement } from 'lib-common/generated/api-types/incomestatement'
-import { ChildId } from 'lib-common/generated/api-types/shared'
+import {
+  ChildId,
+  IncomeStatementId
+} from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import useRouteParams, { useIdRouteParam } from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Main from 'lib-components/atoms/Main'
 import ResponsiveInlineButton from 'lib-components/atoms/buttons/ResponsiveInlineButton'
@@ -36,7 +39,8 @@ import { childIncomeStatementQuery } from './queries'
 
 export default React.memo(function ChildIncomeStatementView() {
   const childId = useIdRouteParam<ChildId>('childId')
-  const { incomeStatementId } = useRouteParams(['incomeStatementId'])
+  const incomeStatementId =
+    useIdRouteParam<IncomeStatementId>('incomeStatementId')
   const t = useTranslation()
   const navigate = useNavigate()
   const result = useQueryResult(

--- a/frontend/src/citizen-frontend/income-statements/ChildrenIncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildrenIncomeStatements.tsx
@@ -13,7 +13,6 @@ import {
   IncomeStatementId
 } from 'lib-common/generated/api-types/shared'
 import { useMutation, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import Pagination from 'lib-components/Pagination'
 import ResponsiveAddButton from 'lib-components/atoms/buttons/ResponsiveAddButton'
 import ResponsiveInlineButton from 'lib-components/atoms/buttons/ResponsiveInlineButton'
@@ -48,7 +47,11 @@ const ChildIncomeStatementsContainer = styled.div`
   border-width: 1px 0 0 0;
 `
 
-function getLink(childId: UUID, id: UUID, mode: 'view' | 'edit') {
+function getLink(
+  childId: ChildId,
+  id: IncomeStatementId,
+  mode: 'view' | 'edit'
+) {
   return `/child-income/${childId}/${id}/${mode === 'edit' ? 'edit' : ''}`
 }
 
@@ -69,7 +72,7 @@ const ChildIncomeStatementsTable = React.memo(
     )
 
     const onEdit = useCallback(
-      (id: UUID) => () => navigate(getLink(child.id, id, 'edit')),
+      (id: IncomeStatementId) => () => navigate(getLink(child.id, id, 'edit')),
       [navigate, child.id]
     )
 

--- a/frontend/src/citizen-frontend/income-statements/ChildrenIncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildrenIncomeStatements.tsx
@@ -8,7 +8,10 @@ import styled from 'styled-components'
 
 import { renderResult } from 'citizen-frontend/async-rendering'
 import { ChildBasicInfo } from 'lib-common/generated/api-types/incomestatement'
-import { ChildId } from 'lib-common/generated/api-types/shared'
+import {
+  ChildId,
+  IncomeStatementId
+} from 'lib-common/generated/api-types/shared'
 import { useMutation, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import Pagination from 'lib-components/Pagination'
@@ -163,7 +166,7 @@ type DeletionState =
     }
   | {
       status: 'confirming' | 'deleting'
-      rowToDelete: UUID
+      rowToDelete: IncomeStatementId
       childId: ChildId
     }
 
@@ -187,7 +190,7 @@ export default React.memo(function ChildrenIncomeStatements({
   )
 
   const onDelete = useCallback(
-    (childId: ChildId, id: UUID) => {
+    (childId: ChildId, id: IncomeStatementId) => {
       setDeletionState({ status: 'deleting', rowToDelete: id, childId })
       deleteChildIncomeStatement({ childId, id })
         .then(() => {

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
@@ -6,8 +6,10 @@ import React, { useCallback } from 'react'
 
 import { wrapResult } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
-import { AttachmentId } from 'lib-common/generated/api-types/shared'
-import { UUID } from 'lib-common/types'
+import {
+  AttachmentId,
+  IncomeStatementId
+} from 'lib-common/generated/api-types/shared'
 import UnorderedList from 'lib-components/atoms/UnorderedList'
 import { ContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
@@ -30,11 +32,11 @@ export default React.memo(function Attachments({
   onUploaded,
   onDeleted
 }: {
-  incomeStatementId: UUID | undefined
+  incomeStatementId: IncomeStatementId | undefined
   requiredAttachments: Set<AttachmentType>
   attachments: Attachment[]
   onUploaded: (attachment: Attachment) => void
-  onDeleted: (attachmentId: UUID) => void
+  onDeleted: (attachmentId: AttachmentId) => void
 }) {
   const t = useTranslation()
 

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
@@ -7,13 +7,14 @@ import { useNavigate } from 'react-router'
 
 import { combine, Loading, Result } from 'lib-common/api'
 import { IncomeStatementStatus } from 'lib-common/generated/api-types/incomestatement'
+import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
+import { fromUuid } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import {
   constantQuery,
   useMutationResult,
   useQueryResult
 } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import useRouteParams from 'lib-common/useRouteParams'
 import Main from 'lib-components/atoms/Main'
 
@@ -38,7 +39,9 @@ interface EditorState {
   formData: Form.IncomeStatementForm
 }
 
-function useInitialEditorState(id: UUID | undefined): Result<EditorState> {
+function useInitialEditorState(
+  id: IncomeStatementId | undefined
+): Result<EditorState> {
   const incomeStatement = useQueryResult(
     id ? incomeStatementQuery({ incomeStatementId: id }) : constantQuery(null)
   )
@@ -61,7 +64,9 @@ export default React.memo(function IncomeStatementEditor() {
   const params = useRouteParams(['incomeStatementId'])
   const navigate = useNavigate()
   const incomeStatementId =
-    params.incomeStatementId === 'new' ? undefined : params.incomeStatementId
+    params.incomeStatementId === 'new'
+      ? undefined
+      : fromUuid<IncomeStatementId>(params.incomeStatementId)
 
   const [state, setState] = useState<Result<EditorState>>(Loading.of())
   const initialEditorState = useInitialEditorState(incomeStatementId)

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -18,8 +18,11 @@ import {
   OtherIncome,
   otherIncomes
 } from 'lib-common/generated/api-types/incomestatement'
+import {
+  AttachmentId,
+  IncomeStatementId
+} from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import { scrollToRef } from 'lib-common/utils/scrolling'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
@@ -61,7 +64,7 @@ import { AttachmentType } from './types/common'
 import * as Form from './types/form'
 
 interface Props {
-  incomeStatementId: UUID | undefined
+  incomeStatementId: IncomeStatementId | undefined
   status: IncomeStatementStatus
   formData: Form.IncomeStatementForm
   showFormErrors: boolean
@@ -173,7 +176,7 @@ export default React.memo(
     )
 
     const onAttachmentDeleted = useCallback(
-      (id: UUID) =>
+      (id: AttachmentId) =>
         onChange((prev) => ({
           ...prev,
           attachments: prev.attachments.filter((a) => a.id !== id)

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
@@ -15,8 +15,9 @@ import {
   Gross,
   IncomeStatement
 } from 'lib-common/generated/api-types/incomestatement'
+import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Main from 'lib-components/atoms/Main'
 import ResponsiveInlineButton from 'lib-components/atoms/buttons/ResponsiveInlineButton'
@@ -40,7 +41,8 @@ import { useTranslation } from '../localization'
 import { incomeStatementQuery } from './queries'
 
 export default React.memo(function IncomeStatementView() {
-  const { incomeStatementId } = useRouteParams(['incomeStatementId'])
+  const incomeStatementId =
+    useIdRouteParam<IncomeStatementId>('incomeStatementId')
   const t = useTranslation()
   const navigate = useNavigate()
   const result = useQueryResult(incomeStatementQuery({ incomeStatementId }))

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
@@ -10,7 +10,6 @@ import { renderResult } from 'citizen-frontend/async-rendering'
 import { IncomeStatement } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
 import { useMutation, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import Pagination from 'lib-components/Pagination'
 import Main from 'lib-components/atoms/Main'
 import ResponsiveAddButton from 'lib-components/atoms/buttons/ResponsiveAddButton'
@@ -42,7 +41,7 @@ const Buttons = styled.div`
   justify-content: flex-end;
 `
 
-function getLink(id: UUID, mode: 'view' | 'edit') {
+function getLink(id: IncomeStatementId, mode: 'view' | 'edit') {
   return `/income/${id}/${mode === 'edit' ? 'edit' : ''}`
 }
 
@@ -57,7 +56,7 @@ const IncomeStatementsTable = React.memo(function IncomeStatementsTable({
   const navigate = useNavigate()
 
   const onEdit = useCallback(
-    (id: UUID) => () => navigate(getLink(id, 'edit')),
+    (id: IncomeStatementId) => () => navigate(getLink(id, 'edit')),
     [navigate]
   )
 

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatements.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 
 import { renderResult } from 'citizen-frontend/async-rendering'
 import { IncomeStatement } from 'lib-common/generated/api-types/incomestatement'
+import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
 import { useMutation, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import Pagination from 'lib-components/Pagination'
@@ -50,7 +51,7 @@ const IncomeStatementsTable = React.memo(function IncomeStatementsTable({
   onRemoveIncomeStatement
 }: {
   items: IncomeStatement[]
-  onRemoveIncomeStatement: (id: UUID) => void
+  onRemoveIncomeStatement: (id: IncomeStatementId) => void
 }) {
   const t = useTranslation()
   const navigate = useNavigate()
@@ -124,7 +125,7 @@ type DeletionState =
     }
   | {
       status: 'confirming' | 'deleting'
-      rowToDelete: UUID
+      rowToDelete: IncomeStatementId
     }
 
 export default React.memo(function IncomeStatements() {
@@ -147,7 +148,7 @@ export default React.memo(function IncomeStatements() {
   })
 
   const onDelete = useCallback(
-    (id: UUID) => {
+    (id: IncomeStatementId) => {
       setDeletionState({ status: 'deleting', rowToDelete: id })
       deleteIncomeStatement({ id })
         .then(() => {

--- a/frontend/src/citizen-frontend/income-statements/queries.ts
+++ b/frontend/src/citizen-frontend/income-statements/queries.ts
@@ -2,8 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import {
+  ChildId,
+  IncomeStatementId
+} from 'lib-common/generated/api-types/shared'
 import { mutation, query } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 
 import {
   createChildIncomeStatement,
@@ -25,7 +28,7 @@ import { createQueryKeys } from '../query'
 const queryKeys = createQueryKeys('incomeStatements', {
   allIncomeStatements: () => ['incomeStatements'],
   incomeStatements: (page: number) => ['incomeStatements', 'paginated', page],
-  incomeStatement: (incomeStatementId: UUID) => [
+  incomeStatement: (incomeStatementId: IncomeStatementId) => [
     'incomeStatements',
     'single',
     incomeStatementId
@@ -34,11 +37,11 @@ const queryKeys = createQueryKeys('incomeStatements', {
 
   guardianIncomeStatementChildren: () => ['guardianIncomeStatementChildren'],
 
-  allChildIncomeStatements: (childId: UUID) => [
+  allChildIncomeStatements: (childId: ChildId) => [
     'childIncomeStatements',
     childId
   ],
-  childIncomeStatements: (childId: UUID, page: number) => [
+  childIncomeStatements: (childId: ChildId, page: number) => [
     'childIncomeStatements',
     childId,
     'paginated',
@@ -48,10 +51,10 @@ const queryKeys = createQueryKeys('incomeStatements', {
     childId,
     incomeStatementId
   }: {
-    childId: UUID
-    incomeStatementId: UUID
+    childId: ChildId
+    incomeStatementId: IncomeStatementId
   }) => ['childIncomeStatements', childId, 'single', incomeStatementId],
-  childIncomeStatementStartDates: (childId: UUID) => [
+  childIncomeStatementStartDates: (childId: ChildId) => [
     'childIncomeStatements',
     childId,
     'startDates'

--- a/frontend/src/citizen-frontend/messages/ConfirmDeleteThread.tsx
+++ b/frontend/src/citizen-frontend/messages/ConfirmDeleteThread.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react'
 
-import { UUID } from 'lib-common/types'
+import { MessageThreadId } from 'lib-common/generated/api-types/shared'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
 import { faQuestion } from 'lib-icons'
 
@@ -13,7 +13,7 @@ import { useTranslation } from '../localization'
 import { archiveThreadMutation } from './queries'
 
 export interface Props {
-  threadId: UUID
+  threadId: MessageThreadId
   onClose: () => void
   onSuccess: () => void
 }

--- a/frontend/src/citizen-frontend/messages/MessagesPage.tsx
+++ b/frontend/src/citizen-frontend/messages/MessagesPage.tsx
@@ -18,8 +18,8 @@ import { useUser } from 'citizen-frontend/auth/state'
 import { useTranslation } from 'citizen-frontend/localization'
 import { focusElementAfterDelay } from 'citizen-frontend/utils/focus'
 import { combine } from 'lib-common/api'
+import { MessageThreadId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { NotificationsContext } from 'lib-components/Notifications'
 import Main from 'lib-components/atoms/Main'
 import { desktopMin, tabletMin } from 'lib-components/breakpoints'
@@ -81,7 +81,7 @@ export default React.memo(function MessagesPage() {
     [navigate]
   )
 
-  const params = useParams<{ threadId: UUID | undefined }>()
+  const params = useParams<{ threadId: MessageThreadId | undefined }>()
   useEffect(() => {
     setSelectedThread(params.threadId)
   }, [setSelectedThread, params.threadId])
@@ -89,7 +89,7 @@ export default React.memo(function MessagesPage() {
   const threadView = useRef<ThreadViewApi>(null)
 
   const selectThread = useCallback(
-    (threadId: UUID | undefined) => {
+    (threadId: MessageThreadId | undefined) => {
       if (!threadId) {
         void navigate('/messages')
       } else {

--- a/frontend/src/citizen-frontend/messages/ThreadList.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadList.tsx
@@ -7,6 +7,7 @@ import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 
 import { CitizenMessageThread } from 'lib-common/generated/api-types/messaging'
+import { MessageThreadId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 import { NotificationsContext } from 'lib-components/Notifications'
 import { OnEnterView } from 'lib-components/OnEnterView'
@@ -51,7 +52,7 @@ export default React.memo(function ThreadList({
   const { selectedThread, threads, loadMoreThreads, hasMoreThreads } =
     useContext(MessageContext)
   const { addTimedNotification } = useContext(NotificationsContext)
-  const [confirmDelete, setConfirmDelete] = useState<UUID>()
+  const [confirmDelete, setConfirmDelete] = useState<MessageThreadId>()
 
   return (
     <>

--- a/frontend/src/citizen-frontend/messages/ThreadList.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadList.tsx
@@ -7,8 +7,10 @@ import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 
 import { CitizenMessageThread } from 'lib-common/generated/api-types/messaging'
-import { MessageThreadId } from 'lib-common/generated/api-types/shared'
-import { UUID } from 'lib-common/types'
+import {
+  MessageAccountId,
+  MessageThreadId
+} from 'lib-common/generated/api-types/shared'
 import { NotificationsContext } from 'lib-components/Notifications'
 import { OnEnterView } from 'lib-components/OnEnterView'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
@@ -30,14 +32,17 @@ import { ConfirmDeleteThread } from './ConfirmDeleteThread'
 import ThreadListItem from './ThreadListItem'
 import { isRedactedThread, MessageContext } from './state'
 
-const hasUnreadMessages = (thread: CitizenMessageThread, accountId: UUID) =>
+const hasUnreadMessages = (
+  thread: CitizenMessageThread,
+  accountId: MessageAccountId
+) =>
   isRedactedThread(thread)
     ? thread.hasUnreadMessages
     : thread.messages.some((m) => !m.readAt && m.sender.id !== accountId)
 
 interface Props {
-  accountId: UUID
-  selectThread: (threadId: UUID | undefined) => void
+  accountId: MessageAccountId
+  selectThread: (threadId: MessageThreadId | undefined) => void
   setEditorVisible: (value: boolean) => void
   newMessageButtonEnabled: boolean
 }

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -21,6 +21,7 @@ import {
   Message,
   MessageAccount
 } from 'lib-common/generated/api-types/messaging'
+import { MessageAccountId } from 'lib-common/generated/api-types/shared'
 import { formatFirstName } from 'lib-common/names'
 import { UUID } from 'lib-common/types'
 import { scrollRefIntoView } from 'lib-common/utils/scrolling'
@@ -209,7 +210,7 @@ const SingleMessage = React.memo(
 )
 
 interface Props {
-  accountId: UUID
+  accountId: MessageAccountId
   thread: CitizenMessageThread.Regular
   allowedAccounts: Partial<Record<UUID, ChildMessageAccountAccess>>
   closeThread: () => void

--- a/frontend/src/citizen-frontend/messages/ThreadView.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadView.tsx
@@ -21,9 +21,11 @@ import {
   Message,
   MessageAccount
 } from 'lib-common/generated/api-types/messaging'
-import { MessageAccountId } from 'lib-common/generated/api-types/shared'
+import {
+  ChildId,
+  MessageAccountId
+} from 'lib-common/generated/api-types/shared'
 import { formatFirstName } from 'lib-common/names'
-import { UUID } from 'lib-common/types'
 import { scrollRefIntoView } from 'lib-common/utils/scrolling'
 import { NotificationsContext } from 'lib-components/Notifications'
 import { StaticChip } from 'lib-components/atoms/Chip'
@@ -212,7 +214,7 @@ const SingleMessage = React.memo(
 interface Props {
   accountId: MessageAccountId
   thread: CitizenMessageThread.Regular
-  allowedAccounts: Partial<Record<UUID, ChildMessageAccountAccess>>
+  allowedAccounts: Partial<Record<ChildId, ChildMessageAccountAccess>>
   closeThread: () => void
   onThreadDeleted: () => void
 }

--- a/frontend/src/citizen-frontend/messages/state.tsx
+++ b/frontend/src/citizen-frontend/messages/state.tsx
@@ -15,13 +15,13 @@ import {
   CitizenMessageThread,
   MyAccountResponse
 } from 'lib-common/generated/api-types/messaging'
+import { MessageThreadId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import {
   useMutation,
   usePagedInfiniteQueryResult,
   useQueryResult
 } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 
 import { useUser } from '../auth/state'
 
@@ -37,9 +37,9 @@ export interface MessagePageState {
   hasMoreThreads: boolean
   loadMoreThreads: () => void
   selectedThread: CitizenMessageThread | undefined
-  setSelectedThread: (threadId: UUID | undefined) => void
-  setReplyContent: (threadId: UUID, content: string) => void
-  getReplyContent: (threadId: UUID) => string
+  setSelectedThread: (threadId: MessageThreadId | undefined) => void
+  setReplyContent: (threadId: MessageThreadId, content: string) => void
+  getReplyContent: (threadId: MessageThreadId) => string
 }
 
 const defaultState: MessagePageState = {
@@ -64,7 +64,7 @@ export const isRegularThread = (
 
 const markMessagesReadByThreadId = (
   thread: CitizenMessageThread,
-  threadId: UUID
+  threadId: MessageThreadId
 ): CitizenMessageThread =>
   isRegularThread(thread) && thread.id === threadId
     ? {
@@ -93,16 +93,21 @@ export const MessageContextProvider = React.memo(
       enabled: messageAccount.isSuccess
     })
 
-    const [selectedThreadId, setSelectedThreadId] = useState<UUID>()
+    const [selectedThreadId, setSelectedThreadId] = useState<MessageThreadId>()
 
-    const [replyContents, setReplyContents] = useState<Record<UUID, string>>({})
+    const [replyContents, setReplyContents] = useState<
+      Record<MessageThreadId, string>
+    >({})
     const getReplyContent = useCallback(
-      (threadId: UUID) => replyContents[threadId] ?? '',
+      (threadId: MessageThreadId) => replyContents[threadId] ?? '',
       [replyContents]
     )
-    const setReplyContent = useCallback((threadId: UUID, content: string) => {
-      setReplyContents((state) => ({ ...state, [threadId]: content }))
-    }, [])
+    const setReplyContent = useCallback(
+      (threadId: MessageThreadId, content: string) => {
+        setReplyContents((state) => ({ ...state, [threadId]: content }))
+      },
+      []
+    )
 
     const selectedThread = useMemo(
       () =>

--- a/frontend/src/citizen-frontend/navigation/utils.ts
+++ b/frontend/src/citizen-frontend/navigation/utils.ts
@@ -5,8 +5,8 @@
 import sum from 'lodash/sum'
 import { useMemo } from 'react'
 
+import { ChildId } from 'lib-common/generated/api-types/shared'
 import { useQuery } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 
 import { useUser } from '../auth/state'
 import { unreadChildDocumentsCountQuery } from '../child-documents/queries'
@@ -27,10 +27,10 @@ export function useUnreadChildNotifications() {
   )
 
   const unreadChildNotifications = useMemo(() => {
-    const counts: Record<UUID, number> = {}
-    const addCounts = (countRecord: Record<UUID, number>) =>
+    const counts: Record<ChildId, number> = {}
+    const addCounts = (countRecord: Record<ChildId, number>) =>
       Object.entries(countRecord).forEach(([id, count]) => {
-        counts[id] = (counts[id] ?? 0) + count
+        counts[id as ChildId] = (counts[id as ChildId] ?? 0) + count
       })
 
     addCounts(unreadPedagogicalDocumentsCount)

--- a/frontend/src/citizen-frontend/utils/duplicated-child-utils.ts
+++ b/frontend/src/citizen-frontend/utils/duplicated-child-utils.ts
@@ -5,7 +5,7 @@
 import { Translations } from 'citizen-frontend/localization'
 import { ChildAndPermittedActions } from 'lib-common/generated/api-types/children'
 import { ReservationChild } from 'lib-common/generated/api-types/reservations'
-import { UUID } from 'lib-common/types'
+import { ChildId } from 'lib-common/generated/api-types/shared'
 
 const toDuplicatedChildIds = (
   children: (ChildAndPermittedActions | ReservationChild)[]
@@ -27,9 +27,9 @@ export function getDuplicateChildInfo(
   children: (ChildAndPermittedActions | ReservationChild)[],
   i18n: Translations,
   format: 'short' | 'long' = 'short'
-): Record<UUID, string> {
+): Record<ChildId, string> {
   const duplicatedChildIds = toDuplicatedChildIds(children)
-  return children.reduce<Record<UUID, string>>((data, child) => {
+  return children.reduce<Record<ChildId, string>>((data, child) => {
     if (duplicatedChildIds.includes(child.id)) {
       data[child.id] = formatDuplicatedChildIdentifier(i18n, child, format)
     }

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -444,7 +444,7 @@ export class Fixture {
     >
   ): ServiceNeedBuilder {
     return new ServiceNeedBuilder({
-      id: uuidv4(),
+      id: randomId(),
       startDate: LocalDate.todayInSystemTz(),
       endDate: LocalDate.todayInSystemTz(),
       shiftCare: 'NONE',

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -42,7 +42,8 @@ import {
   DaycareId,
   EmployeeId,
   GroupId,
-  PersonId
+  PersonId,
+  PlacementId
 } from 'lib-common/generated/api-types/shared'
 import { EvakaUser } from 'lib-common/generated/api-types/user'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
@@ -400,7 +401,7 @@ export class Fixture {
     initial: SemiPartial<DevPlacement, 'childId' | 'unitId'>
   ): PlacementBuilder {
     return new PlacementBuilder({
-      id: uuidv4(),
+      id: randomId(),
       type: 'DAYCARE',
       startDate: LocalDate.todayInSystemTz(),
       endDate: LocalDate.todayInSystemTz().addYears(1),
@@ -3121,7 +3122,7 @@ export const testDaycareGroup: DevDaycareGroup = {
  *  @deprecated Use `Fixture.placement()` instead
  **/
 export function createDaycarePlacementFixture(
-  id: string,
+  id: PlacementId,
   childId: PersonId,
   unitId: DaycareId,
   startDate = LocalDate.of(2022, 5, 1),

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -41,9 +41,11 @@ import {
   ApplicationId,
   DaycareId,
   EmployeeId,
+  FeeDecisionId,
   GroupId,
   PersonId,
-  PlacementId
+  PlacementId,
+  VoucherValueDecisionId
 } from 'lib-common/generated/api-types/shared'
 import { EvakaUser } from 'lib-common/generated/api-types/user'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
@@ -51,7 +53,6 @@ import { evakaUserId, fromUuid, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
-import { UUID } from 'lib-common/types'
 
 import {
   addAbsence,
@@ -345,7 +346,7 @@ export class Fixture {
     return new EmployeeBuilder({
       id: randomId(),
       email: `email_${id}@evaka.test`,
-      externalId: `espoo-ad:${uuidv4()}`,
+      externalId: `espoo-ad:${randomId()}`,
       firstName: `first_name_${id}`,
       lastName: `last_name_${id}`,
       roles: [],
@@ -364,7 +365,7 @@ export class Fixture {
     >
   ): DecisionBuilder {
     return new DecisionBuilder({
-      id: uuidv4(),
+      id: randomId(),
       type: 'DAYCARE',
       startDate: LocalDate.of(2020, 1, 1),
       endDate: LocalDate.of(2021, 1, 1),
@@ -375,7 +376,7 @@ export class Fixture {
 
   static employeePin(initial: Partial<DevEmployeePin>): EmployeePinBuilder {
     return new EmployeePinBuilder({
-      id: uuidv4(),
+      id: randomId(),
       userId: null,
       pin: uniqueLabel(4),
       employeeExternalId: null,
@@ -388,7 +389,7 @@ export class Fixture {
     initial: SemiPartial<DevPedagogicalDocument, 'childId'>
   ): PedagogicalDocumentBuilder {
     return new PedagogicalDocumentBuilder({
-      id: uuidv4(),
+      id: randomId(),
       description: 'Test description',
       createdBy: systemInternalUser.id,
       modifiedAt: HelsinkiDateTime.now(),
@@ -419,7 +420,7 @@ export class Fixture {
     >
   ): GroupPlacementBuilder {
     return new GroupPlacementBuilder({
-      id: uuidv4(),
+      id: randomId(),
       ...initial
     })
   }
@@ -524,7 +525,7 @@ export class Fixture {
     initial: SemiPartial<DaycareAssistance, 'childId'>
   ): DaycareAssistanceBuilder {
     return new DaycareAssistanceBuilder({
-      id: uuidv4(),
+      id: randomId(),
       level: 'GENERAL_SUPPORT',
       validDuring: new FiniteDateRange(
         LocalDate.todayInSystemTz(),
@@ -540,7 +541,7 @@ export class Fixture {
     initial: SemiPartial<PreschoolAssistance, 'childId'>
   ): PreschoolAssistanceBuilder {
     return new PreschoolAssistanceBuilder({
-      id: uuidv4(),
+      id: randomId(),
       level: 'SPECIAL_SUPPORT',
       validDuring: new FiniteDateRange(
         LocalDate.todayInSystemTz(),
@@ -556,7 +557,7 @@ export class Fixture {
     initial: SemiPartial<OtherAssistanceMeasure, 'childId'>
   ): OtherAssistanceMeasureBuilder {
     return new OtherAssistanceMeasureBuilder({
-      id: uuidv4(),
+      id: randomId(),
       type: 'TRANSPORT_BENEFIT',
       validDuring: new FiniteDateRange(
         LocalDate.todayInSystemTz(),
@@ -807,7 +808,7 @@ export class Fixture {
     initial: SemiPartial<DevIncome, 'personId' | 'modifiedBy'>
   ): IncomeBuilder {
     return new IncomeBuilder({
-      id: uuidv4(),
+      id: randomId(),
       validFrom: LocalDate.todayInSystemTz(),
       validTo: LocalDate.todayInSystemTz().addYears(1),
       data: {
@@ -830,7 +831,7 @@ export class Fixture {
     initial: SemiPartial<DevIncomeStatement, 'personId'>
   ): IncomeStatementBuilder {
     return new IncomeStatementBuilder({
-      id: uuidv4(),
+      id: randomId(),
       createdAt: HelsinkiDateTime.now(),
       modifiedAt: HelsinkiDateTime.now(),
       createdBy: systemInternalUser.id,
@@ -874,7 +875,7 @@ export class Fixture {
 
   static holidayPeriod(initial?: Partial<HolidayPeriod>): HolidayPeriodBuilder {
     return new HolidayPeriodBuilder({
-      id: uuidv4(),
+      id: randomId(),
       period: new FiniteDateRange(
         LocalDate.todayInSystemTz(),
         LocalDate.todayInSystemTz()
@@ -889,7 +890,7 @@ export class Fixture {
     initial?: Partial<FixedPeriodQuestionnaire>
   ): HolidayQuestionnaireBuilder {
     return new HolidayQuestionnaireBuilder({
-      id: uuidv4(),
+      id: randomId(),
       type: 'FIXED_PERIOD',
       absenceType: 'OTHER_ABSENCE',
       title: { fi: '', sv: '', en: '' },
@@ -920,7 +921,7 @@ export class Fixture {
     initial: SemiPartial<DevFridgeChild, 'headOfChild' | 'childId'>
   ) {
     return new FridgeChildBuilder({
-      id: uuidv4(),
+      id: randomId(),
       startDate: LocalDate.of(2020, 1, 1),
       endDate: LocalDate.of(2020, 12, 31),
       conflict: false,
@@ -968,7 +969,7 @@ export class Fixture {
     initial: SemiPartial<DevPayment, 'unitId' | 'unitName'>
   ): PaymentBuilder {
     return new PaymentBuilder({
-      id: uuidv4(),
+      id: randomId(),
       period: new FiniteDateRange(
         LocalDate.todayInHelsinkiTz(),
         LocalDate.todayInHelsinkiTz()
@@ -991,7 +992,7 @@ export class Fixture {
     initial: SemiPartial<DevStaffAttendance, 'employeeId' | 'groupId'>
   ): RealtimeStaffAttendanceBuilder {
     return new RealtimeStaffAttendanceBuilder({
-      id: uuidv4(),
+      id: randomId(),
       arrived: HelsinkiDateTime.now(),
       departed: null,
       occupancyCoefficient: 7,
@@ -1005,7 +1006,7 @@ export class Fixture {
     initial: SemiPartial<DevStaffAttendancePlan, 'employeeId'>
   ): StaffAttendancePlanBuilder {
     return new StaffAttendancePlanBuilder({
-      id: uuidv4(),
+      id: randomId(),
       type: 'PRESENT',
       startTime: HelsinkiDateTime.now(),
       endTime: HelsinkiDateTime.now(),
@@ -1087,7 +1088,7 @@ export class Fixture {
     initial?: Partial<DevDocumentTemplate>
   ): DocumentTemplateBuilder {
     return new DocumentTemplateBuilder({
-      id: uuidv4(),
+      id: randomId(),
       type: 'PEDAGOGICAL_REPORT',
       placementTypes: [
         'DAYCARE',
@@ -1205,7 +1206,7 @@ export class Fixture {
     initial: SemiPartial<DevParentship, 'childId' | 'headOfChildId'>
   ): ParentshipBuilder {
     return new ParentshipBuilder({
-      id: uuidv4(),
+      id: randomId(),
       createdAt: HelsinkiDateTime.now(),
       startDate: LocalDate.todayInSystemTz(),
       endDate: LocalDate.todayInSystemTz(),
@@ -1217,7 +1218,7 @@ export class Fixture {
     initial: SemiPartial<DevInvoice, 'headOfFamilyId' | 'areaId'>
   ): InvoiceBuilder {
     return new InvoiceBuilder({
-      id: uuidv4(),
+      id: randomId(),
       status: 'DRAFT',
       number: null,
       invoiceDate: LocalDate.of(2021, 2, 1),
@@ -1868,7 +1869,7 @@ export class InvoiceBuilder extends FixtureBuilder<DevInvoice> {
     row: SemiPartial<DevInvoiceRow, 'childId' | 'unitId'>
   ): InvoiceBuilder {
     this.data.rows.push({
-      id: uuidv4(),
+      id: randomId(),
       amount: 1,
       unitPrice: 28900,
       periodStart: this.data.periodStart,
@@ -2979,7 +2980,7 @@ export const decisionFixture = (
   startDate: LocalDate,
   endDate: LocalDate
 ): DecisionRequest => ({
-  id: '9dd0e1ba-9b3b-11ea-bb37-0242ac130987',
+  id: fromUuid('9dd0e1ba-9b3b-11ea-bb37-0242ac130987'),
   employeeId,
   applicationId: applicationId,
   unitId: testDaycare.id,
@@ -3000,7 +3001,7 @@ export const feeDecisionsFixture = (
     LocalDate.todayInSystemTz().addYears(1)
   ),
   sentAt: HelsinkiDateTime | null = null,
-  id = 'bcc42d48-765d-4fe1-bc90-7a7b4c8205fe',
+  id = fromUuid<FeeDecisionId>('bcc42d48-765d-4fe1-bc90-7a7b4c8205fe'),
   documentKey: string | null = null,
   decisionNumber: number | null = null
 ): FeeDecision => ({
@@ -3054,7 +3055,7 @@ export const feeDecisionsFixture = (
 })
 
 export const voucherValueDecisionsFixture = (
-  id: UUID,
+  id: VoucherValueDecisionId,
   adultId: PersonId,
   childId: PersonId,
   daycareId: DaycareId,

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -1103,7 +1103,7 @@ export interface SfiMessage {
   streetAddress: string
 }
 
-export type StaffAttendancePlanId = string
+export type StaffAttendancePlanId = Id<'StaffAttendancePlan'>
 
 /**
 * Generated from fi.espoo.evaka.invoicing.domain.VoucherValueDecision

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
-import { CalendarEventId } from 'lib-common/generated/api-types/shared'
+import {
+  CalendarEventId,
+  PlacementId
+} from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
@@ -18,8 +21,7 @@ import {
   testChild,
   testChild2,
   testChildRestricted,
-  testDaycare,
-  uuidv4
+  testDaycare
 } from '../../dev-api/fixtures'
 import {
   createDaycarePlacements,
@@ -52,11 +54,13 @@ beforeEach(async () => {
   children = [testChild, testChild2, testChildRestricted]
   jariId = testChild.id
   await Fixture.family({ guardian: testAdult, children }).save()
-  const placementIds = new Map(children.map((child) => [child.id, uuidv4()]))
+  const placementIds = new Map(
+    children.map((child) => [child.id, randomId<PlacementId>()])
+  )
   await createDaycarePlacements({
     body: children.map((child) =>
       createDaycarePlacementFixture(
-        placementIds.get(child.id) ?? '',
+        placementIds.get(child.id)!,
         child.id,
         testDaycare.id,
         today,
@@ -75,7 +79,7 @@ beforeEach(async () => {
       startDate: today,
       endDate: today.addYears(1),
       daycareGroupId: daycareGroup.id,
-      daycarePlacementId: placementIds.get(child.id) ?? ''
+      daycarePlacementId: placementIds.get(child.id)!
     }).save()
   }
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-documents.spec.ts
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 import { UUID } from 'lib-common/types'
 
 import {
   createDaycarePlacementFixture,
   testDaycareGroup,
   Fixture,
-  uuidv4,
   testAdult,
   testChild,
   testCareArea,
@@ -59,7 +59,7 @@ beforeEach(async () => {
   })
 
   await createDaycarePlacements({
-    body: [createDaycarePlacementFixture(uuidv4(), child.id, unitId)]
+    body: [createDaycarePlacementFixture(randomId(), child.id, unitId)]
   })
 
   templateIdVasu = (

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-documents.spec.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { DocumentTemplateId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { randomId } from 'lib-common/id-type'
 import { UUID } from 'lib-common/types'
@@ -29,11 +30,11 @@ import { enduserLogin } from '../../utils/user'
 
 let page: Page
 let child: DevPerson
-let templateIdVasu: UUID
+let templateIdVasu: DocumentTemplateId
 let documentIdVasu: UUID
-let templateIdHojks: UUID
+let templateIdHojks: DocumentTemplateId
 let documentIdHojks: UUID
-let templateIdPed: UUID
+let templateIdPed: DocumentTemplateId
 let documentIdPed: UUID
 let header: CitizenHeader
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-income-statement.spec.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import {
@@ -10,8 +11,7 @@ import {
   testAdult,
   testCareArea,
   testChild,
-  testDaycare,
-  uuidv4
+  testDaycare
 } from '../../dev-api/fixtures'
 import {
   createDaycarePlacements,
@@ -41,14 +41,14 @@ beforeEach(async () => {
   await createDaycarePlacements({
     body: [
       createDaycarePlacementFixture(
-        uuidv4(),
+        randomId(),
         testChild.id,
         testDaycare.id,
         LocalDate.todayInSystemTz(),
         LocalDate.todayInSystemTz()
       ),
       createDaycarePlacementFixture(
-        uuidv4(),
+        randomId(),
         testChild.id,
         testDaycare.id,
         LocalDate.todayInSystemTz().addDays(1),

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-page.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-page.spec.ts
@@ -4,7 +4,7 @@
 
 import DateRange from 'lib-common/date-range'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
-import { evakaUserId } from 'lib-common/id-type'
+import { evakaUserId, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
@@ -19,8 +19,7 @@ import {
   testChild2,
   testClub,
   testDaycare,
-  testPreschool,
-  uuidv4
+  testPreschool
 } from '../../dev-api/fixtures'
 import {
   createApplications,
@@ -63,7 +62,7 @@ describe('Citizen children page', () => {
   test('Citizen can see its children and navigate to their page', async () => {
     await createDaycarePlacements({
       body: [testChild, testChild2].map((child) => ({
-        id: uuidv4(),
+        id: randomId(),
         type: 'DAYCARE',
         childId: child.id,
         unitId: testDaycare.id,
@@ -96,7 +95,7 @@ describe('Citizen children page', () => {
     await createDaycarePlacements({
       body: [
         {
-          id: uuidv4(),
+          id: randomId(),
           type,
           childId: testChild2.id,
           unitId,
@@ -249,7 +248,7 @@ describe('Citizen children page', () => {
       const daycareAfterPreschoolEnd = preschool2End.addMonths(6)
       const placements: DevPlacement[] = [
         {
-          id: uuidv4(),
+          id: randomId(),
           type: 'DAYCARE',
           childId: testChild2.id,
           unitId: testDaycare.id,
@@ -260,7 +259,7 @@ describe('Citizen children page', () => {
           terminationRequestedDate: null
         },
         {
-          id: uuidv4(),
+          id: randomId(),
           type: 'DAYCARE',
           childId: testChild2.id,
           unitId: testPreschool.id,
@@ -271,7 +270,7 @@ describe('Citizen children page', () => {
           terminationRequestedDate: null
         },
         {
-          id: uuidv4(),
+          id: randomId(),
           type: 'PRESCHOOL',
           childId: testChild2.id,
           unitId: testPreschool.id,
@@ -282,7 +281,7 @@ describe('Citizen children page', () => {
           terminationRequestedDate: null
         },
         {
-          id: uuidv4(),
+          id: randomId(),
           type: 'PRESCHOOL_DAYCARE', // this gets grouped with the above
           childId: testChild2.id,
           unitId: testPreschool.id,
@@ -293,7 +292,7 @@ describe('Citizen children page', () => {
           terminationRequestedDate: null
         },
         {
-          id: uuidv4(),
+          id: randomId(),
           type: 'DAYCARE', // this is shown under PRESCHOOL as "Maksullinen varhaiskasvatus"
           childId: testChild2.id,
           unitId: testPreschool.id,
@@ -337,7 +336,7 @@ describe('Citizen children page', () => {
       const daycare2end = daycare1End.addMonths(2)
       const placements: DevPlacement[] = [
         {
-          id: uuidv4(),
+          id: randomId(),
           type: 'DAYCARE',
           childId: testChild2.id,
           unitId: testDaycare.id,
@@ -348,7 +347,7 @@ describe('Citizen children page', () => {
           terminationRequestedDate: null
         },
         {
-          id: uuidv4(),
+          id: randomId(),
           type: 'DAYCARE',
           childId: testChild2.id,
           unitId: testPreschool.id,
@@ -409,7 +408,7 @@ describe('Citizen children page', () => {
       const daycareAfterPreschoolEnd = preschool2End.addMonths(6)
       const placements: DevPlacement[] = [
         {
-          id: uuidv4(),
+          id: randomId(),
           type: 'PRESCHOOL_DAYCARE', // this gets grouped with the above
           childId: testChild2.id,
           unitId: testPreschool.id,
@@ -420,7 +419,7 @@ describe('Citizen children page', () => {
           terminationRequestedDate: null
         },
         {
-          id: uuidv4(),
+          id: randomId(),
           type: 'DAYCARE', // this is shown under PRESCHOOL as "Maksullinen varhaiskasvatus"
           childId: testChild2.id,
           unitId: testPreschool.id,

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 
 import { execSimpleApplicationActions } from '../../dev-api'
 import {
   applicationFixture,
   testDaycare,
   testAdult,
-  uuidv4,
   Fixture,
   testAdult2,
   testChild,
@@ -178,7 +178,7 @@ describe('Citizen daycare applications', () => {
     await createDaycarePlacements({
       body: [
         {
-          id: uuidv4(),
+          id: randomId(),
           type: 'DAYCARE',
           childId: testChild.id,
           unitId: testDaycare.id,

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
@@ -7,7 +7,8 @@ import FiniteDateRange from 'lib-common/finite-date-range'
 import {
   CalendarEventId,
   CalendarEventTimeId,
-  GroupId
+  GroupId,
+  PlacementId
 } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { randomId } from 'lib-common/id-type'
@@ -22,8 +23,7 @@ import {
   testCareArea,
   testChild,
   testChild2,
-  testDaycare,
-  uuidv4
+  testDaycare
 } from '../../dev-api/fixtures'
 import {
   createDaycarePlacements,
@@ -67,12 +67,14 @@ beforeEach(async () => {
     children: children
   }).save()
 
-  const placementIds = new Map(children.map((child) => [child.id, uuidv4()]))
+  const placementIds = new Map(
+    children.map((child) => [child.id, randomId<PlacementId>()])
+  )
 
   await createDaycarePlacements({
     body: children.map((child) =>
       createDaycarePlacementFixture(
-        placementIds.get(child.id) ?? '',
+        placementIds.get(child.id)!,
         child.id,
         testDaycare.id,
         today,
@@ -92,7 +94,7 @@ beforeEach(async () => {
       startDate: today,
       endDate: today.addYears(1),
       daycareGroupId: daycareGroup.id,
-      daycarePlacementId: placementIds.get(child.id) ?? ''
+      daycarePlacementId: placementIds.get(child.id)!
     }).save()
   }
 
@@ -457,7 +459,7 @@ describe.each(e)('Citizen calendar event time visibility (%s)', (env) => {
   })
   test('Citizen receives only one correct set of event times despite 2 placements', async () => {
     const placement1 = createDaycarePlacementFixture(
-      uuidv4(),
+      randomId(),
       testChild2.id,
       testDaycare.id,
       today,
@@ -465,7 +467,7 @@ describe.each(e)('Citizen calendar event time visibility (%s)', (env) => {
     )
 
     const placement2 = createDaycarePlacementFixture(
-      uuidv4(),
+      randomId(),
       testChild2.id,
       testDaycare.id,
       today.addDays(4),
@@ -505,7 +507,7 @@ describe.each(e)('Citizen calendar event time visibility (%s)', (env) => {
 
   test('Citizen is receives only one correct set of event times despite 2 group placements', async () => {
     const placement1 = createDaycarePlacementFixture(
-      uuidv4(),
+      randomId(),
       testChild2.id,
       testDaycare.id,
       today,

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-finance-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-finance-decisions.spec.ts
@@ -8,14 +8,15 @@ import {
   DecisionIncome,
   FeeDecision
 } from 'lib-common/generated/api-types/invoicing'
+import { FeeDecisionId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import config from '../../config'
 import {
   testDaycare,
   feeDecisionsFixture,
-  uuidv4,
   voucherValueDecisionsFixture,
   Fixture,
   testAdultRestricted,
@@ -73,12 +74,12 @@ beforeEach(async () => {
     partner,
     feeDecisionValidDuring,
     now,
-    uuidv4(),
+    randomId<FeeDecisionId>(),
     'test-fd-key'
   )
   await insertFeeDecision(feeDecision)
   voucherValueDecision = voucherValueDecisionsFixture(
-    uuidv4(),
+    randomId(),
     headOfFamily.id,
     child.id,
     testDaycare.id,

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income.spec.ts
@@ -2,8 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { EmployeeId } from 'lib-common/generated/api-types/shared'
-import { evakaUserId } from 'lib-common/id-type'
+import {
+  EmployeeId,
+  ServiceNeedId
+} from 'lib-common/generated/api-types/shared'
+import { evakaUserId, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -13,8 +16,7 @@ import {
   testDaycareGroup,
   testChild,
   testAdult,
-  Fixture,
-  uuidv4
+  Fixture
 } from '../../dev-api/fixtures'
 import { resetServiceState } from '../../generated/api-clients'
 import { DevDaycare, DevPerson } from '../../generated/api-types'
@@ -86,7 +88,7 @@ describe.each(e)('Citizen income (%s)', (env) => {
     }).save()
 
     await Fixture.serviceNeed({
-      id: uuidv4(),
+      id: randomId<ServiceNeedId>(),
       placementId: placement.id,
       startDate: placementStart,
       endDate: placementEnd,

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-pedagogical-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-pedagogical-documents.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import { insertPedagogicalDocumentAttachment } from '../../dev-api'
@@ -12,8 +13,7 @@ import {
   testAdult,
   testCareArea,
   testChild,
-  testDaycare,
-  uuidv4
+  testDaycare
 } from '../../dev-api/fixtures'
 import {
   createDaycarePlacements,
@@ -42,7 +42,7 @@ beforeEach(async () => {
 
   await createDaycarePlacements({
     body: [
-      createDaycarePlacementFixture(uuidv4(), testChild.id, testDaycare.id)
+      createDaycarePlacementFixture(randomId(), testChild.id, testDaycare.id)
     ]
   })
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -8,7 +8,7 @@ import FiniteDateRange from 'lib-common/finite-date-range'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { evakaUserId } from 'lib-common/id-type'
+import { evakaUserId, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
@@ -24,7 +24,6 @@ import {
   testAdult,
   Fixture,
   systemInternalUser,
-  uuidv4,
   testChild,
   testChildRestricted,
   preschoolTerm2021
@@ -88,7 +87,7 @@ describe.each(e)('Citizen attendance reservations (%s)', (env) => {
     const placementFixtures = zip(children, placementTypes).map(
       ([child, placementType]) =>
         createDaycarePlacementFixture(
-          uuidv4(),
+          randomId(),
           child!.id,
           testDaycare.id,
           today,
@@ -1249,21 +1248,21 @@ describe('Citizen calendar child visibility', () => {
     await createDaycarePlacements({
       body: [
         createDaycarePlacementFixture(
-          uuidv4(),
+          randomId(),
           child.id,
           testDaycare.id,
           placement1start,
           placement1end
         ),
         createDaycarePlacementFixture(
-          uuidv4(),
+          randomId(),
           child.id,
           testDaycare.id,
           placement2start,
           placement2end
         ),
         createDaycarePlacementFixture(
-          uuidv4(),
+          randomId(),
           child2.id,
           testDaycare.id,
           placement1start.subYears(1),
@@ -1332,7 +1331,7 @@ describe('Citizen calendar child visibility', () => {
 
     // Sibling is in 24/7 daycare with shift care
     const placement = createDaycarePlacementFixture(
-      uuidv4(),
+      randomId(),
       testChild2.id,
       testDaycare2.id,
       placement1start,
@@ -1375,7 +1374,7 @@ describe('Citizen calendar child visibility', () => {
 
     // Child is in 24/7 daycare with shift care
     const placement = createDaycarePlacementFixture(
-      uuidv4(),
+      randomId(),
       testChild2.id,
       testDaycare2.id,
       placement1start,
@@ -1453,7 +1452,7 @@ describe('Citizen calendar visibility', () => {
     await createDaycarePlacements({
       body: [
         createDaycarePlacementFixture(
-          uuidv4(),
+          randomId(),
           child.id,
           daycareId,
           today.addDays(13),
@@ -1474,7 +1473,7 @@ describe('Citizen calendar visibility', () => {
     await createDaycarePlacements({
       body: [
         createDaycarePlacementFixture(
-          uuidv4(),
+          randomId(),
           child.id,
           daycareId,
           today.addDays(15),
@@ -1498,7 +1497,7 @@ describe('Citizen calendar visibility', () => {
     await createDaycarePlacements({
       body: [
         createDaycarePlacementFixture(
-          uuidv4(),
+          randomId(),
           child.id,
           daycareId,
           today.subYears(1),
@@ -1534,7 +1533,7 @@ describe.each(e)('Citizen calendar shift care reservations', (env) => {
     await createDaycarePlacements({
       body: [
         createDaycarePlacementFixture(
-          uuidv4(),
+          randomId(),
           testChild2.id,
           testDaycare2.id,
           placement1start,

--- a/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
@@ -19,8 +19,7 @@ import {
   Fixture,
   testAdult,
   testCareArea,
-  testDaycare,
-  uuidv4
+  testDaycare
 } from '../../dev-api/fixtures'
 import {
   createFosterParent,
@@ -65,7 +64,7 @@ beforeEach(async () => {
   await createFosterParent({
     body: [
       {
-        id: uuidv4(),
+        id: randomId(),
         childId: fosterChild.id,
         parentId: fosterParent.id,
         validDuring: new DateRange(mockedDate, mockedDate),
@@ -157,7 +156,7 @@ test('Foster parent can create a daycare application and accept a daycare decisi
   await createFosterParent({
     body: [
       {
-        id: uuidv4(),
+        id: randomId(),
         childId: fosterChild.id,
         parentId: fosterParent.id,
         validDuring: new DateRange(mockedDate, mockedDate),

--- a/frontend/src/e2e-test/specs/4_finance/income-staments.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/income-staments.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 
 import config from '../../config'
 import {
@@ -11,7 +12,6 @@ import {
   testChild,
   testAdult,
   Fixture,
-  uuidv4,
   testCareArea
 } from '../../dev-api/fixtures'
 import {
@@ -119,7 +119,7 @@ describe('Income statements', () => {
     await createDaycarePlacements({
       body: [
         createDaycarePlacementFixture(
-          uuidv4(),
+          randomId(),
           testChild.id,
           testDaycare.id,
           startDate,

--- a/frontend/src/e2e-test/specs/4_finance/invoices.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/invoices.spec.ts
@@ -4,7 +4,7 @@
 
 import { DevEmployee, DevPlacement } from 'e2e-test/generated/api-types'
 import FiniteDateRange from 'lib-common/finite-date-range'
-import { PersonId } from 'lib-common/generated/api-types/shared'
+import { FeeDecisionId, PersonId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { fromUuid } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
@@ -105,7 +105,7 @@ describe('Invoices', () => {
       codebtor,
       FiniteDateRange.ofMonth(today.subMonths(1)),
       now,
-      'bcc42d48-765d-4fe1-bc90-7a7b4c8205fe',
+      fromUuid<FeeDecisionId>('bcc42d48-765d-4fe1-bc90-7a7b4c8205fe'),
       null,
       123123123
     )
@@ -261,7 +261,7 @@ describe('Invoices', () => {
       codebtor,
       FiniteDateRange.ofMonth(today.subMonths(1)),
       now,
-      'bcc42d48-765d-4fe1-bc90-7a7b4c8205fe',
+      fromUuid<FeeDecisionId>('bcc42d48-765d-4fe1-bc90-7a7b4c8205fe'),
       null,
       123123123
     )

--- a/frontend/src/e2e-test/specs/4_finance/person-finance-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/person-finance-decisions.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { FeeDecisionId } from 'lib-common/generated/api-types/shared'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -16,7 +17,6 @@ import {
   testAdult,
   feeDecisionsFixture,
   Fixture,
-  uuidv4,
   voucherValueDecisionsFixture,
   testCareArea
 } from '../../dev-api/fixtures'
@@ -69,7 +69,7 @@ describe('Person finance decisions', () => {
             null,
             new FiniteDateRange(sentAt, sentAt),
             sentAt.toHelsinkiDateTime(LocalTime.of(12, 0)),
-            uuidv4()
+            randomId<FeeDecisionId>()
           )
         ]
       })
@@ -98,7 +98,7 @@ describe('Person finance decisions', () => {
       await createVoucherValueDecisions({
         body: [
           voucherValueDecisionsFixture(
-            uuidv4(),
+            randomId(),
             testAdult.id,
             testChild2.id,
             testDaycare.id,

--- a/frontend/src/e2e-test/specs/4_finance/person-finance-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/person-finance-decisions.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -142,7 +143,7 @@ describe('Person finance decisions', () => {
     await createDaycarePlacements({
       body: [
         createDaycarePlacementFixture(
-          uuidv4(),
+          randomId(),
           testChild2.id,
           testDaycarePrivateVoucher.id,
           from,

--- a/frontend/src/e2e-test/specs/4_finance/value-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/value-decisions.spec.ts
@@ -4,6 +4,7 @@
 
 import { DecisionIncome } from 'lib-common/generated/api-types/invoicing'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { fromUuid } from 'lib-common/id-type'
 
 import config from '../../config'
 import { runPendingAsyncJobs } from '../../dev-api'
@@ -60,7 +61,7 @@ const insertTwoValueDecisionsFixturesAndNavigateToValueDecisions = async () => {
   await createVoucherValueDecisions({
     body: [
       voucherValueDecisionsFixture(
-        'e2d75fa4-7359-406b-81b8-1703785ca649',
+        fromUuid('e2d75fa4-7359-406b-81b8-1703785ca649'),
         testAdult.id,
         testChild2.id,
         testDaycare.id,
@@ -70,7 +71,7 @@ const insertTwoValueDecisionsFixturesAndNavigateToValueDecisions = async () => {
         decision1DateTo
       ),
       voucherValueDecisionsFixture(
-        'ed462aca-f74e-4384-910f-628823201023',
+        fromUuid('ed462aca-f74e-4384-910f-628823201023'),
         testAdult.id,
         testChild.id,
         testDaycare2.id,
@@ -89,7 +90,7 @@ const insertValueDecisionWithPartnerFixtureAndNavigateToValueDecisions = async (
   childIncome: DecisionIncome | null = null
 ) => {
   const decision = voucherValueDecisionsFixture(
-    'e2d75fa4-7359-406b-81b8-1703785ca649',
+    fromUuid('e2d75fa4-7359-406b-81b8-1703785ca649'),
     familyWithTwoGuardians.guardian.id,
     familyWithTwoGuardians.children[0].id,
     testDaycare.id,

--- a/frontend/src/e2e-test/specs/4_finance/voucher-reports.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/voucher-reports.spec.ts
@@ -4,6 +4,7 @@
 
 import assert from 'assert'
 
+import { fromUuid } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import config from '../../config'
@@ -63,7 +64,7 @@ beforeEach(async () => {
   await createVoucherValueDecisions({
     body: [
       voucherValueDecisionsFixture(
-        'e2d75fa4-7359-406b-81b8-1703785ca649',
+        fromUuid('e2d75fa4-7359-406b-81b8-1703785ca649'),
         guardian.id,
         child.id,
         testDaycare.id,
@@ -73,7 +74,7 @@ beforeEach(async () => {
         endDate
       ),
       voucherValueDecisionsFixture(
-        'ed462aca-f74e-4384-910f-628823201023',
+        fromUuid('ed462aca-f74e-4384-910f-628823201023'),
         guardian.id,
         otherChild.id,
         testDaycare2.id,

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decision.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { PersonId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -13,7 +14,6 @@ import {
   testDaycareGroup,
   familyWithTwoGuardians,
   Fixture,
-  uuidv4,
   testCareArea
 } from '../../dev-api/fixtures'
 import {
@@ -56,7 +56,7 @@ beforeEach(async () => {
   childId = familyWithTwoGuardians.children[0].id
 
   const daycarePlacementFixture = createDaycarePlacementFixture(
-    uuidv4(),
+    randomId(),
     childId,
     unitId
   )

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-decisions-report.spec.ts
@@ -21,8 +21,7 @@ import {
   testDaycareGroup,
   testChild,
   familyWithTwoGuardians,
-  Fixture,
-  uuidv4
+  Fixture
 } from '../../dev-api/fixtures'
 import {
   createDaycareGroups,
@@ -62,7 +61,7 @@ beforeEach(async () => {
   childId = familyWithTwoGuardians.children[0].id
 
   const daycarePlacementFixture = createDaycarePlacementFixture(
-    uuidv4(),
+    randomId(),
     childId,
     unitId
   )
@@ -386,7 +385,7 @@ describe('Assistance need decisions report', () => {
     }).save()
 
     const daycarePlacementFixture2 = createDaycarePlacementFixture(
-      uuidv4(),
+      randomId(),
       anotherChildId,
       anotherDaycare.id
     )

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-preschool-decision.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-preschool-decision.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { PersonId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -12,7 +13,6 @@ import {
   testDaycare,
   testDaycareGroup,
   Fixture,
-  uuidv4,
   familyWithTwoGuardians,
   testCareArea
 } from '../../dev-api/fixtures'
@@ -61,7 +61,7 @@ beforeEach(async () => {
 
   staff = await Fixture.employee().staff(unitId).save()
   const daycarePlacementFixture = createDaycarePlacementFixture(
-    uuidv4(),
+    randomId(),
     childId,
     unitId
   )

--- a/frontend/src/e2e-test/specs/5_employee/child-income-statements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-income-statements.spec.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
@@ -11,7 +12,6 @@ import {
   testDaycare,
   testChild,
   Fixture,
-  uuidv4,
   testCareArea
 } from '../../dev-api/fixtures'
 import {
@@ -43,7 +43,7 @@ beforeEach(async () => {
 describe('Child profile income statements', () => {
   test('Shows income statements', async () => {
     const daycarePlacementFixture = createDaycarePlacementFixture(
-      uuidv4(),
+      randomId(),
       testChild.id,
       testDaycare.id
     )

--- a/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
@@ -3,9 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { PlacementType } from 'lib-common/generated/api-types/placement'
-import { DaycareId, PersonId } from 'lib-common/generated/api-types/shared'
+import {
+  DaycareId,
+  PersonId,
+  PlacementId
+} from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { evakaUserId } from 'lib-common/id-type'
+import { evakaUserId, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { UUID } from 'lib-common/types'
@@ -16,7 +20,6 @@ import {
   testDaycareGroup,
   familyWithTwoGuardians,
   Fixture,
-  uuidv4,
   testCareArea,
   testDaycare
 } from '../../dev-api/fixtures'
@@ -34,7 +37,7 @@ import { employeeLogin } from '../../utils/user'
 beforeEach(async (): Promise<void> => resetServiceState())
 
 const setupPlacement = async (
-  placementId: string,
+  placementId: PlacementId,
   childId: PersonId,
   unitId: DaycareId,
   childPlacementType: PlacementType
@@ -83,7 +86,7 @@ describe('Child Information placement info', () => {
   })
 
   test('A terminated placement is indicated', async () => {
-    const placementId = uuidv4()
+    const placementId = randomId<PlacementId>()
     await setupPlacement(placementId, childId, unitId, 'DAYCARE')
 
     let childPlacements = await openChildPlacements(page, childId)

--- a/frontend/src/e2e-test/specs/5_employee/fridge-head-information.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/fridge-head-information.spec.ts
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import DateRange from 'lib-common/date-range'
-import { PersonId } from 'lib-common/generated/api-types/shared'
+import { ParentshipId, PersonId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { evakaUserId, fromUuid } from 'lib-common/id-type'
+import { evakaUserId, fromUuid, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -16,8 +16,7 @@ import {
   testAdultRestricted,
   testCareArea,
   testChildZeroYearOld,
-  testDaycare,
-  uuidv4
+  testDaycare
 } from '../../dev-api/fixtures'
 import {
   createDefaultServiceNeedOptions,
@@ -191,7 +190,7 @@ describe('Employee - Head of family details', () => {
 
   test('Manually added income is shown in family overview', async () => {
     await Fixture.fridgeChild({
-      id: uuidv4(),
+      id: randomId<ParentshipId>(),
       childId: child.id,
       headOfChild: regularPerson.id,
       startDate: mockToday,

--- a/frontend/src/e2e-test/specs/5_employee/guardian-income-statements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/guardian-income-statements.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 import { UUID } from 'lib-common/types'
 
 import config from '../../config'
@@ -11,7 +12,6 @@ import {
   testDaycare,
   testAdult,
   Fixture,
-  uuidv4,
   testChildRestricted,
   testCareArea
 } from '../../dev-api/fixtures'
@@ -52,7 +52,7 @@ beforeEach(async () => {
 describe('Guardian income statements', () => {
   test("Shows placed child's income statements", async () => {
     const daycarePlacementFixture = createDaycarePlacementFixture(
-      uuidv4(),
+      randomId(),
       child.id,
       testDaycare.id
     )

--- a/frontend/src/e2e-test/specs/5_employee/guardian-information-page.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/guardian-information-page.spec.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import {
+  ApplicationId,
+  PlacementId
+} from 'lib-common/generated/api-types/shared'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
@@ -47,7 +50,7 @@ beforeEach(async () => {
   const admin = await Fixture.employee().admin().save()
 
   const daycarePlacementFixture = createDaycarePlacementFixture(
-    randomId<ApplicationId>(),
+    randomId<PlacementId>(),
     testChild.id,
     testDaycare.id
   )

--- a/frontend/src/e2e-test/specs/5_employee/guardian-information-page.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/guardian-information-page.spec.ts
@@ -4,6 +4,7 @@
 
 import {
   ApplicationId,
+  DecisionId,
   PlacementId
 } from 'lib-common/generated/api-types/shared'
 import { randomId } from 'lib-common/id-type'
@@ -73,7 +74,7 @@ beforeEach(async () => {
       decisionFixture(admin.id, application.id, startDate, startDate),
       {
         ...decisionFixture(admin.id, application2.id, startDate, startDate),
-        id: randomId<ApplicationId>()
+        id: randomId<DecisionId>()
       }
     ]
   })

--- a/frontend/src/e2e-test/specs/5_employee/pedagogical-document.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/pedagogical-document.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { PersonId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import config from '../../config'
@@ -10,7 +11,6 @@ import {
   createDaycarePlacementFixture,
   testDaycareGroup,
   Fixture,
-  uuidv4,
   familyWithTwoGuardians,
   testDaycare,
   testCareArea
@@ -49,7 +49,7 @@ beforeEach(async () => {
   childId = familyWithTwoGuardians.children[0].id
 
   const daycarePlacementFixture = createDaycarePlacementFixture(
-    uuidv4(),
+    randomId(),
     childId,
     unitId
   )

--- a/frontend/src/e2e-test/specs/5_employee/placement-sketching-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/placement-sketching-report.spec.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { ApplicationId } from 'lib-common/generated/api-types/shared'
+import {
+  ApplicationId,
+  PlacementId
+} from 'lib-common/generated/api-types/shared'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -129,7 +132,7 @@ describe('Placement sketching report', () => {
     const currentUnit = preferredUnit
 
     const daycarePlacementFixture = createDaycarePlacementFixture(
-      randomId<ApplicationId>(),
+      randomId<PlacementId>(),
       createdApplication.childId,
       preferredUnit.id,
       placementStartDate

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -3,12 +3,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { UnitStaffAttendancesTable } from 'e2e-test/pages/employee/units/unit-calendar-page-base'
-import { GroupId } from 'lib-common/generated/api-types/shared'
+import { GroupId, PlacementId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
-import { UUID } from 'lib-common/types'
 
 import {
   testCareArea2,
@@ -37,7 +36,7 @@ let page: Page
 let unitPage: UnitPage
 let calendarPage: UnitCalendarPage
 let child1Fixture: DevPerson
-let child1DaycarePlacementId: UUID
+let child1DaycarePlacementId: PlacementId
 let careArea: DevCareArea
 let daycare: DevDaycare
 let unitSupervisor: DevEmployee
@@ -84,7 +83,7 @@ beforeEach(async () => {
   }).save()
 
   child1Fixture = familyWithTwoGuardians.children[0]
-  child1DaycarePlacementId = uuidv4()
+  child1DaycarePlacementId = randomId()
   await Fixture.placement({
     id: child1DaycarePlacementId,
     childId: child1Fixture.id,

--- a/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/realtime-attendances.spec.ts
@@ -13,7 +13,6 @@ import {
   testCareArea2,
   testDaycare2,
   Fixture,
-  uuidv4,
   familyWithTwoGuardians,
   testDaycare
 } from '../../dev-api/fixtures'
@@ -25,7 +24,8 @@ import {
   DevCareArea,
   DevDaycare,
   DevEmployee,
-  DevPerson
+  DevPerson,
+  StaffAttendancePlanId
 } from '../../generated/api-types'
 import { UnitCalendarPage, UnitPage } from '../../pages/employee/units/unit'
 import { waitUntilEqual } from '../../utils'
@@ -189,7 +189,7 @@ describe('Realtime staff attendances', () => {
   describe('Group staff attendances', () => {
     test('Attendance is shown on week view and day modal', async () => {
       await Fixture.staffAttendancePlan({
-        id: uuidv4(),
+        id: randomId<StaffAttendancePlanId>(),
         employeeId: groupStaff.id,
         startTime: mockedToday.toHelsinkiDateTime(LocalTime.of(7, 0)),
         endTime: mockedToday.toHelsinkiDateTime(LocalTime.of(15, 0))
@@ -324,7 +324,7 @@ describe('Realtime staff attendances', () => {
       }).save()
 
       await Fixture.staffAttendancePlan({
-        id: uuidv4(),
+        id: randomId<StaffAttendancePlanId>(),
         employeeId: otherGroupStaff.id,
         startTime: yesterday.toHelsinkiDateTime(LocalTime.of(7, 0)),
         endTime: yesterday.toHelsinkiDateTime(LocalTime.of(15, 0))

--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar-child-date-modal.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar-child-date-modal.spec.ts
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { PlacementType } from 'lib-common/generated/api-types/placement'
-import { ServiceNeedOptionId } from 'lib-common/generated/api-types/shared'
+import {
+  PlacementId,
+  ServiceNeedOptionId
+} from 'lib-common/generated/api-types/shared'
 import { evakaUserId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -25,7 +28,7 @@ import { employeeLogin } from '../../utils/user'
 let daycareId: UUID
 let groupId: UUID
 let childId: UUID
-let placementId: UUID
+let placementId: PlacementId
 let unitSupervisor: DevEmployee
 let daycareServiceNeedOptionId: ServiceNeedOptionId
 

--- a/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/reservation-calendar.spec.ts
@@ -5,19 +5,21 @@
 import DateRange from 'lib-common/date-range'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import { ShiftCareType } from 'lib-common/generated/api-types/serviceneed'
-import { BackupCareId, GroupId } from 'lib-common/generated/api-types/shared'
+import {
+  BackupCareId,
+  GroupId,
+  PlacementId
+} from 'lib-common/generated/api-types/shared'
 import { evakaUserId, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
-import { UUID } from 'lib-common/types'
 
 import {
   testCareArea2,
   testDaycare2,
   testDaycare,
   Fixture,
-  uuidv4,
   familyWithTwoGuardians,
   testCareArea,
   fullDayTimeRange
@@ -35,7 +37,7 @@ import { employeeLogin } from '../../utils/user'
 
 let page: Page
 let child1Fixture: DevPerson
-let child1DaycarePlacementId: UUID
+let child1DaycarePlacementId: PlacementId
 let daycare: DevDaycare
 let unitSupervisor: DevEmployee
 
@@ -82,7 +84,7 @@ const insertTestDataAndLogin = async ({
   }).save()
 
   child1Fixture = familyWithTwoGuardians.children[0]
-  child1DaycarePlacementId = uuidv4()
+  child1DaycarePlacementId = randomId()
   const placementBuilder = await Fixture.placement({
     id: child1DaycarePlacementId,
     childId: child1Fixture.id,

--- a/frontend/src/e2e-test/specs/5_employee/unit-application-process.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-application-process.spec.ts
@@ -2,10 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { ApplicationId, GroupId } from 'lib-common/generated/api-types/shared'
+import {
+  ApplicationId,
+  GroupId,
+  PlacementId
+} from 'lib-common/generated/api-types/shared'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 
 import {
   applicationFixture,
@@ -40,8 +43,8 @@ let unitPage: UnitPage
 const groupId = randomId<GroupId>()
 let child1Fixture: DevPerson
 let child2Fixture: DevPerson
-let child1DaycarePlacementId: UUID
-let child2DaycarePlacementId: UUID
+let child1DaycarePlacementId: PlacementId
+let child2DaycarePlacementId: PlacementId
 
 let daycare: DevDaycare
 let unitSupervisor: DevEmployee
@@ -67,7 +70,7 @@ beforeEach(async () => {
   }).save()
 
   child1Fixture = familyWithTwoGuardians.children[0]
-  child1DaycarePlacementId = randomId<ApplicationId>()
+  child1DaycarePlacementId = randomId()
   await Fixture.placement({
     id: child1DaycarePlacementId,
     childId: child1Fixture.id,
@@ -81,7 +84,7 @@ beforeEach(async () => {
     children: [testChild, testChild2]
   }).save()
   child2Fixture = testChild2
-  child2DaycarePlacementId = randomId<ApplicationId>()
+  child2DaycarePlacementId = randomId()
   await Fixture.placement({
     id: child2DaycarePlacementId,
     childId: child2Fixture.id,

--- a/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-calendar-events.spec.ts
@@ -6,7 +6,8 @@ import FiniteDateRange from 'lib-common/finite-date-range'
 import {
   CalendarEventId,
   CalendarEventTimeId,
-  GroupId
+  GroupId,
+  PlacementId
 } from 'lib-common/generated/api-types/shared'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
@@ -17,7 +18,6 @@ import {
   testDaycare2,
   familyWithRestrictedDetailsGuardian,
   Fixture,
-  uuidv4,
   familyWithTwoGuardians
 } from '../../dev-api/fixtures'
 import {
@@ -49,8 +49,8 @@ const groupId2 = randomId<GroupId>()
 const testSurveyId = randomId<CalendarEventId>()
 const eventTimeId = randomId<CalendarEventTimeId>()
 const eventTimeId2 = randomId<CalendarEventTimeId>()
-const child1DaycarePlacementId = uuidv4()
-const child1DaycarePlacementId2 = uuidv4()
+const child1DaycarePlacementId = randomId<PlacementId>()
+const child1DaycarePlacementId2 = randomId<PlacementId>()
 
 beforeEach(async () => {
   await resetServiceState()
@@ -112,7 +112,7 @@ beforeEach(async () => {
     endDate: placementEndDate
   }).save()
 
-  const child2DaycarePlacementId = uuidv4()
+  const child2DaycarePlacementId = randomId<PlacementId>()
   await Fixture.placement({
     id: child2DaycarePlacementId,
     childId: child2Fixture.id,

--- a/frontend/src/e2e-test/specs/5_employee/unit-groups.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/unit-groups.spec.ts
@@ -3,10 +3,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
-import { GroupId } from 'lib-common/generated/api-types/shared'
+import { GroupId, PlacementId } from 'lib-common/generated/api-types/shared'
 import { evakaUserId, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 
 import {
   familyWithTwoGuardians,
@@ -16,8 +15,7 @@ import {
   testChild2,
   testChildZeroYearOld,
   testDaycare,
-  testDaycarePrivateVoucher,
-  uuidv4
+  testDaycarePrivateVoucher
 } from '../../dev-api/fixtures'
 import {
   createDefaultServiceNeedOptions,
@@ -36,8 +34,8 @@ const groupId = randomId<GroupId>()
 let child1Fixture: DevPerson
 let child2Fixture: DevPerson
 let child3Fixture: DevPerson
-let child1DaycarePlacementId: UUID
-let child2DaycarePlacementId: UUID
+let child1DaycarePlacementId: PlacementId
+let child2DaycarePlacementId: PlacementId
 
 let daycare: DevDaycare
 let daycare2: DevDaycare
@@ -65,7 +63,7 @@ beforeEach(async () => {
   }).save()
 
   child1Fixture = familyWithTwoGuardians.children[0]
-  child1DaycarePlacementId = uuidv4()
+  child1DaycarePlacementId = randomId()
   await Fixture.placement({
     id: child1DaycarePlacementId,
     childId: child1Fixture.id,
@@ -75,7 +73,7 @@ beforeEach(async () => {
   }).save()
 
   child2Fixture = await Fixture.person(testChildZeroYearOld).saveChild()
-  child2DaycarePlacementId = uuidv4()
+  child2DaycarePlacementId = randomId()
   await Fixture.placement({
     id: child2DaycarePlacementId,
     childId: child2Fixture.id,
@@ -221,7 +219,7 @@ describe('Unit groups - unit supervisor', () => {
   })
 
   test('Supervisor sees backup care numeric child occupancy factor when not equal to 1', async () => {
-    const child3DaycarePlacementId = uuidv4()
+    const child3DaycarePlacementId = randomId<PlacementId>()
     await Fixture.placement({
       id: child3DaycarePlacementId,
       childId: child3Fixture.id,

--- a/frontend/src/e2e-test/specs/6_mobile/pin-login.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/pin-login.spec.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { PartnershipId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { randomId } from 'lib-common/id-type'
 
@@ -101,7 +102,7 @@ describe('Mobile PIN login', () => {
     }).save()
     await Fixture.person(testAdult2).saveAdult()
 
-    const parentshipId = uuidv4()
+    const parentshipId = randomId<PartnershipId>()
     await createFridgePartner({
       body: [
         {
@@ -160,7 +161,7 @@ describe('Mobile PIN login', () => {
     await createFridgeChild({
       body: [
         {
-          id: uuidv4(),
+          id: randomId(),
           childId: child.id,
           headOfChild: testAdult.id,
           startDate: today,

--- a/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts
@@ -15,7 +15,6 @@ import {
   testDaycareGroup,
   Fixture,
   fullDayTimeRange,
-  uuidv4,
   familyWithTwoGuardians,
   testDaycare
 } from '../../dev-api/fixtures'
@@ -27,7 +26,8 @@ import {
 import {
   DevCareArea,
   DevDaycareGroup,
-  DevEmployee
+  DevEmployee,
+  StaffAttendancePlanId
 } from '../../generated/api-types'
 import MobileNav from '../../pages/mobile/mobile-nav'
 import {
@@ -373,7 +373,7 @@ describe('Realtime staff attendance page', () => {
     const planStart = HelsinkiDateTime.of(2022, 5, 5, 8, 0)
     const planEnd = HelsinkiDateTime.of(2022, 5, 5, 16, 0)
     await Fixture.staffAttendancePlan({
-      id: uuidv4(),
+      id: randomId<StaffAttendancePlanId>(),
       employeeId: staffFixture.id,
       startTime: planStart,
       endTime: planEnd
@@ -418,7 +418,7 @@ describe('Realtime staff attendance page', () => {
     const planStart = HelsinkiDateTime.of(2022, 5, 5, 8, 0)
     const planEnd = HelsinkiDateTime.of(2022, 5, 5, 16, 0)
     await Fixture.staffAttendancePlan({
-      id: uuidv4(),
+      id: randomId<StaffAttendancePlanId>(),
       employeeId: staffFixture.id,
       startTime: planStart,
       endTime: planEnd
@@ -458,7 +458,7 @@ describe('Realtime staff attendance page', () => {
     const planStart = HelsinkiDateTime.of(2022, 5, 5, 8, 0)
     const planEnd = HelsinkiDateTime.of(2022, 5, 5, 16, 0)
     await Fixture.staffAttendancePlan({
-      id: uuidv4(),
+      id: randomId<StaffAttendancePlanId>(),
       employeeId: staffFixture.id,
       startTime: planStart,
       endTime: planEnd
@@ -500,7 +500,7 @@ describe('Realtime staff attendance page', () => {
     const planStart = HelsinkiDateTime.of(2022, 5, 5, 8, 0)
     const planEnd = HelsinkiDateTime.of(2022, 5, 5, 16, 0)
     await Fixture.staffAttendancePlan({
-      id: uuidv4(),
+      id: randomId<StaffAttendancePlanId>(),
       employeeId: staffFixture.id,
       startTime: planStart,
       endTime: planEnd
@@ -551,7 +551,7 @@ describe('Realtime staff attendance page', () => {
     const planStart = HelsinkiDateTime.of(2022, 5, 5, 8, 0)
     const planEnd = HelsinkiDateTime.of(2022, 5, 5, 16, 0)
     await Fixture.staffAttendancePlan({
-      id: uuidv4(),
+      id: randomId<StaffAttendancePlanId>(),
       employeeId: staffFixture.id,
       startTime: planStart,
       endTime: planEnd
@@ -594,7 +594,7 @@ describe('Realtime staff attendance page', () => {
     const planStart = HelsinkiDateTime.of(2022, 5, 5, 8, 0)
     const planEnd = HelsinkiDateTime.of(2022, 5, 5, 16, 0)
     await Fixture.staffAttendancePlan({
-      id: uuidv4(),
+      id: randomId<StaffAttendancePlanId>(),
       employeeId: staffFixture.id,
       startTime: planStart,
       endTime: planEnd
@@ -648,7 +648,7 @@ describe('Realtime staff attendance page', () => {
     const planStart = HelsinkiDateTime.of(2022, 5, 5, 8, 0)
     const planEnd = HelsinkiDateTime.of(2022, 5, 5, 16, 0)
     await Fixture.staffAttendancePlan({
-      id: uuidv4(),
+      id: randomId<StaffAttendancePlanId>(),
       employeeId: staffFixture.id,
       startTime: planStart,
       endTime: planEnd

--- a/frontend/src/e2e-test/utils/mobile.ts
+++ b/frontend/src/e2e-test/utils/mobile.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { DaycareId, EmployeeId } from 'lib-common/generated/api-types/shared'
+import { randomId } from 'lib-common/id-type'
 
 import config from '../config'
 import { uuidv4 } from '../dev-api/fixtures'
@@ -19,7 +20,7 @@ export async function pairMobileDevice(unitId: DaycareId): Promise<string> {
   const longTermToken = uuidv4()
   await postMobileDevice({
     body: {
-      id: uuidv4(),
+      id: randomId(),
       unitId,
       name: 'testMobileDevice',
       longTermToken,
@@ -39,7 +40,7 @@ export async function pairPersonalMobileDevice(
   const longTermToken = uuidv4()
   await postPersonalMobileDevice({
     body: {
-      id: uuidv4(),
+      id: randomId(),
       employeeId,
       name: 'testMobileDevice',
       longTermToken

--- a/frontend/src/employee-frontend/components/GroupCaretakers.tsx
+++ b/frontend/src/employee-frontend/components/GroupCaretakers.tsx
@@ -10,9 +10,12 @@ import {
   CaretakerAmount,
   CaretakersResponse
 } from 'lib-common/generated/api-types/daycare'
-import { DaycareId, GroupId } from 'lib-common/generated/api-types/shared'
+import {
+  DaycareCaretakerId,
+  DaycareId,
+  GroupId
+} from 'lib-common/generated/api-types/shared'
 import { capitalizeFirstLetter } from 'lib-common/string'
-import { UUID } from 'lib-common/types'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Loader from 'lib-components/atoms/Loader'
 import Title from 'lib-components/atoms/Title'
@@ -93,7 +96,7 @@ export default React.memo(function GroupCaretakers() {
     loadData()
   }, [unitId, groupId]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const deleteRow = (id: UUID) => {
+  const deleteRow = (id: DaycareCaretakerId) => {
     void removeCaretakersResult({ daycareId: unitId, groupId, id }).then(
       loadData
     )

--- a/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
+++ b/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
@@ -17,9 +17,13 @@ import {
   IncomeStatement,
   SetIncomeStatementHandledBody
 } from 'lib-common/generated/api-types/incomestatement'
-import { AttachmentId, PersonId } from 'lib-common/generated/api-types/shared'
+import {
+  AttachmentId,
+  IncomeStatementId,
+  PersonId
+} from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
-import useRouteParams, { useIdRouteParam } from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -56,7 +60,8 @@ const setIncomeStatementHandledResult = wrapResult(setIncomeStatementHandled)
 
 export default React.memo(function IncomeStatementPage() {
   const personId = useIdRouteParam<PersonId>('personId')
-  const { incomeStatementId } = useRouteParams(['incomeStatementId'])
+  const incomeStatementId =
+    useIdRouteParam<IncomeStatementId>('incomeStatementId')
   const { i18n } = useTranslation()
   const navigate = useNavigate()
 

--- a/frontend/src/employee-frontend/components/PersonalMobileDevicesPage.tsx
+++ b/frontend/src/employee-frontend/components/PersonalMobileDevicesPage.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useContext, useState } from 'react'
 
 import { wrapResult } from 'lib-common/api'
-import { UUID } from 'lib-common/types'
+import { MobileDeviceId } from 'lib-common/generated/api-types/shared'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
@@ -45,7 +45,7 @@ export default React.memo(function PersonalMobileDevicesPage() {
     []
   )
   const [openModal, setOpenModal] = useState<{
-    id: UUID
+    id: MobileDeviceId
     action: 'rename' | 'delete'
     currentName?: string
   }>()
@@ -136,7 +136,7 @@ const EditNameModal = React.memo(function EditNameModal({
   close,
   currentName
 }: {
-  id: UUID
+  id: MobileDeviceId
   close: () => void
   currentName: string
 }) {
@@ -173,7 +173,7 @@ const DeleteModal = React.memo(function DeleteModal({
   id,
   close
 }: {
-  id: UUID
+  id: MobileDeviceId
   close: () => void
 }) {
   const { i18n } = useTranslation()

--- a/frontend/src/employee-frontend/components/child-information/ChildDocuments.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildDocuments.tsx
@@ -14,7 +14,10 @@ import {
   ChildDocumentSummaryWithPermittedActions,
   DocumentTemplateSummary
 } from 'lib-common/generated/api-types/document'
-import { ChildId } from 'lib-common/generated/api-types/shared'
+import {
+  ChildId,
+  DocumentTemplateId
+} from 'lib-common/generated/api-types/shared'
 import {
   constantQuery,
   useMutationResult,
@@ -115,7 +118,7 @@ const CreationModal = React.memo(function CreationModal({
   )
   const navigate = useNavigate()
 
-  const form = required(oneOf<UUID>())
+  const form = required(oneOf<DocumentTemplateId>())
   const bind = useForm(
     form,
     () => ({

--- a/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
@@ -10,10 +10,13 @@ import {
   Attachment,
   PedagogicalDocument
 } from 'lib-common/generated/api-types/pedagogicaldocument'
-import { AttachmentId, ChildId } from 'lib-common/generated/api-types/shared'
+import {
+  AttachmentId,
+  ChildId,
+  PedagogicalDocumentId
+} from 'lib-common/generated/api-types/shared'
 import { EvakaUser } from 'lib-common/generated/api-types/user'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { UUID } from 'lib-common/types'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
@@ -36,7 +39,7 @@ const updatePedagogicalDocumentResult = wrapResult(updatePedagogicalDocument)
 const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 interface Props {
-  id: UUID
+  id: PedagogicalDocumentId
   childId: ChildId
   attachments: Attachment[]
   description: string

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedDecisionEditPage.tsx
@@ -105,7 +105,7 @@ export default React.memo(function AssistanceNeedDecisionEditPage() {
 
   const navigate = useNavigate()
 
-  const languageOptions = useMemo<SelectOption[]>(
+  const languageOptions = useMemo<SelectOption<OfficialLanguage>[]>(
     () => [
       {
         value: 'FI',
@@ -119,11 +119,11 @@ export default React.memo(function AssistanceNeedDecisionEditPage() {
     [i18n]
   )
   const selectLanguage = useCallback(
-    (o: SelectOption | null) => {
+    (o: SelectOption<OfficialLanguage> | null) => {
       if (formState && o) {
         setFormState({
           ...formState,
-          language: (o.value as OfficialLanguage) ?? 'FI'
+          language: o.value
         })
       }
     },

--- a/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationEditor.tsx
@@ -11,7 +11,11 @@ import {
 import { Result, Success, wrapResult } from 'lib-common/api'
 import { Attachment } from 'lib-common/api-types/attachment'
 import { FeeAlteration } from 'lib-common/generated/api-types/invoicing'
-import { AttachmentId, PersonId } from 'lib-common/generated/api-types/shared'
+import {
+  AttachmentId,
+  FeeAlterationId,
+  PersonId
+} from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import Title from 'lib-components/atoms/Title'
@@ -35,7 +39,7 @@ const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 const newFeeAlteration = (
   personId: PersonId,
-  feeAlterationId?: UUID
+  feeAlterationId?: FeeAlterationId
 ): PartialFeeAlteration => ({
   id: feeAlterationId ?? null,
   personId,

--- a/frontend/src/employee-frontend/components/child-information/placements/ServiceNeeds.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/ServiceNeeds.tsx
@@ -14,6 +14,7 @@ import {
   ServiceNeed,
   ServiceNeedOption
 } from 'lib-common/generated/api-types/serviceneed'
+import { ServiceNeedId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -50,8 +51,8 @@ export default React.memo(function ServiceNeeds({
   const t = i18n.childInformation.placements.serviceNeeds
 
   const [creatingNew, setCreatingNew] = useState<boolean | LocalDate>(false)
-  const [editingId, setEditingId] = useState<string | null>(null)
-  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<ServiceNeedId | null>(null)
+  const [deletingId, setDeletingId] = useState<ServiceNeedId | null>(null)
 
   const gaps = useMemo(
     () =>

--- a/frontend/src/employee-frontend/components/child-information/placements/service-needs/ServiceNeedEditorRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/service-needs/ServiceNeedEditorRow.tsx
@@ -18,7 +18,10 @@ import {
   ShiftCareType,
   shiftCareType
 } from 'lib-common/generated/api-types/serviceneed'
-import { ServiceNeedOptionId } from 'lib-common/generated/api-types/shared'
+import {
+  ServiceNeedId,
+  ServiceNeedOptionId
+} from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { SelectF } from 'lib-components/atoms/dropdowns/Select'
@@ -62,7 +65,7 @@ interface ServiceNeedCreateRowProps {
   initialRange?: FiniteDateRange
   onSuccess: () => void
   onCancel: () => void
-  editingId?: string
+  editingId?: ServiceNeedId
 }
 
 function ServiceNeedEditorRow({

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/DocumentTemplatesPage.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/DocumentTemplatesPage.tsx
@@ -12,6 +12,7 @@ import { openEndedLocalDateRange } from 'lib-common/form/fields'
 import { required } from 'lib-common/form/form'
 import { useBoolean, useForm } from 'lib-common/form/hooks'
 import { DocumentTemplateSummary } from 'lib-common/generated/api-types/document'
+import { DocumentTemplateId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
@@ -56,7 +57,7 @@ const ValidityEditor = React.memo(function ValidityEditor({
   validity,
   onClose
 }: {
-  id: UUID
+  id: DocumentTemplateId
   validity: DateRange
   onClose: () => void
 }) {

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateEditorPage.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateEditorPage.tsx
@@ -4,8 +4,9 @@
 
 import React from 'react'
 
+import { DocumentTemplateId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Container from 'lib-components/layout/Container'
 
 import { renderResult } from '../../async-rendering'
@@ -14,7 +15,7 @@ import { documentTemplateQuery } from '../queries'
 import TemplateContentEditor from './TemplateContentEditor'
 
 export default React.memo(function TemplateEditorPage() {
-  const { templateId } = useRouteParams(['templateId'])
+  const templateId = useIdRouteParam<DocumentTemplateId>('templateId')
 
   const templateResult = useQueryResult(documentTemplateQuery({ templateId }))
 

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
@@ -30,12 +30,12 @@ import {
 } from 'lib-common/generated/api-types/document'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import {
+  DocumentTemplateId,
   OfficialLanguage,
   officialLanguages
 } from 'lib-common/generated/api-types/shared'
 import { JsonOf } from 'lib-common/json'
 import { useMutationResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { SelectF } from 'lib-components/atoms/dropdowns/Select'
 import { CheckboxF } from 'lib-components/atoms/form/Checkbox'
 import { InputFieldF } from 'lib-components/atoms/form/InputField'
@@ -94,7 +94,7 @@ export const documentTemplateForm = transformed(
 
 export type TemplateModalMode =
   | { type: 'new' }
-  | { type: 'duplicate'; from: UUID }
+  | { type: 'duplicate'; from: DocumentTemplateId }
   | { type: 'import'; data: JsonOf<ExportedDocumentTemplate> }
 
 interface Props {

--- a/frontend/src/employee-frontend/components/fee-decision-details/FeeDecisionDetailsPage.tsx
+++ b/frontend/src/employee-frontend/components/fee-decision-details/FeeDecisionDetailsPage.tsx
@@ -10,9 +10,9 @@ import {
   FeeDecisionResponse,
   FeeDecisionType
 } from 'lib-common/generated/api-types/invoicing'
+import { FeeDecisionId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
@@ -42,7 +42,7 @@ const FeeDecisionMetadataSection = React.memo(
   function FeeDecisionMetadataSection({
     feeDecisionId
   }: {
-    feeDecisionId: UUID
+    feeDecisionId: FeeDecisionId
   }) {
     const result = useQueryResult(feeDecisionMetadataQuery({ feeDecisionId }))
     return <MetadataSection metadataResult={result} />
@@ -52,7 +52,7 @@ const FeeDecisionMetadataSection = React.memo(
 export default React.memo(function FeeDecisionDetailsPage() {
   const [showHandlerSelectModal, setShowHandlerSelectModal] = useState(false)
   const navigate = useNavigate()
-  const { id } = useRouteParams(['id'])
+  const id = useIdRouteParam<FeeDecisionId>('id')
   const { i18n } = useTranslation()
   const { setTitle, formatTitleName } = useContext<TitleState>(TitleContext)
   const [decisionResponse, setDecisionResponse] = useState<

--- a/frontend/src/employee-frontend/components/fee-decisions/Actions.tsx
+++ b/frontend/src/employee-frontend/components/fee-decisions/Actions.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 
 import { wrapResult } from 'lib-common/api'
 import { FeeDecisionStatus } from 'lib-common/generated/api-types/invoicing'
+import { FeeDecisionId } from 'lib-common/generated/api-types/shared'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
@@ -33,7 +34,7 @@ const ErrorMessage = styled.div`
 
 type Props = {
   statuses: FeeDecisionStatus[]
-  checkedIds: string[]
+  checkedIds: FeeDecisionId[]
   clearChecked: () => void
   loadDecisions: () => void
   onHandlerSelectModal: () => void

--- a/frontend/src/employee-frontend/components/fee-decisions/FeeDecisions.tsx
+++ b/frontend/src/employee-frontend/components/fee-decisions/FeeDecisions.tsx
@@ -11,6 +11,7 @@ import {
   FeeDecisionSummary,
   SortDirection
 } from 'lib-common/generated/api-types/invoicing'
+import { FeeDecisionId } from 'lib-common/generated/api-types/shared'
 import { formatCents } from 'lib-common/money'
 import Pagination from 'lib-components/Pagination'
 import Loader from 'lib-components/atoms/Loader'
@@ -61,8 +62,8 @@ interface Props {
   sortDirection: SortDirection
   setSortDirection: (v: SortDirection) => void
   showCheckboxes: boolean
-  checked: Record<string, boolean>
-  toggleChecked: (id: string) => void
+  isChecked: (id: FeeDecisionId) => boolean
+  toggleChecked: (id: FeeDecisionId) => void
   checkAll: () => void
   clearChecked: () => void
 }
@@ -78,7 +79,7 @@ const FeeDecisions = React.memo(function FeeDecisions({
   sortDirection,
   setSortDirection,
   showCheckboxes,
-  checked,
+  isChecked,
   toggleChecked,
   checkAll,
   clearChecked
@@ -87,7 +88,7 @@ const FeeDecisions = React.memo(function FeeDecisions({
 
   const allChecked =
     decisions
-      ?.map((ds) => ds.length > 0 && ds.every((it) => checked[it.id]))
+      ?.map((ds) => ds.length > 0 && ds.every((it) => isChecked(it.id)))
       .getOrElse(false) ?? false
 
   const isSorted = (column: FeeDecisionSortParam) =>
@@ -144,7 +145,7 @@ const FeeDecisions = React.memo(function FeeDecisions({
               <Checkbox
                 label={item.id}
                 hiddenLabel
-                checked={!!checked[item.id]}
+                checked={isChecked(item.id)}
                 onChange={() => toggleChecked(item.id)}
                 data-qa="toggle-decision"
               />

--- a/frontend/src/employee-frontend/components/fee-decisions/FeeDecisionsPage.tsx
+++ b/frontend/src/employee-frontend/components/fee-decisions/FeeDecisionsPage.tsx
@@ -12,6 +12,7 @@ import {
   SearchFeeDecisionRequest,
   SortDirection
 } from 'lib-common/generated/api-types/invoicing'
+import { FeeDecisionId } from 'lib-common/generated/api-types/shared'
 import { useRestApi } from 'lib-common/utils/useRestApi'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { Gap } from 'lib-components/white-space'
@@ -63,7 +64,7 @@ export default React.memo(function FeeDecisionsPage() {
     feeDecisions: { searchFilters, debouncedSearchTerms }
   } = useContext(InvoicingUiContext)
 
-  const checkedState = useCheckedState()
+  const checkedState = useCheckedState<FeeDecisionId>()
 
   const loadDecisions = useCallback(() => {
     const { startDate, endDate } = searchFilters
@@ -119,9 +120,7 @@ export default React.memo(function FeeDecisionsPage() {
     }
   }, [decisions, checkedState.checkIds]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const checkedIds = Object.keys(checkedState.checked).filter(
-    (id) => !!checkedState.checked[id]
-  )
+  const checkedIds = checkedState.getCheckedIds()
 
   return (
     <Container data-qa="fee-decisions-page">
@@ -162,7 +161,7 @@ export default React.memo(function FeeDecisionsPage() {
             searchFilters.statuses.length === 1 &&
             ['DRAFT', 'IGNORED'].includes(searchFilters.statuses[0])
           }
-          checked={checkedState.checked}
+          isChecked={checkedState.isChecked}
           toggleChecked={checkedState.toggleChecked}
           checkAll={checkAll}
           clearChecked={checkedState.clearChecked}

--- a/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsEditor.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsEditor.tsx
@@ -9,6 +9,7 @@ import { Failure, Result, wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import { throwIfNull } from 'lib-common/form-validation'
 import { FeeThresholds } from 'lib-common/generated/api-types/invoicing'
+import { FeeThresholdsId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { isValidCents, parseCents, parseCentsOrThrow } from 'lib-common/money'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -57,7 +58,7 @@ export default React.memo(function FeeThresholdsEditor({
   existingThresholds
 }: {
   i18n: Translations
-  id: string | undefined
+  id: FeeThresholdsId | undefined
   initialState: FormState
   close: () => void
   reloadData: () => void

--- a/frontend/src/employee-frontend/components/finance-basics/VoucherValueEditor.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/VoucherValueEditor.tsx
@@ -11,9 +11,9 @@ import {
   ServiceNeedOptionVoucherValueRange,
   ServiceNeedOptionVoucherValueRangeWithId
 } from 'lib-common/generated/api-types/invoicing'
+import { ServiceNeedOptionVoucherValueId } from 'lib-common/generated/api-types/shared'
 import { isValidCents, parseCentsOrThrow } from 'lib-common/money'
 import { useMutationResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import InputField from 'lib-components/atoms/form/InputField'
@@ -30,7 +30,7 @@ import {
 
 export type VoucherValueEditorProps = {
   i18n: Translations
-  id: UUID | undefined
+  id: ServiceNeedOptionVoucherValueId | undefined
   initialState: FormState
   close: () => void
   existingVoucherValues: ServiceNeedOptionVoucherValueRangeWithId[]

--- a/frontend/src/employee-frontend/components/holiday-term-periods/HolidayAndTermPeriodsPage.tsx
+++ b/frontend/src/employee-frontend/components/holiday-term-periods/HolidayAndTermPeriodsPage.tsx
@@ -6,8 +6,11 @@ import orderBy from 'lodash/orderBy'
 import React, { useCallback, useState } from 'react'
 import { useNavigate } from 'react-router'
 
+import {
+  HolidayPeriodId,
+  HolidayQuestionnaireId
+} from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import Container, { ContentArea } from 'lib-components/layout/Container'
@@ -37,7 +40,7 @@ export default React.memo(function HolidayAndTermPeriodsPage() {
   const holidayPeriods = useQueryResult(holidayPeriodsQuery())
   const questionnaires = useQueryResult(questionnairesQuery())
 
-  const [periodToDelete, setPeriodToDelete] = useState<UUID>()
+  const [periodToDelete, setPeriodToDelete] = useState<HolidayPeriodId>()
   const { mutateAsync: deleteHolidayPeriod } = useMutationResult(
     deleteHolidayPeriodMutation
   )
@@ -52,7 +55,8 @@ export default React.memo(function HolidayAndTermPeriodsPage() {
     void navigate('/holiday-periods/new')
   }, [navigate])
 
-  const [questionnaireToDelete, setQuestionnaireToDelete] = useState<UUID>()
+  const [questionnaireToDelete, setQuestionnaireToDelete] =
+    useState<HolidayQuestionnaireId>()
   const { mutateAsync: deleteQuestionnaire } = useMutationResult(
     deleteQuestionnaireMutation
   )

--- a/frontend/src/employee-frontend/components/holiday-term-periods/HolidayPeriodEditor.tsx
+++ b/frontend/src/employee-frontend/components/holiday-term-periods/HolidayPeriodEditor.tsx
@@ -5,7 +5,9 @@
 import React, { useCallback } from 'react'
 import { useNavigate } from 'react-router'
 
-import { useQueryResult } from 'lib-common/query'
+import { HolidayPeriodId } from 'lib-common/generated/api-types/shared'
+import { fromUuid } from 'lib-common/id-type'
+import { constantQuery, useQueryResult } from 'lib-common/query'
 import useRouteParams from 'lib-common/useRouteParams'
 import Container, { ContentArea } from 'lib-components/layout/Container'
 
@@ -16,10 +18,14 @@ import { holidayPeriodQuery } from './queries'
 
 export default React.memo(function HolidayPeriodEditor() {
   const { id } = useRouteParams(['id'])
+  const holidayPeriodId =
+    id === 'new' ? undefined : fromUuid<HolidayPeriodId>(id)
 
-  const holidayPeriod = useQueryResult(holidayPeriodQuery({ id }), {
-    enabled: id !== 'new'
-  })
+  const holidayPeriod = useQueryResult(
+    holidayPeriodId
+      ? holidayPeriodQuery({ id: holidayPeriodId })
+      : constantQuery(null)
+  )
 
   const navigate = useNavigate()
 
@@ -31,19 +37,19 @@ export default React.memo(function HolidayPeriodEditor() {
   return (
     <Container>
       <ContentArea opaque>
-        {id === 'new' ? (
-          <HolidayPeriodForm
-            onSuccess={navigateToList}
-            onCancel={navigateToList}
-          />
-        ) : (
-          renderResult(holidayPeriod, (holiday) => (
+        {renderResult(holidayPeriod, (holiday) =>
+          holiday === null ? (
+            <HolidayPeriodForm
+              onSuccess={navigateToList}
+              onCancel={navigateToList}
+            />
+          ) : (
             <HolidayPeriodForm
               holidayPeriod={holiday}
               onSuccess={navigateToList}
               onCancel={navigateToList}
             />
-          ))
+          )
         )}
       </ContentArea>
     </Container>

--- a/frontend/src/employee-frontend/components/invoice/InvoicePage.tsx
+++ b/frontend/src/employee-frontend/components/invoice/InvoicePage.tsx
@@ -7,8 +7,9 @@ import { Link } from 'react-router'
 
 import { combine } from 'lib-common/api'
 import { InvoiceDetailed } from 'lib-common/generated/api-types/invoicing'
+import { InvoiceId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Title from 'lib-components/atoms/Title'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
@@ -28,7 +29,7 @@ import Sum from './Sum'
 import { formatInvoicePeriod } from './utils'
 
 export default React.memo(function InvoiceDetailsPage() {
-  const { id } = useRouteParams(['id'])
+  const id = useIdRouteParam<InvoiceId>('id')
   const { i18n } = useTranslation()
   const invoiceCodes = useQueryResult(invoiceCodesQuery())
   const response = useQueryResult(invoiceDetailsQuery(id))

--- a/frontend/src/employee-frontend/components/invoices/Actions.tsx
+++ b/frontend/src/employee-frontend/components/invoices/Actions.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import { InvoiceStatus } from 'lib-common/generated/api-types/invoicing'
-import { UUID } from 'lib-common/types'
+import { InvoiceId } from 'lib-common/generated/api-types/shared'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import { MutateButton } from 'lib-components/atoms/buttons/MutateButton'
 import { fontWeights } from 'lib-components/typography'
@@ -33,7 +33,7 @@ type Props = {
   status: InvoiceStatus
   canSend: boolean
   canDelete: boolean
-  checkedInvoices: Set<UUID>
+  checkedInvoices: Set<InvoiceId>
   clearCheckedInvoices: () => void
   checkedAreas: string[]
   fullAreaSelection: boolean

--- a/frontend/src/employee-frontend/components/invoices/Invoices.tsx
+++ b/frontend/src/employee-frontend/components/invoices/Invoices.tsx
@@ -15,6 +15,7 @@ import {
   PagedInvoiceSummaryResponses,
   SortDirection
 } from 'lib-common/generated/api-types/invoicing'
+import { InvoiceId } from 'lib-common/generated/api-types/shared'
 import { formatCents } from 'lib-common/money'
 import { UUID } from 'lib-common/types'
 import YearMonth from 'lib-common/year-month'
@@ -60,7 +61,7 @@ interface Props {
   checked: Set<UUID>
   checkAll: () => void
   clearChecked: () => void
-  toggleChecked: (id: UUID) => void
+  toggleChecked: (id: InvoiceId) => void
 
   fullAreaSelection: boolean
   setFullAreaSelection: (checked: boolean) => void

--- a/frontend/src/employee-frontend/components/invoices/InvoicesPage.tsx
+++ b/frontend/src/employee-frontend/components/invoices/InvoicesPage.tsx
@@ -12,6 +12,7 @@ import {
   InvoiceSortParam,
   SortDirection
 } from 'lib-common/generated/api-types/invoicing'
+import { InvoiceId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import {
   first,
@@ -20,7 +21,6 @@ import {
   useQueryResult,
   useSelectMutation
 } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { DatePickerDeprecated } from 'lib-components/molecules/DatePickerDeprecated'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
@@ -77,8 +77,10 @@ export default React.memo(function InvoicesPage() {
 
   const [fullAreaSelection, { set: setFullAreaSelection }] = useBoolean(false)
 
-  const [checkedInvoices, setCheckedInvoices] = useState<Set<UUID>>(new Set())
-  const toggleChecked = (invoiceId: UUID) =>
+  const [checkedInvoices, setCheckedInvoices] = useState<Set<InvoiceId>>(
+    new Set()
+  )
+  const toggleChecked = (invoiceId: InvoiceId) =>
     setCheckedInvoices((prev) => {
       const next = new Set([...prev])
       if (next.has(invoiceId)) {
@@ -173,7 +175,7 @@ const Modal = React.memo(function Modal({
 }: {
   onClose: () => void
   onSendDone: () => void
-  checkedInvoices: Set<UUID>
+  checkedInvoices: Set<InvoiceId>
   fullAreaSelection: boolean
 }) {
   const { i18n } = useTranslation()

--- a/frontend/src/employee-frontend/components/invoices/queries.ts
+++ b/frontend/src/employee-frontend/components/invoices/queries.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { InvoiceId } from 'lib-common/generated/api-types/shared'
 import { mutation, query } from 'lib-common/query'
 import { Arg0, UUID } from 'lib-common/types'
 
@@ -37,7 +38,7 @@ export const invoicesQuery = query({
 })
 
 export const invoiceDetailsQuery = query({
-  api: (id: UUID) => getInvoice({ id }),
+  api: (id: InvoiceId) => getInvoice({ id }),
   queryKey: queryKeys.invoiceDetails
 })
 

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -19,7 +19,11 @@ import {
   PostMessageFilters,
   UpdatableDraftContent
 } from 'lib-common/generated/api-types/messaging'
-import { AttachmentId } from 'lib-common/generated/api-types/shared'
+import {
+  AttachmentId,
+  MessageAccountId,
+  MessageDraftId
+} from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
@@ -80,7 +84,7 @@ type Message = Omit<
   UpdatableDraftContent,
   'recipientIds' | 'recipientNames'
 > & {
-  sender: SelectOption
+  sender: SelectOption<MessageAccountId>
   attachments: Attachment[]
 }
 
@@ -98,7 +102,10 @@ const messageToUpdatableDraftWithAccount = (
   accountId: m.sender.value
 })
 
-const getEmptyMessage = (sender: SelectOption, title: string): Message => ({
+const getEmptyMessage = (
+  sender: SelectOption<MessageAccountId>,
+  title: string
+): Message => ({
   sender,
   title,
   content: '',
@@ -110,7 +117,7 @@ const getEmptyMessage = (sender: SelectOption, title: string): Message => ({
 
 const getInitialMessage = (
   draft: DraftContent | undefined,
-  sender: SelectOption,
+  sender: SelectOption<MessageAccountId>,
   title: string
 ): Message => (draft ? { ...draft, sender } : getEmptyMessage(sender, title))
 
@@ -174,17 +181,17 @@ const FlagsInfoContent = React.memo(function FlagsInfoContent({
 
 interface Props {
   availableReceivers: MessageReceiversResponse[]
-  defaultSender: SelectOption
+  defaultSender: SelectOption<MessageAccountId>
   deleteAttachment: (arg: {
     attachmentId: AttachmentId
   }) => Promise<Result<void>>
   draftContent?: DraftContent
   getAttachmentUrl: (attachmentId: UUID, fileName: string) => string
-  initDraftRaw: (accountId: string) => Promise<Result<string>>
+  initDraftRaw: (accountId: MessageAccountId) => Promise<Result<MessageDraftId>>
   accounts: AuthorizedMessageAccount[]
   onClose: (didChanges: boolean) => void
-  onDiscard: (accountId: UUID, draftId: UUID) => void
-  onSend: (accountId: UUID, msg: PostMessageBody) => void
+  onDiscard: (accountId: MessageAccountId, draftId: MessageDraftId) => void
+  onSend: (accountId: MessageAccountId, msg: PostMessageBody) => void
   saveDraftRaw: (params: SaveDraftParams) => Promise<Result<void>>
   saveMessageAttachment: (
     draftId: UUID,
@@ -293,7 +300,7 @@ export default React.memo(function MessageEditor({
   )
 
   const handleSenderChange = useCallback(
-    (sender: SelectOption | null) => {
+    (sender: SelectOption<MessageAccountId> | null) => {
       const shouldResetSensitivity = !shouldSensitiveCheckboxBeEnabled(
         selectedReceivers,
         message.type,

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -18,7 +18,10 @@ import {
   PostMessageBody
 } from 'lib-common/generated/api-types/messaging'
 import { PersonJSON } from 'lib-common/generated/api-types/pis'
-import { UUID } from 'lib-common/types'
+import {
+  MessageAccountId,
+  MessageDraftId
+} from 'lib-common/generated/api-types/shared'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Container from 'lib-components/layout/Container'
 import { defaultMargins } from 'lib-components/white-space'
@@ -117,7 +120,7 @@ export default React.memo(function MessagesPage({
   }, [setSelectedDraft])
 
   const onSend = useCallback(
-    (accountId: UUID, messageBody: PostMessageBody) => {
+    (accountId: MessageAccountId, messageBody: PostMessageBody) => {
       setSending(true)
       void createMessageResult({
         accountId,
@@ -167,7 +170,7 @@ export default React.memo(function MessagesPage({
     ]
   )
 
-  const onDiscard = (accountId: UUID, draftId: UUID) => {
+  const onDiscard = (accountId: MessageAccountId, draftId: MessageDraftId) => {
     hideEditor()
     void deleteDraftMessageResult({ accountId, draftId }).then(() =>
       refreshMessages(accountId)

--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -22,8 +22,8 @@ import {
   MessageType,
   ThreadReply
 } from 'lib-common/generated/api-types/messaging'
+import { MessageAccountId } from 'lib-common/generated/api-types/shared'
 import { formatAccountNames } from 'lib-common/messaging'
-import { UUID } from 'lib-common/types'
 import { scrollRefIntoView } from 'lib-common/utils/scrolling'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Linkify from 'lib-components/atoms/Linkify'
@@ -175,7 +175,7 @@ const AutoScrollPositionSpan = styled.span<{ top: string }>`
 `
 
 interface Props {
-  accountId: UUID
+  accountId: MessageAccountId
   goBack: () => void
   thread: MessageThread
   view: View

--- a/frontend/src/employee-frontend/components/messages/ThreadList.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadList.tsx
@@ -6,8 +6,11 @@ import React from 'react'
 
 import { Result, wrapResult } from 'lib-common/api'
 import { MessageType } from 'lib-common/generated/api-types/messaging'
+import {
+  MessageAccountId,
+  MessageThreadId
+} from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { UUID } from 'lib-common/types'
 import { AsyncIconOnlyButton } from 'lib-components/atoms/buttons/AsyncIconOnlyButton'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { MessageCharacteristics } from 'lib-components/messages/MessageCharacteristics'
@@ -31,7 +34,7 @@ import {
 const archiveThreadResult = wrapResult(archiveThread)
 
 export type ThreadListItem = {
-  id: UUID
+  id: MessageThreadId
   title: string
   content: string
   urgent: boolean
@@ -47,7 +50,7 @@ export type ThreadListItem = {
 
 interface Props {
   items: Result<ThreadListItem[]>
-  accountId: UUID
+  accountId: MessageAccountId
   onArchive?: () => void
 }
 

--- a/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
@@ -10,6 +10,8 @@ import {
   MessageAccount,
   MessageThread
 } from 'lib-common/generated/api-types/messaging'
+import { MessageThreadId } from 'lib-common/generated/api-types/shared'
+import { fromUuid } from 'lib-common/id-type'
 import { formatPreferredName } from 'lib-common/names'
 import Pagination from 'lib-components/Pagination'
 import { ContentArea } from 'lib-components/layout/Container'
@@ -148,7 +150,7 @@ export default React.memo(function ThreadListContainer({
     () =>
       messageDrafts.map((value) =>
         value.map((draft) => ({
-          id: draft.id,
+          id: fromUuid<MessageThreadId>(draft.id), // Hack
           title: draft.title,
           content: draft.content,
           urgent: draft.urgent,

--- a/frontend/src/employee-frontend/components/payments/Actions.tsx
+++ b/frontend/src/employee-frontend/components/payments/Actions.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 
 import { wrapResult } from 'lib-common/api'
 import { PaymentStatus } from 'lib-common/generated/api-types/invoicing'
+import { PaymentId } from 'lib-common/generated/api-types/shared'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import { fontWeights } from 'lib-components/typography'
@@ -38,17 +39,16 @@ type Props = {
   actions: PaymentsActions
   reloadPayments: () => void
   status: PaymentStatus
-  checkedPayments: Record<string, true>
+  checkedIds: PaymentId[]
 }
 
 const Actions = React.memo(function Actions({
   actions,
   reloadPayments,
   status,
-  checkedPayments
+  checkedIds
 }: Props) {
   const { i18n } = useTranslation()
-  const checkedIds = Object.keys(checkedPayments)
 
   return selectablePaymentStatuses.includes(status) ? (
     <StickyActionBar align="right">

--- a/frontend/src/employee-frontend/components/payments/PaymentsPage.tsx
+++ b/frontend/src/employee-frontend/components/payments/PaymentsPage.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 
 import { Result } from 'lib-common/api'
 import { PaymentStatus } from 'lib-common/generated/api-types/invoicing'
+import { PaymentId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { DatePickerDeprecated } from 'lib-components/molecules/DatePickerDeprecated'
@@ -71,7 +72,7 @@ export default React.memo(function PaymentsPage() {
         actions={actions}
         reloadPayments={reloadPayments}
         status={searchFilters.status}
-        checkedPayments={checkedPayments}
+        checkedIds={Object.keys(checkedPayments) as PaymentId[]}
       />
       {showModal ? (
         <Modal

--- a/frontend/src/employee-frontend/components/payments/payments-state.ts
+++ b/frontend/src/employee-frontend/components/payments/payments-state.ts
@@ -19,6 +19,7 @@ import {
   PaymentSortParam,
   SortDirection
 } from 'lib-common/generated/api-types/invoicing'
+import { PaymentId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useRestApi } from 'lib-common/utils/useRestApi'
 
@@ -40,7 +41,7 @@ type State = {
   sortBy: PaymentSortParam
   sortDirection: SortDirection
   payments: Result<Payment[]>
-  checkedPayments: Record<string, true>
+  checkedPayments: Record<PaymentId, true>
   showModal: boolean
 }
 
@@ -65,7 +66,7 @@ const useActions = (setState: Dispatch<SetStateAction<State>>) =>
         setState((s) => ({ ...s, sortDirection })),
       openModal: () => setState((s) => ({ ...s, showModal: true })),
       closeModal: () => setState((s) => ({ ...s, showModal: false })),
-      toggleChecked: (payment: string) =>
+      toggleChecked: (payment: PaymentId) =>
         setState((s) => {
           if (s.checkedPayments[payment]) {
             const { [payment]: _, ...rest } = s.checkedPayments
@@ -185,7 +186,7 @@ export function usePaymentsState() {
     }) =>
       sendPaymentsResult({
         body: {
-          paymentIds: Object.keys(state.checkedPayments),
+          paymentIds: Object.keys(state.checkedPayments) as PaymentId[],
           paymentDate,
           dueDate
         }

--- a/frontend/src/employee-frontend/components/person-profile/FosterChildren.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/FosterChildren.tsx
@@ -8,9 +8,12 @@ import { Link } from 'react-router'
 
 import { wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
-import { ChildId, PersonId } from 'lib-common/generated/api-types/shared'
+import {
+  ChildId,
+  FosterParentId,
+  PersonId
+} from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
@@ -58,15 +61,18 @@ export default React.memo(function FosterChildren({
   const { permittedActions } = useContext(PersonContext)
   const { uiMode, toggleUiMode, clearUiMode } = useContext(UIContext)
   const [open, setOpen] = useState(startOpen)
-  const [editing, setEditing] = useState<{ id: UUID; validDuring: DateRange }>()
-  const [deleting, setDeleting] = useState<UUID>()
+  const [editing, setEditing] = useState<{
+    id: FosterParentId
+    validDuring: DateRange
+  }>()
+  const [deleting, setDeleting] = useState<FosterParentId>()
   const [fosterChildren, reloadFosterChildren] = useApiState(
     () => getFosterChildrenResult({ parentId: id }),
     [id]
   )
 
   const startEditing = useCallback(
-    (id: UUID, validDuring: DateRange) => {
+    (id: FosterParentId, validDuring: DateRange) => {
       toggleUiMode('edit-foster-child')
       setEditing({ id, validDuring })
     },
@@ -79,7 +85,7 @@ export default React.memo(function FosterChildren({
   }, [clearUiMode])
 
   const startDeleting = useCallback(
-    (id: UUID) => {
+    (id: FosterParentId) => {
       toggleUiMode('delete-foster-child')
       setDeleting(id)
     },
@@ -289,7 +295,7 @@ const FosterChildEditingModal = React.memo(function FosterChildEditingModal({
   reload,
   close
 }: {
-  id: UUID
+  id: FosterParentId
   initialValidDuring: DateRange
   reload: () => Promise<unknown>
   close: () => void
@@ -332,7 +338,7 @@ const FosterChildDeleteConfirmationModal = React.memo(
     reload,
     close
   }: {
-    id: UUID
+    id: FosterParentId
     reload: () => Promise<unknown>
     close: () => void
   }) {

--- a/frontend/src/employee-frontend/components/person-profile/PersonFridgeChild.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFridgeChild.tsx
@@ -8,8 +8,7 @@ import { Link } from 'react-router'
 
 import { wrapResult } from 'lib-common/api'
 import { ParentshipWithPermittedActions } from 'lib-common/generated/api-types/pis'
-import { PersonId } from 'lib-common/generated/api-types/shared'
-import { UUID } from 'lib-common/types'
+import { ParentshipId, PersonId } from 'lib-common/generated/api-types/shared'
 import { getAge } from 'lib-common/utils/local-date'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
@@ -50,9 +49,10 @@ export default React.memo(function PersonFridgeChild({
   const { uiMode, toggleUiMode, clearUiMode, setErrorMessage } =
     useContext(UIContext)
   const [open, setOpen] = useState(startOpen)
-  const [selectedParentshipId, setSelectedParentshipId] = useState('')
+  const [selectedParentshipId, setSelectedParentshipId] =
+    useState<ParentshipId>()
 
-  const getFridgeChildById = (id: UUID) =>
+  const getFridgeChildById = (id: ParentshipId | undefined) =>
     fridgeChildren
       .map((ps) => ps.find(({ data }) => data.id === id)?.data)
       .getOrElse(undefined)
@@ -76,7 +76,7 @@ export default React.memo(function PersonFridgeChild({
           reject={{ action: () => clearUiMode(), label: i18n.common.cancel }}
           resolve={{
             action: () =>
-              deleteParentshipResult({ id: selectedParentshipId }).then(
+              deleteParentshipResult({ id: selectedParentshipId! }).then(
                 (res) => {
                   clearUiMode()
                   if (res.isFailure) {

--- a/frontend/src/employee-frontend/components/person-profile/PersonFridgePartner.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFridgePartner.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components'
 
 import { wrapResult } from 'lib-common/api'
 import { PersonJSON } from 'lib-common/generated/api-types/pis'
-import { PersonId } from 'lib-common/generated/api-types/shared'
+import { PartnershipId, PersonId } from 'lib-common/generated/api-types/shared'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
@@ -61,7 +61,8 @@ const PersonFridgePartner = React.memo(function PersonFridgePartner({
     () => getPartnershipsResult({ personId: id }),
     [id]
   )
-  const [selectedPartnershipId, setSelectedPartnershipId] = useState('')
+  const [selectedPartnershipId, setSelectedPartnershipId] =
+    useState<PartnershipId>()
 
   // FIXME: This component shouldn't know about family's dependency on its data
   const reload = () => {
@@ -101,7 +102,7 @@ const PersonFridgePartner = React.memo(function PersonFridgePartner({
           resolve={{
             action: () =>
               deletePartnershipResult({
-                partnershipId: selectedPartnershipId
+                partnershipId: selectedPartnershipId!
               }).then((res) => {
                 clearUiMode()
                 if (res.isFailure) {
@@ -133,7 +134,7 @@ const PersonFridgePartner = React.memo(function PersonFridgePartner({
             flipped
             text={i18n.personProfile.partnerAdd}
             onClick={() => {
-              setSelectedPartnershipId('')
+              setSelectedPartnershipId(undefined)
               toggleUiMode('add-fridge-partner')
             }}
             data-qa="add-partner-button"

--- a/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
@@ -8,9 +8,8 @@ import styled from 'styled-components'
 import { combine, Failure, Result, wrapResult } from 'lib-common/api'
 import { Action } from 'lib-common/generated/action'
 import { IncomeRequest } from 'lib-common/generated/api-types/invoicing'
-import { PersonId } from 'lib-common/generated/api-types/shared'
+import { IncomeId, PersonId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Pagination from 'lib-components/Pagination'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
@@ -34,7 +33,6 @@ import { getChildPlacementPeriods } from '../../generated/api-clients/placement'
 import { useTranslation } from '../../state/i18n'
 import { PersonContext } from '../../state/person'
 import { UIContext } from '../../state/ui'
-import { IncomeId } from '../../types/income'
 import { useIncomeTypeOptions } from '../../utils/income'
 import { renderResult } from '../async-rendering'
 
@@ -154,14 +152,14 @@ export const Incomes = React.memo(function Incomes({
     [personId]
   )
 
-  const [openIncomeRows, setOpenIncomeRows] = useState<IncomeId[]>([])
-  const toggleIncomeRow = useCallback((id: IncomeId) => {
+  const [openIncomeRows, setOpenIncomeRows] = useState<(IncomeId | 'new')[]>([])
+  const toggleIncomeRow = useCallback((id: IncomeId | 'new') => {
     setOpenIncomeRows((prev) =>
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
     )
   }, [])
   const isIncomeRowOpen = useCallback(
-    (id: IncomeId) => openIncomeRows.includes(id),
+    (id: IncomeId | 'new') => openIncomeRows.includes(id),
     [openIncomeRows]
   )
 
@@ -201,7 +199,7 @@ export const Incomes = React.memo(function Incomes({
   const [editing, setEditing] = useState<string>()
   const [deleting, setDeleting] = useState<string>()
 
-  const toggleCreated = (res: Result<string>): Result<string> => {
+  const toggleCreated = (res: Result<IncomeId>): Result<IncomeId> => {
     if (res.isSuccess) {
       toggleIncomeRow(res.value)
     }
@@ -267,10 +265,10 @@ export const Incomes = React.memo(function Incomes({
                   toggleCreated
                 )
               }
-              updateIncome={(incomeId: UUID, income: IncomeRequest) =>
+              updateIncome={(incomeId: IncomeId, income: IncomeRequest) =>
                 updateIncomeResult({ incomeId, body: income })
               }
-              deleteIncome={(incomeId: UUID) =>
+              deleteIncome={(incomeId: IncomeId) =>
                 deleteIncomeResult({ incomeId })
               }
               onSuccessfulUpdate={() => {

--- a/frontend/src/employee-frontend/components/person-profile/PersonInvoiceCorrections.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonInvoiceCorrections.tsx
@@ -31,6 +31,7 @@ import { PersonJSON } from 'lib-common/generated/api-types/pis'
 import {
   ChildId,
   DaycareId,
+  InvoiceCorrectionId,
   PersonId
 } from 'lib-common/generated/api-types/shared'
 import { formatCents, parseCents } from 'lib-common/money'
@@ -605,7 +606,7 @@ const NoteQuickEditor = React.memo(function NoteQuickEditor({
   closeNote
 }: {
   initialValue: string
-  correctionId: UUID
+  correctionId: InvoiceCorrectionId
   personId: PersonId
   closeNote: () => void
 }) {

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeList.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeList.tsx
@@ -14,14 +14,12 @@ import {
   IncomeTypeOptions,
   IncomeWithPermittedActions
 } from 'lib-common/generated/api-types/invoicing'
-import { PersonId } from 'lib-common/generated/api-types/shared'
-import { UUID } from 'lib-common/types'
+import { IncomeId, PersonId } from 'lib-common/generated/api-types/shared'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { Gap } from 'lib-components/white-space'
 import { faQuestion } from 'lib-icons'
 
 import { useTranslation } from '../../../state/i18n'
-import { IncomeId } from '../../../types/income'
 
 import IncomeItemBody from './IncomeItemBody'
 import IncomeItemEditor from './IncomeItemEditor'
@@ -34,18 +32,18 @@ interface Props {
   incomeTypeOptions: IncomeTypeOptions
   coefficientMultipliers: Partial<Record<IncomeCoefficient, number>>
   incomeNotifications: IncomeNotification[]
-  isRowOpen: (id: IncomeId) => boolean
-  toggleRow: (id: IncomeId) => void
+  isRowOpen: (id: IncomeId | 'new') => boolean
+  toggleRow: (id: IncomeId | 'new') => void
   editing: string | undefined
   setEditing: React.Dispatch<React.SetStateAction<string | undefined>>
   deleting: string | undefined
   setDeleting: React.Dispatch<React.SetStateAction<string | undefined>>
   createIncome: (income: IncomeRequest) => Promise<Result<unknown>>
   updateIncome: (
-    incomeId: UUID,
+    incomeId: IncomeId,
     income: IncomeRequest
   ) => Promise<Result<unknown>>
-  deleteIncome: (incomeId: UUID) => Promise<Result<unknown>>
+  deleteIncome: (incomeId: IncomeId) => Promise<Result<unknown>>
   onSuccessfulUpdate: () => void
   onFailedUpdate: (value: Failure<unknown>) => void
 }

--- a/frontend/src/employee-frontend/components/reports/HolidayPeriodAttendanceReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/HolidayPeriodAttendanceReport.tsx
@@ -14,12 +14,15 @@ import {
   ChildWithName,
   HolidayPeriodAttendanceReportRow
 } from 'lib-common/generated/api-types/reports'
-import { DaycareId, GroupId } from 'lib-common/generated/api-types/shared'
+import {
+  DaycareId,
+  GroupId,
+  HolidayPeriodId
+} from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatFirstName } from 'lib-common/names'
 import { constantQuery, useQueryResult } from 'lib-common/query'
 import { capitalizeFirstLetter } from 'lib-common/string'
-import { UUID } from 'lib-common/types'
 import Title from 'lib-components/atoms/Title'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -46,7 +49,7 @@ import { holidayPeriodAttendanceReportQuery } from './queries'
 
 interface ReportQueryParams {
   unitId: DaycareId
-  periodId: UUID
+  periodId: HolidayPeriodId
   groupIds: GroupId[] | null
 }
 

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupTransferModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupTransferModal.tsx
@@ -98,7 +98,7 @@ export default React.memo(function GroupTransferModal({
         form.group !== null
           ? {
               unitId,
-              groupPlacementId: groupPlacementId || '',
+              groupPlacementId: groupPlacementId!,
               body: {
                 groupId: form.group.id,
                 startDate: form.startDate

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitMobileDevices.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitMobileDevices.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 
 import { isLoading, wrapResult } from 'lib-common/api'
 import { MobileDevice } from 'lib-common/generated/api-types/pairing'
-import { UUID } from 'lib-common/types'
+import { MobileDeviceId } from 'lib-common/generated/api-types/shared'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
@@ -50,8 +50,8 @@ const DevicesTable = React.memo(function DevicesTable({
   onDeleteDevice
 }: {
   rows: MobileDevice[]
-  onEditDevice: (deviceId: UUID) => void
-  onDeleteDevice: (deviceId: UUID) => void
+  onEditDevice: (deviceId: MobileDeviceId) => void
+  onDeleteDevice: (deviceId: MobileDeviceId) => void
 }) {
   const { i18n } = useTranslation()
 
@@ -175,7 +175,9 @@ export default React.memo(function UnitMobileDevices({ canAddNew }: Props) {
     () => getMobileDevicesResult({ unitId }),
     [unitId]
   )
-  const [mobileId, setMobileId] = useState<UUID | undefined>(undefined)
+  const [mobileId, setMobileId] = useState<MobileDeviceId | undefined>(
+    undefined
+  )
 
   const { uiMode, toggleUiMode, clearUiMode, startPairing } =
     useContext(UIContext)
@@ -189,7 +191,7 @@ export default React.memo(function UnitMobileDevices({ canAddNew }: Props) {
   }, [clearUiMode, mobileId, reloadMobileDevices])
 
   const openRemoveMobileDeviceModal = useCallback(
-    (id: UUID) => {
+    (id: MobileDeviceId) => {
       setMobileId(id)
       toggleUiMode(`remove-daycare-mobile-device-${unitId}`)
     },
@@ -197,7 +199,7 @@ export default React.memo(function UnitMobileDevices({ canAddNew }: Props) {
   )
 
   const openEditMobileDeviceModal = useCallback(
-    (id: UUID) => {
+    (id: MobileDeviceId) => {
       setMobileId(id)
       toggleUiMode(`edit-daycare-mobile-device-${unitId}`)
     },

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceDetailsModal.tsx
@@ -19,11 +19,11 @@ import {
 import { DaycareGroup } from 'lib-common/generated/api-types/daycare'
 import { EmployeeId, GroupId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { Id } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { constantQuery, useQueryResult } from 'lib-common/query'
 import { presentInGroup } from 'lib-common/staff-attendance'
-import { UUID } from 'lib-common/types'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -54,7 +54,7 @@ import { errorToInputInfo } from '../../../utils/validation/input-info-helper'
 import { openAttendanceQuery } from '../queries'
 
 export interface ModalAttendance {
-  id: UUID
+  id: Id<string>
   groupId: GroupId | null
   arrived: HelsinkiDateTime
   departed: HelsinkiDateTime | null
@@ -87,7 +87,7 @@ interface Props<
 }
 
 export interface EditedAttendance {
-  id: UUID | null
+  id: Id<string> | null
   groupId: GroupId | null
   arrived: string
   departed: string

--- a/frontend/src/employee-frontend/components/voucher-value-decision/VoucherValueDecisionPage.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decision/VoucherValueDecisionPage.tsx
@@ -10,9 +10,9 @@ import {
   VoucherValueDecisionResponse,
   VoucherValueDecisionType
 } from 'lib-common/generated/api-types/invoicing'
+import { VoucherValueDecisionId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { Gap } from 'lib-components/white-space'
@@ -42,7 +42,7 @@ const VoucherValueDecisionMetadataSection = React.memo(
   function VoucherValueDecisionMetadataSection({
     voucherValueDecisionId
   }: {
-    voucherValueDecisionId: UUID
+    voucherValueDecisionId: VoucherValueDecisionId
   }) {
     const result = useQueryResult(
       voucherValueDecisionMetadataQuery({ voucherValueDecisionId })
@@ -54,7 +54,7 @@ const VoucherValueDecisionMetadataSection = React.memo(
 export default React.memo(function VoucherValueDecisionPage() {
   const [showHandlerSelectModal, setShowHandlerSelectModal] = useState(false)
   const navigate = useNavigate()
-  const { id } = useRouteParams(['id'])
+  const id = useIdRouteParam<VoucherValueDecisionId>('id')
   const { i18n } = useTranslation()
   const { setTitle, formatTitleName } = useContext<TitleState>(TitleContext)
   const [decisionResponse, setDecisionResponse] = useState<

--- a/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionActions.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionActions.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 
 import { wrapResult } from 'lib-common/api'
 import { VoucherValueDecisionStatus } from 'lib-common/generated/api-types/invoicing'
+import { VoucherValueDecisionId } from 'lib-common/generated/api-types/shared'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import { featureFlags } from 'lib-customizations/employee'
@@ -38,7 +39,7 @@ const ErrorMessage = styled.div`
 
 type Props = {
   statuses: VoucherValueDecisionStatus[]
-  checkedIds: string[]
+  checkedIds: VoucherValueDecisionId[]
   clearChecked: () => void
   loadDecisions: () => void
   onHandlerSelectModal: () => void

--- a/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisions.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisions.tsx
@@ -11,6 +11,7 @@ import {
   VoucherValueDecisionSortParam,
   VoucherValueDecisionSummary
 } from 'lib-common/generated/api-types/invoicing'
+import { VoucherValueDecisionId } from 'lib-common/generated/api-types/shared'
 import { formatCents } from 'lib-common/money'
 import Pagination from 'lib-components/Pagination'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
@@ -57,8 +58,8 @@ interface Props {
   sortDirection: SortDirection
   setSortDirection: (v: SortDirection) => void
   showCheckboxes: boolean
-  checked: Record<string, boolean>
-  toggleChecked: (id: string) => void
+  isChecked: (id: VoucherValueDecisionId) => boolean
+  toggleChecked: (id: VoucherValueDecisionId) => void
   checkAll: () => void
   clearChecked: () => void
 }
@@ -74,7 +75,7 @@ export default React.memo(function VoucherValueDecisions({
   sortDirection,
   setSortDirection,
   showCheckboxes,
-  checked,
+  isChecked,
   toggleChecked,
   checkAll,
   clearChecked
@@ -83,7 +84,7 @@ export default React.memo(function VoucherValueDecisions({
 
   const allChecked =
     decisions
-      ?.map((ds) => ds.length > 0 && ds.every((d) => checked[d.id]))
+      ?.map((ds) => ds.length > 0 && ds.every((d) => isChecked(d.id)))
       .getOrElse(false) ?? false
 
   const isSorted = (column: VoucherValueDecisionSortParam) =>
@@ -141,7 +142,7 @@ export default React.memo(function VoucherValueDecisions({
               <Checkbox
                 label={item.id}
                 hiddenLabel
-                checked={!!checked[item.id]}
+                checked={isChecked(item.id)}
                 onChange={() => toggleChecked(item.id)}
                 data-qa="toggle-decision"
               />

--- a/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionsPage.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionsPage.tsx
@@ -11,6 +11,7 @@ import {
   VoucherValueDecisionSortParam,
   VoucherValueDecisionSummary
 } from 'lib-common/generated/api-types/invoicing'
+import { VoucherValueDecisionId } from 'lib-common/generated/api-types/shared'
 import { useRestApi } from 'lib-common/utils/useRestApi'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { Gap } from 'lib-components/white-space'
@@ -71,7 +72,7 @@ export default React.memo(function VoucherValueDecisionsPage() {
     valueDecisions: { searchFilters, debouncedSearchTerms }
   } = useContext(InvoicingUiContext)
 
-  const checkedState = useCheckedState()
+  const checkedState = useCheckedState<VoucherValueDecisionId>()
 
   const loadDecisions = useCallback(() => {
     const { startDate, endDate } = searchFilters
@@ -129,9 +130,7 @@ export default React.memo(function VoucherValueDecisionsPage() {
     }
   }, [decisions, checkedState.checkIds]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const checkedIds = Object.keys(checkedState.checked).filter(
-    (id) => !!checkedState.checked[id]
-  )
+  const checkedIds = checkedState.getCheckedIds()
 
   return (
     <Container data-qa="voucher-value-decisions-page">
@@ -172,7 +171,7 @@ export default React.memo(function VoucherValueDecisionsPage() {
             searchFilters.statuses.length === 1 &&
             ['DRAFT', 'IGNORED'].includes(searchFilters.statuses[0])
           }
-          checked={checkedState.checked}
+          isChecked={checkedState.isChecked}
           toggleChecked={checkedState.toggleChecked}
           checkAll={checkAll}
           clearChecked={checkedState.clearChecked}

--- a/frontend/src/employee-frontend/state/invoicing-ui.tsx
+++ b/frontend/src/employee-frontend/state/invoicing-ui.tsx
@@ -40,8 +40,6 @@ import { areaQuery } from '../components/unit/queries'
 
 import { UserContext } from './user'
 
-export type Checked = Record<string, boolean>
-
 interface FeeDecisionSearchFilters {
   area: string[]
   unit?: DaycareId

--- a/frontend/src/employee-frontend/state/invoicing.ts
+++ b/frontend/src/employee-frontend/state/invoicing.ts
@@ -4,24 +4,28 @@
 
 import { useState } from 'react'
 
-import { Checked } from './invoicing-ui'
+export type Checked<T extends string> = Partial<Record<T, boolean | undefined>>
 
-export function useCheckedState() {
-  const [checked, setChecked] = useState<Checked>({})
-  const toggleChecked = (id: string) =>
+export function useCheckedState<T extends string>() {
+  const [checked, setChecked] = useState<Checked<T>>({} as Checked<T>)
+  const toggleChecked = (id: T) =>
     setChecked({
       ...checked,
       [id]: !checked[id]
     })
-  const checkIds = (ids: string[]) => {
-    const idsChecked = ids.map((id) => ({ [id]: true }))
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const checkIds = (ids: T[]) => {
+    const idsChecked = ids.map((id) => [id, true] as const)
     setChecked({
       ...checked,
-      ...Object.assign({}, ...idsChecked)
+      ...Object.fromEntries(idsChecked)
     })
   }
-  const clearChecked = () => setChecked({})
+  const clearChecked = () => setChecked({} as Checked<T>)
+  const isChecked = (id: T) => checked[id] ?? false
+  const getCheckedIds = () =>
+    Object.entries(checked).flatMap(([id, checked]) =>
+      checked ? [id as T] : []
+    )
 
-  return { checked, toggleChecked, checkIds, clearChecked }
+  return { isChecked, getCheckedIds, toggleChecked, checkIds, clearChecked }
 }

--- a/frontend/src/employee-frontend/types/income.ts
+++ b/frontend/src/employee-frontend/types/income.ts
@@ -3,9 +3,5 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { IncomeRequest } from 'lib-common/generated/api-types/invoicing'
-import { UUID } from 'lib-common/types'
-
-// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-export type IncomeId = 'new' | UUID
 
 export type IncomeFields = IncomeRequest['data']

--- a/frontend/src/employee-frontend/types/unit.ts
+++ b/frontend/src/employee-frontend/types/unit.ts
@@ -9,11 +9,12 @@ import {
   PlacementType
 } from 'lib-common/generated/api-types/placement'
 import { ServiceNeed } from 'lib-common/generated/api-types/serviceneed'
+import { GroupPlacementId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { UUID } from 'lib-common/types'
 
 export interface DaycareGroupPlacementDetailed {
-  id: UUID | null
+  id: GroupPlacementId | null
   groupId: UUID | null
   groupName: string | null
   daycarePlacementId: UUID

--- a/frontend/src/employee-mobile-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/MessageEditor.tsx
@@ -18,9 +18,11 @@ import {
   PostMessageBody,
   UpdatableDraftContent
 } from 'lib-common/generated/api-types/messaging'
-import { DaycareId } from 'lib-common/generated/api-types/shared'
+import {
+  DaycareId,
+  MessageDraftId
+} from 'lib-common/generated/api-types/shared'
 import { cancelMutation, useMutation, useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { isAutomatedTest } from 'lib-common/utils/helpers'
 import { useDebounce } from 'lib-common/utils/useDebounce'
 import { useDebouncedCallback } from 'lib-common/utils/useDebouncedCallback'
@@ -81,7 +83,9 @@ const messageForm = mapped(
       familyDaycare: false
     }
     return {
-      messageContent: (draftId: UUID | null): PostMessageBody | undefined =>
+      messageContent: (
+        draftId: MessageDraftId | null
+      ): PostMessageBody | undefined =>
         selectedRecipients.length === 0 ||
         output.title === '' ||
         output.content === ''
@@ -121,7 +125,9 @@ export default React.memo(function MessageEditor({
 }: Props) {
   const { i18n } = useTranslation()
 
-  const [draftId, setDraftId] = useState<UUID | null>(draft?.id ?? null)
+  const [draftId, setDraftId] = useState<MessageDraftId | null>(
+    draft?.id ?? null
+  )
   const { mutateAsync: init } = useMutation(initDraftMutation)
   const { mutate: saveDraft, isPending: isSavingDraft } =
     useMutation(saveDraftMutation)

--- a/frontend/src/employee-mobile-frontend/messages/ThreadView.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/ThreadView.tsx
@@ -22,11 +22,14 @@ import {
   MessageThread,
   SentMessage
 } from 'lib-common/generated/api-types/messaging'
-import { DaycareId } from 'lib-common/generated/api-types/shared'
+import {
+  DaycareId,
+  MessageAccountId,
+  MessageThreadId
+} from 'lib-common/generated/api-types/shared'
 import { formatAccountNames } from 'lib-common/messaging'
 import { constantQuery, useChainedQuery } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { scrollRefIntoView } from 'lib-common/utils/scrolling'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Linkify from 'lib-components/atoms/Linkify'
@@ -60,7 +63,7 @@ export const ReceivedThreadPage = React.memo(function ReceivedThreadPage({
   unitOrGroup: UnitOrGroup
 }) {
   const navigate = useNavigate()
-  const { threadId } = useRouteParams(['threadId'])
+  const threadId = useIdRouteParam<MessageThreadId>('threadId')
   const { groupAccount } = useContext(MessageContext)
 
   const selectedAccount = groupAccount(
@@ -101,7 +104,7 @@ export const ReceivedThreadPage = React.memo(function ReceivedThreadPage({
 
 interface ReceivedThreadProps {
   unitId: DaycareId
-  accountId: UUID
+  accountId: MessageAccountId
   thread: MessageThread
   onBack: () => void
 }

--- a/frontend/src/employee-mobile-frontend/messages/queries.ts
+++ b/frontend/src/employee-mobile-frontend/messages/queries.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { DaycareId } from 'lib-common/generated/api-types/shared'
+import {
+  DaycareId,
+  MessageAccountId
+} from 'lib-common/generated/api-types/shared'
 import { mutation, pagedInfiniteQuery, query } from 'lib-common/query'
 import { Arg0, UUID } from 'lib-common/types'
 
@@ -57,14 +60,14 @@ export const messagingAccountsQuery = query({
 })
 
 export const receivedMessagesQuery = pagedInfiniteQuery({
-  api: (accountId: string) => (page: number) =>
+  api: (accountId: MessageAccountId) => (page: number) =>
     getReceivedMessages({ accountId, page }),
   id: (thread) => thread.id,
   queryKey: queryKeys.receivedMessages
 })
 
 export const sentMessagesQuery = pagedInfiniteQuery({
-  api: (accountId: string) => (page: number) =>
+  api: (accountId: MessageAccountId) => (page: number) =>
     getSentMessages({ accountId, page }),
   id: (message) => message.contentId,
   queryKey: queryKeys.sentMessages

--- a/frontend/src/employee-mobile-frontend/staff-attendance/ExternalStaffMemberPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/ExternalStaffMemberPage.tsx
@@ -5,11 +5,14 @@
 import React, { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 
-import { DaycareId } from 'lib-common/generated/api-types/shared'
+import {
+  DaycareId,
+  StaffAttendanceExternalId
+} from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalTime from 'lib-common/local-time'
 import { useQueryResult } from 'lib-common/query'
-import useRouteParams from 'lib-common/useRouteParams'
+import { useIdRouteParam } from 'lib-common/useRouteParams'
 import {
   MutateButton,
   cancelMutation
@@ -36,7 +39,8 @@ export default React.memo(function ExternalStaffMemberPage({
   unitId: DaycareId
 }) {
   const navigate = useNavigate()
-  const { attendanceId } = useRouteParams(['attendanceId'])
+  const attendanceId =
+    useIdRouteParam<StaffAttendanceExternalId>('attendanceId')
   const { i18n } = useTranslation()
 
   const staffAttendanceResponse = useQueryResult(

--- a/frontend/src/employee-mobile-frontend/staff-attendance/StaffAttendanceEditPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/StaffAttendanceEditPage.tsx
@@ -35,12 +35,15 @@ import {
   StaffMember,
   StaffMemberAttendance
 } from 'lib-common/generated/api-types/attendance'
-import { EmployeeId, GroupId } from 'lib-common/generated/api-types/shared'
+import {
+  EmployeeId,
+  GroupId,
+  StaffAttendanceRealtimeId
+} from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { useQueryResult } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import UnderRowStatusIcon from 'lib-components/atoms/StatusIcon'
 import Title from 'lib-components/atoms/Title'
@@ -92,7 +95,7 @@ const getDeparted = (
 const staffAttendanceForm = mapped(
   validated(
     object({
-      id: value<UUID | null>(),
+      id: value<StaffAttendanceRealtimeId | null>(),
       type: required(oneOf<StaffAttendanceType>()),
       groupEditMode: required(boolean()),
       groupId: required(oneOf<GroupId | null>()),

--- a/frontend/src/employee-mobile-frontend/staff-attendance/queries.ts
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/queries.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { DaycareId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { mutation, query } from 'lib-common/query'
 import { Arg0, UUID } from 'lib-common/types'
@@ -68,13 +69,13 @@ export const staffDepartureMutation = mutation({
 })
 
 export const externalStaffArrivalMutation = mutation({
-  api: (arg: Arg0<typeof markExternalArrival> & { unitId: UUID }) =>
+  api: (arg: Arg0<typeof markExternalArrival> & { unitId: DaycareId }) =>
     markExternalArrival(arg),
   invalidateQueryKeys: ({ unitId }) => [queryKeys.unit(unitId)]
 })
 
 export const externalStaffDepartureMutation = mutation({
-  api: (arg: Arg0<typeof markExternalDeparture> & { unitId: UUID }) =>
+  api: (arg: Arg0<typeof markExternalDeparture> & { unitId: DaycareId }) =>
     markExternalDeparture(arg),
   invalidateQueryKeys: ({ unitId }) => [queryKeys.unit(unitId)]
 })

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -101,15 +101,15 @@ export interface DaycareAclRowEmployee {
   temporary: boolean
 }
 
-export type DaycareAssistanceId = string
+export type DaycareAssistanceId = Id<'DaycareAssistance'>
 
-export type DaycareCaretakerId = string
+export type DaycareCaretakerId = Id<'DaycareCaretaker'>
 
 export type DaycareId = Id<'Daycare'>
 
-export type DecisionId = string
+export type DecisionId = Id<'Decision'>
 
-export type DocumentTemplateId = string
+export type DocumentTemplateId = Id<'DocumentTemplate'>
 
 /**
 * Generated from fi.espoo.evaka.shared.security.EmployeeFeatures
@@ -144,19 +144,19 @@ export type EmployeeId = Id<'Employee'>
 
 export type EvakaUserId = Id<'EvakaUser'>
 
-export type FeeAlterationId = string
+export type FeeAlterationId = Id<'FeeAlteration'>
 
-export type FeeDecisionId = string
+export type FeeDecisionId = Id<'FeeDecision'>
 
-export type FeeThresholdsId = string
+export type FeeThresholdsId = Id<'FeeThresholds'>
 
-export type FosterParentId = string
+export type FosterParentId = Id<'FosterParent'>
 
 export type GroupId = Id<'Group'>
 
 export type GroupNoteId = Id<'GroupNote'>
 
-export type GroupPlacementId = string
+export type GroupPlacementId = Id<'GroupPlacement'>
 
 /**
 * Generated from fi.espoo.evaka.shared.domain.HelsinkiDateTimeRange
@@ -166,31 +166,31 @@ export interface HelsinkiDateTimeRange {
   start: HelsinkiDateTime
 }
 
-export type HolidayPeriodId = string
+export type HolidayPeriodId = Id<'HolidayPeriod'>
 
-export type HolidayQuestionnaireId = string
+export type HolidayQuestionnaireId = Id<'HolidayQuestionnaire'>
 
-export type IncomeId = string
+export type IncomeId = Id<'Income'>
 
-export type IncomeStatementId = string
+export type IncomeStatementId = Id<'IncomeStatement'>
 
-export type InvoiceCorrectionId = string
+export type InvoiceCorrectionId = Id<'InvoiceCorrection'>
 
-export type InvoiceId = string
+export type InvoiceId = Id<'Invoice'>
 
-export type InvoiceRowId = string
+export type InvoiceRowId = Id<'InvoiceRow'>
 
-export type MessageAccountId = string
+export type MessageAccountId = Id<'MessageAccount'>
 
-export type MessageContentId = string
+export type MessageContentId = Id<'MessageContent'>
 
-export type MessageDraftId = string
+export type MessageDraftId = Id<'MessageDraft'>
 
-export type MessageId = string
+export type MessageId = Id<'Message'>
 
-export type MessageThreadId = string
+export type MessageThreadId = Id<'MessageThread'>
 
-export type MobileDeviceId = string
+export type MobileDeviceId = Id<'MobileDevice'>
 
 /**
 * Generated from fi.espoo.evaka.shared.domain.OfficialLanguage
@@ -202,17 +202,17 @@ export const officialLanguages = [
 
 export type OfficialLanguage = typeof officialLanguages[number]
 
-export type OtherAssistanceMeasureId = string
+export type OtherAssistanceMeasureId = Id<'OtherAssistanceMeasure'>
 
-export type PairingId = string
+export type PairingId = Id<'Pairing'>
 
-export type ParentshipId = string
+export type ParentshipId = Id<'Parentship'>
 
-export type PartnershipId = string
+export type PartnershipId = Id<'Partnership'>
 
-export type PaymentId = string
+export type PaymentId = Id<'Payment'>
 
-export type PedagogicalDocumentId = string
+export type PedagogicalDocumentId = Id<'PedagogicalDocument'>
 
 export type PersonId = Id<'Person'>
 
@@ -235,23 +235,23 @@ export type PilotFeature = typeof pilotFeatures[number]
 
 export type PlacementId = Id<'Placement'>
 
-export type PlacementPlanId = string
+export type PlacementPlanId = Id<'PlacementPlan'>
 
-export type PreschoolAssistanceId = string
+export type PreschoolAssistanceId = Id<'PreschoolAssistance'>
 
 export type PreschoolTermId = Id<'PreschoolTerm'>
 
-export type ServiceApplicationId = string
+export type ServiceApplicationId = Id<'ServiceApplication'>
 
 export type ServiceNeedId = Id<'ServiceNeed'>
 
 export type ServiceNeedOptionId = Id<'ServiceNeedOption'>
 
-export type ServiceNeedOptionVoucherValueId = string
+export type ServiceNeedOptionVoucherValueId = Id<'ServiceNeedOptionVoucherValue'>
 
-export type StaffAttendanceExternalId = string
+export type StaffAttendanceExternalId = Id<'StaffAttendanceExternal'>
 
-export type StaffAttendanceRealtimeId = string
+export type StaffAttendanceRealtimeId = Id<'StaffAttendanceRealtime'>
 
 /**
 * Generated from fi.espoo.evaka.shared.domain.Translatable
@@ -278,7 +278,7 @@ export type UserRole =
   | 'SPECIAL_EDUCATION_TEACHER'
   | 'EARLY_CHILDHOOD_EDUCATION_SECRETARY'
 
-export type VoucherValueDecisionId = string
+export type VoucherValueDecisionId = Id<'VoucherValueDecision'>
 
 export type ChildId = PersonId
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -243,7 +243,7 @@ export type PreschoolTermId = Id<'PreschoolTerm'>
 
 export type ServiceApplicationId = string
 
-export type ServiceNeedId = string
+export type ServiceNeedId = Id<'ServiceNeed'>
 
 export type ServiceNeedOptionId = Id<'ServiceNeedOption'>
 

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -233,7 +233,7 @@ export const pilotFeatures = [
 
 export type PilotFeature = typeof pilotFeatures[number]
 
-export type PlacementId = string
+export type PlacementId = Id<'Placement'>
 
 export type PlacementPlanId = string
 

--- a/frontend/src/lib-components/messages/MessageReplyEditor.tsx
+++ b/frontend/src/lib-components/messages/MessageReplyEditor.tsx
@@ -6,8 +6,8 @@ import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
 import { AccountType } from 'lib-common/generated/api-types/messaging'
+import { MessageAccountId } from 'lib-common/generated/api-types/shared'
 import { type cancelMutation, MutationDescription } from 'lib-common/query'
-import { UUID } from 'lib-common/types'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { faTrash } from 'lib-icons'
 
@@ -36,7 +36,7 @@ const EditorRow = styled.div`
 `
 
 export interface SelectableAccount {
-  id: UUID
+  id: MessageAccountId
   name: string
   selected: boolean
   toggleable: boolean
@@ -45,7 +45,7 @@ export interface SelectableAccount {
 
 interface Props<T, R> {
   recipients: SelectableAccount[]
-  onToggleRecipient: (id: UUID, selected: boolean) => void
+  onToggleRecipient: (id: MessageAccountId, selected: boolean) => void
   mutation: MutationDescription<T, R>
   onSubmit: () => T | typeof cancelMutation
   onSuccess: (response: R) => void

--- a/frontend/src/lib-components/messages/ToggleableRecipient.tsx
+++ b/frontend/src/lib-components/messages/ToggleableRecipient.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React from 'react'
 import styled from 'styled-components'
 
-import { UUID } from 'lib-common/types'
+import { MessageAccountId } from 'lib-common/generated/api-types/shared'
 import { faTimes } from 'lib-icons'
 
 import { useTranslations } from '../i18n'
@@ -18,7 +18,7 @@ import { SelectableAccount } from './MessageReplyEditor'
 interface ToggleableRecipientProps {
   'data-qa'?: string
   recipient: SelectableAccount
-  onToggleRecipient: (id: UUID, selected: boolean) => void
+  onToggleRecipient: (id: MessageAccountId, selected: boolean) => void
   labelAdd: string
 }
 

--- a/frontend/src/lib-components/messages/types.ts
+++ b/frontend/src/lib-components/messages/types.ts
@@ -7,7 +7,10 @@ import {
   AuthorizedMessageAccount,
   UpdatableDraftContent
 } from 'lib-common/generated/api-types/messaging'
-import { UUID } from 'lib-common/types'
+import {
+  MessageAccountId,
+  MessageDraftId
+} from 'lib-common/generated/api-types/shared'
 
 export interface GroupMessageAccount extends AuthorizedMessageAccount {
   daycareGroup: Group
@@ -31,7 +34,7 @@ export const isServiceWorkerMessageAccount = (
 ): acc is AuthorizedMessageAccount => acc.account.type === 'SERVICE_WORKER'
 
 export interface SaveDraftParams {
-  accountId: UUID
-  draftId: UUID
+  accountId: MessageAccountId
+  draftId: MessageDraftId
   content: UpdatableDraftContent
 }

--- a/frontend/src/lib-components/messages/useDraft.ts
+++ b/frontend/src/lib-components/messages/useDraft.ts
@@ -6,7 +6,10 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { Result } from 'lib-common/api'
 import { UpdatableDraftContent } from 'lib-common/generated/api-types/messaging'
-import { UUID } from 'lib-common/types'
+import {
+  MessageAccountId,
+  MessageDraftId
+} from 'lib-common/generated/api-types/shared'
 import { isAutomatedTest } from 'lib-common/utils/helpers'
 import { useDebouncedCallback } from 'lib-common/utils/useDebouncedCallback'
 import { useRestApi } from 'lib-common/utils/useRestApi'
@@ -14,9 +17,12 @@ import { SaveDraftParams } from 'lib-components/messages/types'
 
 type SaveState = 'clean' | 'dirty' | 'saving'
 
-export type Draft = UpdatableDraftContent & { accountId: UUID }
+export type Draft = UpdatableDraftContent & { accountId: MessageAccountId }
 
-const draftToSaveParams = ({ accountId, ...content }: Draft, id: string) => ({
+const draftToSaveParams = (
+  { accountId, ...content }: Draft,
+  id: MessageDraftId
+) => ({
   content,
   accountId,
   draftId: id
@@ -27,22 +33,22 @@ export function useDraft({
   saveDraftRaw,
   initDraftRaw
 }: {
-  initialId: UUID | null
+  initialId: MessageDraftId | null
   saveDraftRaw: (params: SaveDraftParams) => Promise<Result<void>>
-  initDraftRaw: (accountId: string) => Promise<Result<string>>
+  initDraftRaw: (accountId: MessageAccountId) => Promise<Result<MessageDraftId>>
 }): {
-  draftId: string | null
+  draftId: MessageDraftId | null
   saveDraft: () => void
   wasModified: boolean
   state: 'clean' | 'dirty' | 'saving'
   setDraft: (draft: Draft) => void
 } {
   const [saveState, setSaveState] = useState<SaveState>('clean')
-  const [id, setId] = useState<UUID | null>(initialId)
+  const [id, setId] = useState<MessageDraftId | null>(initialId)
   const [draft, setDraft] = useState<Draft>()
   const [wasModified, setWasModified] = useState(false)
 
-  const initDraft = useRestApi(initDraftRaw, (res: Result<UUID>) => {
+  const initDraft = useRestApi(initDraftRaw, (res) => {
     if (res.isSuccess) {
       setId(res.value)
       setInitializing(false)

--- a/frontend/src/lib-components/molecules/FileDownloadButton.tsx
+++ b/frontend/src/lib-components/molecules/FileDownloadButton.tsx
@@ -8,7 +8,7 @@ import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
 import { Attachment } from 'lib-common/api-types/attachment'
-import { UUID } from 'lib-common/types'
+import { AttachmentId } from 'lib-common/generated/api-types/shared'
 
 import { FixedSpaceRow } from '../layout/flex-helpers'
 
@@ -27,7 +27,7 @@ const DownloadButton = styled.button`
 
 interface FileDownloadButtonProps {
   file: Attachment
-  getFileUrl: (fileId: UUID, fileName: string) => string
+  getFileUrl: (fileId: AttachmentId, fileName: string) => string
   afterOpen?: () => void
   icon?: IconDefinition | boolean
   'data-qa'?: string

--- a/frontend/src/lib-components/molecules/FileUpload.tsx
+++ b/frontend/src/lib-components/molecules/FileUpload.tsx
@@ -84,7 +84,7 @@ interface FileUploadProps {
   ) => Promise<Result<AttachmentId>>
   onDelete: (id: AttachmentId) => Promise<Result<void>>
   onStateChange?: (status: UploadStatus) => void
-  getDownloadUrl: (id: UUID, fileName: string) => string
+  getDownloadUrl: (id: AttachmentId, fileName: string) => string
   disabled?: boolean
   slim?: boolean
   'data-qa'?: string

--- a/frontend/src/lib-components/molecules/Select.tsx
+++ b/frontend/src/lib-components/molecules/Select.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { memo } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import Combobox, {
@@ -10,8 +10,8 @@ import Combobox, {
 } from 'lib-components/atoms/dropdowns/Combobox'
 import { BaseProps } from 'lib-components/utils'
 
-export interface SelectOption {
-  value: string
+export interface SelectOption<T extends string> {
+  value: T
   label: string
 }
 
@@ -27,19 +27,19 @@ const Container = styled.div<{
   }
 `
 
-const getItemLabel = ({ label }: SelectOption) => label
+const getItemLabel = ({ label }: SelectOption<string>) => label
 
-const Select = memo(function Select({
+function Select_<T extends string>({
   'data-qa': dataQa,
   className,
   fullWidth,
   ...rest
-}: ComboboxProps<SelectOption> & BaseProps) {
+}: ComboboxProps<SelectOption<T>> & BaseProps) {
   return (
     <Container fullWidth={fullWidth} data-qa={dataQa} className={className}>
       <Combobox getItemLabel={getItemLabel} fullWidth={fullWidth} {...rest} />
     </Container>
   )
-})
+}
 
-export default Select
+export default React.memo(Select_) as typeof Select_

--- a/frontend/src/lib-components/utils/useReplyRecipients.ts
+++ b/frontend/src/lib-components/utils/useReplyRecipients.ts
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import { Message } from 'lib-common/generated/api-types/messaging'
+import { MessageAccountId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 
 import { SelectableAccount } from '../messages/MessageReplyEditor'
@@ -37,19 +38,25 @@ function getInitialRecipients(
   ]
 }
 
-export function useRecipients(messages: Message[], accountId: UUID) {
+export function useRecipients(
+  messages: Message[],
+  accountId: MessageAccountId
+) {
   const [recipients, setRecipients] = useState<SelectableAccount[]>([])
 
   useEffect(() => {
     setRecipients(getInitialRecipients(messages, accountId))
   }, [messages, accountId])
 
-  const onToggleRecipient = useCallback((id: UUID, selected: boolean) => {
-    setRecipients((prev) =>
-      prev.map((acc) =>
-        acc.id === id && acc.toggleable ? { ...acc, selected } : acc
+  const onToggleRecipient = useCallback(
+    (id: MessageAccountId, selected: boolean) => {
+      setRecipients((prev) =>
+        prev.map((acc) =>
+          acc.id === id && acc.toggleable ? { ...acc, selected } : acc
+        )
       )
-    )
-  }, [])
+    },
+    []
+  )
   return { recipients, onToggleRecipient }
 }

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -12,7 +12,6 @@ import fi.espoo.evaka.invoicing.service.ProductKey
 import fi.espoo.evaka.messaging.MessageReceiver
 import fi.espoo.evaka.pairing.MobileDeviceDetails
 import fi.espoo.evaka.pis.SystemController
-import fi.espoo.evaka.shared.DatabaseTable
 import fi.espoo.evaka.shared.Id
 import fi.espoo.evaka.shared.data.DateSet
 import fi.espoo.evaka.shared.domain.DateRange
@@ -70,56 +69,6 @@ object Imports {
     val createUrlSearchParams = TsImport.Named(LibCommon / "api.ts", "createUrlSearchParams")
     val devApiError = TsImport.Named(E2ETest / "dev-api", "DevApiError")
 }
-
-// For lenient id types, a string type alias is generated: `type FooId = string`.
-// For others, a strict type is generated: `type FooId = Id<'Foo'>`.
-val lenientIdTypes =
-    setOf(
-        DatabaseTable.DaycareAssistance::class,
-        DatabaseTable.DaycareCaretaker::class,
-        DatabaseTable.Decision::class,
-        DatabaseTable.DocumentTemplate::class,
-        DatabaseTable.EmployeePin::class,
-        DatabaseTable.FamilyContact::class,
-        DatabaseTable.FeeAlteration::class,
-        DatabaseTable.FeeDecision::class,
-        DatabaseTable.FeeThresholds::class,
-        DatabaseTable.FosterParent::class,
-        DatabaseTable.GroupPlacement::class,
-        DatabaseTable.HolidayPeriod::class,
-        DatabaseTable.HolidayQuestionnaire::class,
-        DatabaseTable.Income::class,
-        DatabaseTable.IncomeNotification::class,
-        DatabaseTable.IncomeStatement::class,
-        DatabaseTable.Invoice::class,
-        DatabaseTable.InvoiceCorrection::class,
-        DatabaseTable.InvoiceRow::class,
-        DatabaseTable.KoskiStudyRight::class,
-        DatabaseTable.Message::class,
-        DatabaseTable.MessageAccount::class,
-        DatabaseTable.MessageContent::class,
-        DatabaseTable.MessageDraft::class,
-        DatabaseTable.MessageRecipients::class,
-        DatabaseTable.MessageThread::class,
-        DatabaseTable.MessageThreadFolder::class,
-        DatabaseTable.MobileDevice::class,
-        DatabaseTable.OtherAssistanceMeasure::class,
-        DatabaseTable.Pairing::class,
-        DatabaseTable.Parentship::class,
-        DatabaseTable.Partnership::class,
-        DatabaseTable.Payment::class,
-        DatabaseTable.PedagogicalDocument::class,
-        DatabaseTable.PlacementPlan::class,
-        DatabaseTable.PreschoolAssistance::class,
-        DatabaseTable.ServiceApplication::class,
-        DatabaseTable.ServiceNeedOptionVoucherValue::class,
-        DatabaseTable.StaffAttendance::class,
-        DatabaseTable.StaffAttendanceRealtime::class,
-        DatabaseTable.StaffAttendanceExternal::class,
-        DatabaseTable.StaffAttendancePlan::class,
-        DatabaseTable.StaffOccupancyCoefficient::class,
-        DatabaseTable.VoucherValueDecision::class,
-    )
 
 val idTypeAliases = mapOf("PersonId" to listOf("ChildId"))
 

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -109,7 +109,6 @@ val lenientIdTypes =
         DatabaseTable.Partnership::class,
         DatabaseTable.Payment::class,
         DatabaseTable.PedagogicalDocument::class,
-        DatabaseTable.Placement::class,
         DatabaseTable.PlacementPlan::class,
         DatabaseTable.PreschoolAssistance::class,
         DatabaseTable.ServiceApplication::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/Config.kt
@@ -113,7 +113,6 @@ val lenientIdTypes =
         DatabaseTable.PlacementPlan::class,
         DatabaseTable.PreschoolAssistance::class,
         DatabaseTable.ServiceApplication::class,
-        DatabaseTable.ServiceNeed::class,
         DatabaseTable.ServiceNeedOptionVoucherValue::class,
         DatabaseTable.StaffAttendance::class,
         DatabaseTable.StaffAttendanceRealtime::class,

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/TsCodeGenerator.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/TsCodeGenerator.kt
@@ -197,11 +197,7 @@ export type ${sealed.name} = ${variants.joinToString(separator = " | ") { "${sea
     }
 
     fun tsIdType(namedType: TsIdType): TsCode =
-        if (namedType.strict) {
-            TsCode("export type ${namedType.name} = Id<'${namedType.tableName}'>", Imports.id)
-        } else {
-            TsCode("export type ${namedType.name} = string")
-        }
+        TsCode("export type ${namedType.name} = Id<'${namedType.tableName}'>", Imports.id)
 
     fun namedType(namedType: TsNamedType<*>): TsCode =
         when (namedType) {

--- a/service/codegen/src/main/kotlin/evaka/codegen/api/TsRepresentation.kt
+++ b/service/codegen/src/main/kotlin/evaka/codegen/api/TsRepresentation.kt
@@ -110,9 +110,6 @@ data class TsIdType(override val clazz: KClass<*>) : TsNamedType<Nothing> {
 
     override val name: String
         get() = tableName + "Id"
-
-    val strict: Boolean
-        get() = !lenientIdTypes.contains(clazz)
 }
 
 data class TsPlainObject(


### PR DESCRIPTION
Muutetaan kaikki loput ID-tyypit vahvoiksi.

Tämä ei vielä poista `UUID`- tai `string`-tyypitettyjä ID:itä frontista kokonaan, ainoastaan korjaa ne paikat jotka eivät mene tyyppitarkastuksesta läpi. `Id<T>` on yhteensopiva `string`:n kanssa "toiseen suuntaan", joten kaikki käyttöpaikat eivät löydy tyyppitarkastuksessa.