### PR TITLE
Lisätään MA003-suodatin Varda-lapsivirheet -raportille

### DIFF
--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -8,7 +8,7 @@ import { ApplicationStatus } from 'lib-common/generated/api-types/application'
 import LocalDate from 'lib-common/local-date'
 
 import { captureTextualDownload } from '../../browser'
-import { waitUntilEqual, waitUntilTrue } from '../../utils'
+import { waitUntilEqual } from '../../utils'
 import {
   Checkbox,
   Combobox,
@@ -74,11 +74,6 @@ export default class ReportsPage {
   async openHolidayPeriodAttendanceReport() {
     await this.page.findByDataQa('report-holiday-period-attendance').click()
     return new HolidayPeriodAttendanceReport(this.page)
-  }
-
-  async openVardaErrorsReport() {
-    await this.page.findByDataQa('report-varda-child-errors').click()
-    return new VardaErrorsReport(this.page)
   }
 
   async openStartingPlacementsReport() {
@@ -415,35 +410,6 @@ export class ManualDuplicationReport {
           .assertTextEquals(data.preschoolUnitName)
       })
     )
-  }
-}
-
-export class VardaErrorsReport {
-  #errorsTable: Element
-  #errorRows: ElementCollection
-
-  constructor(private page: Page) {
-    this.#errorsTable = page.findByDataQa('varda-errors-table')
-    this.#errorRows = page.findAll('[data-qa="varda-error-row"]')
-  }
-
-  #errors = (childId: string) => this.page.findByDataQa(`errors-${childId}`)
-  #resetChild = (childId: string) =>
-    this.page.findByDataQa(`reset-button-${childId}`)
-
-  async assertErrorsContains(childId: string, expected: string) {
-    await waitUntilTrue(async () =>
-      ((await this.#errors(childId).text) || '').includes(expected)
-    )
-  }
-
-  async resetChild(childId: string) {
-    await this.#resetChild(childId).click()
-  }
-
-  async assertErrorRowCount(expected: number) {
-    await waitUntilTrue(() => this.#errorsTable.visible)
-    await waitUntilEqual(() => this.#errorRows.count(), expected)
   }
 }
 

--- a/frontend/src/employee-frontend/components/reports/VardaChildErrors.tsx
+++ b/frontend/src/employee-frontend/components/reports/VardaChildErrors.tsx
@@ -14,20 +14,13 @@ import Title from 'lib-components/atoms/Title'
 import { MutateButton } from 'lib-components/atoms/buttons/MutateButton'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
-import { Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
+import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { Gap } from 'lib-components/white-space'
 
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
 
-import { TableScrollable } from './common'
 import { resetVardaChildMutation, vardaChildErrorsQuery } from './queries'
-
-const FlatList = styled.ul`
-  list-style: none;
-  padding-left: 0;
-  margin-top: 0;
-`
 
 export default React.memo(function VardaChildErrors() {
   const { i18n } = useTranslation()
@@ -44,7 +37,7 @@ export default React.memo(function VardaChildErrors() {
         <Gap size="xxs" />
         {renderResult(vardaErrorsResult, (rows) => (
           <>
-            <TableScrollable data-qa="varda-errors-table">
+            <Table data-qa="varda-errors-table">
               <Thead>
                 <Tr>
                   <Th>{i18n.reports.vardaChildErrors.age}</Th>
@@ -99,13 +92,19 @@ export default React.memo(function VardaChildErrors() {
                   </Tr>
                 ))}
               </Tbody>
-            </TableScrollable>
+            </Table>
           </>
         ))}
       </ContentArea>
     </Container>
   )
 })
+
+const FlatList = styled.ul`
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0;
+`
 
 const BreakAll = styled.span`
   word-break: break-all;

--- a/frontend/src/employee-frontend/components/reports/VardaChildErrors.tsx
+++ b/frontend/src/employee-frontend/components/reports/VardaChildErrors.tsx
@@ -43,14 +43,13 @@ export default React.memo(function VardaChildErrors() {
                   <Th>{i18n.reports.vardaChildErrors.age}</Th>
                   <Th>{i18n.reports.vardaChildErrors.child}</Th>
                   <Th>{i18n.reports.vardaChildErrors.error}</Th>
-                  <Th>{i18n.reports.vardaChildErrors.serviceNeed}</Th>
                   <Th>{i18n.reports.vardaChildErrors.updated}</Th>
-                  <Th>{i18n.reports.vardaChildErrors.childLastReset}</Th>
+                  <Th />
                 </Tr>
               </Thead>
               <Tbody>
                 {rows.map((row: VardaChildErrorReportRow) => (
-                  <Tr data-qa="varda-error-row" key={row.serviceNeedId}>
+                  <Tr data-qa="varda-error-row" key={row.childId}>
                     <Td data-qa={`age-${row.childId}`}>
                       {ageInDays(row.created)}
                     </Td>
@@ -61,33 +60,19 @@ export default React.memo(function VardaChildErrors() {
                     </Td>
 
                     <Td data-qa={`errors-${row.childId}`}>
-                      <BreakAll>{row.errors.join('\n')}</BreakAll>
-                    </Td>
-                    <Td>
-                      <FlatList>
-                        <li>{row.serviceNeedOptionName}</li>
-                        <li>{row.serviceNeedValidity?.format()}</li>
-                        <li>{row.serviceNeedId}</li>
-                      </FlatList>
+                      <BreakAll>{row.error}</BreakAll>
                     </Td>
                     <Td data-qa={`updated-${row.childId}`}>
                       {row.updated.format()}
                     </Td>
                     <Td data-qa={`last-reset-${row.childId}`}>
-                      <>
-                        <span>
-                          {row.resetTimeStamp
-                            ? row.resetTimeStamp.format()
-                            : ''}
-                        </span>
-                        <MutateButton
-                          primary
-                          text={i18n.reports.vardaChildErrors.resetChild}
-                          mutation={resetVardaChildMutation}
-                          onClick={() => ({ childId: row.childId })}
-                          data-qa={`reset-button-${row.childId}`}
-                        />
-                      </>
+                      <MutateButton
+                        primary
+                        text={i18n.reports.vardaChildErrors.updateChild}
+                        mutation={resetVardaChildMutation}
+                        onClick={() => ({ childId: row.childId })}
+                        data-qa={`reset-button-${row.childId}`}
+                      />
                     </Td>
                   </Tr>
                 ))}
@@ -99,12 +84,6 @@ export default React.memo(function VardaChildErrors() {
     </Container>
   )
 })
-
-const FlatList = styled.ul`
-  list-style: none;
-  padding-left: 0;
-  margin-top: 0;
-`
 
 const BreakAll = styled.span`
   word-break: break-all;

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -29,7 +29,6 @@ import { PlacementId } from './shared'
 import { PlacementType } from './placement'
 import { PreschoolAssistanceLevel } from './assistance'
 import { ProviderType } from './daycare'
-import { ServiceNeedId } from './shared'
 import { ServiceNeedOption } from './application'
 import { TitaniaErrorsId } from './shared'
 import { UUID } from '../../types'
@@ -1042,11 +1041,7 @@ export interface UnitsReportRow {
 export interface VardaChildErrorReportRow {
   childId: PersonId
   created: HelsinkiDateTime
-  errors: string[]
-  resetTimeStamp: HelsinkiDateTime | null
-  serviceNeedId: ServiceNeedId | null
-  serviceNeedOptionName: string | null
-  serviceNeedValidity: FiniteDateRange | null
+  error: string
   updated: HelsinkiDateTime
 }
 
@@ -1322,8 +1317,6 @@ export function deserializeJsonVardaChildErrorReportRow(json: JsonOf<VardaChildE
   return {
     ...json,
     created: HelsinkiDateTime.parseIso(json.created),
-    resetTimeStamp: (json.resetTimeStamp != null) ? HelsinkiDateTime.parseIso(json.resetTimeStamp) : null,
-    serviceNeedValidity: (json.serviceNeedValidity != null) ? FiniteDateRange.parseJson(json.serviceNeedValidity) : null,
     updated: HelsinkiDateTime.parseIso(json.updated)
   }
 }

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4120,18 +4120,12 @@ export const fi = {
     },
     vardaChildErrors: {
       title: 'Varda-lapsivirheet',
-      vardaUpdateButton: 'Aloita päivitys',
-      vardaResetButton: 'Aloita uudelleenvienti',
       description: 'Varda-lasten päivityksissä tapahtuneet virheet',
       updated: 'Päivitetty viimeksi',
       age: 'Ikä (päivää)',
       child: 'Lapsi',
-      serviceNeed: 'Palveluntarve',
       error: 'Virhe',
-      childLastReset: 'Uudelleenviety viimeksi',
-      childMarkedForRest: 'Lapsen tiedot nollataan seuraavalla ajolla',
-      resetChild: 'Uudelleenvie',
-      updating: 'Päivittää'
+      updateChild: 'Uudelleenvie'
     },
     vardaUnitErrors: {
       title: 'Varda-yksikkövirheet',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4120,6 +4120,11 @@ export const fi = {
     },
     vardaChildErrors: {
       title: 'Varda-lapsivirheet',
+      ma003: {
+        include: 'Sisällytä MA003-virheet',
+        exclude: 'Piilota MA003-virheet',
+        only: 'Näytä vain MA003-virheet'
+      },
       description: 'Varda-lasten päivityksissä tapahtuneet virheet',
       updated: 'Päivitetty viimeksi',
       age: 'Ikä (päivää)',

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/VardaErrorsReport.kt
@@ -7,11 +7,9 @@ package fi.espoo.evaka.reports
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
-import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.EvakaClock
-import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -68,14 +66,10 @@ private fun Database.Read.getVardaChildErrors(): List<VardaChildErrorReportRow> 
             sql(
                 """
 SELECT
-    NULL AS service_need_id,
-    NULL AS service_need_validity,
-    NULL AS service_need_option_name,
     child_id,
     errored_at AS updated,
     coalesce(last_success_at, created_at) AS created,
-    ARRAY[error] AS errors,
-    NULL AS reset_timestamp
+    error
 FROM varda_state
 WHERE errored_at IS NOT NULL
 ORDER BY updated DESC
@@ -85,14 +79,10 @@ ORDER BY updated DESC
         .toList<VardaChildErrorReportRow>()
 
 data class VardaChildErrorReportRow(
-    val serviceNeedId: ServiceNeedId?,
-    val serviceNeedValidity: FiniteDateRange?,
-    val serviceNeedOptionName: String?,
     val childId: ChildId,
     val updated: HelsinkiDateTime,
     val created: HelsinkiDateTime,
-    val errors: List<String>,
-    val resetTimeStamp: HelsinkiDateTime?,
+    val error: String,
 )
 
 private fun Database.Read.getVardaUnitErrors(): List<VardaUnitErrorReportRow> =


### PR DESCRIPTION
`MA003` on Varda-virheistä vähiten hyödyllinen, koska se korjautuu yleensä itsestään kunhan Varda hakee uudet tiedot VTJ:stä.

<img width="895" alt="Screenshot 2024-12-31 at 12 43 40" src="https://github.com/user-attachments/assets/fc5969e8-7778-40b4-b43b-88b1f91165b7" />
