### PR TITLE
Luetaan arkistoitavan metadatan disclosure policy tiedot metadatasta

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
@@ -200,16 +200,11 @@ class ArchiveChildDocumentService(
                                             if (documentMetadata.confidential == true)
                                                 DisclosureLevelType.CONFIDENTIAL
                                             else DisclosureLevelType.PUBLIC
-                                        // TODO lue tämä confidentiality.durationYears kentästä kun
-                                        // https://github.com/espoon-voltti/evaka/pull/6416 on
-                                        // masterissa
                                         disclosurePeriod =
-                                            if (documentMetadata.confidential == true) "100"
-                                            else null
-                                        // TODO lue tämä confidentiality.basis kentästä kun
-                                        // https://github.com/espoon-voltti/evaka/pull/6416 on
-                                        // masterissa
-                                        // disclosureReason = "JulkL 24 § 1 mom. 32 k"
+                                            documentMetadata.confidentiality
+                                                ?.durationYears
+                                                .toString()
+                                        disclosureReason = documentMetadata.confidentiality?.basis
                                     }
                                 // TODO Evaka_Särmä_metatietomääritykset.xlsx sanotaan, että nämä
                                 // tulisi olla "Ei turvallisuusluokiteltu". Tarvitaan oikea versio


### PR DESCRIPTION
Tämän muutoksen jälkeen `disclosureReason` ja `disclosurePeriod` poimitaan dokumentin metadatasta kovakoodatun arvon sijaan.

```xml
<RecordMetadataInstance xmlns="http://www.avaintec.com/2005/x-archive/record-metadata-instance/2.0"
    xmlns:ns2="http://www.avaintec.com/2004/records-schedule-fi/1.0">
    <StandardMetadata>
        ...
        <policies>
            <retentionPolicy>
                <ns2:retentionPeriod>100</ns2:retentionPeriod>
                <ns2:retentionReason>InPerpetuity</ns2:retentionReason>
            </retentionPolicy>
            <disclosurePolicy>
                <ns2:disclosureLevel>Confidential</ns2:disclosureLevel>
                <ns2:disclosureReason>Joku laki §300</ns2:disclosureReason>
                <ns2:disclosurePeriod>100</ns2:disclosurePeriod>
            </disclosurePolicy>
            <informationSecurityPolicy>
                <ns2:securityLevel>Unclassified</ns2:securityLevel>
            </informationSecurityPolicy>
            <protectionPolicy>
                <ns2:protectionLevel>High</ns2:protectionLevel>
            </protectionPolicy>
        </policies>
        ...
    </StandardMetadata>
</RecordMetadataInstance>
```

Kaikki XML-rakenne `ns2` alla on edelleen mock tasoista, joten nämä tulevat varmasti muuttumaan vielä.