### PR TITLE
Korjataan palvelutuottajien Keycloak-uloskirjautuminen toimimaan myös Keycloakin puolella oikein

### DIFF
--- a/apigw/src/app.ts
+++ b/apigw/src/app.ts
@@ -232,16 +232,20 @@ export function apiRouter(config: Config, redisClient: RedisClient) {
     })
   )
 
-  router.all('/employee/auth/ad/*', (req: express.Request, _, next) => {
-    // horrible hack to fix logout URL
-    if (req.session?.idpProvider === 'evaka') {
-      req.url = req.url.replace(
-        '/employee/auth/ad/',
-        '/employee/auth/keycloak/'
-      )
+  router.all(
+    '/employee/auth/ad/*',
+    employeeSessions.middleware,
+    (req: express.Request, _, next) => {
+      // horrible hack to fix logout URL
+      if (req.session?.idpProvider === 'evaka') {
+        req.url = req.url.replace(
+          '/employee/auth/ad/',
+          '/employee/auth/keycloak/'
+        )
+      }
+      next()
     }
-    next()
-  })
+  )
 
   if (config.ad.type === 'mock') {
     router.use(


### PR DESCRIPTION
`req.session` oli undefined koska sessio-middlewarea ei ollut tässä routessa

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- Lisää linkki dokumentaation relevanttiin kohtaan.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
