### PR TITLE
Päivämääräkentän validointivirhe ruudunlukijalle

### DIFF
--- a/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/AbsenceModal.tsx
@@ -189,7 +189,9 @@ export default React.memo(function AbsenceModal({
                 </TabletAndDesktop>
               </LineContainer>
               <CalendarModalSection>
-                <H2>{i18n.calendar.absenceModal.dateRange}</H2>
+                <H2 id="absence-daterange-label">
+                  {i18n.calendar.absenceModal.dateRange}
+                </H2>
                 <DateRangePickerF
                   bind={range}
                   locale={lang}
@@ -197,6 +199,8 @@ export default React.memo(function AbsenceModal({
                   onFocus={(ev) => {
                     scrollIntoViewSoftKeyboard(ev.target, 'start')
                   }}
+                  required
+                  ariaId="absence-daterange-label"
                 />
                 <Gap size="s" />
                 <P noMargin>{i18n.calendar.absenceModal.selectChildrenInfo}</P>

--- a/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/ReservationModal.tsx
@@ -255,7 +255,9 @@ export default React.memo(function ReservationModal({
                   }
                   inlineChildren
                 >
-                  <Label>{i18n.calendar.reservationModal.dateRangeLabel}</Label>
+                  <Label id="reservation-daterange-label">
+                    {i18n.calendar.reservationModal.dateRangeLabel}
+                  </Label>
                 </ExpandingInfo>
                 <DateRangePickerF
                   bind={dateRange}
@@ -264,6 +266,8 @@ export default React.memo(function ReservationModal({
                   onFocus={(ev) => {
                     scrollIntoViewSoftKeyboard(ev.target, 'start')
                   }}
+                  required
+                  ariaId="reservation-daterange-label"
                 />
 
                 {overlappingClosedHolidayPeriods.length > 0 && (

--- a/frontend/src/lib-components/atoms/form/InputField.tsx
+++ b/frontend/src/lib-components/atoms/form/InputField.tsx
@@ -312,6 +312,8 @@ const InputField = React.memo(function InputField({
         step={step}
         id={id}
         aria-describedby={ariaId}
+        aria-invalid={infoStatus === 'warning'}
+        aria-required={required ?? false}
         required={required ?? false}
         ref={inputRef}
         autoFocus={autoFocus}
@@ -334,7 +336,10 @@ const InputField = React.memo(function InputField({
       )}
       {!!infoText && (
         <InputFieldUnderRow className={classNames(infoStatus)}>
-          <span data-qa={dataQa ? `${dataQa}-info` : undefined}>
+          <span
+            data-qa={dataQa ? `${dataQa}-info` : undefined}
+            role={infoStatus === 'warning' ? 'alert' : undefined}
+          >
             {infoText}
           </span>
           <UnderRowStatusIcon status={info?.status} />

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
@@ -143,7 +143,7 @@ const DateRangePicker = React.memo(function DateRangePicker({
 export default DateRangePicker
 
 export const DatePickerSpacer = React.memo(function DatePickerSpacer() {
-  return <DateInputSpacer>–</DateInputSpacer>
+  return <DateInputSpacer aria-hidden>–</DateInputSpacer>
 })
 
 const DateInputSpacer = styled.div`
@@ -157,6 +157,7 @@ export interface DateRangePickerFProps
   > {
   bind: BoundForm<LocalDateRangeField>
   info?: InputInfo | undefined
+  ariaId?: string
 }
 
 export const DateRangePickerF = React.memo(function DateRangePickerF({
@@ -197,7 +198,10 @@ export const DateRangePickerF = React.memo(function DateRangePickerF({
       />
       {info !== undefined && (!hideErrorsBeforeTouched || touched) ? (
         <InputFieldUnderRow className={classNames(info.status)}>
-          <span>{info.text}</span> <UnderRowStatusIcon status={info.status} />
+          <span role={info.status === 'warning' ? 'alert' : undefined}>
+            {info.text}
+          </span>
+          <UnderRowStatusIcon status={info.status} />
         </InputFieldUnderRow>
       ) : null}
     </div>

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePickerLowLevel.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePickerLowLevel.tsx
@@ -20,6 +20,7 @@ export interface DateRangePickerLowLevelProps
   onChange: (value: [string, string]) => void
   startInfo?: InputInfo
   endInfo?: InputInfo
+  ariaId?: string
 }
 
 export default React.memo(function DateRangePickerLowLevel({
@@ -30,6 +31,7 @@ export default React.memo(function DateRangePickerLowLevel({
   'data-qa': dataQa,
   minDate,
   maxDate,
+  ariaId,
   ...datePickerProps
 }: DateRangePickerLowLevelProps) {
   const startDate = useMemo(() => LocalDate.parseFiOrNull(start), [start])
@@ -68,7 +70,7 @@ export default React.memo(function DateRangePickerLowLevel({
   )
 
   return (
-    <FixedSpaceRow data-qa={dataQa}>
+    <FixedSpaceRow data-qa={dataQa} aria-labelledby={ariaId} role="group">
       <DatePickerLowLevel
         value={start}
         onChange={handleChangeStart}


### PR DESCRIPTION
_Ennen muutosta_

Päivämääräkentän validointivirhe (esim. "Pakollinen tieto") jää ruudunlukijalta huomioimatta.

_Muutoksen jälkeen_

Ruudunlukija lausuu virheen kun validointi tapahtuu. Lisättiin 'alert'-role infoStatuksen ollessa tyyppiä "warning".

Samalla asetettiin daterangepickerin roleksi "group", joka toteuttaa fieldset/legend -yhdistelmän toiminnon ruudunlukijan näkökulmasta.

Lisätty myös semanttiset puutokset aria-required ja aria-invalid.
