### PR TITLE
Lisätty tuki palveluohjauksen sisäisille liitteille hakemuksilla

### DIFF
--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -1292,6 +1292,21 @@ export default React.memo(function ApplicationEditView({
               />
             </>
           )}
+          <Label>
+            {i18n.application.additionalInfo.serviceWorkerAttachmentsTitle}
+          </Label>
+
+          <FileUploadGridContainer>
+            <FileUpload
+              onUpload={onUploadAttachment('SERVICE_WORKER_ATTACHMENT')}
+              onDelete={onDeleteAttachment}
+              getDownloadUrl={getAttachmentUrl}
+              files={attachments.filter(
+                (a) => a.type === 'SERVICE_WORKER_ATTACHMENT'
+              )}
+              data-qa="file-upload-service-worker"
+            />
+          </FileUploadGridContainer>
         </ListGrid>
       </CollapsibleSection>
 

--- a/frontend/src/employee-frontend/components/application-page/ApplicationReadView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationReadView.tsx
@@ -115,6 +115,10 @@ export default React.memo(function ApplicationReadView({
     ({ type }) => type === 'EXTENDED_CARE'
   )
 
+  const serviceWorkerAttachments = attachments.filter(
+    ({ type }) => type === 'SERVICE_WORKER_ATTACHMENT'
+  )
+
   const connectedDaycare = type === 'PRESCHOOL' && serviceNeed !== null
   const paid = type === 'DAYCARE' || connectedDaycare
 
@@ -576,6 +580,25 @@ export default React.memo(function ApplicationReadView({
               <span>{child.diet}</span>
             </>
           )}
+          <Label>
+            {i18n.application.additionalInfo.serviceWorkerAttachmentsTitle}
+          </Label>
+          <AttachmentContainer>
+            {serviceWorkerAttachments.length ? (
+              <>
+                {serviceWorkerAttachments.map((attachment) => (
+                  <Attachment
+                    key={attachment.id}
+                    attachment={attachment}
+                    receivedAt={attachmentReceivedAt(attachment)}
+                    data-qa={`service-need-attachment-${attachment.name}`}
+                  />
+                ))}
+              </>
+            ) : (
+              <Dimmed>{i18n.application.additionalInfo.noAttachments}</Dimmed>
+            )}
+          </AttachmentContainer>
         </ListGrid>
       </CollapsibleSection>
 

--- a/frontend/src/lib-common/generated/api-types/attachment.ts
+++ b/frontend/src/lib-common/generated/api-types/attachment.ts
@@ -12,6 +12,7 @@ import { AttachmentId } from './shared'
 export type AttachmentType =
   | 'URGENCY'
   | 'EXTENDED_CARE'
+  | 'SERVICE_WORKER_ATTACHMENT'
 
 /**
 * Generated from fi.espoo.evaka.attachment.IncomeAttachment

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -524,7 +524,9 @@ export const fi = {
       applicationInfo: 'Hakemuksen lisätiedot',
       allergies: 'Allergiat',
       diet: 'Erityisruokavalio',
-      maxFeeAccepted: 'Suostumus korkeimpaan maksuun'
+      maxFeeAccepted: 'Suostumus korkeimpaan maksuun',
+      serviceWorkerAttachmentsTitle: 'Palveluohjauksen liitteet',
+      noAttachments: 'Ei liitteitä'
     },
     decisions: {
       title: 'Päätökset',

--- a/service/src/main/kotlin/fi/espoo/evaka/attachment/Attachment.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attachment/Attachment.kt
@@ -54,4 +54,5 @@ data class MessageAttachment(val id: AttachmentId, val name: String, val content
 enum class AttachmentType {
     URGENCY,
     EXTENDED_CARE,
+    SERVICE_WORKER_ATTACHMENT,
 }


### PR DESCRIPTION
## Ennen tätä muutosta
Palveluohjaus ei pystynyt lisäämään yleisiä liitteitä hakemukselle. Ainoastaan kiireellisyyteen tai vuorohoitoon liittyviä liitteitä oli mahdollista lisätä.

## Tämän muutoksen jälkeen
Hakemuksen Lisätiedot-kohdassa on vapaa kenttä liitetiedostoille.
<img width="841" alt="image" src="https://github.com/user-attachments/assets/25bf88ab-2e19-4e9e-92f6-2e9515cbda2a" />
Editointinäkymä

<img width="996" alt="image" src="https://github.com/user-attachments/assets/3b931a34-ca08-465a-bf22-4eb760c4ee04" />
Lukunäkymä


Nämä uuden tyyppiset liitteet eivät tule kuntalaisen puolelle näkyviin, koska kuntalaisen puolella näytetään vain käyttäjän itsensä lisäämät liitteet.