### PR TITLE
Yksinkertaistetaan `FileUpload`-komponentin käyttöä

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -18,11 +18,7 @@ import { H3, Label, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/citizen'
 
-import {
-  deleteAttachment,
-  getAttachmentUrl,
-  saveApplicationAttachment
-} from '../../../attachments'
+import { getAttachmentUrl, applicationAttachment } from '../../../attachments'
 import { errorToInputInfo } from '../../../input-info-helper'
 import { useLang, useTranslation } from '../../../localization'
 import { isValidPreferredStartDate } from '../validations'
@@ -142,7 +138,10 @@ export default React.memo(function PreferredStartSubSection({
 
                 <FileUpload
                   files={formData.urgencyAttachments}
-                  onUpload={saveApplicationAttachment(applicationId, 'URGENCY')}
+                  uploadHandler={applicationAttachment(
+                    applicationId,
+                    'URGENCY'
+                  )}
                   onUploaded={(attachment) =>
                     updateFormData({
                       urgencyAttachments: [
@@ -158,7 +157,6 @@ export default React.memo(function PreferredStartSubSection({
                       ]
                     })
                   }
-                  onDelete={deleteAttachment}
                   onDeleted={(id) =>
                     updateFormData({
                       urgencyAttachments: formData.urgencyAttachments.filter(

--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react'
 
-import { Result, wrapResult } from 'lib-common/api'
+import { wrapResult } from 'lib-common/api'
 import {
   ApplicationId,
   AttachmentId
@@ -51,36 +51,6 @@ export default React.memo(function PreferredStartSubSection({
   const t = useTranslation()
   const [lang] = useLang()
   const labelId = useUniqueId()
-
-  const uploadUrgencyAttachment = (
-    file: File,
-    onUploadProgress: (percentage: number) => void
-  ): Promise<Result<AttachmentId>> =>
-    saveApplicationAttachment(
-      applicationId,
-      file,
-      'URGENCY',
-      onUploadProgress
-    ).then((result) => {
-      if (result.isSuccess) {
-        updateFormData({
-          urgencyAttachments: [
-            ...formData.urgencyAttachments,
-            {
-              id: result.value,
-              name: file.name,
-              contentType: file.type,
-              updated: HelsinkiDateTime.now(),
-              receivedAt: HelsinkiDateTime.now(),
-              type: 'URGENCY',
-              uploadedByEmployee: null,
-              uploadedByPerson: null
-            }
-          ]
-        })
-      }
-      return result
-    })
 
   const deleteUrgencyAttachment = (id: AttachmentId) =>
     deleteAttachmentResult({ attachmentId: id }).then((result) => {
@@ -190,7 +160,22 @@ export default React.memo(function PreferredStartSubSection({
 
                 <FileUpload
                   files={formData.urgencyAttachments}
-                  onUpload={uploadUrgencyAttachment}
+                  onUpload={saveApplicationAttachment(applicationId, 'URGENCY')}
+                  onUploaded={(attachment) =>
+                    updateFormData({
+                      urgencyAttachments: [
+                        ...formData.urgencyAttachments,
+                        {
+                          ...attachment,
+                          updated: HelsinkiDateTime.now(),
+                          receivedAt: HelsinkiDateTime.now(),
+                          type: 'URGENCY',
+                          uploadedByEmployee: null,
+                          uploadedByPerson: null
+                        }
+                      ]
+                    })
+                  }
                   onDelete={deleteUrgencyAttachment}
                   getDownloadUrl={getAttachmentUrl}
                   data-qa="urgent-file-upload"

--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -4,11 +4,7 @@
 
 import React from 'react'
 
-import { wrapResult } from 'lib-common/api'
-import {
-  ApplicationId,
-  AttachmentId
-} from 'lib-common/generated/api-types/shared'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
@@ -23,18 +19,16 @@ import { Gap } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/citizen'
 
 import {
+  deleteAttachment,
   getAttachmentUrl,
   saveApplicationAttachment
 } from '../../../attachments'
-import { deleteAttachment } from '../../../generated/api-clients/attachment'
 import { errorToInputInfo } from '../../../input-info-helper'
 import { useLang, useTranslation } from '../../../localization'
 import { isValidPreferredStartDate } from '../validations'
 
 import { ClubTermsInfo } from './ClubTermsInfo'
 import { ServiceNeedSectionProps } from './ServiceNeedSection'
-
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 export default React.memo(function PreferredStartSubSection({
   originalPreferredStartDate,
@@ -51,18 +45,6 @@ export default React.memo(function PreferredStartSubSection({
   const t = useTranslation()
   const [lang] = useLang()
   const labelId = useUniqueId()
-
-  const deleteUrgencyAttachment = (id: AttachmentId) =>
-    deleteAttachmentResult({ attachmentId: id }).then((result) => {
-      if (result.isSuccess) {
-        updateFormData({
-          urgencyAttachments: formData.urgencyAttachments.filter(
-            (file) => file.id !== id
-          )
-        })
-      }
-      return result
-    })
 
   const showDaycare4MonthWarning = (): boolean =>
     type === 'DAYCARE' &&
@@ -176,7 +158,14 @@ export default React.memo(function PreferredStartSubSection({
                       ]
                     })
                   }
-                  onDelete={deleteUrgencyAttachment}
+                  onDelete={deleteAttachment}
+                  onDeleted={(id) =>
+                    updateFormData({
+                      urgencyAttachments: formData.urgencyAttachments.filter(
+                        (file) => file.id !== id
+                      )
+                    })
+                  }
                   getDownloadUrl={getAttachmentUrl}
                   data-qa="urgent-file-upload"
                 />

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -5,12 +5,8 @@
 import React, { useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 
-import { wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
-import {
-  ApplicationId,
-  AttachmentId
-} from 'lib-common/generated/api-types/shared'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
@@ -29,10 +25,10 @@ import { featureFlags } from 'lib-customizations/citizen'
 import { placementTypes } from 'lib-customizations/employee'
 
 import {
+  deleteAttachment,
   getAttachmentUrl,
   saveApplicationAttachment
 } from '../../../attachments'
-import { deleteAttachment } from '../../../generated/api-clients/attachment'
 import { errorToInputInfo } from '../../../input-info-helper'
 import { useLang, useTranslation } from '../../../localization'
 
@@ -45,8 +41,6 @@ const Hyphenbox = styled.div`
 type ServiceTimeSubSectionProps = Omit<ServiceNeedSectionProps, 'type'>
 
 const applicationType = 'DAYCARE'
-
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 export default React.memo(function ServiceTimeSubSectionDaycare({
   formData,
@@ -118,18 +112,6 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
       serviceNeedOption
     })
   }
-
-  const deleteExtendedCareAttachment = (id: AttachmentId) =>
-    deleteAttachmentResult({ attachmentId: id }).then((result) => {
-      if (result.isSuccess) {
-        updateFormData({
-          shiftCareAttachments: formData.shiftCareAttachments.filter(
-            (file) => file.id !== id
-          )
-        })
-      }
-      return result
-    })
 
   function renderServiceNeedSelection() {
     if (serviceNeedOptions.length > 0 && !preferredStartDate) {
@@ -342,7 +324,14 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
                 ]
               })
             }
-            onDelete={deleteExtendedCareAttachment}
+            onDelete={deleteAttachment}
+            onDeleted={(id) =>
+              updateFormData({
+                shiftCareAttachments: formData.shiftCareAttachments.filter(
+                  (file) => file.id !== id
+                )
+              })
+            }
             getDownloadUrl={getAttachmentUrl}
           />
         </>

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 
-import { Result, wrapResult } from 'lib-common/api'
+import { wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import {
   ApplicationId,
@@ -118,36 +118,6 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
       serviceNeedOption
     })
   }
-
-  const uploadExtendedCareAttachment = (
-    file: File,
-    onUploadProgress: (percentage: number) => void
-  ): Promise<Result<AttachmentId>> =>
-    saveApplicationAttachment(
-      applicationId,
-      file,
-      'EXTENDED_CARE',
-      onUploadProgress
-    ).then((result) => {
-      if (result.isSuccess) {
-        updateFormData({
-          shiftCareAttachments: [
-            ...formData.shiftCareAttachments,
-            {
-              id: result.value,
-              name: file.name,
-              contentType: file.type,
-              updated: HelsinkiDateTime.now(),
-              receivedAt: HelsinkiDateTime.now(),
-              type: 'EXTENDED_CARE',
-              uploadedByEmployee: null,
-              uploadedByPerson: null
-            }
-          ]
-        })
-      }
-      return result
-    })
 
   const deleteExtendedCareAttachment = (id: AttachmentId) =>
     deleteAttachmentResult({ attachmentId: id }).then((result) => {
@@ -356,7 +326,22 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
 
           <FileUpload
             files={formData.shiftCareAttachments}
-            onUpload={uploadExtendedCareAttachment}
+            onUpload={saveApplicationAttachment(applicationId, 'EXTENDED_CARE')}
+            onUploaded={(attachment) =>
+              updateFormData({
+                shiftCareAttachments: [
+                  ...formData.shiftCareAttachments,
+                  {
+                    ...attachment,
+                    updated: HelsinkiDateTime.now(),
+                    receivedAt: HelsinkiDateTime.now(),
+                    type: 'EXTENDED_CARE',
+                    uploadedByEmployee: null,
+                    uploadedByPerson: null
+                  }
+                ]
+              })
+            }
             onDelete={deleteExtendedCareAttachment}
             getDownloadUrl={getAttachmentUrl}
           />

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -24,11 +24,7 @@ import { defaultMargins, Gap } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/citizen'
 import { placementTypes } from 'lib-customizations/employee'
 
-import {
-  deleteAttachment,
-  getAttachmentUrl,
-  saveApplicationAttachment
-} from '../../../attachments'
+import { getAttachmentUrl, applicationAttachment } from '../../../attachments'
 import { errorToInputInfo } from '../../../input-info-helper'
 import { useLang, useTranslation } from '../../../localization'
 
@@ -308,7 +304,10 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
 
           <FileUpload
             files={formData.shiftCareAttachments}
-            onUpload={saveApplicationAttachment(applicationId, 'EXTENDED_CARE')}
+            uploadHandler={applicationAttachment(
+              applicationId,
+              'EXTENDED_CARE'
+            )}
             onUploaded={(attachment) =>
               updateFormData({
                 shiftCareAttachments: [
@@ -324,7 +323,6 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
                 ]
               })
             }
-            onDelete={deleteAttachment}
             onDeleted={(id) =>
               updateFormData({
                 shiftCareAttachments: formData.shiftCareAttachments.filter(

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -28,11 +28,7 @@ import { H3, Label } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/citizen'
 
-import {
-  deleteAttachment,
-  getAttachmentUrl,
-  saveApplicationAttachment
-} from '../../../attachments'
+import { getAttachmentUrl, applicationAttachment } from '../../../attachments'
 import { errorToInputInfo } from '../../../input-info-helper'
 import { useLang, useTranslation } from '../../../localization'
 import { isValidPreferredStartDate } from '../validations'
@@ -339,7 +335,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
 
               <FileUpload
                 files={formData.shiftCareAttachments}
-                onUpload={saveApplicationAttachment(
+                uploadHandler={applicationAttachment(
                   applicationId,
                   'EXTENDED_CARE'
                 )}
@@ -358,7 +354,6 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
                     ]
                   })
                 }
-                onDelete={deleteAttachment}
                 onDeleted={(id) =>
                   updateFormData({
                     shiftCareAttachments: formData.shiftCareAttachments.filter(

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -5,14 +5,10 @@
 import React, { useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 
-import { wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import { ServiceNeedOptionPublicInfo } from 'lib-common/generated/api-types/serviceneed'
-import {
-  ApplicationId,
-  AttachmentId
-} from 'lib-common/generated/api-types/shared'
+import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
@@ -33,10 +29,10 @@ import { defaultMargins, Gap } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/citizen'
 
 import {
+  deleteAttachment,
   getAttachmentUrl,
   saveApplicationAttachment
 } from '../../../attachments'
-import { deleteAttachment } from '../../../generated/api-clients/attachment'
 import { errorToInputInfo } from '../../../input-info-helper'
 import { useLang, useTranslation } from '../../../localization'
 import { isValidPreferredStartDate } from '../validations'
@@ -50,8 +46,6 @@ const Hyphenbox = styled.div`
 type ServiceTimeSubSectionProps = Omit<ServiceNeedSectionProps, 'type'>
 
 const applicationType = 'PRESCHOOL'
-
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 export default React.memo(function ServiceTimeSubSectionPreschool({
   originalPreferredStartDate,
@@ -83,18 +77,6 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
       new Map<PlacementType, ServiceNeedOptionPublicInfo[]>(),
     [serviceNeedOptions]
   )
-
-  const deleteExtendedCareAttachment = (id: AttachmentId) =>
-    deleteAttachmentResult({ attachmentId: id }).then((result) => {
-      if (result.isSuccess) {
-        updateFormData({
-          shiftCareAttachments: formData.shiftCareAttachments.filter(
-            (file) => file.id !== id
-          )
-        })
-      }
-      return result
-    })
 
   const preferredStartDate = featureFlags.preschoolApplication
     .connectedDaycarePreferredStartDate
@@ -376,7 +358,14 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
                     ]
                   })
                 }
-                onDelete={deleteExtendedCareAttachment}
+                onDelete={deleteAttachment}
+                onDeleted={(id) =>
+                  updateFormData({
+                    shiftCareAttachments: formData.shiftCareAttachments.filter(
+                      (file) => file.id !== id
+                    )
+                  })
+                }
                 getDownloadUrl={getAttachmentUrl}
               />
             </>

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 
-import { Result, wrapResult } from 'lib-common/api'
+import { wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import { ServiceNeedOptionPublicInfo } from 'lib-common/generated/api-types/serviceneed'
@@ -83,36 +83,6 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
       new Map<PlacementType, ServiceNeedOptionPublicInfo[]>(),
     [serviceNeedOptions]
   )
-
-  const uploadExtendedCareAttachment = (
-    file: File,
-    onUploadProgress: (percentage: number) => void
-  ): Promise<Result<AttachmentId>> =>
-    saveApplicationAttachment(
-      applicationId,
-      file,
-      'EXTENDED_CARE',
-      onUploadProgress
-    ).then((result) => {
-      if (result.isSuccess) {
-        updateFormData({
-          shiftCareAttachments: [
-            ...formData.shiftCareAttachments,
-            {
-              id: result.value,
-              name: file.name,
-              contentType: file.type,
-              updated: HelsinkiDateTime.now(),
-              receivedAt: HelsinkiDateTime.now(),
-              type: 'EXTENDED_CARE',
-              uploadedByEmployee: null,
-              uploadedByPerson: null
-            }
-          ]
-        })
-      }
-      return result
-    })
 
   const deleteExtendedCareAttachment = (id: AttachmentId) =>
     deleteAttachmentResult({ attachmentId: id }).then((result) => {
@@ -387,7 +357,25 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
 
               <FileUpload
                 files={formData.shiftCareAttachments}
-                onUpload={uploadExtendedCareAttachment}
+                onUpload={saveApplicationAttachment(
+                  applicationId,
+                  'EXTENDED_CARE'
+                )}
+                onUploaded={(attachment) =>
+                  updateFormData({
+                    shiftCareAttachments: [
+                      ...formData.shiftCareAttachments,
+                      {
+                        ...attachment,
+                        updated: HelsinkiDateTime.now(),
+                        receivedAt: HelsinkiDateTime.now(),
+                        type: 'EXTENDED_CARE',
+                        uploadedByEmployee: null,
+                        uploadedByPerson: null
+                      }
+                    ]
+                  })
+                }
                 onDelete={deleteExtendedCareAttachment}
                 getDownloadUrl={getAttachmentUrl}
               />

--- a/frontend/src/citizen-frontend/attachments.ts
+++ b/frontend/src/citizen-frontend/attachments.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Failure, Success } from 'lib-common/api'
+import { Failure, Success, wrapResult } from 'lib-common/api'
 import { AttachmentType } from 'lib-common/generated/api-types/attachment'
 import {
   ApplicationId,
@@ -12,6 +12,7 @@ import {
 import { UploadHandler } from 'lib-components/molecules/FileUpload'
 
 import { API_URL, client } from './api-client'
+import { deleteAttachment as deleteAttachmentPromise } from './generated/api-clients/attachment'
 
 function uploadHandler(url: string): UploadHandler {
   return async (file, onUploadProgress) => {
@@ -65,3 +66,5 @@ export function getAttachmentUrl(
   const encodedFilename = encodeURIComponent(requestedFilename)
   return `${API_URL}/citizen/attachments/${attachmentId}/download/${encodedFilename}`
 }
+
+export const deleteAttachment = wrapResult(deleteAttachmentPromise)

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback } from 'react'
+import React from 'react'
 
-import { wrapResult } from 'lib-common/api'
 import { Attachment } from 'lib-common/generated/api-types/attachment'
 import {
   AttachmentId,
@@ -13,10 +12,11 @@ import {
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import FileUpload from 'lib-components/molecules/FileUpload'
 
-import { getAttachmentUrl, saveIncomeStatementAttachment } from '../attachments'
-import { deleteAttachment } from '../generated/api-clients/attachment'
-
-const deleteAttachmentResult = wrapResult(deleteAttachment)
+import {
+  deleteAttachment,
+  getAttachmentUrl,
+  saveIncomeStatementAttachment
+} from '../attachments'
 
 export default React.memo(function Attachments({
   incomeStatementId,
@@ -29,21 +29,14 @@ export default React.memo(function Attachments({
   onUploaded: (attachment: Attachment) => void
   onDeleted: (attachmentId: AttachmentId) => void
 }) {
-  const handleDelete = useCallback(
-    async (id: AttachmentId) =>
-      (await deleteAttachmentResult({ attachmentId: id })).map(() => {
-        onDeleted(id)
-      }),
-    [onDeleted]
-  )
-
   return (
     <FixedSpaceColumn spacing="zero">
       <FileUpload
         files={attachments}
         onUpload={saveIncomeStatementAttachment(incomeStatementId)}
         onUploaded={onUploaded}
-        onDelete={handleDelete}
+        onDelete={deleteAttachment}
+        onDeleted={onDeleted}
         getDownloadUrl={getAttachmentUrl}
       />
     </FixedSpaceColumn>

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
@@ -12,11 +12,7 @@ import {
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import FileUpload from 'lib-components/molecules/FileUpload'
 
-import {
-  deleteAttachment,
-  getAttachmentUrl,
-  saveIncomeStatementAttachment
-} from '../attachments'
+import { getAttachmentUrl, incomeStatementAttachment } from '../attachments'
 
 export default React.memo(function Attachments({
   incomeStatementId,
@@ -33,9 +29,8 @@ export default React.memo(function Attachments({
     <FixedSpaceColumn spacing="zero">
       <FileUpload
         files={attachments}
-        onUpload={saveIncomeStatementAttachment(incomeStatementId)}
+        uploadHandler={incomeStatementAttachment(incomeStatementId)}
         onUploaded={onUploaded}
-        onDelete={deleteAttachment}
         onDeleted={onDeleted}
         getDownloadUrl={getAttachmentUrl}
       />

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
@@ -29,25 +29,6 @@ export default React.memo(function Attachments({
   onUploaded: (attachment: Attachment) => void
   onDeleted: (attachmentId: AttachmentId) => void
 }) {
-  const handleUpload = useCallback(
-    async (file: File, onUploadProgress: (percentage: number) => void) =>
-      (
-        await saveIncomeStatementAttachment(
-          incomeStatementId,
-          file,
-          onUploadProgress
-        )
-      ).map((id) => {
-        onUploaded({
-          id,
-          name: file.name,
-          contentType: file.type
-        })
-        return id
-      }),
-    [incomeStatementId, onUploaded]
-  )
-
   const handleDelete = useCallback(
     async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() => {
@@ -60,7 +41,8 @@ export default React.memo(function Attachments({
     <FixedSpaceColumn spacing="zero">
       <FileUpload
         files={attachments}
-        onUpload={handleUpload}
+        onUpload={saveIncomeStatementAttachment(incomeStatementId)}
+        onUploaded={onUploaded}
         onDelete={handleDelete}
         getDownloadUrl={getAttachmentUrl}
       />

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
@@ -40,25 +40,6 @@ export default React.memo(function Attachments({
 }) {
   const t = useTranslation()
 
-  const handleUpload = useCallback(
-    async (file: File, onUploadProgress: (percentage: number) => void) =>
-      (
-        await saveIncomeStatementAttachment(
-          incomeStatementId,
-          file,
-          onUploadProgress
-        )
-      ).map((id) => {
-        onUploaded({
-          id,
-          name: file.name,
-          contentType: file.type
-        })
-        return id
-      }),
-    [incomeStatementId, onUploaded]
-  )
-
   const handleDelete = useCallback(
     async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() => {
@@ -90,7 +71,8 @@ export default React.memo(function Attachments({
         )}
         <FileUpload
           files={attachments}
-          onUpload={handleUpload}
+          onUpload={saveIncomeStatementAttachment(incomeStatementId)}
+          onUploaded={onUploaded}
           onDelete={handleDelete}
           getDownloadUrl={getAttachmentUrl}
         />

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback } from 'react'
+import React from 'react'
 
-import { wrapResult } from 'lib-common/api'
 import { Attachment } from 'lib-common/generated/api-types/attachment'
 import {
   AttachmentId,
@@ -17,13 +16,14 @@ import FileUpload from 'lib-components/molecules/FileUpload'
 import { H3, H4, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
-import { getAttachmentUrl, saveIncomeStatementAttachment } from '../attachments'
-import { deleteAttachment } from '../generated/api-clients/attachment'
+import {
+  deleteAttachment,
+  getAttachmentUrl,
+  saveIncomeStatementAttachment
+} from '../attachments'
 import { useTranslation } from '../localization'
 
 import { AttachmentType } from './types/common'
-
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 export default React.memo(function Attachments({
   incomeStatementId,
@@ -39,14 +39,6 @@ export default React.memo(function Attachments({
   onDeleted: (attachmentId: AttachmentId) => void
 }) {
   const t = useTranslation()
-
-  const handleDelete = useCallback(
-    async (id: AttachmentId) =>
-      (await deleteAttachmentResult({ attachmentId: id })).map(() => {
-        onDeleted(id)
-      }),
-    [onDeleted]
-  )
 
   return (
     <ContentArea opaque paddingVertical="L">
@@ -73,7 +65,8 @@ export default React.memo(function Attachments({
           files={attachments}
           onUpload={saveIncomeStatementAttachment(incomeStatementId)}
           onUploaded={onUploaded}
-          onDelete={handleDelete}
+          onDelete={deleteAttachment}
+          onDeleted={onDeleted}
           getDownloadUrl={getAttachmentUrl}
         />
       </FixedSpaceColumn>

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
@@ -16,11 +16,7 @@ import FileUpload from 'lib-components/molecules/FileUpload'
 import { H3, H4, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
-import {
-  deleteAttachment,
-  getAttachmentUrl,
-  saveIncomeStatementAttachment
-} from '../attachments'
+import { getAttachmentUrl, incomeStatementAttachment } from '../attachments'
 import { useTranslation } from '../localization'
 
 import { AttachmentType } from './types/common'
@@ -63,9 +59,8 @@ export default React.memo(function Attachments({
         )}
         <FileUpload
           files={attachments}
-          onUpload={saveIncomeStatementAttachment(incomeStatementId)}
+          uploadHandler={incomeStatementAttachment(incomeStatementId)}
           onUploaded={onUploaded}
-          onDelete={deleteAttachment}
           onDeleted={onDeleted}
           getDownloadUrl={getAttachmentUrl}
         />

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -44,11 +44,7 @@ import colors from 'lib-customizations/common'
 import { faTimes } from 'lib-icons'
 
 import ModalAccessibilityWrapper from '../ModalAccessibilityWrapper'
-import {
-  deleteAttachment,
-  getAttachmentUrl,
-  saveMessageAttachment
-} from '../attachments'
+import { getAttachmentUrl, messageAttachment } from '../attachments'
 import { useUser } from '../auth/state'
 import { useTranslation } from '../localization'
 
@@ -399,11 +395,10 @@ export default React.memo(function MessageEditor({
                 <FileUpload
                   slimSingleFile
                   files={attachments}
-                  onUpload={saveMessageAttachment}
+                  uploadHandler={messageAttachment}
                   onUploaded={(attachment) =>
                     setAttachments((prev) => [...prev, attachment])
                   }
-                  onDelete={deleteAttachment}
                   onDeleted={(id) =>
                     setAttachments((prev) => prev.filter((a) => a.id !== id))
                   }

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -109,18 +109,6 @@ export default React.memo(function MessageEditor({
 
   const [isChildSelectionTouched, setChildSelectionTouched] = useBoolean(false)
 
-  const handleAttachmentUpload = useCallback(
-    async (file: File, onUploadProgress: (percentage: number) => void) =>
-      (await saveMessageAttachment(file, onUploadProgress)).map((id) => {
-        setAttachments((prev) => [
-          ...prev,
-          { id, name: file.name, contentType: file.type }
-        ])
-        return id
-      }),
-    []
-  )
-
   const handleAttachmentDelete = useCallback(
     async (id: AttachmentId) =>
       deleteAttachment({ attachmentId: id })
@@ -420,7 +408,10 @@ export default React.memo(function MessageEditor({
                 <FileUpload
                   slimSingleFile
                   files={attachments}
-                  onUpload={handleAttachmentUpload}
+                  onUpload={saveMessageAttachment}
+                  onUploaded={(attachment) =>
+                    setAttachments((prev) => [...prev, attachment])
+                  }
                   onDelete={handleAttachmentDelete}
                   onStateChange={setUploadStatus}
                   getDownloadUrl={getAttachmentUrl}

--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components'
 
 import { ErrorMessageBox } from 'citizen-frontend/calendar/ChildSelector'
 import { getDuplicateChildInfo } from 'citizen-frontend/utils/duplicated-child-utils'
-import { Failure, Result, Success } from 'lib-common/api'
+import { Result } from 'lib-common/api'
 import { useBoolean } from 'lib-common/form/hooks'
 import { Attachment } from 'lib-common/generated/api-types/attachment'
 import { ChildAndPermittedActions } from 'lib-common/generated/api-types/children'
@@ -19,7 +19,6 @@ import {
   GetReceiversResponse,
   MessageAccount
 } from 'lib-common/generated/api-types/messaging'
-import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { formatFirstName } from 'lib-common/names'
 import { SelectionChip } from 'lib-components/atoms/Chip'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -45,9 +44,12 @@ import colors from 'lib-customizations/common'
 import { faTimes } from 'lib-icons'
 
 import ModalAccessibilityWrapper from '../ModalAccessibilityWrapper'
-import { getAttachmentUrl, saveMessageAttachment } from '../attachments'
+import {
+  deleteAttachment,
+  getAttachmentUrl,
+  saveMessageAttachment
+} from '../attachments'
 import { useUser } from '../auth/state'
-import { deleteAttachment } from '../generated/api-clients/attachment'
 import { useTranslation } from '../localization'
 
 const emptyMessage: CitizenMessageBody = {
@@ -108,17 +110,6 @@ export default React.memo(function MessageEditor({
     useState<UploadStatus>(initialUploadStatus)
 
   const [isChildSelectionTouched, setChildSelectionTouched] = useBoolean(false)
-
-  const handleAttachmentDelete = useCallback(
-    async (id: AttachmentId) =>
-      deleteAttachment({ attachmentId: id })
-        .then(() => {
-          setAttachments((prev) => prev.filter((a) => a.id !== id))
-          return Success.of()
-        })
-        .catch((e) => Failure.fromError<void>(e)),
-    []
-  )
 
   useEffect(
     () =>
@@ -412,7 +403,10 @@ export default React.memo(function MessageEditor({
                   onUploaded={(attachment) =>
                     setAttachments((prev) => [...prev, attachment])
                   }
-                  onDelete={handleAttachmentDelete}
+                  onDelete={deleteAttachment}
+                  onDeleted={(id) =>
+                    setAttachments((prev) => prev.filter((a) => a.id !== id))
+                  }
                   onStateChange={setUploadStatus}
                   getDownloadUrl={getAttachmentUrl}
                   data-qa="upload-message-attachment"

--- a/frontend/src/employee-frontend/api/attachments.ts
+++ b/frontend/src/employee-frontend/api/attachments.ts
@@ -2,11 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Failure, Success } from 'lib-common/api'
+import { Failure, Success, wrapResult } from 'lib-common/api'
 import { AttachmentType } from 'lib-common/generated/api-types/attachment'
 import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
 import { UploadHandler } from 'lib-components/molecules/FileUpload'
+
+import { deleteAttachment as deleteAttachmentPromise } from '../generated/api-clients/attachment'
 
 import { API_URL, client } from './client'
 
@@ -95,3 +97,5 @@ export function getAttachmentUrl(
   const encodedFilename = encodeURIComponent(requestedFilename)
   return `${API_URL}/employee/attachments/${attachmentId}/download/${encodedFilename}`
 }
+
+export const deleteAttachment = wrapResult(deleteAttachmentPromise)

--- a/frontend/src/employee-frontend/api/attachments.ts
+++ b/frontend/src/employee-frontend/api/attachments.ts
@@ -2,131 +2,91 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Failure, Result, Success } from 'lib-common/api'
+import { Failure, Success } from 'lib-common/api'
 import { AttachmentType } from 'lib-common/generated/api-types/attachment'
 import { AttachmentId } from 'lib-common/generated/api-types/shared'
 import { UUID } from 'lib-common/types'
+import { UploadHandler } from 'lib-components/molecules/FileUpload'
 
 import { API_URL, client } from './client'
 
-async function doSaveAttachment(
-  config: { path: string; params?: unknown },
-  file: File,
-  onUploadProgress: (percentage: number) => void
-): Promise<Result<AttachmentId>> {
-  const formData = new FormData()
-  formData.append('file', file)
+function uploadHandler(config: {
+  path: string
+  params?: unknown
+}): UploadHandler {
+  return async (file, onUploadProgress) => {
+    const formData = new FormData()
+    formData.append('file', file)
 
-  try {
-    const { data } = await client.post<AttachmentId>(config.path, formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
-      params: config.params,
-      onUploadProgress: ({ loaded, total }) =>
-        onUploadProgress(
-          total !== undefined && total !== 0
-            ? Math.round((loaded * 100) / total)
-            : 0
-        )
-    })
-    return Success.of(data)
-  } catch (e) {
-    return Failure.fromError(e)
+    try {
+      const { data } = await client.post<AttachmentId>(config.path, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+        params: config.params,
+        onUploadProgress: ({ loaded, total }) =>
+          onUploadProgress(
+            total !== undefined && total !== 0
+              ? Math.round((loaded * 100) / total)
+              : 0
+          )
+      })
+      return Success.of(data)
+    } catch (e) {
+      return Failure.fromError(e)
+    }
   }
 }
 
-export async function saveApplicationAttachment(
+export function saveApplicationAttachment(
   applicationId: UUID,
-  file: File,
-  type: AttachmentType,
-  onUploadProgress: (percentage: number) => void
-): Promise<Result<AttachmentId>> {
-  return await doSaveAttachment(
-    {
-      path: `/employee/attachments/applications/${applicationId}`,
-      params: { type }
-    },
-    file,
-    onUploadProgress
-  )
+  type: AttachmentType
+): UploadHandler {
+  return uploadHandler({
+    path: `/employee/attachments/applications/${applicationId}`,
+    params: { type }
+  })
 }
 
-export async function saveIncomeStatementAttachment(
-  incomeStatementId: UUID,
-  file: File,
-  onUploadProgress: (percentage: number) => void
-): Promise<Result<AttachmentId>> {
-  return await doSaveAttachment(
-    { path: `/employee/attachments/income-statements/${incomeStatementId}` },
-    file,
-    onUploadProgress
-  )
+export function saveIncomeStatementAttachment(
+  incomeStatementId: UUID
+): UploadHandler {
+  return uploadHandler({
+    path: `/employee/attachments/income-statements/${incomeStatementId}`
+  })
 }
 
-export async function saveIncomeAttachment(
-  incomeId: UUID | null,
-  file: File,
-  onUploadProgress: (percentage: number) => void
-): Promise<Result<AttachmentId>> {
-  return await doSaveAttachment(
-    {
-      path: incomeId
-        ? `/employee/attachments/income/${incomeId}`
-        : `/employee/attachments/income`
-    },
-    file,
-    onUploadProgress
-  )
+export function saveIncomeAttachment(incomeId: UUID | null): UploadHandler {
+  return uploadHandler({
+    path: incomeId
+      ? `/employee/attachments/income/${incomeId}`
+      : `/employee/attachments/income`
+  })
 }
 
-export async function saveInvoiceAttachment(
-  invoiceId: UUID,
-  file: File,
-  onUploadProgress: (percentage: number) => void
-): Promise<Result<AttachmentId>> {
-  return await doSaveAttachment(
-    { path: `/employee/attachments/invoices/${invoiceId}` },
-    file,
-    onUploadProgress
-  )
+export function saveInvoiceAttachment(invoiceId: UUID): UploadHandler {
+  return uploadHandler({ path: `/employee/attachments/invoices/${invoiceId}` })
 }
 
-export async function saveFeeAlterationAttachment(
-  feeAlterationId: UUID | null,
-  file: File,
-  onUploadProgress: (percentage: number) => void
-): Promise<Result<AttachmentId>> {
-  return await doSaveAttachment(
-    {
-      path: feeAlterationId
-        ? `/employee/attachments/fee-alteration/${feeAlterationId}`
-        : `/employee/attachments/fee-alteration`
-    },
-    file,
-    onUploadProgress
-  )
+export function saveFeeAlterationAttachment(
+  feeAlterationId: UUID | null
+): UploadHandler {
+  return uploadHandler({
+    path: feeAlterationId
+      ? `/employee/attachments/fee-alteration/${feeAlterationId}`
+      : `/employee/attachments/fee-alteration`
+  })
 }
 
-export const saveMessageAttachment = (
-  draftId: UUID,
-  file: File,
-  onUploadProgress: (percentage: number) => void
-): Promise<Result<AttachmentId>> =>
-  doSaveAttachment(
-    { path: `/employee/attachments/messages/${draftId}` },
-    file,
-    onUploadProgress
-  )
+export function saveMessageAttachment(draftId: UUID): UploadHandler {
+  return uploadHandler({ path: `/employee/attachments/messages/${draftId}` })
+}
 
-export const savePedagogicalDocumentAttachment = (
-  documentId: UUID,
-  file: File,
-  onUploadProgress: (percentage: number) => void
-): Promise<Result<AttachmentId>> =>
-  doSaveAttachment(
-    { path: `/employee/attachments/pedagogical-documents/${documentId}` },
-    file,
-    onUploadProgress
-  )
+export function savePedagogicalDocumentAttachment(
+  documentId: UUID
+): UploadHandler {
+  return uploadHandler({
+    path: `/employee/attachments/pedagogical-documents/${documentId}`
+  })
+}
 
 export function getAttachmentUrl(
   attachmentId: UUID,

--- a/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
+++ b/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
@@ -38,11 +38,7 @@ import FileUpload, { fileIcon } from 'lib-components/molecules/FileUpload'
 import { H1, H2, H3, Label, P } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 
-import {
-  deleteAttachment,
-  getAttachmentUrl,
-  saveIncomeStatementAttachment
-} from '../api/attachments'
+import { getAttachmentUrl, incomeStatementAttachment } from '../api/attachments'
 import {
   getIncomeStatement,
   setIncomeStatementHandled
@@ -467,9 +463,8 @@ function EmployeeAttachments({
       <P>{i18n.incomeStatement.employeeAttachments.description}</P>
       <FileUpload
         files={attachments}
-        onUpload={saveIncomeStatementAttachment(incomeStatementId)}
+        uploadHandler={incomeStatementAttachment(incomeStatementId)}
         onUploaded={onUploaded}
-        onDelete={deleteAttachment}
         onDeleted={onDeleted}
         getDownloadUrl={getAttachmentUrl}
       />

--- a/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
+++ b/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
@@ -463,21 +463,6 @@ function EmployeeAttachments({
 }) {
   const { i18n } = useTranslation()
 
-  const handleUpload = useCallback(
-    async (file: File, onUploadProgress: (percentage: number) => void) =>
-      (
-        await saveIncomeStatementAttachment(
-          incomeStatementId,
-          file,
-          onUploadProgress
-        )
-      ).map((id) => {
-        onUploaded({ id, name: file.name, contentType: file.type })
-        return id
-      }),
-    [incomeStatementId, onUploaded]
-  )
-
   const handleDelete = useCallback(
     async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() => {
@@ -492,7 +477,8 @@ function EmployeeAttachments({
       <P>{i18n.incomeStatement.employeeAttachments.description}</P>
       <FileUpload
         files={attachments}
-        onUpload={handleUpload}
+        onUpload={saveIncomeStatementAttachment(incomeStatementId)}
+        onUploaded={onUploaded}
         onDelete={handleDelete}
         getDownloadUrl={getAttachmentUrl}
       />

--- a/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
+++ b/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
@@ -18,7 +18,6 @@ import {
   SetIncomeStatementHandledBody
 } from 'lib-common/generated/api-types/incomestatement'
 import {
-  AttachmentId,
   IncomeStatementId,
   PersonId
 } from 'lib-common/generated/api-types/shared'
@@ -40,10 +39,10 @@ import { H1, H2, H3, Label, P } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 
 import {
+  deleteAttachment,
   getAttachmentUrl,
   saveIncomeStatementAttachment
 } from '../api/attachments'
-import { deleteAttachment } from '../generated/api-clients/attachment'
 import {
   getIncomeStatement,
   setIncomeStatementHandled
@@ -54,7 +53,6 @@ import { Translations, useTranslation } from '../state/i18n'
 import { renderResult } from './async-rendering'
 
 const getPersonIdentityResult = wrapResult(getPersonIdentity)
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 const getIncomeStatementResult = wrapResult(getIncomeStatement)
 const setIncomeStatementHandledResult = wrapResult(setIncomeStatementHandled)
 
@@ -463,14 +461,6 @@ function EmployeeAttachments({
 }) {
   const { i18n } = useTranslation()
 
-  const handleDelete = useCallback(
-    async (id: AttachmentId) =>
-      (await deleteAttachmentResult({ attachmentId: id })).map(() => {
-        onDeleted(id)
-      }),
-    [onDeleted]
-  )
-
   return (
     <>
       <H1>{i18n.incomeStatement.employeeAttachments.title}</H1>
@@ -479,7 +469,8 @@ function EmployeeAttachments({
         files={attachments}
         onUpload={saveIncomeStatementAttachment(incomeStatementId)}
         onUploaded={onUploaded}
-        onDelete={handleDelete}
+        onDelete={deleteAttachment}
+        onDeleted={onDeleted}
         getDownloadUrl={getAttachmentUrl}
       />
     </>

--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -57,11 +57,7 @@ import {
   faUsers
 } from 'lib-icons'
 
-import {
-  deleteAttachment,
-  getAttachmentUrl,
-  saveApplicationAttachment
-} from '../../api/attachments'
+import { getAttachmentUrl, applicationAttachment } from '../../api/attachments'
 import ApplicationStatusSection from '../../components/application-page/ApplicationStatusSection'
 import ApplicationTitle from '../../components/application-page/ApplicationTitle'
 import VTJGuardian from '../../components/application-page/VTJGuardian'
@@ -293,12 +289,11 @@ export default React.memo(function ApplicationEditView({
               {urgent && featureFlags.urgencyAttachments && (
                 <FileUploadGridContainer>
                   <FileUpload
-                    onUpload={saveApplicationAttachment(
+                    uploadHandler={applicationAttachment(
                       application.id,
                       'URGENCY'
                     )}
                     onUploaded={onAttachmentUploaded('URGENCY')}
-                    onDelete={deleteAttachment}
                     onDeleted={handleAttachmentDeleted}
                     getDownloadUrl={getAttachmentUrl}
                     files={attachments.filter((a) => a.type === 'URGENCY')}
@@ -595,12 +590,11 @@ export default React.memo(function ApplicationEditView({
               {serviceNeed.shiftCare && (
                 <FileUploadGridContainer>
                   <FileUpload
-                    onUpload={saveApplicationAttachment(
+                    uploadHandler={applicationAttachment(
                       application.id,
                       'EXTENDED_CARE'
                     )}
                     onUploaded={onAttachmentUploaded('EXTENDED_CARE')}
-                    onDelete={deleteAttachment}
                     onDeleted={handleAttachmentDeleted}
                     getDownloadUrl={getAttachmentUrl}
                     files={attachments.filter(
@@ -1330,12 +1324,11 @@ export default React.memo(function ApplicationEditView({
 
           <FileUploadGridContainer>
             <FileUpload
-              onUpload={saveApplicationAttachment(
+              uploadHandler={applicationAttachment(
                 application.id,
                 'SERVICE_WORKER_ATTACHMENT'
               )}
               onUploaded={onAttachmentUploaded('SERVICE_WORKER_ATTACHMENT')}
-              onDelete={deleteAttachment}
               onDeleted={handleAttachmentDeleted}
               getDownloadUrl={getAttachmentUrl}
               files={attachments.filter(

--- a/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
+++ b/frontend/src/employee-frontend/components/application-page/ApplicationEditView.tsx
@@ -8,7 +8,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { Link } from 'react-router'
 import styled from 'styled-components'
 
-import { Result, wrapResult } from 'lib-common/api'
+import { Result } from 'lib-common/api'
 import { swapElements } from 'lib-common/array'
 import DateRange from 'lib-common/date-range'
 import {
@@ -58,18 +58,16 @@ import {
 } from 'lib-icons'
 
 import {
+  deleteAttachment,
   getAttachmentUrl,
   saveApplicationAttachment
 } from '../../api/attachments'
 import ApplicationStatusSection from '../../components/application-page/ApplicationStatusSection'
 import ApplicationTitle from '../../components/application-page/ApplicationTitle'
 import VTJGuardian from '../../components/application-page/VTJGuardian'
-import { deleteAttachment } from '../../generated/api-clients/attachment'
 import { Translations, useTranslation } from '../../state/i18n'
 import { formatName } from '../../utils'
 import { InputWarning } from '../common/InputWarning'
-
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 interface PreschoolApplicationProps {
   application: ApplicationDetails
@@ -211,19 +209,17 @@ export default React.memo(function ApplicationEditView({
     [setApplication]
   )
 
-  const onDeleteAttachment = (id: AttachmentId) =>
-    deleteAttachmentResult({ attachmentId: id }).then((res) => {
-      if (res.isSuccess) {
-        setApplication(
-          (prev) =>
-            prev && {
-              ...prev,
-              attachments: prev.attachments.filter((a) => a.id !== id)
-            }
-        )
-      }
-      return res
-    })
+  const handleAttachmentDeleted = useCallback(
+    (id: AttachmentId) =>
+      setApplication(
+        (prev) =>
+          prev && {
+            ...prev,
+            attachments: prev.attachments.filter((a) => a.id !== id)
+          }
+      ),
+    [setApplication]
+  )
 
   const validationErrorInfo = (field: string): InputInfo | undefined =>
     errors[field]
@@ -302,7 +298,8 @@ export default React.memo(function ApplicationEditView({
                       'URGENCY'
                     )}
                     onUploaded={onAttachmentUploaded('URGENCY')}
-                    onDelete={onDeleteAttachment}
+                    onDelete={deleteAttachment}
+                    onDeleted={handleAttachmentDeleted}
                     getDownloadUrl={getAttachmentUrl}
                     files={attachments.filter((a) => a.type === 'URGENCY')}
                     data-qa="file-upload-urgent"
@@ -603,7 +600,8 @@ export default React.memo(function ApplicationEditView({
                       'EXTENDED_CARE'
                     )}
                     onUploaded={onAttachmentUploaded('EXTENDED_CARE')}
-                    onDelete={onDeleteAttachment}
+                    onDelete={deleteAttachment}
+                    onDeleted={handleAttachmentDeleted}
                     getDownloadUrl={getAttachmentUrl}
                     files={attachments.filter(
                       (a) => a.type === 'EXTENDED_CARE'
@@ -1337,7 +1335,8 @@ export default React.memo(function ApplicationEditView({
                 'SERVICE_WORKER_ATTACHMENT'
               )}
               onUploaded={onAttachmentUploaded('SERVICE_WORKER_ATTACHMENT')}
-              onDelete={onDeleteAttachment}
+              onDelete={deleteAttachment}
+              onDeleted={handleAttachmentDeleted}
               getDownloadUrl={getAttachmentUrl}
               files={attachments.filter(
                 (a) => a.type === 'SERVICE_WORKER_ATTACHMENT'

--- a/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
@@ -24,9 +24,8 @@ import { defaultMargins } from 'lib-components/white-space'
 import { faPen, faTrash } from 'lib-icons'
 
 import {
-  deleteAttachment,
   getAttachmentUrl,
-  savePedagogicalDocumentAttachment
+  pedagogicalDocumentAttachment
 } from '../../api/attachments'
 import { updatePedagogicalDocument } from '../../generated/api-clients/pedagogicaldocument'
 import { useTranslation } from '../../state/i18n'
@@ -147,12 +146,11 @@ const PedagogicalDocumentRow = React.memo(function PedagogicalDocument({
             data-qa="upload-pedagogical-document-attachment-new"
             files={attachments}
             getDownloadUrl={getAttachmentUrl}
-            onUpload={savePedagogicalDocumentAttachment(id)}
+            uploadHandler={pedagogicalDocumentAttachment(id)}
             onUploaded={() => {
               setSubmitting(false)
               onReload()
             }}
-            onDelete={deleteAttachment}
             onDeleted={() =>
               setPedagogicalDocument(({ ...rest }) => ({
                 ...rest,

--- a/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
@@ -9,7 +9,6 @@ import { wrapResult } from 'lib-common/api'
 import { Attachment } from 'lib-common/generated/api-types/attachment'
 import { PedagogicalDocument } from 'lib-common/generated/api-types/pedagogicaldocument'
 import {
-  AttachmentId,
   ChildId,
   PedagogicalDocumentId
 } from 'lib-common/generated/api-types/shared'
@@ -25,16 +24,15 @@ import { defaultMargins } from 'lib-components/white-space'
 import { faPen, faTrash } from 'lib-icons'
 
 import {
+  deleteAttachment,
   getAttachmentUrl,
   savePedagogicalDocumentAttachment
 } from '../../api/attachments'
-import { deleteAttachment } from '../../generated/api-clients/attachment'
 import { updatePedagogicalDocument } from '../../generated/api-clients/pedagogicaldocument'
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
 
 const updatePedagogicalDocumentResult = wrapResult(updatePedagogicalDocument)
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 interface Props {
   id: PedagogicalDocumentId
@@ -111,17 +109,6 @@ const PedagogicalDocumentRow = React.memo(function PedagogicalDocument({
     })
   }, [endEdit, i18n, id, onReload, pedagogicalDocument, setErrorMessage])
 
-  const handleAttachmentDelete = useCallback(
-    async (id: AttachmentId) =>
-      (await deleteAttachmentResult({ attachmentId: id })).map(() =>
-        setPedagogicalDocument(({ ...rest }) => ({
-          ...rest,
-          attachment: null
-        }))
-      ),
-    []
-  )
-
   return (
     <Tr key={pedagogicalDocument.id} data-qa="table-pedagogical-document-row">
       <DateTd data-qa="pedagogical-document-start-date">
@@ -165,7 +152,13 @@ const PedagogicalDocumentRow = React.memo(function PedagogicalDocument({
               setSubmitting(false)
               onReload()
             }}
-            onDelete={handleAttachmentDelete}
+            onDelete={deleteAttachment}
+            onDeleted={() =>
+              setPedagogicalDocument(({ ...rest }) => ({
+                ...rest,
+                attachment: null
+              }))
+            }
             allowedFileTypes={['image', 'document', 'audio', 'video']}
           />
         </AttachmentsContainer>

--- a/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/PedagogicalDocumentRow.tsx
@@ -111,20 +111,6 @@ const PedagogicalDocumentRow = React.memo(function PedagogicalDocument({
     })
   }, [endEdit, i18n, id, onReload, pedagogicalDocument, setErrorMessage])
 
-  const handleAttachmentUpload = useCallback(
-    async (file: File, onUploadProgress: (percentage: number) => void) => {
-      setSubmitting(true)
-      return (
-        await savePedagogicalDocumentAttachment(id, file, onUploadProgress)
-      ).map((id) => {
-        setSubmitting(false)
-        onReload()
-        return id
-      })
-    },
-    [id, onReload]
-  )
-
   const handleAttachmentDelete = useCallback(
     async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() =>
@@ -174,7 +160,11 @@ const PedagogicalDocumentRow = React.memo(function PedagogicalDocument({
             data-qa="upload-pedagogical-document-attachment-new"
             files={attachments}
             getDownloadUrl={getAttachmentUrl}
-            onUpload={handleAttachmentUpload}
+            onUpload={savePedagogicalDocumentAttachment(id)}
+            onUploaded={() => {
+              setSubmitting(false)
+              onReload()
+            }}
             onDelete={handleAttachmentDelete}
             allowedFileTypes={['image', 'document', 'audio', 'video']}
           />

--- a/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationEditor.tsx
@@ -207,21 +207,6 @@ function FeeAlterationAttachments({
 }) {
   const { i18n } = useTranslation()
 
-  const handleUpload = useCallback(
-    async (file: File, onUploadProgress: (percentage: number) => void) =>
-      (
-        await saveFeeAlterationAttachment(
-          feeAlterationId,
-          file,
-          onUploadProgress
-        )
-      ).map((id) => {
-        onUploaded({ id, name: file.name, contentType: file.type })
-        return id
-      }),
-    [feeAlterationId, onUploaded]
-  )
-
   const handleDelete = useCallback(
     async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() => {
@@ -241,7 +226,8 @@ function FeeAlterationAttachments({
       <FileUpload
         data-qa="fee-alteration-attachment-upload"
         files={attachments}
-        onUpload={handleUpload}
+        onUpload={saveFeeAlterationAttachment(feeAlterationId)}
+        onUploaded={onUploaded}
         onDelete={handleDelete}
         getDownloadUrl={getAttachmentUrl}
       />

--- a/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationEditor.tsx
@@ -5,14 +5,14 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
 import {
+  deleteAttachment,
   getAttachmentUrl,
   saveFeeAlterationAttachment
 } from 'employee-frontend/api/attachments'
-import { Result, Success, wrapResult } from 'lib-common/api'
+import { Result, Success } from 'lib-common/api'
 import { Attachment } from 'lib-common/generated/api-types/attachment'
 import { FeeAlteration } from 'lib-common/generated/api-types/invoicing'
 import {
-  AttachmentId,
   FeeAlterationId,
   PersonId
 } from 'lib-common/generated/api-types/shared'
@@ -29,13 +29,10 @@ import { Gap } from 'lib-components/white-space'
 
 import DateRangeInput from '../../../components/common/DateRangeInput'
 import LabelValueList from '../../../components/common/LabelValueList'
-import { deleteAttachment } from '../../../generated/api-clients/attachment'
 import { useTranslation } from '../../../state/i18n'
 import { PartialFeeAlteration } from '../../../types/fee-alteration'
 
 import FeeAlterationRowInput from './FeeAlterationRowInput'
-
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 const newFeeAlteration = (
   personId: PersonId,
@@ -207,14 +204,6 @@ function FeeAlterationAttachments({
 }) {
   const { i18n } = useTranslation()
 
-  const handleDelete = useCallback(
-    async (id: AttachmentId) =>
-      (await deleteAttachmentResult({ attachmentId: id })).map(() => {
-        onDeleted(id)
-      }),
-    [onDeleted]
-  )
-
   return (
     <>
       <Title size={4}>
@@ -228,7 +217,8 @@ function FeeAlterationAttachments({
         files={attachments}
         onUpload={saveFeeAlterationAttachment(feeAlterationId)}
         onUploaded={onUploaded}
-        onDelete={handleDelete}
+        onDelete={deleteAttachment}
+        onDeleted={onDeleted}
         getDownloadUrl={getAttachmentUrl}
       />
     </>

--- a/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-information/fee-alteration/FeeAlterationEditor.tsx
@@ -5,9 +5,8 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
 import {
-  deleteAttachment,
   getAttachmentUrl,
-  saveFeeAlterationAttachment
+  feeAlterationAttachment
 } from 'employee-frontend/api/attachments'
 import { Result, Success } from 'lib-common/api'
 import { Attachment } from 'lib-common/generated/api-types/attachment'
@@ -215,9 +214,8 @@ function FeeAlterationAttachments({
       <FileUpload
         data-qa="fee-alteration-attachment-upload"
         files={attachments}
-        onUpload={saveFeeAlterationAttachment(feeAlterationId)}
+        uploadHandler={feeAlterationAttachment(feeAlterationId)}
         onUploaded={onUploaded}
-        onDelete={deleteAttachment}
         onDeleted={onDeleted}
         getDownloadUrl={getAttachmentUrl}
       />

--- a/frontend/src/employee-frontend/components/invoice/ReplacementDraftInfo.tsx
+++ b/frontend/src/employee-frontend/components/invoice/ReplacementDraftInfo.tsx
@@ -5,7 +5,6 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { wrapResult } from 'lib-common/api'
 import { string } from 'lib-common/form/fields'
 import { object, oneOf, required, validated } from 'lib-common/form/form'
 import { useForm, useFormFields } from 'lib-common/form/hooks'
@@ -27,12 +26,13 @@ import FileUpload from 'lib-components/molecules/FileUpload'
 import { InfoBox } from 'lib-components/molecules/MessageBoxes'
 import { H3, Label, P } from 'lib-components/typography'
 
-import { getAttachmentUrl, saveInvoiceAttachment } from '../../api/attachments'
-import { deleteAttachment } from '../../generated/api-clients/attachment'
+import {
+  deleteAttachment,
+  getAttachmentUrl,
+  saveInvoiceAttachment
+} from '../../api/attachments'
 import { useTranslation } from '../../state/i18n'
 import { markReplacementDraftSentMutation } from '../invoices/queries'
-
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 const replacementDraftForm = validated(
   object({
@@ -97,9 +97,7 @@ export function ReplacementDraftForm({
           <FileUpload
             files={invoiceResponse.invoice.attachments}
             onUpload={saveInvoiceAttachment(invoiceResponse.invoice.id)}
-            onDelete={(attachmentId) =>
-              deleteAttachmentResult({ attachmentId })
-            }
+            onDelete={deleteAttachment}
             getDownloadUrl={getAttachmentUrl}
             data-qa="attachments"
           />

--- a/frontend/src/employee-frontend/components/invoice/ReplacementDraftInfo.tsx
+++ b/frontend/src/employee-frontend/components/invoice/ReplacementDraftInfo.tsx
@@ -26,11 +26,7 @@ import FileUpload from 'lib-components/molecules/FileUpload'
 import { InfoBox } from 'lib-components/molecules/MessageBoxes'
 import { H3, Label, P } from 'lib-components/typography'
 
-import {
-  deleteAttachment,
-  getAttachmentUrl,
-  saveInvoiceAttachment
-} from '../../api/attachments'
+import { getAttachmentUrl, invoiceAttachment } from '../../api/attachments'
 import { useTranslation } from '../../state/i18n'
 import { markReplacementDraftSentMutation } from '../invoices/queries'
 
@@ -96,8 +92,7 @@ export function ReplacementDraftForm({
         <FixedSpaceColumn>
           <FileUpload
             files={invoiceResponse.invoice.attachments}
-            onUpload={saveInvoiceAttachment(invoiceResponse.invoice.id)}
-            onDelete={deleteAttachment}
+            uploadHandler={invoiceAttachment(invoiceResponse.invoice.id)}
             getDownloadUrl={getAttachmentUrl}
             data-qa="attachments"
           />

--- a/frontend/src/employee-frontend/components/invoice/ReplacementDraftInfo.tsx
+++ b/frontend/src/employee-frontend/components/invoice/ReplacementDraftInfo.tsx
@@ -96,13 +96,7 @@ export function ReplacementDraftForm({
         <FixedSpaceColumn>
           <FileUpload
             files={invoiceResponse.invoice.attachments}
-            onUpload={(file, onUploadProgress) =>
-              saveInvoiceAttachment(
-                invoiceResponse.invoice.id,
-                file,
-                onUploadProgress
-              )
-            }
+            onUpload={saveInvoiceAttachment(invoiceResponse.invoice.id)}
             onDelete={(attachmentId) =>
               deleteAttachmentResult({ attachmentId })
             }

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -76,7 +76,6 @@ import {
   faUpRightAndDownLeftFromCenter
 } from 'lib-icons'
 
-import { deleteAttachment } from '../../api/attachments'
 import { useTranslation } from '../../state/i18n'
 
 import { createMessagePreflightCheckQuery } from './queries'
@@ -788,13 +787,12 @@ export default React.memo(function MessageEditor({
                 data-qa="upload-message-attachment"
                 files={message.attachments}
                 getDownloadUrl={getAttachmentUrl}
-                onUpload={saveMessageAttachment(draftId)}
+                uploadHandler={saveMessageAttachment(draftId)}
                 onUploaded={(attachment) =>
                   updateMessage({
                     attachments: [...message.attachments, attachment]
                   })
                 }
-                onDelete={deleteAttachment}
                 onDeleted={(id) =>
                   setMessage(({ attachments, ...rest }) => ({
                     ...rest,

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -27,7 +27,6 @@ import Container from 'lib-components/layout/Container'
 import { defaultMargins } from 'lib-components/white-space'
 
 import { getAttachmentUrl, saveMessageAttachment } from '../../api/attachments'
-import { deleteAttachment } from '../../generated/api-clients/attachment'
 import {
   initDraftMessage,
   updateDraftMessage,
@@ -46,7 +45,6 @@ import Sidebar from './Sidebar'
 import MessageList from './ThreadListContainer'
 
 const getPersonIdentityResult = wrapResult(getPersonIdentity)
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 const initDraftMessageResult = wrapResult(initDraftMessage)
 const updateDraftMessageResult = wrapResult(updateDraftMessage)
 const deleteDraftMessageResult = wrapResult(deleteDraftMessage)
@@ -238,7 +236,6 @@ export default React.memo(function MessagesPage({
                 value: selectedAccount.account.id,
                 label: selectedAccount.account.name
               }}
-              deleteAttachment={deleteAttachmentResult}
               draftContent={selectedDraft}
               getAttachmentUrl={getAttachmentUrl}
               initDraftRaw={(accountId) =>

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -26,7 +26,7 @@ import { useApiState } from 'lib-common/utils/useRestApi'
 import Container from 'lib-components/layout/Container'
 import { defaultMargins } from 'lib-components/white-space'
 
-import { getAttachmentUrl, saveMessageAttachment } from '../../api/attachments'
+import { getAttachmentUrl, messageAttachment } from '../../api/attachments'
 import {
   initDraftMessage,
   updateDraftMessage,
@@ -252,7 +252,7 @@ export default React.memo(function MessagesPage({
                   body: params.content
                 })
               }
-              saveMessageAttachment={saveMessageAttachment}
+              saveMessageAttachment={messageAttachment}
               sending={sending}
               defaultTitle={prefilledTitle ?? undefined}
             />

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
@@ -448,17 +448,6 @@ function IncomeAttachments({
 }) {
   const { i18n } = useTranslation()
 
-  const handleUpload = useCallback(
-    async (file: File, onUploadProgress: (percentage: number) => void) =>
-      (await saveIncomeAttachment(incomeId, file, onUploadProgress)).map(
-        (id) => {
-          onUploaded({ id, name: file.name, contentType: file.type })
-          return id
-        }
-      ),
-    [incomeId, onUploaded]
-  )
-
   const handleDelete = useCallback(
     async (id: AttachmentId) =>
       (await deleteAttachmentResult({ attachmentId: id })).map(() => {
@@ -474,7 +463,8 @@ function IncomeAttachments({
       <FileUpload
         data-qa="income-attachment-upload"
         files={attachments}
-        onUpload={handleUpload}
+        onUpload={saveIncomeAttachment(incomeId)}
+        onUploaded={onUploaded}
         onDelete={handleDelete}
         getDownloadUrl={getAttachmentUrl}
       />

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
@@ -39,11 +39,7 @@ import DateRangePicker from 'lib-components/molecules/date-picker/DateRangePicke
 import { H1, Label, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
-import {
-  deleteAttachment,
-  getAttachmentUrl,
-  saveIncomeAttachment
-} from '../../../api/attachments'
+import { getAttachmentUrl, incomeAttachment } from '../../../api/attachments'
 import { useTranslation } from '../../../state/i18n'
 import { IncomeFields } from '../../../types/income'
 import RetroactiveConfirmation, {
@@ -453,9 +449,8 @@ function IncomeAttachments({
       <FileUpload
         data-qa="income-attachment-upload"
         files={attachments}
-        onUpload={saveIncomeAttachment(incomeId)}
+        uploadHandler={incomeAttachment(incomeId)}
         onUploaded={onUploaded}
-        onDelete={deleteAttachment}
         onDeleted={onDeleted}
         getDownloadUrl={getAttachmentUrl}
       />

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
@@ -7,7 +7,7 @@ import omit from 'lodash/omit'
 import React, { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
-import { Failure, Result, wrapResult } from 'lib-common/api'
+import { Failure, Result } from 'lib-common/api'
 import { incomeEffects } from 'lib-common/api-types/income'
 import DateRange from 'lib-common/date-range'
 import { Attachment } from 'lib-common/generated/api-types/attachment'
@@ -19,7 +19,7 @@ import {
   IncomeTypeOptions,
   IncomeValue
 } from 'lib-common/generated/api-types/invoicing'
-import { AttachmentId, PersonId } from 'lib-common/generated/api-types/shared'
+import { PersonId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { parseCents } from 'lib-common/money'
 import { UUID } from 'lib-common/types'
@@ -40,10 +40,10 @@ import { H1, Label, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
 import {
+  deleteAttachment,
   getAttachmentUrl,
   saveIncomeAttachment
 } from '../../../api/attachments'
-import { deleteAttachment } from '../../../generated/api-clients/attachment'
 import { useTranslation } from '../../../state/i18n'
 import { IncomeFields } from '../../../types/income'
 import RetroactiveConfirmation, {
@@ -54,8 +54,6 @@ import IncomeTable, {
   IncomeTableData,
   tableDataFromIncomeFields
 } from './IncomeTable'
-
-const deleteAttachmentResult = wrapResult(deleteAttachment)
 
 const ButtonsContainer = styled(FixedSpaceRow)`
   margin: 20px 0;
@@ -448,14 +446,6 @@ function IncomeAttachments({
 }) {
   const { i18n } = useTranslation()
 
-  const handleDelete = useCallback(
-    async (id: AttachmentId) =>
-      (await deleteAttachmentResult({ attachmentId: id })).map(() => {
-        onDeleted(id)
-      }),
-    [onDeleted]
-  )
-
   return (
     <>
       <H1>{i18n.incomeStatement.employeeAttachments.title}</H1>
@@ -465,7 +455,8 @@ function IncomeAttachments({
         files={attachments}
         onUpload={saveIncomeAttachment(incomeId)}
         onUploaded={onUploaded}
-        onDelete={handleDelete}
+        onDelete={deleteAttachment}
+        onDeleted={onDeleted}
         getDownloadUrl={getAttachmentUrl}
       />
     </>

--- a/frontend/src/employee-frontend/components/placement-tool/PlacementToolPage.tsx
+++ b/frontend/src/employee-frontend/components/placement-tool/PlacementToolPage.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
 import WarningLabel from '../common/WarningLabel'
 
-import { deletePlacementFile, uploadPlacementFile } from './api'
+import { placementFile } from './api'
 import { nextPreschoolTermQuery } from './queries'
 
 export default React.memo(function PlacementToolPage() {
@@ -41,8 +41,7 @@ export default React.memo(function PlacementToolPage() {
                 <FileUpload
                   disabled={term === null}
                   files={[]}
-                  onUpload={uploadPlacementFile}
-                  onDelete={deletePlacementFile}
+                  uploadHandler={placementFile}
                   getDownloadUrl={() => ''}
                   allowedFileTypes={['csv']}
                 />

--- a/frontend/src/employee-frontend/components/placement-tool/api.ts
+++ b/frontend/src/employee-frontend/components/placement-tool/api.ts
@@ -4,38 +4,36 @@
 
 import { Failure, Result, Success } from 'lib-common/api'
 import { AttachmentId } from 'lib-common/generated/api-types/shared'
+import { UploadHandler } from 'lib-components/molecules/FileUpload'
 
 import { client } from '../../api/client'
 
-export async function uploadPlacementFile(
-  file: File,
-  onUploadProgress: (percentage: number) => void
-): Promise<Result<AttachmentId>> {
-  const formData = new FormData()
-  formData.append('file', file)
+export const placementFile: UploadHandler = {
+  upload: async (
+    file: File,
+    onUploadProgress: (percentage: number) => void
+  ): Promise<Result<AttachmentId>> => {
+    const formData = new FormData()
+    formData.append('file', file)
 
-  try {
-    const { data } = await client.post<AttachmentId>(
-      '/employee/placement-tool',
-      formData,
-      {
-        headers: { 'Content-Type': 'multipart/form-data' },
-        onUploadProgress: ({ loaded, total }) =>
-          onUploadProgress(
-            total !== undefined && total !== 0
-              ? Math.round((loaded / total) * 100)
-              : 0
-          )
-      }
-    )
-    return Success.of(data)
-  } catch (e) {
-    return Failure.fromError(e)
-  }
-}
-
-export function deletePlacementFile(): Promise<Result<void>> {
-  return new Promise<Result<void>>((resolve) => {
-    resolve(Success.of(void 0))
-  })
+    try {
+      const { data } = await client.post<AttachmentId>(
+        '/employee/placement-tool',
+        formData,
+        {
+          headers: { 'Content-Type': 'multipart/form-data' },
+          onUploadProgress: ({ loaded, total }) =>
+            onUploadProgress(
+              total !== undefined && total !== 0
+                ? Math.round((loaded / total) * 100)
+                : 0
+            )
+        }
+      )
+      return Success.of(data)
+    } catch (e) {
+      return Failure.fromError(e)
+    }
+  },
+  delete: () => Promise.resolve(Success.of(undefined))
 }

--- a/frontend/src/lib-components/molecules/FileUpload.tsx
+++ b/frontend/src/lib-components/molecules/FileUpload.tsx
@@ -86,7 +86,7 @@ interface FileUploadProps {
   files: Attachment[]
   onUpload: UploadHandler
   onUploaded?: (attachment: Attachment) => void
-  onDelete: (id: AttachmentId) => Promise<Result<void>>
+  onDelete: (request: { attachmentId: AttachmentId }) => Promise<Result<void>>
   onDeleted?: (id: AttachmentId) => void
   onStateChange?: (status: UploadStatus) => void
   getDownloadUrl: (id: AttachmentId, fileName: string) => string
@@ -373,7 +373,7 @@ export default React.memo(function FileUpload({
     try {
       let success = false
       if (file.error === undefined) {
-        const result = await onDelete(file.id)
+        const result = await onDelete({ attachmentId: file.id })
         if (result.isSuccess) {
           onDeleted?.(file.id)
           success = true


### PR DESCRIPTION
Ennen tarvittiin paljon boilerplatea:

```tsx
const onUpload = (file, progress) => saveFooAttachment(file, progress).then((result) => {
  if (result.isSuccess) {
    setState({ id: result.value, name: file.name, ... });
    return result.value
  }
})
const onDelete = (id) => deleteAttachment({ attachmentId: id }).then((result) => {
  if (result.isSuccess) setState({ id: result.value, ... })
})
<FileUpload
  onUpload={onUpload}
  onDelete={onDelete}
  ...
/>
```

Nyt riittää:

```tsx
<FileUpload
  uploadHandler={fooAttachment}
  onUploaded={(attachment) => setState({ ...attachment, ... })}
  onDeleted={(id) => setState({ id, ... })}
/>
```