### PR TITLE
Luetaan Särmän vastauskoodi oikeasta paikasta

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1195,6 +1195,7 @@ export class Fixture {
       publishedContent: null,
       answeredAt: null,
       answeredBy: null,
+      processId: null,
       ...initial
     })
   }

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -17,6 +17,7 @@ import { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { ApplicationOrigin } from 'lib-common/generated/api-types/application'
 import { ApplicationStatus } from 'lib-common/generated/api-types/application'
 import { ApplicationType } from 'lib-common/generated/api-types/application'
+import { ArchivedProcessId } from 'lib-common/generated/api-types/shared'
 import { AreaId } from 'lib-common/generated/api-types/shared'
 import { AssistanceActionId } from 'lib-common/generated/api-types/shared'
 import { AssistanceFactorId } from 'lib-common/generated/api-types/shared'
@@ -413,6 +414,7 @@ export interface DevChildDocument {
   contentModifiedBy: EmployeeId | null
   id: ChildDocumentId
   modifiedAt: HelsinkiDateTime
+  processId: ArchivedProcessId | null
   publishedAt: HelsinkiDateTime | null
   publishedContent: DocumentContent | null
   status: DocumentStatus

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
@@ -308,6 +308,7 @@ describe('Holiday periods and questionnaires', () => {
       await holidayModal.markNoHolidays([child, child2])
 
       holidayModal = await calendar.openHolidayModal()
+
       await holidayModal.assertSelectedFixedPeriods(
         selections.map((s) => ({ ...s, option: 'Ei maksutonta poissaoloa' }))
       )

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -97,6 +97,9 @@ dependencies {
     // OkHttp
     implementation("com.squareup.okhttp3:okhttp")
 
+    // Apache HttpClient
+    implementation("org.apache.httpcomponents:httpclient")
+
     // SFTP
     implementation("com.github.mwiede:jsch")
 

--- a/service/evaka-bom/build.gradle.kts
+++ b/service/evaka-bom/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
         api("org.apache.commons:commons-csv:1.14.0")
         api("org.apache.commons:commons-text:1.13.0")
         api("org.apache.commons:commons-imaging:1.0-alpha3")
+        api("org.apache.httpcomponents:httpclient:4.5.13")
         api("org.apache.tika:tika-core:3.1.0")
         api(libs.bouncycastle.bcpkix)
         api(libs.bouncycastle.bcprov)

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceIntegrationTest.kt
@@ -114,6 +114,9 @@ class ArchiveChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBe
 
     @BeforeTest
     fun setUp() {
+        // Reset and clear Särmä client for clean test state
+        särmäClient.resetResponse()
+        särmäClient.clearCalls()
 
         // Set up test data in database using DevApi
         db.transaction { tx ->
@@ -226,9 +229,5 @@ class ArchiveChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBe
             // Verify that our test client was still called
             assertEquals(1, särmäClient.calls.size)
         }
-
-        // Reset client for other tests
-        särmäClient.resetResponse()
-        särmäClient.clearCalls()
     }
 }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceIntegrationTest.kt
@@ -26,11 +26,11 @@ import java.io.InputStream
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
-import kotlin.test.BeforeTest
-import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.ContentDisposition
 import org.springframework.http.ResponseEntity
@@ -112,7 +112,7 @@ class ArchiveChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBe
         }
     }
 
-    @BeforeTest
+    @BeforeEach
     fun setUp() {
         // Reset and clear Särmä client for clean test state
         särmäClient.resetResponse()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceIntegrationTest.kt
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.document.archival
+
+import fi.espoo.evaka.FullApplicationTest
+import fi.espoo.evaka.document.DocumentTemplateContent
+import fi.espoo.evaka.document.DocumentType
+import fi.espoo.evaka.document.childdocument.*
+import fi.espoo.evaka.placement.PlacementType
+import fi.espoo.evaka.process.DocumentConfidentiality
+import fi.espoo.evaka.process.insertProcess
+import fi.espoo.evaka.s3.Document
+import fi.espoo.evaka.s3.DocumentKey
+import fi.espoo.evaka.s3.DocumentLocation
+import fi.espoo.evaka.s3.DocumentService
+import fi.espoo.evaka.shared.ChildDocumentId
+import fi.espoo.evaka.shared.DocumentTemplateId
+import fi.espoo.evaka.shared.PersonId
+import fi.espoo.evaka.shared.dev.*
+import fi.espoo.evaka.shared.domain.DateRange
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import fi.espoo.evaka.shared.domain.OfficialLanguage
+import java.io.InputStream
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.ContentDisposition
+import org.springframework.http.ResponseEntity
+
+class ArchiveChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
+
+    private var documentService = TestDocumentService()
+
+    private var särmäClient = TestSärmäClient()
+
+    private val templateId = DocumentTemplateId(UUID.randomUUID())
+    private val documentId = ChildDocumentId(UUID.randomUUID())
+    private val childId = PersonId(UUID.randomUUID())
+    private val now = HelsinkiDateTime.of(LocalDateTime.of(2023, 2, 1, 12, 0))
+
+    // Mock document service implementation
+    inner class TestDocumentService : DocumentService {
+
+        override fun locate(key: DocumentKey): DocumentLocation =
+            DocumentLocation(bucket = "test-bucket", key = key.value)
+
+        override fun get(location: DocumentLocation): Document =
+            Document("test-document.pdf", byteArrayOf(1, 2, 3, 4), "application/pdf")
+
+        override fun response(
+            location: DocumentLocation,
+            contentDisposition: ContentDisposition,
+        ): ResponseEntity<Any> = throw NotImplementedError("Not used in this test")
+
+        override fun upload(
+            location: DocumentLocation,
+            inputStream: InputStream,
+            size: Long,
+            contentType: String,
+        ) {}
+
+        override fun delete(location: DocumentLocation) {}
+    }
+
+    // Client for Särmä archival system that only captures calls for verification
+    class TestSärmäClient : SärmäClientInterface {
+        data class Call(
+            val documentContent: Document,
+            val metadataXml: String,
+            val masterId: String,
+            val classId: String,
+            val virtualArchiveId: String,
+        )
+
+        val calls = mutableListOf<Call>()
+        private var responseCode = 200
+        private var responseString =
+            "status_message=Success.&transaction_id=2872934&protocol_version=1.0&status_code=200&instance_ids=354319&"
+
+        fun setResponse(code: Int, response: String) {
+            responseCode = code
+            responseString = response
+        }
+
+        fun resetResponse() {
+            responseCode = 200
+            responseString =
+                "status_message=Success.&transaction_id=2872934&protocol_version=1.0&status_code=200&instance_ids=354319&"
+        }
+
+        fun clearCalls() {
+            calls.clear()
+        }
+
+        override fun putDocument(
+            documentContent: Document,
+            metadataXml: String,
+            masterId: String,
+            classId: String,
+            virtualArchiveId: String,
+        ): Pair<Int, String?> {
+            calls.add(Call(documentContent, metadataXml, masterId, classId, virtualArchiveId))
+            return Pair(responseCode, responseString)
+        }
+    }
+
+    @BeforeTest
+    fun setUp() {
+
+        // Set up test data in database using DevApi
+        db.transaction { tx ->
+            // Create a child using DevPerson
+            val personData =
+                DevPerson(
+                    id = childId,
+                    firstName = "Testi",
+                    lastName = "Testinen",
+                    dateOfBirth = LocalDate.of(2016, 6, 16),
+                    ssn = "160616A978U",
+                )
+            tx.insert(personData, DevPersonType.CHILD)
+
+            // Create a document template using DevDocumentTemplate
+            val templateContent = DocumentTemplateContent(sections = emptyList())
+            val template =
+                DevDocumentTemplate(
+                    id = templateId,
+                    name = "VASU 2023-2024",
+                    type = DocumentType.VASU,
+                    placementTypes = setOf(PlacementType.PRESCHOOL),
+                    language = OfficialLanguage.FI,
+                    confidentiality = DocumentConfidentiality(10, "JulkL 24 § 1 mom. 32 k"),
+                    legalBasis = "EARLY_CHILDHOOD_EDUCATION",
+                    validity = DateRange(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 12, 31)),
+                    published = true,
+                    processDefinitionNumber = "1234",
+                    archiveDurationMonths = 120,
+                    content = templateContent,
+                )
+            tx.insert(template)
+
+            // Create a child document using DevChildDocument
+            val emptyContent = DocumentContent(emptyList())
+            val childDocument =
+                DevChildDocument(
+                    id = documentId,
+                    childId = childId,
+                    templateId = templateId,
+                    status = DocumentStatus.COMPLETED,
+                    content = emptyContent,
+                    publishedContent = emptyContent,
+                    modifiedAt = now,
+                    contentModifiedAt = now,
+                    contentModifiedBy = null,
+                    publishedAt = now,
+                    answeredAt = null,
+                    answeredBy = null,
+                )
+            tx.insert(childDocument)
+
+            // Set document key and link to archived process
+
+            // Set document key
+            tx.updateChildDocumentKey(documentId, "test-document-key")
+
+            // Create archived process
+            val process =
+                tx.insertProcess(
+                    processDefinitionNumber = "1234",
+                    year = 2023,
+                    organization = "Espoon kaupungin esiopetus ja varhaiskasvatus",
+                    archiveDurationMonths = 120,
+                )
+
+            // Connect document to process
+            tx.setChildDocumentProcessId(documentId, process.id)
+        }
+    }
+
+    @Test
+    fun `uploadToArchive marks document as archived in database when successful`() {
+        // Execute the archive method on the real service with our test dependencies
+        uploadToArchive(db, documentId, särmäClient, documentService)
+
+        // Verify the document was marked as archived in the database
+        db.read { tx ->
+            val document = tx.getChildDocument(documentId)
+            assertNotNull(document)
+            assertNotNull(document.archivedAt)
+
+            // Verify that our test client was used correctly
+            assertEquals(1, särmäClient.calls.size)
+            assertEquals("yleinen", särmäClient.calls[0].masterId)
+            assertEquals("12.06.01.SL1.RT34", särmäClient.calls[0].classId)
+            assertEquals("YLEINEN", särmäClient.calls[0].virtualArchiveId)
+        }
+    }
+
+    @Test
+    fun `uploadToArchive does not mark document as archived when Särmä returns error`() {
+        // Configure Särmä client to return an validation error response
+        särmäClient.setResponse(
+            200,
+            "status_message=No message associated with the status code.&transaction_id=2868078&protocol_version=1.0&status_code=-2176&",
+        )
+
+        // Execute the archive method and expect exception
+        assertThrows<RuntimeException> {
+            uploadToArchive(db, documentId, särmäClient, documentService)
+        }
+
+        // Verify the document was NOT marked as archived in the database
+        db.read { tx ->
+            val document = tx.getChildDocument(documentId)
+            assertNotNull(document)
+            assertNull(document.archivedAt)
+
+            // Verify that our test client was still called
+            assertEquals(1, särmäClient.calls.size)
+        }
+
+        // Reset client for other tests
+        särmäClient.resetResponse()
+        särmäClient.clearCalls()
+    }
+}

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceIntegrationTest.kt
@@ -150,7 +150,15 @@ class ArchiveChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBe
                 )
             tx.insert(template)
 
