### PR TITLE
Kuntalainen: Viestieditorin responsiivisuusparannus

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -507,7 +507,6 @@ const FormArea = styled.div`
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  position: relative;
 `
 
 const TextAreaLabel = styled.label`

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -192,6 +192,14 @@ export default React.memo(function MessageEditor({
 
   const chipGroupContainerRef = React.useRef<HTMLDivElement>(null)
 
+  const ChipContainer = styled(FixedSpaceFlexWrap)`
+    margin-bottom: -${defaultMargins.xxs};
+
+    > * {
+      margin-bottom: ${defaultMargins.xxs};
+    }
+  `
+
   return (
     <ModalAccessibilityWrapper>
       <FocusLock>
@@ -223,7 +231,7 @@ export default React.memo(function MessageEditor({
                 <label>
                   <Bold>{required(i18n.messages.messageEditor.children)}</Bold>
                   <FixedSpaceColumn>
-                    <FixedSpaceFlexWrap
+                    <ChipContainer
                       horizontalSpacing="xs"
                       ref={chipGroupContainerRef}
                     >
@@ -278,7 +286,7 @@ export default React.memo(function MessageEditor({
                             />
                           </div>
                         ))}
-                    </FixedSpaceFlexWrap>
+                    </ChipContainer>
                     {isChildSelectionTouched &&
                       message.children.length === 0 && (
                         <ErrorMessageBox
@@ -421,23 +429,23 @@ export default React.memo(function MessageEditor({
                 {i18n.messages.messageEditor.messageSendError}
               </ErrorMessage>
             )}
-            <BottomRow>
-              <LegacyButton
-                text={i18n.messages.messageEditor.discard}
-                onClick={onClose}
-              />
-              <span />
-              <AsyncButton
-                primary
-                text={i18n.messages.messageEditor.send}
-                disabled={!sendEnabled}
-                onClick={send}
-                onSuccess={onSuccess}
-                onFailure={onFailure}
-                data-qa="send-message-btn"
-              />
-            </BottomRow>
           </FormArea>
+          <BottomRow>
+            <LegacyButton
+              text={i18n.messages.messageEditor.discard}
+              onClick={onClose}
+            />
+            <span />
+            <AsyncButton
+              primary
+              text={i18n.messages.messageEditor.send}
+              disabled={!sendEnabled}
+              onClick={send}
+              onSuccess={onSuccess}
+              onFailure={onFailure}
+              data-qa="send-message-btn"
+            />
+          </BottomRow>
         </Container>
       </FocusLock>
     </ModalAccessibilityWrapper>
@@ -447,8 +455,8 @@ export default React.memo(function MessageEditor({
 const Container = styled.div`
   width: 100%;
   max-width: 680px;
-  height: 100%;
-  max-height: 700px;
+  height: calc(100% - 32px);
+  margin: ${defaultMargins.s};
   position: fixed;
   z-index: 100;
   right: 0;
@@ -466,6 +474,7 @@ const Container = styled.div`
     top: 0;
     left: 0;
     overflow-y: scroll;
+    margin: 0;
   }
 `
 
@@ -497,6 +506,8 @@ const FormArea = styled.div`
   padding: ${defaultMargins.m};
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
+  position: relative;
 `
 
 const TextAreaLabel = styled.label`
@@ -509,7 +520,7 @@ const StyledTextArea = styled.textarea`
   width: 100%;
   resize: none;
   flex-grow: 1;
-  min-height: 100px;
+  min-height: 200px;
 `
 
 const BottomRow = styled.div`
@@ -517,6 +528,12 @@ const BottomRow = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  position: sticky;
+  bottom: 0;
+  background-color: ${colors.grayscale.g0};
+  padding: ${defaultMargins.m};
+  margin-top: auto;
+  border-top: 1px solid ${colors.grayscale.g35};
 `
 
 const SecondaryRecipients = styled.span`


### PR DESCRIPTION
## Parannuksia "Uusi viesti"-modaalin esponsiivisuuteen.

## Ennen tätä muutosta
<img width="1178" alt="Screenshot 2025-01-10 at 10 28 21" src="https://github.com/user-attachments/assets/3defa57b-d356-41f7-af9a-e764fdd26a41" />

Napit jää piiloon desktop-näkymässä

<img width="360" alt="Screenshot 2025-01-10 at 10 57 30" src="https://github.com/user-attachments/assets/e64251d6-0c15-4803-9934-5c2269795d31" />

Mobiili versio

## Tämän muutoksen jälkeen
<img width="1179" alt="Screenshot 2025-01-10 at 10 29 00" src="https://github.com/user-attachments/assets/cfe898ea-ac42-4334-9957-d36574d3c111" />

Napit aina näkyvissä desktop versiossa

<img width="1413" alt="Screenshot 2025-01-10 at 10 29 23" src="https://github.com/user-attachments/assets/133ab6fa-e207-4fc9-b161-5fdeac02bb39" />

Jos käytössä korkeampi resoluutio, viestimodaali täyttää koko sivun (kuten henkilökunnan puolella)

<img width="364" alt="Screenshot 2025-01-10 at 10 57 59" src="https://github.com/user-attachments/assets/6e20a3d4-1286-4a65-ae8c-0d51f67cc487" />

Mobiili muutosten jälkeen