### PR TITLE
Laskujen uudelleenlähetys

### DIFF
--- a/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
+++ b/frontend/src/e2e-test/pages/employee/finance/finance-page.ts
@@ -362,12 +362,14 @@ export class InvoicesPage {
   #invoiceInList: Element
   #allInvoicesToggle: Checkbox
   #openSendInvoicesDialogButton: Element
+  #deleteInvoicesButton: Element
   #sendInvoicesDialog: Element
   #navigateBack: Element
   #markInvoiceSentButton: AsyncButton
   #invoices: Element
   #sendInvoicesButton: AsyncButton
   #searchButton: Element
+  #sendInvoicesSuccessOkButton: Element
 
   constructor(private readonly page: Page) {
     this.#invoicesPage = page.findByDataQa('invoices-page')
@@ -380,6 +382,7 @@ export class InvoicesPage {
     this.#openSendInvoicesDialogButton = page.findByDataQa(
       'open-send-invoices-dialog'
     )
+    this.#deleteInvoicesButton = page.findByDataQa('delete-invoices')
     this.#sendInvoicesDialog = page.findByDataQa('send-invoices-dialog')
     this.#navigateBack = page.findByDataQa('navigate-back')
     this.#markInvoiceSentButton = new AsyncButton(
@@ -390,6 +393,9 @@ export class InvoicesPage {
       page.find('[data-qa="send-invoices-dialog"] [data-qa="modal-okBtn"]')
     )
     this.#searchButton = page.findByDataQa('search-button')
+    this.#sendInvoicesSuccessOkButton = page.find(
+      '[data-qa="modal"] [data-qa="modal-okBtn"]'
+    )
   }
 
   async assertLoaded() {
@@ -419,12 +425,29 @@ export class InvoicesPage {
     await this.#allInvoicesToggle.waitUntilChecked(toggled)
   }
 
+  async selectFirstInvoice() {
+    const firstRow = this.page
+      .findByDataQa('table-of-invoices')
+      .findAllByDataQa('table-invoice-row')
+      .first()
+
+    const selectInvoiceCheckbox = new Checkbox(firstRow)
+
+    await selectInvoiceCheckbox.waitUntilChecked(false)
+    await selectInvoiceCheckbox.check()
+    await selectInvoiceCheckbox.waitUntilChecked(true)
+  }
+
   async sendInvoices() {
     await this.#openSendInvoicesDialogButton.click()
     await this.#sendInvoicesDialog.waitUntilVisible()
     await this.#sendInvoicesDialog.find('[data-qa="title"]').click()
     await this.#sendInvoicesButton.click()
     await this.#sendInvoicesButton.waitUntilHidden()
+
+    await this.#sendInvoicesSuccessOkButton.waitUntilVisible()
+    await this.#sendInvoicesSuccessOkButton.click()
+    await this.#sendInvoicesSuccessOkButton.waitUntilHidden()
   }
 
   async filterByStatus(status: InvoiceStatus) {
@@ -451,6 +474,11 @@ export class InvoicesPage {
   async markInvoiceSent() {
     await this.#markInvoiceSentButton.click()
     await this.#markInvoiceSentButton.waitUntilHidden()
+  }
+
+  async assertButtonsDisabled() {
+    await this.#openSendInvoicesDialogButton.assertDisabled(true)
+    await this.#deleteInvoicesButton.assertDisabled(true)
   }
 }
 

--- a/frontend/src/e2e-test/specs/4_finance/invoices.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/invoices.spec.ts
@@ -220,6 +220,43 @@ describe('Invoices', () => {
       await invoicesPage.assertInvoiceCount(2)
     })
 
+    test('Filtering invoices result selection resets after change', async () => {
+      await Fixture.invoice({
+        headOfFamilyId: testAdult.id,
+        areaId: testCareArea.id
+      })
+        .addRow({
+          childId: testChild.id,
+          unitId: testDaycare.id
+        })
+        .save()
+      await Fixture.invoice({
+        headOfFamilyId: familyWithRestrictedDetailsGuardian.guardian.id,
+        areaId: testCareArea.id
+      })
+        .addRow({
+          childId: familyWithRestrictedDetailsGuardian.children[0].id,
+          unitId: testDaycare.id
+        })
+        .save()
+
+      const invoicesPage = await openInvoicesPage()
+      await invoicesPage.searchInvoices()
+      await invoicesPage.assertInvoiceCount(2)
+      await invoicesPage.createInvoiceDrafts()
+      await invoicesPage.selectFirstInvoice()
+      await invoicesPage.sendInvoices()
+      await invoicesPage.assertInvoiceCount(1)
+      await invoicesPage.filterByStatus('SENT')
+      await invoicesPage.searchInvoices()
+      await invoicesPage.assertInvoiceCount(1)
+      await invoicesPage.toggleAllInvoices(true)
+      await invoicesPage.filterByStatus('DRAFT')
+      await invoicesPage.searchInvoices()
+      await invoicesPage.assertInvoiceCount(1)
+      await invoicesPage.assertButtonsDisabled()
+    })
+
     test('Sending an invoice with a recipient without a SSN', async () => {
       const adultWithoutSSN = await Fixture.person({
         id: fromUuid<PersonId>('a6cf0ec0-4573-4816-be30-6b87fd943817'),

--- a/frontend/src/employee-frontend/components/invoices/Actions.tsx
+++ b/frontend/src/employee-frontend/components/invoices/Actions.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 
 import { InvoiceStatus } from 'lib-common/generated/api-types/invoicing'
 import { InvoiceId } from 'lib-common/generated/api-types/shared'
+import { Button } from 'lib-components/atoms/buttons/Button'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import { MutateButton } from 'lib-components/atoms/buttons/MutateButton'
 import { fontWeights } from 'lib-components/typography'
@@ -30,9 +31,11 @@ const CheckedRowsInfo = styled.div`
 
 type Props = {
   openModal: () => void
+  openResendModal: () => void
   status: InvoiceStatus
   canSend: boolean
   canDelete: boolean
+  canResend: boolean
   checkedInvoices: Set<InvoiceId>
   clearCheckedInvoices: () => void
   checkedAreas: string[]
@@ -41,9 +44,11 @@ type Props = {
 
 const Actions = React.memo(function Actions({
   openModal,
+  openResendModal,
   status,
   canSend,
   canDelete,
+  canResend,
   checkedInvoices,
   clearCheckedInvoices,
   checkedAreas,
@@ -93,6 +98,29 @@ const Actions = React.memo(function Actions({
           text={i18n.invoices.buttons.sendInvoice(checkedInvoices.size)}
           onClick={openModal}
           data-qa="open-send-invoices-dialog"
+        />
+      )}
+    </StickyActionBar>
+  ) : status === 'SENT' ? (
+    <StickyActionBar align="right">
+      {checkedInvoices.size > 0 ? (
+        <>
+          <CheckedRowsInfo>
+            {i18n.invoices.buttons.checked(checkedInvoices.size)}
+          </CheckedRowsInfo>
+          <Gap size="s" horizontal />
+        </>
+      ) : null}
+      {canResend && (
+        <Button
+          primary
+          text={i18n.invoices.buttons.resendInvoice(checkedInvoices.size)}
+          onClick={openResendModal}
+          disabled={
+            (!fullAreaSelection && checkedInvoices.size === 0) ||
+            (fullAreaSelection && checkedAreas.length === 0)
+          }
+          data-qa="send-again"
         />
       )}
     </StickyActionBar>

--- a/frontend/src/employee-frontend/components/invoices/InvoiceFilters.tsx
+++ b/frontend/src/employee-frontend/components/invoices/InvoiceFilters.tsx
@@ -23,7 +23,13 @@ import {
   UnitFilter
 } from '../common/Filters'
 
-export default React.memo(function InvoiceFilters() {
+interface Props {
+  clearPreviousResults: () => void
+}
+
+export default React.memo(function InvoiceFilters({
+  clearPreviousResults
+}: Props) {
   const {
     invoices: {
       searchFilters,
@@ -116,7 +122,10 @@ export default React.memo(function InvoiceFilters() {
       setFreeText={(s) =>
         setSearchFilters((prev) => ({ ...prev, searchTerms: s }))
       }
-      onSearch={confirmSearchFilters}
+      onSearch={() => {
+        clearPreviousResults()
+        confirmSearchFilters()
+      }}
       clearFilters={clearSearchFilters}
       column1={
         <>

--- a/frontend/src/employee-frontend/components/invoices/queries.ts
+++ b/frontend/src/employee-frontend/components/invoices/queries.ts
@@ -10,6 +10,8 @@ import {
   getInvoice,
   getInvoiceCodes,
   markInvoicesSent,
+  resendInvoices,
+  resendInvoicesByDate,
   searchInvoices,
   sendInvoices,
   sendInvoicesByDate
@@ -34,6 +36,16 @@ export const sendInvoicesMutation = q.mutation(sendInvoices, [
 ])
 
 export const sendInvoicesByDateMutation = q.mutation(sendInvoicesByDate, [
+  invoicesQuery.prefix,
+  invoiceDetailsQuery.prefix
+])
+
+export const resendInvoicesMutation = q.mutation(resendInvoices, [
+  invoicesQuery.prefix,
+  invoiceDetailsQuery.prefix
+])
+
+export const resendInvoicesByDateMutation = q.mutation(resendInvoicesByDate, [
   invoicesQuery.prefix,
   invoiceDetailsQuery.prefix
 ])

--- a/frontend/src/employee-frontend/generated/api-clients/invoicing.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/invoicing.ts
@@ -685,6 +685,40 @@ export async function markReplacementDraftSent(
 
 
 /**
+* Generated from fi.espoo.evaka.invoicing.controller.InvoiceController.resendInvoices
+*/
+export async function resendInvoices(
+  request: {
+    body: InvoiceId[]
+  }
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/employee/invoices/resend`.toString(),
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<InvoiceId[]>
+  })
+  return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.invoicing.controller.InvoiceController.resendInvoicesByDate
+*/
+export async function resendInvoicesByDate(
+  request: {
+    body: InvoicePayload
+  }
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/employee/invoices/resend/by-date`.toString(),
+    method: 'POST',
+    data: request.body satisfies JsonCompatible<InvoicePayload>
+  })
+  return json
+}
+
+
+/**
 * Generated from fi.espoo.evaka.invoicing.controller.InvoiceController.searchInvoices
 */
 export async function searchInvoices(

--- a/frontend/src/lib-common/generated/action.d.ts
+++ b/frontend/src/lib-common/generated/action.d.ts
@@ -320,6 +320,7 @@ export type Invoice =
   | 'DELETE'
   | 'MARK_SENT'
   | 'READ'
+  | 'RESEND'
   | 'SEND'
   | 'UPLOAD_ATTACHMENT'
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2866,6 +2866,10 @@ export const fi = {
         count === 1 ? `${count} lasku valittu` : `${count} laskua valittu`,
       sendInvoice: (count: number) =>
         count === 1 ? 'Siirrä valittu lasku' : 'Siirrä valitut laskut',
+      resendInvoice: (count: number) =>
+        count === 1
+          ? 'Lähetä valittu lasku uudelleen'
+          : 'Lähetä valitut laskut uudelleen',
       createInvoices: 'Luo laskuluonnokset',
       deleteInvoice: (count: number) =>
         count === 1 ? 'Poista valittu lasku' : 'Poista valitut laskut',
@@ -2880,7 +2884,12 @@ export const fi = {
       title: 'Siirrä valitut laskut',
       invoiceDate: 'Laskun päivä',
       dueDate: 'Laskun eräpäivä'
-    }
+    },
+    resendModal: {
+      title: 'Lähetä uudelleen?'
+    },
+    sendSuccess: 'Lähettäminen onnistui',
+    sendFailure: 'Lähettäminen epäonnistui'
   },
   invoice: {
     status: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/InvoiceIntegrationTest.kt
@@ -64,6 +64,7 @@ import fi.espoo.evaka.user.EvakaUserType
 import java.time.LocalDate
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -357,6 +357,8 @@ enum class Audit(
     InvoicesMarkReplacementDraftSent,
     InvoicesRead,
     InvoicesReportRead,
+    InvoicesResend,
+    InvoicesResendByDate,
     InvoicesSearch,
     InvoicesSend,
     InvoicesSendByDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/InvoiceQueries.kt
@@ -214,9 +214,10 @@ fun Database.Read.getSentInvoicesOfMonth(
         .toList()
 }
 
-fun Database.Read.getInvoiceIdsByDates(
+fun Database.Read.getInvoiceIdsByDatesAndStatus(
     range: FiniteDateRange,
     areas: List<String>,
+    status: InvoiceStatus,
 ): List<InvoiceId> {
     return createQuery {
             sql(
@@ -224,7 +225,7 @@ fun Database.Read.getInvoiceIdsByDates(
                 SELECT id FROM invoice
                 WHERE between_start_and_end(${bind(range)}, invoice_date)
                 AND area_id IN (SELECT id FROM care_area WHERE short_name = ANY(${bind(areas)}))
-                AND status = ${bind(InvoiceStatus.DRAFT)}::invoice_status
+                AND status = ${bind(status)}
                 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -1641,6 +1641,7 @@ sealed interface Action {
         UPLOAD_ATTACHMENT(HasGlobalRole(ADMIN, FINANCE_ADMIN, FINANCE_STAFF)),
         MARK_SENT(HasGlobalRole(ADMIN, FINANCE_ADMIN, FINANCE_STAFF)),
         SEND(HasGlobalRole(ADMIN, FINANCE_ADMIN)),
+        RESEND(HasGlobalRole(ADMIN, FINANCE_ADMIN)),
         DELETE(HasGlobalRole(ADMIN, FINANCE_ADMIN));
 
         override fun toString(): String = "${javaClass.name}.$name"


### PR DESCRIPTION
Työntekijän puoli:

Lähetettyjen laskujen listaan lisätty samanlaiset checkboxit kuin luonnosten listaan. -> Valitse lähetetty lasku(t) ja lähetä uudelleen.

Modaalin tekstit/ux hieman draftimaiset.

https://github.com/user-attachments/assets/16d11697-e2d1-4581-9f6c-08696aebc822


