### PR TITLE
Ehdottavan esiopetuksen hakemuksen sovittu yhdessä tiedon poisto

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/contact-info/SecondGuardianSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/SecondGuardianSubSection.tsx
@@ -31,6 +31,11 @@ type SecondGuardianSubSectionProps = {
   otherGuardianStatus: 'NO' | 'SAME_ADDRESS' | 'DIFFERENT_ADDRESS'
 }
 
+export type SelectableOtherGuardianAgreementStatus = Exclude<
+  OtherGuardianAgreementStatus,
+  'AUTOMATED'
+>
+
 export default React.memo(function SecondGuardianSubSection({
   type,
   formData,
@@ -41,7 +46,7 @@ export default React.memo(function SecondGuardianSubSection({
 }: SecondGuardianSubSectionProps) {
   const t = useTranslation()
 
-  const agreementStatuses: OtherGuardianAgreementStatus[] = [
+  const agreementStatuses: SelectableOtherGuardianAgreementStatus[] = [
     'AGREED',
     'NOT_AGREED',
     'RIGHT_TO_GET_NOTIFIED'

--- a/frontend/src/citizen-frontend/applications/editor/contact-info/SecondGuardianSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/SecondGuardianSubSection.tsx
@@ -4,12 +4,12 @@
 
 import React from 'react'
 
-import { ContactInfoFormData } from 'lib-common/api-types/application/ApplicationFormData'
-import { UpdateStateFn } from 'lib-common/form-state'
 import {
-  ApplicationType,
-  OtherGuardianAgreementStatus
-} from 'lib-common/generated/api-types/application'
+  ContactInfoFormData,
+  SelectableOtherGuardianAgreementStatus
+} from 'lib-common/api-types/application/ApplicationFormData'
+import { UpdateStateFn } from 'lib-common/form-state'
+import { ApplicationType } from 'lib-common/generated/api-types/application'
 import InputField from 'lib-components/atoms/form/InputField'
 import Radio from 'lib-components/atoms/form/Radio'
 import AdaptiveFlex from 'lib-components/layout/AdaptiveFlex'
@@ -30,11 +30,6 @@ type SecondGuardianSubSectionProps = {
   verificationRequested: boolean
   otherGuardianStatus: 'NO' | 'SAME_ADDRESS' | 'DIFFERENT_ADDRESS'
 }
-
-export type SelectableOtherGuardianAgreementStatus = Exclude<
-  OtherGuardianAgreementStatus,
-  'AUTOMATED'
->
 
 export default React.memo(function SecondGuardianSubSection({
   type,

--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -9,13 +9,13 @@ import { Link } from 'react-router'
 import styled from 'styled-components'
 
 import { Result } from 'lib-common/api'
+import { SelectableOtherGuardianAgreementStatus } from 'lib-common/api-types/application/ApplicationFormData'
 import { swapElements } from 'lib-common/array'
 import DateRange from 'lib-common/date-range'
 import {
   Address,
   ApplicationDetails,
   FutureAddress,
-  OtherGuardianAgreementStatus,
   PersonBasics
 } from 'lib-common/generated/api-types/application'
 import {
@@ -91,12 +91,7 @@ const PreferredUnitGridContainer = styled.div`
   grid-template-columns: 1fr auto auto auto auto;
 `
 
-export type SelectableOtherGuardianAgreementStatus = Exclude<
-  OtherGuardianAgreementStatus,
-  'AUTOMATED'
-> | null
-
-const selectableOtherGuardianAgreementStatuses: SelectableOtherGuardianAgreementStatus[] =
+const selectableOtherGuardianAgreementStatuses: (SelectableOtherGuardianAgreementStatus | null)[] =
   ['AGREED', 'NOT_AGREED', 'RIGHT_TO_GET_NOTIFIED', null]
 
 export default React.memo(function ApplicationEditView({

--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -15,6 +15,7 @@ import {
   Address,
   ApplicationDetails,
   FutureAddress,
+  OtherGuardianAgreementStatus,
   PersonBasics
 } from 'lib-common/generated/api-types/application'
 import {
@@ -89,6 +90,14 @@ const PreferredUnitGridContainer = styled.div`
   grid-column-gap: ${defaultMargins.s};
   grid-template-columns: 1fr auto auto auto auto;
 `
+
+export type SelectableOtherGuardianAgreementStatus = Exclude<
+  OtherGuardianAgreementStatus,
+  'AUTOMATED'
+> | null
+
+const selectableOtherGuardianAgreementStatuses: SelectableOtherGuardianAgreementStatus[] =
+  ['AGREED', 'NOT_AGREED', 'RIGHT_TO_GET_NOTIFIED', null]
 
 export default React.memo(function ApplicationEditView({
   application,
@@ -1072,35 +1081,32 @@ export default React.memo(function ApplicationEditView({
                       {i18n.application.person.agreementStatus}
                     </Label>
                     <div>
-                      {(
-                        [
-                          'AGREED',
-                          'NOT_AGREED',
-                          'RIGHT_TO_GET_NOTIFIED',
-                          null
-                        ] as const
-                      ).map((id, index) => (
-                        <React.Fragment key={id ?? 'NOT_SET'}>
-                          {index !== 0 ? <Gap size="xxs" /> : null}
-                          <Radio
-                            label={
-                              i18n.application.person
-                                .otherGuardianAgreementStatuses[id ?? 'NOT_SET']
-                            }
-                            checked={
-                              id === (secondGuardian?.agreementStatus ?? null)
-                            }
-                            onChange={() => {
-                              setApplication(
-                                set('form.secondGuardian.agreementStatus', id)
-                              )
-                            }}
-                            data-qa={`radio-other-guardian-agreement-status-${
-                              id ?? 'null'
-                            }`}
-                          />
-                        </React.Fragment>
-                      ))}
+                      {selectableOtherGuardianAgreementStatuses.map(
+                        (id, index) => (
+                          <React.Fragment key={id ?? 'NOT_SET'}>
+                            {index !== 0 ? <Gap size="xxs" /> : null}
+                            <Radio
+                              label={
+                                i18n.application.person
+                                  .otherGuardianAgreementStatuses[
+                                  id ?? 'NOT_SET'
+                                ]
+                              }
+                              checked={
+                                id === (secondGuardian?.agreementStatus ?? null)
+                              }
+                              onChange={() => {
+                                setApplication(
+                                  set('form.secondGuardian.agreementStatus', id)
+                                )
+                              }}
+                              data-qa={`radio-other-guardian-agreement-status-${
+                                id ?? 'null'
+                              }`}
+                            />
+                          </React.Fragment>
+                        )
+                      )}
                     </div>
                   </ListGrid>
                 </>

--- a/frontend/src/lib-common/api-types/application/ApplicationFormData.ts
+++ b/frontend/src/lib-common/api-types/application/ApplicationFormData.ts
@@ -46,6 +46,11 @@ export type UnitPreferenceFormData = {
   preferredUnits: { id: DaycareId; name: string }[]
 }
 
+export type SelectableOtherGuardianAgreementStatus = Exclude<
+  OtherGuardianAgreementStatus,
+  'AUTOMATED'
+>
+
 export type ContactInfoFormData = {
   childFirstName: string
   childLastName: string

--- a/frontend/src/lib-common/generated/api-types/application.ts
+++ b/frontend/src/lib-common/generated/api-types/application.ts
@@ -598,6 +598,7 @@ export type OtherGuardianAgreementStatus =
   | 'AGREED'
   | 'NOT_AGREED'
   | 'RIGHT_TO_GET_NOTIFIED'
+  | 'AUTOMATED'
 
 /**
 * Generated from fi.espoo.evaka.application.PagedApplicationSummaries

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -440,6 +440,7 @@ export const fi = {
         AGREED: 'Sovittu yhdessä',
         NOT_AGREED: 'Ei ole sovittu yhdessä',
         RIGHT_TO_GET_NOTIFIED: 'Vain tiedonsaantioikeus',
+        AUTOMATED: 'Automaattinen päätös',
         NOT_SET: 'Huoltajat asuvat samassa osoitteessa'
       },
       noOtherChildren: 'Ei muita lapsia',

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationForm.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationForm.kt
@@ -477,6 +477,7 @@ enum class OtherGuardianAgreementStatus {
     AGREED,
     NOT_AGREED,
     RIGHT_TO_GET_NOTIFIED,
+    AUTOMATED,
 }
 
 data class PersonBasics(

--- a/service/src/main/kotlin/fi/espoo/evaka/application/PlacementToolService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/PlacementToolService.kt
@@ -312,7 +312,7 @@ class PlacementToolService(
                                     SecondGuardian(
                                         phoneNumber = guardian2.phone,
                                         email = guardian2.email ?: "",
-                                        agreementStatus = OtherGuardianAgreementStatus.AGREED,
+                                        agreementStatus = OtherGuardianAgreementStatus.AUTOMATED,
                                     )
                                 },
                     ),


### PR DESCRIPTION
Ehdottavan esiopetuksen hakemuksille tulee tällä hetkellä teksti "Sovittu yhdessä: Sovittu yhdessä", vaikka tämä ei pidä paikkaansa, koska hakemukset luodaan automaattisesti järjestelmän toimesta. Luodaan uusi tyyppi tällaisia hakemuksia varten.