### PR TITLE
Korjaus ryhmäpostilaatikon näkyvyyteen kun työntekijä luvitettiin toiseen ryhmään

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/MobileRealtimeStaffAttendanceControllerIntegrationTest.kt
@@ -13,7 +13,7 @@ import fi.espoo.evaka.shared.StaffAttendanceRealtimeId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
-import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
+import fi.espoo.evaka.shared.auth.syncDaycareGroupAcl
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.DevDaycareGroupAcl
@@ -84,8 +84,8 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
             tx.insertDaycareAclRow(testDaycare2.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
-            tx.insertDaycareGroupAcl(testDaycare2.id, employee.id, listOf(groupId2), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare2.id, employee.id, listOf(groupId2), now)
 
             tx.markStaffArrival(
                 employee.id,
@@ -110,7 +110,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
         }
 
         val arrivalTime = HelsinkiDateTime.of(today, LocalTime.of(8, 0))
@@ -146,7 +146,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
         }
 
         val arrivalTime = HelsinkiDateTime.of(today, LocalTime.of(8, 0))
@@ -176,7 +176,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
         }
 
         val arrivalTime = HelsinkiDateTime.of(today, LocalTime.of(8, 0))
@@ -211,7 +211,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -243,7 +243,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -276,7 +276,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -309,7 +309,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -351,7 +351,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -376,7 +376,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
         }
 
         val lastLoginBeforeArrival = db.read { db -> db.getEmployeeLastLogin(employee.id) }
