### PR TITLE
Arkistoitavien dokumenttien metadata Särmän hyväksymässä muodossa

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
@@ -336,7 +336,7 @@ describe('Employee - Child documents', () => {
     await modal.validityStartInput.fill('01.08.2022')
     await modal.confidentialityDurationYearsInput.fill('100')
     await modal.confidentialityBasisInput.fill('Joku laki §300')
-    await modal.processDefinitionNumberInput.fill('1234')
+    await modal.processDefinitionNumberInput.fill('12.06.01')
     await modal.archiveDurationMonthsInput.fill('1320')
     await modal.confirmCreateButton.click()
     await documentTemplatesPage.openTemplate(documentName)

--- a/service/sarmamodel/src/main/schema/common/include-extended.xsd
+++ b/service/sarmamodel/src/main/schema/common/include-extended.xsd
@@ -15,29 +15,14 @@
     <xs:simpleType name="AcceptedMimeTypeType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="application/pdf"/>
-            <xs:enumeration value="text/plain"/>
-            <xs:enumeration value="text/xml"/>
-            <xs:enumeration value="application/msword"/>
-            <xs:enumeration value="application/vnd.openxmlformats-officedocument.wordprocessingml.document"/>
-            <xs:enumeration value="image/jpeg"/>
-            <xs:enumeration value="image/png"/>
-            <xs:enumeration value="image/tiff"/>
         </xs:restriction>
     </xs:simpleType>
 
     <!-- AcceptedFileFormatType for specific file formats -->
     <xs:simpleType name="AcceptedFileFormatType">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="pdf"/>
-            <xs:enumeration value="txt"/>
-            <xs:enumeration value="docx"/>
-            <xs:enumeration value="doc"/>
-            <xs:enumeration value="xml"/>
-            <xs:enumeration value="jpg"/>
-            <xs:enumeration value="png"/>
-            <xs:enumeration value="tiff"/>
-            <xs:enumeration value="cda/level2"/>
+            <xs:enumeration value="not applicable"/>
         </xs:restriction>
     </xs:simpleType>
 
-</xs:schema> 
+</xs:schema>

--- a/service/sarmamodel/src/main/schema/common/include-policies.xsd
+++ b/service/sarmamodel/src/main/schema/common/include-policies.xsd
@@ -7,66 +7,89 @@
     <!-- Information Security Level Type -->
     <xs:simpleType name="InformationSecurityLevelType">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="ST I"/>
-            <xs:enumeration value="ST II"/>
-            <xs:enumeration value="ST III"/>
-            <xs:enumeration value="ST IV"/>
-            <xs:enumeration value="Unclassified"/>
+            <xs:enumeration value="notSecurityClassified"/>
         </xs:restriction>
     </xs:simpleType>
 
     <!-- Disclosure Level Type -->
     <xs:simpleType name="DisclosureLevelType">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="Public"/>
-            <xs:enumeration value="Internal"/>
-            <xs:enumeration value="Confidential"/>
-            <xs:enumeration value="Secret"/>
+            <xs:enumeration value="public"/>
+            <xs:enumeration value="confidential"/>
         </xs:restriction>
     </xs:simpleType>
 
     <!-- Protection Level Type -->
     <xs:simpleType name="ProtectionLevelType">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="Basic"/>
-            <xs:enumeration value="Enhanced"/>
-            <xs:enumeration value="High"/>
+            <xs:enumeration value="3"/>
         </xs:restriction>
     </xs:simpleType>
+
+    <!-- Policy Configuration Type -->
+    <xs:element name="PolicyConfiguration">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="PolicyName" type="xs:string"/>
+                <xs:element name="InitialTargetState" type="xs:string" minOccurs="0"/>
+                <xs:element name="Rules">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="Rule">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="TimeSpan" type="xs:unsignedByte"/>
+                                        <xs:element name="TriggerEvent" type="xs:string"/>
+                                        <xs:element name="Action">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element name="ActionType" type="xs:string"/>
+                                                    <xs:element name="ActionArguments" minOccurs="0">
+                                                        <xs:complexType>
+                                                            <xs:sequence>
+                                                                <xs:element name="ActionArgument" type="xs:string"/>
+                                                            </xs:sequence>
+                                                        </xs:complexType>
+                                                    </xs:element>
+                                                    <xs:element name="ActionAnnotation" type="xs:string" minOccurs="0"/>
+                                                </xs:sequence>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
 
     <!-- Retention Policy Type -->
     <xs:complexType name="RetentionPolicyType">
         <xs:sequence>
-            <xs:element name="retentionPeriod" type="xs:string"/>
-            <xs:element name="retentionTrigger" type="xs:string" minOccurs="0"/>
-            <xs:element name="retentionReason" type="xs:string" minOccurs="0"/>
+            <xs:element ref="rs:PolicyConfiguration"/>
         </xs:sequence>
     </xs:complexType>
 
     <!-- Disclosure Policy Type -->
     <xs:complexType name="DisclosurePolicyType">
         <xs:sequence>
-            <xs:element name="disclosureLevel" type="rs:DisclosureLevelType"/>
-            <xs:element name="disclosureReason" type="xs:string" minOccurs="0"/>
-            <xs:element name="disclosurePeriod" type="xs:string" minOccurs="0"/>
+            <xs:element ref="rs:PolicyConfiguration"/>
         </xs:sequence>
     </xs:complexType>
 
     <!-- Information Security Policy Type -->
     <xs:complexType name="InformationSecurityPolicyType">
         <xs:sequence>
-            <xs:element name="securityLevel" type="rs:InformationSecurityLevelType"/>
-            <xs:element name="securityReason" type="xs:string" minOccurs="0"/>
-            <xs:element name="securityPeriod" type="xs:string" minOccurs="0"/>
+            <xs:element ref="rs:PolicyConfiguration"/>
         </xs:sequence>
     </xs:complexType>
 
     <!-- Protection Policy Type -->
     <xs:complexType name="ProtectionPolicyType">
         <xs:sequence>
-            <xs:element name="protectionLevel" type="rs:ProtectionLevelType"/>
-            <xs:element name="protectionReason" type="xs:string" minOccurs="0"/>
-            <xs:element name="protectionMeasures" type="xs:string" minOccurs="0"/>
+            <xs:element ref="rs:PolicyConfiguration"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/service/sarmamodel/src/main/schema/yleinen/yleinen-1.0.xsd
+++ b/service/sarmamodel/src/main/schema/yleinen/yleinen-1.0.xsd
@@ -72,10 +72,7 @@
 								<xs:appinfo>uiwidget=textarea;rows=6;cols=60;</xs:appinfo>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="firstName" type="xs:string" minOccurs="0"/>
-						<xs:element name="lastName" type="xs:string" minOccurs="0"/>
-						<xs:element name="socialSecurityNumber" type="xs:string" minOccurs="0"/>
-                        <xs:element name="keywords" type="xs:string" minOccurs="0">
+						<xs:element name="keywords" type="xs:string" minOccurs="0">
 							<xs:annotation>
 								<xs:appinfo>uiwidget=textarea;rows=6;cols=60;</xs:appinfo>
 							</xs:annotation>
@@ -96,6 +93,10 @@
 						<xs:element name="signer" type="xs:string" minOccurs="0"/>
 						<xs:element name="SignatureDescription" type="xs:string" minOccurs="0"/>						
 						<xs:element name="accessRight" type="xa:accessRightType" minOccurs="0"/>
+						<xs:element name="firstName" type="xs:string" minOccurs="0"/>
+						<xs:element name="lastName" type="xs:string" minOccurs="0"/>
+						<xs:element name="socialSecurityNumber" type="xs:string" minOccurs="0"/>
+						<xs:element name="birthDate" type="xs:date" minOccurs="0" />
 						<xs:element name="Agents" minOccurs="0">
 					    <xs:complexType>
 							<xs:sequence>

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -676,6 +676,8 @@ data class ArchiveEnv(
     /** URL up to the endpoint name e.g. http://10.0.0.10/archive-core */
     val url: URI,
     val useMockClient: Boolean,
+    val userId: String,
+    val userRole: String,
 ) {
 
     companion object {
@@ -683,6 +685,8 @@ data class ArchiveEnv(
             ArchiveEnv(
                 url = URI.create(env.lookup("evaka.integration.särmä.url")),
                 useMockClient = env.lookup("evaka.integration.särmä.use_mock_client") ?: false,
+                userId = env.lookup("evaka.integration.särmä.user_id"),
+                userRole = env.lookup("evaka.integration.särmä.user_role"),
             )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäHttpClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäHttpClient.kt
@@ -12,6 +12,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 
 class SärmäHttpClient(private val archiveEnv: ArchiveEnv?) : SärmäClientInterface {
+
     private val httpClient =
         OkHttpClient.Builder()
             .connectTimeout(Duration.ofMinutes(1))
@@ -35,8 +36,8 @@ class SärmäHttpClient(private val archiveEnv: ArchiveEnv?) : SärmäClientInte
                 .setType(MultipartBody.FORM)
                 .addFormDataPart("protocol_version", "1.0")
                 .addFormDataPart("operation_id", "PUT")
-                .addFormDataPart("user_id", "XXXX")
-                .addFormDataPart("user_role", "XXXX")
+                .addFormDataPart("user_id", archiveEnv.userId)
+                .addFormDataPart("user_role", archiveEnv.userRole)
                 .addFormDataPart("nr_of_instances", "1")
                 .addFormDataPart("instance_1_md_model_id", "standard")
                 .addFormDataPart("instance_1_md_model_version", "1.0")

--- a/service/src/main/resources/application-local.yaml
+++ b/service/src/main/resources/application-local.yaml
@@ -66,7 +66,9 @@ evaka:
     särmä:
       enabled: true
       use_mock_client: true
-      url: https://eoy3xw8tftt5shn.m.pipedream.net/archive-core
+      url: https://eoy3xw8tftt5shn.m.pipedream.net/archive-core/
+      user_id: eVaka
+      user_role: xa-api-integration
   not_for_prod:
     force_unpublish_document_template_enabled: true
   jwt:

--- a/service/src/test/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceTest.kt
@@ -226,6 +226,7 @@ class ArchiveChildDocumentServiceTest {
                 archivedProcess,
                 filename,
                 ExternalIdentifier.SSN.getInstance("160616A978U"),
+                LocalDate.of(2020, 2, 1),
             )
 
         val metadataXml = marshalMetadata(metadata)


### PR DESCRIPTION
## Ennen tätä muutosta
Arkistoitavien dokumenttien metadatan säännöt (disclosurePolicy, informationSecurityPolicy, retentionPolicy ja protectionPolicy) olivat rakenteeltaan mock tasoisia.
## Tämän muutoksen jälkeen
Metadatan säännöt luodaan Särmän hyväksymässä formaatissa. Lisätty myös lapsen syntymäaika, ja muutettu muutamia muita yksityiskohtia noudattamaan Särmän todellista metadataformaattia.

Tämä muutos pilkkoo myös `createDocumentMetadata` eri osioiden luonnin erillisiksi funktioiksi koodin luettavuuden parantamiseksi.