### PR TITLE
Piilota poissaolokyselyn toast-viesti, mikäli kyselyyn on jo vastattu

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarNotifications.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarNotifications.tsx
@@ -107,7 +107,12 @@ export default React.memo(function CalendarNotifications({
     if (activeQuestionnaire === undefined) return
 
     let cta: HolidayCta
-    if (activeQuestionnaire) {
+    if (
+      activeQuestionnaire &&
+      activeQuestionnaire.eligibleChildren.some(
+        (c) => !activeQuestionnaire.previousAnswers.some((a) => a.childId === c)
+      )
+    ) {
       cta = {
         type: 'questionnaire',
         deadline: activeQuestionnaire.questionnaire.active.end

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
@@ -196,6 +196,18 @@ describe('Holiday periods and questionnaires', () => {
       )
     })
 
+    test('The holiday reservations toast is hidden after answering questionnaire', async () => {
+      await enduserLogin(page, guardian)
+      await new CitizenHeader(page).selectTab('calendar')
+      const calendar = new CitizenCalendarPage(page, 'desktop')
+      await calendar.assertHolidayCtaContent(
+        'Vastaa poissaolokyselyyn 06.12.2035 mennessä.'
+      )
+      const holidayModal = await calendar.openHolidayModal()
+      await holidayModal.markNoHoliday(child)
+      await calendar.assertHolidayCtaNotVisible()
+    })
+
     test('Clicking on the holiday reservations toast opens the holiday modal', async () => {
       await enduserLogin(page, guardian)
       await new CitizenHeader(page).selectTab('calendar')


### PR DESCRIPTION
Poissaolokyselyn toast näytetään ainoastaan, jos siihen ei ole vastattu kaikkien vastausvelvollisten lasten osalta.