### PR TITLE
Korjataan viestit-sivun käyttö pienillä resoluutioilla

### DIFF
--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -5,7 +5,12 @@
 import isPropValid from '@emotion/is-prop-valid'
 import { ErrorBoundary } from '@sentry/react'
 import React, { useContext } from 'react'
-import { createBrowserRouter, Navigate, Outlet } from 'react-router'
+import {
+  createBrowserRouter,
+  Navigate,
+  Outlet,
+  useLocation
+} from 'react-router'
 import { StyleSheetManager, ThemeProvider } from 'styled-components'
 
 import { Notifications } from 'lib-components/Notifications'
@@ -170,6 +175,8 @@ const Content = React.memo(function Content() {
   const { sessionExpirationDetected, dismissSessionExpiredDetection } =
     useKeepSessionAlive(sessionKeepalive, loggedIn)
 
+  const location = useLocation()
+
   const handleLoginClick = () => {
     window.open('/employee/close-after-login', '_blank')
     const authChecker = () => {
@@ -189,7 +196,7 @@ const Content = React.memo(function Content() {
       {/* the matched route element will be inserted at <Outlet /> */}
       <Outlet />
 
-      <Footer />
+      {!location.pathname.startsWith('/messages') && <Footer />}
       {!!featureFlags.environmentLabel && (
         <EnvironmentLabel>{featureFlags.environmentLabel}</EnvironmentLabel>
       )}

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -37,7 +37,6 @@ import { getPersonIdentity } from '../../generated/api-clients/pis'
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
 import { formatPersonName } from '../../utils'
-import { footerHeight } from '../Footer'
 import { headerHeight } from '../Header'
 
 import { MessageContext } from './MessageContext'
@@ -49,9 +48,7 @@ const deleteDraftMessageResult = wrapResult(deleteDraftMessage)
 const createMessageResult = wrapResult(createMessage)
 
 const PanelContainer = styled.div`
-  height: calc(
-    100vh - ${headerHeight} - ${footerHeight} - ${defaultMargins.XL}
-  );
+  height: calc(100vh - ${headerHeight} - ${defaultMargins.m});
   display: flex;
 `
 

--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -288,53 +288,53 @@ export function SingleThreadView({
             />
           </React.Fragment>
         ))}
-        {canReply &&
-          (isFolderView(view) ||
-            (isStandardView(view) && ['received', 'thread'].includes(view))) &&
-          (replyEditorVisible ? (
-            <MessageContainer>
-              <MessageReplyEditor
-                mutation={replyToThreadMutation}
-                onSubmit={onSubmitReply}
-                onSuccess={handleReplySent}
-                onDiscard={onDiscard}
-                onUpdateContent={onUpdateContent}
-                recipients={recipients}
-                onToggleRecipient={onToggleRecipient}
-                replyContent={replyContent}
-                sendEnabled={sendEnabled}
-              />
-            </MessageContainer>
-          ) : (
-            <>
-              <Gap size="s" />
-              <ActionRow justifyContent="space-between">
-                <Button
-                  appearance="inline"
-                  icon={faReply}
-                  onClick={() => setReplyEditorVisible(true)}
-                  data-qa="message-reply-editor-btn"
-                  text={i18n.messages.replyToThread}
-                />
-                {onArchived && (
-                  <AsyncButton
-                    appearance="inline"
-                    icon={faBoxArchive}
-                    aria-label={i18n.common.archive}
-                    data-qa="delete-thread-btn"
-                    className="delete-btn"
-                    onClick={() => archiveThreadResult({ accountId, threadId })}
-                    onSuccess={onArchived}
-                    text={i18n.messages.archiveThread}
-                    stopPropagation
-                  />
-                )}
-              </ActionRow>
-              <Gap size="m" />
-            </>
-          ))}
         {replyEditorVisible && <span ref={autoScrollRef} />}
       </ScrollContainer>
+      {canReply &&
+        (isFolderView(view) ||
+          (isStandardView(view) && ['received', 'thread'].includes(view))) &&
+        (replyEditorVisible ? (
+          <MessageContainer>
+            <MessageReplyEditor
+              mutation={replyToThreadMutation}
+              onSubmit={onSubmitReply}
+              onSuccess={handleReplySent}
+              onDiscard={onDiscard}
+              onUpdateContent={onUpdateContent}
+              recipients={recipients}
+              onToggleRecipient={onToggleRecipient}
+              replyContent={replyContent}
+              sendEnabled={sendEnabled}
+            />
+          </MessageContainer>
+        ) : (
+          <>
+            <Gap size="s" />
+            <ActionRow justifyContent="space-between">
+              <Button
+                appearance="inline"
+                icon={faReply}
+                onClick={() => setReplyEditorVisible(true)}
+                data-qa="message-reply-editor-btn"
+                text={i18n.messages.replyToThread}
+              />
+              {onArchived && (
+                <AsyncButton
+                  appearance="inline"
+                  icon={faBoxArchive}
+                  aria-label={i18n.common.archive}
+                  data-qa="delete-thread-btn"
+                  className="delete-btn"
+                  onClick={() => archiveThreadResult({ accountId, threadId })}
+                  onSuccess={onArchived}
+                  text={i18n.messages.archiveThread}
+                  stopPropagation
+                />
+              )}
+            </ActionRow>
+            <Gap size="m" />
+          </>
+        ))}
     </ThreadContainer>
   )
 }


### PR DESCRIPTION
Viestit-sivu toimii eri tavalla kuin kaikki muut sivut, jossa sisällölle varattu alue lasketaan ikkunnan koko - (yläpalkki + alapalkki). Pienillä resoluutioilla alapalkki vie itse sisällöltä turhan paljon tilaa.

Korjauksena poistetaan koko alapalkki kyseiseltä sivulta. Lisäksi muutettu viestiketjun vierityspalkki loppumaan mahdolliseen vastauskenttään, jotta pienillä resoluutioilla ketjun otsikko ei mene vastauskentän päälle.