### PR TITLE
Raporttien CSV-viennin rivityskorjaus Firefox selaimelle

### DIFF
--- a/frontend/src/employee-frontend/components/reports/ReportDownload.tsx
+++ b/frontend/src/employee-frontend/components/reports/ReportDownload.tsx
@@ -47,7 +47,7 @@ function ReportDownload<T>({
   const downloadCsv = useCallback(() => {
     const link = document.createElement('a')
     link.download = typeof filename === 'function' ? filename() : filename
-    link.href = `data:text/csv;charset=utf-8,${toCsv(data, columns)}`
+    link.href = `data:text/csv;charset=utf-8,${encodeURIComponent(toCsv(data, columns))}`
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)


### PR DESCRIPTION
## Ennen tätä muutosta
CSV-datasta hävisi rivinvaihtomerkit ainakin Firefox selaimella
## Tämän muutoksen jälkeen
CSV-data escapetaan oikein ja rivinvaihdot pysyvät liitetiedostossa tallessa myös Firefox selaimella