### PR TITLE
Muutetaan laskujen täsmäytysraportin hakuehto

### DIFF
--- a/frontend/src/employee-frontend/components/reports/Invoices.tsx
+++ b/frontend/src/employee-frontend/components/reports/Invoices.tsx
@@ -25,16 +25,16 @@ import { useTranslation } from '../../state/i18n'
 import { FilterLabel, FilterRow, TableScrollable } from './common'
 import { invoicesReportQuery } from './queries'
 
-const currentMonth = YearMonth.todayInHelsinkiTz()
+const previousMonth = YearMonth.todayInHelsinkiTz().subMonths(1)
 const monthOptions = range(1, 13)
-const yearOptions = range(currentMonth.year, currentMonth.year - 4, -1)
+const yearOptions = range(previousMonth.year, previousMonth.year - 4, -1)
 
 type InvoiceReportFilters = Arg0<typeof getInvoiceReport>
 
 export default React.memo(function ReportInvoices() {
   const { i18n } = useTranslation()
   const [filters, setFilters] = useState<InvoiceReportFilters>({
-    yearMonth: currentMonth
+    yearMonth: previousMonth
   })
   const report = useQueryResult(invoicesReportQuery(filters))
 
@@ -44,7 +44,7 @@ export default React.memo(function ReportInvoices() {
       <ContentArea opaque>
         <Title size={1}>{i18n.reports.invoices.title}</Title>
         <FilterRow>
-          <FilterLabel>{i18n.reports.common.period}</FilterLabel>
+          <FilterLabel>{i18n.reports.invoices.period}</FilterLabel>
           <Combobox
             items={monthOptions}
             selectedItem={filters.yearMonth.month}

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4029,6 +4029,7 @@ export const fi = {
       title: 'Laskujen täsmäytys',
       description:
         'Laskujen täsmäytysraportti laskutusjärjestelmään vertailua varten',
+      period: 'Laskutuskausi',
       areaCode: 'Alue',
       amountOfInvoices: 'Laskuja',
       totalSumCents: 'Summa',

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
@@ -25,7 +25,6 @@ import fi.espoo.evaka.shared.db.QuerySql
 import fi.espoo.evaka.shared.db.freeTextSearchPredicate
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
-import fi.espoo.evaka.shared.domain.HelsinkiDateTimeRange
 import fi.espoo.evaka.shared.mapToPaged
 import java.time.LocalDate
 import java.time.YearMonth
@@ -364,13 +363,19 @@ ORDER BY ${sortColumn.second} ${sortDirection.name}, invoice.id
 
 fun Database.Read.searchInvoices(
     status: InvoiceStatus? = null,
-    sentAt: HelsinkiDateTimeRange? = null,
+    period: FiniteDateRange? = null,
 ): List<InvoiceDetailed> {
     val predicate =
         Predicate.all(
             listOfNotNull(
                 if (status != null) Predicate { where("$it.status = ${bind(status)}") } else null,
-                if (sentAt != null) Predicate { where("$it.sent_at <@ ${bind(sentAt)}") } else null,
+                if (period != null)
+                    Predicate {
+                        where(
+                            "$it.period_start = ${bind(period.start)} AND $it.period_end = ${bind(period.end)}"
+                        )
+                    }
+                else null,
             )
         )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/InvoiceReport.kt
@@ -50,7 +50,7 @@ class InvoiceReportController(private val accessControl: AccessControl) {
 }
 
 private fun Database.Read.getInvoiceReportWithRows(period: FiniteDateRange): InvoiceReport {
-    val invoices = searchInvoices(InvoiceStatus.SENT, sentAt = period.asHelsinkiDateTimeRange())
+    val invoices = searchInvoices(InvoiceStatus.SENT, period = period)
 
     val rows =
         invoices


### PR DESCRIPTION
Laskujen täsmäytysraportti olisi selkeämpi, jos valittu kuukausi näyttäisi kyseisen kuukauden täsmäytyksen. Tällä hetkellä raportilla kun valitsee ajanjaksoksi tammikuun, niin raportti tuottaa joulukuun laskujen täsmäytyksen.

Eli vaihdetaan raportti hakemaan tiedot laskutuskauden mukaan.