### PR TITLE
Lisää asiakirjapohjiin ulkoisen arkistoinnin mahdollistavan flägin

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1131,6 +1131,7 @@ export class Fixture {
       validity: new DateRange(LocalDate.of(2000, 1, 1), null),
       processDefinitionNumber: null,
       archiveDurationMonths: null,
+      archiveExternally: false,
       content: {
         sections: [
           {

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -565,6 +565,7 @@ export interface DevDaycareGroupPlacement {
 */
 export interface DevDocumentTemplate {
   archiveDurationMonths: number | null
+  archiveExternally: boolean
   confidentiality: DocumentConfidentiality | null
   content: DocumentTemplateContent
   id: DocumentTemplateId

--- a/frontend/src/e2e-test/pages/employee/documents/document-templates.ts
+++ b/frontend/src/e2e-test/pages/employee/documents/document-templates.ts
@@ -81,6 +81,7 @@ export class TemplateModal extends Element {
   readonly archiveDurationMonthsInput
   readonly confidentialityDurationYearsInput
   readonly confidentialityBasisInput
+  readonly archiveExternallyCheckbox
   readonly confirmCreateButton
 
   constructor(locator: Locator) {
@@ -102,6 +103,9 @@ export class TemplateModal extends Element {
     )
     this.confidentialityBasisInput = new TextInput(
       this.findByDataQa('confidentiality-basis')
+    )
+    this.archiveExternallyCheckbox = new Checkbox(
+      this.findByDataQa('archive-externally-checkbox')
     )
     this.confirmCreateButton = this.findByDataQa('modal-okBtn')
   }

--- a/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
@@ -347,6 +347,7 @@ describe('Employee - Child documents', () => {
     await modal.confidentialityBasisInput.fill('Joku laki §300')
     await modal.processDefinitionNumberInput.fill('12.06.01')
     await modal.archiveDurationMonthsInput.fill('1320')
+    await modal.archiveExternallyCheckbox.check()
     await modal.confirmCreateButton.click()
     await documentTemplatesPage.openTemplate(documentName)
 

--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentEditor.tsx
@@ -493,7 +493,10 @@ const ChildDocumentReadViewInner = React.memo(
                           mutation={planArchiveChildDocumentMutation}
                           onClick={() => ({ documentId: document.id })}
                           data-qa="archive-button"
-                          disabled={document.archivedAt !== null}
+                          disabled={
+                            !document.template.archiveExternally ||
+                            document.archivedAt !== null
+                          }
                         />
                       </Tooltip>
                     )}

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateContentEditor.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateContentEditor.tsx
@@ -265,6 +265,10 @@ const BasicsSection = React.memo(function BasicsSection({
                 label:
                   i18n.documentTemplates.templateModal.archiveDurationMonths,
                 value: template.archiveDurationMonths ?? '-'
+              },
+              {
+                label: 'Asiakirja arkistoitavissa',
+                value: template.archiveExternally ? 'Kyllä' : 'Ei'
               }
             ]}
           />
@@ -336,7 +340,8 @@ const BasicsEditor = React.memo(function BasicsEditor({
       legalBasis: template.legalBasis,
       validity: openEndedLocalDateRange.fromRange(template.validity),
       processDefinitionNumber: template.processDefinitionNumber ?? '',
-      archiveDurationMonths: template.archiveDurationMonths?.toString() ?? '0'
+      archiveDurationMonths: template.archiveDurationMonths?.toString() ?? '0',
+      archiveExternally: template.archiveExternally ?? false
     }),
     {
       ...i18n.validationErrors
@@ -352,7 +357,8 @@ const BasicsEditor = React.memo(function BasicsEditor({
     legalBasis,
     validity,
     processDefinitionNumber,
-    archiveDurationMonths
+    archiveDurationMonths,
+    archiveExternally
   } = useFormFields(form)
 
   return (
@@ -416,6 +422,12 @@ const BasicsEditor = React.memo(function BasicsEditor({
             />
           </>
         )}
+        <Gap />
+        <CheckboxF
+          bind={archiveExternally}
+          label={i18n.documentTemplates.templateModal.archiveExternally}
+          data-qa="archive-externally-checkbox"
+        />
       </div>
       <FixedSpaceRow justifyContent="flex-end">
         <LegacyButton onClick={onClose} text={i18n.common.cancel} />

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
@@ -71,7 +71,8 @@ export const documentTemplateForm = transformed(
     legalBasis: string(),
     validity: required(openEndedLocalDateRange()),
     processDefinitionNumber: required(value<string>()),
-    archiveDurationMonths: required(value<string>())
+    archiveDurationMonths: required(value<string>()),
+    archiveExternally: boolean()
   }),
   (value) => {
     const archived = value.processDefinitionNumber.trim().length > 0
@@ -197,7 +198,8 @@ export default React.memo(function TemplateModal({ onClose, mode }: Props) {
             ),
             processDefinitionNumber: mode.data.processDefinitionNumber ?? '',
             archiveDurationMonths:
-              mode.data.archiveDurationMonths?.toString() ?? '120'
+              mode.data.archiveDurationMonths?.toString() ?? '120',
+            archiveExternally: mode.data.archiveExternally
           }
         : {
             name: '',
@@ -216,7 +218,8 @@ export default React.memo(function TemplateModal({ onClose, mode }: Props) {
             legalBasis: '',
             validity: openEndedLocalDateRange.empty(),
             processDefinitionNumber: '',
-            archiveDurationMonths: '120'
+            archiveDurationMonths: '120',
+            archiveExternally: false
           },
     {
       ...i18n.validationErrors
@@ -234,7 +237,8 @@ export default React.memo(function TemplateModal({ onClose, mode }: Props) {
     legalBasis,
     validity,
     processDefinitionNumber,
-    archiveDurationMonths
+    archiveDurationMonths,
+    archiveExternally
   } = useFormFields(form)
 
   return (
@@ -351,6 +355,12 @@ export default React.memo(function TemplateModal({ onClose, mode }: Props) {
           />
         </>
       )}
+      <Gap />
+      <CheckboxF
+        bind={archiveExternally}
+        label={i18n.documentTemplates.templateModal.archiveExternally}
+        data-qa="archive-externally-checkbox"
+      />
     </AsyncFormModal>
   )
 })

--- a/frontend/src/lib-common/generated/api-types/document.ts
+++ b/frontend/src/lib-common/generated/api-types/document.ts
@@ -228,6 +228,7 @@ export type DocumentStatus =
 */
 export interface DocumentTemplate {
   archiveDurationMonths: number | null
+  archiveExternally: boolean
   confidentiality: DocumentConfidentiality | null
   content: DocumentTemplateContent
   id: DocumentTemplateId
@@ -246,6 +247,7 @@ export interface DocumentTemplate {
 */
 export interface DocumentTemplateBasicsRequest {
   archiveDurationMonths: number | null
+  archiveExternally: boolean
   confidentiality: DocumentConfidentiality | null
   language: UiLanguage
   legalBasis: string
@@ -308,6 +310,7 @@ export interface DocumentWriteLock {
 */
 export interface ExportedDocumentTemplate {
   archiveDurationMonths: number | null
+  archiveExternally: boolean
   confidentiality: DocumentConfidentiality | null
   content: DocumentTemplateContent
   language: UiLanguage

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -5080,7 +5080,8 @@ export const fi = {
       processDefinitionNumber: 'Tehtäväluokka',
       processDefinitionNumberInfo:
         'Tiedonohjaussuunnitelmassa määritelty tehtäväluokan numero. Jätä tyhjäksi jos lomaketta ei arkistoida.',
-      archiveDurationMonths: 'Arkistointiaika (kuukautta)'
+      archiveDurationMonths: 'Arkistointiaika (kuukautta)',
+      archiveExternally: 'Siirrettävä ulkoiseen arkistoon ennen poistoa'
     },
     templateEditor: {
       confidential: 'Salassapidettävä',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/DocumentTemplateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/DocumentTemplateIntegrationTest.kt
@@ -71,6 +71,7 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             validity = DateRange(LocalDate.of(2022, 7, 1), null),
             processDefinitionNumber = "123.456.789",
             archiveDurationMonths = 120,
+            archiveExternally = false,
         )
 
     @BeforeEach
@@ -288,6 +289,7 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                     validity = newValidity,
                     processDefinitionNumber = "123.456.789b",
                     archiveDurationMonths = 1200,
+                    archiveExternally = false,
                 ),
             )
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pdfgen/PdfGeneratorTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pdfgen/PdfGeneratorTest.kt
@@ -291,6 +291,7 @@ class PdfGeneratorTest {
                         processDefinitionNumber = null,
                         archiveDurationMonths = null,
                         published = true,
+                        archiveExternally = false,
                         content =
                             DocumentTemplateContent(
                                 sections =

--- a/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplate.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplate.kt
@@ -357,6 +357,7 @@ data class DocumentTemplate(
     val published: Boolean,
     val processDefinitionNumber: String?,
     val archiveDurationMonths: Int?,
+    val archiveExternally: Boolean,
     @Json val content: DocumentTemplateContent,
 )
 
@@ -370,6 +371,7 @@ data class ExportedDocumentTemplate(
     val validity: DateRange,
     val processDefinitionNumber: String?,
     val archiveDurationMonths: Int?,
+    val archiveExternally: Boolean,
     @Json val content: DocumentTemplateContent,
 )
 
@@ -383,6 +385,7 @@ data class DocumentTemplateBasicsRequest(
     val validity: DateRange,
     val processDefinitionNumber: String?,
     val archiveDurationMonths: Int?,
+    val archiveExternally: Boolean,
 )
 
 data class DocumentTemplateSummary(

--- a/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplateQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplateQueries.kt
@@ -12,8 +12,8 @@ fun Database.Transaction.insertTemplate(template: DocumentTemplateBasicsRequest)
     return createQuery {
             sql(
                 """
-INSERT INTO document_template (name, type, placement_types,  language, confidential, confidentiality_duration_years, confidentiality_basis, legal_basis, validity, process_definition_number, archive_duration_months, content) 
-VALUES (${bind(template.name)}, ${bind(template.type)}, ${bind(template.placementTypes)}, ${bind(template.language)}, ${bind(template.confidentiality != null)}, ${bind(template.confidentiality?.durationYears)}, ${bind(template.confidentiality?.basis)}, ${bind(template.legalBasis)}, ${bind(template.validity)}, ${bind(template.processDefinitionNumber)}, ${bind(template.archiveDurationMonths)}, ${bind(DocumentTemplateContent(sections = emptyList()))}::jsonb)
+INSERT INTO document_template (name, type, placement_types,  language, confidential, confidentiality_duration_years, confidentiality_basis, legal_basis, validity, process_definition_number, archive_duration_months, archive_externally, content) 
+VALUES (${bind(template.name)}, ${bind(template.type)}, ${bind(template.placementTypes)}, ${bind(template.language)}, ${bind(template.confidentiality != null)}, ${bind(template.confidentiality?.durationYears)}, ${bind(template.confidentiality?.basis)}, ${bind(template.legalBasis)}, ${bind(template.validity)}, ${bind(template.processDefinitionNumber)}, ${bind(template.archiveDurationMonths)}, ${bind(template.archiveExternally)}, ${bind(DocumentTemplateContent(sections = emptyList()))}::jsonb)
 RETURNING *
 """
             )
@@ -25,8 +25,8 @@ fun Database.Transaction.importTemplate(template: ExportedDocumentTemplate): Doc
     createQuery {
             sql(
                 """
-INSERT INTO document_template (name, type, placement_types, language, confidential, confidentiality_duration_years, confidentiality_basis, legal_basis, validity, process_definition_number, archive_duration_months, content)
-VALUES (${bind(template.name)}, ${bind(template.type)}, ${bind(template.placementTypes)}, ${bind(template.language)}, ${bind(template.confidentiality != null)}, ${bind(template.confidentiality?.durationYears)}, ${bind(template.confidentiality?.basis)}, ${bind(template.legalBasis)}, ${bind(template.validity)}, ${bind(template.processDefinitionNumber)}, ${bind(template.archiveDurationMonths)}, ${bind(template.content)})
+INSERT INTO document_template (name, type, placement_types, language, confidential, confidentiality_duration_years, confidentiality_basis, legal_basis, validity, process_definition_number, archive_duration_months, archive_externally, content)
+VALUES (${bind(template.name)}, ${bind(template.type)}, ${bind(template.placementTypes)}, ${bind(template.language)}, ${bind(template.confidentiality != null)}, ${bind(template.confidentiality?.durationYears)}, ${bind(template.confidentiality?.basis)}, ${bind(template.legalBasis)}, ${bind(template.validity)}, ${bind(template.processDefinitionNumber)}, ${bind(template.archiveDurationMonths)}, ${bind(template.archiveExternally)}, ${bind(template.content)})
 RETURNING *
 """
             )
@@ -40,8 +40,8 @@ fun Database.Transaction.duplicateTemplate(
     return createQuery {
             sql(
                 """
-INSERT INTO document_template (name, type, placement_types, language, confidential, confidentiality_duration_years, confidentiality_basis, legal_basis, validity, process_definition_number, archive_duration_months, content) 
-SELECT ${bind(template.name)}, ${bind(template.type)}, ${bind(template.placementTypes)}, ${bind(template.language)}, ${bind(template.confidentiality != null)}, ${bind(template.confidentiality?.durationYears)}, ${bind(template.confidentiality?.basis)}, ${bind(template.legalBasis)}, ${bind(template.validity)}, ${bind(template.processDefinitionNumber)}, ${bind(template.archiveDurationMonths)}, content FROM document_template WHERE id = ${bind(id)}
+INSERT INTO document_template (name, type, placement_types, language, confidential, confidentiality_duration_years, confidentiality_basis, legal_basis, validity, process_definition_number, archive_duration_months, archive_externally, content) 
+SELECT ${bind(template.name)}, ${bind(template.type)}, ${bind(template.placementTypes)}, ${bind(template.language)}, ${bind(template.confidentiality != null)}, ${bind(template.confidentiality?.durationYears)}, ${bind(template.confidentiality?.basis)}, ${bind(template.legalBasis)}, ${bind(template.validity)}, ${bind(template.processDefinitionNumber)}, ${bind(template.archiveDurationMonths)}, ${bind(template.archiveExternally)}, content FROM document_template WHERE id = ${bind(id)}
 RETURNING *
 """
             )
@@ -98,7 +98,8 @@ fun Database.Transaction.updateDraftTemplateBasics(
                     legal_basis = ${bind(basics.legalBasis)},
                     validity = ${bind(basics.validity)},
                     process_definition_number = ${bind(basics.processDefinitionNumber)},
-                    archive_duration_months = ${bind(basics.archiveDurationMonths)}
+                    archive_duration_months = ${bind(basics.archiveDurationMonths)},
+                    archive_externally = ${bind(basics.archiveExternally)}
                 WHERE id = ${bind(id)} AND published = false
                 """
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentService.kt
@@ -4,7 +4,6 @@
 
 package fi.espoo.evaka.document.archival
 
-import fi.espoo.evaka.document.DocumentType
 import fi.espoo.evaka.document.childdocument.*
 import fi.espoo.evaka.pis.getPersonById
 import fi.espoo.evaka.process.*
@@ -52,21 +51,6 @@ fun uploadToArchive(
         db.read { tx ->
             tx.getChildDocument(documentId) ?: throw NotFound("document $documentId not found")
         }
-    if (
-        document.template.type !in
-            setOf(
-                DocumentType.VASU,
-                DocumentType.LEOPS,
-                DocumentType.HOJKS,
-                DocumentType.MIGRATED_VASU,
-                DocumentType.MIGRATED_LEOPS,
-            )
-    ) {
-        logger.warn {
-            "Refusing to archive non-supported document type ${document.template.type} with id $documentId"
-        }
-        return
-    }
     val childInfo =
         db.read { tx ->
             val childId = document.child.id

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
@@ -83,7 +83,8 @@ SELECT
     dt.confidential as template_confidential,
     dt.validity as template_validity,
     dt.published as template_published,
-    dt.content as template_content
+    dt.content as template_content,
+    dt.archive_externally as template_archive_externally
 FROM child_document cd
 JOIN document_template dt on cd.template_id = dt.id
 JOIN person p on cd.child_id = p.id

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueriesCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueriesCitizen.kt
@@ -95,7 +95,8 @@ fun Database.Read.getCitizenChildDocument(id: ChildDocumentId): ChildDocumentCit
                     dt.confidential as template_confidential,
                     dt.validity as template_validity,
                     dt.published as template_published,
-                    dt.content as template_content
+                    dt.content as template_content,
+                    dt.archive_externally as template_archive_externally
                 FROM child_document cd
                 JOIN document_template dt on cd.template_id = dt.id
                 JOIN person p on cd.child_id = p.id

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -1446,8 +1446,8 @@ fun Database.Transaction.insert(row: DevDocumentTemplate): DocumentTemplateId =
     createUpdate {
             sql(
                 """
-INSERT INTO document_template (id, name, type, placement_types, language, confidential, confidentiality_duration_years, confidentiality_basis, legal_basis, validity, process_definition_number, archive_duration_months, published, content) 
-VALUES (${bind(row.id)}, ${bind(row.name)}, ${bind(row.type)}, ${bind(row.placementTypes)}, ${bind(row.language)}, ${bind(row.confidentiality != null)}, ${bind(row.confidentiality?.durationYears)}, ${bind(row.confidentiality?.basis)}, ${bind(row.legalBasis)}, ${bind(row.validity)}, ${bind(row.processDefinitionNumber)}, ${bind(row.archiveDurationMonths)}, ${bind(row.published)}, ${bind(row.content)})
+INSERT INTO document_template (id, name, type, placement_types, language, confidential, confidentiality_duration_years, confidentiality_basis, legal_basis, validity, process_definition_number, archive_duration_months, published, archive_externally, content) 
+VALUES (${bind(row.id)}, ${bind(row.name)}, ${bind(row.type)}, ${bind(row.placementTypes)}, ${bind(row.language)}, ${bind(row.confidentiality != null)}, ${bind(row.confidentiality?.durationYears)}, ${bind(row.confidentiality?.basis)}, ${bind(row.legalBasis)}, ${bind(row.validity)}, ${bind(row.processDefinitionNumber)}, ${bind(row.archiveDurationMonths)}, ${bind(row.published)}, ${bind(row.archiveExternally)}, ${bind(row.content)})
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -2320,6 +2320,7 @@ data class DevDocumentTemplate(
     val archiveDurationMonths: Int? = null,
     val published: Boolean = true,
     @Json val content: DocumentTemplateContent,
+    val archiveExternally: Boolean = false,
 ) {
     fun toDocumentTemplate() =
         DocumentTemplate(
@@ -2335,6 +2336,7 @@ data class DevDocumentTemplate(
             processDefinitionNumber = processDefinitionNumber,
             archiveDurationMonths = archiveDurationMonths,
             content = content,
+            archiveExternally = archiveExternally,
         )
 }
 

--- a/service/src/main/resources/db/migration/V521__document_template_archiveable.sql
+++ b/service/src/main/resources/db/migration/V521__document_template_archiveable.sql
@@ -5,3 +5,5 @@ ALTER TABLE document_template
 UPDATE document_template
 SET archive_externally = TRUE
 WHERE type IN ('VASU', 'LEOPS', 'HOJKS', 'MIGRATED_VASU', 'MIGRATED_LEOPS');
+
+ALTER TABLE document_template ALTER COLUMN archive_externally DROP DEFAULT;

--- a/service/src/main/resources/db/migration/V521__document_template_archiveable.sql
+++ b/service/src/main/resources/db/migration/V521__document_template_archiveable.sql
@@ -1,0 +1,7 @@
+ALTER TABLE document_template
+    ADD COLUMN archive_externally boolean DEFAULT FALSE NOT NULL;
+
+-- Set existing document types that previously had hard-coded support for archiving to true
+UPDATE document_template
+SET archive_externally = TRUE
+WHERE type IN ('VASU', 'LEOPS', 'HOJKS', 'MIGRATED_VASU', 'MIGRATED_LEOPS');

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -516,3 +516,4 @@ V517__nekku_eats_breakfast.sql
 V518__more_child_document_constraints.sql
 V519__nekku_special_diet_choices.sql
 V520__nekku_customer_type_changes.sql
+V521__document_template_archiveable.sql

--- a/service/src/test/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/document/archival/ArchiveChildDocumentServiceTest.kt
@@ -157,6 +157,7 @@ class ArchiveChildDocumentServiceTest {
                                         )
                                     )
                             ),
+                        archiveExternally = true,
                     ),
             )
 


### PR DESCRIPTION
## Ennen tätä muutosta
Asiakirjojen arkistoitavuus määräytyi kovakoodatusti asiakirjatyypin perusteella. Vain tietyt asiakirjatyypit (`VASU`, `LEOPS`, `HOJKS`, `MIGRATED_VASU`, `MIGRATED_LEOPS`) voitiin lähettää ulkoiseen arkistoon. Asiakirjan tyyppi tarkastettiin vasta kun `AsyncJob` ajettiin
## Tämän muutoksen jälkeen
Asiakirjapohjiin on lisätty uusi flägi `archiveExternally`, joka määrittää, voidaanko asiakirjapohjan mukainen asiakirja arkistoida ulkoiseen järjestelmään. Muutoksen myötä:
- Dokumenttipohjan editoriin on lisätty checbox "Siirrettävä ulkoiseen arkistoon ennen poistoa"
- Yksittäisen asiakirjan "Arkistoi" toiminta on deaktivoitu asiakirjoille, joiden pohjaa ei ole merkitty ulkoisesti arkistoitavaksi
- Tietokantamigraatio asettaa flägin arvoksi `TRUE` niille asiakirjatyypeille, joilla oli aiemmin kovakoodattu tuki arkistoinnille
- Async jobissa; `ArchiveChildDocumentService.uploadToArchive`ssa; tehty kovakoodattu tyyppitarkistus on korvattu flägin tarkistuksella `ChildDocumentController.planArchiveChildDocument` handlerissa