### PR TITLE
Lisätään esiopetushakemukselle täydentävän varhaiskasvatuksen aloituspäivämäärän validointi

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -163,6 +163,11 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
                 }
                 minDate={minDate}
                 maxDate={maxDate}
+                initialMonth={
+                  formData.connectedDaycarePreferredStartDate ??
+                  formData.preferredStartDate ??
+                  undefined
+                }
                 data-qa="connectedDaycarePreferredStartDate-input"
                 id={labelId}
                 required={true}

--- a/frontend/src/lib-common/form-validation.ts
+++ b/frontend/src/lib-common/form-validation.ts
@@ -30,6 +30,7 @@ export type ErrorKey =
   | 'timeRequired'
   | 'unitNotSelected'
   | 'preferredStartDate'
+  | 'connectedPreferredStartDate'
   | 'emailsDoNotMatch'
   | 'httpUrl'
   | 'openAttendance'

--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -131,6 +131,7 @@ export interface Translations {
     phone: string
     email: string
     preferredStartDate: string
+    connectedPreferredStartDate: string
     timeFormat: string
     timeRequired: string
     dateTooEarly: string

--- a/frontend/src/lib-components/utils/TestContextProvider.tsx
+++ b/frontend/src/lib-components/utils/TestContextProvider.tsx
@@ -135,6 +135,7 @@ export const testTranslations: Translations = {
     phone: '',
     email: '',
     preferredStartDate: '',
+    connectedPreferredStartDate: '',
     timeFormat: '',
     timeRequired: '',
     dateTooEarly: '',

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -155,6 +155,8 @@ const components: Translations = {
     phone: 'Invalid telephone number',
     email: 'Invalid email',
     preferredStartDate: 'Invalid preferred start date',
+    connectedPreferredStartDate:
+      "You can apply for supplementary early childhood education from the start of your child's preschool education.",
     timeFormat: 'Check',
     timeRequired: 'Required',
     dateTooEarly: 'Pick a later date',

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -152,6 +152,8 @@ const components: Translations = {
     phone: 'Virheellinen numero',
     email: 'Virheellinen sähköpostiosoite',
     preferredStartDate: 'Aloituspäivä ei ole sallittu',
+    connectedPreferredStartDate:
+      'Voit hakea täydentävää varhaiskasvatusta lapsen esiopetuksen alkamisesta alkaen.',
     timeFormat: 'Tarkista',
     timeRequired: 'Pakollinen',
     dateTooEarly: 'Valitse myöhäisempi päivä',

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -155,6 +155,8 @@ const components: Translations = {
     phone: 'Ogiltigt telefonnummer',
     email: 'Ogiltig e-postadress',
     preferredStartDate: 'Ogiltigt datum',
+    connectedPreferredStartDate:
+      'Du kan ansöka om kompletterande förskoleutbildning från början av ditt barns förskoleutbildning',
     timeFormat: 'Kolla',
     timeRequired: 'Nödvändig',
     dateTooEarly: 'Välj ett senare datum',

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -1367,6 +1367,22 @@ class ApplicationStateService(
             if (!canApplyForPreferredDate) {
                 throw BadRequest("Cannot apply to preschool on $preferredStartDate at the moment")
             }
+
+            val connectedDaycarePreferredStartDate =
+                application.preferences.connectedDaycarePreferredStartDate
+            if (
+                connectedDaycarePreferredStartDate != null &&
+                    connectedDaycarePreferredStartDate != preferredStartDate &&
+                    validateApplicationPeriod
+            ) {
+                val connectedPreschoolTerm =
+                    tx.getActivePreschoolTermAt(connectedDaycarePreferredStartDate)
+                if (connectedPreschoolTerm != activePreschoolTerm) {
+                    throw BadRequest(
+                        "Cannot apply to different preschool term for connected daycare"
+                    )
+                }
+            }
         }
 
         if (type == ApplicationType.CLUB && preferredStartDate != null) {


### PR DESCRIPTION
Täydentävän varhaiskasvatuksen aloituspäivämäärä pitää olla samalla toimintakaudella kuin valittu esiopetuksen aloituspäivämäärä.