### PR TITLE
Kuntalainen: Kaikkien viestin vastaanottajien pitää olla sallittuja kaikille valituille lapsille

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -165,7 +165,8 @@ export default React.memo(function MessageEditor({
       .filter(
         (account) =>
           selectedChildrenInSameUnit &&
-          message.children.some(
+          message.children.length > 0 &&
+          message.children.every(
             (childId) =>
               receiverOptions.childrenToMessageAccounts[
                 childId

--- a/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-messages.ts
@@ -257,6 +257,11 @@ export class CitizenMessageEditor extends Element {
     await this.#recipientSelection.assertNoOptions()
   }
 
+  async assertRecipients(recipients: string[]) {
+    await this.#recipientSelection.click()
+    await this.#recipientSelection.assertOptions(recipients)
+  }
+
   async fillMessage(title: string, content: string) {
     await this.title.fill(title)
     await this.content.fill(content)

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -527,6 +527,16 @@ export class MultiSelect extends Element {
   async assertNoOptions() {
     await this.findByDataQa('no-options').waitUntilVisible()
   }
+
+  async assertOptions(options: string[]) {
+    await waitUntilTrue(async () => {
+      const actualOptions = await this.findAllByDataQa('option').allTexts()
+      return (
+        actualOptions.length === options.length &&
+        options.every((option) => actualOptions.includes(option))
+      )
+    })
+  }
 }
 
 export class Collapsible extends Element {


### PR DESCRIPTION
Viestiin on mahdollista valita vain sellaisia vastaanottajia, jotka ovat sallittuja jokaiselle viestiin valituista lapsista. Esimerkiksi samaa viestiä ei voi lähettää kahteen eri ryhmäpostilaatikkoon.