### PR TITLE
Tampereen Seutuselvitysraportti osa 2: ikäjaotteluarvojen CSV

### DIFF
--- a/frontend/src/employee-frontend/components/reports/queries.ts
+++ b/frontend/src/employee-frontend/components/reports/queries.ts
@@ -35,7 +35,8 @@ import {
   getPreschoolApplicationReport,
   getServiceVoucherReportForAllUnits,
   getStartingPlacementsReport,
-  getTampereRegionalSurvey,
+  getTampereRegionalSurveyAgeStatistics,
+  getTampereRegionalSurveyMonthlyStatistics,
   getTitaniaErrorsReport,
   getUnitsReport,
   getVardaChildErrorsReport,
@@ -144,4 +145,10 @@ export const startingPlacementsReportQuery = q.query(
   getStartingPlacementsReport
 )
 
-export const tampereRegionalSurveyReport = q.query(getTampereRegionalSurvey)
+export const tampereRegionalSurveyMonthlyReport = q.query(
+  getTampereRegionalSurveyMonthlyStatistics
+)
+
+export const tampereRegionalSurveyAgeReport = q.query(
+  getTampereRegionalSurveyAgeStatistics
+)

--- a/frontend/src/employee-frontend/generated/api-clients/reports.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reports.ts
@@ -64,6 +64,7 @@ import { PreschoolUnitsReportRow } from 'lib-common/generated/api-types/reports'
 import { PresenceReportRow } from 'lib-common/generated/api-types/reports'
 import { ProviderType } from 'lib-common/generated/api-types/daycare'
 import { RawReportRow } from 'lib-common/generated/api-types/reports'
+import { RegionalSurveyReportAgeStatisticsResult } from 'lib-common/generated/api-types/reports'
 import { RegionalSurveyReportResult } from 'lib-common/generated/api-types/reports'
 import { Report } from 'lib-common/generated/api-types/reports'
 import { ServiceNeedReportRow } from 'lib-common/generated/api-types/reports'
@@ -1061,9 +1062,29 @@ export async function getStartingPlacementsReport(
 
 
 /**
-* Generated from fi.espoo.evaka.reports.TampereRegionalSurvey.getTampereRegionalSurvey
+* Generated from fi.espoo.evaka.reports.TampereRegionalSurvey.getTampereRegionalSurveyAgeStatistics
 */
-export async function getTampereRegionalSurvey(
+export async function getTampereRegionalSurveyAgeStatistics(
+  request: {
+    year: number
+  }
+): Promise<RegionalSurveyReportAgeStatisticsResult> {
+  const params = createUrlSearchParams(
+    ['year', request.year.toString()]
+  )
+  const { data: json } = await client.request<JsonOf<RegionalSurveyReportAgeStatisticsResult>>({
+    url: uri`/employee/reports/tampere-regional-survey/age-statistics`.toString(),
+    method: 'GET',
+    params
+  })
+  return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.reports.TampereRegionalSurvey.getTampereRegionalSurveyMonthlyStatistics
+*/
+export async function getTampereRegionalSurveyMonthlyStatistics(
   request: {
     year: number
   }
@@ -1072,7 +1093,7 @@ export async function getTampereRegionalSurvey(
     ['year', request.year.toString()]
   )
   const { data: json } = await client.request<JsonOf<RegionalSurveyReportResult>>({
-    url: uri`/employee/reports/tampere-regional-survey/monthly`.toString(),
+    url: uri`/employee/reports/tampere-regional-survey/monthly-statistics`.toString(),
     method: 'GET',
     params
   })

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -37,6 +37,24 @@ import { UUID } from '../../types'
 import { VoucherValueDecisionId } from './shared'
 
 /**
+* Generated from fi.espoo.evaka.reports.TampereRegionalSurvey.AgeStatisticsResult
+*/
+export interface AgeStatisticsResult {
+  clubOver3Count: number
+  clubUnder3Count: number
+  effectiveCareDaysOver3Count: number
+  effectiveCareDaysUnder3Count: number
+  effectiveFamilyDaycareDaysOver3Count: number
+  effectiveFamilyDaycareDaysUnder3Count: number
+  nonNativeLanguageOver3Count: number
+  nonNativeLanguageUnder3Count: number
+  purchasedOver3Count: number
+  purchasedUnder3Count: number
+  voucherOver3Count: number
+  voucherUnder3Count: number
+}
+
+/**
 * Generated from fi.espoo.evaka.reports.ApplicationsReportRow
 */
 export interface ApplicationsReportRow {
@@ -820,6 +838,14 @@ export interface ReferenceCount {
   column: string
   count: number
   table: string
+}
+
+/**
+* Generated from fi.espoo.evaka.reports.TampereRegionalSurvey.RegionalSurveyReportAgeStatisticsResult
+*/
+export interface RegionalSurveyReportAgeStatisticsResult {
+  ageStatistics: AgeStatisticsResult[]
+  year: number
 }
 
 /**

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4325,6 +4325,7 @@ export const fi = {
       description:
         'Raportti kerää kunnan vuosittaiseen seutuselvitykseen tarvittavat tiedot ladattaviksi CSV-tiedostoiksi',
       monthlyReport: 'Seutuselvityksen kuukausittaiset määrät',
+      ageStatisticsReport: 'Seutuselvityksen ikäjakaumat',
       reportLabel: 'Seutuselvitys',
       monthlyColumns: {
         month: 'Kuukausi',
@@ -4341,6 +4342,22 @@ export const fi = {
         municipalShiftCareCount: 'Vuorohoidossa olevien määrä',
         assistanceCount:
           'Tehostetun ja erityisen tuen lapset / Eritystä tai kasvun ja oppimisen tukea tarvitsevat lapset'
+      },
+      ageStatisticColumns: {
+        voucherUnder3Count: 'Alle 3v palvelusetelipaikkojen määrä',
+        voucherOver3Count: '3v ja yli palvelusetelipaikkojen määrä',
+        purchasedUnder3Count: 'Alle 3v ostopalvelupaikkojen määrä',
+        purchasedOver3Count: '3v ja yli ostopalvelupaikkojen määrä',
+        clubUnder3Count: 'Alle 3v kerhopaikkojen määrä',
+        clubOver3Count: '3v ja yli kerhopaikkojen määrä',
+        nonNativeLanguageUnder3Count: 'Alle 3v vieraskielisten määrä',
+        nonNativeLanguageOver3Count: '3v ja yli vieraskielisten määrä',
+        effectiveCareDaysUnder3Count: 'Alle 3v varhaiskasvatuksen hoitopäivät',
+        effectiveCareDaysOver3Count: '3v ja yli varhaiskasvatuksen hoitopäivät',
+        effectiveFamilyDaycareDaysUnder3Count:
+          'Alle 3v perhepäivähoidon hoitopäivät',
+        effectiveFamilyDaycareDaysOver3Count:
+          '3v ja yli perhepäivähoidon hoitopäivät'
       }
     }
   },

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/TampereRegionalSurveyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/TampereRegionalSurveyTest.kt
@@ -20,6 +20,7 @@ import fi.espoo.evaka.shared.dev.DevAbsence
 import fi.espoo.evaka.shared.dev.DevAssistanceAction
 import fi.espoo.evaka.shared.dev.DevAssistanceActionOption
 import fi.espoo.evaka.shared.dev.DevAssistanceFactor
+import fi.espoo.evaka.shared.dev.DevBackupCare
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevDaycareAssistance
@@ -614,6 +615,7 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
                     endDate = defaultPlacementRange.end.plusMonths(2),
                     unitId = testUnitData[1],
                 )
+
             tx.insert(shiftCarePlacement)
 
             tx.insert(
@@ -624,6 +626,21 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
                     startDate = shiftCarePlacement.startDate,
                     endDate = shiftCarePlacement.endDate,
                     confirmedBy = admin.evakaUserId,
+                )
+            )
+
+            // add a backup care to see that it is not counted twice
+            val aapoFirstPlacement = testPlacementData[0].second.first()
+
+            tx.insert(
+                DevBackupCare(
+                    childId = aapo.id,
+                    unitId = testUnitData[1],
+                    period =
+                        FiniteDateRange(
+                            aapoFirstPlacement.startDate.plusDays(1),
+                            aapoFirstPlacement.startDate.plusDays(2),
+                        ),
                 )
             )
         }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/TampereRegionalSurveyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/TampereRegionalSurveyTest.kt
@@ -5,7 +5,9 @@
 package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.absence.AbsenceCategory
 import fi.espoo.evaka.daycare.CareType
+import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.serviceneed.ServiceNeedOption
 import fi.espoo.evaka.serviceneed.ShiftCareType
@@ -14,6 +16,7 @@ import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.dev.DevAbsence
 import fi.espoo.evaka.shared.dev.DevAssistanceAction
 import fi.espoo.evaka.shared.dev.DevAssistanceActionOption
 import fi.espoo.evaka.shared.dev.DevAssistanceFactor
@@ -35,6 +38,7 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
+import kotlin.test.assertEquals
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -82,7 +86,7 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
         val testUnitData = initTestUnitData(startDate)
         initTestPlacementData(startDate, testUnitData[0])
         val results =
-            tampereRegionalSurvey.getTampereRegionalSurvey(
+            tampereRegionalSurvey.getTampereRegionalSurveyMonthlyStatistics(
                 dbInstance(),
                 adminLoginUser,
                 mockClock,
@@ -98,7 +102,7 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
         val testUnitData = initTestUnitData(startDate)
         initTestPlacementData(startDate, testUnitData[0])
         val results =
-            tampereRegionalSurvey.getTampereRegionalSurvey(
+            tampereRegionalSurvey.getTampereRegionalSurveyMonthlyStatistics(
                 dbInstance(),
                 adminLoginUser,
                 mockClock,
@@ -170,7 +174,7 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
         }
 
         val results =
-            tampereRegionalSurvey.getTampereRegionalSurvey(
+            tampereRegionalSurvey.getTampereRegionalSurveyMonthlyStatistics(
                 dbInstance(),
                 adminLoginUser,
                 mockClock,
@@ -227,7 +231,7 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
         }
 
         val results =
-            tampereRegionalSurvey.getTampereRegionalSurvey(
+            tampereRegionalSurvey.getTampereRegionalSurveyMonthlyStatistics(
                 dbInstance(),
                 adminLoginUser,
                 mockClock,
@@ -266,7 +270,7 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
         initTestPlacementData(startDate, testUnitData[0])
 
         val results =
-            tampereRegionalSurvey.getTampereRegionalSurvey(
+            tampereRegionalSurvey.getTampereRegionalSurveyMonthlyStatistics(
                 dbInstance(),
                 adminLoginUser,
                 mockClock,
@@ -292,6 +296,430 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
         assertThat(assistanceResults).containsExactlyInAnyOrderElementsOf(expectedResults)
     }
 
+    @Test
+    fun `Private service voucher age distribution results are correct `() {
+        val testUnitData = initTestUnitData(startDate)
+        initTestPlacementData(
+            startDate,
+            testUnitData[3],
+            FiniteDateRange(startDate, startDate.plusYears(1)),
+        )
+
+        // add some non-compliant data that should not show up
+        db.transaction { tx ->
+            val testChildCecilia =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(2),
+                    firstName = "Cecilia",
+                    lastName = "af Clubbenberg",
+                    language = "sv",
+                )
+
+            val testChildVeikko =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(4),
+                    firstName = "Veikko",
+                    lastName = "Vakalapsi",
+                    language = "fi",
+                )
+
+            tx.insert(testChildCecilia, DevPersonType.CHILD)
+            tx.insert(testChildVeikko, DevPersonType.CHILD)
+
+            val placementC =
+                DevPlacement(
+                    type = PlacementType.CLUB,
+                    childId = testChildCecilia.id,
+                    unitId = testUnitData[1],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            val placementV =
+                DevPlacement(
+                    type = PlacementType.DAYCARE,
+                    childId = testChildVeikko.id,
+                    unitId = testUnitData[0],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            tx.insert(placementC)
+            tx.insert(placementV)
+        }
+
+        val results =
+            tampereRegionalSurvey.getTampereRegionalSurveyAgeStatistics(
+                dbInstance(),
+                adminLoginUser,
+                mockClock,
+                year = startDate.year,
+            )
+
+        val expectedResults = Pair(1, 2)
+
+        val assistanceResults =
+            Pair(
+                results.ageStatistics.first().voucherUnder3Count,
+                results.ageStatistics.first().voucherOver3Count,
+            )
+
+        assertEquals(expectedResults, assistanceResults)
+    }
+
+    @Test
+    fun `Purchased age distribution results are correct `() {
+        val testUnitData = initTestUnitData(startDate)
+        initTestPlacementData(
+            startDate,
+            testUnitData[4],
+            FiniteDateRange(startDate, startDate.plusYears(1)),
+        )
+
+        // add some non-compliant data that should not show up
+        db.transaction { tx ->
+            val testChildCecilia =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(2),
+                    firstName = "Cecilia",
+                    lastName = "af Clubbenberg",
+                    language = "sv",
+                )
+
+            val testChildVeikko =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(4),
+                    firstName = "Veikko",
+                    lastName = "Vakalapsi",
+                    language = "fi",
+                )
+
+            tx.insert(testChildCecilia, DevPersonType.CHILD)
+            tx.insert(testChildVeikko, DevPersonType.CHILD)
+
+            val placementC =
+                DevPlacement(
+                    type = PlacementType.CLUB,
+                    childId = testChildCecilia.id,
+                    unitId = testUnitData[1],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            val placementV =
+                DevPlacement(
+                    type = PlacementType.DAYCARE,
+                    childId = testChildVeikko.id,
+                    unitId = testUnitData[0],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            tx.insert(placementC)
+            tx.insert(placementV)
+        }
+
+        val results =
+            tampereRegionalSurvey.getTampereRegionalSurveyAgeStatistics(
+                dbInstance(),
+                adminLoginUser,
+                mockClock,
+                year = startDate.year,
+            )
+
+        val expectedResults = Pair(1, 2)
+
+        val assistanceResults =
+            Pair(
+                results.ageStatistics.first().purchasedUnder3Count,
+                results.ageStatistics.first().purchasedOver3Count,
+            )
+
+        assertEquals(expectedResults, assistanceResults)
+    }
+
+    @Test
+    fun `Non-native language results are correct `() {
+        val testUnitData = initTestUnitData(startDate)
+        initTestPlacementData(
+            startDate,
+            testUnitData[0],
+            FiniteDateRange(startDate, startDate.plusYears(1)),
+        )
+
+        val results =
+            tampereRegionalSurvey.getTampereRegionalSurveyAgeStatistics(
+                dbInstance(),
+                adminLoginUser,
+                mockClock,
+                year = startDate.year,
+            )
+
+        val expectedResults = Pair(1, 1)
+
+        val assistanceResults =
+            Pair(
+                results.ageStatistics.first().nonNativeLanguageUnder3Count,
+                results.ageStatistics.first().nonNativeLanguageOver3Count,
+            )
+
+        assertEquals(expectedResults, assistanceResults)
+    }
+
+    @Test
+    fun `Club results are correct `() {
+        val testUnitData = initTestUnitData(startDate)
+        initTestPlacementData(
+            startDate,
+            testUnitData[1],
+            FiniteDateRange(startDate, startDate.plusYears(1)),
+        )
+
+        // add club placements
+        db.transaction { tx ->
+            val testChildCecilia =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(2),
+                    firstName = "Cecilia",
+                    lastName = "af Clubbenberg",
+                    language = "sv",
+                )
+
+            val testChildKaarlo =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(4),
+                    firstName = "Kaarlo",
+                    lastName = "Kerholainen",
+                    language = "fi",
+                )
+
+            tx.insert(testChildCecilia, DevPersonType.CHILD)
+            tx.insert(testChildKaarlo, DevPersonType.CHILD)
+
+            val placementC =
+                DevPlacement(
+                    type = PlacementType.CLUB,
+                    childId = testChildCecilia.id,
+                    unitId = testUnitData[1],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            val placementK =
+                DevPlacement(
+                    type = PlacementType.CLUB,
+                    childId = testChildKaarlo.id,
+                    unitId = testUnitData[1],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            tx.insert(placementC)
+            tx.insert(placementK)
+        }
+
+        val results =
+            tampereRegionalSurvey.getTampereRegionalSurveyAgeStatistics(
+                dbInstance(),
+                adminLoginUser,
+                mockClock,
+                year = startDate.year,
+            )
+
+        val expectedResults = Pair(1, 1)
+
+        val assistanceResults =
+            Pair(
+                results.ageStatistics.first().clubUnder3Count,
+                results.ageStatistics.first().clubOver3Count,
+            )
+
+        assertEquals(expectedResults, assistanceResults)
+    }
+
+    @Test
+    fun `Daycare care day counts are correct `() {
+        val octFirst = LocalDate.of(2024, 10, 1)
+        val defaultPlacementRange = FiniteDateRange(octFirst, octFirst.plusMonths(2).minusDays(1))
+        val testUnitData = initTestUnitData(startDate)
+        // 2024-10-01 - 2024-11-30
+        val testPlacementData =
+            initTestPlacementData(octFirst, testUnitData[0], defaultPlacementRange)
+
+        db.transaction { tx ->
+            // add some non-compliant data that should not show up
+            val testChildCecilia =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(2),
+                    firstName = "Cecilia",
+                    lastName = "af Clubbenberg",
+                    language = "sv",
+                )
+
+            val testChildElmo =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(4),
+                    firstName = "Elmo",
+                    lastName = "Esiopetettava",
+                    language = "fi",
+                )
+
+            tx.insert(testChildCecilia, DevPersonType.CHILD)
+            tx.insert(testChildElmo, DevPersonType.CHILD)
+
+            val placementC =
+                DevPlacement(
+                    type = PlacementType.CLUB,
+                    childId = testChildCecilia.id,
+                    unitId = testUnitData[1],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            val placementV =
+                DevPlacement(
+                    type = PlacementType.PRESCHOOL,
+                    childId = testChildElmo.id,
+                    unitId = testUnitData[0],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            tx.insert(placementC)
+            tx.insert(placementV)
+
+            val aapo = testPlacementData[0].first
+            // add full day absence to see that it is not counted as a care day
+            tx.insert(
+                DevAbsence(
+                    childId = aapo.id,
+                    date = LocalDate.of(2024, 11, 1),
+                    absenceCategory = AbsenceCategory.BILLABLE,
+                )
+            )
+            tx.insert(
+                DevAbsence(
+                    childId = aapo.id,
+                    date = LocalDate.of(2024, 11, 1),
+                    absenceCategory = AbsenceCategory.NONBILLABLE,
+                )
+            )
+
+            // add shift care placement for Aapo during December to see that it counts
+            val shiftCarePlacement =
+                DevPlacement(
+                    type = PlacementType.DAYCARE,
+                    childId = aapo.id,
+                    startDate = defaultPlacementRange.end.plusDays(1),
+                    endDate = defaultPlacementRange.end.plusMonths(2),
+                    unitId = testUnitData[1],
+                )
+            tx.insert(shiftCarePlacement)
+
+            tx.insert(
+                DevServiceNeed(
+                    placementId = shiftCarePlacement.id,
+                    optionId = fullTimeSno.id,
+                    shiftCare = ShiftCareType.FULL,
+                    startDate = shiftCarePlacement.startDate,
+                    endDate = shiftCarePlacement.endDate,
+                    confirmedBy = admin.evakaUserId,
+                )
+            )
+        }
+
+        val results =
+            tampereRegionalSurvey.getTampereRegionalSurveyAgeStatistics(
+                dbInstance(),
+                adminLoginUser,
+                mockClock,
+                year = startDate.year,
+            )
+        //             oct   nov              dec
+        // Aapo   (<3y) 23 + 21 - 1 absence + 31
+        // Bertil (>3y) 23 + 21
+        // Cecil  (>3y) 23 + 21
+        val expectedResults = Pair(74, 88)
+
+        val assistanceResults =
+            Pair(
+                results.ageStatistics.first().effectiveCareDaysUnder3Count,
+                results.ageStatistics.first().effectiveCareDaysOver3Count,
+            )
+
+        assertEquals(expectedResults, assistanceResults)
+    }
+
+    @Test
+    fun `Family daycare care day counts are correct`() {
+        val octFirst = LocalDate.of(2024, 10, 1)
+        val testUnitData = initTestUnitData(startDate)
+        val testChildren = initTestPlacementData(octFirst, testUnitData[0])
+
+        // add family daycare placements for 2 children: 1 under and over 3
+        db.transaction { tx ->
+            tx.insert(
+                DevPlacement(
+                    // 2024-12-01 - 2025-02-01
+                    startDate = octFirst,
+                    endDate = octFirst.plusMonths(4),
+                    unitId = testUnitData[2],
+                    childId = testChildren[4].first.id,
+                    type = PlacementType.DAYCARE,
+                )
+            )
+            val aapo = testChildren[0].first
+            val aapoPlacementEnd = testChildren[0].second.last().endDate
+            tx.insert(
+                // 2024-12-02 - 2025-02-01
+                DevPlacement(
+                    startDate = aapoPlacementEnd.plusDays(1),
+                    endDate = aapoPlacementEnd.plusMonths(4),
+                    unitId = testUnitData[2],
+                    childId = testChildren[0].first.id,
+                    type = PlacementType.DAYCARE,
+                )
+            )
+
+            // add full day absence to see that it is not counted as a care day
+            tx.insert(
+                DevAbsence(
+                    childId = aapo.id,
+                    date = LocalDate.of(2024, 12, 5),
+                    absenceCategory = AbsenceCategory.BILLABLE,
+                )
+            )
+            tx.insert(
+                DevAbsence(
+                    childId = aapo.id,
+                    date = LocalDate.of(2024, 12, 5),
+                    absenceCategory = AbsenceCategory.NONBILLABLE,
+                )
+            )
+        }
+
+        val results =
+            tampereRegionalSurvey.getTampereRegionalSurveyAgeStatistics(
+                dbInstance(),
+                adminLoginUser,
+                mockClock,
+                year = startDate.year,
+            )
+
+        //             oct  nov  dec
+        // Aapo  (<3y)           (22 - 4 - 1)
+        // Fabio (>3y) 23 + 21 + (22 - 4)
+        val expectedResults = Pair(17, 62)
+
+        val assistanceResults =
+            Pair(
+                results.ageStatistics.first().effectiveFamilyDaycareDaysUnder3Count,
+                results.ageStatistics.first().effectiveFamilyDaycareDaysOver3Count,
+            )
+
+        assertEquals(expectedResults, assistanceResults)
+    }
+
     private fun initTestUnitData(monday: LocalDate): List<DaycareId> {
         return db.transaction { tx ->
             val areaAId = tx.insert(DevCareArea(name = "Area A", shortName = "Area A"))
@@ -314,10 +742,10 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
             val daycareBId =
                 tx.insert(
                     DevDaycare(
-                        name = "Daycare B",
+                        name = "Daycare and Club B",
                         areaId = areaBId,
                         openingDate = monday.minusDays(7),
-                        type = setOf(CareType.CENTRE),
+                        type = setOf(CareType.CENTRE, CareType.CLUB),
                         operationTimes =
                             List(5) { TimeRange(LocalTime.of(8, 0), LocalTime.of(18, 0)) } +
                                 List(2) { null },
@@ -342,13 +770,44 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
                     )
                 )
 
-            listOf(daycareAId, daycareBId, daycareCId)
+            val daycareDId =
+                tx.insert(
+                    DevDaycare(
+                        name = "Private service voucher daycare",
+                        areaId = areaAId,
+                        openingDate = monday.minusMonths(1),
+                        type = setOf(CareType.CENTRE),
+                        providerType = ProviderType.PRIVATE_SERVICE_VOUCHER,
+                        operationTimes =
+                            List(5) { TimeRange(LocalTime.of(8, 0), LocalTime.of(18, 0)) } +
+                                List(2) { null },
+                        enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS),
+                    )
+                )
+
+            val daycareEId =
+                tx.insert(
+                    DevDaycare(
+                        name = "Purchased care daycare",
+                        areaId = areaAId,
+                        openingDate = monday.minusMonths(1),
+                        type = setOf(CareType.CENTRE),
+                        providerType = ProviderType.PURCHASED,
+                        operationTimes =
+                            List(5) { TimeRange(LocalTime.of(8, 0), LocalTime.of(18, 0)) } +
+                                List(2) { null },
+                        enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS),
+                    )
+                )
+
+            listOf(daycareAId, daycareBId, daycareCId, daycareDId, daycareEId)
         }
     }
 
     private fun initTestPlacementData(
         start: LocalDate,
         daycareId: DaycareId,
+        defaultPlacementDuration: FiniteDateRange = FiniteDateRange(start, start.plusMonths(2)),
     ): List<Pair<DevPerson, List<DevPlacement>>> {
 
         val actionOption10 =
@@ -437,6 +896,7 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
                     dateOfBirth = start.minusYears(2),
                     firstName = "Aapo",
                     lastName = "Aarnio",
+                    language = "si",
                 )
             tx.insert(testChildAapo, DevPersonType.CHILD)
 
@@ -445,6 +905,7 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
                     dateOfBirth = start.minusYears(4),
                     firstName = "Bertil",
                     lastName = "Becker",
+                    language = "99",
                 )
             tx.insert(testChildBertil, DevPersonType.CHILD)
 
@@ -453,6 +914,7 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
                     dateOfBirth = start.minusYears(4),
                     firstName = "Cecil",
                     lastName = "Cilliacus",
+                    language = "sv",
                 )
             tx.insert(testChildCecil, DevPersonType.CHILD)
 
@@ -461,6 +923,7 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
                     dateOfBirth = start.minusYears(4),
                     firstName = "Ville",
                     lastName = "Varahoidettava",
+                    language = "se",
                 )
 
             tx.insert(testChildVille, DevPersonType.CHILD)
@@ -477,7 +940,6 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
             // Aapo:   2v, no sn, DAYCARE placement, 09-15 -> 11-15
             // Bertil: 4v, 2x part time sn, DAYCARE placement, 09-15 -> 11-15
             // Cecil:  4v, no sn, 2x DAYCARE placement, 09-15 -> 11-15
-            val defaultPlacementDuration = FiniteDateRange(start, start.plusMonths(2))
 
             val placementA =
                 DevPlacement(

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -510,7 +510,7 @@ enum class Audit(
     SystemNotificationsReadCitizen,
     SystemNotificationsReadEmployeeMobile,
     TampereRegionalSurveyMonthly,
-    TampereRegionalSurveyAgeDivision,
+    TampereRegionalSurveyAgeStatistics,
     TemporaryEmployeesRead,
     TemporaryEmployeeCreate,
     TemporaryEmployeeRead,

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -510,6 +510,7 @@ enum class Audit(
     SystemNotificationsReadCitizen,
     SystemNotificationsReadEmployeeMobile,
     TampereRegionalSurveyMonthly,
+    TampereRegionalSurveyAgeDivision,
     TemporaryEmployeesRead,
     TemporaryEmployeeCreate,
     TemporaryEmployeeRead,


### PR DESCRIPTION
Täydentää Tampereen seutuselvitysraportille toisen CSV:n ikäjaotteluarvojen toimittamiseen. Muokkaa myös raportin käyttöliittymää niin, että eri CSV-tiedot ladataan erillisillä napeilla, sillä kyselyt ovat suurissa kunnissa raskaita.

Huom. Sisältää Kuusikkovertailuraportin hoitopäivälaskentamalliin perustuvan kyselyn, joka on testattu suorituskyvyltään hitaaksi, mutta kuitenkin hieman kuusikkovertailun pahimpia skenaarioita nopeammaksi.