### PR TITLE
Siivotaan käyttämättömiä kehitysympäristön resursseja

### DIFF
--- a/compose/docker-compose.integration.yml
+++ b/compose/docker-compose.integration.yml
@@ -28,7 +28,6 @@ services:
       - ./test-results/:/evaka/service/build/test-results/
     depends_on:
       - db
-      - redis
       - s3-mock
       - sftp
     ipc: host

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -70,11 +70,6 @@ services:
       - ./sftp/ssh_host_rsa_key:/etc/ssh/ssh_host_rsa_key
     command: foo:pass:::upload
 
-  smtp:
-    image: mailhog/mailhog
-    ports:
-      - "8025:8025"
-
   dummy-idp:
     build:
       context: ../dummy-idp


### PR DESCRIPTION
1. service ei käytä redistä (käynnistyy tarpeettomasti CI:llä integraatiotesteissä)
2. smtp-palvelinta ei enää tarvita, koska keycloak poistettu