### PR TITLE
Korjataan ryhmää odottavien lasten ikäsarake

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/MissingGroupPlacements.tsx
@@ -68,9 +68,7 @@ function renderMissingGroupPlacementRow(
       </Td>
       <Td>
         <FixedSpaceRow spacing="xs" alignItems="center">
-          <AgeIndicatorChip
-            age={placementPeriod.start.differenceInYears(dateOfBirth)}
-          />
+          <AgeIndicatorChip age={gap.start.differenceInYears(dateOfBirth)} />
           <span data-qa="child-dob">{dateOfBirth.format()}</span>
         </FixedSpaceRow>
       </Td>


### PR DESCRIPTION
Lapsen ikä "Ryhmää odottavat lapset" kohdassa lasketaan väärästä päivämäärästä (=sijoituksen alkupäivästä), vaikka oikea toiminnallisuus olisi tietysti ryhmityksen puuttumisen alkupäivä.