### PR TITLE
Korjataan gradle-varoitus

### DIFF
--- a/service/settings.gradle.kts
+++ b/service/settings.gradle.kts
@@ -8,8 +8,6 @@ include("service-lib")
 
 include("vtjclient")
 
-include("sficlient")
-
 include("evaka-bom")
 
 include("codegen")


### PR DESCRIPTION
Gradle antaa esim. `assemble`-komennolla varoituksen: "Configuring project ':sficlient' without an existing directory is deprecated.".

Projekti on poistettu https://github.com/espoon-voltti/evaka/pull/6405.