### PR TITLE
Pedagogisten dokumenttien arkistointegraation 1. osa

### DIFF
--- a/frontend/src/e2e-test/pages/employee/documents/child-document.ts
+++ b/frontend/src/e2e-test/pages/employee/documents/child-document.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { Page, TextInput, Element } from '../../../utils/page'
+import { Page, TextInput, Element, AsyncButton } from '../../../utils/page'
 
 export class ChildDocumentPage {
   status: Element
@@ -10,7 +10,7 @@ export class ChildDocumentPage {
   previewButton: Element
   editButton: Element
   returnButton: Element
-  archiveButton: Element
+  archiveButton: AsyncButton
   archiveTooltip: Element
   constructor(private readonly page: Page) {
     this.status = page.findByDataQa('document-state-chip')
@@ -18,7 +18,7 @@ export class ChildDocumentPage {
     this.previewButton = page.findByDataQa('preview-button')
     this.editButton = page.findByDataQa('edit-button')
     this.returnButton = page.findByDataQa('return-button')
-    this.archiveButton = page.findByDataQa('archive-button')
+    this.archiveButton = new AsyncButton(page.findByDataQa('archive-button'))
     this.archiveTooltip = page.findByDataQa('archive-tooltip')
   }
 

--- a/frontend/src/e2e-test/pages/employee/documents/child-document.ts
+++ b/frontend/src/e2e-test/pages/employee/documents/child-document.ts
@@ -10,12 +10,16 @@ export class ChildDocumentPage {
   previewButton: Element
   editButton: Element
   returnButton: Element
+  archiveButton: Element
+  archiveTooltip: Element
   constructor(private readonly page: Page) {
     this.status = page.findByDataQa('document-state-chip')
     this.savingIndicator = page.findByDataQa('saving-spinner')
     this.previewButton = page.findByDataQa('preview-button')
     this.editButton = page.findByDataQa('edit-button')
     this.returnButton = page.findByDataQa('return-button')
+    this.archiveButton = page.findByDataQa('archive-button')
+    this.archiveTooltip = page.findByDataQa('archive-tooltip')
   }
 
   getTextQuestion(sectionName: string, questionName: string) {

--- a/frontend/src/e2e-test/pages/employee/documents/document-templates.ts
+++ b/frontend/src/e2e-test/pages/employee/documents/document-templates.ts
@@ -77,6 +77,8 @@ export class TemplateModal extends Element {
   readonly typeSelect
   readonly placementTypesSelect
   readonly validityStartInput
+  readonly processDefinitionNumberInput
+  readonly archiveDurationMonthsInput
   readonly confirmCreateButton
 
   constructor(locator: Locator) {
@@ -87,6 +89,12 @@ export class TemplateModal extends Element {
       this.findByDataQa('placement-types-select')
     )
     this.validityStartInput = new TextInput(this.findByDataQa('start-date'))
+    this.processDefinitionNumberInput = new TextInput(
+      this.findByDataQa('process-definition-number')
+    )
+    this.archiveDurationMonthsInput = new TextInput(
+      this.findByDataQa('archive-duration-months')
+    )
     this.confirmCreateButton = this.findByDataQa('modal-okBtn')
   }
 }

--- a/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
@@ -395,6 +395,7 @@ describe('Employee - Child documents', () => {
     await row2.openLink.click()
     const childDocument2 = new ChildDocumentPage(page)
     await childDocument2.archiveButton.click()
+    await childDocument2.archiveButton.waitUntilIdle()
     await runJobs({ mockedTime: now })
 
     await page.reload()

--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
@@ -29,7 +29,9 @@ import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { UUID } from 'lib-common/types'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useDebounce } from 'lib-common/utils/useDebounce'
+import Tooltip from 'lib-components/atoms/Tooltip'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
+import { MutateButton } from 'lib-components/atoms/buttons/MutateButton'
 import Spinner from 'lib-components/atoms/state/Spinner'
 import { ChildDocumentStateChip } from 'lib-components/document-templates/ChildDocumentStateChip'
 import DocumentView from 'lib-components/document-templates/DocumentView'
@@ -47,9 +49,11 @@ import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { H1, H2 } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
+import featureFlags from 'lib-customizations/espoo/featureFlags'
 import { faFilePdf } from 'lib-icons'
 import { faExclamationTriangle } from 'lib-icons'
 import { fasCheckCircle, fasExclamationTriangle } from 'lib-icons'
+import { faBoxArchive } from 'lib-icons'
 
 import { API_URL } from '../../api/client'
 import { useTranslation } from '../../state/i18n'
@@ -63,6 +67,7 @@ import {
   childDocumentQuery,
   childDocumentWriteLockQuery,
   deleteChildDocumentMutation,
+  planArchiveChildDocumentMutation,
   publishChildDocumentMutation,
   updateChildDocumentContentMutation
 } from '../child-information/queries'
@@ -449,6 +454,30 @@ const ChildDocumentReadViewInner = React.memo(
                       </span>
                     </FixedSpaceRow>
                   </a>
+                  {featureFlags.archiveIntegrationEnabled &&
+                    permittedActions.includes('ARCHIVE') && (
+                      <Tooltip
+                        tooltip={
+                          document.archivedAt
+                            ? i18n.childInformation.childDocuments.editor.alreadyArchived(
+                                document.archivedAt
+                              )
+                            : undefined
+                        }
+                        data-qa="archive-tooltip"
+                      >
+                        <MutateButton
+                          icon={faBoxArchive}
+                          text={
+                            i18n.childInformation.childDocuments.editor.archive
+                          }
+                          mutation={planArchiveChildDocumentMutation}
+                          onClick={() => ({ documentId: document.id })}
+                          data-qa="archive-button"
+                          disabled={document.archivedAt !== null}
+                        />
+                      </Tooltip>
+                    )}
                 </FlexRow>
               </Container>
               <Gap size="xs" />

--- a/frontend/src/employee-frontend/components/child-information/queries.ts
+++ b/frontend/src/employee-frontend/components/child-information/queries.ts
@@ -71,7 +71,8 @@ import {
   prevDocumentStatus,
   publishDocument,
   takeDocumentWriteLock,
-  updateDocumentContent
+  updateDocumentContent,
+  planArchiveChildDocument
 } from '../../generated/api-clients/document'
 import {
   createFeeAlteration,
@@ -143,6 +144,10 @@ export const deleteChildDocumentMutation = q.parametricMutation<{
   ({ childId }) => childDocumentsQuery({ childId }),
   ({ documentId }) => childDocumentQuery({ documentId })
 ])
+
+export const planArchiveChildDocumentMutation = q.mutation(
+  planArchiveChildDocument
+)
 
 export const childServiceApplicationsQuery = q.query(
   getChildServiceApplications

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateContentEditor.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateContentEditor.tsx
@@ -389,7 +389,11 @@ const BasicsEditor = React.memo(function BasicsEditor({
             {i18n.documentTemplates.templateModal.processDefinitionNumber}
           </Label>
         </ExpandingInfo>
-        <InputFieldF bind={processDefinitionNumber} hideErrorsBeforeTouched />
+        <InputFieldF
+          bind={processDefinitionNumber}
+          hideErrorsBeforeTouched
+          data-qa="process-definition-number"
+        />
         {processDefinitionNumber.value().trim().length > 0 && (
           <>
             <Gap />

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
@@ -269,7 +269,11 @@ export default React.memo(function TemplateModal({ onClose, mode }: Props) {
           {i18n.documentTemplates.templateModal.processDefinitionNumber}
         </Label>
       </ExpandingInfo>
-      <InputFieldF bind={processDefinitionNumber} hideErrorsBeforeTouched />
+      <InputFieldF
+        bind={processDefinitionNumber}
+        hideErrorsBeforeTouched
+        data-qa="process-definition-number"
+      />
       {processDefinitionNumber.value().trim().length > 0 && (
         <>
           <Gap />
@@ -277,6 +281,7 @@ export default React.memo(function TemplateModal({ onClose, mode }: Props) {
             {i18n.documentTemplates.templateModal.archiveDurationMonths}
           </Label>
           <InputFieldF
+            data-qa="archive-duration-months"
             bind={archiveDurationMonths}
             type="number"
             hideErrorsBeforeTouched

--- a/frontend/src/employee-frontend/generated/api-clients/document.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/document.ts
@@ -338,6 +338,22 @@ export async function nextDocumentStatus(
 
 
 /**
+* Generated from fi.espoo.evaka.document.childdocument.ChildDocumentController.planArchiveChildDocument
+*/
+export async function planArchiveChildDocument(
+  request: {
+    documentId: ChildDocumentId
+  }
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/employee/child-documents/${request.documentId}/archive`.toString(),
+    method: 'POST'
+  })
+  return json
+}
+
+
+/**
 * Generated from fi.espoo.evaka.document.childdocument.ChildDocumentController.prevDocumentStatus
 */
 export async function prevDocumentStatus(

--- a/frontend/src/lib-common/generated/action.d.ts
+++ b/frontend/src/lib-common/generated/action.d.ts
@@ -254,6 +254,7 @@ export type ChildDailyNote =
   | 'UPDATE'
 
 export type ChildDocument =
+  | 'ARCHIVE'
   | 'DELETE'
   | 'DOWNLOAD'
   | 'NEXT_STATUS'

--- a/frontend/src/lib-common/generated/api-types/document.ts
+++ b/frontend/src/lib-common/generated/api-types/document.ts
@@ -152,6 +152,7 @@ export interface ChildDocumentCreateRequest {
 * Generated from fi.espoo.evaka.document.childdocument.ChildDocumentDetails
 */
 export interface ChildDocumentDetails {
+  archivedAt: HelsinkiDateTime | null
   child: ChildBasics
   content: DocumentContent
   id: ChildDocumentId
@@ -480,6 +481,7 @@ export function deserializeJsonChildDocumentCitizenSummary(json: JsonOf<ChildDoc
 export function deserializeJsonChildDocumentDetails(json: JsonOf<ChildDocumentDetails>): ChildDocumentDetails {
   return {
     ...json,
+    archivedAt: (json.archivedAt != null) ? HelsinkiDateTime.parseIso(json.archivedAt) : null,
     child: deserializeJsonChildBasics(json.child),
     content: deserializeJsonDocumentContent(json.content),
     publishedAt: (json.publishedAt != null) ? HelsinkiDateTime.parseIso(json.publishedAt) : null,

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -866,6 +866,9 @@ export const fi = {
         publishConfirmText:
           'Huoltaja saa nähdäkseen tämänhetkisen version. Tämän jälkeen tekemäsi muutokset eivät näy huoltajalle ennen kuin julkaiset uudelleen.',
         downloadPdf: 'Lataa PDF-tiedostona',
+        archive: 'Arkistoi',
+        alreadyArchived: (archivedAt: HelsinkiDateTime) =>
+          `Asiakirja on arkistoitu ${archivedAt.toLocalDate().format()}`,
         goToNextStatus: {
           DRAFT: 'Julkaise luonnos-tilassa',
           PREPARED: 'Julkaise laadittu-tilassa',

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -46,7 +46,8 @@ const features: Features = {
     serviceApplications: true,
     multiSelectDeparture: true,
     weakLogin: true,
-    employeeSfiLogin: true
+    employeeSfiLogin: true,
+    archiveIntegrationEnabled: true
   },
   staging: {
     environmentLabel: 'Staging',
@@ -83,7 +84,8 @@ const features: Features = {
     serviceApplications: true,
     multiSelectDeparture: true,
     weakLogin: true,
-    employeeSfiLogin: true
+    employeeSfiLogin: true,
+    archiveIntegrationEnabled: true
   },
   prod: {
     environmentLabel: null,
@@ -119,7 +121,8 @@ const features: Features = {
     serviceApplications: false,
     multiSelectDeparture: false,
     weakLogin: true,
-    employeeSfiLogin: true
+    employeeSfiLogin: true,
+    archiveIntegrationEnabled: false
   }
 }
 

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -293,6 +293,11 @@ interface BaseFeatureFlags {
    * Enable support for employee Suomi.fi login
    */
   employeeSfiLogin?: boolean
+
+  /**
+   * Enable support for document archival integration
+   */
+  archiveIntegrationEnabled?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerIntegrationTest.kt
@@ -236,6 +236,7 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
                                 archiveDurationMonths = null,
                                 content = templateContent,
                             ),
+                        archivedAt = null,
                     ),
                 permittedActions =
                     setOf(
@@ -247,6 +248,7 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
                         Action.ChildDocument.PREV_STATUS,
                         Action.ChildDocument.READ_METADATA,
                         Action.ChildDocument.DOWNLOAD,
+                        Action.ChildDocument.ARCHIVE,
                     ),
             ),
             document,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pdfgen/PdfGeneratorTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pdfgen/PdfGeneratorTest.kt
@@ -414,6 +414,7 @@ class PdfGeneratorTest {
                     ),
                 content = content,
                 publishedContent = content,
+                archivedAt = null,
             )
 
         val html = generateChildDocumentHtml(document)

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -174,6 +174,7 @@ enum class Audit(
     ChildDatePresenceExpectedAbsencesCheck,
     ChildDocumentCreate,
     ChildDocumentDelete,
+    ChildDocumentArchive,
     ChildDocumentDownload,
     ChildDocumentMarkRead,
     ChildDocumentNextStatus,

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -687,10 +687,15 @@ private fun snakeCaseName(job: Enum<*>): String =
 
 data class ArchiveEnv(
     /** URL up to the endpoint name e.g. http://10.0.0.10/archive-core */
-    val url: URI
+    val url: URI,
+    val useMockClient: Boolean,
 ) {
+
     companion object {
         fun fromEnvironment(env: Environment) =
-            ArchiveEnv(url = URI.create(env.lookup("evaka.integration.särmä.url")))
+            ArchiveEnv(
+                url = URI.create(env.lookup("evaka.integration.särmä.url")),
+                useMockClient = env.lookup("evaka.integration.särmä.use_mock_client") ?: false,
+            )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -29,6 +29,7 @@ data class EvakaEnv(
     val vtjEnabled: Boolean,
     val webPushEnabled: Boolean,
     val jamixEnabled: Boolean,
+    val särmäEnabled: Boolean,
     val forceUnpublishDocumentTemplateEnabled: Boolean,
     val asyncJobRunnerDisabled: Boolean,
     val frontendBaseUrlFi: String,
@@ -51,6 +52,7 @@ data class EvakaEnv(
                 vtjEnabled = env.lookup("evaka.integration.vtj.enabled") ?: false,
                 webPushEnabled = env.lookup("evaka.web_push.enabled") ?: false,
                 jamixEnabled = env.lookup("evaka.integration.jamix.enabled") ?: false,
+                särmäEnabled = env.lookup("evaka.integration.särmä.enabled") ?: false,
                 forceUnpublishDocumentTemplateEnabled =
                     env.lookup("evaka.not_for_prod.force_unpublish_document_template_enabled")
                         ?: false,
@@ -682,3 +684,13 @@ private fun snakeCaseName(job: Enum<*>): String =
             }
         }
         .joinToString(separator = "")
+
+data class ArchiveEnv(
+    /** URL up to the endpoint name e.g. http://10.0.0.10/archive-core */
+    val url: URI
+) {
+    companion object {
+        fun fromEnvironment(env: Environment) =
+            ArchiveEnv(url = URI.create(env.lookup("evaka.integration.särmä.url")))
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.document.archival
+
+import fi.espoo.evaka.document.childdocument.getChildDocumentKey
+import fi.espoo.evaka.document.childdocument.markDocumentAsArchived
+import fi.espoo.evaka.s3.DocumentKey
+import fi.espoo.evaka.s3.DocumentService
+import fi.espoo.evaka.shared.ChildDocumentId
+import fi.espoo.evaka.shared.async.AsyncJob
+import fi.espoo.evaka.shared.async.AsyncJobRunner
+import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.NotFound
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class ArchiveChildDocumentService(
+    private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
+    private val documentClient: DocumentService,
+    private val client: SärmäClientInterface,
+) {
+
+    init {
+        asyncJobRunner.registerHandler<AsyncJob.ArchiveChildDocument> { db, _, msg ->
+            uploadToArchive(db, msg.documentId)
+        }
+    }
+
+    fun uploadToArchive(db: Database.Connection, documentId: ChildDocumentId) {
+        logger.info { "Starting archival process for document $documentId" }
+
+        // TODO luo document metadata ChildDocumentDetails perusteella
+        //        val document =
+        //            db.read { tx ->
+        //                tx.getChildDocument(documentId) ?: throw NotFound("document $documentId
+        // not found")
+        //            }
+
+        val documentKey =
+            db.read { tx ->
+                tx.getChildDocumentKey(documentId)
+                    ?: throw NotFound("Document key not found for document $documentId")
+            }
+
+        // Get the document from the original location
+        val originalLocation = documentClient.locate(DocumentKey.ChildDocument(documentKey))
+        val documentContent = documentClient.get(originalLocation)
+
+        val masterId =
+            "yleinen" // TODO ei varmuudella tiedossa. Muissa Särmä integraatioissa käytetty esim.
+        // "taloushallinto"
+        // tai "paatoksenteko"
+        val classId =
+            "12.01.SL1.RT34" // Arvo perustuu Evaka_Särmä_metatietomääritykset.xlsx -tiedostoon
+        val virtualArchiveId =
+            "YLEINEN" // Arvo perustuu Evaka_Särmä_metatietomääritykset.xlsx -tiedostoon
+        val (responseCode, responseBody) =
+            client.putDocument(documentContent, masterId, classId, virtualArchiveId)
+        logger.info { "Response code: $responseCode" }
+
+        if (responseCode == 200) {
+            db.transaction { tx -> tx.markDocumentAsArchived(documentId, HelsinkiDateTime.now()) }
+            logger.info { "Successfully archived document $documentId" }
+        } else {
+            logger.error {
+                "Failed to archive document $documentId. Response code: $responseCode, Response body: ${responseBody?.string() ?: "No response body"}"
+            }
+        }
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
@@ -53,9 +53,8 @@ class ArchiveChildDocumentService(
         val documentContent = documentClient.get(originalLocation)
 
         val masterId =
-            "yleinen" // TODO ei varmuudella tiedossa. Muissa Särmä integraatioissa käytetty esim.
-        // "taloushallinto"
-        // tai "paatoksenteko"
+            "yleinen" // TODO ei vielä varmuudella tiedossa. Muissa Särmä integraatioissa käytetty
+        // esim. "taloushallinto" tai "paatoksenteko"
         val classId =
             "12.01.SL1.RT34" // Arvo perustuu Evaka_Särmä_metatietomääritykset.xlsx -tiedostoon
         val virtualArchiveId =
@@ -69,8 +68,9 @@ class ArchiveChildDocumentService(
             logger.info { "Successfully archived document $documentId" }
         } else {
             logger.error {
-                "Failed to archive document $documentId. Response code: $responseCode, Response body: ${responseBody?.string() ?: "No response body"}"
+                "Failed to archive document $documentId. Response code: $responseCode, Response body: ${responseBody ?: "No response body"}"
             }
+            throw RuntimeException("Failed to archive document $documentId")
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäClient.kt
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.document.archival
+
+import fi.espoo.evaka.ArchiveEnv
+import fi.espoo.evaka.s3.Document
+import java.time.Duration
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.springframework.stereotype.Component
+
+@Component
+class SärmäClient(private val archiveEnv: ArchiveEnv?) : SärmäClientInterface {
+    private val httpClient =
+        OkHttpClient.Builder()
+            .connectTimeout(Duration.ofMinutes(1))
+            .readTimeout(Duration.ofMinutes(1))
+            .writeTimeout(Duration.ofMinutes(1))
+            .build()
+
+    override fun putDocument(
+        documentContent: Document,
+        masterId: String,
+        classId: String,
+        virtualArchiveId: String,
+    ): Pair<Int, ResponseBody?> {
+        if (archiveEnv == null) {
+            throw IllegalStateException("Archive environment not configured")
+        }
+        val pdfBody = documentContent.bytes.toRequestBody("application/pdf".toMediaType())
+        val requestBody =
+            MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart("protocol_version", "1.0")
+                .addFormDataPart("operation_id", "PUT")
+                .addFormDataPart("user_id", "XXXX")
+                .addFormDataPart("user_role", "XXXX")
+                .addFormDataPart("nr_of_instances", "1")
+                .addFormDataPart("instance_1_md_model_id", "standard")
+                .addFormDataPart("instance_1_md_model_version", "1.0")
+                .addFormDataPart("instance_1_md_master_id", masterId)
+                .addFormDataPart("instance_1_md_master_version", "1.0")
+                .addFormDataPart("instance_1_class_id", classId)
+                .addFormDataPart("instance_1_virtual_archive_id", virtualArchiveId)
+                .addFormDataPart("instance_1_record_payload_location", "SELF_CONTAINED")
+                // .addFormDataPart("instance_1_md_instance", null, xmlBody)
+                .addFormDataPart(
+                    "instance_1_record_payload_content_size",
+                    documentContent.bytes.size.toString(),
+                )
+                .addFormDataPart("instance_1_record_payload_data", documentContent.name, pdfBody)
+                .build()
+
+        val endpointUrl = archiveEnv.url.resolve("PUT").toString()
+        val response =
+            httpClient
+                .newCall(Request.Builder().url(endpointUrl).post(requestBody).build())
+                .execute()
+        val responseCode = response.code
+        val responseBody = response.body
+        return Pair(responseCode, responseBody)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäClientConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäClientConfig.kt
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.document.archival
+
+import fi.espoo.evaka.ArchiveEnv
+import fi.espoo.evaka.EvakaEnv
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SärmäClientConfig {
+
+    @Bean
+    fun getSärmäClient(evakaEnv: EvakaEnv, archiveEnv: ArchiveEnv?): SärmäClientInterface {
+        if (!evakaEnv.särmäEnabled || archiveEnv?.useMockClient == true) {
+            return SärmäMockClient()
+        }
+        return SärmäHttpClient(archiveEnv)
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäClientInterface.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäClientInterface.kt
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.document.archival
+
+import fi.espoo.evaka.s3.Document
+import okhttp3.ResponseBody
+
+interface SärmäClientInterface {
+    fun putDocument(
+        documentContent: Document,
+        masterId: String,
+        classId: String,
+        virtualArchiveId: String,
+    ): Pair<Int, ResponseBody?>
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäHttpClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäHttpClient.kt
@@ -10,10 +10,8 @@ import java.time.Duration
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
-import org.springframework.stereotype.Component
 
-@Component
-class SärmäClient(private val archiveEnv: ArchiveEnv?) : SärmäClientInterface {
+class SärmäHttpClient(private val archiveEnv: ArchiveEnv?) : SärmäClientInterface {
     private val httpClient =
         OkHttpClient.Builder()
             .connectTimeout(Duration.ofMinutes(1))
@@ -26,7 +24,7 @@ class SärmäClient(private val archiveEnv: ArchiveEnv?) : SärmäClientInterfac
         masterId: String,
         classId: String,
         virtualArchiveId: String,
-    ): Pair<Int, ResponseBody?> {
+    ): Pair<Int, String?> {
         if (archiveEnv == null) {
             throw IllegalStateException("Archive environment not configured")
         }
@@ -59,8 +57,6 @@ class SärmäClient(private val archiveEnv: ArchiveEnv?) : SärmäClientInterfac
             httpClient
                 .newCall(Request.Builder().url(endpointUrl).post(requestBody).build())
                 .execute()
-        val responseCode = response.code
-        val responseBody = response.body
-        return Pair(responseCode, responseBody)
+        return Pair(response.code, response.body?.string())
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäMockClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäMockClient.kt
@@ -6,11 +6,13 @@ package fi.espoo.evaka.document.archival
 
 import fi.espoo.evaka.s3.Document
 
-interface SärmäClientInterface {
-    fun putDocument(
+class SärmäMockClient : SärmäClientInterface {
+    override fun putDocument(
         documentContent: Document,
         masterId: String,
         classId: String,
         virtualArchiveId: String,
-    ): Pair<Int, String?>
+    ): Pair<Int, String?> {
+        return Pair(200, "OK")
+    }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocument.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocument.kt
@@ -145,6 +145,7 @@ data class ChildDocumentDetails(
     val id: ChildDocumentId,
     val status: DocumentStatus,
     val publishedAt: HelsinkiDateTime?,
+    val archivedAt: HelsinkiDateTime?,
     val pdfAvailable: Boolean,
     @Json val content: DocumentContent,
     @Json val publishedContent: DocumentContent?,

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentController.kt
@@ -488,6 +488,7 @@ class ChildDocumentController(
                         tx = tx,
                         payloads = listOf(AsyncJob.ArchiveChildDocument(documentId)),
                         runAt = clock.now(),
+                        retryCount = 1,
                     )
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
@@ -56,6 +56,7 @@ SELECT
     cd.id,
     cd.status,
     cd.published_at,
+    cd.archived_at,
     cd.document_key IS NOT NULL AS pdf_available,
     cd.content,
     cd.published_content,
@@ -328,4 +329,17 @@ WHERE id = ${bind { it }}
 """
         )
     }
+}
+
+fun Database.Transaction.markDocumentAsArchived(id: ChildDocumentId, now: HelsinkiDateTime) {
+    createUpdate {
+            sql(
+                """
+            UPDATE child_document
+            SET archived_at = ${bind(now)}
+            WHERE id = ${bind(id)}
+            """
+            )
+        }
+        .updateExactlyOne()
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -409,6 +409,10 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class ArchiveChildDocument(val documentId: ChildDocumentId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     companion object {
         val main =
             AsyncJobRunner.Pool(
@@ -444,6 +448,7 @@ sealed interface AsyncJob : AsyncJobPayload {
                     PlacementToolFromSSN::class,
                     InvoiceCorrectionMigration::class,
                     DeletePersonalDevicesIfNeeded::class,
+                    ArchiveChildDocument::class,
                 ),
             )
         val email =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/EnvConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/EnvConfig.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.config
 
+import fi.espoo.evaka.ArchiveEnv
 import fi.espoo.evaka.BucketEnv
 import fi.espoo.evaka.CitizenCalendarEnv
 import fi.espoo.evaka.DatabaseEnv
@@ -90,6 +91,13 @@ class EnvConfig {
     fun jamixEnv(evakaEnv: EvakaEnv, env: Environment): JamixEnv? =
         when (evakaEnv.jamixEnabled) {
             true -> JamixEnv.fromEnvironment(env)
+            false -> null
+        }
+
+    @Bean
+    fun archiveEnv(evakaEnv: EvakaEnv, env: Environment): ArchiveEnv? =
+        when (evakaEnv.särmäEnabled) {
+            true -> ArchiveEnv.fromEnvironment(env)
             false -> null
         }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -2392,7 +2392,8 @@ sealed interface Action {
             HasGroupRole(STAFF)
                 .withUnitFeatures(PilotFeature.VASU_AND_PEDADOC)
                 .inPlacementGroupOfChildOfChildDocument(deletable = true),
-        );
+        ),
+        ARCHIVE(HasGlobalRole(ADMIN));
 
         override fun toString(): String = "${javaClass.name}.$name"
     }

--- a/service/src/main/resources/application-local.yaml
+++ b/service/src/main/resources/application-local.yaml
@@ -65,6 +65,7 @@ evaka:
           type: JKS
     särmä:
       enabled: true
+      use_mock_client: true
       url: https://eoy3xw8tftt5shn.m.pipedream.net/archive-core
   not_for_prod:
     force_unpublish_document_template_enabled: true

--- a/service/src/main/resources/application-local.yaml
+++ b/service/src/main/resources/application-local.yaml
@@ -63,6 +63,9 @@ evaka:
         trust_store:
           password: password
           type: JKS
+    särmä:
+      enabled: true
+      url: https://eoy3xw8tftt5shn.m.pipedream.net/archive-core
   not_for_prod:
     force_unpublish_document_template_enabled: true
   jwt:

--- a/service/src/main/resources/db/migration/V498__child_document_archived_at.sql
+++ b/service/src/main/resources/db/migration/V498__child_document_archived_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE child_document
+    ADD COLUMN archived_at timestamptz DEFAULT NULL; 

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -493,3 +493,4 @@ V494__daycare_acl_schedule.sql
 V495__draft_message_recipients.sql
 V496__staff_attendance_integration_feature.sql
 V497__application_primary_preferred_unit.sql
+V498__child_document_archived_at.sql


### PR DESCRIPTION
Tämä muutos lisää pääkäyttäjälle näkyvän toiminnon "Arkistoi" lapsen dokumenttinäkymään:

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/1fb72133-7566-4ef4-bb12-fa61820a6585" />

Nappi näkyy vain jos frontendin experimental feature flag `archiveIntegrationEnabled` on päällä.

Jos `integrations.särmä.enabled == true`, tätä painamalla käynnistyy async jobi joka lähettää k.o. dokumentin `integrations.särmä.url` propertyn kautta konfiguroitavaan REST endpoittiin:
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/e8d38cfe-2987-4447-af27-488edc081ba5" />
