### PR TITLE
Lisätään hakemukselle tuki muuttaa yksikön valinnan ohjeteksti hakemuksen tyypin mukaan

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
@@ -157,9 +157,12 @@ export default React.memo(function UnitsSubSection({
 
               <Gap size="s" />
               <Info>
-                {t.applications.editor.unitPreference.units.preferences.info(
-                  maxUnits
-                )}
+                {t.applications.editor.unitPreference.units.preferences.infoByApplicationType[
+                  applicationType
+                ]?.(maxUnits) ??
+                  t.applications.editor.unitPreference.units.preferences.info(
+                    maxUnits
+                  )}
               </Info>
               <Gap size="xs" />
             </FixedWidthDiv>

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1396,6 +1396,7 @@ const en: Translations = {
                 ? 'Application preference you selected'
                 : 'Application preferences you selected',
             noSelections: 'No selections',
+            infoByApplicationType: {},
             info: (maxUnits: number) =>
               maxUnits === 1
                 ? 'Select one preferred unit'

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -5,6 +5,7 @@
 import React, { ReactNode } from 'react'
 
 import FiniteDateRange from 'lib-common/finite-date-range'
+import { ApplicationType } from 'lib-common/generated/api-types/application'
 import { EmailVerification } from 'lib-common/generated/api-types/pis'
 import LocalDate from 'lib-common/local-date'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
@@ -1345,6 +1346,9 @@ export default {
                 ? 'Valitsemasi hakutoive'
                 : 'Valitsemasi hakutoiveet',
             noSelections: 'Ei valintoja',
+            infoByApplicationType: {} as Partial<
+              Record<ApplicationType, (maxUnits: number) => string>
+            >,
             info: (maxUnits: number) =>
               maxUnits === 1
                 ? 'Valitse yksi varhaiskasvatusyksikkö'

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1347,6 +1347,7 @@ const sv: Translations = {
                 ? 'Enhet som du har valt'
                 : 'Enheter som du har valt',
             noSelections: 'Inga val',
+            infoByApplicationType: {},
             info: (maxUnits: number) =>
               maxUnits === 1
                 ? 'Välj en enhet'


### PR DESCRIPTION
Esim. eskarihakemuksella voidaan sanoa "Valitse yksi vaihtoehto" ja kerhohakemuksella "Laita 1-3 kerhoa toivomaasi järjestykseen.".