### PR TITLE
Korjataan CSP-raporttiendpointin polku

### DIFF
--- a/apigw/src/app.ts
+++ b/apigw/src/app.ts
@@ -102,7 +102,7 @@ export function apiRouter(config: Config, redisClient: RedisClient) {
   )
 
   router.post(
-    '/csp/report',
+    '/csp',
     express.json({ type: 'application/csp-report' }),
     handleCspReport
   )


### PR DESCRIPTION
Tällä hetkellä näistä tulee CSRF-virhe, koska route ei osu ja mennään normaaliin API-käsittelyyn jossa CSRF-header on pakollinen.

Muutoksen jälkeen CSP-raportit tulee taas läpi ja CSRF-virheet vähenee