### PR TITLE
Lisätään esiopetuksen tuen päätökselle vastuuvapauslauseke

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
@@ -833,7 +833,11 @@ const DecisionEditor = React.memo(function DecisionEditor({
                 </P>
               )}
               <H3 noMargin>{t.jurisdiction}</H3>
-              <P noMargin>{t.jurisdictionText}</P>
+              {typeof t.jurisdictionText === 'string' ? (
+                <P noMargin>{t.jurisdictionText}</P>
+              ) : (
+                t.jurisdictionText
+              )}
             </SectionSpacer>
 
             <SectionSpacer>

--- a/frontend/src/lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly.tsx
+++ b/frontend/src/lib-components/assistance-need-decision/AssistanceNeedPreschoolDecisionReadOnly.tsx
@@ -104,7 +104,8 @@ interface ViewTranslations {
   legalInstructionsText: string
   legalInstructionsTextExtendedCompulsoryEducation: string
   jurisdiction: string
-  jurisdictionText: string
+  jurisdictionText: string | React.ReactNode
+  disclaimer: string | null
   appealInstructionsTitle: string
   appealInstructions: React.JSX.Element
 }
@@ -346,7 +347,11 @@ export default React.memo(function DecisionFormReadView({
               </P>
             )}
             <H3 noMargin>{t.jurisdiction}</H3>
-            <P noMargin>{t.jurisdictionText}</P>
+            {typeof t.jurisdictionText === 'string' ? (
+              <P noMargin>{t.jurisdictionText}</P>
+            ) : (
+              t.jurisdictionText
+            )}
           </SectionSpacer>
 
           <SectionSpacer>
@@ -381,6 +386,12 @@ export default React.memo(function DecisionFormReadView({
               </span>
             </LabeledValue>
           </SectionSpacer>
+
+          {t.disclaimer !== null && (
+            <SectionSpacer>
+              <P noMargin>{t.disclaimer}</P>
+            </SectionSpacer>
+          )}
         </FixedSpaceColumn>
       </ContentArea>
 

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -1676,7 +1676,10 @@ export default {
         'Oppivelvollisuulaki 2 §',
       jurisdiction: 'Toimivalta',
       jurisdictionText:
-        'Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 1 kohta',
+        'Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 1 kohta' as
+          | string
+          | React.ReactNode,
+      disclaimer: null as string | null,
       appealInstructionsTitle: 'Oikaisuvaatimusohje',
       appealInstructions: (
         <>

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1676,6 +1676,7 @@ const sv: Translations = {
       jurisdiction: 'Befogenhet',
       jurisdictionText:
         'Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 1 kohta',
+      disclaimer: null,
       appealInstructionsTitle: 'Anvisning om begäran om omprövning',
       appealInstructions: (
         <>

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -1000,7 +1000,10 @@ export const fi = {
         'Oppivelvollisuulaki 2 §',
       jurisdiction: 'Toimivalta',
       jurisdictionText:
-        'Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 1 kohta',
+        'Delegointipäätös suomenkielisen varhaiskasvatuksen sekä kasvun ja oppimisen toimialan esikunnan viranhaltijoiden ratkaisuvallasta A osa 3 § 1 kohta' as
+          | string
+          | React.ReactNode,
+      disclaimer: null as string | null,
       appealInstructionsTitle: 'Oikaisuvaatimusohje',
       appealInstructions: (
         <>


### PR DESCRIPTION
Vastaava kuin varhaiskasvatuksen tuen päätöksellä. Espoon PDF:ssä tekstiä ei näytä olevan, joten jätetty oletuksena tyhjäksi. Muut kunnat voivat sen lisätä halutessaan. Esim. Tampereella teksti on "Perusopetuslain 17 §:n mukaan tämä päätös voidaan panna täytäntöön muutoksenhausta huolimatta.".

Muokattu samalla toimivalta-tekstin tyyppi tukemaan esim. rivinvaihtoja.