### PR TITLE
Korjataan flaky e2e testi

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/income.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/income.spec.ts
@@ -289,6 +289,8 @@ describe('Income', () => {
     await incomesSection.edit()
 
     await incomesSection.deleteIncomeAttachment(0)
+    await waitUntilEqual(() => incomesSection.getAttachmentCount(), 0)
+
     await incomesSection.cancelEdit()
     await waitUntilEqual(() => incomesSection.getAttachmentCount(), 0)
   })


### PR DESCRIPTION
hypoteesi: liian nopea peruuta-napin klikkaus keskeyttää liitteen poistamisen, joten odotetaan jo ennen sitä että liite poistuu