### PR TITLE
Korjataan tuen päätöksen otsikko

### DIFF
--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1692,7 +1692,7 @@ const en: Translations = {
       }
     },
     assistanceDecisions: {
-      title: 'Support decision',
+      title: 'Decision of support in early childhood education',
       assistanceLevel: 'Level of support',
       validityPeriod: 'Valid',
       unit: 'Unit',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -1784,7 +1784,7 @@ export default {
       )
     },
     assistanceDecisions: {
-      title: 'Päätös erityisestä tuesta varhaiskasvatuksessa',
+      title: 'Päätös tuesta varhaiskasvatuksessa',
       assistanceLevel: 'Tuen taso',
       validityPeriod: 'Voimassa',
       unit: 'Yksikkö',


### PR DESCRIPTION
Sama teksti kuin PDF:llä: https://github.com/espoon-voltti/evaka/blob/27095aa3fb59b95340789dcc900f62f6cfc1ef73/service/src/main/resources/WEB-INF/templates/assistance-need/decision.properties#L4

Enkkuversion muutin vastaamaan esiopetuksen vastinetta: https://github.com/espoon-voltti/evaka/blob/27095aa3fb59b95340789dcc900f62f6cfc1ef73/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx#L1677