### PR TITLE
Korvataan xjctool Gradle plugin suoralla xjc käytöllä

### DIFF
--- a/service/sarmamodel/build.gradle.kts
+++ b/service/sarmamodel/build.gradle.kts
@@ -3,26 +3,45 @@
 
 plugins {
     java
-    id("org.unbroken-dome.xjc") version "2.0.0"
 }
 
-repositories {
-    mavenCentral()
+configurations {
+    create("jaxb")
 }
 
 dependencies {
-    implementation(platform(project(":evaka-bom")))
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api")
-    xjcTool("com.sun.xml.bind:jaxb-xjc:3.0.2")
-    xjcTool("com.sun.xml.bind:jaxb-impl:3.0.2")
+    "jaxb"("com.sun.xml.bind:jaxb-xjc:4.0.5")
+    "jaxb"("com.sun.xml.bind:jaxb-impl:4.0.5")
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.2")
 }
 
-sourceSets {
-    main {
-        xjcTargetPackage.set("fi.espoo.evaka.sarma.model")
+tasks.register("generateJaxb") {
+    val outputDir = layout.buildDirectory.dir("generated-sources/jaxb")
+    val schemaDir = project.file("src/main/schema")
+    
+    inputs.dir(schemaDir)
+    outputs.dir(outputDir)
+    
+    doLast {
+        outputDir.get().asFile.mkdirs()
+        
+        ant.withGroovyBuilder {
+            "taskdef"(
+                "name" to "xjc",
+                "classname" to "com.sun.tools.xjc.XJCTask",
+                "classpath" to configurations["jaxb"].asPath
+            )
+            "xjc"(
+                "destdir" to outputDir.get().asFile,
+                "package" to "fi.espoo.evaka.sarma.model"
+            ) {
+                "schema"("dir" to schemaDir, "includes" to "**/*.xsd")
+            }
+        }
     }
 }
 
 tasks.named("compileJava") {
-    dependsOn("xjcGenerate")
+    dependsOn("generateJaxb")
+    sourceSets.main.get().java.srcDir(layout.buildDirectory.dir("generated-sources/jaxb"))
 } 


### PR DESCRIPTION
xjctool ei ollut yhteensopiva modernien `jaxb` versioiden kanssa (#6504)