### PR TITLE
Lisää sanity checkejä

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/SanityChecks.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/SanityChecks.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.db
 
+import fi.espoo.evaka.invoicing.domain.FeeDecisionStatus
 import fi.espoo.evaka.shared.domain.EvakaClock
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.LocalDate
@@ -14,6 +15,20 @@ fun runSanityChecks(tx: Database.Read, clock: EvakaClock) {
     logResult("child attendances on future days", tx.sanityCheckAttendancesInFuture(clock.today()))
     logResult("service need outside placement", tx.sanityCheckServiceNeedOutsidePlacement())
     logResult("group placement outside placement", tx.sanityCheckGroupPlacementOutsidePlacement())
+    logResult(
+        "same child in overlapping draft fee decisions",
+        tx.sanityCheckChildInOverlappingFeeDecisions(listOf(FeeDecisionStatus.DRAFT)),
+    )
+    logResult(
+        "same child in overlapping sent fee decisions",
+        tx.sanityCheckChildInOverlappingFeeDecisions(
+            listOf(
+                FeeDecisionStatus.SENT,
+                FeeDecisionStatus.WAITING_FOR_SENDING,
+                FeeDecisionStatus.WAITING_FOR_MANUAL_SENDING,
+            )
+        ),
+    )
 }
 
 private fun logResult(description: String, violations: Int) {
@@ -59,6 +74,32 @@ fun Database.Read.sanityCheckGroupPlacementOutsidePlacement(): Int {
         FROM daycare_group_placement gpl
         JOIN placement pl on pl.id = gpl.daycare_placement_id
         WHERE gpl.start_date < pl.start_date OR gpl.end_date > pl.end_date
+    """
+            )
+        }
+        .exactlyOne()
+}
+
+fun Database.Read.sanityCheckChildInOverlappingFeeDecisions(
+    statuses: List<FeeDecisionStatus>
+): Int {
+    return createQuery {
+            sql(
+                """
+        SELECT count(DISTINCT fdc.child_id)
+        FROM fee_decision fd
+        JOIN fee_decision_child fdc on fdc.fee_decision_id = fd.id
+        WHERE
+            fd.status = ANY(${bind(statuses)}) AND
+            EXISTS (
+                SELECT FROM fee_decision fd_overlapping
+                JOIN fee_decision_child fdc_overlapping ON fdc_overlapping.fee_decision_id = fd_overlapping.id
+                WHERE
+                    fd_overlapping.id != fd.id AND
+                    fd.valid_during && fd_overlapping.valid_during AND
+                    fdc_overlapping.child_id = fdc.child_id AND
+                    fd_overlapping.status = ANY(${bind(statuses)})
+            )
     """
             )
         }


### PR DESCRIPTION
- Sama lapsi päällekkäisillä maksupäätöksillä (Espoon tuotanto: 44 kpl)
- Varasijoitus sijoitusten ulkopuolella (146)
- Varaus sijoitustyypillä joka ei salli varauksia (6784)