### PR TITLE
Tuloselvityksen tekstimuutos

### DIFF
--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2109,7 +2109,7 @@ const en: Translations = {
       provideAttachments:
         'I will submit the information as attachments, and my information can be checked from Kela if necessary',
       attachmentsVerificationInfo:
-        'Income information is verified at least annually.',
+        'Make a new income statement no later than in a year.',
       estimate: 'Estimate of my gross income',
       noIncome:
         'I have no income or allowance, and my information can be checked from the Incomes Register and Kela',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2353,7 +2353,7 @@ export default {
         'Minulla ei ole mitään tuloja tai tukia. Tietoni saa tarkastaa tulorekisteristä sekä Kelasta.',
       noIncomeDescription: 'Kuvaile tilannettasi tarkemmin',
       attachmentsVerificationInfo:
-        'Tulotiedot tarkistetaan vähintään vuoden välein.',
+        'Tee uusi tuloselvitys viimeistään vuoden päästä.',
       estimate: 'Arvio bruttotuloistani',
       estimatedMonthlyIncome: 'Keskimääräiset tulot sisältäen lomarahat, €/kk',
       otherIncome: 'Muut tulot',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2353,7 +2353,7 @@ const sv: Translations = {
       provideAttachments:
         'Jag lämnar in uppgifterna som bilaga, och mina uppgifter får kontrolleras hos FPA vid behov',
       attachmentsVerificationInfo:
-        'Inkomstuppgifter kontrolleras minst årligen.',
+        'Gör en ny inkomstutredning senast om ett år.',
       estimate: 'Uppskattning av mina bruttoinkomster',
       noIncome:
         'Jag har inga inkomster eller bidrag, och mina uppgifter får kontrolleras i inkomstregistret samt hos FPA',


### PR DESCRIPTION
Vanha:
<img width="449" alt="Screenshot 2025-04-04 at 15 05 33" src="https://github.com/user-attachments/assets/d8befe0e-dfc8-4b72-88b0-dca2a3b67ce5" />

Uusi:
<img width="445" alt="Screenshot 2025-04-04 at 15 07 12" src="https://github.com/user-attachments/assets/03f2bd57-6543-4d56-831f-5d7a7363a53a" />
