### PR TITLE
Tampereen Seutuselvitysraportti osa 3: vuosittaisten arvojen CSV

### DIFF
--- a/frontend/src/employee-frontend/components/reports/TampereRegionalSurvey.tsx
+++ b/frontend/src/employee-frontend/components/reports/TampereRegionalSurvey.tsx
@@ -350,6 +350,12 @@ export default React.memo(function TampereRegionalSurveyReport() {
                       key: 'preschoolDaycareUnitCareCount'
                     },
                     {
+                      label:
+                        t.yearlyStatisticsColumns
+                          .preschoolDaycareSchoolCareCount,
+                      key: 'preschoolDaycareSchoolCareCount'
+                    },
+                    {
                       label: t.yearlyStatisticsColumns.preschoolFamilyCareCount,
                       key: 'preschoolDaycareFamilyCareCount'
                     },

--- a/frontend/src/employee-frontend/components/reports/TampereRegionalSurvey.tsx
+++ b/frontend/src/employee-frontend/components/reports/TampereRegionalSurvey.tsx
@@ -356,8 +356,22 @@ export default React.memo(function TampereRegionalSurveyReport() {
                       key: 'preschoolDaycareSchoolCareCount'
                     },
                     {
-                      label: t.yearlyStatisticsColumns.preschoolFamilyCareCount,
+                      label:
+                        t.yearlyStatisticsColumns
+                          .preschoolDaycareFamilyCareCount,
                       key: 'preschoolDaycareFamilyCareCount'
+                    },
+                    {
+                      label:
+                        t.yearlyStatisticsColumns
+                          .preschoolDaycareSchoolShiftCareCount,
+                      key: 'preschoolDaycareSchoolShiftCareCount'
+                    },
+                    {
+                      label:
+                        t.yearlyStatisticsColumns
+                          .preschoolDaycareUnitShiftCareCount,
+                      key: 'preschoolDaycareUnitShiftCareCount'
                     },
                     {
                       label:

--- a/frontend/src/employee-frontend/components/reports/TampereRegionalSurvey.tsx
+++ b/frontend/src/employee-frontend/components/reports/TampereRegionalSurvey.tsx
@@ -51,7 +51,7 @@ interface ReportSelection {
 const emptyReportSelection = {
   monthlyStatistics: false,
   ageStatistics: false,
-  yearlyStatistics: false,
+  yearlyStatistics: false
 }
 
 const emptyMonthlyValue: RegionalSurveyReportResult = {
@@ -345,7 +345,8 @@ export default React.memo(function TampereRegionalSurveyReport() {
                       key: 'club5YearOldCount'
                     },
                     {
-                      label: t.yearlyStatisticsColumns.preschoolDaycareUnitCareCount,
+                      label:
+                        t.yearlyStatisticsColumns.preschoolDaycareUnitCareCount,
                       key: 'preschoolDaycareUnitCareCount'
                     },
                     {
@@ -353,20 +354,38 @@ export default React.memo(function TampereRegionalSurveyReport() {
                       key: 'preschoolDaycareFamilyCareCount'
                     },
                     {
-                      label: t.yearlyStatisticsColumns.generalAssistanceCount,
-                      key: 'generalAssistanceCount'
+                      label:
+                        t.yearlyStatisticsColumns.voucherGeneralAssistanceCount,
+                      key: 'voucherGeneralAssistanceCount'
+                    },
+                    {
+                      label:
+                        t.yearlyStatisticsColumns.voucherSpecialAssistanceCount,
+                      key: 'voucherSpecialAssistanceCount'
                     },
                     {
                       label:
                         t.yearlyStatisticsColumns
-                          .specialAssistanceCount,
-                      key: 'specialAssistanceCount'
+                          .voucherEnhancedAssistanceCount,
+                      key: 'voucherEnhancedAssistanceCount'
                     },
                     {
                       label:
                         t.yearlyStatisticsColumns
-                          .enhancedAssistanceCount,
-                      key: 'enhancedAssistanceCount'
+                          .municipalGeneralAssistanceCount,
+                      key: 'municipalGeneralAssistanceCount'
+                    },
+                    {
+                      label:
+                        t.yearlyStatisticsColumns
+                          .municipalSpecialAssistanceCount,
+                      key: 'municipalSpecialAssistanceCount'
+                    },
+                    {
+                      label:
+                        t.yearlyStatisticsColumns
+                          .municipalEnhancedAssistanceCount,
+                      key: 'municipalEnhancedAssistanceCount'
                     }
                   ]}
                   filename={`${t.reportLabel} ${selectedYear} - ${t.yearlyStatisticsReport}.csv`}

--- a/frontend/src/employee-frontend/components/reports/queries.ts
+++ b/frontend/src/employee-frontend/components/reports/queries.ts
@@ -37,6 +37,7 @@ import {
   getStartingPlacementsReport,
   getTampereRegionalSurveyAgeStatistics,
   getTampereRegionalSurveyMonthlyStatistics,
+  getTampereRegionalSurveyYearlyStatistics,
   getTitaniaErrorsReport,
   getUnitsReport,
   getVardaChildErrorsReport,
@@ -151,4 +152,8 @@ export const tampereRegionalSurveyMonthlyReport = q.query(
 
 export const tampereRegionalSurveyAgeReport = q.query(
   getTampereRegionalSurveyAgeStatistics
+)
+
+export const tampereRegionalSurveyYearlyReport = q.query(
+  getTampereRegionalSurveyYearlyStatistics
 )

--- a/frontend/src/employee-frontend/generated/api-clients/reports.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reports.ts
@@ -66,6 +66,7 @@ import { ProviderType } from 'lib-common/generated/api-types/daycare'
 import { RawReportRow } from 'lib-common/generated/api-types/reports'
 import { RegionalSurveyReportAgeStatisticsResult } from 'lib-common/generated/api-types/reports'
 import { RegionalSurveyReportResult } from 'lib-common/generated/api-types/reports'
+import { RegionalSurveyReportYearlyStatisticsResult } from 'lib-common/generated/api-types/reports'
 import { Report } from 'lib-common/generated/api-types/reports'
 import { ServiceNeedReportRow } from 'lib-common/generated/api-types/reports'
 import { ServiceVoucherReport } from 'lib-common/generated/api-types/reports'
@@ -1094,6 +1095,26 @@ export async function getTampereRegionalSurveyMonthlyStatistics(
   )
   const { data: json } = await client.request<JsonOf<RegionalSurveyReportResult>>({
     url: uri`/employee/reports/tampere-regional-survey/monthly-statistics`.toString(),
+    method: 'GET',
+    params
+  })
+  return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.reports.TampereRegionalSurvey.getTampereRegionalSurveyYearlyStatistics
+*/
+export async function getTampereRegionalSurveyYearlyStatistics(
+  request: {
+    year: number
+  }
+): Promise<RegionalSurveyReportYearlyStatisticsResult> {
+  const params = createUrlSearchParams(
+    ['year', request.year.toString()]
+  )
+  const { data: json } = await client.request<JsonOf<RegionalSurveyReportYearlyStatisticsResult>>({
+    url: uri`/employee/reports/tampere-regional-survey/yearly-statistics`.toString(),
     method: 'GET',
     params
   })

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -1172,6 +1172,7 @@ export interface YearlyStatisticsResult {
   municipalGeneralAssistanceCount: number
   municipalSpecialAssistanceCount: number
   preschoolDaycareFamilyCareCount: number
+  preschoolDaycareSchoolCareCount: number
   preschoolDaycareUnitCareCount: number
   purchased5YearOldCount: number
   voucher5YearOldCount: number

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -1173,7 +1173,9 @@ export interface YearlyStatisticsResult {
   municipalSpecialAssistanceCount: number
   preschoolDaycareFamilyCareCount: number
   preschoolDaycareSchoolCareCount: number
+  preschoolDaycareSchoolShiftCareCount: number
   preschoolDaycareUnitCareCount: number
+  preschoolDaycareUnitShiftCareCount: number
   purchased5YearOldCount: number
   voucher5YearOldCount: number
   voucherAssistanceCount: number

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -872,6 +872,14 @@ export interface RegionalSurveyReportResult {
 }
 
 /**
+* Generated from fi.espoo.evaka.reports.TampereRegionalSurvey.RegionalSurveyReportYearlyStatisticsResult
+*/
+export interface RegionalSurveyReportYearlyStatisticsResult {
+  year: number
+  yearlyStatistics: YearlyStatisticsResult[]
+}
+
+/**
 * Generated from fi.espoo.evaka.reports.Report
 */
 export type Report =
@@ -1152,6 +1160,24 @@ export type VoucherReportRowType =
   | 'REFUND'
   | 'CORRECTION'
   | 'ORIGINAL'
+
+/**
+* Generated from fi.espoo.evaka.reports.TampereRegionalSurvey.YearlyStatisticsResult
+*/
+export interface YearlyStatisticsResult {
+  club5YearOldCount: number
+  enhancedAssistanceCount: number
+  familyCare5YearOldCount: number
+  generalAssistanceCount: number
+  municipal5YearOldCount: number
+  preschoolDaycareFamilyCareCount: number
+  preschoolDaycareUnitCareCount: number
+  purchased5YearOldCount: number
+  specialAssistanceCount: number
+  voucher5YearOldCount: number
+  voucherAssistanceCount: number
+  voucherTotalCount: number
+}
 
 
 export function deserializeJsonAssistanceNeedDecisionsReportRow(json: JsonOf<AssistanceNeedDecisionsReportRow>): AssistanceNeedDecisionsReportRow {

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -1166,16 +1166,19 @@ export type VoucherReportRowType =
 */
 export interface YearlyStatisticsResult {
   club5YearOldCount: number
-  enhancedAssistanceCount: number
   familyCare5YearOldCount: number
-  generalAssistanceCount: number
   municipal5YearOldCount: number
+  municipalEnhancedAssistanceCount: number
+  municipalGeneralAssistanceCount: number
+  municipalSpecialAssistanceCount: number
   preschoolDaycareFamilyCareCount: number
   preschoolDaycareUnitCareCount: number
   purchased5YearOldCount: number
-  specialAssistanceCount: number
   voucher5YearOldCount: number
   voucherAssistanceCount: number
+  voucherEnhancedAssistanceCount: number
+  voucherGeneralAssistanceCount: number
+  voucherSpecialAssistanceCount: number
   voucherTotalCount: number
 }
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4327,6 +4327,7 @@ export const fi = {
         'Raportti kerää kunnan vuosittaiseen seutuselvitykseen tarvittavat tiedot ladattaviksi CSV-tiedostoiksi',
       monthlyReport: 'Seutuselvityksen kuukausittaiset määrät',
       ageStatisticsReport: 'Seutuselvityksen ikäjakaumat',
+      yearlyStatisticsReport: 'Seutuselvityksen vuosittaiset määrät',
       reportLabel: 'Seutuselvitys',
       monthlyColumns: {
         month: 'Kuukausi',
@@ -4359,6 +4360,20 @@ export const fi = {
           'Alle 3v perhepäivähoidon hoitopäivät',
         effectiveFamilyDaycareDaysOver3Count:
           '3v ja yli perhepäivähoidon hoitopäivät'
+      },
+      yearlyStatisticsColumns: {
+        voucherTotalCount: 'Palvelusetelien määrä',
+        voucherAssistanceCount: 'Tuen lasten määrä palveluseteliyksiköissä',
+        voucher5YearOldCount: '5-vuotiaat palveluseteliyksiköissä',
+        purchased5YearlOldCount: '5-vuotiaat ostopalveluyksiköissä',
+        municipal5YearOldCount: '5-vuotiaat kunnallisissa yksiköissä',
+        familyCare5YearOldCount: '5-vuotiaat perhepäivähoidossa',
+        club5YearOldCount: '5-vuotiaat kerhossa',
+        preschoolDaycareUnitCareCount: 'Täydentävän varhaiskasvatuksen lapset yksiköissä',
+        preschoolFamilyCareCount: 'Täydentävän varhaiskasvatuksen lapset perhepäivähoidossa',
+        generalAssistanceCount: 'Yleisen tuen lapsimäärä',
+        specialAssistanceCount: 'Erityisen tuen lapsimäärä',
+        enhancedAssistanceCount: 'Tehostetun tuen lapsimäärä',
       }
     }
   },

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4369,11 +4369,22 @@ export const fi = {
         municipal5YearOldCount: '5-vuotiaat kunnallisissa yksiköissä',
         familyCare5YearOldCount: '5-vuotiaat perhepäivähoidossa',
         club5YearOldCount: '5-vuotiaat kerhossa',
-        preschoolDaycareUnitCareCount: 'Täydentävän varhaiskasvatuksen lapset yksiköissä',
-        preschoolFamilyCareCount: 'Täydentävän varhaiskasvatuksen lapset perhepäivähoidossa',
-        generalAssistanceCount: 'Yleisen tuen lapsimäärä',
-        specialAssistanceCount: 'Erityisen tuen lapsimäärä',
-        enhancedAssistanceCount: 'Tehostetun tuen lapsimäärä',
+        preschoolDaycareUnitCareCount:
+          'Täydentävän varhaiskasvatuksen lapset yksiköissä',
+        preschoolFamilyCareCount:
+          'Täydentävän varhaiskasvatuksen lapset perhepäivähoidossa',
+        voucherGeneralAssistanceCount:
+          'Yleisen tuen lapsimäärä (palveluseteli)',
+        voucherSpecialAssistanceCount:
+          'Erityisen tuen lapsimäärä (palveluseteli)',
+        voucherEnhancedAssistanceCount:
+          'Tehostetun tuen lapsimäärä (palveluseteli)',
+        municipalGeneralAssistanceCount:
+          'Yleisen tuen lapsimäärä (kunnallinen)',
+        municipalSpecialAssistanceCount:
+          'Erityisen tuen lapsimäärä (kunnallinen)',
+        municipalEnhancedAssistanceCount:
+          'Tehostetun tuen lapsimäärä (kunnallinen)'
       }
     }
   },

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4370,7 +4370,9 @@ export const fi = {
         familyCare5YearOldCount: '5-vuotiaat perhepäivähoidossa',
         club5YearOldCount: '5-vuotiaat kerhossa',
         preschoolDaycareUnitCareCount:
-          'Täydentävän varhaiskasvatuksen lapset yksiköissä',
+          'Täydentävän varhaiskasvatuksen lapset vaka-yksiköissä',
+        preschoolDaycareSchoolCareCount:
+          'Täydentävän varhaiskasvatuksen lapset kouluissa',
         preschoolFamilyCareCount:
           'Täydentävän varhaiskasvatuksen lapset perhepäivähoidossa',
         voucherGeneralAssistanceCount:

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4373,8 +4373,12 @@ export const fi = {
           'Täydentävän varhaiskasvatuksen lapset vaka-yksiköissä',
         preschoolDaycareSchoolCareCount:
           'Täydentävän varhaiskasvatuksen lapset kouluissa',
-        preschoolFamilyCareCount:
+        preschoolDaycareFamilyCareCount:
           'Täydentävän varhaiskasvatuksen lapset perhepäivähoidossa',
+        preschoolDaycareUnitShiftCareCount:
+          'Täydentävän varhaiskasvatuksen vuorohoidon lapset vaka-yksiköissä',
+        preschoolDaycareSchoolShiftCareCount:
+          'Täydentävän varhaiskasvatuksen vuorohoidon lapset kouluissa',
         voucherGeneralAssistanceCount:
           'Yleisen tuen lapsimäärä (palveluseteli)',
         voucherSpecialAssistanceCount:

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/TampereRegionalSurveyTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/TampereRegionalSurveyTest.kt
@@ -1239,6 +1239,254 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
         assertEquals(1, results.yearlyStatistics.first().voucherEnhancedAssistanceCount)
     }
 
+    @Test
+    fun `Preschool daycare municipal unit and school counts are correct`() {
+        val octFirst = LocalDate.of(2024, 10, 1)
+        val defaultPlacementRange = FiniteDateRange(octFirst, octFirst.plusMonths(3).minusDays(1))
+        val testUnitData = initTestUnitData(startDate)
+        // 2024-10-01 - 2024-12-31
+        initTestPlacementData(octFirst, testUnitData[0], defaultPlacementRange)
+
+        db.transaction { tx ->
+            // add some non-compliant data that should not show up
+            val testChildCecilia =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(2),
+                    firstName = "Cecilia",
+                    lastName = "af Clubbenberg",
+                    language = "sv",
+                )
+
+            val testChildElmo =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(4),
+                    firstName = "Elmo",
+                    lastName = "Esiopetettava",
+                    language = "fi",
+                )
+
+            tx.insert(testChildCecilia, DevPersonType.CHILD)
+            tx.insert(testChildElmo, DevPersonType.CHILD)
+
+            val placementC =
+                DevPlacement(
+                    type = PlacementType.CLUB,
+                    childId = testChildCecilia.id,
+                    unitId = testUnitData[1],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            val placementV =
+                DevPlacement(
+                    type = PlacementType.PRESCHOOL,
+                    childId = testChildElmo.id,
+                    unitId = testUnitData[0],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            tx.insert(placementC)
+            tx.insert(placementV)
+
+            // add shift care placement to daycare
+            val testChildVanja =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(4),
+                    firstName = "Vanja",
+                    lastName = "Vakayksikköläinen",
+                    language = "fi",
+                )
+            tx.insert(testChildVanja, DevPersonType.CHILD)
+
+            val vanjaPlacement =
+                DevPlacement(
+                    type = PlacementType.PRESCHOOL_DAYCARE,
+                    childId = testChildVanja.id,
+                    startDate = defaultPlacementRange.start,
+                    endDate = defaultPlacementRange.end,
+                    unitId = testUnitData[0],
+                )
+
+            tx.insert(vanjaPlacement)
+
+            // add a preschool daycare placement to a school unit
+            val testChildSirpa =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(4),
+                    firstName = "Sirpa",
+                    lastName = "Schüler",
+                    language = "fi",
+                )
+
+            tx.insert(testChildSirpa, DevPersonType.CHILD)
+            val sirpaPlacement =
+                DevPlacement(
+                    type = PlacementType.PRESCHOOL_DAYCARE,
+                    childId = testChildSirpa.id,
+                    startDate = defaultPlacementRange.start,
+                    endDate = defaultPlacementRange.end,
+                    unitId = testUnitData[5],
+                )
+
+            tx.insert(sirpaPlacement)
+        }
+
+        val results =
+            tampereRegionalSurvey.getTampereRegionalSurveyYearlyStatistics(
+                dbInstance(),
+                adminLoginUser,
+                mockClock,
+                year = startDate.year,
+            )
+
+        // Vanja + Bertil in daycare and Sirpa in school
+        val expectedResults = Pair(2, 1)
+
+        val shiftCareCountResults =
+            Pair(
+                results.yearlyStatistics.first().preschoolDaycareUnitCareCount,
+                results.yearlyStatistics.first().preschoolDaycareSchoolCareCount,
+            )
+
+        assertEquals(expectedResults, shiftCareCountResults)
+    }
+
+    @Test
+    fun `Preschool daycare municipal unit and school shift care counts are correct`() {
+        val octFirst = LocalDate.of(2024, 10, 1)
+        val defaultPlacementRange = FiniteDateRange(octFirst, octFirst.plusMonths(3).minusDays(1))
+        val testUnitData = initTestUnitData(startDate)
+        // 2024-10-01 - 2024-12-31
+        initTestPlacementData(octFirst, testUnitData[0], defaultPlacementRange)
+
+        db.transaction { tx ->
+            // add some non-compliant data that should not show up
+            val testChildCecilia =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(2),
+                    firstName = "Cecilia",
+                    lastName = "af Clubbenberg",
+                    language = "sv",
+                )
+
+            val testChildElmo =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(4),
+                    firstName = "Elmo",
+                    lastName = "Esiopetettava",
+                    language = "fi",
+                )
+
+            tx.insert(testChildCecilia, DevPersonType.CHILD)
+            tx.insert(testChildElmo, DevPersonType.CHILD)
+
+            val placementC =
+                DevPlacement(
+                    type = PlacementType.CLUB,
+                    childId = testChildCecilia.id,
+                    unitId = testUnitData[1],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            val placementV =
+                DevPlacement(
+                    type = PlacementType.PRESCHOOL,
+                    childId = testChildElmo.id,
+                    unitId = testUnitData[0],
+                    startDate = startDate,
+                    endDate = startDate.plusYears(1),
+                )
+
+            tx.insert(placementC)
+            tx.insert(placementV)
+
+            // add shift care placement to daycare
+            val testChildVanja =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(4),
+                    firstName = "Vanja",
+                    lastName = "Vakayksikköläinen",
+                    language = "fi",
+                )
+            tx.insert(testChildVanja, DevPersonType.CHILD)
+
+            val shiftCarePlacement =
+                DevPlacement(
+                    type = PlacementType.PRESCHOOL_DAYCARE,
+                    childId = testChildVanja.id,
+                    startDate = defaultPlacementRange.start,
+                    endDate = defaultPlacementRange.end,
+                    unitId = testUnitData[0],
+                )
+
+            tx.insert(shiftCarePlacement)
+
+            tx.insert(
+                DevServiceNeed(
+                    placementId = shiftCarePlacement.id,
+                    optionId = fullTimeSno.id,
+                    shiftCare = ShiftCareType.FULL,
+                    startDate = shiftCarePlacement.startDate,
+                    endDate = shiftCarePlacement.endDate,
+                    confirmedBy = admin.evakaUserId,
+                )
+            )
+
+            // add a preschool daycare shift care placement to a school unit
+            val testChildSirpa =
+                DevPerson(
+                    dateOfBirth = startDate.minusYears(4),
+                    firstName = "Sirpa",
+                    lastName = "Schüler",
+                    language = "fi",
+                )
+
+            tx.insert(testChildSirpa, DevPersonType.CHILD)
+            val shiftCarePlacement2 =
+                DevPlacement(
+                    type = PlacementType.PRESCHOOL_DAYCARE,
+                    childId = testChildSirpa.id,
+                    startDate = defaultPlacementRange.start,
+                    endDate = defaultPlacementRange.end,
+                    unitId = testUnitData[5],
+                )
+
+            tx.insert(shiftCarePlacement2)
+
+            tx.insert(
+                DevServiceNeed(
+                    placementId = shiftCarePlacement2.id,
+                    optionId = fullTimeSno.id,
+                    shiftCare = ShiftCareType.INTERMITTENT,
+                    startDate = shiftCarePlacement.startDate,
+                    endDate = shiftCarePlacement.endDate,
+                    confirmedBy = admin.evakaUserId,
+                )
+            )
+        }
+
+        val results =
+            tampereRegionalSurvey.getTampereRegionalSurveyYearlyStatistics(
+                dbInstance(),
+                adminLoginUser,
+                mockClock,
+                year = startDate.year,
+            )
+
+        // Vanja + Bertil in daycare and Sirpa in school
+        val expectedResults = Pair(2, 1)
+
+        val shiftCareCountResults =
+            Pair(
+                results.yearlyStatistics.first().preschoolDaycareUnitShiftCareCount,
+                results.yearlyStatistics.first().preschoolDaycareSchoolShiftCareCount,
+            )
+
+        assertEquals(expectedResults, shiftCareCountResults)
+    }
+
     private fun initTestUnitData(monday: LocalDate): List<DaycareId> {
         return db.transaction { tx ->
             val areaAId = tx.insert(DevCareArea(name = "Area A", shortName = "Area A"))
@@ -1319,7 +1567,25 @@ class TampereRegionalSurveyTest : FullApplicationTest(resetDbBeforeEach = true) 
                     )
                 )
 
-            listOf(daycareAId, daycareBId, daycareCId, daycareDId, daycareEId)
+            val daycareFId =
+                tx.insert(
+                    DevDaycare(
+                        name = "School",
+                        areaId = areaAId,
+                        openingDate = monday.minusMonths(1),
+                        type = setOf(CareType.PRESCHOOL),
+                        providerType = ProviderType.MUNICIPAL,
+                        operationTimes =
+                            List(5) { TimeRange(LocalTime.of(8, 0), LocalTime.of(18, 0)) } +
+                                List(2) { null },
+                        shiftCareOperationTimes =
+                            List(7) { TimeRange(LocalTime.of(0, 0), LocalTime.of(23, 59)) },
+                        shiftCareOpenOnHolidays = true,
+                        enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS),
+                    )
+                )
+
+            listOf(daycareAId, daycareBId, daycareCId, daycareDId, daycareEId, daycareFId)
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -511,6 +511,7 @@ enum class Audit(
     SystemNotificationsReadCitizen,
     SystemNotificationsReadEmployeeMobile,
     TampereRegionalSurveyMonthly,
+    TampereRegionalSurveyYearly,
     TampereRegionalSurveyAgeStatistics,
     TemporaryEmployeesRead,
     TemporaryEmployeeCreate,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/TampereRegionalSurvey.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/TampereRegionalSurvey.kt
@@ -22,6 +22,13 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class TampereRegionalSurvey(private val accessControl: AccessControl) {
+
+    private val preschoolDaycarePredicate = Predicate { where("$it.type && '{CENTRE}'") }
+
+    private val preschoolSchoolPredicate = Predicate {
+        where("$it.type && '{PRESCHOOL}' && NOT ($it.type && '{CENTRE}')")
+    }
+
     @GetMapping("/employee/reports/tampere-regional-survey/monthly-statistics")
     fun getTampereRegionalSurveyMonthlyStatistics(
         db: Database,
@@ -316,7 +323,19 @@ class TampereRegionalSurvey(private val accessControl: AccessControl) {
                     val preschoolDaycareUnitCare =
                         tx.getPlacementCount(
                             statDay = yearlyStatDay,
-                            daycarePred = Predicate { where("$it.type && '{CENTRE}'") },
+                            daycarePred = preschoolDaycarePredicate,
+                            placementPred =
+                                Predicate {
+                                    where(
+                                        "$it.type = ANY ('{PRESCHOOL_DAYCARE,PRESCHOOL_DAYCARE_ONLY}')"
+                                    )
+                                },
+                        )
+
+                    val preschoolDaycareSchoolCare =
+                        tx.getPlacementCount(
+                            statDay = yearlyStatDay,
+                            daycarePred = preschoolSchoolPredicate,
                             placementPred =
                                 Predicate {
                                     where(
@@ -372,6 +391,8 @@ class TampereRegionalSurvey(private val accessControl: AccessControl) {
                                         preschoolDaycareFamilyCare.placementCount,
                                     preschoolDaycareUnitCareCount =
                                         preschoolDaycareUnitCare.placementCount,
+                                    preschoolDaycareSchoolCareCount =
+                                        preschoolDaycareSchoolCare.placementCount,
                                     voucherGeneralAssistanceCount =
                                         voucherAssistanceCounts.generalSupportWithDecisionCount,
                                     voucherSpecialAssistanceCount =
@@ -465,6 +486,7 @@ class TampereRegionalSurvey(private val accessControl: AccessControl) {
         val municipal5YearOldCount: Int,
         val familyCare5YearOldCount: Int,
         val preschoolDaycareUnitCareCount: Int,
+        val preschoolDaycareSchoolCareCount: Int,
         val preschoolDaycareFamilyCareCount: Int,
         val voucherGeneralAssistanceCount: Int,
         val voucherSpecialAssistanceCount: Int,

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/TampereRegionalSurvey.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/TampereRegionalSurvey.kt
@@ -43,6 +43,12 @@ class TampereRegionalSurvey(private val accessControl: AccessControl) {
         where("$it.type && '{FAMILY,GROUP_FAMILY}'")
     }
 
+    private val purchasedDaycareUnitPredicate = Predicate {
+        where(
+            "$it.provider_type = ANY ('{PURCHASED,EXTERNAL_PURCHASED}') AND $it.type && '{CENTRE}'"
+        )
+    }
+
     // placement predicates
     private val preschoolDaycarePlacementPredicate = Predicate {
         where("$it.type = ANY ('{PRESCHOOL_DAYCARE,PRESCHOOL_DAYCARE_ONLY}')")
@@ -147,23 +153,13 @@ class TampereRegionalSurvey(private val accessControl: AccessControl) {
                     val voucherCounts =
                         tx.getAgeDivisionCounts(
                             statDay = yearlyStatDay,
-                            daycarePred =
-                                Predicate {
-                                    where(
-                                        "$it.provider_type = ANY ('{PRIVATE_SERVICE_VOUCHER}') AND $it.type && '{CENTRE}'"
-                                    )
-                                },
+                            daycarePred = voucherDaycareUnitPredicate,
                         )
 
                     val purchasedCounts =
                         tx.getAgeDivisionCounts(
                             statDay = yearlyStatDay,
-                            daycarePred =
-                                Predicate {
-                                    where(
-                                        "$it.provider_type = ANY ('{PURCHASED,EXTERNAL_PURCHASED}') AND $it.type && '{CENTRE}'"
-                                    )
-                                },
+                            daycarePred = purchasedDaycareUnitPredicate,
                         )
 
                     val clubCounts =
@@ -193,28 +189,13 @@ class TampereRegionalSurvey(private val accessControl: AccessControl) {
                     val familyCareDayCounts =
                         tx.getEffectiveCareDayCounts(
                             range = yearlyRange,
-                            daycarePred =
-                                Predicate {
-                                    where(
-                                        """
-                                 $it.type && '{FAMILY, GROUP_FAMILY}'
-                            """
-                                    )
-                                },
+                            daycarePred = familyCareDaycarePredicate,
                         )
 
                     val daycareDayCounts =
                         tx.getEffectiveCareDayCounts(
                             range = yearlyRange,
-                            daycarePred =
-                                Predicate {
-                                    where(
-                                        """
-                               $it.provider_type = ANY ('{MUNICIPAL}')
-                                 AND $it.type && '{CENTRE}'
-                            """
-                                    )
-                                },
+                            daycarePred = municipalDaycareUnitPredicate,
                         )
 
                     RegionalSurveyReportAgeStatisticsResult(
@@ -271,24 +252,14 @@ class TampereRegionalSurvey(private val accessControl: AccessControl) {
                     val purchasedFiveYearOlds =
                         tx.getPlacementCount(
                             statDay = yearlyStatDay,
-                            daycarePred =
-                                Predicate {
-                                    where(
-                                        "$it.provider_type = ANY ('{PURCHASED,EXTERNAL_PURCHASED}') AND $it.type && '{CENTRE}'"
-                                    )
-                                },
+                            daycarePred = purchasedDaycareUnitPredicate,
                             personPred = fiveYearOldPersonPred,
                         )
 
                     val voucher5YearOld =
                         tx.getPlacementCount(
                             statDay = yearlyStatDay,
-                            daycarePred =
-                                Predicate {
-                                    where(
-                                        "$it.provider_type = ANY ('{PRIVATE_SERVICE_VOUCHER}') AND $it.type && '{CENTRE}'"
-                                    )
-                                },
+                            daycarePred = voucherDaycareUnitPredicate,
                             personPred = fiveYearOldPersonPred,
                         )
 

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/TampereRegionalSurvey.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/TampereRegionalSurvey.kt
@@ -791,8 +791,8 @@ WHERE ${predicate(placementPred.forTable("pl"))}
 SELECT count(pl.child_id) as placement_count
 FROM placement pl
          JOIN daycare d ON pl.unit_id = d.id
-         JOIN daycare_assistance da 
-            ON da.child_id = pl.child_id 
+         JOIN daycare_assistance da
+            ON da.child_id = pl.child_id
                 AND da.valid_during @> ${bind(statDay)}
 WHERE ${predicate(daycarePred.forTable("d"))}
   AND ${predicate(assistancePred.forTable("da"))}


### PR DESCRIPTION
Laajentaa Tampereen seudun seutuselvityksen tueksi laadittua raporttia valikoimalla vuosittaisia tilastoarvoja. Viimeinen suunniteltu osa raporttikokonaisuudesta.