### PR TITLE
Piilotetaan tuen päätökset huoltajalta jos lapsen asiakkuus on päättynyt

### DIFF
--- a/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
@@ -255,6 +255,17 @@ describe('Citizen application decisions', () => {
 })
 
 describe('Citizen assistance decisions', () => {
+  beforeEach(async () => {
+    for (const child of [testChild, testChild2, testChildRestricted]) {
+      await Fixture.placement({
+        childId: child.id,
+        unitId: testDaycare.id,
+        startDate: now.toLocalDate(),
+        endDate: now.toLocalDate().addMonths(6)
+      }).save()
+    }
+  })
+
   test('Accepted decision', async () => {
     const decision = await Fixture.preFilledAssistanceNeedDecision({
       childId: testChild2.id,
@@ -485,6 +496,17 @@ describe('Citizen assistance decisions', () => {
 })
 
 describe('Citizen assistance preschool decisions', () => {
+  beforeEach(async () => {
+    for (const child of [testChild, testChild2, testChildRestricted]) {
+      await Fixture.placement({
+        childId: child.id,
+        unitId: testDaycare.id,
+        startDate: now.toLocalDate(),
+        endDate: now.toLocalDate().addMonths(6)
+      }).save()
+    }
+  })
+
   test('Decisions are properly listed', async () => {
     const decision = await Fixture.assistanceNeedPreschoolDecision({
       childId: testChild2.id

--- a/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/foster-parents.spec.ts
@@ -286,6 +286,12 @@ test('Foster parent can receive and reply to messages', async () => {
 
 test('Foster parent can read an accepted assistance decision', async () => {
   const citizenDecisionsPage = new CitizenDecisionsPage(activeRelationshipPage)
+  await Fixture.placement({
+    childId: fosterChild.id,
+    unitId: testDaycare.id,
+    startDate: mockedDate,
+    endDate: mockedDate.addMonths(6)
+  }).save()
   const decision = await Fixture.preFilledAssistanceNeedDecision({
     childId: fosterChild.id,
     selectedUnit: testDaycare.id,


### PR DESCRIPTION
Näytetään tuen päätökset vain jos lapsella on sijoitus nyt, tulevaisuudessa tai alle kuukausi menneisyydessä.