### PR TITLE
Lisätään työntekijätiedot lomakkeen vastaaja-kenttään

### DIFF
--- a/frontend/src/citizen-frontend/children/sections/ChildDocumentsSection.tsx
+++ b/frontend/src/citizen-frontend/children/sections/ChildDocumentsSection.tsx
@@ -261,7 +261,12 @@ const Answered = ({ document }: { document: ChildDocumentCitizenSummary }) => {
         {document.answeredAt?.toLocalDate().format()}
       </span>
       {document.answeredBy !== null && (
-        <span>, {document.answeredBy.name}</span>
+        <span>
+          ,{' '}
+          {document.answeredBy.type === 'CITIZEN'
+            ? document.answeredBy.name
+            : i18n.children.childDocuments.answeredByEmployee}
+        </span>
       )}
     </>
   )

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2636,6 +2636,7 @@ const en: Translations = {
       confidential: 'Confidential',
       unanswered: 'Ei vastattu (en)',
       answered: 'Vastattu (en)',
+      answeredByEmployee: 'Henkilökunta (en)',
       preview: 'Esikatsele (en)',
       send: 'Lähetä (en)',
       success: 'Lomake lähetetty (en)',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2858,6 +2858,7 @@ export default {
       confidential: 'Salassapidettävä',
       unanswered: 'Ei vastattu',
       answered: 'Vastattu',
+      answeredByEmployee: 'Henkilökunta',
       preview: 'Esikatsele',
       send: 'Lähetä',
       success: 'Lomake lähetetty',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2879,6 +2879,7 @@ const sv: Translations = {
       confidential: 'Konfidentiellt',
       unanswered: 'Ei vastattu (sv)',
       answered: 'Vastattu (sv)',
+      answeredByEmployee: 'Henkilökunta (sv)',
       preview: 'Esikatsele (sv)',
       send: 'Lähetä (sv)',
       success: 'Lomake lähetetty (sv)',

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueries.kt
@@ -299,6 +299,7 @@ fun Database.Transaction.changeStatusAndPublish(
     id: ChildDocumentId,
     statusTransition: StatusTransition,
     now: HelsinkiDateTime,
+    answeredBy: EvakaUserId?,
 ) {
     createUpdate {
             sql(
@@ -306,6 +307,7 @@ fun Database.Transaction.changeStatusAndPublish(
                 UPDATE child_document
                 SET status = ${bind(statusTransition.newStatus)}, modified_at = ${bind(now)}, 
                     published_at = ${bind(now)}, published_content = content
+                    ${if (answeredBy != null) ", answered_at = ${bind(now)}, answered_by = ${bind(answeredBy)}" else ""}
                 WHERE id = ${bind(id)} AND status = ${bind(statusTransition.currentStatus)}
                 """
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueriesCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentQueriesCitizen.kt
@@ -35,7 +35,10 @@ SELECT
     child.date_of_birth AS child_date_of_birth,
     cd.answered_at,
     answered_by.id AS answered_by_id,
-    answered_by.name AS answered_by_name,
+    CASE answered_by.type
+        WHEN 'CITIZEN' THEN answered_by.name
+        ELSE ''
+    END AS answered_by_name,
     answered_by.type AS answered_by_type
 FROM child_document cd
 JOIN document_template dt ON cd.template_id = dt.id


### PR DESCRIPTION
Aiemmin työntekijän tietoja ei tallennettu ollenkaan, eikä niitä siten voitu näyttääkään.

Kuntalaisen puolelta piilotetaan tällaisessa tapauksessa vastaajan nimi.