### PR TITLE
Varauksen muokkaaminen työntekijän mobiilissa ei muuta koko aikaväliä henkilökunnan merkinnöiksi

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -80,7 +80,7 @@ fun reservationRequestRange(body: List<DailyReservationRequest>): FiniteDateRang
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 sealed class Reservation : Comparable<Reservation> {
-    @JsonTypeName("NO_TIMES") object NoTimes : Reservation()
+    @JsonTypeName("NO_TIMES") data object NoTimes : Reservation()
 
     @JsonTypeName("TIMES") data class Times(val range: TimeRange) : Reservation()
 
@@ -147,6 +147,12 @@ sealed class ReservationResponse : Comparable<ReservationResponse> {
             is Times -> range
         }
     }
+
+    fun toReservation(): Reservation =
+        when (this) {
+            is NoTimes -> Reservation.NoTimes
+            is Times -> Reservation.Times(range)
+        }
 
     companion object {
         fun from(reservationRow: ReservationRow) =

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -95,6 +95,7 @@ import fi.espoo.evaka.shared.domain.TimeRange
 import fi.espoo.evaka.shared.domain.europeHelsinki
 import fi.espoo.evaka.shared.security.upsertCitizenUser
 import fi.espoo.evaka.shared.security.upsertEmployeeUser
+import fi.espoo.evaka.shared.security.upsertMobileDeviceUser
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Instant
 import java.time.LocalDate
@@ -309,6 +310,7 @@ RETURNING id
         }
         .executeAndReturnGeneratedKeys()
         .exactlyOne<MobileDeviceId>()
+        .also { upsertMobileDeviceUser(it) }
 
 fun Database.Transaction.insert(row: DevPersonalMobileDevice) =
     createUpdate {

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -2114,6 +2114,10 @@ data class DevMobileDevice(
 ) {
     val user: AuthenticatedUser.MobileDevice
         @JsonIgnore get() = AuthenticatedUser.MobileDevice(id)
+
+    val evakaUser: EvakaUser
+        @JsonIgnore
+        get() = EvakaUser(id = EvakaUserId(id.raw), name = name, type = EvakaUserType.MOBILE_DEVICE)
 }
 
 data class DevPersonalMobileDevice(


### PR DESCRIPTION
_Ennen muutosta:_

Kun työntekijän mobiilissa muokkaa tulevia varauksia (ja vaikkei muuttaisi mitään) ja painaa vahvista, muuttuvat aikavälin merkinnät henkilökunnan tekemiksi.

<img width="674" alt="Screenshot 2025-04-11 at 16 54 30" src="https://github.com/user-attachments/assets/b5f6f8e6-379e-4b71-a1aa-9beb1cc29df4" />


_Muutoksen jälkeen:_

Tarkistetaan backendilla mitkä varaukset ovat muuttuneet ja muokataan vain niitä.
(Poikkeuksena jos samalla päivällä on kaksi varausta ja työntekijä muokkaa yhtä tai lisää niistä toisen, tulevat molemmat merkityksi henkilökunnan tekemiksi)