### PR TITLE
Korjataan virhe 0-oikaisulaskujen generoinnissa

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -183,9 +183,11 @@ class InvoiceGenerator(
                 }
             }
         val zeroInvoices =
-            // Sent invoices that don't have a corresponding draft invoice -> add a zero-priced
+            // Sent non-zero invoices that don't have a corresponding draft invoice -> add a
+            // zero-priced
             // replacement draft
             sentInvoices.values
+                .filterNot { it.totalPrice == 0 }
                 .filterNot { headsOfFamilyWithInvoices.contains(it.headOfFamily.id) }
                 .map { sentInvoice ->
                     DraftInvoice(


### PR DESCRIPTION
Virheen johdosta siirretyn 0-oikaisulaskun tilalle saattoi generoitua uusi 0-oikaisulasku kuten kuvassa:

![](https://github.com/user-attachments/assets/1f59432a-0634-4561-95c8-e649586cf801)
