### PR TITLE
Espoo: käyttöoikeusmuutoksia

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/non-ssn-children-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/non-ssn-children-report.spec.ts
@@ -93,7 +93,8 @@ describe('Non SSN children report', () => {
     await assertReport(report)
   })
 
-  test('report data is shown to finance admin', async () => {
+  // This test is skipped until e2e tests use default action rules instead of Espoo customizations
+  test.skip('report data is shown to finance admin', async () => {
     const financeAdmin = await Fixture.employee().financeAdmin().save()
 
     const page = await Page.open({

--- a/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooActionRuleMapping.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooActionRuleMapping.kt
@@ -18,6 +18,8 @@ class EspooActionRuleMapping : ActionRuleMapping {
         when (action) {
             Action.Global.SEND_PATU_REPORT,
             Action.Global.SUBMIT_PATU_REPORT -> sequenceOf(HasGlobalRole(UserRole.ADMIN))
+            Action.Global.READ_NON_SSN_CHILDREN_REPORT ->
+                sequenceOf(HasGlobalRole(UserRole.ADMIN, UserRole.SERVICE_WORKER))
             else -> action.defaultRules.asSequence()
         }
 
@@ -44,6 +46,64 @@ class EspooActionRuleMapping : ActionRuleMapping {
                     sequenceOf(
                         HasUnitRole(UserRole.UNIT_SUPERVISOR).inUnit() as ScopedActionRule<in T>
                     )
+            }
+            Action.Unit.READ_SERVICE_VOUCHER_REPORT -> {
+                @Suppress("UNCHECKED_CAST")
+                sequenceOf(
+                    HasGlobalRole(UserRole.ADMIN, UserRole.REPORT_VIEWER, UserRole.FINANCE_ADMIN)
+                        as ScopedActionRule<in T>
+                ) +
+                    sequenceOf(
+                        HasUnitRole(
+                                UserRole.UNIT_SUPERVISOR,
+                                UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY,
+                            )
+                            .inUnit() as ScopedActionRule<in T>
+                    )
+            }
+            Action.Unit.READ_FAMILY_DAYCARE_MEAL_REPORT -> {
+                @Suppress("UNCHECKED_CAST")
+                sequenceOf(HasGlobalRole(UserRole.ADMIN) as ScopedActionRule<in T>) +
+                    sequenceOf(
+                        HasUnitRole(UserRole.UNIT_SUPERVISOR).inUnit() as ScopedActionRule<in T>
+                    )
+            }
+            Action.Unit.READ_FAMILY_CONFLICT_REPORT -> {
+                @Suppress("UNCHECKED_CAST")
+                sequenceOf(
+                    HasGlobalRole(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN)
+                        as ScopedActionRule<in T>
+                )
+            }
+            Action.Person.CREATE_PARTNERSHIP -> {
+                @Suppress("UNCHECKED_CAST")
+                sequenceOf(
+                    HasGlobalRole(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN)
+                        as ScopedActionRule<in T>
+                )
+            }
+            Action.Person.CREATE_PARENTSHIP -> {
+                @Suppress("UNCHECKED_CAST")
+                sequenceOf(
+                    HasGlobalRole(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN)
+                        as ScopedActionRule<in T>
+                )
+            }
+            Action.Partnership.UPDATE,
+            Action.Partnership.RETRY -> {
+                @Suppress("UNCHECKED_CAST")
+                sequenceOf(
+                    HasGlobalRole(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN)
+                        as ScopedActionRule<in T>
+                )
+            }
+            Action.Parentship.UPDATE,
+            Action.Parentship.RETRY -> {
+                @Suppress("UNCHECKED_CAST")
+                sequenceOf(
+                    HasGlobalRole(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN)
+                        as ScopedActionRule<in T>
+                )
             }
             Action.Child.READ_DAILY_SERVICE_TIMES -> {
                 @Suppress("UNCHECKED_CAST")

--- a/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooActionRuleMapping.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooActionRuleMapping.kt
@@ -98,7 +98,8 @@ class EspooActionRuleMapping : ActionRuleMapping {
                 )
             }
             Action.Parentship.UPDATE,
-            Action.Parentship.RETRY -> {
+            Action.Parentship.RETRY,
+            Action.Parentship.DELETE_CONFLICTED_PARENTSHIP -> {
                 @Suppress("UNCHECKED_CAST")
                 sequenceOf(
                     HasGlobalRole(UserRole.ADMIN, UserRole.SERVICE_WORKER, UserRole.FINANCE_ADMIN)


### PR DESCRIPTION
specsi:

- Hetuttomat- raportti pois talouden näkymästä
- Palveluseteliyksiköt ja perhepäivähoitajien ateriaraportti pois hallinnon näkymästä
- Perhekonfliktit raportti pois johtajan ja veon näkymästä 
- Perhetietojen muokkaus pois johtajan roolilta (ts. pois lisäys ja muokkausmahdollisuus puolisotiedosta ja päämiehen alle 18-v. lasten tiedoista, jätetään vain katselu)