### PR TITLE
Lisätään yksikköroolit & yksikön toimintamuoto suodattimet käyttäjälistaukseen

### DIFF
--- a/frontend/src/lib-common/generated/api-types/pis.ts
+++ b/frontend/src/lib-common/generated/api-types/pis.ts
@@ -28,6 +28,7 @@ import { ParentshipId } from './shared'
 import { PartnershipId } from './shared'
 import { PersonEmailVerificationId } from './shared'
 import { PersonId } from './shared'
+import { ProviderType } from './daycare'
 import { UserRole } from './shared'
 
 /**
@@ -712,6 +713,8 @@ export interface SearchEmployeeRequest {
   hideDeactivated: boolean | null
   page: number | null
   searchTerm: string | null
+  unitProviderTypes: ProviderType[] | null
+  unitRoles: UserRole[] | null
 }
 
 /**

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4772,6 +4772,7 @@ export const fi = {
     editor: {
       globalRoles: 'Järjestelmäroolit',
       unitRoles: {
+        name: 'Yksikköroolit',
         title: 'Luvitukset',
         scheduledRolesTitle: 'Tulevat luvitukset',
         unit: 'Yksikkö',

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/EmployeeController.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.pis.controllers
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.daycare.deactivatePersonalMessageAccountIfNeeded
+import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.messaging.upsertEmployeeMessageAccount
 import fi.espoo.evaka.pis.Employee
 import fi.espoo.evaka.pis.EmployeeWithDaycareRoles
@@ -402,6 +403,13 @@ class EmployeeController(private val accessControl: AccessControl) {
                                 ?.takeIf { it.isNotEmpty() }
                                 ?.filter { it.isGlobalRole() }
                                 ?.toSet(),
+                        unitRoles =
+                            body.unitRoles
+                                ?.takeIf { it.isNotEmpty() }
+                                ?.filter { it.isUnitScopedRole() }
+                                ?.toSet(),
+                        unitProviderTypes =
+                            body.unitProviderTypes?.takeIf { it.isNotEmpty() }?.toSet(),
                     )
                 }
             }
@@ -499,4 +507,6 @@ data class SearchEmployeeRequest(
     val searchTerm: String?,
     val hideDeactivated: Boolean?,
     val globalRoles: Set<UserRole>?,
+    val unitRoles: Set<UserRole>?,
+    val unitProviderTypes: Set<ProviderType>?,
 )


### PR DESCRIPTION
Käyttäjät hakuun tullut järjestelmärooli -filtteri (pääkäyttäjä, talous, viestintä jne.)

Vastaava filtteri myös muille rooleille/”oikeudet” (=yksikkörooleille = johtaja, palsejohtaja, veo, työntekijä)