### PR TITLE
Lisätään testi Jamix API kutsun muotoon

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/jamix/JamixService.kt
@@ -396,8 +396,13 @@ interface JamixClient {
     fun getTextures(): List<JamixTexture>
 }
 
+class JacksonJamixSerializer(private val jsonMapper: JsonMapper) {
+    fun serialize(value: Any?): String = jsonMapper.writeValueAsString(value)
+}
+
 class JamixHttpClient(private val env: JamixEnv, private val jsonMapper: JsonMapper) : JamixClient {
     private val fuel = FuelManager()
+    private val serializer = JacksonJamixSerializer(jsonMapper)
 
     override fun getCustomers(): List<JamixClient.Customer> =
         request(Method.GET, env.url.resolve("customers"))
@@ -418,7 +423,7 @@ class JamixHttpClient(private val env: JamixEnv, private val jsonMapper: JsonMap
                 .timeoutRead(120000)
                 .authentication()
                 .basic(env.user, env.password.value)
-                .let { if (body != null) it.jsonBody(jsonMapper.writeValueAsString(body)) else it }
+                .let { if (body != null) it.jsonBody(serializer.serialize(body)) else it }
                 .responseString()
         return when (result) {
             is Result.Success -> {

--- a/service/src/test/kotlin/fi/espoo/evaka/jamix/JamixSerializerTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/jamix/JamixSerializerTest.kt
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.jamix
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import fi.espoo.evaka.shared.config.defaultJsonMapperBuilder
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class JamixSerializerTest {
+
+    private lateinit var jsonMapper: JsonMapper
+    private lateinit var serializer: JacksonJamixSerializer
+
+    @BeforeEach
+    fun setup() {
+        jsonMapper = defaultJsonMapperBuilder().build()
+        serializer = JacksonJamixSerializer(jsonMapper)
+    }
+
+    @Test
+    fun `serializes MealOrder object correctly for Jamix API`() {
+        // Arrange
+        val order =
+            JamixClient.MealOrder(
+                customerID = 456,
+                deliveryDate = LocalDate.of(2023, 6, 15),
+                mealOrderRows =
+                    listOf(
+                        JamixClient.MealOrderRow(
+                            orderAmount = 7,
+                            mealTypeID = 3,
+                            dietID = null,
+                            additionalInfo = null,
+                            textureID = null,
+                        ),
+                        JamixClient.MealOrderRow(
+                            orderAmount = 1,
+                            mealTypeID = 5,
+                            dietID = 123,
+                            additionalInfo = "Erkki Esimerkki",
+                            textureID = 1234,
+                        ),
+                    ),
+            )
+
+        // Act
+        val serialized = serializer.serialize(order)
+
+        // Assert
+        // Convert serialized string to JsonNode for comparison
+        val actualJson = jsonMapper.readTree(serialized)
+
+        // Create expected structure directly
+        val expectedJson =
+            jsonMapper.createObjectNode().apply {
+                put("customerID", 456)
+                put("deliveryDate", "2023-06-15")
+                val rows = jsonMapper.createArrayNode()
+                rows.add(
+                    jsonMapper.createObjectNode().apply {
+                        put("orderAmount", 7)
+                        put("mealTypeID", 3)
+                    }
+                )
+                rows.add(
+                    jsonMapper.createObjectNode().apply {
+                        put("orderAmount", 1)
+                        put("mealTypeID", 5)
+                        put("dietID", 123)
+                        put("additionalInfo", "Erkki Esimerkki")
+                        put("textureID", 1234)
+                    }
+                )
+                set<ObjectNode>("mealOrderRows", rows)
+            }
+
+        assertEquals(expectedJson, actualJson)
+    }
+}


### PR DESCRIPTION
## Ennen tätä muutosta
JSON serialisoinnin tuottamalle muodolle ei ollut testiä
## Tämän muutoksen jälkeen
Meillä on testi jota tarkastaa, että tilaus ja sen kaikki kentät menevät Jamix APIn odottamassa muodossa