### PR TITLE
Vähennetään apigw:stä tulevia turhia virhehälyjä

### DIFF
--- a/apigw/src/app.ts
+++ b/apigw/src/app.ts
@@ -321,6 +321,7 @@ export function apiRouter(config: Config, redisClient: RedisClient) {
       redisClient
     )
   )
+  router.all('/citizen/auth/*', (_, res) => res.redirect('/'))
   router.use('/citizen/public/map-api', mapRoutes)
   router.all('/citizen/public/*', citizenProxy)
   router.all('/citizen/*', citizenSessions.requireAuthentication, citizenProxy)
@@ -341,6 +342,7 @@ export function apiRouter(config: Config, redisClient: RedisClient) {
 
   router.use('/employee/', employeeSessions.middleware)
   router.get('/employee/auth/status', internalAuthStatus(employeeSessions))
+  router.all('/employee/auth/*', (_, res) => res.redirect('/employee'))
   router.all('/employee/public/*', employeeProxy)
   router.all(
     '/employee/*',
@@ -375,6 +377,9 @@ export function apiRouter(config: Config, redisClient: RedisClient) {
     employeeMobileSessions.requireAuthentication,
     express.json(),
     pinLogoutRequestHandler(employeeMobileSessions, redisClient)
+  )
+  router.all('/employee-mobile/auth/*', (_, res) =>
+    res.redirect('/employee/mobile')
   )
   router.all('/employee-mobile/public/*', employeeMobileProxy)
   router.all(

--- a/apigw/src/shared/middleware/error-handler.ts
+++ b/apigw/src/shared/middleware/error-handler.ts
@@ -19,7 +19,6 @@ interface LogResponse {
 export const errorHandler: (v: boolean) => ErrorRequestHandler =
   (includeErrorMessage: boolean) => (error, req, res, next) => {
     if (error instanceof InvalidAntiCsrfToken) {
-      logError('Anti-CSRF token error', req, undefined, error)
       if (!res.headersSent) {
         res
           .status(403)


### PR DESCRIPTION
- virheelliset auth-kutsut kiinni heti apigw:ssä -> ei enää Spring-virheitä `no GET endpoint /citizen/auth/...`
- anti-CSRF-virheet pois lokeilta kokonaan
- korjataan bugi SAML logout-käsittelyssä jossa ei huomioitu try/catch -blokkia ennen mahdollisesti tulevia virheitä, jotka lensi ylätasolle yleiseen virhelokitukseen