### PR TITLE
Muutos tuloselvityksen täytön järjestykseen

### DIFF
--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementForm.tsx
@@ -46,6 +46,7 @@ import {
   H3,
   H4,
   Label,
+  LabelLike,
   P
 } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -417,12 +418,82 @@ const IncomeTypeSelection = React.memo(
       [formData, validateEndDate, t]
     )
 
+    const dateRange = useCallback(
+      (isHighestFee: boolean) => {
+        return (
+          <Indent>
+            <FixedSpaceRow spacing="XL">
+              <div>
+                <Label htmlFor="start-date">
+                  {isHighestFee
+                    ? t.income.incomeType.startDate
+                    : t.income.incomeType.starts}{' '}
+                  *
+                </Label>
+                <Gap size="xs" />
+                <DatePicker
+                  id="start-date"
+                  data-qa="income-start-date"
+                  date={formData.startDate}
+                  onChange={onStartDateChange}
+                  info={startDateInputInfo}
+                  hideErrorsBeforeTouched={!showFormErrors}
+                  locale={lang}
+                  required={true}
+                  isInvalidDate={(d) =>
+                    isValidStartDate(d)
+                      ? null
+                      : t.validationErrors.unselectableDate
+                  }
+                />
+              </div>
+              <div>
+                <Label htmlFor="end-date">{`${isHighestFee ? t.income.incomeType.endDate : t.income.incomeType.ends}${isEndDateRequired ? ' *' : ''}`}</Label>
+                <Gap size="xs" />
+                <DatePicker
+                  id="end-date"
+                  data-qa="income-end-date"
+                  date={formData.endDate}
+                  onChange={onEndDateChange}
+                  minDate={formData.startDate ?? undefined}
+                  hideErrorsBeforeTouched={false}
+                  locale={lang}
+                  info={endDateInputInfo}
+                  isInvalidDate={(d) =>
+                    errorToInputInfo(validateEndDate(d), t.validationErrors)
+                      ?.text || null
+                  }
+                  required={isEndDateRequired}
+                />
+              </div>
+            </FixedSpaceRow>
+          </Indent>
+        )
+      },
+      [
+        endDateInputInfo,
+        formData.endDate,
+        formData.startDate,
+        isEndDateRequired,
+        isValidStartDate,
+        lang,
+        onEndDateChange,
+        onStartDateChange,
+        showFormErrors,
+        startDateInputInfo,
+        t,
+        validateEndDate
+      ]
+    )
+
     return (
       <ContentArea opaque paddingVertical="L" ref={ref}>
         <FixedSpaceColumn spacing="zero">
           <H2 noMargin data-qa="title">
             {t.income.incomeInfo}
           </H2>
+          <Gap size="s" />
+          <P noMargin>{t.income.incomeInstructions}</P>
           <Gap size="s" />
           {showFormErrors && (
             <>
@@ -434,50 +505,8 @@ const IncomeTypeSelection = React.memo(
               <Gap size="s" />
             </>
           )}
-          <P noMargin>{t.income.incomeInstructions}</P>
+          <LabelLike>{t.income.incomeType.title} *</LabelLike>
           <Gap size="s" />
-          <FixedSpaceRow spacing="XL">
-            <div>
-              <Label htmlFor="start-date">
-                {t.income.incomeType.startDate} *
-              </Label>
-              <Gap size="xs" />
-              <DatePicker
-                id="start-date"
-                data-qa="income-start-date"
-                date={formData.startDate}
-                onChange={onStartDateChange}
-                info={startDateInputInfo}
-                hideErrorsBeforeTouched={!showFormErrors}
-                locale={lang}
-                required={true}
-                isInvalidDate={(d) =>
-                  isValidStartDate(d)
-                    ? null
-                    : t.validationErrors.unselectableDate
-                }
-              />
-            </div>
-            <div>
-              <Label htmlFor="end-date">{`${t.income.incomeType.endDate}${isEndDateRequired ? ' *' : ''}`}</Label>
-              <Gap size="xs" />
-              <DatePicker
-                id="end-date"
-                data-qa="income-end-date"
-                date={formData.endDate}
-                onChange={onEndDateChange}
-                minDate={formData.startDate ?? undefined}
-                hideErrorsBeforeTouched={false}
-                locale={lang}
-                info={endDateInputInfo}
-                isInvalidDate={(d) =>
-                  errorToInputInfo(validateEndDate(d), t.validationErrors)
-                    ?.text || null
-                }
-                required={isEndDateRequired}
-              />
-            </div>
-          </FixedSpaceRow>
           {invalidDateRange && (
             <>
               <Gap size="s" />
@@ -488,9 +517,6 @@ const IncomeTypeSelection = React.memo(
               />
             </>
           )}
-          <Gap size="L" />
-          <H3 noMargin>{t.income.incomeType.title}</H3>
-          <Gap size="s" />
           <Radio
             label={t.income.incomeType.agreeToHighestFee}
             data-qa="highest-fee-checkbox"
@@ -500,9 +526,9 @@ const IncomeTypeSelection = React.memo(
           {formData.highestFeeSelected && (
             <>
               <Gap size="s" />
-              <HighestFeeInfo>
-                {t.income.incomeType.highestFeeInfo}
-              </HighestFeeInfo>
+              <FeeInfo>{t.income.incomeType.highestFeeInfo}</FeeInfo>
+              <Gap size="s" />
+              {dateRange(true)}
             </>
           )}
           <Gap size="s" />
@@ -512,6 +538,14 @@ const IncomeTypeSelection = React.memo(
             data-qa="gross-income-checkbox"
             onChange={onSelectGross}
           />
+          {formData.grossSelected && (
+            <>
+              <Gap size="s" />
+              <FeeInfo>{t.income.incomeNotifyForPeriod}</FeeInfo>
+              <Gap size="s" />
+              {dateRange(false)}
+            </>
+          )}
         </FixedSpaceColumn>
       </ContentArea>
     )
@@ -1314,7 +1348,7 @@ const OtherInfo = React.memo(function OtherInfo({
   )
 })
 
-const HighestFeeInfo = styled(P).attrs({ noMargin: true })`
+const FeeInfo = styled(P).attrs({ noMargin: true })`
   margin-left: ${defaultMargins.XL};
 `
 

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementView.tsx
@@ -77,12 +77,12 @@ const IncomeStatementView2 = React.memo(function IncomeStatementView2({
             <H1>{t.income.view.title}</H1>
           </FixedSpaceRow>
           <Row
-            label={t.income.view.startDate}
-            value={incomeStatement.startDate.format()}
-          />
-          <Row
             label={t.income.view.feeBasis}
             value={t.income.view.statementTypes[incomeStatement.type]}
+          />
+          <Row
+            label={t.income.view.startDate}
+            value={incomeStatement.startDate.format()}
           />
           {incomeStatement.type === 'INCOME' && (
             <IncomeInfo incomeStatement={incomeStatement} />

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
@@ -67,8 +67,8 @@ describe.each(envs)('Income statements', (env) => {
     test('Highest fee', async () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
-      await incomeStatementsPage.setValidFromDate(startDate)
       await incomeStatementsPage.selectIncomeStatementType('highest-fee')
+      await incomeStatementsPage.setValidFromDate(startDate)
       await incomeStatementsPage.checkAssured()
       await incomeStatementsPage.submit()
 
@@ -80,6 +80,8 @@ describe.each(envs)('Income statements', (env) => {
 
       await incomeStatementsPage.createNewIncomeStatement()
 
+      await incomeStatementsPage.selectIncomeStatementType('gross-income')
+
       // Start date can be max 1y from now so an error is shown
       await incomeStatementsPage.setValidFromDate(
         now.toLocalDate().subMonths(12).subDays(1).format('d.M.yyyy')
@@ -88,9 +90,7 @@ describe.each(envs)('Income statements', (env) => {
 
       await incomeStatementsPage.setValidFromDate(startDate)
       await incomeStatementsPage.incomeStartDateInfo.waitUntilHidden()
-      await incomeStatementsPage.incomeEndDateInfo.waitUntilHidden()
 
-      await incomeStatementsPage.selectIncomeStatementType('gross-income')
       await incomeStatementsPage.incomeEndDateInfo.waitUntilVisible()
 
       await incomeStatementsPage.checkIncomesRegisterConsent()
@@ -114,9 +114,9 @@ describe.each(envs)('Income statements', (env) => {
     test('Limited liability company', async () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
+      await incomeStatementsPage.selectIncomeStatementType('gross-income')
       await incomeStatementsPage.setValidFromDate(startDate)
       await incomeStatementsPage.setValidToDate(endDate)
-      await incomeStatementsPage.selectIncomeStatementType('gross-income')
       await incomeStatementsPage.checkIncomesRegisterConsent()
       await incomeStatementsPage.setGrossIncomeEstimate(1500)
       await incomeStatementsPage.setEntrepreneur(true)
@@ -158,9 +158,9 @@ describe.each(envs)('Income statements', (env) => {
     test('Self employed', async () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
+      await incomeStatementsPage.selectIncomeStatementType('gross-income')
       await incomeStatementsPage.setValidFromDate(startDate)
       await incomeStatementsPage.setValidToDate(endDate)
-      await incomeStatementsPage.selectIncomeStatementType('gross-income')
       await incomeStatementsPage.checkIncomesRegisterConsent()
       await incomeStatementsPage.setGrossIncomeEstimate(1500)
       await incomeStatementsPage.setEntrepreneur(true)
@@ -199,9 +199,9 @@ describe.each(envs)('Income statements', (env) => {
     test('Light entrepreneur', async () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
+      await incomeStatementsPage.selectIncomeStatementType('gross-income')
       await incomeStatementsPage.setValidFromDate(startDate)
       await incomeStatementsPage.setValidToDate(endDate)
-      await incomeStatementsPage.selectIncomeStatementType('gross-income')
       await incomeStatementsPage.checkIncomesRegisterConsent()
       await incomeStatementsPage.setGrossIncomeEstimate(1500)
       await incomeStatementsPage.setEntrepreneur(true)
@@ -236,9 +236,9 @@ describe.each(envs)('Income statements', (env) => {
     test('Partnership', async () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
+      await incomeStatementsPage.selectIncomeStatementType('gross-income')
       await incomeStatementsPage.setValidFromDate(startDate)
       await incomeStatementsPage.setValidToDate(endDate)
-      await incomeStatementsPage.selectIncomeStatementType('gross-income')
       await incomeStatementsPage.checkIncomesRegisterConsent()
       await incomeStatementsPage.setGrossIncomeEstimate(1500)
       await incomeStatementsPage.setEntrepreneur(true)
@@ -275,8 +275,8 @@ describe.each(envs)('Income statements', (env) => {
     test('No need to check assured', async () => {
       await header.selectTab('income')
       await incomeStatementsPage.createNewIncomeStatement()
-      await incomeStatementsPage.setValidFromDate(startDate)
       await incomeStatementsPage.selectIncomeStatementType('highest-fee')
+      await incomeStatementsPage.setValidFromDate(startDate)
       await incomeStatementsPage.saveDraft()
 
       await assertIncomeStatementCreated(startDate, null, env)

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income.spec.ts
@@ -137,8 +137,8 @@ describe.each(envs)('Citizen income (%s)', (env) => {
 
     const incomeStatementsPage = new IncomeStatementsPage(page, env)
     await incomeStatementsPage.createNewIncomeStatement()
-    await incomeStatementsPage.setValidFromDate(today.format())
     await incomeStatementsPage.selectIncomeStatementType('highest-fee')
+    await incomeStatementsPage.setValidFromDate(today.format())
     await incomeStatementsPage.checkAssured()
     await incomeStatementsPage.submit()
 

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2070,10 +2070,13 @@ const en: Translations = {
     childIncomeInfo: "Validity of the child's income information",
     incomeStatementMissing:
       'If your child has income, report it with an income statement.',
+    incomeNotifyForPeriod: 'I declare my income for the following period',
     incomeType: {
       startDate: 'Valid as of',
       endDate: 'Valid until',
-      title: 'Grounds for the client fee',
+      starts: 'Starts on',
+      ends: 'Ends on',
+      title: 'Grounds for the early childhood education fee',
       agreeToHighestFee: 'I agree to the highest early education fee',
       highestFeeInfo:
         'I agree to pay the highest early education fee in accordance with the early education time, the valid Act on Client Charges in Healthcare and Social Welfare and the decisions of the City Board for the time being until I declare otherwise or until the early education of my child ends. (No need to provide income information)',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2311,10 +2311,13 @@ export default {
     childIncomeInfo: 'Lapsen tulotietojen voimassaoloaika',
     incomeStatementMissing:
       'Jos lapsellasi on tuloja, ilmoita se tuloselvityksellä.',
+    incomeNotifyForPeriod: 'Ilmoitan tuloni seuraavalle ajalle',
     incomeType: {
-      startDate: 'Voimassa alkaen',
-      endDate: 'Voimassaolo päättyy',
-      title: 'Asiakasmaksun perusteet',
+      startDate: 'Alkaen',
+      endDate: 'Päättyen',
+      starts: 'Alkaa',
+      ends: 'Päättyy',
+      title: 'Varhaiskasvatusmaksun perusteet',
       agreeToHighestFee: 'Suostun korkeimpaan varhaiskasvatusmaksuun',
       highestFeeInfo:
         'Suostun maksamaan varhaiskasvatusajan ja kulloinkin voimassa olevan asiakasmaksulain ja kaupungin hallituksen päätösten mukaista korkeinta varhaiskasvatusmaksua, joka on voimassa toistaiseksi siihen saakka, kunnes toisin ilmoitan tai kunnes lapseni varhaiskasvatus päättyy. (Tulotietoja ei tarvitse toimittaa)',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2313,10 +2313,13 @@ const sv: Translations = {
     childIncomeInfo: 'Giltigheten av barnets inkomstinformation',
     incomeStatementMissing:
       'Om ditt barn har inkomst, anmäl det med en inkomstredovisning.',
+    incomeNotifyForPeriod: 'Jag anmäler mina inkomster för följande period',
     incomeType: {
-      startDate: 'Gäller från och med',
-      endDate: 'Upphör att gälla',
-      title: 'Grunder för klientavgiften',
+      startDate: 'Från och med',
+      endDate: 'Till och med',
+      starts: 'Börjar',
+      ends: 'Slutar',
+      title: 'Grunder för småbarnspedagogikavgiften',
       agreeToHighestFee:
         'Jag samtycker till den högsta avgiften för småbarnspedagogik',
       highestFeeInfo:


### PR DESCRIPTION
_Ennen muutosta:_
Tulotietojen voimassaolon aika oli ennen maksuperusteen valintaa, joka saattoi mm. muuttaa voimassaolon kenttien pakollisuutta.
<img width="718" alt="Screenshot 2025-03-19 at 16 51 08" src="https://github.com/user-attachments/assets/4ac6ddc2-7af0-4c2d-94f3-70f085bbe662" />

_Muutoksen jälkeen:_
Voimassaolokenttä asetettu maksuperusteen mukaan ao. valinnan alle.
<img width="661" alt="Screenshot 2025-03-19 at 16 51 26" src="https://github.com/user-attachments/assets/7def8cb8-56bd-4a68-9440-05790929822d" />
<img width="1036" alt="Screenshot 2025-03-19 at 16 51 37" src="https://github.com/user-attachments/assets/6919a5df-0494-4bb2-a4e2-05194f7600e8" />
<img width="808" alt="Screenshot 2025-03-19 at 16 51 49" src="https://github.com/user-attachments/assets/e6742e20-472c-4029-bb1c-bf3b1449b584" />