-            // Create a child document using DevChildDocument
+            // Create archived process
+            val process =
+                tx.insertProcess(
+                    processDefinitionNumber = "1234",
+                    year = 2023,
+                    organization = "Espoon kaupungin esiopetus ja varhaiskasvatus",
+                    archiveDurationMonths = 120,
+                )
+
             val emptyContent = DocumentContent(emptyList())
             val childDocument =
                 DevChildDocument(
@@ -166,25 +174,12 @@ class ArchiveChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBe
                     publishedAt = now,
                     answeredAt = null,
                     answeredBy = null,
+                    processId = process.id,
                 )
             tx.insert(childDocument)
 
-            // Set document key and link to archived process
-
             // Set document key
             tx.updateChildDocumentKey(documentId, "test-document-key")
-
-            // Create archived process
-            val process =
-                tx.insertProcess(
-                    processDefinitionNumber = "1234",
-                    year = 2023,
-                    organization = "Espoon kaupungin esiopetus ja varhaiskasvatus",
-                    archiveDurationMonths = 120,
-                )
-
-            // Connect document to process
-            tx.setChildDocumentProcessId(documentId, process.id)
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceIntegrationTest.kt
@@ -21,7 +21,7 @@ import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.dev.*
 import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
-import fi.espoo.evaka.shared.domain.OfficialLanguage
+import fi.espoo.evaka.shared.domain.UiLanguage
 import java.io.InputStream
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -139,7 +139,7 @@ class ArchiveChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBe
                     name = "VASU 2023-2024",
                     type = DocumentType.VASU,
                     placementTypes = setOf(PlacementType.PRESCHOOL),
-                    language = OfficialLanguage.FI,
+                    language = UiLanguage.FI,
                     confidentiality = DocumentConfidentiality(10, "JulkL 24 § 1 mom. 32 k"),
                     legalBasis = "EARLY_CHILDHOOD_EDUCATION",
                     validity = DateRange(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 12, 31)),

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
@@ -21,10 +21,12 @@ import fi.espoo.evaka.shared.domain.NotFound
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.xml.bind.JAXBContext
 import java.io.StringWriter
+import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 import java.time.ZoneId
 import javax.xml.datatype.DatatypeFactory
 import javax.xml.datatype.XMLGregorianCalendar
+import org.apache.http.client.utils.URLEncodedUtils
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {}
@@ -44,6 +46,325 @@ private fun HelsinkiDateTime.asXMLGregorianCalendar(): XMLGregorianCalendar {
         )
 }
 
