### PR TITLE
Näytä aloittavien ryhmä viimeisenä mobiilin vastaanottajavalinnassa

### DIFF
--- a/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
@@ -266,11 +266,11 @@ describe('Sending and receiving messages', () => {
       testDaycareGroup.name,
       `${testChild.lastName} ${testChild.firstName}`,
       `${testChild2.lastName} ${testChild2.firstName}`,
-      `${testPreschool.name} (aloittavat)`,
-      `${preschoolGroup.name} (aloittavat)`,
+      `${testPreschool.name} (aloittavat lapset)`,
+      `${preschoolGroup.name} (aloittavat lapset)`,
       starterChildLabel
     ]
-    expect(labels.sort()).toEqual(expectedReceiverNames.sort())
+    expect(labels).toEqual(expectedReceiverNames)
 
     // Send a message to a starter child -> selects the whole unit
     await receiverSelector.optionByLabel(starterChildLabel).click()
@@ -327,7 +327,7 @@ describe('Sending and receiving messages', () => {
     }).save()
     await createMessageAccounts()
 
-    // Verify that available recipients contain current placements and starters
+    // Verify that available recipients contain the starters
     staffPage = await Page.open({ mockedTime: mockedDateAt10 })
     await employeeLogin(staffPage, futureStaff)
     await staffPage.goto(`${config.employeeUrl}/messages`)
@@ -338,15 +338,15 @@ describe('Sending and receiving messages', () => {
     await receiverSelector.expandAll()
     const labels = await receiverSelector.labels.allTexts()
     const expectedReceiverNames = [
-      `${secondGroup.name} (aloittavat)`,
+      `${secondGroup.name} (aloittavat lapset)`,
       `${testChild.lastName} ${testChild.firstName} (${mockedDate.addYears(1).addDays(1).format()})`,
       `${testChild2.lastName} ${testChild2.firstName} (${mockedDate.addYears(1).addDays(1).format()})`
     ]
-    expect(labels.sort()).toEqual(expectedReceiverNames.sort())
+    expect(labels).toEqual(expectedReceiverNames)
 
     // Send a message to a starter group (contains 2 children)
     await receiverSelector
-      .optionByLabel(`${secondGroup.name} (aloittavat)`)
+      .optionByLabel(`${secondGroup.name} (aloittavat lapset)`)
       .click()
     await receiverSelector.close()
     await messageEditor.inputTitle.fill('Aloittavalle otsikko')

--- a/frontend/src/employee-mobile-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/employee-mobile-frontend/messages/MessageEditor.tsx
@@ -6,6 +6,7 @@ import isEqual from 'lodash/isEqual'
 import React, { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
+import { sortReceivers } from 'lib-common/api-types/messaging'
 import { boolean, string } from 'lib-common/form/fields'
 import { array, mapped, object, recursive, value } from 'lib-common/form/form'
 import { useForm, useFormFields } from 'lib-common/form/hooks'
@@ -152,7 +153,10 @@ export default React.memo(function MessageEditor({
         ? {
             recipients: receiversAsSelectorNode(
               accountId,
-              availableRecipients,
+              availableRecipients.map((r) => ({
+                ...r,
+                receivers: sortReceivers(r.receivers)
+              })),
               i18n.messages.messageEditor.starters,
               draft.recipients
             ),
@@ -163,7 +167,10 @@ export default React.memo(function MessageEditor({
         : {
             recipients: receiversAsSelectorNode(
               accountId,
-              availableRecipients,
+              availableRecipients.map((r) => ({
+                ...r,
+                receivers: sortReceivers(r.receivers)
+              })),
               i18n.messages.messageEditor.starters
             ),
             urgent: false,

--- a/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
+++ b/frontend/src/lib-customizations/defaults/employee-mobile-frontend/i18n/fi.ts
@@ -445,7 +445,7 @@ export const fi = {
       sender: 'Lähettäjä',
       receivers: 'Vastaanottajat',
       recipientsPlaceholder: 'Valitse...',
-      starters: 'aloittavat',
+      starters: 'aloittavat lapset',
       subject: {
         heading: 'Otsikko',
         placeholder: 'Kirjoita...'

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4609,7 +4609,7 @@ export const fi = {
       childDob: 'Syntymäaika',
       receivers: 'Vastaanottajat',
       confirmText: 'Lähetä viesti valituille',
-      starters: 'aloittavat'
+      starters: 'aloittavat lapset'
     },
     noTitle: 'Ei otsikkoa',
     notSent: 'Ei lähetetty',


### PR DESCRIPTION
Ennen muutosta aloittavien ryhmä näkyi satunnaisesti joko ensimmäisenä tai viimeisenä. Muutoksen jälkeen vastaanottajat järjestetään samalla periaatteella kuin työpöytäversiossa.

Lisäksi muutettin alottavien ryhmän nimi näkymään muodossa "Ryhmän nimi (aloittavat lapset)" sekä työpöytäversiossa että mobiilissa.