### PR TITLE
Tuloselvityksen tekstikorjauksia

### DIFF
--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2100,7 +2100,7 @@ const en: Translations = {
         'Average earnings including holiday bonus, €/month',
       otherIncome: 'Other income',
       otherIncomeDescription:
-        'If you have other income, it must be itemised in an attachment. A list of the required attachments can be found at the bottom of the form under: Attachments related to income and early childhood education fees.',
+        'If you have other income, it must be itemised in an attachment.',
       choosePlaceholder: 'Select',
       otherIncomeTypes: {
         PENSION: 'Pension',
@@ -2135,17 +2135,8 @@ const en: Translations = {
     },
     entrepreneurIncome: {
       title: "Filling in the entrepreneur's income information",
-      description: (
-        <>
-          If necessary, you can fill in the information for more than one
-          company by ticking the boxes that apply to all of your companies.
-          Please provide more detailed company-specific information as
-          attachments.
-          <br />A list of the required attachments can be found at the bottom of
-          the form under &quot;Attachments related to income and early childhood
-          education fees&quot;.
-        </>
-      ),
+      description:
+        'If necessary, you can fill in the information for more than one company by ticking the boxes that apply to all of your companies.',
       fullTimeLabel: 'Are the business activities full-time or part-time?',
       fullTime: 'Full-time',
       partTime: 'Part-time',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2341,7 +2341,7 @@ export default {
       estimatedMonthlyIncome: 'Keskimääräiset tulot sisältäen lomarahat, €/kk',
       otherIncome: 'Muut tulot',
       otherIncomeDescription:
-        'Mikäli sinulla on muita tuloja, tulee niistä toimittaa tositteet liitteenä. Listan tarvittavista liitteistä löydät lomakkeen alaosasta kohdasta: Tuloihin ja varhaiskasvatusmaksuihin liittyvät liitteet.',
+        'Mikäli sinulla on muita tuloja, tulee niistä toimittaa tositteet liitteenä.',
       choosePlaceholder: 'Valitse',
       otherIncomeTypes: {
         PENSION: 'Eläke',
@@ -2376,16 +2376,8 @@ export default {
     },
     entrepreneurIncome: {
       title: 'Yrittäjän tulotietojen täyttäminen',
-      description: (
-        <>
-          Tällä lomakkeella voit tarvittaessa täyttää tiedot myös useammalle
-          yritykselle valitsemalla kaikkia yrityksiäsi koskevat kohdat. Toimita
-          tarkemmat yrityskohtaiset tiedot liitteinä.
-          <br />
-          Listan tarvittavista liitteistä löydät lomakkeen alaosasta kohdasta
-          “Tuloihin ja varhaiskasvatusmaksuihin liittyvät liitteet”.
-        </>
-      ),
+      description:
+        'Tällä lomakkeella voit tarvittaessa täyttää tiedot myös useammalle yritykselle valitsemalla kaikkia yrityksiäsi koskevat kohdat.',
       fullTimeLabel: 'Onko yritystoiminta päätoimista vai sivutoimista?',
       fullTime: 'Päätoimista',
       partTime: 'Sivutoimista',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2345,7 +2345,7 @@ const sv: Translations = {
         'Genomsnittliga inkomster inklusive semesterpenning, €/månad',
       otherIncome: 'Övriga inkomster',
       otherIncomeDescription:
-        'Om du har några andra inkomster, ska du lämna in uppgifterna som bilaga. En lista över nödvändiga bilagor finns längst ner på blanketten under: Bilagor som rör inkomsterna och avgifterna för småbarnspedagogik.',
+        'Om du har några andra inkomster, ska du lämna in uppgifterna som bilaga.',
       choosePlaceholder: 'Välj',
       otherIncomeTypes: {
         PENSION: 'Pension',
@@ -2381,17 +2381,8 @@ const sv: Translations = {
     },
     entrepreneurIncome: {
       title: 'Att fylla i företagarens inkomstuppgifter',
-      description: (
-        <>
-          Med denna blankett kan du vid behov fylla i uppgifterna för flera
-          företag genom att välja de punkter som gäller alla dina företag.
-          Skicka mer detaljerade företagsspecifika uppgifter som bilaga.
-          <br />
-          En lista över obligatoriska bilagor finns längst ner på blanketten
-          under ”Bilagor som rör inkomsterna och avgifterna för
-          småbarnspedagogik”.
-        </>
-      ),
+      description:
+        'Med denna blankett kan du vid behov fylla i uppgifterna för flera företag genom att välja de punkter som gäller alla dina företag.',
       fullTimeLabel: 'Är företagsverksamheten en huvudsyssla eller bisyssla?',
       fullTime: 'Huvudsyssla',
       partTime: 'Bisyssla',


### PR DESCRIPTION
Poistetaan seuraava teksti:

> Listan tarvittavista liitteistä löydät lomakkeen alaosasta kohdasta “Tuloihin ja varhaiskasvatusmaksuihin liittyvät liitteet”.

Poistetaan myös:

> Toimita tarkemmat yrityskohtaiset tiedot liitteinä.