### PR TITLE
Mahdollistetaan esikoulupäätösten hyväksyntä ilman huoltajan vahvistusta

### DIFF
--- a/frontend/src/citizen-frontend/applications/ChildApplicationsBlock.tsx
+++ b/frontend/src/citizen-frontend/applications/ChildApplicationsBlock.tsx
@@ -150,11 +150,12 @@ export default React.memo(function ChildApplicationsBlock({
   }
 
   const applicationStatusToIcon = (
-    applicationStatus: ApplicationStatus
+    applicationStatus: ApplicationStatus,
+    decidable: boolean
   ): string => {
     switch (applicationStatus) {
       case 'ACTIVE':
-        return 'ACCEPTED'
+        return decidable ? 'PENDING' : 'ACCEPTED'
       case 'WAITING_PLACEMENT':
       case 'WAITING_DECISION':
       case 'WAITING_UNIT_CONFIRMATION':
@@ -239,23 +240,37 @@ export default React.memo(function ChildApplicationsBlock({
                     <RoundIcon
                       content={
                         applicationStatusIcon[
-                          applicationStatusToIcon(applicationStatus)
+                          applicationStatusToIcon(
+                            applicationStatus,
+                            decidableApplications.includes(applicationId)
+                          )
                         ].icon
                       }
                       color={
                         applicationStatusIcon[
-                          applicationStatusToIcon(applicationStatus)
+                          applicationStatusToIcon(
+                            applicationStatus,
+                            decidableApplications.includes(applicationId)
+                          )
                         ].color
                       }
                       size="m"
                     />
                     <Gap size="xs" horizontal={true} />
                     <Status data-qa={`application-status-${applicationId}`}>
-                      {t.applicationsList.status[applicationStatus]}
+                      {
+                        t.applicationsList.status[
+                          applicationStatus === 'ACTIVE' &&
+                          decidableApplications.includes(applicationId)
+                            ? 'WAITING_CONFIRMATION'
+                            : applicationStatus
+                        ]
+                      }
                     </Status>
                   </div>
 
-                  {applicationStatus === 'WAITING_CONFIRMATION' &&
+                  {(applicationStatus === 'WAITING_CONFIRMATION' ||
+                    applicationStatus === 'ACTIVE') &&
                     permittedActions[applicationId]?.includes(
                       'READ_DECISIONS'
                     ) &&

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -36,6 +36,7 @@ import fi.espoo.evaka.decision.DecisionType
 import fi.espoo.evaka.decision.clearDecisionDrafts
 import fi.espoo.evaka.decision.createDecisionDrafts
 import fi.espoo.evaka.decision.fetchDecisionDrafts
+import fi.espoo.evaka.decision.getDecision
 import fi.espoo.evaka.decision.getDecisionsByApplication
 import fi.espoo.evaka.decision.markApplicationDecisionsSent
 import fi.espoo.evaka.decision.markDecisionAccepted
@@ -647,6 +648,7 @@ class ApplicationStateService(
         user: AuthenticatedUser,
         clock: EvakaClock,
         applicationId: ApplicationId,
+        config: FeatureConfig = featureConfig,
     ) {
         accessControl.requirePermissionFor(
             tx,
@@ -658,7 +660,7 @@ class ApplicationStateService(
 
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_DECISION)
-        val decisionIds = finalizeDecisions(tx, user, clock, application)
+        val decisionIds = finalizeDecisions(tx, user, clock, application, config)
         Audit.ApplicationSendDecisionsWithoutProposal.log(
             targetId = AuditId(applicationId),
             objectId = AuditId(decisionIds),
@@ -766,6 +768,7 @@ class ApplicationStateService(
         clock: EvakaClock,
         unitId: DaycareId,
         rejectReasonTranslations: Map<PlacementPlanRejectReason, String>,
+        config: FeatureConfig = featureConfig,
     ) {
         accessControl.requirePermissionFor(
             tx,
@@ -845,7 +848,9 @@ class ApplicationStateService(
                 }
                 .toList<ApplicationId>()
 
-        validIds.map { getApplication(tx, it) }.forEach { finalizeDecisions(tx, user, clock, it) }
+        validIds
+            .map { getApplication(tx, it) }
+            .forEach { finalizeDecisions(tx, user, clock, it, config) }
         Audit.PlacementProposalAccept.log(targetId = AuditId(unitId), objectId = AuditId(validIds))
     }
 
@@ -1476,7 +1481,11 @@ class ApplicationStateService(
         user: AuthenticatedUser,
         clock: EvakaClock,
         application: ApplicationDetails,
+        config: FeatureConfig = featureConfig,
     ): List<DecisionId> {
+        val skipGuardian =
+            config.skipGuardianPreschoolDecisionApproval &&
+                application.type == ApplicationType.PRESCHOOL
         val sendBySfi = canSendDecisionsBySfi(tx, user, application)
         val decisionDrafts = tx.fetchDecisionDrafts(application.id)
         return if (decisionDrafts.any { it.planned }) {
@@ -1485,6 +1494,22 @@ class ApplicationStateService(
             tx.syncApplicationOtherGuardians(application.id, clock.today())
             val newStatus = if (sendBySfi) WAITING_CONFIRMATION else WAITING_MAILING
             tx.updateApplicationStatus(application.id, newStatus, user.evakaUserId, clock.now())
+
+            if (skipGuardian) {
+                decisionIds.forEach { decisionId ->
+                    val decision = tx.getDecision(decisionId)!!
+                    if (decision.type == DecisionType.PRESCHOOL) {
+                        acceptDecision(
+                            tx,
+                            user,
+                            clock,
+                            application.id,
+                            decisionId,
+                            decision.startDate,
+                        )
+                    }
+                }
+            }
 
             if (newStatus == WAITING_CONFIRMATION) {
                 asyncJobRunner.plan(

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -1501,7 +1501,7 @@ class ApplicationStateService(
                     if (decision.type == DecisionType.PRESCHOOL) {
                         acceptDecision(
                             tx,
-                            user,
+                            AuthenticatedUser.SystemInternalUser,
                             clock,
                             application.id,
                             decisionId,

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -33,7 +33,6 @@ import fi.espoo.evaka.setting.getSettings
 import fi.espoo.evaka.sficlient.SfiMessage
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.DecisionId
-import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -62,7 +61,6 @@ class DecisionService(
     private val emailMessageProvider: IEmailMessageProvider,
     private val emailClient: EmailClient,
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
-    private val featureConfig: FeatureConfig,
 ) {
     fun finalizeDecisions(
         tx: Database.Transaction,
@@ -70,9 +68,9 @@ class DecisionService(
         clock: EvakaClock,
         applicationId: ApplicationId,
         sendAsMessage: Boolean,
+        skipGuardianApproval: Boolean,
     ): List<DecisionId> {
         val decisionIds = tx.finalizeDecisions(applicationId, clock.today())
-        val skipGuardianApproval = featureConfig.skipGuardianPreschoolDecisionApproval
         asyncJobRunner.plan(
             tx,
             decisionIds.map { decisionId ->

--- a/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/decision/DecisionService.kt
@@ -170,7 +170,7 @@ class DecisionService(
         tx: Database.Transaction,
         clock: EvakaClock,
         decisionId: DecisionId,
-        skipGuardianApproval: Boolean,
+        skipGuardianApproval: Boolean?,
     ) {
         val decision =
             tx.getDecision(decisionId) ?: throw NotFound("No decision with id: $decisionId")
@@ -245,7 +245,7 @@ class DecisionService(
         decision: Decision,
         guardian: PersonDTO,
         documentLocation: DocumentLocation,
-        skipGuardianApproval: Boolean,
+        skipGuardianApproval: Boolean?,
     ) {
         if (guardian.identity !is ExternalIdentifier.SSN) {
             logger.info {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -161,6 +161,9 @@ data class FeatureConfig(
      * value is in cents, i.e. 1000 means 10 euros.
      */
     val minimumInvoiceAmount: Int = 0,
+
+    /** Accept preschool decision without asking guardian confirmation */
+    val skipGuardianPreschoolDecisionApproval: Boolean = false,
 )
 
 enum class ArchiveProcessType {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -119,8 +119,10 @@ sealed interface AsyncJob : AsyncJobPayload {
         val skipGuardianApproval: Boolean,
     ) : AsyncJob
 
-    data class SendDecision(val decisionId: DecisionId, val skipGuardianApproval: Boolean) :
-        AsyncJob {
+    data class SendDecision(
+        val decisionId: DecisionId,
+        val skipGuardianApproval: Boolean? = false,
+    ) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -116,9 +116,11 @@ sealed interface AsyncJob : AsyncJobPayload {
         val decisionId: DecisionId,
         override val user: AuthenticatedUser,
         val sendAsMessage: Boolean,
+        val skipGuardianApproval: Boolean,
     ) : AsyncJob
 
-    data class SendDecision(val decisionId: DecisionId) : AsyncJob {
+    data class SendDecision(val decisionId: DecisionId, val skipGuardianApproval: Boolean) :
+        AsyncJob {
         override val user: AuthenticatedUser? = null
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageProvider.kt
@@ -15,10 +15,19 @@ class EvakaMessageProvider : IMessageProvider {
             OfficialLanguage.SV -> """Beslut gällande Esbos småbarnspedagogik"""
         }
 
-    override fun getDecisionContent(lang: OfficialLanguage): String =
+    override fun getDecisionContent(lang: OfficialLanguage, skipGuardianApproval: Boolean): String =
         when (lang) {
             OfficialLanguage.FI ->
-                """Olette hakenut lapsellenne Espoon kaupungin varhaiskasvatus-, esiopetus- ja/tai kerhopaikkaa. Koska olette ottanut Suomi.fi viestit -palvelun käyttöönne, on päätös luettavissa alla olevista liitteistä.
+                if (skipGuardianApproval)
+                    """Olette hakenut lapsellenne Espoon kaupungin varhaiskasvatus-, esiopetus- ja/tai kerhopaikkaa. Koska olette ottanut Suomi.fi viestit -palvelun käyttöönne, on päätös luettavissa alla olevista liitteistä.
+
+
+
+In English:
+
+You have applied for a place in the City of Espoo’s early childhood education, pre-primary education and/or a club for your child. As you are a user of Suomi.fi Messages, you can find the decision in the attachments below."""
+                else
+                    """Olette hakenut lapsellenne Espoon kaupungin varhaiskasvatus-, esiopetus- ja/tai kerhopaikkaa. Koska olette ottanut Suomi.fi viestit -palvelun käyttöönne, on päätös luettavissa alla olevista liitteistä.
 
 Päätös on hakemuksen tehneen huoltajan hyväksyttävissä/hylättävissä Espoon kaupungin varhaiskasvatuksen sähköisessä palvelussa osoitteessa espoonvarhaiskasvatus.fi . Suomi.fi -palvelussa ei voi antaa vastausta sähköisesti, mutta päätöksen yhteydestä voi tulostaa paperisen vastauslomakkeen.
 
@@ -34,7 +43,10 @@ The guardian who submitted the application can accept or reject the decision thr
 
 Please note that you have to respond to the decision within two weeks."""
             OfficialLanguage.SV ->
-                """Du har ansökt om plats i Esbo stads småbarnspedagogiska verksamhet, förskoleundervisning och/eller klubbverksamhet. Eftersom du har tagit i bruk Suomi.fi-meddelandetjänsten kan du läsa beslutet från bilagorna nedan.
+                if (skipGuardianApproval)
+                    """Du har ansökt om plats i Esbo stads småbarnspedagogiska verksamhet, förskoleundervisning och/eller klubbverksamhet. Eftersom du har tagit i bruk Suomi.fi-meddelandetjänsten kan du läsa beslutet från bilagorna nedan."""
+                else
+                    """Du har ansökt om plats i Esbo stads småbarnspedagogiska verksamhet, förskoleundervisning och/eller klubbverksamhet. Eftersom du har tagit i bruk Suomi.fi-meddelandetjänsten kan du läsa beslutet från bilagorna nedan.
 
 Vårdnadshavaren, som har gjort ansökan om plats inom småbarnspedagogik, kan godkänna eller avstå från platsen i Esbo stads elektroniska tjänst på adressen esbosmabarnspedagogik.fi. I tjänsten Suomi.fi kan du inte svara elektroniskt, men du kan skriva ut en svarsblankett.
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/message/EvakaMessageProvider.kt
@@ -15,10 +15,13 @@ class EvakaMessageProvider : IMessageProvider {
             OfficialLanguage.SV -> """Beslut gällande Esbos småbarnspedagogik"""
         }
 
-    override fun getDecisionContent(lang: OfficialLanguage, skipGuardianApproval: Boolean): String =
+    override fun getDecisionContent(
+        lang: OfficialLanguage,
+        skipGuardianApproval: Boolean?,
+    ): String =
         when (lang) {
             OfficialLanguage.FI ->
-                if (skipGuardianApproval)
+                if (skipGuardianApproval == true)
                     """Olette hakenut lapsellenne Espoon kaupungin varhaiskasvatus-, esiopetus- ja/tai kerhopaikkaa. Koska olette ottanut Suomi.fi viestit -palvelun käyttöönne, on päätös luettavissa alla olevista liitteistä.
 
 
@@ -43,7 +46,7 @@ The guardian who submitted the application can accept or reject the decision thr
 
 Please note that you have to respond to the decision within two weeks."""
             OfficialLanguage.SV ->
-                if (skipGuardianApproval)
+                if (skipGuardianApproval == true)
                     """Du har ansökt om plats i Esbo stads småbarnspedagogiska verksamhet, förskoleundervisning och/eller klubbverksamhet. Eftersom du har tagit i bruk Suomi.fi-meddelandetjänsten kan du läsa beslutet från bilagorna nedan."""
                 else
                     """Du har ansökt om plats i Esbo stads småbarnspedagogiska verksamhet, förskoleundervisning och/eller klubbverksamhet. Eftersom du har tagit i bruk Suomi.fi-meddelandetjänsten kan du läsa beslutet från bilagorna nedan.

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/message/IMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/message/IMessageProvider.kt
@@ -10,7 +10,7 @@ import fi.espoo.evaka.shared.domain.OfficialLanguage
 interface IMessageProvider {
     fun getDecisionHeader(lang: OfficialLanguage): String
 
-    fun getDecisionContent(lang: OfficialLanguage, skipGuardianApproval: Boolean): String
+    fun getDecisionContent(lang: OfficialLanguage, skipGuardianApproval: Boolean? = false): String
 
     fun getFeeDecisionHeader(lang: OfficialLanguage): String
 

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/message/IMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/message/IMessageProvider.kt
@@ -10,7 +10,7 @@ import fi.espoo.evaka.shared.domain.OfficialLanguage
 interface IMessageProvider {
     fun getDecisionHeader(lang: OfficialLanguage): String
 
-    fun getDecisionContent(lang: OfficialLanguage): String
+    fun getDecisionContent(lang: OfficialLanguage, skipGuardianApproval: Boolean): String
 
     fun getFeeDecisionHeader(lang: OfficialLanguage): String
 


### PR DESCRIPTION
- Lisätään mahdollisuus hyväksyä automaattisesti esikoulupäätökset kysymättä huoltajan vahvistusta (feature flag)
- Muutetaan kuntalaisen käyttöliittymän hakemuslistausta näyttämään tilaksi "Vahvistettavana huoltajalla", kun hakemusta ei ole hylätty ja hakemukseen liittyy käsittelemättömiä päätöksiä
<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- Lisää linkki dokumentaation relevanttiin kohtaan.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
