### PR TITLE
Estetään loma-ajan kyselyn turha näkyminen kuntalaiselle

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
@@ -105,7 +105,7 @@ class HolidayPeriodControllerCitizenIntegrationTest :
     }
 
     @Test
-    fun `active questionnaire is eligible for all children when there are no conditions`() {
+    fun `active questionnaire is eligible for all children with active placement when there are no conditions`() {
         db.transaction { tx -> tx.insertGuardian(parent.id, child2.id) }
         createFixedPeriodQuestionnaire(freePeriodQuestionnaire)
 
@@ -114,7 +114,7 @@ class HolidayPeriodControllerCitizenIntegrationTest :
         assertEquals(1, response.size)
         assertThat(response[0].eligibleChildren)
             .containsExactlyInAnyOrderEntriesOf(
-                mapOf(child1.id to freePeriodQuestionnaire.periodOptions, child2.id to emptyList())
+                mapOf(child1.id to freePeriodQuestionnaire.periodOptions)
             )
     }
 
@@ -170,7 +170,7 @@ class HolidayPeriodControllerCitizenIntegrationTest :
         assertEquals(1, response.size)
         assertThat(response[0].eligibleChildren)
             .containsExactlyInAnyOrderEntriesOf(
-                mapOf(child1.id to freePeriodQuestionnaire.periodOptions, child4.id to emptyList())
+                mapOf(child1.id to freePeriodQuestionnaire.periodOptions)
             )
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -282,14 +282,21 @@ class HolidayPeriodControllerCitizen(
                         PlacementType.invoiced,
                         FiniteDateRange(min, max),
                     )
-                eligibleChildren.associateWith { childId ->
-                    placementRangesByChild[childId]?.let { placementRanges ->
-                        periodOptions.filter { option -> placementRanges.contains(option) }
-                    } ?: emptyList()
-                }
+                eligibleChildren
+                    .mapNotNull { childId ->
+                        placementRangesByChild[childId]?.let { placementRanges ->
+                            val dates =
+                                periodOptions.filter { option -> placementRanges.contains(option) }
+                            if (dates.isNotEmpty()) childId to dates else null
+                        }
+                    }
+                    .toMap()
             }
-            is HolidayQuestionnaire.OpenRangesQuestionnaire ->
-                eligibleChildren.associateWith { listOf(questionnaire.period) }
+            is HolidayQuestionnaire.OpenRangesQuestionnaire -> {
+                eligibleChildren
+                    .associateWith { listOf(questionnaire.period) }
+                    .filterValues { it.isNotEmpty() }
+            }
         }
     }
 


### PR DESCRIPTION
## Ennen tätä muutosta
Loma-ajan kyselyn muistutus ja vastaus nappi oli näkyvissä kuntalaiselle vaikka yhdellekkään lapselle ei ollut tarjolla valittavaa vastausta
## Tämän muutoksen jälkeen
Turhia kyselyitä ja niiden muistutuksia ei näytetä