### PR TITLE
Lisätty Aromi-ruokatilausten asiakastunnus ryhmille ja nostettu se näkyville raakaraportille

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -267,7 +267,8 @@ export class Fixture {
       startDate: LocalDate.of(2020, 1, 1),
       endDate: null,
       jamixCustomerNumber: null,
-      ...initial
+      ...initial,
+      aromiCustomerId: initial.aromiCustomerId ?? null
     })
   }
 
@@ -3144,7 +3145,8 @@ export const testDaycareGroup: DevDaycareGroup = {
   name: 'Kosmiset vakiot',
   startDate: LocalDate.of(2000, 1, 1),
   endDate: null,
-  jamixCustomerNumber: null
+  jamixCustomerNumber: null,
+  aromiCustomerId: null
 }
 
 /**

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -267,8 +267,8 @@ export class Fixture {
       startDate: LocalDate.of(2020, 1, 1),
       endDate: null,
       jamixCustomerNumber: null,
-      ...initial,
-      aromiCustomerId: initial.aromiCustomerId ?? null
+      aromiCustomerId: null,
+      ...initial
     })
   }
 

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -530,6 +530,7 @@ export interface DevDaycareAssistance {
 * Generated from fi.espoo.evaka.shared.dev.DevDaycareGroup
 */
 export interface DevDaycareGroup {
+  aromiCustomerId: string | null
   daycareId: DaycareId
   endDate: LocalDate | null
   id: GroupId

--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -135,7 +135,8 @@ beforeEach(async () => {
         name: 'Varayksikön ryhmä',
         startDate: LocalDate.of(2000, 1, 1),
         endDate: null,
-        jamixCustomerNumber: null
+        jamixCustomerNumber: null,
+        aromiCustomerId: null
       }
     ]
   })

