### PR TITLE
Fix precommit when modifying generated files

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,7 +7,7 @@ pre-commit:
     - group:
         parallel: true
         jobs:
-          - run: yarn exec eslint --fix --max-warnings 0 {staged_files}
+          - run: yarn exec eslint --fix --no-warn-ignored --max-warnings 0 {staged_files}
             glob: frontend/*.{ts,tsx,js,mjs}
             root: frontend
             stage_fixed: true


### PR DESCRIPTION
Add `–-no-warn-ignored` flag so that eslint doesn't error when `staged_files` contains an ignored file (e.g. files generated by codegen).
