### PR TITLE
Konfiguroitava minimilasku

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGeneratorIntegrationTest.kt
@@ -5656,6 +5656,19 @@ class InvoiceGeneratorIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     }
 
     @Test
+    fun `invoice of less than minimumInvoiceAmount is not generated`() {
+        // 1 operational day => ~13 eur invoice
+        val period = FiniteDateRange(LocalDate.of(2025, 1, 31), LocalDate.of(2025, 1, 31))
+        initDataForAbsences(listOf(period), emptyList())
+
+        val generator = invoiceGenerator(featureConfig.copy(minimumInvoiceAmount = 1400))
+        db.transaction { generator.generateAllDraftInvoices(it, YearMonth.of(2025, 1)) }
+
+        val result = db.read { it.getAllInvoices() }
+        assertEquals(0, result.size)
+    }
+
+    @Test
     fun `Free absence type is treated as other absence if feature is disabled`() {
         // 22 operational days
         val month = YearMonth.of(2019, 1)

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/DraftInvoiceGenerator.kt
@@ -219,13 +219,14 @@ class DraftInvoiceGenerator(
                 }
 
         return DraftInvoice(
-            periodStart = invoiceInput.invoicePeriod.start,
-            periodEnd = invoiceInput.invoicePeriod.end,
-            areaId = areaId,
-            headOfFamily = headInput.headOfFamily,
-            codebtor = headInput.codebtor,
-            rows = rows,
-        )
+                periodStart = invoiceInput.invoicePeriod.start,
+                periodEnd = invoiceInput.invoicePeriod.end,
+                areaId = areaId,
+                headOfFamily = headInput.headOfFamily,
+                codebtor = headInput.codebtor,
+                rows = rows,
+            )
+            .takeIf { it.totalPrice >= invoiceInput.minimumInvoiceAmount }
     }
 
     private fun calculateDailyPriceForInvoiceRow(price: Int, dailyFeeDivisor: Int): Int =
@@ -583,6 +584,7 @@ class DraftInvoiceGenerator(
         val freeChildren: Set<ChildId>,
         val codebtors: Map<PersonId, PersonId?>,
         val defaultServiceNeedOptions: Map<PlacementType, ServiceNeedOption>,
+        val minimumInvoiceAmount: Int, // cents
     ) {
         val businessDayCount = businessDays.ranges().map { it.durationInDays() }.sum().toInt()
 

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/InvoiceGenerator.kt
@@ -335,6 +335,7 @@ class InvoiceGenerator(
             businessDays = businessDays,
             feeThresholds = feeThresholds,
             defaultServiceNeedOptions = defaultServiceNeedOptions,
+            minimumInvoiceAmount = featureConfig.minimumInvoiceAmount,
             areaIds = areaIds,
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/FeatureConfig.kt
@@ -155,6 +155,12 @@ data class FeatureConfig(
 
     /** Type of holiday questionnaire */
     val holidayQuestionnaireType: QuestionnaireType = QuestionnaireType.FIXED_PERIOD,
+
+    /**
+     * Invoices whose total sum is less than `minimumInvoiceAmount` are not generated at all. The
+     * value is in cents, i.e. 1000 means 10 euros.
+     */
+    val minimumInvoiceAmount: Int = 0,
 )
 
 enum class ArchiveProcessType {


### PR DESCRIPTION
Asettamalla `FeatureConfig.minimumInvoiceAmount` voi määrittää pienimmän loppusumman laskulle. Tätä pienemmät laskut jätetään luomatta. Jos oikaisulasku jää alle minimin, generoidaan nollaoikaisulasku.