--- a/frontend/src/employee-frontend/components/reports/Raw.tsx
+++ b/frontend/src/employee-frontend/components/reports/Raw.tsx
@@ -177,7 +177,11 @@ export default React.memo(function Raw() {
                 { label: 'Poissa maksullisesta', key: 'absencePaid' },
                 { label: 'Poissa maksuttomasta', key: 'absenceFree' },
                 { label: 'Henkilöstömitoitus', key: 'staffDimensioning' },
-                { label: 'Kotikunta', key: 'municipalityOfResidence' }
+                { label: 'Kotikunta', key: 'municipalityOfResidence' },
+                {
+                  label: 'Ryhmäkohtainen Aromin asiakastunniste',
+                  key: 'aromiCustomerId'
+                }
               ]}
               filename={`${
                 i18n.reports.raw.title

--- a/frontend/src/employee-frontend/components/reports/Raw.tsx
+++ b/frontend/src/employee-frontend/components/reports/Raw.tsx
@@ -12,6 +12,7 @@ import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { DatePickerDeprecated } from 'lib-components/molecules/DatePickerDeprecated'
+import { featureFlags } from 'lib-customizations/employee'
 
 import ReportDownload from '../../components/reports/ReportDownload'
 import {
@@ -178,11 +179,16 @@ export default React.memo(function Raw() {
                 { label: 'Poissa maksuttomasta', key: 'absenceFree' },
                 { label: 'Henkilöstömitoitus', key: 'staffDimensioning' },
                 { label: 'Kotikunta', key: 'municipalityOfResidence' },
-                {
-                  label: 'Ryhmäkohtainen Aromin asiakastunniste',
-                  key: 'aromiCustomerId'
-                }
-              ]}
+                featureFlags.aromiIntegration
+                  ? {
+                      label: 'Ryhmäkohtainen Aromin asiakastunniste',
+                      key: 'aromiCustomerId'
+                    }
+                  : null
+              ].filter(
+                (h): h is { label: string; key: keyof RawReportRow } =>
+                  h !== null
+              )}
               filename={`${
                 i18n.reports.raw.title
               } ${filters.from.formatIso()}-${filters.to.formatIso()}.csv`}

--- a/frontend/src/employee-frontend/components/unit/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/queries.ts
@@ -194,7 +194,9 @@ export const transferGroupMutation = q.parametricMutation<{
 ])
 
 export const createGroupMutation = q.mutation(createGroup, [
-  ({ daycareId }) => unitNotificationsQuery({ daycareId })
+  ({ daycareId }) => unitNotificationsQuery({ daycareId }),
+  unitQuery.prefix,
+  unitGroupDetailsQuery.prefix
 ])
 
 export const unitGroupsQuery = q.query(getGroups)

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
@@ -12,6 +12,7 @@ import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { DatePickerDeprecated } from 'lib-components/molecules/DatePickerDeprecated'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
 import { Label } from 'lib-components/typography'
+import { featureFlags } from 'lib-customizations/employee'
 
 import { EVAKA_START } from '../../../../constants'
 import { useTranslation } from '../../../../state/i18n'
@@ -27,6 +28,7 @@ interface FormValidationResult {
   valid: boolean
   fields: {
     name: boolean
+    aromiCustomerId: boolean
   }
 }
 
@@ -34,6 +36,7 @@ interface CreateGroupForm {
   name: string
   startDate: LocalDate
   initialCaretakers: number
+  aromiCustomerId: string | null
 }
 
 export default React.memo(function GroupModal({ unitId }: Props) {
@@ -43,20 +46,24 @@ export default React.memo(function GroupModal({ unitId }: Props) {
   const initialForm: CreateGroupForm = {
     name: '',
     startDate: EVAKA_START,
-    initialCaretakers: 3
+    initialCaretakers: 3,
+    aromiCustomerId: null
   }
   const [form, setForm] = useState<CreateGroupForm>(initialForm)
   const [validationResult, setValidationResult] =
     useState<FormValidationResult>({
       valid: true,
       fields: {
-        name: true
+        name: true,
+        aromiCustomerId: true
       }
     })
 
   useEffect(() => {
     const fields = {
-      name: form.name.length > 0
+      name: form.name.length > 0,
+      aromiCustomerId:
+        form.aromiCustomerId !== null && form.aromiCustomerId.length > 0
     }
     setValidationResult({
       valid: allPropertiesTrue(fields),
@@ -77,7 +84,11 @@ export default React.memo(function GroupModal({ unitId }: Props) {
         body: {
           name: form.name,
           startDate: form.startDate,
-          initialCaretakers: form.initialCaretakers
+          initialCaretakers: form.initialCaretakers,
+          aromiCustomerId:
+            form.aromiCustomerId !== null && form.aromiCustomerId.length > 0
+              ? form.aromiCustomerId
+              : null
         }
       })}
       onSuccess={clearUiMode}
@@ -123,6 +134,24 @@ export default React.memo(function GroupModal({ unitId }: Props) {
             data-qa="new-group-name-input"
           />
         </div>
+        {featureFlags.aromiIntegration && (
+          <div>
+            <Label>{i18n.unit.groups.createModal.aromiCustomerId}</Label>
+            <InputField
+              value={form.aromiCustomerId ?? ''}
+              onChange={(value) => assignForm({ aromiCustomerId: value })}
+              data-qa="new-group-aromi-id-input"
+              info={
+                !validationResult.fields.aromiCustomerId
+                  ? {
+                      text: i18n.unit.groups.createModal.errors.aromiWarning,
+                      status: 'warning'
+                    }
+                  : undefined
+              }
+            />
+          </div>
+        )}
       </FixedSpaceColumn>
     </MutateFormModal>
   )

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
@@ -10,9 +10,13 @@ import LocalDate from 'lib-common/local-date'
 import InputField from 'lib-components/atoms/form/InputField'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { DatePickerDeprecated } from 'lib-components/molecules/DatePickerDeprecated'
+import { MessageBox } from 'lib-components/molecules/MessageBoxes'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
 import { Label } from 'lib-components/typography'
+import { Gap } from 'lib-components/white-space'
+import { theme } from 'lib-customizations/common'
 import { featureFlags } from 'lib-customizations/employee'
+import { fasExclamation } from 'lib-icons'
 
 import { EVAKA_START } from '../../../../constants'
 import { useTranslation } from '../../../../state/i18n'
@@ -28,7 +32,6 @@ interface FormValidationResult {
   valid: boolean
   fields: {
     name: boolean
-    aromiCustomerId: boolean
   }
 }
 
@@ -54,16 +57,13 @@ export default React.memo(function GroupModal({ unitId }: Props) {
     useState<FormValidationResult>({
       valid: true,
       fields: {
-        name: true,
-        aromiCustomerId: true
+        name: true
       }
     })
 
   useEffect(() => {
     const fields = {
-      name: form.name.length > 0,
-      aromiCustomerId:
-        form.aromiCustomerId !== null && form.aromiCustomerId.length > 0
+      name: form.name.length > 0
     }
     setValidationResult({
       valid: allPropertiesTrue(fields),
@@ -95,6 +95,7 @@ export default React.memo(function GroupModal({ unitId }: Props) {
       resolveLabel={i18n.unit.groups.createModal.confirmButton}
       rejectAction={clearUiMode}
       rejectLabel={i18n.unit.groups.createModal.cancelButton}
+      resolveDisabled={!validationResult.valid}
     >
       <FixedSpaceColumn spacing="m">
         <div>
@@ -139,17 +140,22 @@ export default React.memo(function GroupModal({ unitId }: Props) {
             <Label>{i18n.unit.groups.createModal.aromiCustomerId}</Label>
             <InputField
               value={form.aromiCustomerId ?? ''}
-              onChange={(value) => assignForm({ aromiCustomerId: value })}
-              data-qa="new-group-aromi-id-input"
-              info={
-                !validationResult.fields.aromiCustomerId
-                  ? {
-                      text: i18n.unit.groups.createModal.errors.aromiWarning,
-                      status: 'warning'
-                    }
-                  : undefined
+              onChange={(value) =>
+                assignForm({ aromiCustomerId: value.length > 0 ? value : null })
               }
+              data-qa="new-group-aromi-id-input"
             />
+            {form.aromiCustomerId === null && (
+              <>
+                <Gap size="s" />
+                <MessageBox
+                  color={theme.colors.status.warning}
+                  icon={fasExclamation}
+                  message={i18n.unit.groups.createModal.errors.aromiWarning}
+                  thin
+                />
+              </>
+            )}
           </div>
         )}
       </FixedSpaceColumn>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupUpdateModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupUpdateModal.tsx
@@ -12,11 +12,12 @@ import {
   DatePickerDeprecated,
   DatePickerClearableDeprecated
 } from 'lib-components/molecules/DatePickerDeprecated'
-import { InfoBox } from 'lib-components/molecules/MessageBoxes'
+import { InfoBox, MessageBox } from 'lib-components/molecules/MessageBoxes'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
 import { Gap } from 'lib-components/white-space'
+import { theme } from 'lib-customizations/common'
 import { featureFlags } from 'lib-customizations/employee'
-import { faPen } from 'lib-icons'
+import { faPen, fasExclamation } from 'lib-icons'
 
 import { useTranslation } from '../../../../../state/i18n'
 import { UIContext } from '../../../../../state/ui'
@@ -134,17 +135,18 @@ export default React.memo(function GroupUpdateModal({ group }: Props) {
                     aromiCustomerId: checkedValue
                   }))
                 }}
-                info={
-                  data.aromiCustomerId === null
-                    ? {
-                        text: i18n.unit.groups.createModal.errors.aromiWarning,
-                        status: 'warning'
-                      }
-                    : undefined
-                }
-                data-qa="aromi-customer-id-input"
-                placeholder={i18n.unit.groups.updateModal.aromiPlaceholder}
               />
+              {data.aromiCustomerId === null && (
+                <>
+                  <Gap size="s" />
+                  <MessageBox
+                    color={theme.colors.status.warning}
+                    icon={fasExclamation}
+                    message={i18n.unit.groups.createModal.errors.aromiWarning}
+                    thin
+                  />
+                </>
+              )}
             </>
           )}
         </section>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupUpdateModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupUpdateModal.tsx
@@ -35,11 +35,13 @@ export default React.memo(function GroupUpdateModal({ group }: Props) {
     startDate: LocalDate
     endDate: LocalDate | null
     jamixCustomerNumber: number | null
+    aromiCustomerId: string | null
   }>({
     name: group.name,
     startDate: group.startDate,
     endDate: group.endDate,
-    jamixCustomerNumber: group.jamixCustomerNumber
+    jamixCustomerNumber: group.jamixCustomerNumber,
+    aromiCustomerId: group.aromiCustomerId
   })
 
   return (
@@ -113,6 +115,35 @@ export default React.memo(function GroupUpdateModal({ group }: Props) {
                 }}
                 data-qa="jamix-customer-id-input"
                 placeholder={i18n.unit.groups.updateModal.jamixPlaceholder}
+              />
+            </>
+          )}
+          {featureFlags.aromiIntegration && (
+            <>
+              <Gap size="s" />
+              <div className="bold">
+                {i18n.unit.groups.updateModal.aromiTitle}
+              </div>
+              <InputField
+                value={data.aromiCustomerId ?? ''}
+                onChange={(value) => {
+                  const checkedValue =
+                    value !== null && value.length > 0 ? value : null
+                  setData((state) => ({
+                    ...state,
+                    aromiCustomerId: checkedValue
+                  }))
+                }}
+                info={
+                  data.aromiCustomerId === null
+                    ? {
+                        text: i18n.unit.groups.createModal.errors.aromiWarning,
+                        status: 'warning'
+                      }
+                    : undefined
+                }
+                data-qa="aromi-customer-id-input"
+                placeholder={i18n.unit.groups.updateModal.aromiPlaceholder}
               />
             </>
           )}

--- a/frontend/src/lib-common/generated/api-types/daycare.ts
+++ b/frontend/src/lib-common/generated/api-types/daycare.ts
@@ -175,6 +175,7 @@ export interface CreateDaycareResponse {
 * Generated from fi.espoo.evaka.daycare.controllers.DaycareController.CreateGroupRequest
 */
 export interface CreateGroupRequest {
+  aromiCustomerId: string | null
   initialCaretakers: number
   name: string
   startDate: LocalDate
@@ -301,6 +302,7 @@ export interface DaycareFields {
 * Generated from fi.espoo.evaka.daycare.service.DaycareGroup
 */
 export interface DaycareGroup {
+  aromiCustomerId: string | null
   daycareId: DaycareId
   deletable: boolean
   endDate: LocalDate | null
@@ -380,6 +382,7 @@ export interface GroupStaffAttendance {
 * Generated from fi.espoo.evaka.daycare.controllers.DaycareController.GroupUpdateRequest
 */
 export interface GroupUpdateRequest {
+  aromiCustomerId: string | null
   endDate: LocalDate | null
   jamixCustomerNumber: number | null
   name: string

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -794,6 +794,7 @@ export interface RawReportRow {
   absenceFree: AbsenceType | null
   absencePaid: AbsenceType | null
   age: number
+  aromiCustomerId: string | null
   assistanceNeedVoucherCoefficient: number | null
   backupGroupId: GroupId | null
   backupUnitId: DaycareId | null

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2541,8 +2541,11 @@ export const fi = {
         name: 'Ryhmän nimi',
         type: 'Tyyppi',
         initialCaretakers: 'Henkilökunnan määrä ryhmän alkaessa',
+        aromiCustomerId: 'Aromin asiakastunniste',
         errors: {
           nameRequired: 'Ryhmällä täytyy olla nimi',
+          aromiWarning:
+            'Mikäli Aromin asiakastunnus puuttuu, ryhmäläiset eivät kuulu ruokatilaukseen',
           initialCaretakersPositive:
             'Henkilökunnan määrä ei voi olla negatiivinen'
         }
@@ -2554,7 +2557,9 @@ export const fi = {
         endDate: 'Viimeinen toimintapäivä',
         info: 'Ryhmän aikaisempia tietoja ei säilytetä',
         jamixPlaceholder: 'Jamix customerNumber',
-        jamixTitle: 'Ruokatilausten asiakasnumero'
+        jamixTitle: 'Ruokatilausten asiakasnumero',
+        aromiPlaceholder: 'Aromin asiakastunnus',
+        aromiTitle: 'Aromi-ruokatilausten asiakastunnus'
       },
       startDate: 'Perustettu',
       endDate: 'Viimeinen toimintapäivä',

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -45,7 +45,8 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: true,
     multiSelectDeparture: true,
-    archiveIntegrationEnabled: true
+    archiveIntegrationEnabled: true,
+    aromiIntegration: true
   },
   staging: {
     environmentLabel: 'Staging',
@@ -116,7 +117,8 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: false,
     multiSelectDeparture: false,
-    archiveIntegrationEnabled: false
+    archiveIntegrationEnabled: false,
+    aromiIntegration: false
   }
 }
 

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -82,7 +82,8 @@ const features: Features = {
     invoiceDisplayAccountNumber: true,
     serviceApplications: true,
     multiSelectDeparture: true,
-    archiveIntegrationEnabled: true
+    archiveIntegrationEnabled: true,
+    aromiIntegration: false
   },
   prod: {
     environmentLabel: null,

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareGroupQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/DaycareGroupQueries.kt
@@ -19,7 +19,7 @@ private fun Database.Read.createDaycareGroupQuery(
     sql(
         """
 SELECT
-  id, daycare_id, name, start_date, end_date, jamix_customer_number,
+  id, daycare_id, name, start_date, end_date, jamix_customer_number, aromi_customer_id,
   (
     NOT exists(SELECT FROM backup_care WHERE group_id = daycare_group.id) AND
     NOT exists(SELECT FROM daycare_group_placement WHERE daycare_group_id = daycare_group.id) AND
@@ -53,13 +53,14 @@ fun Database.Transaction.createDaycareGroup(
     daycareId: DaycareId,
     name: String,
     startDate: LocalDate,
+    aromiCustomerId: String? = null,
 ): DaycareGroup =
     createUpdate {
             sql(
                 """
-INSERT INTO daycare_group (daycare_id, name, start_date, end_date)
-VALUES (${bind(daycareId)}, ${bind(name)}, ${bind(startDate)}, NULL)
-RETURNING id, daycare_id, name, start_date, end_date, true AS deletable, jamix_customer_number
+INSERT INTO daycare_group (daycare_id, name, start_date, end_date, aromi_customer_id)
+VALUES (${bind(daycareId)}, ${bind(name)}, ${bind(startDate)}, NULL, ${bind(aromiCustomerId)})
+RETURNING id, daycare_id, name, start_date, end_date, true AS deletable, jamix_customer_number, aromi_customer_id
 """
             )
         }
@@ -72,12 +73,13 @@ fun Database.Transaction.updateGroup(
     startDate: LocalDate,
     endDate: LocalDate?,
     jamixCustomerNumber: Int?,
+    aromiCustomerId: String?,
 ) {
     createUpdate {
             sql(
                 """
 UPDATE daycare_group
-SET name = ${bind(name)}, start_date = ${bind(startDate)}, end_date = ${bind(endDate)}, jamix_customer_number = ${bind(jamixCustomerNumber)}
+SET name = ${bind(name)}, start_date = ${bind(startDate)}, end_date = ${bind(endDate)}, jamix_customer_number = ${bind(jamixCustomerNumber)}, aromi_customer_id = ${bind(aromiCustomerId)}
 WHERE id = ${bind(groupId)}
         """
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/controllers/DaycareController.kt
@@ -307,6 +307,7 @@ class DaycareController(
                         body.name,
                         body.startDate,
                         body.initialCaretakers,
+                        body.aromiCustomerId,
                     )
                 }
             }
@@ -323,6 +324,7 @@ class DaycareController(
         val startDate: LocalDate,
         val endDate: LocalDate?,
         val jamixCustomerNumber: Int?,
+        val aromiCustomerId: String?,
     )
 
     @PutMapping("/{daycareId}/groups/{groupId}")
@@ -343,6 +345,7 @@ class DaycareController(
                     body.startDate,
                     body.endDate,
                     body.jamixCustomerNumber,
+                    body.aromiCustomerId,
                 )
             }
         }
@@ -764,6 +767,7 @@ class DaycareController(
         val name: String,
         val startDate: LocalDate,
         val initialCaretakers: Double,
+        val aromiCustomerId: String?,
     )
 
     data class CaretakerRequest(

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/service/DaycareService.kt
@@ -33,8 +33,9 @@ class DaycareService {
         name: String,
         startDate: LocalDate,
         initialCaretakers: Double,
+        aromiCustomerId: String?,
     ): DaycareGroup =
-        tx.createDaycareGroup(daycareId, name, startDate).also {
+        tx.createDaycareGroup(daycareId, name, startDate, aromiCustomerId).also {
             tx.initCaretakers(it.id, it.startDate, initialCaretakers)
             tx.createDaycareGroupMessageAccount(it.id)
         }
@@ -77,6 +78,7 @@ data class DaycareGroup(
     val endDate: LocalDate?,
     val deletable: Boolean,
     val jamixCustomerNumber: Int?,
+    val aromiCustomerId: String?,
 )
 
 data class Caretakers(val minimum: Double, val maximum: Double) {

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/RawReport.kt
@@ -120,7 +120,7 @@ SELECT
     coalesce(sn.part_week, false) AS part_week,
     coalesce(sn.shift_care, 'NONE') = 'FULL' AS shift_care,
     coalesce(sno.daycare_hours_per_week, 0.0) AS hours_per_week,
-
+    dg.aromi_customer_id,
     (
         an IS NOT NULL
         OR EXISTS(SELECT FROM assistance_action aa WHERE aa.child_id = pl.child_id AND t::date BETWEEN aa.start_date AND aa.end_date)
@@ -220,4 +220,5 @@ data class RawReportRow(
     val isWeekday: Boolean,
     val isHoliday: Boolean,
     val municipalityOfResidence: String,
+    val aromiCustomerId: String?,
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -620,8 +620,8 @@ fun Database.Transaction.insert(row: DevDaycareGroup): GroupId =
     createUpdate {
             sql(
                 """
-INSERT INTO daycare_group (id, daycare_id, name, start_date, end_date, jamix_customer_number)
-VALUES (${bind(row.id)}, ${bind(row.daycareId)}, ${bind(row.name)}, ${bind(row.startDate)}, ${bind(row.endDate)}, ${bind(row.jamixCustomerNumber)})
+INSERT INTO daycare_group (id, daycare_id, name, start_date, end_date, jamix_customer_number, aromi_customer_id)
+VALUES (${bind(row.id)}, ${bind(row.daycareId)}, ${bind(row.name)}, ${bind(row.startDate)}, ${bind(row.endDate)}, ${bind(row.jamixCustomerNumber)}, ${bind(row.aromiCustomerId)})
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1972,7 +1972,7 @@ data class DevDaycareGroup(
     val startDate: LocalDate = LocalDate.of(2019, 1, 1),
     val endDate: LocalDate? = null,
     val jamixCustomerNumber: Int? = null,
-    val aromiCustomerNumber: String? = null,
+    val aromiCustomerId: String? = null,
 )
 
 data class DevDaycareGroupPlacement(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1972,6 +1972,7 @@ data class DevDaycareGroup(
     val startDate: LocalDate = LocalDate.of(2019, 1, 1),
     val endDate: LocalDate? = null,
     val jamixCustomerNumber: Int? = null,
+    val aromiCustomerNumber: String? = null,
 )
 
 data class DevDaycareGroupPlacement(

--- a/service/src/main/resources/db/migration/V501__aromi_customer_id.sql
+++ b/service/src/main/resources/db/migration/V501__aromi_customer_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE daycare_group ADD COLUMN aromi_customer_id TEXT;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -496,3 +496,4 @@ V497__application_primary_preferred_unit.sql
 V498__child_document_archived_at.sql
 V499__drop_unused_tables.sql
 V500__create_trigger.sql
+V501__aromi_customer_id.sql


### PR DESCRIPTION
Aromi-ruokatilauksia varten tarvitaan tekstimuotoinen ryhmäkohtainen asiakastunnus. Muutoksen myötä se on mahdollista lisätä ryhmää luotaessa ja muokatessa. PR parantaa myös ryhmien luonnin käytettävyyttä estämällä nimettömien ryhmien luomisen ja pakottamalla ryhmätietojen päivityksen uuden ryhmän luonnin jälkeen.

Aromi-tunnuksen syöttäminen on näkyvillä ainoastaan käyttöliittymän lipun `aromiIntegration` aktivoineille konfiguraatioille. Espoon konfiguraatioon lippu asetettu päälle lokaaliin (default) ja pois stagingissa sekä prodissa.

Tunnus on lisätty myös raakaraportille, jotta sen kokonaistilannetta voidaan tarkastella yksikkönäkymää korkeammalta tasolta.