### PR TITLE
Lisätään kuntalaiselle mahdollisuus ladata kalenteritapahtuma ulkopuoliseen kalenteriin

### DIFF
--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -43,6 +43,7 @@ import {
   CalendarEventTimeId,
   ChildId
 } from 'lib-common/generated/api-types/shared'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import { formatFirstName } from 'lib-common/names'
 import { reservationHasTimes } from 'lib-common/reservations'
@@ -601,10 +602,20 @@ const DayModal = React.memo(function DayModal({
                                       </div>
                                       {date.isEqualOrAfter(today) && (
                                         <CalendarEventExportButton
-                                          calendarEvent={event}
-                                          eventAttendeeInfo={
-                                            event.currentAttending
-                                          }
+                                          eventDetails={{
+                                            title: event.title,
+                                            helsinkiStartTime:
+                                              event.period.start.formatIso(),
+                                            //non-inclusive end date
+                                            helsinkiEndTime: event.period.end
+                                              .addDays(1)
+                                              .formatIso(),
+                                            fileName: `${i18n.calendar.calendarEventFilename}_${event.period.start.formatIso()}-${event.period.end.formatIso()}.ics`,
+                                            locationInfo:
+                                              event.currentAttending,
+                                            allDay: true
+                                          }}
+                                          data-qa={`event-export-button-${event.id}`}
                                         />
                                       )}
                                     </FixedSpaceRow>
@@ -647,11 +658,23 @@ const DayModal = React.memo(function DayModal({
                                             </div>
                                             {rt.date.isEqualOrAfter(today) && (
                                               <CalendarEventExportButton
-                                                calendarEvent={event}
-                                                discussionTime={rt}
-                                                eventAttendeeInfo={
-                                                  event.currentAttending
-                                                }
+                                                eventDetails={{
+                                                  title: event.title,
+                                                  helsinkiStartTime:
+                                                    HelsinkiDateTime.fromLocal(
+                                                      rt.date,
+                                                      rt.startTime
+                                                    ).formatIso(),
+                                                  helsinkiEndTime:
+                                                    HelsinkiDateTime.fromLocal(
+                                                      rt.date,
+                                                      rt.endTime
+                                                    ).formatIso(),
+                                                  fileName: `${i18n.calendar.discussionTimeReservation.discussionTimeFileName}_${rt.date.formatIso()}.ics`,
+                                                  locationInfo:
+                                                    event.currentAttending
+                                                }}
+                                                data-qa={`event-export-button-${rt.id}`}
                                               />
                                             )}
                                           </FixedSpaceRow>

--- a/frontend/src/citizen-frontend/calendar/DayView.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayView.tsx
@@ -98,9 +98,9 @@ import { Translations, useLang, useTranslation } from '../localization'
 
 import AttendanceInfo from './AttendanceInfo'
 import { BottomFooterContainer } from './BottomFooterContainer'
+import { CalendarEventExportButton } from './CalendarEventExportButton'
 import { CalendarModalBackground, CalendarModalSection } from './CalendarModal'
 import { useCalendarModalState } from './CalendarPage'
-import { DiscussionTimeExportButton } from './DiscussionTimeExportButton'
 import {
   ChildImageData,
   getChildImages,
@@ -582,15 +582,32 @@ const DayModal = React.memo(function DayModal({
                                     key={event.id}
                                     data-qa={`event-${event.id}`}
                                   >
-                                    <LabelLike data-qa="event-title">
-                                      {event.title} /{' '}
-                                      {event.currentAttending.type === 'UNIT'
-                                        ? event.currentAttending.unitName
-                                        : event.currentAttending.type ===
-                                            'GROUP'
-                                          ? event.currentAttending.groupName
-                                          : row.firstName}
-                                    </LabelLike>
+                                    <FixedSpaceRow
+                                      fullWidth
+                                      justifyContent="space-between"
+                                      alignItems="center"
+                                    >
+                                      <div>
+                                        <LabelLike data-qa="event-title">
+                                          {event.title} /{' '}
+                                          {event.currentAttending.type ===
+                                          'UNIT'
+                                            ? event.currentAttending.unitName
+                                            : event.currentAttending.type ===
+                                                'GROUP'
+                                              ? event.currentAttending.groupName
+                                              : row.firstName}
+                                        </LabelLike>
+                                      </div>
+                                      {date.isEqualOrAfter(today) && (
+                                        <CalendarEventExportButton
+                                          calendarEvent={event}
+                                          eventAttendeeInfo={
+                                            event.currentAttending
+                                          }
+                                        />
+                                      )}
+                                    </FixedSpaceRow>
                                     <P noMargin data-qa="event-description">
                                       {event.description}
                                     </P>
@@ -629,8 +646,8 @@ const DayModal = React.memo(function DayModal({
                                               </P>
                                             </div>
                                             {rt.date.isEqualOrAfter(today) && (
-                                              <DiscussionTimeExportButton
-                                                eventTitle={event.title}
+                                              <CalendarEventExportButton
+                                                calendarEvent={event}
                                                 discussionTime={rt}
                                                 eventAttendeeInfo={
                                                   event.currentAttending

--- a/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
@@ -40,12 +40,12 @@ import { faTimes } from 'lib-icons'
 
 import ModalAccessibilityWrapper from '../../ModalAccessibilityWrapper'
 import { useLang, useTranslation } from '../../localization'
+import { CalendarEventExportButton } from '../CalendarEventExportButton'
 import {
   CalendarModalBackground,
   CalendarModalCloseButton,
   CalendarModalSection
 } from '../CalendarModal'
-import { DiscussionTimeExportButton } from '../DiscussionTimeExportButton'
 import { deleteCalendarEventTimeReservationMutation } from '../queries'
 
 interface ChildWithSurveys {
@@ -336,8 +336,8 @@ const ChildSurveyElement = React.memo(function ChildSurveyElement({
                     ${r.startTime.format()} - ${r.endTime.format()}`}
                         </Bold>
                       </div>
-                      <DiscussionTimeExportButton
-                        eventTitle={survey.title}
+                      <CalendarEventExportButton
+                        calendarEvent={survey}
                         discussionTime={r}
                         eventAttendeeInfo={survey.attendingChildren?.[
                           childId

--- a/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
@@ -16,6 +16,7 @@ import {
   CalendarEventTimeId,
   ChildId
 } from 'lib-common/generated/api-types/shared'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import { formatFirstName } from 'lib-common/names'
 import { StaticChip } from 'lib-components/atoms/Chip'
@@ -337,13 +338,24 @@ const ChildSurveyElement = React.memo(function ChildSurveyElement({
                         </Bold>
                       </div>
                       <CalendarEventExportButton
-                        calendarEvent={survey}
-                        discussionTime={r}
-                        eventAttendeeInfo={survey.attendingChildren?.[
-                          childId
-                        ]?.find(({ periods }) =>
-                          periods.some((period) => period.includes(r.date))
-                        )}
+                        eventDetails={{
+                          title: survey.title,
+                          helsinkiStartTime: HelsinkiDateTime.fromLocal(
+                            r.date,
+                            r.startTime
+                          ).formatIso(),
+                          helsinkiEndTime: HelsinkiDateTime.fromLocal(
+                            r.date,
+                            r.endTime
+                          ).formatIso(),
+                          fileName: `${i18n.calendar.discussionTimeReservation.discussionTimeFileName}_${r.date.formatIso()}.ics`,
+                          locationInfo: survey.attendingChildren?.[
+                            childId
+                          ]?.find(({ periods }) =>
+                            periods.some((period) => period.includes(r.date))
+                          )
+                        }}
+                        data-qa={`event-export-button-${r.id}`}
                       />
                     </FixedSpaceRow>
                   )}

--- a/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-calendar.ts
@@ -803,12 +803,20 @@ class DayView extends Element {
   async assertEvent(
     childId: UUID,
     eventId: UUID,
-    { title, description }: { title: string; description: string }
+    { title, description }: { title: string; description: string },
+    exportable = true
   ) {
     const event = this.#childSection(childId).findByDataQa(`event-${eventId}`)
     await event.waitUntilVisible()
     await event.findByDataQa('event-title').assertTextEquals(title)
     await event.findByDataQa('event-description').assertTextEquals(description)
+
+    const exportButton = event.findByDataQa(`event-export-button-${eventId}`)
+    if (exportable) {
+      await exportButton.waitUntilVisible()
+    } else {
+      await exportButton.waitUntilHidden()
+    }
   }
 
   async assertEventNotShown(childId: UUID, eventId: UUID) {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -354,6 +354,7 @@ const en: Translations = {
       SICKLEAVE: 'Absence due to illness',
       PLANNED_ABSENCE: 'Shift work absence'
     },
+    calendarEventFilename: 'Calendar_event',
     discussionTimeReservation: {
       surveyModalButtonText: 'Reserve a discussion time',
       reservationModalButtonText: 'Reserve a discussion time',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -354,6 +354,7 @@ export default {
       SICKLEAVE: 'Sairauspoissaolo',
       PLANNED_ABSENCE: 'Vuorotyöpoissaolo'
     },
+    calendarEventFilename: 'Kalenteritapahtuma',
     discussionTimeReservation: {
       surveyModalButtonText: 'Varaa keskusteluaika',
       reservationModalButtonText: 'Siirry varaamaan',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -352,6 +352,7 @@ const sv: Translations = {
       SICKLEAVE: 'Sjukfrånvaro',
       PLANNED_ABSENCE: 'Skiftarbete frånvaro'
     },
+    calendarEventFilename: 'Kalenderhändelse',
     discussionTimeReservation: {
       surveyModalButtonText: 'Gå till tidsbokning',
       reservationModalButtonText: 'Gå till bokning',


### PR DESCRIPTION
Laajentaa ics-tiedoston lataamisen keskusteluaikojen lisäksi koko päivän tai useamman päivän kalenteritapahtumiin yksittäisen kalenteripäivän näkymässä. Parantaa samalla VTIMEZONE käsittelyä kohdentamalla aikavyöhykkeen paremmin.