### PR TITLE
Lisätään maksatusaineistoon yksikön kustannuspaikka

### DIFF
--- a/frontend/src/lib-common/generated/api-types/invoicing.ts
+++ b/frontend/src/lib-common/generated/api-types/invoicing.ts
@@ -819,6 +819,7 @@ export type PaymentStatus =
 export interface PaymentUnit {
   businessId: string | null
   careType: CareType[]
+  costCenter: string | null
   iban: string | null
   id: DaycareId
   name: string

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/PaymentsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/PaymentsIntegrationTest.kt
@@ -266,6 +266,7 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             assertEquals(PaymentStatus.DRAFT, payment.status)
             assertEquals(testDaycare.id, payment.unit.id)
             assertEquals(testDaycare.name, payment.unit.name)
+            assertEquals(testDaycare.costCenter, payment.unit.costCenter)
             assertEquals(134850 - 28800, payment.amount)
         }
         payments[1].let { payment ->
@@ -273,12 +274,14 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             assertEquals(testVoucherDaycare.id, payment.unit.id)
             assertEquals(87000 - 28800, payment.amount)
             assertEquals(testVoucherDaycare.name, payment.unit.name)
+            assertEquals(testVoucherDaycare.costCenter, payment.unit.costCenter)
         }
         payments.last().let { payment ->
             assertEquals(PaymentStatus.CONFIRMED, payment.status)
             assertEquals(testVoucherDaycare2.id, payment.unit.id)
             assertEquals(35000 - 28800, payment.amount)
             assertEquals(testVoucherDaycare2.name, payment.unit.name)
+            assertEquals(testVoucherDaycare2.costCenter, payment.unit.costCenter)
         }
 
         // assert that sending details remain unset
@@ -345,12 +348,14 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             assertEquals(DateRange(janFirst, janLast), payment.period)
             assertEquals(testDaycare.id, payment.unit.id)
             assertEquals(testDaycare.name, payment.unit.name)
+            assertEquals(testDaycare.costCenter, payment.unit.costCenter)
             assertEquals(134850 - 28800, payment.amount)
         }
         payments.last().let { payment ->
             assertEquals(testVoucherDaycare.id, payment.unit.id)
             assertEquals(87000 - 28800, payment.amount)
             assertEquals(testVoucherDaycare.name, payment.unit.name)
+            assertEquals(testVoucherDaycare.costCenter, payment.unit.costCenter)
         }
 
         // assert that status is set and sending details remain unset
@@ -406,6 +411,7 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             assertEquals(PaymentStatus.CONFIRMED, payment.status)
             assertEquals(DateRange(janFirst, janLast), payment.period)
             assertEquals(testDaycare.id, payment.unit.id)
+            assertEquals(testDaycare.costCenter, payment.unit.costCenter)
             assertEquals(134850 - 28800, payment.amount)
         }
         payments.last().let { payment ->
@@ -421,6 +427,7 @@ class PaymentsIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             assertEquals(testVoucherDaycare.businessId, payment.unit.businessId)
             assertEquals(testVoucherDaycare.iban, payment.unit.iban)
             assertEquals(testVoucherDaycare.providerId, payment.unit.providerId)
+            assertEquals(testVoucherDaycare.costCenter, payment.unit.costCenter)
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/PaymentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/PaymentQueries.kt
@@ -42,7 +42,7 @@ fun Database.Read.readPaymentsByIdsWithFreshUnitData(ids: List<PaymentId>): List
                 """
 SELECT 
     p.id, p.created, p.updated, p.unit_id, 
-    d.name AS unit_name, d.business_id AS unit_business_id, d.iban AS unit_iban, d.provider_id AS unit_provider_id, d.type as unit_care_type,
+    d.name AS unit_name, d.business_id AS unit_business_id, d.iban AS unit_iban, d.provider_id AS unit_provider_id, d.type as unit_care_type, d.cost_center as unit_cost_center,
     p.period, p.number, p.amount, p.status, p.payment_date, p.due_date, p.sent_at, p.sent_by
 FROM payment p
 JOIN daycare d ON d.id = p.unit_id
@@ -61,7 +61,7 @@ SELECT
     p.id, p.created, p.updated,
     p.unit_id, p.unit_name, p.unit_business_id, p.unit_iban, p.unit_provider_id,
     p.period, p.number, p.amount, p.status, p.payment_date, p.due_date, p.sent_at, p.sent_by,
-    d.type as unit_care_type
+    d.type as unit_care_type, d.cost_center as unit_cost_center
 FROM payment p
 JOIN daycare d ON d.id = p.unit_id
 ORDER BY period DESC, unit_name
@@ -113,6 +113,7 @@ SELECT
     CASE WHEN p.status = 'SENT' THEN unit_iban ELSE d.iban END AS unit_iban,
     CASE WHEN p.status = 'SENT' THEN unit_provider_id ELSE d.provider_id END AS unit_provider_id,
     d.type AS unit_care_type,
+    d.cost_center as unit_cost_center,
     p.period, p.number, p.amount, p.status, p.payment_date, p.due_date, p.sent_at, p.sent_by,
     count(*) OVER () AS count
 FROM payment p

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Payments.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Payments.kt
@@ -114,6 +114,7 @@ data class PaymentUnit(
     val iban: String?,
     val providerId: String?,
     val careType: Set<CareType>,
+    val costCenter: String?,
 )
 
 data class Payment(


### PR DESCRIPTION
Isommat organisaatiot haluavat jyvittää maksut eri kustannuspaikoille yksiköittäin. eVakassa yksikön tiedoista jo löytyy kustannuspaikka, joten annetaan se maksujen lähetykseen.