@@ -402,7 +402,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -438,7 +438,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -464,7 +464,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -488,7 +488,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -531,7 +531,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -570,7 +570,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -596,7 +596,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -629,7 +629,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -671,7 +671,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -708,7 +708,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -757,7 +757,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -792,7 +792,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -828,7 +828,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -873,7 +873,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,
@@ -908,7 +908,7 @@ class MobileRealtimeStaffAttendanceControllerIntegrationTest :
             tx.insert(employee)
             tx.insert(DevEmployeePin(userId = employee.id, pin = pinCode))
             tx.insertDaycareAclRow(testDaycare.id, employee.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId), now)
             tx.insert(
                 DevStaffAttendancePlan(
                     employeeId = employee.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/attendance/RealtimeStaffAttendanceControllerIntegrationTest.kt
@@ -10,7 +10,7 @@ import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
-import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
+import fi.espoo.evaka.shared.auth.syncDaycareGroupAcl
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
 import fi.espoo.evaka.shared.dev.insert
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -63,7 +63,7 @@ class RealtimeStaffAttendanceControllerIntegrationTest :
             tx.insertDaycareAclRow(testDaycare2.id, supervisor.id, UserRole.UNIT_SUPERVISOR)
             tx.insertDaycareAclRow(testDaycare.id, staff.id, UserRole.STAFF)
             tx.insertDaycareAclRow(testDaycare2.id, staff.id, UserRole.STAFF)
-            tx.insertDaycareGroupAcl(testDaycare.id, staff.id, listOf(groupId1), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, staff.id, listOf(groupId1), now)
 
             tx.upsertOccupancyCoefficient(
                 OccupancyCoefficientUpsert(testDaycare.id, staff.id, BigDecimal(7))

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageAccountQueriesTest.kt
@@ -10,7 +10,7 @@ import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
-import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
+import fi.espoo.evaka.shared.auth.syncDaycareGroupAcl
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevDaycareGroup
@@ -84,7 +84,7 @@ class MessageAccountQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
             it.insertDaycareAclRow(daycareId, supervisorId, UserRole.UNIT_SUPERVISOR)
 
             it.insertDaycareAclRow(daycareId, employee1Id, UserRole.STAFF)
-            it.insertDaycareGroupAcl(daycareId, employee1Id, listOf(groupId), clock.now())
+            it.syncDaycareGroupAcl(daycareId, employee1Id, listOf(groupId), clock.now())
 
             // employee2 has no groups
             it.insertDaycareAclRow(daycareId, employee2Id, UserRole.STAFF)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.application.notes.getApplicationNotes
 import fi.espoo.evaka.application.persistence.daycare.DaycareFormV0
 import fi.espoo.evaka.attachment.AttachmentsController
 import fi.espoo.evaka.daycare.CareType
+import fi.espoo.evaka.insertServiceNeedOptions
 import fi.espoo.evaka.messaging.MessageController.PostMessagePreflightResponse
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.serviceneed.ShiftCareType
@@ -27,23 +28,9 @@ import fi.espoo.evaka.shared.MessageThreadId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
-import fi.espoo.evaka.shared.auth.AuthenticatedUser
-import fi.espoo.evaka.shared.auth.CitizenAuthLevel
-import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.auth.insertDaycareAclRow
-import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
+import fi.espoo.evaka.shared.auth.*
 import fi.espoo.evaka.shared.db.Database
-import fi.espoo.evaka.shared.dev.DevDaycare
-import fi.espoo.evaka.shared.dev.DevDaycareGroup
-import fi.espoo.evaka.shared.dev.DevDaycareGroupPlacement
-import fi.espoo.evaka.shared.dev.DevEmployee
-import fi.espoo.evaka.shared.dev.DevParentship
-import fi.espoo.evaka.shared.dev.DevPerson
-import fi.espoo.evaka.shared.dev.DevPersonType
-import fi.espoo.evaka.shared.dev.DevPlacement
-import fi.espoo.evaka.shared.dev.DevServiceNeed
-import fi.espoo.evaka.shared.dev.insert
-import fi.espoo.evaka.shared.dev.insertTestApplication
+import fi.espoo.evaka.shared.dev.*
 import fi.espoo.evaka.shared.domain.*
 import fi.espoo.evaka.shared.security.PilotFeature
 import fi.espoo.evaka.test.validDaycareApplication
@@ -276,7 +263,7 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
 
             employee1Account = tx.upsertEmployeeMessageAccount(employee1.id)
             tx.insertDaycareAclRow(testDaycare.id, employee1.id, UserRole.UNIT_SUPERVISOR)
-            tx.insertDaycareGroupAcl(
+            tx.syncDaycareGroupAcl(
                 testDaycare.id,
                 employee1.id,
                 listOf(groupId1, groupId2),
@@ -1666,7 +1653,7 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             val employee = DevEmployee(firstName = "New", lastName = "Staff")
             tx.insert(employee)
             tx.insertDaycareAclRow(testDaycare.id, employee.id, userRole)
-            tx.insertDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId1), now)
+            tx.syncDaycareGroupAcl(testDaycare.id, employee.id, listOf(groupId1), now)
             employee.user
         }
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/InactiveEmployeesRoleResetIntegrationTest.kt
@@ -12,7 +12,7 @@ import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
-import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
+import fi.espoo.evaka.shared.auth.syncDaycareGroupAcl
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -156,7 +156,7 @@ class InactiveEmployeesRoleResetIntegrationTest : PureJdbiTest(resetDbBeforeEach
                     role = UserRole.STAFF,
                 )
                 it.setDaycareAclUpdated(unitId, employeeId, firstOfAugust2021.minusDays(1000))
-                it.insertDaycareGroupAcl(
+                it.syncDaycareGroupAcl(
                     daycareId = unitId,
                     employeeId = employeeId,
                     groupIds = listOf(groupId),

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/UnitAcl.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/UnitAcl.kt
@@ -7,10 +7,7 @@ package fi.espoo.evaka.daycare
 import fi.espoo.evaka.messaging.deactivateEmployeeMessageAccount
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EmployeeId
-import fi.espoo.evaka.shared.auth.UserRole
-import fi.espoo.evaka.shared.auth.clearDaycareGroupAcl
-import fi.espoo.evaka.shared.auth.deleteDaycareAclRow
-import fi.espoo.evaka.shared.auth.hasAnyDaycareAclRow
+import fi.espoo.evaka.shared.auth.*
 import fi.espoo.evaka.shared.db.Database
 
 fun removeDaycareAclForRole(
@@ -19,7 +16,7 @@ fun removeDaycareAclForRole(
     employeeId: EmployeeId,
     role: UserRole,
 ) {
-    tx.clearDaycareGroupAcl(daycareId, employeeId)
+    tx.syncDaycareGroupAcl(daycareId, employeeId, emptyList())
     tx.deleteDaycareAclRow(daycareId, employeeId, role)
     deactivatePersonalMessageAccountIfNeeded(tx, employeeId)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -88,7 +88,7 @@ import fi.espoo.evaka.shared.VoucherValueDecisionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.auth.insertDaycareAclRow
-import fi.espoo.evaka.shared.auth.insertDaycareGroupAcl
+import fi.espoo.evaka.shared.auth.syncDaycareGroupAcl
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -294,7 +294,7 @@ RETURNING id
                 insertDaycareAclRow(daycareId, employeeId, role)
             }
             groupAcl.forEach { (daycareId, groups) ->
-                insertDaycareGroupAcl(daycareId, employeeId, groups, now)
+                syncDaycareGroupAcl(daycareId, employeeId, groups, now)
             }
         }
 


### PR DESCRIPTION
Kun työntekijä luvitettiin toiseen ryhmään aiemman ryhmän lisäksi, katosivat aiemman ryhmän viikkoa vanhemmat viestit näkyvistä. Kyseinen virhe on korjattu, ja aiemman ryhmän viestien näkyvyyteen ei tule muutosta uusiin ryhmiin luvituksen yhteydessä.

Syynä virheeseen oli, että taustalla uuteen ryhmään luvituksen yhteydessä ensin poistettin luvat kaikkiin yksikön ryhmiin, joihin työntekijällä oli ennestään oikeus, ja välittömästi perään annettiin luvat kaikkiin haluttuihin ryhmiin. Näin kaikkien ryhmien luvitushetkeksi tuli nykyhetki, ja viestien näkyvyys on siitä viikko taaksepäin.

Ennen tätä korjausta tehtyjen ryhmäluvitusten aiheuttamien viestien näkyvyysongelmien korjaaminen taannehtivasti ei ole mahdollista.