### PR TITLE
Korjataan apigw:n kontin tiedosto-oikeudet

### DIFF
--- a/apigw/Dockerfile
+++ b/apigw/Dockerfile
@@ -48,15 +48,13 @@ FROM base
 
 ENV NODE_ENV production
 
-WORKDIR /home/evaka
+RUN adduser evaka --gecos "" -q --home /home/evaka --disabled-password
 
 COPY --from=builder /project .
 
 RUN yarn workspaces focus --production \
  && yarn cache clean --all
 
-RUN adduser evaka --gecos "" -q --home /home/evaka --disabled-password
-RUN chown -R evaka:evaka /home/evaka
 USER evaka
 
 ARG build=none


### PR DESCRIPTION
Tällä hetkellä apigw:n konttiin laitetaan sovelluksen koodit `evaka`-käyttäjän kotihakemistoon kirjoitusoikeuksilla. Tämän muutoksen myötä koodit säilötään jatkossa `/project`-hakemistoon, joihin käyttäjällä ei ole kirjoitusoikeuksia.

Tämän pitäisi myös nopeuttaa kontin rakentamista, koska poistettu `chown`-komento vei lähes puolet ajasta.

Huom! tämä muuttaa oletustyöhakemiston `evaka`-käyttäjän kotihakemistosta `/project`-hakemistoon.