### PR TITLE
Piilotetaan hakemuksen liitteet toiselta huoltajalta

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionDaycare.tsx
@@ -343,6 +343,7 @@ export default React.memo(function ServiceTimeSubSectionDaycare({
               })
             }
             getDownloadUrl={getAttachmentUrl}
+            data-qa="shift-care-file-upload"
           />
         </>
       )}

--- a/frontend/src/citizen-frontend/applications/editor/verification/ApplicationVerificationView.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/verification/ApplicationVerificationView.tsx
@@ -118,7 +118,11 @@ export default React.memo(function ApplicationVerificationViewDaycare({
       <ContentArea opaque>
         <BasicsSection application={application} formData={formData} />
         <HorizontalLine />
-        <ServiceNeedSection formData={formData} type={type} />
+        <ServiceNeedSection
+          formData={formData}
+          type={type}
+          userIsApplicationGuardian
+        />
         <HorizontalLine />
         <UnitPreferenceSection formData={formData.unitPreference} />
         <HorizontalLine />

--- a/frontend/src/citizen-frontend/applications/editor/verification/ServiceNeedAttachments.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/verification/ServiceNeedAttachments.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from '../../../localization'
 
 type Props = {
   formData: ApplicationFormData
+  userIsApplicationGuardian: boolean
 }
 
 export const AttachmentList = styled.ul`
@@ -24,7 +25,8 @@ export const AttachmentList = styled.ul`
 `
 
 export const ServiceNeedUrgency = React.memo(function ServiceNeedUrgency({
-  formData
+  formData,
+  userIsApplicationGuardian
 }: Props) {
   const t = useTranslation()
 
@@ -40,40 +42,46 @@ export const ServiceNeedUrgency = React.memo(function ServiceNeedUrgency({
               .withoutUrgency}
       </span>
 
-      {formData.serviceNeed.urgent && featureFlags.urgencyAttachments && (
-        <>
+      {formData.serviceNeed.urgent &&
+        featureFlags.urgencyAttachments &&
+        userIsApplicationGuardian && (
           <>
-            <Label>
-              {t.applications.editor.verification.serviceNeed.attachments.label}
-            </Label>
-            <span>
-              {formData.serviceNeed.urgencyAttachments.length > 0 ? (
-                <AttachmentList>
-                  {formData.serviceNeed.urgencyAttachments.map((file) => (
-                    <li key={file.id}>
-                      <FileDownloadButton
-                        file={file}
-                        getFileUrl={getAttachmentUrl}
-                        data-qa="service-need-urgency-attachment-download"
-                        icon
-                      />
-                    </li>
-                  ))}
-                </AttachmentList>
-              ) : (
-                t.applications.editor.verification.serviceNeed.attachments
-                  .withoutAttachments
-              )}
-            </span>
+            <>
+              <Label>
+                {
+                  t.applications.editor.verification.serviceNeed.attachments
+                    .label
+                }
+              </Label>
+              <span data-qa="service-need-urgency-attachments">
+                {formData.serviceNeed.urgencyAttachments.length > 0 ? (
+                  <AttachmentList>
+                    {formData.serviceNeed.urgencyAttachments.map((file) => (
+                      <li key={file.id}>
+                        <FileDownloadButton
+                          file={file}
+                          getFileUrl={getAttachmentUrl}
+                          data-qa="service-need-urgency-attachment-download"
+                          icon
+                        />
+                      </li>
+                    ))}
+                  </AttachmentList>
+                ) : (
+                  t.applications.editor.verification.serviceNeed.attachments
+                    .withoutAttachments
+                )}
+              </span>
+            </>
           </>
-        </>
-      )}
+        )}
     </>
   )
 })
 
 export const ServiceNeedShiftCare = React.memo(function ServiceNeedShiftCare({
-  formData
+  formData,
+  userIsApplicationGuardian
 }: Props) {
   const t = useTranslation()
 
@@ -90,12 +98,12 @@ export const ServiceNeedShiftCare = React.memo(function ServiceNeedShiftCare({
               .withoutShiftCare}
       </span>
 
-      {formData.serviceNeed.shiftCare && (
+      {formData.serviceNeed.shiftCare && userIsApplicationGuardian && (
         <>
           <Label>
             {t.applications.editor.verification.serviceNeed.attachments.label}
           </Label>
-          <span>
+          <span data-qa="service-need-shift-care-attachments">
             {formData.serviceNeed.shiftCareAttachments.length > 0 ? (
               <AttachmentList>
                 {formData.serviceNeed.shiftCareAttachments.map((file) => (

--- a/frontend/src/citizen-frontend/applications/editor/verification/ServiceNeedSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/verification/ServiceNeedSection.tsx
@@ -26,11 +26,13 @@ import { ApplicationDataGridLabelWidth } from './const'
 type ServiceNeedSectionProps = {
   formData: ApplicationFormData
   type: ApplicationType
+  userIsApplicationGuardian: boolean
 }
 
 export default React.memo(function ServiceNeedSection({
   formData,
-  type
+  type,
+  userIsApplicationGuardian
 }: ServiceNeedSectionProps) {
   const t = useTranslation()
 
@@ -55,7 +57,12 @@ export default React.memo(function ServiceNeedSection({
         </Label>
         <span>{formData.serviceNeed.preferredStartDate?.format()}</span>
 
-        {type === 'DAYCARE' && <ServiceNeedUrgency formData={formData} />}
+        {type === 'DAYCARE' && (
+          <ServiceNeedUrgency
+            formData={formData}
+            userIsApplicationGuardian={userIsApplicationGuardian}
+          />
+        )}
         {type === 'CLUB' && (
           <>
             <Label>
@@ -98,7 +105,10 @@ export default React.memo(function ServiceNeedSection({
 
         {(type === 'DAYCARE' ||
           (type === 'PRESCHOOL' && formData.serviceNeed.connectedDaycare)) && (
-          <ServiceNeedShiftCare formData={formData} />
+          <ServiceNeedShiftCare
+            formData={formData}
+            userIsApplicationGuardian={userIsApplicationGuardian}
+          />
         )}
       </ListGrid>
 

--- a/frontend/src/citizen-frontend/applications/read-view/ApplicationReadViewContents.tsx
+++ b/frontend/src/citizen-frontend/applications/read-view/ApplicationReadViewContents.tsx
@@ -34,7 +34,7 @@ export default React.memo(function ApplicationReadViewContents({
   const { user } = useContext(AuthContext)
 
   const userIsApplicationGuardian = user
-    .map((u) => u && u.id === application.guardianId)
+    .map((u) => u?.id === application.guardianId)
     .getOrElse(false)
 
   return (
@@ -45,7 +45,11 @@ export default React.memo(function ApplicationReadViewContents({
           <H1>{t.applications.editor.heading.title[type]}</H1>
           <BasicsSection application={application} formData={formData} />
           <HorizontalLine />
-          <ServiceNeedSection formData={formData} type={type} />
+          <ServiceNeedSection
+            formData={formData}
+            type={type}
+            userIsApplicationGuardian={userIsApplicationGuardian}
+          />
           <HorizontalLine />
           <UnitPreferenceSection formData={formData.unitPreference} />
           <HorizontalLine />

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -14,11 +14,11 @@ import { waitUntilDefined, waitUntilEqual } from '../../utils'
 import { FormInput, Section, sections } from '../../utils/application-forms'
 import {
   Checkbox,
-  FileInput,
   Page,
   Radio,
   TextInput,
-  Element
+  Element,
+  FileUpload
 } from '../../utils/page'
 
 export default class CitizenApplicationsPage {
@@ -26,6 +26,7 @@ export default class CitizenApplicationsPage {
   #transferApplicationNotification: Element
   #duplicateApplicationNotification: Element
   #applicationTitle: Element
+
   constructor(private readonly page: Page) {
     this.#createNewApplicationButton = page.findByDataQa('submit')
     this.#transferApplicationNotification = page.findByDataQa(
@@ -139,10 +140,19 @@ export default class CitizenApplicationsPage {
 
 class CitizenApplicationReadView {
   contactInfoSection: Element
+  urgencyAttachments: Element
+  shiftCareAttachments: Element
   unitPreferenceSection: Element
   assistanceNeedDescription: TextInput
+
   constructor(readonly page: Page) {
     this.contactInfoSection = page.findByDataQa('contact-info-section')
+    this.urgencyAttachments = page.findByDataQa(
+      'service-need-urgency-attachments'
+    )
+    this.shiftCareAttachments = page.findByDataQa(
+      'service-need-shift-care-attachments'
+    )
     this.unitPreferenceSection = page.findByDataQa('unit-preference-section')
     this.assistanceNeedDescription = new TextInput(
       page.findByDataQa('assistance-need-description')
@@ -164,6 +174,7 @@ class CitizenApplicationEditor {
   saveAsDraftButton: Element
   modalOkBtn: Element
   guardianPhoneInput: TextInput
+
   constructor(private readonly page: Page) {
     this.#verifyButton = page.findByDataQa('verify-btn')
     this.#verifyCheckbox = new Checkbox(page.findByDataQa('verify-checkbox'))
@@ -419,11 +430,17 @@ class CitizenApplicationEditor {
   async markApplicationUrgentAndAddAttachment(attachmentFilePath: string) {
     await this.openSection('serviceNeed')
     await this.setCheckbox('urgent', true)
-    await new FileInput(
-      this.page.find(
-        '[data-qa="urgent-file-upload"] [data-qa="btn-upload-file"]'
-      )
-    ).setInputFiles(attachmentFilePath)
+    await new FileUpload(this.page.findByDataQa('urgent-file-upload')).upload(
+      attachmentFilePath
+    )
+  }
+
+  async selectShiftCareAndAddAttachment(attachmentFilePath: string) {
+    await this.openSection('serviceNeed')
+    await this.setCheckbox('shiftCare', true)
+    await new FileUpload(
+      this.page.findByDataQa('shift-care-file-upload')
+    ).upload(attachmentFilePath)
   }
 
   async assertAttachmentUploaded(attachmentFileName: string) {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -293,7 +293,7 @@ describe('Citizen daycare applications', () => {
     await editorPage.assertUrgencyFileDownload()
   })
 
-  test('Other guardian can see an application after it has been sent, and cannot see person details', async () => {
+  test('Other guardian can see an application after it has been sent, and cannot see person details or attachments', async () => {
     await header.selectTab('applications')
     const editorPage = await applicationsPage.createApplication(
       testChild.id,
@@ -305,6 +305,8 @@ describe('Citizen daycare applications', () => {
       otherGuardianAgreementStatus: 'AGREED'
     })
     await editorPage.fillData(applicationForm.form)
+    await editorPage.markApplicationUrgentAndAddAttachment(testFilePath)
+    await editorPage.selectShiftCareAndAddAttachment(testFilePath)
     await editorPage.writeAssistanceNeedDescription('Child has assistance need')
     await editorPage.verifyAndSend({ hasOtherGuardian: true })
 
@@ -320,6 +322,8 @@ describe('Citizen daycare applications', () => {
 
     await applicationReadView.unitPreferenceSection.waitUntilVisible()
     await applicationReadView.contactInfoSection.waitUntilHidden()
+    await applicationReadView.urgencyAttachments.waitUntilHidden()
+    await applicationReadView.shiftCareAttachments.waitUntilHidden()
     await applicationReadView.assistanceNeedDescription.assertTextEquals('')
   })
 

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -251,29 +251,6 @@ data class CitizenApplicationSummary(
     val transferApplication: Boolean,
 )
 
-fun fetchApplicationDetailsWithCurrentOtherGuardianInfoAndFilteredAttachments(
-    user: AuthenticatedUser,
-    tx: Database.Transaction,
-    personService: PersonService,
-    applicationId: ApplicationId,
-): ApplicationDetails? =
-    tx.fetchApplicationDetails(applicationId, includeCitizenAttachmentsOnly = true)?.let {
-        application ->
-        val otherGuardian =
-            personService.getOtherGuardian(tx, user, application.guardianId, application.childId)
-        application.copy(
-            hasOtherGuardian = otherGuardian != null,
-            otherGuardianLivesInSameAddress =
-                otherGuardian?.id?.let { otherGuardianId ->
-                    personService.personsLiveInTheSameAddress(
-                        tx,
-                        application.guardianId,
-                        otherGuardianId,
-                    )
-                },
-        )
-    }
-
 fun savePaperApplication(
     tx: Database.Transaction,
     user: AuthenticatedUser,


### PR DESCRIPTION
**Ennen:**

Hakemuksen liitteet näkyivät toiselle huoltajalle, mutta hän ei saanut niitä auki (vaan sai virheilmoituksen).

**Jälkeen:**

Hakemuksen liitteitä ei näytetä lainkaan toiselle huoltajalle.

<img width="502" alt="image" src="https://github.com/user-attachments/assets/c06366be-476f-4561-b977-743232326442" />
