### PR TITLE
Tuloselvityksen saavutettavuus- ja UI-parannuksia

### DIFF
--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementAttachments.tsx
@@ -9,7 +9,7 @@ import {
   AttachmentId,
   IncomeStatementId
 } from 'lib-common/generated/api-types/shared'
-import { IncomeStatementAttachments } from 'lib-common/income-statements'
+import { IncomeStatementAttachments } from 'lib-common/income-statements/attachments'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import FileUpload from 'lib-components/molecules/FileUpload'
 

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementEditor.tsx
@@ -12,6 +12,9 @@ import {
   IncomeStatementId
 } from 'lib-common/generated/api-types/shared'
 import { fromUuid } from 'lib-common/id-type'
+import { fromBody } from 'lib-common/income-statements/body'
+import * as Form from 'lib-common/income-statements/form'
+import { emptyIncomeStatementForm } from 'lib-common/income-statements/form'
 import LocalDate from 'lib-common/local-date'
 import {
   constantQuery,
@@ -31,9 +34,6 @@ import {
   incomeStatementQuery,
   updateIncomeStatementMutation
 } from './queries'
-import { fromBody } from './types/body'
-import * as Form from './types/form'
-import { emptyIncomeStatementForm } from './types/form'
 
 interface EditorState {
   id: string | undefined

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
@@ -8,7 +8,8 @@ import styled from 'styled-components'
 import { Result } from 'lib-common/api'
 import { IncomeStatementStatus } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
-import { numAttachments } from 'lib-common/income-statements'
+import { numAttachments } from 'lib-common/income-statements/attachments'
+import * as Form from 'lib-common/income-statements/form'
 import LocalDate from 'lib-common/local-date'
 import { scrollToRef } from 'lib-common/utils/scrolling'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -42,7 +43,6 @@ import {
   useFieldDispatch,
   useFieldSetState
 } from './IncomeStatementComponents'
-import * as Form from './types/form'
 
 const OtherInfoContainer = styled.div`
   max-width: 716px;

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementForm.tsx
@@ -31,7 +31,7 @@ import { useLang, useTranslation } from '../localization'
 import ChildIncomeStatementAttachments from './ChildIncomeStatementAttachments'
 import {
   AttachmentSection,
-  makeAttachmentHandler
+  useAttachmentHandler
 } from './IncomeStatementAttachments'
 import {
   ActionContainer,
@@ -62,14 +62,10 @@ const ChildIncome = React.memo(function ChildIncome({
   const t = useTranslation()
 
   const onAttachmentChange = useFieldSetState(onChange, 'attachments')
-  const attachmentHandler = useMemo(
-    () =>
-      makeAttachmentHandler(
-        incomeStatementId,
-        formData.attachments,
-        onAttachmentChange
-      ),
-    [formData.attachments, incomeStatementId, onAttachmentChange]
+  const attachmentHandler = useAttachmentHandler(
+    incomeStatementId,
+    formData.attachments,
+    onAttachmentChange
   )
 
   const onOtherInfoChanged = useFieldDispatch(onChange, 'otherInfo')

--- a/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementView.tsx
+++ b/frontend/src/citizen-frontend/income-statements/ChildIncomeStatementView.tsx
@@ -10,7 +10,11 @@ import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
 import {
   collectAttachmentIds,
   toIncomeStatementAttachments
-} from 'lib-common/income-statements'
+} from 'lib-common/income-statements/attachments'
+import {
+  computeRequiredAttachments,
+  fromIncomeStatement
+} from 'lib-common/income-statements/form'
 import { useQueryResult } from 'lib-common/query'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
@@ -36,7 +40,6 @@ import {
   incomeStatementQuery,
   updateSentIncomeStatementMutation
 } from './queries'
-import { computeRequiredAttachments, fromIncomeStatement } from './types/form'
 
 export default React.memo(function ChildIncomeStatementView() {
   const incomeStatementId =

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementAttachments.tsx
@@ -18,7 +18,7 @@ import {
 import {
   IncomeStatementAttachments,
   numAttachments
-} from 'lib-common/income-statements'
+} from 'lib-common/income-statements/attachments'
 import UnorderedList from 'lib-components/atoms/UnorderedList'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { ContentArea } from 'lib-components/layout/Container'

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
@@ -9,6 +9,9 @@ import { combine, Loading, Result } from 'lib-common/api'
 import { IncomeStatementStatus } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
 import { fromUuid } from 'lib-common/id-type'
+import { fromBody } from 'lib-common/income-statements/body'
+import * as Form from 'lib-common/income-statements/form'
+import { emptyIncomeStatementForm } from 'lib-common/income-statements/form'
 import LocalDate from 'lib-common/local-date'
 import {
   constantQuery,
@@ -28,9 +31,6 @@ import {
   incomeStatementStartDatesQuery,
   updateIncomeStatementMutation
 } from './queries'
-import { fromBody } from './types/body'
-import * as Form from './types/form'
-import { emptyIncomeStatementForm } from './types/form'
 
 interface EditorState {
   id: string | undefined

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -56,9 +56,9 @@ import { useLang, useTranslation } from '../localization'
 import {
   IncomeStatementUntypedAttachments,
   IncomeStatementMissingAttachments,
-  makeAttachmentHandler,
   AttachmentHandler,
-  AttachmentSection
+  AttachmentSection,
+  useAttachmentHandler
 } from './IncomeStatementAttachments'
 import {
   ActionContainer,
@@ -180,14 +180,10 @@ export default React.memo(
     )
 
     const onAttachmentChange = useFieldSetState(onChange, 'attachments')
-    const attachmentHandler = useMemo(
-      () =>
-        makeAttachmentHandler(
-          incomeStatementId,
-          formData.attachments,
-          onAttachmentChange
-        ),
-      [formData.attachments, incomeStatementId, onAttachmentChange]
+    const attachmentHandler = useAttachmentHandler(
+      incomeStatementId,
+      formData.attachments,
+      onAttachmentChange
     )
 
     const sendButtonEnabled = useMemo(

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -18,6 +18,7 @@ import {
   otherIncomes
 } from 'lib-common/generated/api-types/incomestatement'
 import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
+import * as Form from 'lib-common/income-statements/form'
 import LocalDate from 'lib-common/local-date'
 import { scrollToRef } from 'lib-common/utils/scrolling'
 import UnorderedList from 'lib-components/atoms/UnorderedList'
@@ -71,7 +72,6 @@ import {
   useFieldDispatch,
   useFieldSetState
 } from './IncomeStatementComponents'
-import * as Form from './types/form'
 
 interface Props {
   incomeStatementId: IncomeStatementId | undefined

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
@@ -17,7 +17,11 @@ import { IncomeStatementId } from 'lib-common/generated/api-types/shared'
 import {
   collectAttachmentIds,
   toIncomeStatementAttachments
-} from 'lib-common/income-statements'
+} from 'lib-common/income-statements/attachments'
+import {
+  computeRequiredAttachments,
+  fromIncomeStatement
+} from 'lib-common/income-statements/form'
 import { useQueryResult } from 'lib-common/query'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
@@ -46,7 +50,6 @@ import {
   incomeStatementQuery,
   updateSentIncomeStatementMutation
 } from './queries'
-import { computeRequiredAttachments, fromIncomeStatement } from './types/form'
 
 export default React.memo(function IncomeStatementView() {
   const incomeStatementId =

--- a/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-child-income.ts
@@ -51,7 +51,7 @@ export class CitizenChildIncomeStatementEditSentPage {
     this.startDate = page.findByDataQa('start-date')
     this.otherInfoInput = new TextInput(page.findByDataQa('other-info'))
     this.attachment = new FileUpload(
-      page.find('#attachment-section-CHILD_INCOME')
+      page.findByDataQa('attachment-section-CHILD_INCOME')
     )
     this.saveButton = page.findByDataQa('save-btn')
   }
@@ -85,7 +85,7 @@ export class CitizenChildIncomeStatementEditPage {
     this.startDateInput = new TextInput(page.findByDataQa('start-date'))
     this.otherInfoInput = new TextInput(page.findByDataQa('other-info'))
     this.attachments = new FileUpload(
-      page.find('#attachment-section-CHILD_INCOME')
+      page.findByDataQa('attachment-section-CHILD_INCOME')
     )
     this.assure = new Checkbox(page.findByDataQa('assure-checkbox'))
     this.sendButton = page.findByDataQa('save-btn')

--- a/frontend/src/e2e-test/pages/citizen/citizen-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-income.ts
@@ -137,7 +137,7 @@ export default class CitizenIncomePage {
   }
 
   attachmentInput(type: IncomeStatementAttachmentType) {
-    return new FileUpload(this.page.find(`#attachment-section-${type}`))
+    return new FileUpload(this.page.findByDataQa(`attachment-section-${type}`))
   }
 
   async toggleEntrepreneurStartupGrant(check: boolean) {

--- a/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
+++ b/frontend/src/employee-frontend/components/IncomeStatementPage.tsx
@@ -26,7 +26,7 @@ import {
 import {
   numAttachments,
   toIncomeStatementAttachments
-} from 'lib-common/income-statements'
+} from 'lib-common/income-statements/attachments'
 import { UUID } from 'lib-common/types'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { useApiState } from 'lib-common/utils/useRestApi'

--- a/frontend/src/lib-common/income-statements/attachments.ts
+++ b/frontend/src/lib-common/income-statements/attachments.ts
@@ -5,12 +5,12 @@
 import groupBy from 'lodash/groupBy'
 import partition from 'lodash/partition'
 
-import { Attachment } from './generated/api-types/attachment'
+import { Attachment } from '../generated/api-types/attachment'
 import {
   IncomeStatementAttachment,
   IncomeStatementAttachmentType
-} from './generated/api-types/incomestatement'
-import { AttachmentId } from './generated/api-types/shared'
+} from '../generated/api-types/incomestatement'
+import { AttachmentId } from '../generated/api-types/shared'
 
 export type AttachmentsByType = Partial<
   Record<IncomeStatementAttachmentType, Attachment[]>

--- a/frontend/src/lib-common/income-statements/body.ts
+++ b/frontend/src/lib-common/income-statements/body.ts
@@ -3,11 +3,10 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { IncomeStatementBody } from 'lib-common/generated/api-types/incomestatement'
-import { collectAttachmentIds } from 'lib-common/income-statements'
+import { collectAttachmentIds } from 'lib-common/income-statements/attachments'
+import * as Form from 'lib-common/income-statements/form'
 import LocalDate from 'lib-common/local-date'
 import { stringToInt } from 'lib-common/utils/number'
-
-import * as Form from './form'
 
 export function fromBody(
   personType: 'adult' | 'child',

--- a/frontend/src/lib-common/income-statements/form.ts
+++ b/frontend/src/lib-common/income-statements/form.ts
@@ -11,7 +11,7 @@ import {
 import {
   IncomeStatementAttachments,
   toIncomeStatementAttachments
-} from 'lib-common/income-statements'
+} from 'lib-common/income-statements/attachments'
 import LocalDate from 'lib-common/local-date'
 
 export interface IncomeStatementForm {

--- a/frontend/src/lib-components/molecules/FileUpload.tsx
+++ b/frontend/src/lib-components/molecules/FileUpload.tsx
@@ -323,23 +323,26 @@ export const fileIcon = (file: Attachment): IconDefinition => {
 
 const inProgress = (file: FileObject): boolean => !file.uploaded
 
-function FileUpload<T>({
-  files,
-  validateHandler,
-  getValidationResult,
-  uploadHandler,
-  onUploaded,
-  onDeleted,
-  onStateChange,
-  getDownloadUrl,
-  slimSingleFile = false,
-  slim = false,
-  disabled = false,
-  'data-qa': dataQa,
-  allowedFileTypes = defaultAllowedFileTypes,
-  buttonText,
-  id
-}: FileUploadProps<T>) {
+function FileUpload<T>(
+  {
+    files,
+    validateHandler,
+    getValidationResult,
+    uploadHandler,
+    onUploaded,
+    onDeleted,
+    onStateChange,
+    getDownloadUrl,
+    slimSingleFile = false,
+    slim = false,
+    disabled = false,
+    'data-qa': dataQa,
+    allowedFileTypes = defaultAllowedFileTypes,
+    buttonText,
+    id
+  }: FileUploadProps<T>,
+  ref: React.ForwardedRef<HTMLSpanElement>
+) {
   const i18n = useTranslations().fileUpload
 
   const ariaId = useUniqueId('file-upload')
@@ -581,7 +584,7 @@ function FileUpload<T>({
           htmlFor={ariaId}
           onKeyDown={onKeyDown}
         >
-          <span role="button" tabIndex={0}>
+          <span role="button" tabIndex={0} ref={ref}>
             {fileInput}
             <H4>{buttonText ?? i18n.input.title}</H4>
             <P>
@@ -669,4 +672,6 @@ function FileUpload<T>({
   )
 }
 
-export default React.memo(FileUpload) as typeof FileUpload
+export default React.memo(React.forwardRef(FileUpload)) as <T>(
+  props: FileUploadProps<T> & { ref?: React.Ref<HTMLSpanElement> }
+) => React.ReactElement

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2083,7 +2083,8 @@ export const fi = {
 
     citizenAttachments: {
       title: 'Tuloihin ja varhaiskasvatusmaksuihin liittyvät liitteet',
-      noAttachments: 'Ei liitteitä'
+      noAttachments: 'Ei liitteitä',
+      attachmentMissing: 'Liite puuttuu'
     },
 
     employeeAttachments: {


### PR DESCRIPTION
- Fokusoidaan tiedostonlatauskenttä kun käyttäjä kuntalainen klikkaa Puuttuvat liitteet -listan elementtiä
- Näytetään työntekijälle myös tieto puuttuvista liitteistä:

<img width="941" alt="Screenshot 2025-02-14 at 14 49 25" src="https://github.com/user-attachments/assets/4bdbab4d-7a4e-4a1a-8f6d-5a893d022987" />
