### PR TITLE
Uusi viesti -dialogin pakolliset kentät

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -314,6 +314,7 @@ export default React.memo(function MessageEditor({
                     : name
                 }
                 data-qa="select-recipient"
+                required
               />
             </label>
 
@@ -373,6 +374,7 @@ export default React.memo(function MessageEditor({
                   setMessage((message) => ({ ...message, title: updated }))
                 }
                 data-qa="input-title"
+                required
               />
             </label>
 
@@ -390,6 +392,7 @@ export default React.memo(function MessageEditor({
                   }))
                 }
                 data-qa="input-content"
+                required
               />
             </TextAreaLabel>
 

--- a/frontend/src/lib-components/atoms/form/MultiSelect.tsx
+++ b/frontend/src/lib-components/atoms/form/MultiSelect.tsx
@@ -33,6 +33,7 @@ interface MultiSelectProps<T> {
   inputId?: Props<never>['inputId']
   'data-qa'?: string
   autoFocus?: boolean
+  required?: boolean
 }
 
 function MultiSelect<T>({
@@ -48,6 +49,7 @@ function MultiSelect<T>({
   maxSelected,
   showValuesInInput: showSelectedValues,
   autoFocus,
+  required,
   ...props
 }: MultiSelectProps<T>) {
   const { colors } = useTheme()
@@ -96,6 +98,7 @@ function MultiSelect<T>({
           })
         }}
         autoFocus={autoFocus}
+        required={required}
         isMulti
         isSearchable={true}
         hideSelectedOptions={false}


### PR DESCRIPTION
Lisätty required -attribuutit kuntalaisen viestieditorin otsikko- ja viestikenttiin, jotta ruudunlukija osaa myös listata ne pakollisina.

