### PR TITLE
Katkaistaan myös määräaikainen päällekkäinen tulotieto automaattisesti uutta luotaessa

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/income.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/income.spec.ts
@@ -197,15 +197,15 @@ describe('Income', () => {
 
   it('Overlapping incomes error', async () => {
     await incomesSection.openNewIncomeForm()
-    await incomesSection.fillIncomeStartDate('1.1.2020')
+    await incomesSection.fillIncomeStartDate('1.2.2020')
     await incomesSection.fillIncomeEndDate('31.3.2020')
     await incomesSection.confirmRetroactive.check()
     await incomesSection.chooseIncomeEffect('MAX_FEE_ACCEPTED')
     await incomesSection.save()
 
     await incomesSection.openNewIncomeForm()
-    await incomesSection.fillIncomeStartDate('1.2.2020')
-    await incomesSection.fillIncomeEndDate('30.4.2020')
+    await incomesSection.fillIncomeStartDate('1.1.2020')
+    await incomesSection.fillIncomeEndDate('15.2.2020')
     await incomesSection.confirmRetroactive.check()
     await incomesSection.chooseIncomeEffect('MAX_FEE_ACCEPTED')
     await incomesSection.saveFailing()
@@ -214,6 +214,34 @@ describe('Income', () => {
     await errorModal.ensureText(
       'Ajanjaksolle on jo tallennettu tulotietoja! Tarkista tulotietojen voimassaoloajat.'
     )
+  })
+
+  it('Overlapping income may be automatically ended', async () => {
+    await incomesSection.openNewIncomeForm()
+    await incomesSection.fillIncomeStartDate('1.1.2020')
+    await incomesSection.fillIncomeEndDate('31.3.2020')
+    await incomesSection.confirmRetroactive.check()
+    await incomesSection.chooseIncomeEffect('MAX_FEE_ACCEPTED')
+    await incomesSection.save()
+
+    await incomesSection.openNewIncomeForm()
+    await incomesSection.fillIncomeStartDate('1.2.2020')
+    await incomesSection.fillIncomeEndDate('15.6.2020')
+    await incomesSection.confirmRetroactive.check()
+    await incomesSection.chooseIncomeEffect('MAX_FEE_ACCEPTED')
+    await incomesSection.save()
+
+    await waitUntilEqual(() => incomesSection.incomeListItemCount(), 2)
+    await incomesSection.incomeListItems
+      .nth(0)
+      .assertText((s) =>
+        s.includes('Tulotiedot ajalle 01.02.2020 - 15.06.2020')
+      )
+    await incomesSection.incomeListItems
+      .nth(1)
+      .assertText((s) =>
+        s.includes('Tulotiedot ajalle 01.01.2020 - 31.01.2020')
+      )
   })
 
   it('Attachments can be added.', async () => {

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/controller/IncomeController.kt
@@ -9,10 +9,10 @@ import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.attachment.AttachmentParent
 import fi.espoo.evaka.attachment.associateOrphanAttachments
 import fi.espoo.evaka.invoicing.data.deleteIncome
+import fi.espoo.evaka.invoicing.data.endEarlierOverlappingIncome
 import fi.espoo.evaka.invoicing.data.getIncome
 import fi.espoo.evaka.invoicing.data.getIncomesForPerson
 import fi.espoo.evaka.invoicing.data.insertIncome
-import fi.espoo.evaka.invoicing.data.splitEarlierIncome
 import fi.espoo.evaka.invoicing.data.updateIncome
 import fi.espoo.evaka.invoicing.domain.Income
 import fi.espoo.evaka.invoicing.domain.IncomeCoefficient
@@ -129,7 +129,12 @@ class IncomeController(
                     val now = clock.now()
                     val incomeTypes = incomeTypesProvider.get()
                     val validIncome = validateIncome(income, incomeTypes)
-                    tx.splitEarlierIncome(now, validIncome.personId, period, user.evakaUserId)
+                    tx.endEarlierOverlappingIncome(
+                        now,
+                        validIncome.personId,
+                        period,
+                        user.evakaUserId,
+                    )
                     val id = tx.insertIncome(now, validIncome, user.evakaUserId)
                     tx.associateOrphanAttachments(
                         user.evakaUserId,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/IncomeQueries.kt
@@ -214,7 +214,7 @@ fun Database.Transaction.deleteIncome(incomeId: IncomeId) {
     handlingExceptions { update.execute() }
 }
 
-fun Database.Transaction.splitEarlierIncome(
+fun Database.Transaction.endEarlierOverlappingIncome(
     now: HelsinkiDateTime,
     personId: PersonId,
     period: DateRange,
@@ -230,7 +230,7 @@ fun Database.Transaction.splitEarlierIncome(
             WHERE
                 person_id = ${bind(personId)}
                 AND valid_from < ${bind(period.start)}
-                AND valid_to IS NULL
+                AND (valid_to IS NULL OR valid_to >= ${bind(period.start)})
             """
         )
     }


### PR DESCRIPTION
Ennen katkaisu tehtiin vain toistaiseksi voimassaoleville. 