### PR TITLE
Hakemusten lähetyksen validointi ruudunlukijalla

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
@@ -39,6 +39,7 @@ export default React.memo(function UnitsSubSection({
   const t = useTranslation()
   const [displayFinnish, setDisplayFinnish] = useState(true)
   const [displaySwedish, setDisplaySwedish] = useState(false)
+  const [isUnitSelectionInvalid, setIsUnitSelectionInvalid] = useState(false)
 
   const { data: units = null } = useQuery(
     applicationUnitsQuery(
@@ -146,6 +147,11 @@ export default React.memo(function UnitsSubSection({
                     }))
                   }
                 }}
+                onBlur={() => {
+                  setIsUnitSelectionInvalid(
+                    formData.preferredUnits.length === 0
+                  )
+                }}
                 maxSelected={maxUnits}
                 isClearable={false}
                 placeholder={
@@ -177,6 +183,7 @@ export default React.memo(function UnitsSubSection({
               </Label>
               <Gap size="xs" />
               {!verificationRequested &&
+                !isUnitSelectionInvalid &&
                 formData.preferredUnits.length === 0 && (
                   <Info>
                     {
@@ -185,14 +192,15 @@ export default React.memo(function UnitsSubSection({
                     }
                   </Info>
                 )}
-              {verificationRequested && errors.preferredUnits?.arrayErrors && (
-                <AlertBox
-                  message={
-                    t.validationErrors[errors.preferredUnits.arrayErrors]
-                  }
-                  thin
-                />
-              )}
+              {(verificationRequested || isUnitSelectionInvalid) &&
+                errors.preferredUnits?.arrayErrors && (
+                  <AlertBox
+                    message={
+                      t.validationErrors[errors.preferredUnits.arrayErrors]
+                    }
+                    thin
+                  />
+                )}
               <FixedSpaceColumn spacing="s">
                 {units
                   ? formData.preferredUnits

--- a/frontend/src/lib-components/atoms/form/MultiSelect.tsx
+++ b/frontend/src/lib-components/atoms/form/MultiSelect.tsx
@@ -23,6 +23,7 @@ interface MultiSelectProps<T> {
   getOptionLabel: (value: T) => string
   getOptionSecondaryText?: (value: T) => string
   onChange: (selected: T[]) => void
+  onBlur?: (ev: React.FocusEvent) => void
   maxSelected?: number
   placeholder: string
   noOptionsMessage?: string
@@ -41,6 +42,7 @@ function MultiSelect<T>({
   getOptionLabel,
   getOptionSecondaryText,
   onChange,
+  onBlur,
   closeMenuOnSelect,
   noOptionsMessage,
   maxSelected,
@@ -112,6 +114,7 @@ function MultiSelect<T>({
             scrollIntoViewSoftKeyboard(parentContainer, 'start')
           }
         }}
+        onBlur={onBlur}
         options={[
           {
             options: value

--- a/frontend/src/lib-components/molecules/MessageBoxes.tsx
+++ b/frontend/src/lib-components/molecules/MessageBoxes.tsx
@@ -60,7 +60,10 @@ export interface MessageBoxProps {
   thin?: boolean
   noMargin?: boolean
   'data-qa'?: string
+  role?: MessageAriaRole
 }
+
+type MessageAriaRole = 'alert' | 'status'
 
 export const MessageBox = React.memo(function MessageBox({
   title,
@@ -70,6 +73,7 @@ export const MessageBox = React.memo(function MessageBox({
   width,
   thin,
   noMargin,
+  role = 'status',
   ...props
 }: MessageBoxProps) {
   if (!title && !message) {
@@ -88,7 +92,7 @@ export const MessageBox = React.memo(function MessageBox({
         <div className="icon-wrapper">
           <FontAwesomeIcon icon={icon} size="1x" color={color} inverse />
         </div>
-        <div>
+        <div role={role}>
           {!!title && <span className="message-title">{title}</span>}
           {!!title && !!message && <Gap size={thin ? 'xxs' : 's'} />}
           {!!message &&
@@ -164,6 +168,7 @@ export const AlertBox = React.memo(function AlertBox({
       thin={thin}
       noMargin={noMargin}
       data-qa={props['data-qa']}
+      role="alert"
     />
   )
 })


### PR DESCRIPTION
_Ennen muutosta_

Ruudunlukija ei reagoi eri hakemusten validointivirheisiin lähetettäessä/tarkistettaessa. 

_Muutoksen jälkeen_

Ruudunlukija listaa validointivirheet. Lisättiin role-attribuutti MessageBoxesin wrapperiin. Lisätty myös pakollisen hakutoiveen validointi onBlurilla, mikäli käyttäjä navigoi osion läpi ilman valintaa.

<img width="1054" alt="Screenshot 2024-12-20 at 15 15 19" src="https://github.com/user-attachments/assets/c201bf0c-7846-4388-ad63-feae1caa74d0" />