+object DocumentMetadataUtils {
+    internal fun marshalMetadata(metadata: RecordMetadataInstance): String {
+        val context = JAXBContext.newInstance(RecordMetadataInstance::class.java)
+        val marshaller =
+            context.createMarshaller().apply {
+                // Use namespaces in a similar way as the shared example xml files. TODO check
+                // if this
+                // is actually needed
+                setProperty(
+                    "org.glassfish.jaxb.namespacePrefixMapper",
+                    object : org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper() {
+                        override fun getPreferredPrefix(
+                            namespaceUri: String,
+                            suggestion: String?,
+                            requirePrefix: Boolean,
+                        ): String {
+                            return when (namespaceUri) {
+                                "http://www.avaintec.com/2005/x-archive/record-metadata-instance/2.0" ->
+                                    "ns0"
+                                "http://www.avaintec.com/2004/records-schedule-fi/1.0" -> "at0"
+                                else -> suggestion ?: "ns"
+                            }
+                        }
+                    },
+                )
+            }
+        return StringWriter().use { writer ->
+            marshaller.marshal(metadata, writer)
+            writer.toString()
+        }
+    }
+
+    private fun createPolicyRule(
+        timeSpan: Short,
+        triggerEvent: String,
+        action: PolicyConfiguration.Rules.Rule.Action,
+    ): PolicyConfiguration.Rules.Rule {
+        return PolicyConfiguration.Rules.Rule().apply {
+            this.timeSpan = timeSpan
+            this.triggerEvent = triggerEvent
+            this.action = action
+        }
+    }
+
+    private fun createPolicyAction(
+        actionType: String,
+        actionArgument: String? = null,
+        actionAnnotation: String? = null,
+    ): PolicyConfiguration.Rules.Rule.Action {
+        return PolicyConfiguration.Rules.Rule.Action().apply {
+            this.actionType = actionType
+            if (actionArgument != null) {
+                actionArguments =
+                    PolicyConfiguration.Rules.Rule.Action.ActionArguments().apply {
+                        this.actionArgument = actionArgument
+                    }
+            }
+            if (actionAnnotation != null) {
+                this.actionAnnotation = actionAnnotation
+            }
+        }
+    }
+
+    private fun createDisclosurePolicy(documentMetadata: DocumentMetadata): DisclosurePolicyType {
+        return DisclosurePolicyType().apply {
+            policyConfiguration =
+                PolicyConfiguration().apply {
+                    policyName = "DisclosurePolicy"
+                    initialTargetState =
+                        if (documentMetadata.confidential == true) "confidential" else "public"
+                    rules =
+                        PolicyConfiguration.Rules().apply {
+                            rule =
+                                createPolicyRule(
+                                    // according to Särmä specs, this should be set to 0 for
+                                    // public and permanently confidential documents. If not
+                                    // defined in metadata, we default to 100 years.
+                                    timeSpan =
+                                        if (documentMetadata.confidential == true)
+                                            documentMetadata.confidentiality
+                                                ?.durationYears
+                                                ?.toShort() ?: 100
+                                        else 0,
+                                    // years from document creation (creation.created in xml)
+                                    triggerEvent = "YearsFromRecordCreation",
+                                    action =
+                                        createPolicyAction(
+                                            actionType = "SetTargetStateToArgument",
+                                            actionArgument = "public",
+                                            actionAnnotation =
+                                                documentMetadata.confidentiality?.basis
+                                                    ?: "JulkL 24 § 1 mom. 32 k",
+                                        ),
+                                )
+                        }
+                }
+        }
+    }
+
+    private fun createInformationSecurityPolicy(): InformationSecurityPolicyType {
+        return InformationSecurityPolicyType().apply {
+            policyConfiguration =
+                PolicyConfiguration().apply {
+                    policyName = "InformationSecurityPolicy"
+                    initialTargetState = "notSecurityClassified"
+                    rules =
+                        PolicyConfiguration.Rules().apply {
+                            rule =
+                                createPolicyRule(
+                                    timeSpan = 0,
+                                    triggerEvent = "InPerpetuity",
+                                    action =
+                                        createPolicyAction(
+                                            actionType = "SetTargetStateToArgument",
+                                            actionArgument = "notSecurityClassified",
+                                        ),
+                                )
+                        }
+                }
+        }
+    }
+
+    private fun createRetentionPolicy(): RetentionPolicyType {
+        return RetentionPolicyType().apply {
+            policyConfiguration =
+                PolicyConfiguration().apply {
+                    policyName = "RetentionPolicy"
+                    rules =
+                        PolicyConfiguration.Rules().apply {
+                            rule =
+                                createPolicyRule(
+                                    timeSpan = 0,
+                                    triggerEvent = "InPerpetuity",
+                                    action =
+                                        createPolicyAction(
+                                            actionType = "AddTimeSpanToTarget",
+                                            actionAnnotation = "KA/13089/07.01.01.03.01/2018",
+                                        ),
+                                )
+                        }
+                }
+        }
+    }
+
+    private fun createProtectionPolicy(): ProtectionPolicyType {
+        return ProtectionPolicyType().apply {
+            policyConfiguration =
+                PolicyConfiguration().apply {
+                    policyName = "ProtectionPolicy"
+                    initialTargetState = "3"
+                    rules =
+                        PolicyConfiguration.Rules().apply {
+                            rule =
+                                createPolicyRule(
+                                    timeSpan = 0,
+                                    triggerEvent = "InPerpetuity",
+                                    action =
+                                        createPolicyAction(
+                                            actionType = "SetTargetStateToArgument",
+                                            actionArgument = "3",
+                                        ),
+                                )
+                        }
+                }
+        }
+    }
+
+    private fun createAgents(
+        archivedProcess: ArchivedProcess?
+    ): StandardMetadataType.DocumentDescription.Agents {
+        return StandardMetadataType.DocumentDescription.Agents().apply {
+            // Get unique agents by their ID to avoid duplicates
+            archivedProcess
+                ?.history
+                ?.map { it.enteredBy }
+                ?.distinctBy { it.id }
+                ?.forEach { user ->
+                    agent.add(
+                        AgentType().apply {
+                            corporateName = archivedProcess.organization
+                            role = "Henkilökunta" // TODO pitäisikö tämän olla tarkempi rooli?
+                            name = user.name
+                        }
+                    )
+                }
+        }
+    }
+
+    private fun createDocumentDescription(
+        document: ChildDocumentDetails,
+        documentMetadata: DocumentMetadata,
+        archivedProcess: ArchivedProcess?,
+        childIdentifier: ExternalIdentifier,
+        childBirthDate: java.time.LocalDate,
+    ): StandardMetadataType.DocumentDescription {
+        return StandardMetadataType.DocumentDescription().apply {
+            // Basic document info
+            title = documentMetadata.name
+            documentType = "Suunnitelma" // From Evaka_Särmä_metatietomääritykset.xlsx
+            documentTypeSpecifier =
+                "Varhaiskasvatussuunnitelma" // From Evaka_Särmä_metatietomääritykset.xlsx
+            personalData = PersonalDataType.CONTAINS_PERSONAL_INFORMATION // TODO md_instance.xml:
+            // containsPersonalInformation tai
+            // containsSensitivePersonalInformation.
+            // Mistä tämä tulisi päätellä?
+            language = document.template.language.isoLanguage.alpha2
+
+            // From Evaka_Särmä_metatietomääritykset.xlsx
+            dataManagement = "Palvelujen tiedonhallinta"
+            dataSource = "Varhaiskasvatuksen tietovaranto"
+            registerName = "Varhaiskasvatuksen asiakastietorekisteri"
+            personalDataCollectionReason =
+                "Rekisterinpitäjän lakisääteisten velvoitteiden noudattaminen"
+
+            // Child's information
+            firstName = document.child.firstName
+            lastName = document.child.lastName
+            socialSecurityNumber =
+                if (childIdentifier is ExternalIdentifier.SSN) childIdentifier.ssn else null
+            birthDate =
+                childBirthDate.let { date ->
+                    DatatypeFactory.newInstance()
+                        .newXMLGregorianCalendar(
+                            date.year,
+                            date.monthValue,
+                            date.dayOfMonth,
+                            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+                            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+                            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+                            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+                            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+                        )
+                }
+            agents = createAgents(archivedProcess)
+        }
+    }
+
+    private fun createFormat(filename: String): StandardMetadataType.Format {
+        return StandardMetadataType.Format().apply {
+            recordType = ResourceTypeType.DIGITAL
+            mimeType = AcceptedMimeTypeType.APPLICATION_PDF
+            this.fileName = filename
+            fileFormat = AcceptedFileFormatType.NOT_APPLICABLE
+        }
+    }
+
+    private fun createCreation(documentMetadata: DocumentMetadata): StandardMetadataType.Creation {
+        return StandardMetadataType.Creation().apply {
+            created = documentMetadata.createdAt?.asXMLGregorianCalendar()
+            originatingSystem = "Varhaiskasvatuksen toiminnanohjausjärjestelmä"
+        }
+    }
+
+    private fun createPolicies(documentMetadata: DocumentMetadata): StandardMetadataType.Policies {
+        return StandardMetadataType.Policies().apply {
+            // Salassapitosääntö
+            disclosurePolicy = createDisclosurePolicy(documentMetadata)
+            // Turvallisuussääntö
+            informationSecurityPolicy = createInformationSecurityPolicy()
+            // Säilytyssääntö
+            retentionPolicy = createRetentionPolicy()
+            // Suojeluluokkasääntö
+            protectionPolicy = createProtectionPolicy()
+        }
+    }
+
+    private fun createCaseFile(
+        documentMetadata: DocumentMetadata,
+        archivedProcess: ArchivedProcess?,
+    ): CaseFileType {
+        return CaseFileType().apply {
+            caseCreated = documentMetadata.createdAt?.asXMLGregorianCalendar()
+            caseFinished =
+                archivedProcess
+                    ?.history
+                    ?.find { it.state == ArchivedProcessState.COMPLETED }
+                    ?.enteredAt
+                    ?.asXMLGregorianCalendar()
+        }
+    }
+
+    internal fun createDocumentMetadata(
+        document: ChildDocumentDetails,
+        documentMetadata: DocumentMetadata,
+        archivedProcess: ArchivedProcess?,
+        filename: String,
+        childIdentifier: ExternalIdentifier,
+        birthDate: java.time.LocalDate,
+    ): RecordMetadataInstance {
+        return RecordMetadataInstance().apply {
+            standardMetadata =
+                StandardMetadataType().apply {
+                    metadataMasterVersion =
+                        MetadataMasterVersionType().apply {
+                            masterName = "yleinen"
+                            versionNumber = "1.0"
+                        }
+                    virtualArchiveId = "YLEINEN"
+                    recordIdentifiers =
+                        StandardMetadataType.RecordIdentifiers().apply {
+                            recordIdentifier = document.id.toString()
+                        }
+                    documentDescription =
+                        createDocumentDescription(
+                            document,
+                            documentMetadata,
+                            archivedProcess,
+                            childIdentifier,
+                            birthDate,
+                        )
+                    format = createFormat(filename)
+                    creation = createCreation(documentMetadata)
+                    policies = createPolicies(documentMetadata)
+                    caseFile = createCaseFile(documentMetadata, archivedProcess)
+                }
+        }
+    }
+}
+
 @Service
 class ArchiveChildDocumentService(
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
@@ -53,412 +374,99 @@ class ArchiveChildDocumentService(
 
     init {
         asyncJobRunner.registerHandler<AsyncJob.ArchiveChildDocument> { db, _, msg ->
-            uploadToArchive(db, msg.documentId)
+            uploadToArchive(db, msg.documentId, client, documentClient)
         }
     }
+}
 
-    companion object {
-        internal fun marshalMetadata(metadata: RecordMetadataInstance): String {
-            val context = JAXBContext.newInstance(RecordMetadataInstance::class.java)
-            val marshaller =
-                context.createMarshaller().apply {
-                    // Use namespaces in a similar way as the shared example xml files. TODO check
-                    // if this
-                    // is actually needed
-                    setProperty(
-                        "org.glassfish.jaxb.namespacePrefixMapper",
-                        object : org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper() {
-                            override fun getPreferredPrefix(
-                                namespaceUri: String,
-                                suggestion: String?,
-                                requirePrefix: Boolean,
-                            ): String {
-                                return when (namespaceUri) {
-                                    "http://www.avaintec.com/2005/x-archive/record-metadata-instance/2.0" ->
-                                        "ns0"
-                                    "http://www.avaintec.com/2004/records-schedule-fi/1.0" -> "at0"
-                                    else -> suggestion ?: "ns"
-                                }
-                            }
-                        },
-                    )
-                }
-            return StringWriter().use { writer ->
-                marshaller.marshal(metadata, writer)
-                writer.toString()
-            }
+fun uploadToArchive(
+    db: Database.Connection,
+    documentId: ChildDocumentId,
+    uploadClient: SärmäClientInterface,
+    documentClient: DocumentService,
+) {
+    logger.info { "Starting archival process for document $documentId" }
+
+    val document =
+        db.read { tx ->
+            tx.getChildDocument(documentId) ?: throw NotFound("document $documentId not found")
         }
-
-        private fun createPolicyRule(
-            timeSpan: Short,
-            triggerEvent: String,
-            action: PolicyConfiguration.Rules.Rule.Action,
-        ): PolicyConfiguration.Rules.Rule {
-            return PolicyConfiguration.Rules.Rule().apply {
-                this.timeSpan = timeSpan
-                this.triggerEvent = triggerEvent
-                this.action = action
-            }
-        }
-
-        private fun createPolicyAction(
-            actionType: String,
-            actionArgument: String? = null,
-            actionAnnotation: String? = null,
-        ): PolicyConfiguration.Rules.Rule.Action {
-            return PolicyConfiguration.Rules.Rule.Action().apply {
-                this.actionType = actionType
-                if (actionArgument != null) {
-                    actionArguments =
-                        PolicyConfiguration.Rules.Rule.Action.ActionArguments().apply {
-                            this.actionArgument = actionArgument
-                        }
-                }
-                if (actionAnnotation != null) {
-                    this.actionAnnotation = actionAnnotation
-                }
-            }
-        }
-
-        private fun createDisclosurePolicy(
-            documentMetadata: DocumentMetadata
-        ): DisclosurePolicyType {
-            return DisclosurePolicyType().apply {
-                policyConfiguration =
-                    PolicyConfiguration().apply {
-                        policyName = "DisclosurePolicy"
-                        initialTargetState =
-                            if (documentMetadata.confidential == true) "confidential" else "public"
-                        rules =
-                            PolicyConfiguration.Rules().apply {
-                                rule =
-                                    createPolicyRule(
-                                        // according to Särmä specs, this should be set to 0 for
-                                        // public and permanently confidential documents. If not
-                                        // defined in metadata, we default to 100 years.
-                                        timeSpan =
-                                            if (documentMetadata.confidential == true)
-                                                documentMetadata.confidentiality
-                                                    ?.durationYears
-                                                    ?.toShort() ?: 100
-                                            else 0,
-                                        // years from document creation (creation.created in xml)
-                                        triggerEvent = "YearsFromRecordCreation",
-                                        action =
-                                            createPolicyAction(
-                                                actionType = "SetTargetStateToArgument",
-                                                actionArgument = "public",
-                                                actionAnnotation =
-                                                    documentMetadata.confidentiality?.basis
-                                                        ?: "JulkL 24 § 1 mom. 32 k",
-                                            ),
-                                    )
-                            }
-                    }
-            }
-        }
-
-        private fun createInformationSecurityPolicy(): InformationSecurityPolicyType {
-            return InformationSecurityPolicyType().apply {
-                policyConfiguration =
-                    PolicyConfiguration().apply {
-                        policyName = "InformationSecurityPolicy"
-                        initialTargetState = "notSecurityClassified"
-                        rules =
-                            PolicyConfiguration.Rules().apply {
-                                rule =
-                                    createPolicyRule(
-                                        timeSpan = 0,
-                                        triggerEvent = "InPerpetuity",
-                                        action =
-                                            createPolicyAction(
-                                                actionType = "SetTargetStateToArgument",
-                                                actionArgument = "notSecurityClassified",
-                                            ),
-                                    )
-                            }
-                    }
-            }
-        }
-
-        private fun createRetentionPolicy(): RetentionPolicyType {
-            return RetentionPolicyType().apply {
-                policyConfiguration =
-                    PolicyConfiguration().apply {
-                        policyName = "RetentionPolicy"
-                        rules =
-                            PolicyConfiguration.Rules().apply {
-                                rule =
-                                    createPolicyRule(
-                                        timeSpan = 0,
-                                        triggerEvent = "InPerpetuity",
-                                        action =
-                                            createPolicyAction(
-                                                actionType = "AddTimeSpanToTarget",
-                                                actionAnnotation = "KA/13089/07.01.01.03.01/2018",
-                                            ),
-                                    )
-                            }
-                    }
-            }
-        }
-
-        private fun createProtectionPolicy(): ProtectionPolicyType {
-            return ProtectionPolicyType().apply {
-                policyConfiguration =
-                    PolicyConfiguration().apply {
-                        policyName = "ProtectionPolicy"
-                        initialTargetState = "3"
-                        rules =
-                            PolicyConfiguration.Rules().apply {
-                                rule =
-                                    createPolicyRule(
-                                        timeSpan = 0,
-                                        triggerEvent = "InPerpetuity",
-                                        action =
-                                            createPolicyAction(
-                                                actionType = "SetTargetStateToArgument",
-                                                actionArgument = "3",
-                                            ),
-                                    )
-                            }
-                    }
-            }
-        }
-
-        private fun createAgents(
-            archivedProcess: ArchivedProcess?
-        ): StandardMetadataType.DocumentDescription.Agents {
-            return StandardMetadataType.DocumentDescription.Agents().apply {
-                // Get unique agents by their ID to avoid duplicates
-                archivedProcess
-                    ?.history
-                    ?.map { it.enteredBy }
-                    ?.distinctBy { it.id }
-                    ?.forEach { user ->
-                        agent.add(
-                            AgentType().apply {
-                                corporateName = archivedProcess.organization
-                                role = "Henkilökunta" // TODO pitäisikö tämän olla tarkempi rooli?
-                                name = user.name
-                            }
-                        )
-                    }
-            }
-        }
-
-        private fun createDocumentDescription(
-            document: ChildDocumentDetails,
-            documentMetadata: DocumentMetadata,
-            archivedProcess: ArchivedProcess?,
-            childIdentifier: ExternalIdentifier,
-            childBirthDate: java.time.LocalDate,
-        ): StandardMetadataType.DocumentDescription {
-            return StandardMetadataType.DocumentDescription().apply {
-                // Basic document info
-                title = documentMetadata.name
-                documentType = "Suunnitelma" // From Evaka_Särmä_metatietomääritykset.xlsx
-                documentTypeSpecifier =
-                    "Varhaiskasvatussuunnitelma" // From Evaka_Särmä_metatietomääritykset.xlsx
-                personalData =
-                    PersonalDataType.CONTAINS_PERSONAL_INFORMATION // TODO md_instance.xml:
-                // containsPersonalInformation tai
-                // containsSensitivePersonalInformation.
-                // Mistä tämä tulisi päätellä?
-                language = document.template.language.isoLanguage.alpha2
-
-                // From Evaka_Särmä_metatietomääritykset.xlsx
-                dataManagement = "Palvelujen tiedonhallinta"
-                dataSource = "Varhaiskasvatuksen tietovaranto"
-                registerName = "Varhaiskasvatuksen asiakastietorekisteri"
-                personalDataCollectionReason =
-                    "Rekisterinpitäjän lakisääteisten velvoitteiden noudattaminen"
-
-                // Child's information
-                firstName = document.child.firstName
-                lastName = document.child.lastName
-                socialSecurityNumber =
-                    if (childIdentifier is ExternalIdentifier.SSN) childIdentifier.ssn else null
-                birthDate =
-                    childBirthDate.let { date ->
-                        DatatypeFactory.newInstance()
-                            .newXMLGregorianCalendar(
-                                date.year,
-                                date.monthValue,
-                                date.dayOfMonth,
-                                javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-                                javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-                                javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-                                javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-                                javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-                            )
-                    }
-                agents = createAgents(archivedProcess)
-            }
-        }
-
-        private fun createFormat(filename: String): StandardMetadataType.Format {
-            return StandardMetadataType.Format().apply {
-                recordType = ResourceTypeType.DIGITAL
-                mimeType = AcceptedMimeTypeType.APPLICATION_PDF
-                this.fileName = filename
-                fileFormat = AcceptedFileFormatType.NOT_APPLICABLE
-            }
-        }
-
-        private fun createCreation(
-            documentMetadata: DocumentMetadata
-        ): StandardMetadataType.Creation {
-            return StandardMetadataType.Creation().apply {
-                created = documentMetadata.createdAt?.asXMLGregorianCalendar()
-                originatingSystem = "Varhaiskasvatuksen toiminnanohjausjärjestelmä"
-            }
-        }
-
-        private fun createPolicies(
-            documentMetadata: DocumentMetadata
-        ): StandardMetadataType.Policies {
-            return StandardMetadataType.Policies().apply {
-                // Salassapitosääntö
-                disclosurePolicy = createDisclosurePolicy(documentMetadata)
-                // Turvallisuussääntö
-                informationSecurityPolicy = createInformationSecurityPolicy()
-                // Säilytyssääntö
-                retentionPolicy = createRetentionPolicy()
-                // Suojeluluokkasääntö
-                protectionPolicy = createProtectionPolicy()
-            }
-        }
-
-        private fun createCaseFile(
-            documentMetadata: DocumentMetadata,
-            archivedProcess: ArchivedProcess?,
-        ): CaseFileType {
-            return CaseFileType().apply {
-                caseCreated = documentMetadata.createdAt?.asXMLGregorianCalendar()
-                caseFinished =
-                    archivedProcess
-                        ?.history
-                        ?.find { it.state == ArchivedProcessState.COMPLETED }
-                        ?.enteredAt
-                        ?.asXMLGregorianCalendar()
-            }
-        }
-
-        internal fun createDocumentMetadata(
-            document: ChildDocumentDetails,
-            documentMetadata: DocumentMetadata,
-            archivedProcess: ArchivedProcess?,
-            filename: String,
-            childIdentifier: ExternalIdentifier,
-            birthDate: java.time.LocalDate,
-        ): RecordMetadataInstance {
-            return RecordMetadataInstance().apply {
-                standardMetadata =
-                    StandardMetadataType().apply {
-                        metadataMasterVersion =
-                            MetadataMasterVersionType().apply {
-                                masterName = "yleinen"
-                                versionNumber = "1.0"
-                            }
-                        virtualArchiveId = "YLEINEN"
-                        recordIdentifiers =
-                            StandardMetadataType.RecordIdentifiers().apply {
-                                recordIdentifier = document.id.toString()
-                            }
-                        documentDescription =
-                            createDocumentDescription(
-                                document,
-                                documentMetadata,
-                                archivedProcess,
-                                childIdentifier,
-                                birthDate,
-                            )
-                        format = createFormat(filename)
-                        creation = createCreation(documentMetadata)
-                        policies = createPolicies(documentMetadata)
-                        caseFile = createCaseFile(documentMetadata, archivedProcess)
-                    }
-            }
-        }
-    }
-
-    fun uploadToArchive(db: Database.Connection, documentId: ChildDocumentId) {
-        logger.info { "Starting archival process for document $documentId" }
-
-        val document =
-            db.read { tx ->
-                tx.getChildDocument(documentId) ?: throw NotFound("document $documentId not found")
-            }
-        if (
-            document.template.type !in
-                setOf(
-                    DocumentType.VASU,
-                    DocumentType.LEOPS,
-                    DocumentType.HOJKS,
-                    DocumentType.MIGRATED_VASU,
-                    DocumentType.MIGRATED_LEOPS,
-                )
-        ) {
-            logger.warn {
-                "Refusing to archive non-supported document type ${document.template.type} with id $documentId"
-            }
-            return
-        }
-        val childInfo =
-            db.read { tx ->
-                val childId = document.child.id
-                tx.getPersonById(childId)
-                    ?: throw IllegalStateException("No person found with $childId")
-            }
-        val archivedProcess = db.read { tx -> tx.getArchiveProcessByChildDocumentId(documentId) }
-        val documentMetadata = db.read { tx -> tx.getChildDocumentMetadata(documentId) }
-
-        val documentKey =
-            db.read { tx ->
-                tx.getChildDocumentKey(documentId)
-                    ?: throw NotFound("Document key not found for document $documentId")
-            }
-
-        // Get the document from the original location
-        val originalLocation = documentClient.locate(DocumentKey.ChildDocument(documentKey))
-        val documentContent = documentClient.get(originalLocation)
-        val masterId =
-            "yleinen" // Defined as fixed value in Evaka_Särmä_metatietomääritykset.xlsx specs. TODO
-        // should be mapped from metadata
-        val classId =
-            "12.06.01.SL1.RT34" // Defined as fixed value in Evaka_Särmä_metatietomääritykset.xlsx
-        // specs. TODO should be mapped from metadata
-        val virtualArchiveId =
-            "YLEINEN" // Defined as fixed value in Evaka_Särmä_metatietomääritykset.xlsx specs. TODO
-        // should be mapped from metadata
-
-        // Create metadata object and convert to XML
-        val metadata =
-            createDocumentMetadata(
-                document,
-                documentMetadata,
-                archivedProcess,
-                Paths.get(documentContent.name).fileName.toString(),
-                childInfo.identity,
-                childInfo.dateOfBirth,
+    if (
+        document.template.type !in
+            setOf(
+                DocumentType.VASU,
+                DocumentType.LEOPS,
+                DocumentType.HOJKS,
+                DocumentType.MIGRATED_VASU,
+                DocumentType.MIGRATED_LEOPS,
             )
-        val metadataXml = marshalMetadata(metadata)
-        logger.info { "Generated metadata XML: $metadataXml" }
-
-        val (responseCode, responseBody) =
-            client.putDocument(documentContent, metadataXml, masterId, classId, virtualArchiveId)
-        logger.info { "Response code: $responseCode" }
-        logger.info { "Response body: $responseBody" }
-
-        if (responseCode == 200) {
-            db.transaction { tx -> tx.markDocumentAsArchived(documentId, HelsinkiDateTime.now()) }
-            logger.info { "Successfully archived document $documentId" }
-        } else {
-            logger.error {
-                "Failed to archive document $documentId. Response code: $responseCode, Response body: ${responseBody ?: "No response body"}"
-            }
-            throw RuntimeException("Failed to archive document $documentId")
+    ) {
+        logger.warn {
+            "Refusing to archive non-supported document type ${document.template.type} with id $documentId"
         }
+        return
     }
+    val childInfo =
+        db.read { tx ->
+            val childId = document.child.id
+            tx.getPersonById(childId)
+                ?: throw IllegalStateException("No person found with $childId")
+        }
+    val archivedProcess = db.read { tx -> tx.getArchiveProcessByChildDocumentId(documentId) }
+    val documentMetadata = db.read { tx -> tx.getChildDocumentMetadata(documentId) }
+
+    val documentKey =
+        db.read { tx ->
+            tx.getChildDocumentKey(documentId)
+                ?: throw NotFound("Document key not found for document $documentId")
+        }
+
+    // Get the document from the original location
+    val originalLocation = documentClient.locate(DocumentKey.ChildDocument(documentKey))
+    val documentContent = documentClient.get(originalLocation)
+    val masterId =
+        "yleinen" // Defined as fixed value in Evaka_Särmä_metatietomääritykset.xlsx specs. TODO
+    // should be mapped from metadata
+    val classId =
+        "12.06.01.SL1.RT34" // Defined as fixed value in Evaka_Särmä_metatietomääritykset.xlsx
+    // specs. TODO should be mapped from metadata
+    val virtualArchiveId =
+        "YLEINEN" // Defined as fixed value in Evaka_Särmä_metatietomääritykset.xlsx specs. TODO
+    // should be mapped from metadata
+
+    // Create metadata object and convert to XML
+    val metadata =
+        DocumentMetadataUtils.createDocumentMetadata(
+            document,
+            documentMetadata,
+            archivedProcess,
+            Paths.get(documentContent.name).fileName.toString(),
+            childInfo.identity,
+            childInfo.dateOfBirth,
+        )
+    val metadataXml = DocumentMetadataUtils.marshalMetadata(metadata)
+    logger.info { "Generated metadata XML: $metadataXml" }
+
+    val (responseCode, responseBody) =
+        uploadClient.putDocument(documentContent, metadataXml, masterId, classId, virtualArchiveId)
+    logger.info { "HTTP response code: $responseCode" }
+    logger.info { "Response body: $responseBody" }
+
+    val statusCode =
+        URLEncodedUtils.parse(responseBody, StandardCharsets.UTF_8)
+            .find { it.name == "status_code" }
+            ?.value
+            ?.toIntOrNull()
+
+    logger.info { "Parsed status code from response body: $statusCode" }
+
+    if (responseCode != 200 || statusCode != 200) {
+        logger.error {
+            "Failed to archive document $documentId. Response code: $responseCode, Response body: ${responseBody ?: "No response body"}, Parsed status code: $statusCode"
+        }
+        throw RuntimeException("Failed to archive document $documentId")
+    }
+
+    db.transaction { tx -> tx.markDocumentAsArchived(documentId, HelsinkiDateTime.now()) }
+    logger.info { "Successfully archived document $documentId" }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
@@ -6,12 +6,10 @@ package fi.espoo.evaka.document.archival
 
 import fi.espoo.evaka.document.DocumentType
 import fi.espoo.evaka.document.childdocument.*
-import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.process.*
 import fi.espoo.evaka.s3.DocumentKey
 import fi.espoo.evaka.s3.DocumentService
-import fi.espoo.evaka.sarma.model.*
 import fi.espoo.evaka.shared.ChildDocumentId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -19,351 +17,12 @@ import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
 import io.github.oshai.kotlinlogging.KotlinLogging
-import jakarta.xml.bind.JAXBContext
-import java.io.StringWriter
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
-import java.time.ZoneId
-import javax.xml.datatype.DatatypeFactory
-import javax.xml.datatype.XMLGregorianCalendar
 import org.apache.http.client.utils.URLEncodedUtils
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {}
-
-private fun HelsinkiDateTime.asXMLGregorianCalendar(): XMLGregorianCalendar {
-    val zdt = this.toLocalDateTime().atZone(ZoneId.of("Europe/Helsinki"))
-    return DatatypeFactory.newInstance()
-        .newXMLGregorianCalendar(
-            zdt.year,
-            zdt.monthValue,
-            zdt.dayOfMonth,
-            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-        )
-}
-
-object DocumentMetadataUtils {
-    internal fun marshalMetadata(metadata: RecordMetadataInstance): String {
-        val context = JAXBContext.newInstance(RecordMetadataInstance::class.java)
-        val marshaller =
-            context.createMarshaller().apply {
-                // Use namespaces in a similar way as the shared example xml files. TODO check
-                // if this
-                // is actually needed
-                setProperty(
-                    "org.glassfish.jaxb.namespacePrefixMapper",
-                    object : org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper() {
-                        override fun getPreferredPrefix(
-                            namespaceUri: String,
-                            suggestion: String?,
-                            requirePrefix: Boolean,
-                        ): String {
-                            return when (namespaceUri) {
-                                "http://www.avaintec.com/2005/x-archive/record-metadata-instance/2.0" ->
-                                    "ns0"
-                                "http://www.avaintec.com/2004/records-schedule-fi/1.0" -> "at0"
-                                else -> suggestion ?: "ns"
-                            }
-                        }
-                    },
-                )
-            }
-        return StringWriter().use { writer ->
-            marshaller.marshal(metadata, writer)
-            writer.toString()
-        }
-    }
-
-    private fun createPolicyRule(
-        timeSpan: Short,
-        triggerEvent: String,
-        action: PolicyConfiguration.Rules.Rule.Action,
-    ): PolicyConfiguration.Rules.Rule {
-        return PolicyConfiguration.Rules.Rule().apply {
-            this.timeSpan = timeSpan
-            this.triggerEvent = triggerEvent
-            this.action = action
-        }
-    }
-
-    private fun createPolicyAction(
-        actionType: String,
-        actionArgument: String? = null,
-        actionAnnotation: String? = null,
-    ): PolicyConfiguration.Rules.Rule.Action {
-        return PolicyConfiguration.Rules.Rule.Action().apply {
-            this.actionType = actionType
-            if (actionArgument != null) {
-                actionArguments =
-                    PolicyConfiguration.Rules.Rule.Action.ActionArguments().apply {
-                        this.actionArgument = actionArgument
-                    }
-            }
-            if (actionAnnotation != null) {
-                this.actionAnnotation = actionAnnotation
-            }
-        }
-    }
-
-    private fun createDisclosurePolicy(documentMetadata: DocumentMetadata): DisclosurePolicyType {
-        return DisclosurePolicyType().apply {
-            policyConfiguration =
-                PolicyConfiguration().apply {
-                    policyName = "DisclosurePolicy"
-                    initialTargetState =
-                        if (documentMetadata.confidential == true) "confidential" else "public"
-                    rules =
-                        PolicyConfiguration.Rules().apply {
-                            rule =
-                                createPolicyRule(
-                                    // according to Särmä specs, this should be set to 0 for
-                                    // public and permanently confidential documents. If not
-                                    // defined in metadata, we default to 100 years.
-                                    timeSpan =
-                                        if (documentMetadata.confidential == true)
-                                            documentMetadata.confidentiality
-                                                ?.durationYears
-                                                ?.toShort() ?: 100
-                                        else 0,
-                                    // years from document creation (creation.created in xml)
-                                    triggerEvent = "YearsFromRecordCreation",
-                                    action =
-                                        createPolicyAction(
-                                            actionType = "SetTargetStateToArgument",
-                                            actionArgument = "public",
-                                            actionAnnotation =
-                                                documentMetadata.confidentiality?.basis
-                                                    ?: "JulkL 24 § 1 mom. 32 k",
-                                        ),
-                                )
-                        }
-                }
-        }
-    }
-
-    private fun createInformationSecurityPolicy(): InformationSecurityPolicyType {
-        return InformationSecurityPolicyType().apply {
-            policyConfiguration =
-                PolicyConfiguration().apply {
-                    policyName = "InformationSecurityPolicy"
-                    initialTargetState = "notSecurityClassified"
-                    rules =
-                        PolicyConfiguration.Rules().apply {
-                            rule =
-                                createPolicyRule(
-                                    timeSpan = 0,
-                                    triggerEvent = "InPerpetuity",
-                                    action =
-                                        createPolicyAction(
-                                            actionType = "SetTargetStateToArgument",
-                                            actionArgument = "notSecurityClassified",
-                                        ),
-                                )
-                        }
-                }
-        }
-    }
-
-    private fun createRetentionPolicy(): RetentionPolicyType {
-        return RetentionPolicyType().apply {
-            policyConfiguration =
-                PolicyConfiguration().apply {
-                    policyName = "RetentionPolicy"
-                    rules =
-                        PolicyConfiguration.Rules().apply {
-                            rule =
-                                createPolicyRule(
-                                    timeSpan = 0,
-                                    triggerEvent = "InPerpetuity",
-                                    action =
-                                        createPolicyAction(
-                                            actionType = "AddTimeSpanToTarget",
-                                            actionAnnotation = "KA/13089/07.01.01.03.01/2018",
-                                        ),
-                                )
-                        }
-                }
-        }
-    }
-
-    private fun createProtectionPolicy(): ProtectionPolicyType {
-        return ProtectionPolicyType().apply {
-            policyConfiguration =
-                PolicyConfiguration().apply {
-                    policyName = "ProtectionPolicy"
-                    initialTargetState = "3"
-                    rules =
-                        PolicyConfiguration.Rules().apply {
-                            rule =
-                                createPolicyRule(
-                                    timeSpan = 0,
-                                    triggerEvent = "InPerpetuity",
-                                    action =
-                                        createPolicyAction(
-                                            actionType = "SetTargetStateToArgument",
-                                            actionArgument = "3",
-                                        ),
-                                )
-                        }
-                }
-        }
-    }
-
-    private fun createAgents(
-        archivedProcess: ArchivedProcess?
-    ): StandardMetadataType.DocumentDescription.Agents {
-        return StandardMetadataType.DocumentDescription.Agents().apply {
-            // Get unique agents by their ID to avoid duplicates
-            archivedProcess
-                ?.history
-                ?.map { it.enteredBy }
-                ?.distinctBy { it.id }
-                ?.forEach { user ->
-                    agent.add(
-                        AgentType().apply {
-                            corporateName = archivedProcess.organization
-                            role = "Henkilökunta" // TODO pitäisikö tämän olla tarkempi rooli?
-                            name = user.name
-                        }
-                    )
-                }
-        }
-    }
-
-    private fun createDocumentDescription(
-        document: ChildDocumentDetails,
-        documentMetadata: DocumentMetadata,
-        archivedProcess: ArchivedProcess?,
-        childIdentifier: ExternalIdentifier,
-        childBirthDate: java.time.LocalDate,
-    ): StandardMetadataType.DocumentDescription {
-        return StandardMetadataType.DocumentDescription().apply {
-            // Basic document info
-            title = documentMetadata.name
-            documentType = "Suunnitelma" // From Evaka_Särmä_metatietomääritykset.xlsx
-            documentTypeSpecifier =
-                "Varhaiskasvatussuunnitelma" // From Evaka_Särmä_metatietomääritykset.xlsx
-            personalData = PersonalDataType.CONTAINS_PERSONAL_INFORMATION // TODO md_instance.xml:
-            // containsPersonalInformation tai
-            // containsSensitivePersonalInformation.
-            // Mistä tämä tulisi päätellä?
-            language = document.template.language.isoLanguage.alpha2
-
-            // From Evaka_Särmä_metatietomääritykset.xlsx
-            dataManagement = "Palvelujen tiedonhallinta"
-            dataSource = "Varhaiskasvatuksen tietovaranto"
-            registerName = "Varhaiskasvatuksen asiakastietorekisteri"
-            personalDataCollectionReason =
-                "Rekisterinpitäjän lakisääteisten velvoitteiden noudattaminen"
-
-            // Child's information
-            firstName = document.child.firstName
-            lastName = document.child.lastName
-            socialSecurityNumber =
-                if (childIdentifier is ExternalIdentifier.SSN) childIdentifier.ssn else null
-            birthDate =
-                childBirthDate.let { date ->
-                    DatatypeFactory.newInstance()
-                        .newXMLGregorianCalendar(
-                            date.year,
-                            date.monthValue,
-                            date.dayOfMonth,
-                            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-                            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-                            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-                            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-                            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
-                        )
-                }
-            agents = createAgents(archivedProcess)
-        }
-    }
-
-    private fun createFormat(filename: String): StandardMetadataType.Format {
-        return StandardMetadataType.Format().apply {
-            recordType = ResourceTypeType.DIGITAL
-            mimeType = AcceptedMimeTypeType.APPLICATION_PDF
-            this.fileName = filename
-            fileFormat = AcceptedFileFormatType.NOT_APPLICABLE
-        }
-    }
-
-    private fun createCreation(documentMetadata: DocumentMetadata): StandardMetadataType.Creation {
-        return StandardMetadataType.Creation().apply {
-            created = documentMetadata.createdAt?.asXMLGregorianCalendar()
-            originatingSystem = "Varhaiskasvatuksen toiminnanohjausjärjestelmä"
-        }
-    }
-
-    private fun createPolicies(documentMetadata: DocumentMetadata): StandardMetadataType.Policies {
-        return StandardMetadataType.Policies().apply {
-            // Salassapitosääntö
-            disclosurePolicy = createDisclosurePolicy(documentMetadata)
-            // Turvallisuussääntö
-            informationSecurityPolicy = createInformationSecurityPolicy()
-            // Säilytyssääntö
-            retentionPolicy = createRetentionPolicy()
-            // Suojeluluokkasääntö
-            protectionPolicy = createProtectionPolicy()
-        }
-    }
-
-    private fun createCaseFile(
-        documentMetadata: DocumentMetadata,
-        archivedProcess: ArchivedProcess?,
-    ): CaseFileType {
-        return CaseFileType().apply {
-            caseCreated = documentMetadata.createdAt?.asXMLGregorianCalendar()
-            caseFinished =
-                archivedProcess
-                    ?.history
-                    ?.find { it.state == ArchivedProcessState.COMPLETED }
-                    ?.enteredAt
-                    ?.asXMLGregorianCalendar()
-        }
-    }
-
-    internal fun createDocumentMetadata(
-        document: ChildDocumentDetails,
-        documentMetadata: DocumentMetadata,
-        archivedProcess: ArchivedProcess?,
-        filename: String,
-        childIdentifier: ExternalIdentifier,
-        birthDate: java.time.LocalDate,
-    ): RecordMetadataInstance {
-        return RecordMetadataInstance().apply {
-            standardMetadata =
-                StandardMetadataType().apply {
-                    metadataMasterVersion =
-                        MetadataMasterVersionType().apply {
-                            masterName = "yleinen"
-                            versionNumber = "1.0"
-                        }
-                    virtualArchiveId = "YLEINEN"
-                    recordIdentifiers =
-                        StandardMetadataType.RecordIdentifiers().apply {
-                            recordIdentifier = document.id.toString()
-                        }
-                    documentDescription =
-                        createDocumentDescription(
-                            document,
-                            documentMetadata,
-                            archivedProcess,
-                            childIdentifier,
-                            birthDate,
-                        )
-                    format = createFormat(filename)
-                    creation = createCreation(documentMetadata)
-                    policies = createPolicies(documentMetadata)
-                    caseFile = createCaseFile(documentMetadata, archivedProcess)
-                }
-        }
-    }
-}
 
 @Service
 class ArchiveChildDocumentService(
@@ -436,7 +95,7 @@ fun uploadToArchive(
 
     // Create metadata object and convert to XML
     val metadata =
-        DocumentMetadataUtils.createDocumentMetadata(
+        createDocumentMetadata(
             document,
             documentMetadata,
             archivedProcess,
@@ -444,7 +103,7 @@ fun uploadToArchive(
             childInfo.identity,
             childInfo.dateOfBirth,
         )
-    val metadataXml = DocumentMetadataUtils.marshalMetadata(metadata)
+    val metadataXml = marshalMetadata(metadata)
     logger.info { "Generated metadata XML: $metadataXml" }
 
     val (responseCode, responseBody) =

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/DocumentMetadataUtils.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/DocumentMetadataUtils.kt
@@ -1,0 +1,349 @@
+// SPDX-FileCopyrightText: 2017-2025 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.document.archival
+
+import fi.espoo.evaka.document.childdocument.ChildDocumentDetails
+import fi.espoo.evaka.identity.ExternalIdentifier
+import fi.espoo.evaka.process.ArchivedProcess
+import fi.espoo.evaka.process.ArchivedProcessState
+import fi.espoo.evaka.process.DocumentMetadata
+import fi.espoo.evaka.sarma.model.*
+import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import jakarta.xml.bind.JAXBContext
+import java.io.StringWriter
+import java.time.ZoneId
+import javax.xml.datatype.DatatypeFactory
+import javax.xml.datatype.XMLGregorianCalendar
+
+private fun HelsinkiDateTime.asXMLGregorianCalendar(): XMLGregorianCalendar {
+    val zdt = this.toLocalDateTime().atZone(ZoneId.of("Europe/Helsinki"))
+    return DatatypeFactory.newInstance()
+        .newXMLGregorianCalendar(
+            zdt.year,
+            zdt.monthValue,
+            zdt.dayOfMonth,
+            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+        )
+}
+
+fun marshalMetadata(metadata: RecordMetadataInstance): String {
+    val context = JAXBContext.newInstance(RecordMetadataInstance::class.java)
+    val marshaller =
+        context.createMarshaller().apply {
+            // Use namespaces in a similar way as the shared example xml files. TODO check
+            // if this
+            // is actually needed
+            setProperty(
+                "org.glassfish.jaxb.namespacePrefixMapper",
+                object : org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper() {
+                    override fun getPreferredPrefix(
+                        namespaceUri: String,
+                        suggestion: String?,
+                        requirePrefix: Boolean,
+                    ): String {
+                        return when (namespaceUri) {
+                            "http://www.avaintec.com/2005/x-archive/record-metadata-instance/2.0" ->
+                                "ns0"
+                            "http://www.avaintec.com/2004/records-schedule-fi/1.0" -> "at0"
+                            else -> suggestion ?: "ns"
+                        }
+                    }
+                },
+            )
+        }
+    return StringWriter().use { writer ->
+        marshaller.marshal(metadata, writer)
+        writer.toString()
+    }
+}
+
+private fun createPolicyRule(
+    timeSpan: Short,
+    triggerEvent: String,
+    action: PolicyConfiguration.Rules.Rule.Action,
+): PolicyConfiguration.Rules.Rule {
+    return PolicyConfiguration.Rules.Rule().apply {
+        this.timeSpan = timeSpan
+        this.triggerEvent = triggerEvent
+        this.action = action
+    }
+}
+
+private fun createPolicyAction(
+    actionType: String,
+    actionArgument: String? = null,
+    actionAnnotation: String? = null,
+): PolicyConfiguration.Rules.Rule.Action {
+    return PolicyConfiguration.Rules.Rule.Action().apply {
+        this.actionType = actionType
+        if (actionArgument != null) {
+            actionArguments =
+                PolicyConfiguration.Rules.Rule.Action.ActionArguments().apply {
+                    this.actionArgument = actionArgument
+                }
+        }
+        if (actionAnnotation != null) {
+            this.actionAnnotation = actionAnnotation
+        }
+    }
+}
+
+private fun createDisclosurePolicy(documentMetadata: DocumentMetadata): DisclosurePolicyType {
+    return DisclosurePolicyType().apply {
+        policyConfiguration =
+            PolicyConfiguration().apply {
+                policyName = "DisclosurePolicy"
+                initialTargetState =
+                    if (documentMetadata.confidential == true) "confidential" else "public"
+                rules =
+                    PolicyConfiguration.Rules().apply {
+                        rule =
+                            createPolicyRule(
+                                // according to Särmä specs, this should be set to 0 for
+                                // public and permanently confidential documents. If not
+                                // defined in metadata, we default to 100 years.
+                                timeSpan =
+                                    if (documentMetadata.confidential == true)
+                                        documentMetadata.confidentiality?.durationYears?.toShort()
+                                            ?: 100
+                                    else 0,
+                                // years from document creation (creation.created in xml)
+                                triggerEvent = "YearsFromRecordCreation",
+                                action =
+                                    createPolicyAction(
+                                        actionType = "SetTargetStateToArgument",
+                                        actionArgument = "public",
+                                        actionAnnotation =
+                                            documentMetadata.confidentiality?.basis
+                                                ?: "JulkL 24 § 1 mom. 32 k",
+                                    ),
+                            )
+                    }
+            }
+    }
+}
+
+private fun createInformationSecurityPolicy(): InformationSecurityPolicyType {
+    return InformationSecurityPolicyType().apply {
+        policyConfiguration =
+            PolicyConfiguration().apply {
+                policyName = "InformationSecurityPolicy"
+                initialTargetState = "notSecurityClassified"
+                rules =
+                    PolicyConfiguration.Rules().apply {
+                        rule =
+                            createPolicyRule(
+                                timeSpan = 0,
+                                triggerEvent = "InPerpetuity",
+                                action =
+                                    createPolicyAction(
+                                        actionType = "SetTargetStateToArgument",
+                                        actionArgument = "notSecurityClassified",
+                                    ),
+                            )
+                    }
+            }
+    }
+}
+
+private fun createRetentionPolicy(): RetentionPolicyType {
+    return RetentionPolicyType().apply {
+        policyConfiguration =
+            PolicyConfiguration().apply {
+                policyName = "RetentionPolicy"
+                rules =
+                    PolicyConfiguration.Rules().apply {
+                        rule =
+                            createPolicyRule(
+                                timeSpan = 0,
+                                triggerEvent = "InPerpetuity",
+                                action =
+                                    createPolicyAction(
+                                        actionType = "AddTimeSpanToTarget",
+                                        actionAnnotation = "KA/13089/07.01.01.03.01/2018",
+                                    ),
+                            )
+                    }
+            }
+    }
+}
+
+private fun createProtectionPolicy(): ProtectionPolicyType {
+    return ProtectionPolicyType().apply {
+        policyConfiguration =
+            PolicyConfiguration().apply {
+                policyName = "ProtectionPolicy"
+                initialTargetState = "3"
+                rules =
+                    PolicyConfiguration.Rules().apply {
+                        rule =
+                            createPolicyRule(
+                                timeSpan = 0,
+                                triggerEvent = "InPerpetuity",
+                                action =
+                                    createPolicyAction(
+                                        actionType = "SetTargetStateToArgument",
+                                        actionArgument = "3",
+                                    ),
+                            )
+                    }
+            }
+    }
+}
+
+private fun createAgents(
+    archivedProcess: ArchivedProcess?
+): StandardMetadataType.DocumentDescription.Agents {
+    return StandardMetadataType.DocumentDescription.Agents().apply {
+        // Get unique agents by their ID to avoid duplicates
+        archivedProcess
+            ?.history
+            ?.map { it.enteredBy }
+            ?.distinctBy { it.id }
+            ?.forEach { user ->
+                agent.add(
+                    AgentType().apply {
+                        corporateName = archivedProcess.organization
+                        role = "Henkilökunta" // TODO pitäisikö tämän olla tarkempi rooli?
+                        name = user.name
+                    }
+                )
+            }
+    }
+}
+
+private fun createDocumentDescription(
+    document: ChildDocumentDetails,
+    documentMetadata: DocumentMetadata,
+    archivedProcess: ArchivedProcess?,
+    childIdentifier: ExternalIdentifier,
+    childBirthDate: java.time.LocalDate,
+): StandardMetadataType.DocumentDescription {
+    return StandardMetadataType.DocumentDescription().apply {
+        // Basic document info
+        title = documentMetadata.name
+        documentType = "Suunnitelma" // From Evaka_Särmä_metatietomääritykset.xlsx
+        documentTypeSpecifier =
+            "Varhaiskasvatussuunnitelma" // From Evaka_Särmä_metatietomääritykset.xlsx
+        personalData = PersonalDataType.CONTAINS_PERSONAL_INFORMATION // TODO md_instance.xml:
+        // containsPersonalInformation tai
+        // containsSensitivePersonalInformation.
+        // Mistä tämä tulisi päätellä?
+        language = document.template.language.isoLanguage.alpha2
+
+        // From Evaka_Särmä_metatietomääritykset.xlsx
+        dataManagement = "Palvelujen tiedonhallinta"
+        dataSource = "Varhaiskasvatuksen tietovaranto"
+        registerName = "Varhaiskasvatuksen asiakastietorekisteri"
+        personalDataCollectionReason =
+            "Rekisterinpitäjän lakisääteisten velvoitteiden noudattaminen"
+
+        // Child's information
+        firstName = document.child.firstName
+        lastName = document.child.lastName
+        socialSecurityNumber =
+            if (childIdentifier is ExternalIdentifier.SSN) childIdentifier.ssn else null
+        birthDate =
+            childBirthDate.let { date ->
+                DatatypeFactory.newInstance()
+                    .newXMLGregorianCalendar(
+                        date.year,
+                        date.monthValue,
+                        date.dayOfMonth,
+                        javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+                        javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+                        javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+                        javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+                        javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED,
+                    )
+            }
+        agents = createAgents(archivedProcess)
+    }
+}
+
+private fun createFormat(filename: String): StandardMetadataType.Format {
+    return StandardMetadataType.Format().apply {
+        recordType = ResourceTypeType.DIGITAL
+        mimeType = AcceptedMimeTypeType.APPLICATION_PDF
+        this.fileName = filename
+        fileFormat = AcceptedFileFormatType.NOT_APPLICABLE
+    }
+}
+
+private fun createCreation(documentMetadata: DocumentMetadata): StandardMetadataType.Creation {
+    return StandardMetadataType.Creation().apply {
+        created = documentMetadata.createdAt?.asXMLGregorianCalendar()
+        originatingSystem = "Varhaiskasvatuksen toiminnanohjausjärjestelmä"
+    }
+}
+
+private fun createPolicies(documentMetadata: DocumentMetadata): StandardMetadataType.Policies {
+    return StandardMetadataType.Policies().apply {
+        // Salassapitosääntö
+        disclosurePolicy = createDisclosurePolicy(documentMetadata)
+        // Turvallisuussääntö
+        informationSecurityPolicy = createInformationSecurityPolicy()
+        // Säilytyssääntö
+        retentionPolicy = createRetentionPolicy()
+        // Suojeluluokkasääntö
+        protectionPolicy = createProtectionPolicy()
+    }
+}
+
+private fun createCaseFile(
+    documentMetadata: DocumentMetadata,
+    archivedProcess: ArchivedProcess?,
+): CaseFileType {
+    return CaseFileType().apply {
+        caseCreated = documentMetadata.createdAt?.asXMLGregorianCalendar()
+        caseFinished =
+            archivedProcess
+                ?.history
+                ?.find { it.state == ArchivedProcessState.COMPLETED }
+                ?.enteredAt
+                ?.asXMLGregorianCalendar()
+    }
+}
+
+fun createDocumentMetadata(
+    document: ChildDocumentDetails,
+    documentMetadata: DocumentMetadata,
+    archivedProcess: ArchivedProcess?,
+    filename: String,
+    childIdentifier: ExternalIdentifier,
+    birthDate: java.time.LocalDate,
+): RecordMetadataInstance {
+    return RecordMetadataInstance().apply {
+        standardMetadata =
+            StandardMetadataType().apply {
+                metadataMasterVersion =
+                    MetadataMasterVersionType().apply {
+                        masterName = "yleinen"
+                        versionNumber = "1.0"
+                    }
+                virtualArchiveId = "YLEINEN"
+                recordIdentifiers =
+                    StandardMetadataType.RecordIdentifiers().apply {
+                        recordIdentifier = document.id.toString()
+                    }
+                documentDescription =
+                    createDocumentDescription(
+                        document,
+                        documentMetadata,
+                        archivedProcess,
+                        childIdentifier,
+                        birthDate,
+                    )
+                format = createFormat(filename)
+                creation = createCreation(documentMetadata)
+                policies = createPolicies(documentMetadata)
+                caseFile = createCaseFile(documentMetadata, archivedProcess)
+            }
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäHttpClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäHttpClient.kt
@@ -36,6 +36,7 @@ class SärmäHttpClient(private val archiveEnv: ArchiveEnv?) : SärmäClientInte
                 .setType(MultipartBody.FORM)
                 .addFormDataPart("protocol_version", "1.0")
                 .addFormDataPart("operation_id", "PUT")
+                .addFormDataPart("response_format", "URL-ENCODED")
                 .addFormDataPart("user_id", archiveEnv.userId)
                 .addFormDataPart("user_role", archiveEnv.userRole)
                 .addFormDataPart("nr_of_instances", "1")

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäMockClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/SärmäMockClient.kt
@@ -14,6 +14,9 @@ class SärmäMockClient : SärmäClientInterface {
         classId: String,
         virtualArchiveId: String,
     ): Pair<Int, String?> {
-        return Pair(200, "OK")
+        return Pair(
+            200,
+            "status_message=Success.&transaction_id=2872934&protocol_version=1.0&status_code=200&instance_ids=354319&",
+        )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
@@ -366,22 +366,6 @@ fun Database.Transaction.updateChildDocumentKey(id: ChildDocumentId, documentKey
         .updateExactlyOne()
 }
 
-fun Database.Transaction.setChildDocumentProcessId(
-    documentId: ChildDocumentId,
-    processId: ArchivedProcessId,
-) {
-    createUpdate {
-            sql(
-                """
-UPDATE child_document 
-SET process_id = ${bind(processId)} 
-WHERE id = ${bind(documentId)}
-"""
-            )
-        }
-        .updateExactlyOne()
-}
-
 fun Database.Transaction.resetChildDocumentKey(ids: List<ChildDocumentId>) {
     executeBatch(ids) {
         sql(

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
@@ -366,6 +366,22 @@ fun Database.Transaction.updateChildDocumentKey(id: ChildDocumentId, documentKey
         .updateExactlyOne()
 }
 
+fun Database.Transaction.setChildDocumentProcessId(
+    documentId: ChildDocumentId,
+    processId: ArchivedProcessId,
+) {
+    createUpdate {
+            sql(
+                """
+UPDATE child_document 
+SET process_id = ${bind(processId)} 
+WHERE id = ${bind(documentId)}
+"""
+            )
+        }
+        .updateExactlyOne()
+}
+
 fun Database.Transaction.resetChildDocumentKey(ids: List<ChildDocumentId>) {
     executeBatch(ids) {
         sql(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -1454,8 +1454,8 @@ fun Database.Transaction.insert(row: DevChildDocument): ChildDocumentId =
     createUpdate {
             sql(
                 """
-INSERT INTO child_document (id, status, child_id, template_id, content, published_content, modified_at, content_modified_at, content_modified_by, published_at, answered_at, answered_by)
-VALUES (${bind(row.id)}, ${bind(row.status)}, ${bind(row.childId)}, ${bind(row.templateId)}, ${bind(row.content)}, ${bind(row.publishedContent)}, ${bind(row.modifiedAt)}, ${bind(row.contentModifiedAt)}, ${bind(row.contentModifiedBy)}, ${bind(row.publishedAt)}, ${bind(row.answeredAt)}, ${bind(row.answeredBy)})
+INSERT INTO child_document (id, status, child_id, template_id, content, published_content, modified_at, content_modified_at, content_modified_by, published_at, answered_at, answered_by, process_id)
+VALUES (${bind(row.id)}, ${bind(row.status)}, ${bind(row.childId)}, ${bind(row.templateId)}, ${bind(row.content)}, ${bind(row.publishedContent)}, ${bind(row.modifiedAt)}, ${bind(row.contentModifiedAt)}, ${bind(row.contentModifiedBy)}, ${bind(row.publishedAt)}, ${bind(row.answeredAt)}, ${bind(row.answeredBy)}, ${bind(row.processId)})
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -128,61 +128,7 @@ import fi.espoo.evaka.serviceneed.ShiftCareType
 import fi.espoo.evaka.serviceneed.application.ServiceApplicationDecisionStatus
 import fi.espoo.evaka.sficlient.MockSfiMessagesClient
 import fi.espoo.evaka.sficlient.SfiMessage
-import fi.espoo.evaka.shared.AbsenceId
-import fi.espoo.evaka.shared.ApplicationId
-import fi.espoo.evaka.shared.AreaId
-import fi.espoo.evaka.shared.AssistanceActionId
-import fi.espoo.evaka.shared.AssistanceActionOptionId
-import fi.espoo.evaka.shared.AssistanceFactorId
-import fi.espoo.evaka.shared.AssistanceNeedDecisionId
-import fi.espoo.evaka.shared.AssistanceNeedPreschoolDecisionId
-import fi.espoo.evaka.shared.AssistanceNeedVoucherCoefficientId
-import fi.espoo.evaka.shared.BackupCareId
-import fi.espoo.evaka.shared.CalendarEventAttendeeId
-import fi.espoo.evaka.shared.CalendarEventId
-import fi.espoo.evaka.shared.CalendarEventTimeId
-import fi.espoo.evaka.shared.ChildDailyNoteId
-import fi.espoo.evaka.shared.ChildDocumentId
-import fi.espoo.evaka.shared.ChildId
-import fi.espoo.evaka.shared.ChildStickyNoteId
-import fi.espoo.evaka.shared.ClubTermId
-import fi.espoo.evaka.shared.DailyServiceTimeNotificationId
-import fi.espoo.evaka.shared.DailyServiceTimesId
-import fi.espoo.evaka.shared.DaycareAssistanceId
-import fi.espoo.evaka.shared.DaycareCaretakerId
-import fi.espoo.evaka.shared.DaycareId
-import fi.espoo.evaka.shared.DecisionId
-import fi.espoo.evaka.shared.DocumentTemplateId
-import fi.espoo.evaka.shared.EmployeeId
-import fi.espoo.evaka.shared.EvakaUserId
-import fi.espoo.evaka.shared.FeatureConfig
-import fi.espoo.evaka.shared.FeeDecisionId
-import fi.espoo.evaka.shared.FeeThresholdsId
-import fi.espoo.evaka.shared.GroupId
-import fi.espoo.evaka.shared.GroupNoteId
-import fi.espoo.evaka.shared.GroupPlacementId
-import fi.espoo.evaka.shared.HolidayPeriodId
-import fi.espoo.evaka.shared.HolidayQuestionnaireId
-import fi.espoo.evaka.shared.HtmlSafe
-import fi.espoo.evaka.shared.IncomeStatementId
-import fi.espoo.evaka.shared.MessageAccountId
-import fi.espoo.evaka.shared.MessageThreadFolderId
-import fi.espoo.evaka.shared.MessageThreadId
-import fi.espoo.evaka.shared.MobileDeviceId
-import fi.espoo.evaka.shared.OtherAssistanceMeasureId
-import fi.espoo.evaka.shared.PairingId
-import fi.espoo.evaka.shared.ParentshipId
-import fi.espoo.evaka.shared.PaymentId
-import fi.espoo.evaka.shared.PedagogicalDocumentId
-import fi.espoo.evaka.shared.PersonId
-import fi.espoo.evaka.shared.PlacementId
-import fi.espoo.evaka.shared.PreschoolAssistanceId
-import fi.espoo.evaka.shared.PreschoolTermId
-import fi.espoo.evaka.shared.ServiceApplicationId
-import fi.espoo.evaka.shared.ServiceNeedId
-import fi.espoo.evaka.shared.ServiceNeedOptionId
-import fi.espoo.evaka.shared.StaffAttendanceRealtimeId
-import fi.espoo.evaka.shared.VoucherValueDecisionId
+import fi.espoo.evaka.shared.*
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.*
 import fi.espoo.evaka.shared.data.DateSet
@@ -2379,6 +2325,7 @@ data class DevChildDocument(
     val publishedAt: HelsinkiDateTime?,
     val answeredAt: HelsinkiDateTime?,
     val answeredBy: EvakaUserId?,
+    val processId: ArchivedProcessId? = null,
 )
 
 data class Citizen(

--- a/service/src/test/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceTest.kt
@@ -5,8 +5,8 @@
 package fi.espoo.evaka.document.archival
 
 import fi.espoo.evaka.document.*
-import fi.espoo.evaka.document.archival.ArchiveChildDocumentService.Companion.createDocumentMetadata
-import fi.espoo.evaka.document.archival.ArchiveChildDocumentService.Companion.marshalMetadata
+import fi.espoo.evaka.document.archival.DocumentMetadataUtils.createDocumentMetadata
+import fi.espoo.evaka.document.archival.DocumentMetadataUtils.marshalMetadata
 import fi.espoo.evaka.document.childdocument.*
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.placement.PlacementType

--- a/service/src/test/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceTest.kt
@@ -5,8 +5,6 @@
 package fi.espoo.evaka.document.archival
 
 import fi.espoo.evaka.document.*
-import fi.espoo.evaka.document.archival.DocumentMetadataUtils.createDocumentMetadata
-import fi.espoo.evaka.document.archival.DocumentMetadataUtils.marshalMetadata
 import fi.espoo.evaka.document.childdocument.*
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.placement.PlacementType


### PR DESCRIPTION
## Ennen tätä muutosta
Särmän APIn HTTP 200 tulkittiin onnistuneeksi arkistoon vienniksi, vaikka todellisuudessa HTTP 200 saattoi sisältää response bodyssä virheviestin "validaatio failure"

## Tämän muutoksen jälkeen
Särmän API response pyydetään `response_format` `"URL-ENCODED"` muodossa ja tästä parsitaan `status_code` tieto. Lisätty myös integraatiotestit