### PR TITLE
Lyhennetään kasvattajan mobiilin paritusavainten pituus 6 merkkiin

### DIFF
--- a/frontend/src/employee-frontend/components/MobilePairingModal.tsx
+++ b/frontend/src/employee-frontend/components/MobilePairingModal.tsx
@@ -70,7 +70,7 @@ export default React.memo(function MobilePairingModal({
   }, [phase]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (responseKey.length === 12) {
+    if (responseKey.length === 6) {
       if (pairingResponse.isSuccess) {
         void postPairingResponseResult({
           id: pairingResponse.value.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pairing/PairingIntegrationTest.kt
@@ -60,7 +60,7 @@ class PairingIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         val id = res1.id
         val challengeKey = res1.challengeKey
         assertEquals(testUnit, res1.unitId)
-        assertEquals(12, challengeKey.length)
+        assertEquals(keyLength, challengeKey.length)
         assertNull(res1.responseKey)
         assertNull(res1.mobileDeviceId)
         assertEquals(PairingStatus.WAITING_CHALLENGE, res1.status)
@@ -74,7 +74,7 @@ class PairingIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         assertEquals(id, res2.id)
         assertEquals(testUnit, res2.unitId)
         assertEquals(challengeKey, res2.challengeKey)
-        assertEquals(12, responseKey!!.length)
+        assertEquals(keyLength, responseKey!!.length)
         assertNull(res1.mobileDeviceId)
         assertEquals(PairingStatus.WAITING_RESPONSE, res2.status)
 
@@ -422,7 +422,7 @@ class PairingIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         val count = 100
         val values = (1..count).map { generatePairingKey() }.toSet()
         assertEquals(count, values.size)
-        assertTrue(values.all { key -> key.length == 12 })
+        assertTrue(values.all { key -> key.length == keyLength })
 
         val concatenated = values.joinToString(separator = "")
         val badChars = listOf('i', 'l', 'I', '1', 'o', 'O', '0', ' ')

--- a/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pairing/PairingQueries.kt
@@ -142,7 +142,7 @@ fun Database.Transaction.incrementAttempts(id: PairingId, challengeKey: String) 
 }
 
 const val distinguishableChars = "abcdefghkmnpqrstuvwxyz23456789"
-const val keyLength = 12
+const val keyLength = 6
 val random: SecureRandom = SecureRandom()
 
 fun generatePairingKey(): String =


### PR DESCRIPTION
Aiempi pituus oli 12 merkkiä, ja se oli työläs kirjoittaa. 6 merkkiä tarjoaa yhä riittävän hyvän satunnaistamisen tason (noin 700 miljoonaa vaihtoehtoa)