### PR TITLE
Pedagogisen asiakirjan lataaminen PDF:nä

### DIFF
--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
@@ -47,9 +47,11 @@ import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { H1, H2 } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
+import { faFilePdf } from 'lib-icons'
 import { faExclamationTriangle } from 'lib-icons'
 import { fasCheckCircle, fasExclamationTriangle } from 'lib-icons'
 
+import { API_URL } from '../../api/client'
 import { useTranslation } from '../../state/i18n'
 import { TitleContext, TitleState } from '../../state/title'
 import MetadataSection from '../archive-metadata/MetadataSection'
@@ -65,6 +67,7 @@ import {
   queryKeys,
   updateChildDocumentContentMutation
 } from '../child-information/queries'
+import { FlexRow } from '../common/styled/containers'
 
 import { getNextDocumentStatus, getPrevDocumentStatus } from './statuses'
 
@@ -426,6 +429,32 @@ const ChildDocumentReadViewInner = React.memo(
 
     return (
       <div>
+        {permittedActions.includes('DOWNLOAD') &&
+          document.pdfAvailable &&
+          publishedUpToDate && (
+            <>
+              <Container>
+                <FlexRow justifyContent="flex-end">
+                  <a
+                    href={`${API_URL}/employee/child-documents/${document.id}/pdf`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <FixedSpaceRow spacing="xs" alignItems="center">
+                      <FontAwesomeIcon icon={faFilePdf} />
+                      <span>
+                        {
+                          i18n.childInformation.childDocuments.editor
+                            .downloadPdf
+                        }
+                      </span>
+                    </FixedSpaceRow>
+                  </a>
+                </FlexRow>
+              </Container>
+              <Gap size="xs" />
+            </>
+          )}
         <Container>
           <ContentArea opaque>
             <DocumentBasics document={document} />

--- a/frontend/src/lib-common/generated/api-types/document.ts
+++ b/frontend/src/lib-common/generated/api-types/document.ts
@@ -155,6 +155,7 @@ export interface ChildDocumentDetails {
   child: ChildBasics
   content: DocumentContent
   id: ChildDocumentId
+  pdfAvailable: boolean
   publishedAt: HelsinkiDateTime | null
   publishedContent: DocumentContent | null
   status: DocumentStatus

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -857,6 +857,7 @@ export const fi = {
         publishConfirmTitle: 'Haluatko varmasti julkaista huoltajalle?',
         publishConfirmText:
           'Huoltaja saa nähdäkseen tämänhetkisen version. Tämän jälkeen tekemäsi muutokset eivät näy huoltajalle ennen kuin julkaiset uudelleen.',
+        downloadPdf: 'Lataa PDF-tiedostona',
         goToNextStatus: {
           DRAFT: 'Julkaise luonnos-tilassa',
           PREPARED: 'Julkaise laadittu-tilassa',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerIntegrationTest.kt
@@ -211,6 +211,7 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
                         id = documentId,
                         status = DocumentStatus.DRAFT,
                         publishedAt = null,
+                        pdfAvailable = false,
                         content = DocumentContent(answers = emptyList()),
                         publishedContent = null,
                         child =

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pdfgen/PdfGeneratorTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pdfgen/PdfGeneratorTest.kt
@@ -266,6 +266,7 @@ class PdfGeneratorTest {
                 id = ChildDocumentId(UUID.randomUUID()),
                 status = DocumentStatus.COMPLETED,
                 publishedAt = HelsinkiDateTime.now(),
+                pdfAvailable = false,
                 child =
                     ChildBasics(
                         id = PersonId(UUID.randomUUID()),

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocument.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocument.kt
@@ -145,6 +145,7 @@ data class ChildDocumentDetails(
     val id: ChildDocumentId,
     val status: DocumentStatus,
     val publishedAt: HelsinkiDateTime?,
+    val pdfAvailable: Boolean,
     @Json val content: DocumentContent,
     @Json val publishedContent: DocumentContent?,
     @Nested("child") val child: ChildBasics,

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
@@ -56,6 +56,7 @@ SELECT
     cd.id,
     cd.status,
     cd.published_at,
+    cd.document_key IS NOT NULL AS pdf_available,
     cd.content,
     cd.published_content,
     p.id as child_id,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -2296,7 +2296,21 @@ sealed interface Action {
                 .inPlacementGroupOfDuplicateChildOfHojksChildDocument(),
         ),
         READ_METADATA(HasGlobalRole(ADMIN)),
-        DOWNLOAD(HasGlobalRole(ADMIN)),
+        DOWNLOAD(
+            HasGlobalRole(ADMIN),
+            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
+                .withUnitFeatures(PilotFeature.VASU_AND_PEDADOC)
+                .inPlacementUnitOfChildOfChildDocument(),
+            HasGroupRole(STAFF)
+                .withUnitFeatures(PilotFeature.VASU_AND_PEDADOC)
+                .inPlacementGroupOfChildOfChildDocument(),
+            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
+                .withUnitFeatures(PilotFeature.VASU_AND_PEDADOC)
+                .inPlacementUnitOfDuplicateChildOfHojksChildDocument(),
+            HasGroupRole(STAFF)
+                .withUnitFeatures(PilotFeature.VASU_AND_PEDADOC)
+                .inPlacementGroupOfDuplicateChildOfHojksChildDocument(),
+        ),
         UPDATE(
             HasGlobalRole(ADMIN),
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)


### PR DESCRIPTION
Työntekijät jotka voivat lukea pedagogisen asiakirjan voivat myös ladata sen pdf:nä silloin kun viimeisimmät muutokset on julkaistu ja pdf on ehditty generoida.

<img width="1324" alt="Screenshot 2024-12-19 at 12 26 45" src="https://github.com/user-attachments/assets/8a8766a9-820b-4682-8eb9-de9b8ff72c69" />
