### PR TITLE
Korjataan huoltajien käyttöliittymään lukemattomien päätöksien ilmoitusmerkki

### DIFF
--- a/frontend/src/citizen-frontend/navigation/DesktopNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/DesktopNav.tsx
@@ -48,7 +48,11 @@ import {
   DropDownLocalLink,
   LanguageMenu
 } from './shared-components'
-import { useChildrenWithOwnPage, useUnreadChildNotifications } from './utils'
+import {
+  isPersonalDetailsIncomplete,
+  useChildrenWithOwnPage,
+  useUnreadChildNotifications
+} from './utils'
 
 interface Props {
   unreadMessagesCount: number
@@ -323,7 +327,7 @@ const SubNavigationMenu = React.memo(function SubNavigationMenu({
   const dropDownContainerRef = useCloseOnOutsideClick<HTMLDivElement>(() =>
     setOpen(false)
   )
-  const showUserAttentionIndicator = !user.email
+  const showUserAttentionIndicator = isPersonalDetailsIncomplete(user)
   const weakAuth = user.authLevel !== 'STRONG'
   const maybeLockElem = weakAuth && (
     <FontAwesomeIcon icon={faLockAlt} size="xs" />
@@ -346,7 +350,7 @@ const SubNavigationMenu = React.memo(function SubNavigationMenu({
       >
         {t.header.nav.subNavigationMenu}
         <AttentionIndicator
-          toggled={showUserAttentionIndicator}
+          toggled={showUserAttentionIndicator || unreadDecisions > 0}
           position="bottom"
           data-qa="attention-indicator-sub-menu-desktop"
         >

--- a/frontend/src/citizen-frontend/navigation/Header.tsx
+++ b/frontend/src/citizen-frontend/navigation/Header.tsx
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import sumBy from 'lodash/sumBy'
 import React from 'react'
 import { useLocation } from 'react-router'
 import styled from 'styled-components'
@@ -12,9 +11,6 @@ import { desktopMin, desktopMinPx } from 'lib-components/breakpoints'
 import colors from 'lib-customizations/common'
 
 import { useUser } from '../auth/state'
-import { assistanceDecisionUnreadCountsQuery } from '../decisions/assistance-decision-page/queries'
-import { assistanceNeedPreschoolDecisionUnreadCountsQuery } from '../decisions/assistance-decision-page/queries-preschool'
-import { applicationNotificationsQuery } from '../decisions/queries'
 import { unreadMessagesCountQuery } from '../messages/queries'
 
 import CityLogo from './CityLogo'
@@ -22,6 +18,7 @@ import DesktopNav from './DesktopNav'
 import EvakaLogo from './EvakaLogo'
 import { headerHeightDesktop, headerHeightMobile } from './const'
 import { LanguageMenu } from './shared-components'
+import { useUnreadDecisions } from './utils'
 
 export default React.memo(function Header(props: { ariaHidden: boolean }) {
   const loggedIn = useUser() !== undefined
@@ -30,20 +27,7 @@ export default React.memo(function Header(props: { ariaHidden: boolean }) {
     enabled: loggedIn
   })
 
-  const { data: unreadAssistanceNeedDecisionCounts = [] } = useQuery(
-    assistanceDecisionUnreadCountsQuery(),
-    { enabled: loggedIn }
-  )
-
-  const { data: unreadAssistanceNeedPreschoolDecisionCounts = [] } = useQuery(
-    assistanceNeedPreschoolDecisionUnreadCountsQuery(),
-    { enabled: loggedIn }
-  )
-
-  const { data: waitingConfirmationCount = 0 } = useQuery(
-    applicationNotificationsQuery(),
-    { enabled: loggedIn }
-  )
+  const unreadDecisions = useUnreadDecisions()
 
   const location = useLocation()
   const isLoginPage = location.pathname === '/login'
@@ -60,14 +44,7 @@ export default React.memo(function Header(props: { ariaHidden: boolean }) {
         )}
         <DesktopNav
           unreadMessagesCount={unreadMessagesCount ?? 0}
-          unreadDecisions={
-            waitingConfirmationCount +
-            sumBy(unreadAssistanceNeedDecisionCounts, ({ count }) => count) +
-            sumBy(
-              unreadAssistanceNeedPreschoolDecisionCounts,
-              ({ count }) => count
-            )
-          }
+          unreadDecisions={unreadDecisions}
           hideLoginButton={isLoginPage}
         />
       </HeaderContainer>

--- a/frontend/src/citizen-frontend/navigation/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/MobileNav.tsx
@@ -33,7 +33,6 @@ import {
 import ModalAccessibilityWrapper from '../ModalAccessibilityWrapper'
 import { UnwrapResult } from '../async-rendering'
 import { AuthContext, User } from '../auth/state'
-import { applicationNotificationsQuery } from '../decisions/queries'
 import { langs, useLang, useTranslation } from '../localization'
 import { unreadMessagesCountQuery } from '../messages/queries'
 
@@ -49,7 +48,12 @@ import {
   DropDownLink,
   DropDownLocalLink
 } from './shared-components'
-import { useChildrenWithOwnPage, useUnreadChildNotifications } from './utils'
+import {
+  isPersonalDetailsIncomplete,
+  useChildrenWithOwnPage,
+  useUnreadChildNotifications,
+  useUnreadDecisions
+} from './utils'
 
 export default React.memo(function MobileNav() {
   const t = useTranslation()
@@ -61,10 +65,7 @@ export default React.memo(function MobileNav() {
       enabled: loggedIn
     }
   )
-  const { data: unreadDecisions = 0 } = useQuery(
-    applicationNotificationsQuery(),
-    { enabled: loggedIn }
-  )
+  const unreadDecisions = useUnreadDecisions()
 
   const [menuOpen, setMenuOpen] = useState<'children' | 'submenu'>()
   const toggleSubMenu = useCallback(
@@ -119,7 +120,7 @@ export default React.memo(function MobileNav() {
               >
                 <AttentionIndicator
                   toggled={
-                    showUserAttentionIndicator(user) || unreadDecisions > 0
+                    isPersonalDetailsIncomplete(user) || unreadDecisions > 0
                   }
                   position="top"
                   data-qa="attention-indicator-sub-menu-mobile"
@@ -146,8 +147,6 @@ export default React.memo(function MobileNav() {
     </UnwrapResult>
   )
 })
-
-const showUserAttentionIndicator = (user: User) => !user.email
 
 const BottomBar = styled.nav`
   z-index: 25;
@@ -402,7 +401,7 @@ const Menu = React.memo(function Menu({
           onClick={closeMenu}
         >
           {t.header.nav.personalDetails}
-          {showUserAttentionIndicator(user) && (
+          {isPersonalDetailsIncomplete(user) && (
             <CircledChar
               aria-label={t.header.attention}
               data-qa="personal-details-notification"

--- a/frontend/src/citizen-frontend/navigation/utils.ts
+++ b/frontend/src/citizen-frontend/navigation/utils.ts
@@ -3,15 +3,19 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import sum from 'lodash/sum'
+import sumBy from 'lodash/sumBy'
 import { useMemo } from 'react'
 
 import { useQuery } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 
-import { useUser } from '../auth/state'
+import { User, useUser } from '../auth/state'
 import { unreadChildDocumentsCountQuery } from '../child-documents/queries'
 import { childrenQuery } from '../children/queries'
 import { unreadPedagogicalDocumentsCountQuery } from '../children/sections/pedagogical-documents/queries'
+import { assistanceDecisionUnreadCountsQuery } from '../decisions/assistance-decision-page/queries'
+import { assistanceNeedPreschoolDecisionUnreadCountsQuery } from '../decisions/assistance-decision-page/queries-preschool'
+import { applicationNotificationsQuery } from '../decisions/queries'
 
 const empty = {}
 
@@ -57,3 +61,27 @@ export function useChildrenWithOwnPage() {
     )
   }, [data])
 }
+
+export function useUnreadDecisions() {
+  const loggedIn = useUser() !== undefined
+  const { data: unreadDaycareAssistanceDecisionCounts = [] } = useQuery(
+    assistanceDecisionUnreadCountsQuery(),
+    { enabled: loggedIn }
+  )
+  const { data: unreadPreschoolAssistanceDecisionCounts = [] } = useQuery(
+    assistanceNeedPreschoolDecisionUnreadCountsQuery(),
+    { enabled: loggedIn }
+  )
+  const { data: decisionWaitingConfirmationCount = 0 } = useQuery(
+    applicationNotificationsQuery(),
+    { enabled: loggedIn }
+  )
+
+  return (
+    decisionWaitingConfirmationCount +
+    sumBy(unreadDaycareAssistanceDecisionCounts, ({ count }) => count) +
+    sumBy(unreadPreschoolAssistanceDecisionCounts, ({ count }) => count)
+  )
+}
+
+export const isPersonalDetailsIncomplete = (user: User) => !user.email


### PR DESCRIPTION
Hyväksyttävien paikkapäätöksien ja lukemattomien tuen päätöksien ilmoitusmerkki henkilön nimen vieressä toimii tällä hetkellä hieman eri tavalla työpöytä- ja mobiiliresoluutioilla (työpöytä ei näytä ilmoitusmerkkiä ollenkaan ja mobiili ei näytä lukemattomia tuen päätöksiä). Tämä yhtenäistää toteutukset eli jatkossa ilmoitusmerkki näkyy sekä hyväksyttävistä paikkapäätöksistä että lukemattomista tuen päätöksistä kaikilla resoluutioilla.