### PR TITLE
Säilytetään hakutoiveiden järjestys

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
+import { PreferredUnit } from 'lib-common/generated/api-types/application'
 import { PublicUnit } from 'lib-common/generated/api-types/daycare'
 import { SelectionChip } from 'lib-components/atoms/Chip'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
@@ -127,7 +128,10 @@ export default React.memo(function UnitsSubSection({
                   if (selected.length <= maxUnits) {
                     updateFormData((prev) => ({
                       ...prev,
-                      preferredUnits: selected
+                      preferredUnits: updatePreferredUnits(
+                        prev.preferredUnits,
+                        selected
+                      )
                     }))
                   }
                 }}
@@ -241,6 +245,25 @@ export default React.memo(function UnitsSubSection({
     </>
   )
 })
+
+function updatePreferredUnits(
+  prev: PreferredUnit[],
+  next: PreferredUnit[]
+): PreferredUnit[] {
+  // <MultiSelect> doesn't preserve the order in which items are selected, so this function tries to do it manually.
+  // In practice, the items should be added/removed one at a time, but there's limited support here to handle
+  // additions/removals of multiple items at once.
+
+  if (next.length > prev.length) {
+    const added = next.filter(
+      (u) => prev.find((u2) => u2.id === u.id) === undefined
+    )
+    return [...prev, ...added]
+  } else if (next.length < prev.length) {
+    return prev.filter((u) => next.find((u2) => u2.id === u.id) !== undefined)
+  }
+  return prev
+}
 
 const FixedWidthDiv = styled.div`
   width: 100%;

--- a/frontend/src/lib-common/api-types/application/ApplicationFormData.ts
+++ b/frontend/src/lib-common/api-types/application/ApplicationFormData.ts
@@ -10,12 +10,11 @@ import {
   ApplicationFormUpdate,
   CitizenChildren,
   OtherGuardianAgreementStatus,
+  PreferredUnit,
   ServiceNeedOption
 } from 'lib-common/generated/api-types/application'
 import { PlacementType } from 'lib-common/generated/api-types/placement'
 import LocalDate from 'lib-common/local-date'
-
-import { DaycareId } from '../../generated/api-types/shared'
 
 export type ServiceNeedFormData = {
   preferredStartDate: LocalDate | null
@@ -43,7 +42,7 @@ export type UnitPreferenceFormData = {
   siblingName: string
   siblingSsn: string
   siblingUnit: string
-  preferredUnits: { id: DaycareId; name: string }[]
+  preferredUnits: PreferredUnit[]
 }
 
 export type SelectableOtherGuardianAgreementStatus = Exclude<


### PR DESCRIPTION
**Ennen**: Uuden yksikön lisäys saattoi järjesti aiemmin valitut yksiköt aakkosjärjestykseen.

https://github.com/user-attachments/assets/39bf2e80-036a-47f1-8b26-0936fab596bd


**Jälkeen**:

https://github.com/user-attachments/assets/89ce069a-2dc1-4100-82f3-bef525f9a388

