### PR TITLE
Tulotiedot: poimitaan viimeksi muokattu päivämäärä oikeasta tietueesta

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
@@ -260,7 +260,7 @@ fun Row.toIncome(
                 column("created_by_name"),
                 column("created_by_type"),
             ),
-        modifiedAt = column("updated_at"),
+        modifiedAt = column("modified_at"),
         modifiedBy =
             EvakaUser(
                 column("modified_by_id"),


### PR DESCRIPTION
## Ennen tätä muutosta
Näytettiin tekninen `updated_at` aikaleima
## Tämän muutoksen jälkeen
Näytetään aikaleima `modified_at` sarakkeesta