### PR TITLE
Lisätään kuntalaiselle mahdollisuus ladata keskusteluaikavaraus ulkopuoliseen kalenteriin

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,8 @@
     "date-fns-tz": "^3.2.0",
     "downshift": "^9.0.4",
     "history": "^5.3.0",
+    "ical-generator": "^8.1.1",
+    "icalzone": "^0.0.1",
     "intersection-observer": "^0.12.2",
     "leaflet": "^1.9.4",
     "lib-common": "link:src/lib-common",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,6 @@
     "downshift": "^9.0.4",
     "history": "^5.3.0",
     "ical-generator": "^8.1.1",
-    "icalzone": "^0.0.1",
     "intersection-observer": "^0.12.2",
     "leaflet": "^1.9.4",
     "lib-common": "link:src/lib-common",

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -100,7 +100,7 @@ import AttendanceInfo from './AttendanceInfo'
 import { BottomFooterContainer } from './BottomFooterContainer'
 import { CalendarModalBackground, CalendarModalSection } from './CalendarModal'
 import { useCalendarModalState } from './CalendarPage'
-import { DiscussionTimeExportButton } from './DiscussionTimeExport'
+import { DiscussionTimeExportButton } from './DiscussionTimeExportButton'
 import {
   ChildImageData,
   getChildImages,

--- a/frontend/src/citizen-frontend/calendar/DiscussionTimeExport.tsx
+++ b/frontend/src/citizen-frontend/calendar/DiscussionTimeExport.tsx
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2017-2025 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import ical, { ICalCalendarMethod } from 'ical-generator'
+import { getZoneString } from 'icalzone'
+import React, { useCallback } from 'react'
+
+import { useTranslation } from 'citizen-frontend/localization'
+import { CitizenCalendarEventTime } from 'lib-common/generated/api-types/calendarevent'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { Button } from 'lib-components/atoms/buttons/Button'
+import { faCalendar } from 'lib-icons'
+
+interface DiscussionTimeAttendeeInfo {
+  groupName: string | null
+  unitName: string | null
+}
+
+interface DiscussionTimeExportProps {
+  discussionTime: CitizenCalendarEventTime
+  eventTitle: string
+  eventAttendeeInfo?: DiscussionTimeAttendeeInfo
+}
+
+export const DiscussionTimeExportButton = React.memo(
+  function DiscussionTimeExportButton({
+    discussionTime,
+    eventTitle,
+    eventAttendeeInfo
+  }: DiscussionTimeExportProps) {
+    const i18n = useTranslation()
+
+    const downloadIcs = useCallback(() => {
+      const fileName = `${i18n.calendar.discussionTimeReservation.discussionTimeFileName}_${discussionTime.date.formatIso()}.ics`
+      const calendar = ical()
+      calendar.method(ICalCalendarMethod.REQUEST)
+      calendar.timezone({
+        name: 'VTZ',
+        generator: (zoneName: string) => getZoneString(zoneName) ?? null
+      })
+      calendar.createEvent({
+        summary: eventTitle,
+        location: `${eventAttendeeInfo?.unitName ?? ''} ${eventAttendeeInfo?.groupName ? `(${eventAttendeeInfo.groupName})` : ''}`,
+        start: HelsinkiDateTime.fromLocal(
+          discussionTime.date,
+          discussionTime.startTime
+        ).formatIso(),
+        end: HelsinkiDateTime.fromLocal(
+          discussionTime.date,
+          discussionTime.endTime
+        ).formatIso(),
+        timezone: 'Europe/Helsinki'
+      })
+      const link = document.createElement('a')
+      link.download = fileName
+      link.href = `data:text/calendar;charset=utf-8,${calendar.toString()}`
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    }, [i18n, eventTitle, eventAttendeeInfo, discussionTime])
+
+    return (
+      <Button
+        appearance="inline"
+        text={i18n.calendar.discussionTimeReservation.calendarExportButtonLabel}
+        onClick={() => {
+          downloadIcs()
+        }}
+        icon={faCalendar}
+      />
+    )
+  }
+)

--- a/frontend/src/citizen-frontend/calendar/DiscussionTimeExportButton.tsx
+++ b/frontend/src/citizen-frontend/calendar/DiscussionTimeExportButton.tsx
@@ -62,6 +62,7 @@ export const DiscussionTimeExportButton = React.memo(
 
     return (
       <Button
+        data-qa={`event-export-button-${discussionTime.id}`}
         appearance="inline"
         text={i18n.calendar.discussionTimeReservation.calendarExportButtonLabel}
         onClick={() => {

--- a/frontend/src/citizen-frontend/calendar/DiscussionTimeExportButton.tsx
+++ b/frontend/src/citizen-frontend/calendar/DiscussionTimeExportButton.tsx
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import ical, { ICalCalendarMethod } from 'ical-generator'
-import { getZoneString } from 'icalzone'
 import React, { useCallback } from 'react'
 
 import { useTranslation } from 'citizen-frontend/localization'
@@ -11,6 +10,26 @@ import { CitizenCalendarEventTime } from 'lib-common/generated/api-types/calenda
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { faCalendar } from 'lib-icons'
+
+const helsinkiVTZLines = [
+  'BEGIN:VTIMEZONE',
+  'TZID:Europe/Helsinki',
+  'BEGIN:STANDARD',
+  'TZNAME:EET',
+  'TZOFFSETFROM:+0300',
+  'TZOFFSETTO:+0200',
+  'DTSTART:19701025T040000',
+  'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
+  'END:STANDARD',
+  'BEGIN:DAYLIGHT',
+  'TZNAME:EEST',
+  'TZOFFSETFROM:+0200',
+  'TZOFFSETTO:+0300',
+  'DTSTART:19700329T030000',
+  'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU',
+  'END:DAYLIGHT',
+  'END:VTIMEZONE'
+]
 
 interface DiscussionTimeAttendeeInfo {
   groupName: string | null
@@ -36,8 +55,8 @@ export const DiscussionTimeExportButton = React.memo(
       const calendar = ical()
       calendar.method(ICalCalendarMethod.REQUEST)
       calendar.timezone({
-        name: 'VTZ',
-        generator: (zoneName: string) => getZoneString(zoneName) ?? null
+        name: 'EET',
+        generator: () => helsinkiVTZLines.join('\r\n')
       })
       calendar.createEvent({
         summary: eventTitle,
@@ -49,12 +68,11 @@ export const DiscussionTimeExportButton = React.memo(
         end: HelsinkiDateTime.fromLocal(
           discussionTime.date,
           discussionTime.endTime
-        ).formatIso(),
-        timezone: 'Europe/Helsinki'
+        ).formatIso()
       })
       const link = document.createElement('a')
       link.download = fileName
-      link.href = `data:text/calendar;charset=utf-8,${calendar.toString()}`
+      link.href = `data:text/calendar;charset=utf-8,${encodeURIComponent(calendar.toString())}`
       document.body.appendChild(link)
       link.click()
       document.body.removeChild(link)

--- a/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
@@ -45,6 +45,7 @@ import {
   CalendarModalCloseButton,
   CalendarModalSection
 } from '../CalendarModal'
+import { DiscussionTimeExportButton } from '../DiscussionTimeExport'
 import { deleteCalendarEventTimeReservationMutation } from '../queries'
 
 interface ChildWithSurveys {
@@ -315,7 +316,7 @@ const ChildSurveyElement = React.memo(function ChildSurveyElement({
             </span>
             {reservations.map((r) => (
               <FixedSpaceColumn key={r.id} alignItems="flex-start">
-                <div data-qa={`reservation-${r.id}`}>
+                <ReservationRow data-qa={`reservation-${r.id}`}>
                   {r.date.isBefore(today) ? (
                     <Light>
                       {`${r.date.format('EEEEEE d.M.', lang)}
@@ -323,13 +324,30 @@ const ChildSurveyElement = React.memo(function ChildSurveyElement({
                     ${r.startTime.format()} - ${r.endTime.format()}`}
                     </Light>
                   ) : (
-                    <Bold>
-                      {`${r.date.format('EEEEEE d.M.', lang)}
+                    <FixedSpaceRow
+                      fullWidth
+                      alignItems="center"
+                      justifyContent="space-between"
+                    >
+                      <div>
+                        <Bold>
+                          {`${r.date.format('EEEEEE d.M.', lang)}
                     ${i18n.calendar.discussionTimeReservation.timePreDescriptor}
                     ${r.startTime.format()} - ${r.endTime.format()}`}
-                    </Bold>
+                        </Bold>
+                      </div>
+                      <DiscussionTimeExportButton
+                        eventTitle={survey.title}
+                        discussionTime={r}
+                        eventAttendeeInfo={survey.attendingChildren?.[
+                          childId
+                        ]?.find(({ periods }) =>
+                          periods.some((period) => period.includes(r.date))
+                        )}
+                      />
+                    </FixedSpaceRow>
                   )}
-                </div>
+                </ReservationRow>
                 {r.date.isEqualOrAfter(today) && (
                   <>
                     <Button
@@ -411,4 +429,7 @@ const ReservationButtonContainer = styled.div`
 const SurveyElementContainer = styled(FixedSpaceColumn)`
   margin: 0 10px;
   word-break: break-word;
+`
+const ReservationRow = styled.div`
+  width: 100%;
 `

--- a/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
@@ -45,7 +45,7 @@ import {
   CalendarModalCloseButton,
   CalendarModalSection
 } from '../CalendarModal'
-import { DiscussionTimeExportButton } from '../DiscussionTimeExport'
+import { DiscussionTimeExportButton } from '../DiscussionTimeExportButton'
 import { deleteCalendarEventTimeReservationMutation } from '../queries'
 
 interface ChildWithSurveys {
@@ -329,7 +329,7 @@ const ChildSurveyElement = React.memo(function ChildSurveyElement({
                       alignItems="center"
                       justifyContent="space-between"
                     >
-                      <div>
+                      <div data-qa={`reservation-content-${r.id}`}>
                         <Bold>
                           {`${r.date.format('EEEEEE d.M.', lang)}
                     ${i18n.calendar.discussionTimeReservation.timePreDescriptor}

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -826,7 +826,8 @@ class DayView extends Element {
       title,
       description,
       reservationText
-    }: { title: string; description: string; reservationText: string }
+    }: { title: string; description: string; reservationText: string },
+    exportable = true
   ) {
     const event = this.#childSection(childId).findByDataQa(`event-${eventId}`)
     await event.findByDataQa('title-text').assertTextEquals(title)
@@ -838,6 +839,15 @@ class DayView extends Element {
       event.findByDataQa(`reservation-cancel-button-${eventTimeId}`)
     )
     await cancelButton.assertDisabled(!cancellable)
+
+    const exportButton = event.findByDataQa(
+      `event-export-button-${eventTimeId}`
+    )
+    if (exportable) {
+      await exportButton.waitUntilVisible()
+    } else {
+      await exportButton.waitUntilHidden()
+    }
   }
 
   async cancelDiscussionReservation(

--- a/frontend/src/e2e-test/pages/citizen/citizen-discussion-surveys.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-discussion-surveys.ts
@@ -67,7 +67,8 @@ export class DiscussionSurveyModal extends Element {
     title: string,
     reservationId: string,
     reservationText: string,
-    isCancellable: boolean
+    isCancellable: boolean,
+    isExportable = true
   ) => {
     const childElement = this.findByDataQa(`discussion-child-${childId}`)
     await childElement.waitUntilVisible()
@@ -81,12 +82,21 @@ export class DiscussionSurveyModal extends Element {
       .assertTextEquals(title)
 
     await surveyElement
-      .findByDataQa(`reservation-${reservationId}`)
+      .findByDataQa(`reservation-content-${reservationId}`)
       .assertTextEquals(reservationText)
 
     const cancelButton = surveyElement.findByDataQa(`reservation-cancel-button`)
     await cancelButton.waitUntilVisible()
     await cancelButton.assertDisabled(!isCancellable)
+
+    const exportButton = surveyElement.findByDataQa(
+      `event-export-button-${reservationId}`
+    )
+    if (isExportable) {
+      await exportButton.waitUntilVisible()
+    } else {
+      await exportButton.waitUntilHidden()
+    }
   }
 
   showReservationModal = async (surveyId: string, childId: string) => {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
@@ -503,7 +503,7 @@ describe.each(envs)('Citizen calendar event time visibility (%s)', (env) => {
     ])
   })
 
-  test('Citizen is receives only one correct set of event times despite 2 group placements', async () => {
+  test('Citizen receives only one correct set of event times despite 2 group placements', async () => {
     const placement1 = createDaycarePlacementFixture(
       randomId(),
       testChild2.id,

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -369,7 +369,9 @@ const en: Translations = {
       confirmCancel: {
         title: 'Do you wish to cancel the reservation?',
         cancel: 'Do not cancel'
-      }
+      },
+      discussionTimeFileName: 'Discussion_time',
+      calendarExportButtonLabel: 'Add to calendar'
     },
     absenceMarkedByEmployee: 'Absence marked by staff',
     contactStaffToEditAbsence:

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -370,7 +370,9 @@ export default {
       confirmCancel: {
         title: 'Haluatko perua varauksen?',
         cancel: 'Älä peru'
-      }
+      },
+      discussionTimeFileName: 'Keskusteluaika',
+      calendarExportButtonLabel: 'Vie kalenteriin'
     },
 
     absenceMarkedByEmployee: 'Henkilökunnan merkitsemä poissaolo',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -368,7 +368,9 @@ const sv: Translations = {
       confirmCancel: {
         title: 'Vill du avboka din bokning?',
         cancel: 'Avboka inte'
-      }
+      },
+      discussionTimeFileName: 'Diskussionstid',
+      calendarExportButtonLabel: 'Lägg till i kalender'
     },
     absenceMarkedByEmployee: 'Frånvaro markerad av personal',
     contactStaffToEditAbsence: 'Kontakta personalen om du vill ändra frånvaron',

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6833,7 +6833,6 @@ __metadata:
     history: "npm:^5.3.0"
     html-webpack-plugin: "npm:^5.6.0"
     ical-generator: "npm:^8.1.1"
-    icalzone: "npm:^0.0.1"
     intersection-observer: "npm:^0.12.2"
     jest: "npm:^29.7.0"
     jest-circus: "npm:^29.7.0"
@@ -7765,13 +7764,6 @@ __metadata:
     rrule:
       optional: true
   checksum: 10/c9ddc6f3345d6199345f8854c65302e0dc4f03ee027c2f38d70743c1b8df1fea0f5362c8bf98dfeea82f99e53af3274847448afd77ff830a4674a3bbf0be184a
-  languageName: node
-  linkType: hard
-
-"icalzone@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "icalzone@npm:0.0.1"
-  checksum: 10/897c8ffb570494555c6e73c04907f9f4890b76c78482bea4a8b25bbd6a76bde8608f256112f9803796135a27fdd2df2d68cedf8dce77f96805fd933a57efc7c5
   languageName: node
   linkType: hard
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6832,6 +6832,8 @@ __metadata:
     globals: "npm:^16.0.0"
     history: "npm:^5.3.0"
     html-webpack-plugin: "npm:^5.6.0"
+    ical-generator: "npm:^8.1.1"
+    icalzone: "npm:^0.0.1"
     intersection-observer: "npm:^0.12.2"
     jest: "npm:^29.7.0"
     jest-circus: "npm:^29.7.0"
@@ -7726,6 +7728,50 @@ __metadata:
   dependencies:
     ms: "npm:^2.0.0"
   checksum: 10/9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"ical-generator@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "ical-generator@npm:8.1.1"
+  dependencies:
+    uuid-random: "npm:^1.3.2"
+  peerDependencies:
+    "@touch4it/ical-timezones": ">=1.6.0"
+    "@types/luxon": ">= 1.26.0"
+    "@types/mocha": ">= 8.2.1"
+    dayjs: ">= 1.10.0"
+    luxon: ">= 1.26.0"
+    moment: ">= 2.29.0"
+    moment-timezone: ">= 0.5.33"
+    rrule: ">= 2.6.8"
+  peerDependenciesMeta:
+    "@touch4it/ical-timezones":
+      optional: true
+    "@types/luxon":
+      optional: true
+    "@types/mocha":
+      optional: true
+    "@types/node":
+      optional: true
+    dayjs:
+      optional: true
+    luxon:
+      optional: true
+    moment:
+      optional: true
+    moment-timezone:
+      optional: true
+    rrule:
+      optional: true
+  checksum: 10/c9ddc6f3345d6199345f8854c65302e0dc4f03ee027c2f38d70743c1b8df1fea0f5362c8bf98dfeea82f99e53af3274847448afd77ff830a4674a3bbf0be184a
+  languageName: node
+  linkType: hard
+
+"icalzone@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "icalzone@npm:0.0.1"
+  checksum: 10/897c8ffb570494555c6e73c04907f9f4890b76c78482bea4a8b25bbd6a76bde8608f256112f9803796135a27fdd2df2d68cedf8dce77f96805fd933a57efc7c5
   languageName: node
   linkType: hard
 
@@ -12651,6 +12697,13 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 10/5d6949693d58cb2e636a84f3ee1c6e7b2f9c16cb1d42d0ecb386d8c025c69e327205aa1c69e2868cc06a01e5e20681fbba55a4e0ed0cce913d60334024eae798
+  languageName: node
+  linkType: hard
+
+"uuid-random@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "uuid-random@npm:1.3.2"
+  checksum: 10/9070c876651e1893f9255dddab2edc177ba34196660065be074050e4143405382b7f0f5fb922b666ebfd0794a6ef7b9f6acb627865df7b2978edb0da6b448f1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Lisää kuntalaisen kalenterin päivämodaaliin ja keskusteluaikavarausmodaaliin napin, joka tuottaa validin ical ics tapahtuman, jonka voi liittää omaan ical-tuen sisältävään kalenterisovellukseensa. Nappi näytetään tehdyille aikavarauksille, jotka eivät ole menneisyydessä.

Kalenteritapahtumaan tulee:
- Otsikko: keskustelukyselyn nimi
- Aikaväli: keskusteluaikavarauksen aika
- Sijainti: keskustelukyselyn yksikkö + ryhmä
