### PR TITLE
Lisätään monipuolisempi seuraavan laskunumeron valinta

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/config/SharedIntegrationTestConfig.kt
@@ -17,9 +17,11 @@ import fi.espoo.evaka.espoo.invoicing.EspooIncomeCoefficientMultiplierProvider
 import fi.espoo.evaka.invoicing.domain.PaymentIntegrationClient
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
 import fi.espoo.evaka.invoicing.service.DefaultInvoiceGenerationLogic
+import fi.espoo.evaka.invoicing.service.DefaultInvoiceNumberProvider
 import fi.espoo.evaka.invoicing.service.EspooIncomeTypesProvider
 import fi.espoo.evaka.invoicing.service.IncomeCoefficientMultiplierProvider
 import fi.espoo.evaka.invoicing.service.IncomeTypesProvider
+import fi.espoo.evaka.invoicing.service.InvoiceNumberProvider
 import fi.espoo.evaka.invoicing.service.InvoiceProductProvider
 import fi.espoo.evaka.mealintegration.DefaultMealTypeMapper
 import fi.espoo.evaka.mealintegration.MealTypeMapper
@@ -197,6 +199,9 @@ class SharedIntegrationTestConfig {
     @Bean fun invoiceProductProvider(): InvoiceProductProvider = TestInvoiceProductProvider()
 
     @Bean
+    fun invoiceNumberProvider(): InvoiceNumberProvider = DefaultInvoiceNumberProvider(5000000000)
+
+    @Bean
     fun coefficientMultiplierProvider(): IncomeCoefficientMultiplierProvider =
         EspooIncomeCoefficientMultiplierProvider()
 
@@ -219,7 +224,6 @@ val testFeatureConfig =
         freeSickLeaveOnContractDays = false,
         freeAbsenceGivesADailyRefund = true,
         alwaysUseDaycareFinanceDecisionHandler = false,
-        invoiceNumberSeriesStart = 5000000000,
         paymentNumberSeriesStart = 9000000000,
         unplannedAbsencesAreContractSurplusDays = true,
         maxContractDaySurplusThreshold = null,

--- a/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EspooConfig.kt
@@ -22,10 +22,12 @@ import fi.espoo.evaka.invoicing.domain.PaymentIntegrationClient
 import fi.espoo.evaka.invoicing.integration.EspooInvoiceIntegrationClient
 import fi.espoo.evaka.invoicing.integration.InvoiceIntegrationClient
 import fi.espoo.evaka.invoicing.service.DefaultInvoiceGenerationLogic
+import fi.espoo.evaka.invoicing.service.DefaultInvoiceNumberProvider
 import fi.espoo.evaka.invoicing.service.EspooIncomeTypesProvider
 import fi.espoo.evaka.invoicing.service.EspooInvoiceProducts
 import fi.espoo.evaka.invoicing.service.IncomeCoefficientMultiplierProvider
 import fi.espoo.evaka.invoicing.service.IncomeTypesProvider
+import fi.espoo.evaka.invoicing.service.InvoiceNumberProvider
 import fi.espoo.evaka.invoicing.service.InvoiceProductProvider
 import fi.espoo.evaka.logging.defaultAccessLoggingValve
 import fi.espoo.evaka.mealintegration.DefaultMealTypeMapper
@@ -145,6 +147,9 @@ class EspooConfig {
     @Bean fun invoiceProductsProvider(): InvoiceProductProvider = EspooInvoiceProducts.Provider()
 
     @Bean
+    fun invoiceNumberProvider(): InvoiceNumberProvider = DefaultInvoiceNumberProvider(5000000000)
+
+    @Bean
     fun titaniaEmployeeIdConverter(): TitaniaEmployeeIdConverter =
         object : TitaniaEmployeeIdConverter {
             override fun fromTitania(employeeId: String): String = employeeId.trimStart('0')
@@ -178,7 +183,6 @@ class EspooConfig {
             freeSickLeaveOnContractDays = false, // Doesn't affect Espoo
             freeAbsenceGivesADailyRefund = true,
             alwaysUseDaycareFinanceDecisionHandler = false, // Doesn't affect Espoo
-            invoiceNumberSeriesStart = 5000000000,
             paymentNumberSeriesStart = 1, // Payments are not yet in use in Espoo
             unplannedAbsencesAreContractSurplusDays = false, // Doesn't affect Espoo
             maxContractDaySurplusThreshold = null, // Doesn't affect Espoo

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -63,13 +63,6 @@ data class FeatureConfig(
     val alwaysUseDaycareFinanceDecisionHandler: Boolean,
 
     /**
-     * The first invoice number to use
-     *
-     * The number of subsequent invoices is the previous number plus one.
-     */
-    val invoiceNumberSeriesStart: Long,
-
-    /**
      * The first payment number to use
      *
      * The number of subsequent payments is the previous number plus one. If null, payments cannot


### PR DESCRIPTION
Jos esimerkiksi laskutusjärjestelmän vaihdon yhteydessä uudet laskunumerot ovat pienempiä kuin vanhassa, ei nykyinen toteutus riitä. Tämä mahdollistaa monipuolisemman laskunumeron valinnan kuntakohtaisesti.

**Päivitysohje**

vanhan asetuksen poisto (`FeatureConfig`):
```
invoiceNumberSeriesStart = xyz,
```

uuden toteutuksen lisäys:
```
@Bean
fun invoiceNumberProvider(): InvoiceNumberProvider = DefaultInvoiceNumberProvider(xyz)
```