### PR TITLE
Tampereen seuturaportoinnin "koulun yhteydessä"- filtterin käyttöönotto

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -254,6 +254,7 @@ export class Fixture {
       mealtimeSnack: null,
       mealtimeSupper: null,
       mealtimeEveningSnack: null,
+      withSchool: false,
       ...initial
     })
   }
@@ -2171,7 +2172,8 @@ export const testClub: DevDaycare = {
   mealtimeLunch: null,
   mealtimeSnack: null,
   mealtimeSupper: null,
-  mealtimeEveningSnack: null
+  mealtimeEveningSnack: null,
+  withSchool: false
 }
 
 export const testDaycare: DevDaycare = {
@@ -2265,7 +2267,8 @@ export const testDaycare: DevDaycare = {
   mealtimeLunch: null,
   mealtimeSnack: null,
   mealtimeSupper: null,
-  mealtimeEveningSnack: null
+  mealtimeEveningSnack: null,
+  withSchool: false
 }
 
 export const testDaycare2: DevDaycare = {
@@ -2351,7 +2354,8 @@ export const testDaycare2: DevDaycare = {
   mealtimeLunch: null,
   mealtimeSnack: null,
   mealtimeSupper: null,
-  mealtimeEveningSnack: null
+  mealtimeEveningSnack: null,
+  withSchool: false
 }
 
 export const testDaycarePrivateVoucher: DevDaycare = {
@@ -2436,7 +2440,8 @@ export const testDaycarePrivateVoucher: DevDaycare = {
   mealtimeLunch: null,
   mealtimeSnack: null,
   mealtimeSupper: null,
-  mealtimeEveningSnack: null
+  mealtimeEveningSnack: null,
+  withSchool: false
 }
 
 export const testPreschool: DevDaycare = {
@@ -2519,7 +2524,8 @@ export const testPreschool: DevDaycare = {
   mealtimeLunch: null,
   mealtimeSnack: null,
   mealtimeSupper: null,
-  mealtimeEveningSnack: null
+  mealtimeEveningSnack: null,
+  withSchool: false
 }
 
 export const testAdult = Fixture.person({

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -505,6 +505,7 @@ export interface DevDaycare {
   uploadToVarda: boolean
   url: string | null
   visitingAddress: VisitingAddress
+  withSchool: boolean
 }
 
 /**

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -180,7 +180,7 @@ INSERT INTO daycare (
     decision_daycare_name, decision_preschool_name, decision_handler, decision_handler_address,
     oph_unit_oid, oph_organizer_oid, operation_times, shift_care_operation_times, shift_care_open_on_holidays, enabled_pilot_features,
     finance_decision_handler, business_id, iban, provider_id, partner_code, mealtime_breakfast, mealtime_lunch, mealtime_snack,
-    mealtime_supper, mealtime_evening_snack
+    mealtime_supper, mealtime_evening_snack, with_school
 ) VALUES (
     ${bind(row.id)}, ${bind(row.name)}, ${bind(row.openingDate)}, ${bind(row.closingDate)}, ${bind(row.areaId)},
     ${bind(row.type)}::care_types[], ${bind(row.dailyPreschoolTime)}, ${bind(row.dailyPreparatoryTime)}, ${bind(row.daycareApplyPeriod)},
@@ -195,7 +195,7 @@ INSERT INTO daycare (
     ${bind(row.decisionCustomization.handlerAddress)}, ${bind(row.ophUnitOid)}, ${bind(row.ophOrganizerOid)},
     ${bind(row.operationTimes)}, ${bind(row.shiftCareOperationTimes)}, ${bind(row.shiftCareOpenOnHolidays)}, ${bind(row.enabledPilotFeatures)}::pilot_feature[], ${bind(row.financeDecisionHandler)}, ${bind(row.businessId)},
     ${bind(row.iban)}, ${bind(row.providerId)}, ${bind(row.partnerCode)}, ${bind(row.mealtimeBreakfast)}, ${bind(row.mealtimeLunch)}, ${bind(row.mealtimeSnack)},
-    ${bind(row.mealtimeSupper)}, ${bind(row.mealtimeEveningSnack)}
+    ${bind(row.mealtimeSupper)}, ${bind(row.mealtimeEveningSnack)}, ${bind(row.withSchool)}
 )
 RETURNING id
 """

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1922,6 +1922,7 @@ data class DevDaycare(
     val mealtimeSnack: TimeRange? = null,
     val mealtimeSupper: TimeRange? = null,
     val mealtimeEveningSnack: TimeRange? = null,
+    val withSchool: Boolean = false,
 )
 
 data class DevDaycareGroup(


### PR DESCRIPTION
Tunnistetaan kouluilla tapahtuvan täydentävän esiopetuksen yksiköt "Koulun yhteydessä" lipun perusteella Tampereen seutuselvityksen tilastoinnissa.