### PR TITLE
Sallitaan pieni kellopoikkeama dummy-idp:lle lokaalissa kehityksessä

### DIFF
--- a/apigw/src/shared/__tests__/saml-slo.ts
+++ b/apigw/src/shared/__tests__/saml-slo.ts
@@ -78,7 +78,8 @@ describe('SAML Single Logout', () => {
           publicCert: 'config/test-cert/slo-test-idp-cert.pem',
           privateCert: 'config/test-cert/saml-private.pem',
           validateInResponseTo: ValidateInResponseTo.never,
-          decryptAssertions: false
+          decryptAssertions: false,
+          acceptedClockSkewMs: 0
         }
       }
     }

--- a/apigw/src/shared/config.ts
+++ b/apigw/src/shared/config.ts
@@ -437,6 +437,7 @@ export interface EvakaSamlConfig {
   privateCert: string
   validateInResponseTo: ValidateInResponseTo
   decryptAssertions: boolean
+  acceptedClockSkewMs: number
   nameIdFormat?: string | undefined
 }
 
@@ -570,6 +571,7 @@ export function configFromEnv(): Config {
             privateCert: required('AD_SAML_PRIVATE_CERT', unchanged),
             validateInResponseTo: ValidateInResponseTo.always,
             decryptAssertions: required('AD_DECRYPT_ASSERTIONS', parseBoolean),
+            acceptedClockSkewMs: 0,
             nameIdFormat: required('AD_NAME_ID_FORMAT', unchanged)
           }
         })
@@ -608,7 +610,9 @@ export function configFromEnv(): Config {
             ),
             privateCert: required('SFI_SAML_PRIVATE_CERT', unchanged),
             validateInResponseTo: ValidateInResponseTo.always,
-            decryptAssertions: true
+            decryptAssertions: true,
+            // Allow some clock skew for dummy-idp
+            acceptedClockSkewMs: sfiMode === 'test' ? 1000 : 0
           }
         }
 

--- a/apigw/src/shared/saml/index.ts
+++ b/apigw/src/shared/saml/index.ts
@@ -32,7 +32,7 @@ export function createSamlConfig(
     : lookupPublicCert(config.publicCert)
 
   return {
-    acceptedClockSkewMs: 0,
+    acceptedClockSkewMs: config.acceptedClockSkewMs,
     audience: config.issuer,
     cacheProvider,
     callbackUrl: config.callbackUrl,


### PR DESCRIPTION
On macOS, it seems that colima virtual machine may be a few milliseconds behind the host machine's clock, which makes dummy-idp logins fail. Fix this by allowing a bit of clock skew in SAML validation.
