### PR TITLE
Henkilökunta: Korjaus poissaolokoosteen tooltippiin

### DIFF
--- a/frontend/src/employee-frontend/components/invoice/AbsencesModal.tsx
+++ b/frontend/src/employee-frontend/components/invoice/AbsencesModal.tsx
@@ -83,7 +83,6 @@ export default React.memo(function AbsencesModal({ child, date }: Props) {
 
   return (
     <InfoModal
-      data-qa="backup-care-group-modal"
       title={i18n.absences.modal.absenceSummaryTitle}
       icon={faAbacus}
       close={() => clearUiMode()}
@@ -141,7 +140,7 @@ export default React.memo(function AbsencesModal({ child, date }: Props) {
                         'BILLABLE',
                         lang
                       )}
-                      position="right"
+                      position="left"
                     >
                       {calculateAbsences(
                         absences,
@@ -192,5 +191,15 @@ function createTooltipText(
         abs.absenceType === absenceType && abs.category === category
     )
     .map(({ date }) => date.format('EEEEEE dd.MM.yyyy', lang))
-  return absencesList.join('<br />')
+
+  return (
+    <div>
+      {absencesList.map((date, index) => (
+        <React.Fragment key={index}>
+          {date}
+          {index < absencesList.length - 1 && <br />}
+        </React.Fragment>
+      ))}
+    </div>
+  )
 }


### PR DESCRIPTION
## Ennen tätä muutosta
Laskun poissaolokoosteen tooltipissä näkyi HTML-koodia
![image](https://github.com/user-attachments/assets/feec4e8d-5fca-493b-9a11-3a45115df5c5)

## Tämän muutoksen jälkeen
Tooltipin rivitys toimii oikein, eikä HTML-koodi ole näkyvissä käyttäjälle
![image](https://github.com/user-attachments/assets/8767a610-c259-4ea2-a4a7-1a3a53a8485f)
