### PR TITLE
Change release and dependency update schedules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,6 +22,9 @@
   // No rate limit for PR creation
   prHourlyLimit: 0,
 
+  // Pin all dependencies to exact versions
+  rangeStrategy: 'pin',
+
   labels: ['dependencies'],
   packageRules: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,19 @@
   ],
   semanticCommits: 'disabled',
   automergeStrategy: 'merge-commit',
+
+  // Wait for a version to be 3 days old before making a PR
   minimumReleaseAge: '3 days',
+
+  // Update during weekends
+  schedule: ['* * * * 0,6'],
+
+  // Allow most 20 PRs open concurrently
+  prConcurrentLimit: 20,
+
+  // No rate limit for PR creation
+  prHourlyLimit: 0,
+
   labels: ['dependencies'],
   packageRules: [
     {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@
 name: 'Create a release'
 on:
   schedule:
-    - cron: '0 23 * * 0'  # Sunday at 23:00
+    # Friday at 22:00 or 23:00 (depending on daylight saving time)
+    - cron: '0 20 * * 5'
   workflow_dispatch:
     inputs:
       git-tag:


### PR DESCRIPTION
Changes in this PR:
- Make a release on Friday evening
- Update dependencies during the weekeend

This way, each release has about week-old dependency updates, and dependency updates are deployed in environments in the beginning of the week, which helps pinpoint potential problems to dependency updates instead of eVaka's own code.

As an unrelated change, also configure renovate to pin dependencies to exact versions. This way the actual used package versions are recorded in package.json in addition to lockfile.