### PR TITLE
Päivitetään ikärajoja ja parannetaan validointeja

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/paper-application.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/paper-application.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import LocalDate from 'lib-common/local-date'
 
 import {
   testDaycareGroup,
@@ -98,6 +99,7 @@ describe('Employee - paper application', () => {
     }).saveChild({ updateMockVtj: true })
     await Fixture.person({
       ssn,
+      dateOfBirth: LocalDate.of(1972, 3, 27),
       firstName: 'Sirkka-Liisa Marja-Leena Minna-Mari Anna-Kaisa',
       lastName: 'Korhonen-Hämäläinen',
       streetAddress: 'Kamreerintie 2',

--- a/frontend/src/employee-frontend/components/ChildInformation.tsx
+++ b/frontend/src/employee-frontend/components/ChildInformation.tsx
@@ -5,7 +5,7 @@
 import { faCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useContext, useEffect, useMemo } from 'react'
-import { Link } from 'react-router'
+import { Link, useNavigate } from 'react-router'
 import styled from 'styled-components'
 
 import { Action } from 'lib-common/generated/action'
@@ -13,9 +13,14 @@ import { ParentshipWithPermittedActions } from 'lib-common/generated/api-types/p
 import { ChildId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
+import { getAge } from 'lib-common/utils/local-date'
 import Title from 'lib-components/atoms/Title'
+import { Button } from 'lib-components/atoms/buttons/Button'
 import { Container, ContentArea } from 'lib-components/layout/Container'
-import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import {
+  FixedSpaceColumn,
+  FixedSpaceRow
+} from 'lib-components/layout/flex-helpers'
 import { fontWeights } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { faUsers } from 'lib-icons'
@@ -286,6 +291,7 @@ const ChildInformation = React.memo(function ChildInformation({
   id: ChildId
 }) {
   const { i18n } = useTranslation()
+  const navigate = useNavigate()
   const { roles } = useContext(UserContext)
   const { person, parentships } = useContext<ChildState>(ChildContext)
 
@@ -330,24 +336,35 @@ const ChildInformation = React.memo(function ChildInformation({
               {person.isSuccess && person.value.restrictedDetailsEnabled && (
                 <WarningLabel text={i18n.childInformation.restrictedDetails} />
               )}
-              {currentHeadOfChildId ? (
-                <HeadOfFamilyLink
-                  to={`/profile/${currentHeadOfChildId}`}
-                  className="person-details-family-link"
-                >
-                  <span className="fa-layers fa-fw link-icon">
-                    <FontAwesomeIcon className="dark-blue" icon={faCircle} />
-                    <FontAwesomeIcon
-                      icon={faUsers}
-                      inverse
-                      transform="shrink-6"
+              <FixedSpaceRow spacing="L">
+                {person.isSuccess &&
+                  getAge(person.value.dateOfBirth) >= 10 &&
+                  getAge(person.value.dateOfBirth) < 18 && (
+                    <Button
+                      appearance="inline"
+                      text={i18n.childInformation.asAdult}
+                      onClick={() => navigate(`/profile/${id}`)}
                     />
-                  </span>
-                  <div className="link-text">
-                    {i18n.childInformation.personDetails.familyLink}
-                  </div>
-                </HeadOfFamilyLink>
-              ) : null}
+                  )}
+                {currentHeadOfChildId && (
+                  <HeadOfFamilyLink
+                    to={`/profile/${currentHeadOfChildId}`}
+                    className="person-details-family-link"
+                  >
+                    <span className="fa-layers fa-fw link-icon">
+                      <FontAwesomeIcon className="dark-blue" icon={faCircle} />
+                      <FontAwesomeIcon
+                        icon={faUsers}
+                        inverse
+                        transform="shrink-6"
+                      />
+                    </span>
+                    <div className="link-text">
+                      {i18n.childInformation.personDetails.familyLink}
+                    </div>
+                  </HeadOfFamilyLink>
+                )}
+              </FixedSpaceRow>
             </div>
           </HeaderRow>
         </ContentArea>

--- a/frontend/src/employee-frontend/components/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/PersonProfile.tsx
@@ -3,16 +3,21 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React, { useContext, useMemo } from 'react'
+import { useNavigate } from 'react-router'
 import styled from 'styled-components'
 
 import { Action } from 'lib-common/generated/action'
 import { PersonId } from 'lib-common/generated/api-types/shared'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
+import { getAge } from 'lib-common/utils/local-date'
 import Title from 'lib-components/atoms/Title'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { Td } from 'lib-components/layout/Table'
-import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import {
+  FixedSpaceColumn,
+  FixedSpaceRow
+} from 'lib-components/layout/flex-helpers'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import { faListTimeline } from 'lib-icons'
 
@@ -214,6 +219,7 @@ const PersonProfile = React.memo(function PersonProfile({
   id: PersonId
 }) {
   const { i18n } = useTranslation()
+  const navigate = useNavigate()
 
   const { roles } = useContext(UserContext)
   const { person, permittedActions } = useContext(PersonContext)
@@ -251,17 +257,28 @@ const PersonProfile = React.memo(function PersonProfile({
                     )}
                   </InfoLabelContainer>
                 )}
-              {permittedActions.has('READ_TIMELINE') && (
-                <a href={`/employee/profile/${id}/timeline`}>
-                  <Button
-                    appearance="inline"
-                    text={i18n.personProfile.timeline}
-                    onClick={() => undefined}
-                    icon={faListTimeline}
-                    data-qa="timeline-button"
-                  />
-                </a>
-              )}
+              <FixedSpaceRow spacing="L">
+                {person.isSuccess &&
+                  getAge(person.value.dateOfBirth) >= 10 &&
+                  getAge(person.value.dateOfBirth) < 18 && (
+                    <Button
+                      appearance="inline"
+                      text={i18n.personProfile.asChild}
+                      onClick={() => navigate(`/child-information/${id}`)}
+                    />
+                  )}
+                {permittedActions.has('READ_TIMELINE') && (
+                  <a href={`/employee/profile/${id}/timeline`}>
+                    <Button
+                      appearance="inline"
+                      text={i18n.personProfile.timeline}
+                      onClick={() => undefined}
+                      icon={faListTimeline}
+                      data-qa="timeline-button"
+                    />
+                  </a>
+                )}
+              </FixedSpaceRow>
             </FixedSpaceColumn>
           </HeaderRow>
         </ContentArea>

--- a/frontend/src/employee-frontend/components/Search.tsx
+++ b/frontend/src/employee-frontend/components/Search.tsx
@@ -24,7 +24,7 @@ import { faSearch } from 'lib-icons'
 
 import AddVTJPersonModal from '../components/person-search/AddVTJPersonModal'
 import CreatePersonModal from '../components/person-search/CreatePersonModal'
-import { CHILD_AGE } from '../constants'
+import { PROFILE_AGE_THRESHOLD_DEFAULT } from '../constants'
 import { CustomersContext } from '../state/customers'
 import { useTranslation } from '../state/i18n'
 import { formatName } from '../utils'
@@ -151,7 +151,8 @@ export default React.memo(function Search() {
                       <Td align="left">
                         <Link
                           to={
-                            getAge(person.dateOfBirth) >= CHILD_AGE
+                            getAge(person.dateOfBirth) >=
+                            PROFILE_AGE_THRESHOLD_DEFAULT
                               ? `/profile/${person.id}`
                               : `/child-information/${person.id}`
                           }

--- a/frontend/src/employee-frontend/components/child-information/CreateApplicationModal.tsx
+++ b/frontend/src/employee-frontend/components/child-information/CreateApplicationModal.tsx
@@ -266,6 +266,8 @@ function CreateApplicationModal({
               <PersonSearch
                 onResult={(res) => setPersonId(res?.id)}
                 onFocus={() => setPersonType('DB_SEARCH')}
+                ageAtLeast={10}
+                excludePeople={[child.id]}
               />
             </div>
 
@@ -278,6 +280,8 @@ function CreateApplicationModal({
               />
               <VtjPersonSearch
                 data-qa="select-search-from-vtj-guardian"
+                ageAtLeast={10}
+                excludePeople={[child.id]}
                 onResult={(res) =>
                   setNewVtjPersonSsn(res?.socialSecurityNumber || undefined)
                 }

--- a/frontend/src/employee-frontend/components/child-information/CreateApplicationModal.tsx
+++ b/frontend/src/employee-frontend/components/child-information/CreateApplicationModal.tsx
@@ -132,7 +132,7 @@ function CreateApplicationModal({
       case 'GUARDIAN':
         return !!guardian
       case 'DB_SEARCH':
-        return !!personId
+        return !!personId && personId !== child.id
       case 'VTJ':
         return !!newVtjPersonSsn
       case 'NEW_NO_SSN':

--- a/frontend/src/employee-frontend/components/common/PersonSearch.tsx
+++ b/frontend/src/employee-frontend/components/common/PersonSearch.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -15,7 +15,6 @@ import { useRestApi } from 'lib-common/utils/useRestApi'
 import Combobox from 'lib-components/atoms/dropdowns/Combobox'
 import { BaseProps } from 'lib-components/utils'
 
-import { CHILD_AGE } from '../../constants'
 import {
   getOrCreatePersonBySsn,
   getPersonIdentity,
@@ -75,8 +74,8 @@ interface Props extends BaseProps {
   searchFn: (q: string) => Promise<Result<PersonSummary[]>>
   onResult: (result: PersonSummary | undefined) => void
   onFocus?: (e: React.FocusEvent<HTMLElement>) => void
-  onlyChildren?: boolean
-  onlyAdults?: boolean
+  ageLessThan?: number
+  ageAtLeast?: number
 }
 
 function PersonSearch({
@@ -84,8 +83,8 @@ function PersonSearch({
   searchFn,
   onResult,
   onFocus,
-  onlyChildren = false,
-  onlyAdults = false,
+  ageLessThan,
+  ageAtLeast,
   'data-qa': dataQa,
   getItemDataQa
 }: Props) {
@@ -107,15 +106,13 @@ function PersonSearch({
   }, [searchPeople, debouncedQuery])
 
   const filterPeople = (people: PersonSummary[]) =>
-    people.filter((person) =>
-      person.dateOfBirth
-        ? onlyChildren
-          ? getAge(person.dateOfBirth) < CHILD_AGE
-          : onlyAdults
-            ? getAge(person.dateOfBirth) >= CHILD_AGE
-            : true
-        : true
-    )
+    people.filter((person) => {
+      if (!person.dateOfBirth) return true
+      const age = getAge(person.dateOfBirth)
+      if (ageLessThan !== undefined && age >= ageLessThan) return false
+      if (ageAtLeast !== undefined && age < ageAtLeast) return false
+      return true
+    })
 
   const options = useMemo(
     () => persons.map((ps) => filterPeople(ps)).getOrElse([]),

--- a/frontend/src/employee-frontend/components/common/PersonSearch.tsx
+++ b/frontend/src/employee-frontend/components/common/PersonSearch.tsx
@@ -76,6 +76,7 @@ interface Props extends BaseProps {
   onFocus?: (e: React.FocusEvent<HTMLElement>) => void
   ageLessThan?: number
   ageAtLeast?: number
+  excludePeople?: PersonId[]
 }
 
 function PersonSearch({
@@ -85,6 +86,7 @@ function PersonSearch({
   onFocus,
   ageLessThan,
   ageAtLeast,
+  excludePeople,
   'data-qa': dataQa,
   getItemDataQa
 }: Props) {
@@ -107,6 +109,7 @@ function PersonSearch({
 
   const filterPeople = (people: PersonSummary[]) =>
     people.filter((person) => {
+      if (excludePeople && excludePeople.includes(person.id)) return false
       if (!person.dateOfBirth) return true
       const age = getAge(person.dateOfBirth)
       if (ageLessThan !== undefined && age >= ageLessThan) return false

--- a/frontend/src/employee-frontend/components/person-profile/FosterChildren.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/FosterChildren.tsx
@@ -269,6 +269,7 @@ const FosterChildCreationModal = React.memo(function FosterChildCreationModal({
       <DbPersonSearch
         onResult={(person) => setForm({ ...form, childId: person?.id ?? null })}
         ageLessThan={18}
+        excludePeople={[parentId]}
         data-qa="person-search"
       />
       <Label>{i18n.personProfile.fosterChildren.validDuringLabel}</Label>

--- a/frontend/src/employee-frontend/components/person-profile/FosterChildren.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/FosterChildren.tsx
@@ -268,7 +268,7 @@ const FosterChildCreationModal = React.memo(function FosterChildCreationModal({
       <Label>{i18n.personProfile.fosterChildren.childLabel}</Label>
       <DbPersonSearch
         onResult={(person) => setForm({ ...form, childId: person?.id ?? null })}
-        onlyChildren
+        ageLessThan={18}
         data-qa="person-search"
       />
       <Label>{i18n.personProfile.fosterChildren.validDuringLabel}</Label>

--- a/frontend/src/employee-frontend/components/person-profile/person-fridge-child/FridgeChildModal.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/person-fridge-child/FridgeChildModal.tsx
@@ -208,7 +208,7 @@ function FridgeChildModal({ headPersonId, onSuccess, parentship }: Props) {
                     }
                     assignFridgeChildForm({ child: person, endDate })
                   }}
-                  onlyChildren
+                  ageLessThan={18}
                   data-qa="fridge-child-person-search"
                 />
               </>

--- a/frontend/src/employee-frontend/components/person-profile/person-fridge-child/FridgeChildModal.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/person-fridge-child/FridgeChildModal.tsx
@@ -209,6 +209,7 @@ function FridgeChildModal({ headPersonId, onSuccess, parentship }: Props) {
                     assignFridgeChildForm({ child: person, endDate })
                   }}
                   ageLessThan={18}
+                  excludePeople={[headPersonId]}
                   data-qa="fridge-child-person-search"
                 />
               </>

--- a/frontend/src/employee-frontend/components/person-profile/person-fridge-partner/FridgePartnerModal.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/person-fridge-partner/FridgePartnerModal.tsx
@@ -215,6 +215,7 @@ function FridgePartnerModal({ partnership, onSuccess, headPersonId }: Props) {
                 assignFridgePartnerForm({ partner: person })
               }
               ageAtLeast={13}
+              excludePeople={[headPersonId]}
               data-qa="fridge-partner-person-search"
             />
           </>

--- a/frontend/src/employee-frontend/components/person-profile/person-fridge-partner/FridgePartnerModal.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/person-fridge-partner/FridgePartnerModal.tsx
@@ -214,7 +214,7 @@ function FridgePartnerModal({ partnership, onSuccess, headPersonId }: Props) {
               onResult={(person) =>
                 assignFridgePartnerForm({ partner: person })
               }
-              onlyAdults
+              ageAtLeast={13}
               data-qa="fridge-partner-person-search"
             />
           </>

--- a/frontend/src/employee-frontend/components/person-search/CreatePersonModal.tsx
+++ b/frontend/src/employee-frontend/components/person-search/CreatePersonModal.tsx
@@ -18,7 +18,6 @@ import { Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { faPlus } from 'lib-icons'
 
-import { CHILD_AGE } from '../../constants'
 import { createPerson } from '../../generated/api-clients/pis'
 import { useTranslation } from '../../state/i18n'
 
@@ -67,7 +66,7 @@ export default React.memo(function CreatePersonModal({
     }
   }
 
-  const isAdult = (dateOfBirth: LocalDate) => getAge(dateOfBirth) >= CHILD_AGE
+  const isAdult = (dateOfBirth: LocalDate) => getAge(dateOfBirth) >= 18
 
   return (
     <FormModal
@@ -215,7 +214,7 @@ function validateForm(form: Form): CreatePersonBody | undefined {
     !form.streetAddress ||
     !form.postalCode ||
     !form.postOffice ||
-    (getAge(parsedDateOfBirth) >= CHILD_AGE && !form.phone)
+    (getAge(parsedDateOfBirth) >= 18 && !form.phone)
   ) {
     return undefined
   }

--- a/frontend/src/employee-frontend/components/reports/DuplicatePeople.tsx
+++ b/frontend/src/employee-frontend/components/reports/DuplicatePeople.tsx
@@ -23,7 +23,7 @@ import { colors } from 'lib-customizations/common'
 import { featureFlags } from 'lib-customizations/employee'
 import { faQuestion } from 'lib-icons'
 
-import { CHILD_AGE } from '../../constants'
+import { PROFILE_AGE_THRESHOLD_DEFAULT } from '../../constants'
 import { mergePeople, safeDeletePerson } from '../../generated/api-clients/pis'
 import { getDuplicatePeopleReport } from '../../generated/api-clients/reports'
 import { useTranslation } from '../../state/i18n'
@@ -58,7 +58,7 @@ const hasReferences = (row: DuplicatePeopleReportRow) =>
 
 const isChild = (dateOfBirth: LocalDate) => {
   const age = LocalDate.todayInSystemTz().differenceInYears(dateOfBirth)
-  return age < CHILD_AGE
+  return age < PROFILE_AGE_THRESHOLD_DEFAULT
 }
 
 export default React.memo(function DuplicatePeople() {

--- a/frontend/src/employee-frontend/constants.ts
+++ b/frontend/src/employee-frontend/constants.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2022 City of Espoo
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -10,7 +10,7 @@ export const MAX_DATE = LocalDate.of(2099, 12, 31)
 
 export const ENTER_PRESS = 13
 
-export const CHILD_AGE = 18
+export const PROFILE_AGE_THRESHOLD_DEFAULT = 12
 
 export function getEmployeeUrlPrefix(): string {
   const isLocalMultiPortEnv = window.location.host.includes(':9093')

--- a/frontend/src/employee-frontend/constants.ts
+++ b/frontend/src/employee-frontend/constants.ts
@@ -10,7 +10,7 @@ export const MAX_DATE = LocalDate.of(2099, 12, 31)
 
 export const ENTER_PRESS = 13
 
-export const PROFILE_AGE_THRESHOLD_DEFAULT = 12
+export const PROFILE_AGE_THRESHOLD_DEFAULT = 13
 
 export function getEmployeeUrlPrefix(): string {
   const isLocalMultiPortEnv = window.location.host.includes(':9093')

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -614,6 +614,7 @@ export const fi = {
   },
   childInformation: {
     restrictedDetails: 'Turvakielto',
+    asAdult: 'Tarkastele aikuisena',
     personDetails: {
       title: 'Henkilö-, yhteys- ja terveystiedot',
       attendanceReport: 'Läsnä- ja poissaolotiedot',
@@ -1672,6 +1673,7 @@ export const fi = {
   },
   personProfile: {
     restrictedDetails: 'Turvakielto',
+    asChild: 'Tarkastele lapsena',
     timeline: 'Aikajana',
     personDetails: 'Henkilö- ja yhteystiedot',
     addSsn: 'Aseta hetu',

--- a/service/src/main/resources/db/migration/V488__no_head_of_self.sql
+++ b/service/src/main/resources/db/migration/V488__no_head_of_self.sql
@@ -1,0 +1,3 @@
+DELETE FROM fridge_child WHERE child_id = head_of_child;
+
+ALTER TABLE fridge_child ADD CONSTRAINT no_head_of_self CHECK (child_id != head_of_child);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -483,3 +483,4 @@ V484__invoice_attachment.sql
 V485__preschool_manager.sql
 V486__fix_application_confidentiality.sql
 V487__staff_attendance_realtime_modified.sql
+V488__no_head_of_self.sql


### PR DESCRIPTION
- estetään lasta olemasta itsensä päämies (vanhat vialliset päämiessuhteet poistuvat)
- henkilön oletusnäkymä on lapsi, jos henkilö on alle 13v ja aikuinen jos vähintään 13v
- napista voi tarvittaessa vaihtaa moodia jos henkilö on 10-17v
- paperihakemuksella hakija on vähintään 10v eikä voi olla sama henkilö kuin lapsi jota hakemus koskee
- jääkaappipuoliso on vähintään 13v
- ei voi olla itsensä puoliso
- jääkaappilapsi on alle 18v
- ei voi olla itsensä lapsi
- sijaishuollettava on alle 18v
- ei voi olla itsensä huollettava
