### PR TITLE
Raporttien CSV-latauksen korjauksia

### DIFF
--- a/frontend/src/employee-frontend/components/reports/csv.spec.ts
+++ b/frontend/src/employee-frontend/components/reports/csv.spec.ts
@@ -30,11 +30,13 @@ describe('toCsv', () => {
       ]
     )
     const expected =
+      '\uFEFF' +
       [
         'Name;"""Age""";"Sur;name";Info',
         'Pekka;4;"Iso;kylä";"sekä ""että"" kä"',
         '"Tee-\nmu";6;Isokylä;"foo;bar;""baz"""'
-      ].join('\n') + '\n'
+      ].join('\n') +
+      '\n'
 
     expect(csv).toEqual(expected)
   })

--- a/frontend/src/employee-frontend/components/reports/csv.spec.ts
+++ b/frontend/src/employee-frontend/components/reports/csv.spec.ts
@@ -10,30 +10,30 @@ describe('toCsv', () => {
       [
         {
           firstName: 'Pekka',
-          lastName: 'Iso,kylä',
+          lastName: 'Iso;kylä',
           additionalInformation: 'sekä "että" kä',
           age: 2
         },
         {
-          firstName: 'Teemu',
+          firstName: 'Tee-\nmu',
           lastName: 'Isokylä',
-          additionalInformation: 'foo,bar,"baz"',
+          additionalInformation: 'foo;bar;"baz"',
           age: 3
         }
       ],
       [
         { label: 'Name', value: (row) => row.firstName },
         { label: '"Age"', value: (row) => row.age * 2 },
-        { label: 'Sur,name', value: (row) => row.lastName },
+        { label: 'Sur;name', value: (row) => row.lastName },
         { label: 'Excluded field', value: (row) => row.age, exclude: true },
         { label: 'Info', value: (row) => row.additionalInformation }
       ]
     )
     const expected =
       [
-        'Name,"""Age""","Sur,name",Info',
-        'Pekka,4,"Iso,kylä","sekä ""että"" kä"',
-        'Teemu,6,Isokylä,"foo,bar,""baz"""'
+        'Name;"""Age""";"Sur;name";Info',
+        'Pekka;4;"Iso;kylä";"sekä ""että"" kä"',
+        '"Tee-\nmu";6;Isokylä;"foo;bar;""baz"""'
       ].join('\n') + '\n'
 
     expect(csv).toEqual(expected)

--- a/frontend/src/employee-frontend/components/reports/csv.ts
+++ b/frontend/src/employee-frontend/components/reports/csv.ts
@@ -6,6 +6,7 @@ export type CsvValue = string | number | null | undefined
 
 const separator = ';'
 const quote = '"'
+const byteOrderMark = '\uFEFF'
 
 export type ColumnCommon = { label: string; exclude?: boolean }
 
@@ -26,7 +27,7 @@ export function toCsv<T>(data: T[], columns: Column<T>[]) {
       .map((col) => escape(str(col.value(row))))
       .join(separator)
   )
-  return [headerRow, ...dataRows].join('\n') + '\n'
+  return byteOrderMark + [headerRow, ...dataRows].join('\n') + '\n'
 }
 
 function str(value: CsvValue): string {

--- a/frontend/src/employee-frontend/components/reports/csv.ts
+++ b/frontend/src/employee-frontend/components/reports/csv.ts
@@ -4,7 +4,7 @@
 
 export type CsvValue = string | number | null | undefined
 
-const separator = ','
+const separator = ';'
 const quote = '"'
 
 export type ColumnCommon = { label: string; exclude?: boolean }


### PR DESCRIPTION
- Käytetään kenttien erottimena puolipistettä (suomenkielisen Excelin oletus)
- Lisätään tiedoston alkuun BOM `U+FEFF` (Excel käyttää sitä tiedoston enkoodauksen arpomiseen)