### PR TITLE
Massaviestinnän lisäfiltteri sijoitustyyppi

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -19,6 +19,7 @@ import {
   SelectableRecipientsResponse,
   UpdatableDraftContent
 } from 'lib-common/generated/api-types/messaging'
+import { MessagingCategory } from 'lib-common/generated/api-types/placement'
 import {
   AttachmentId,
   MessageAccountId,
@@ -152,8 +153,15 @@ const getEmptyFilters = (): Filters => ({
   yearsOfBirth: [],
   shiftCare: false,
   intermittentShiftCare: false,
-  familyDaycare: false
+  familyDaycare: false,
+  placementTypes: []
 })
+
+export const messagingPlacementTypeCategories: readonly MessagingCategory[] = [
+  'MESSAGING_CLUB',
+  'MESSAGING_DAYCARE',
+  'MESSAGING_PRESCHOOL'
+] as const
 
 interface FlagProps {
   urgent: boolean
@@ -234,6 +242,16 @@ export default React.memo(function MessageEditor({
       children: []
     }))
   )
+
+  const [placementTypeTree, setPlacementTypeTree] = useState<TreeNode[]>(
+    messagingPlacementTypeCategories.map<TreeNode>((type) => ({
+      text: i18n.placement.messagingCategory[type],
+      key: type,
+      checked: false,
+      children: []
+    }))
+  )
+
   const [message, setMessage] = useState<Message>(() =>
     getInitialMessage(draftContent, defaultSender, defaultTitle)
   )
@@ -364,6 +382,20 @@ export default React.memo(function MessageEditor({
       const updatedFilters = {
         ...filters,
         yearsOfBirth: selected.map((y) => +y.key)
+      }
+      setFilters(updatedFilters)
+    },
+    [filters, setFilters]
+  )
+
+  const handlePlacementTypeChange = useCallback(
+    (placementTypes: TreeNode[]) => {
+      setPlacementTypeTree(placementTypes)
+      const selected = placementTypes.filter((type) => type.checked)
+
+      const updatedFilters = {
+        ...filters,
+        placementTypes: selected.map((t) => t.key as MessagingCategory)
       }
       setFilters(updatedFilters)
     },
@@ -691,6 +723,20 @@ export default React.memo(function MessageEditor({
                               i18n.messages.messageEditor.selectPlaceholder
                             }
                             data-qa="select-years-of-birth"
+                          />
+                        </HorizontalField>
+                        <Gap size="s" />
+                        <HorizontalField>
+                          <Bold>
+                            {i18n.messages.messageEditor.filters.placementType}
+                          </Bold>
+                          <TreeDropdown
+                            tree={placementTypeTree}
+                            onChange={handlePlacementTypeChange}
+                            placeholder={
+                              i18n.messages.messageEditor.selectPlaceholder
+                            }
+                            data-qa="select-placement-type"
                           />
                         </HorizontalField>
                       </Dropdowns>

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -19,7 +19,10 @@ import {
   SelectableRecipientsResponse,
   UpdatableDraftContent
 } from 'lib-common/generated/api-types/messaging'
-import { MessagingCategory } from 'lib-common/generated/api-types/placement'
+import {
+  messagingCategory,
+  MessagingCategory
+} from 'lib-common/generated/api-types/placement'
 import {
   AttachmentId,
   MessageAccountId,
@@ -157,12 +160,6 @@ const getEmptyFilters = (): Filters => ({
   placementTypes: []
 })
 
-export const messagingPlacementTypeCategories: readonly MessagingCategory[] = [
-  'MESSAGING_CLUB',
-  'MESSAGING_DAYCARE',
-  'MESSAGING_PRESCHOOL'
-] as const
-
 interface FlagProps {
   urgent: boolean
   sensitive: boolean
@@ -244,7 +241,7 @@ export default React.memo(function MessageEditor({
   )
 
   const [placementTypeTree, setPlacementTypeTree] = useState<TreeNode[]>(
-    messagingPlacementTypeCategories.map<TreeNode>((type) => ({
+    messagingCategory.map<TreeNode>((type) => ({
       text: i18n.placement.messagingCategory[type],
       key: type,
       checked: false,

--- a/frontend/src/lib-common/generated/api-types/messaging.ts
+++ b/frontend/src/lib-common/generated/api-types/messaging.ts
@@ -21,6 +21,7 @@ import { MessageDraftId } from './shared'
 import { MessageId } from './shared'
 import { MessageThreadFolderId } from './shared'
 import { MessageThreadId } from './shared'
+import { MessagingCategory } from './placement'
 import { PersonId } from './shared'
 
 /**
@@ -374,6 +375,7 @@ export interface PostMessageBody {
 export interface PostMessageFilters {
   familyDaycare: boolean
   intermittentShiftCare: boolean
+  placementTypes: MessagingCategory[]
   shiftCare: boolean
   yearsOfBirth: number[]
 }

--- a/frontend/src/lib-common/generated/api-types/placement.ts
+++ b/frontend/src/lib-common/generated/api-types/placement.ts
@@ -124,6 +124,14 @@ export interface GroupTransferRequestBody {
 }
 
 /**
+* Generated from fi.espoo.evaka.placement.MessagingCategory
+*/
+export type MessagingCategory =
+  | 'MESSAGING_CLUB'
+  | 'MESSAGING_DAYCARE'
+  | 'MESSAGING_PRESCHOOL'
+
+/**
 * Generated from fi.espoo.evaka.placement.MissingBackupGroupPlacement
 */
 export interface MissingBackupGroupPlacement {

--- a/frontend/src/lib-common/generated/api-types/placement.ts
+++ b/frontend/src/lib-common/generated/api-types/placement.ts
@@ -126,10 +126,13 @@ export interface GroupTransferRequestBody {
 /**
 * Generated from fi.espoo.evaka.placement.MessagingCategory
 */
-export type MessagingCategory =
-  | 'MESSAGING_CLUB'
-  | 'MESSAGING_DAYCARE'
-  | 'MESSAGING_PRESCHOOL'
+export const messagingCategory = [
+  'MESSAGING_CLUB',
+  'MESSAGING_DAYCARE',
+  'MESSAGING_PRESCHOOL'
+] as const
+
+export type MessagingCategory = typeof messagingCategory[number]
 
 /**
 * Generated from fi.espoo.evaka.placement.MissingBackupGroupPlacement

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3253,6 +3253,11 @@ export const fi = {
       TEMPORARY_DAYCARE: 'Tilapäinen kokopäiväinen varhaiskasvatus',
       TEMPORARY_DAYCARE_PART_DAY: 'Tilapäinen osapäiväinen varhaiskasvatus',
       SCHOOL_SHIFT_CARE: 'Koululaisten vuorohoito'
+    },
+    messagingCategory: {
+      MESSAGING_CLUB: 'Kerho',
+      MESSAGING_DAYCARE: 'Varhaiskasvatus',
+      MESSAGING_PRESCHOOL: 'Esiopetus'
     }
   },
   feeAlteration: {
@@ -4857,6 +4862,7 @@ export const fi = {
         showFilters: 'Näytä lisävalinnat',
         hideFilters: 'Piilota lisävalinnat',
         yearOfBirth: 'Syntymävuosi',
+        placementType: 'Sijoitustyyppi',
         shiftCare: {
           heading: 'Vuorohoito',
           label: 'Vuorohoito',

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -9,7 +9,6 @@ import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.application.personHasSentApplicationWithId
 import fi.espoo.evaka.invoicing.controller.SortDirection
 import fi.espoo.evaka.placement.MessagingCategory
-import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AttachmentId
 import fi.espoo.evaka.shared.ChildId

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -8,6 +8,8 @@ import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.application.personHasSentApplicationWithId
 import fi.espoo.evaka.invoicing.controller.SortDirection
+import fi.espoo.evaka.placement.MessagingCategory
+import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.AttachmentId
 import fi.espoo.evaka.shared.ChildId
@@ -528,6 +530,7 @@ class MessageController(
         val shiftCare: Boolean = false,
         val intermittentShiftCare: Boolean = false,
         val familyDaycare: Boolean = false,
+        val placementTypes: List<MessagingCategory> = listOf(),
     )
 
     data class PostMessagePreflightBody(

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -1598,10 +1598,9 @@ fun Database.Read.getMessageAccountsForRecipients(
 
     val placementPredicate = { col: String ->
         if (filters?.placementTypes?.isNotEmpty() == true) {
-            val placementTypesInCategory = PlacementType.fromMessagingCategories(filters.placementTypes)
-            PredicateSql {
-                where("pl.$col = ANY(${bind(placementTypesInCategory)})")
-            }
+            val placementTypesInCategory =
+                PlacementType.fromMessagingCategories(filters.placementTypes)
+            PredicateSql { where("pl.$col = ANY(${bind(placementTypesInCategory)})") }
         } else PredicateSql.alwaysTrue()
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -9,6 +9,7 @@ import fi.espoo.evaka.application.getCitizenChildren
 import fi.espoo.evaka.attachment.Attachment
 import fi.espoo.evaka.invoicing.controller.SortDirection
 import fi.espoo.evaka.messaging.MessageController.MessageThreadFolder
+import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.*
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.Predicate
@@ -1595,6 +1596,15 @@ fun Database.Read.getMessageAccountsForRecipients(
             } else null,
         )
 
+    val placementPredicate = { col: String ->
+        if (filters?.placementTypes?.isNotEmpty() == true) {
+            val placementTypesInCategory = PlacementType.fromMessagingCategories(filters.placementTypes)
+            PredicateSql {
+                where("pl.$col = ANY(${bind(placementTypesInCategory)})")
+            }
+        } else PredicateSql.alwaysTrue()
+    }
+
     return createQuery {
             sql(
                 """
@@ -1611,7 +1621,7 @@ WITH sender AS (
         OR pl.unit_id = ANY(${bind(currentRecipients.unitIds())})
         OR pl.group_id = ANY(${bind(currentRecipients.groupIds())})
         OR pl.child_id = ANY(${bind(currentRecipients.childIds())}))
-    AND ${predicate(filterPredicates)}
+    AND ${predicate(filterPredicates.and(placementPredicate("placement_type")))}
     AND (sender.type = 'MUNICIPAL'::message_account_type OR pl.group_id IS NOT NULL)
     AND (
         EXISTS (
@@ -1659,7 +1669,7 @@ WITH sender AS (
             OR pl.unit_id = ANY(${bind(starterRecipients.unitIds())})
             OR dgp.daycare_group_id = ANY(${bind(starterRecipients.groupIds())})
             OR pl.child_id = ANY(${bind(starterRecipients.childIds())}))
-    AND ${predicate(filterPredicates)}
+    AND ${predicate(filterPredicates.and(placementPredicate("type")))}
     AND (sender.type = 'MUNICIPAL'::message_account_type OR dgp.daycare_group_id IS NOT NULL)
     AND (
         EXISTS (

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementType.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementType.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.placement
 
+import fi.espoo.evaka.ConstList
 import fi.espoo.evaka.absence.AbsenceCategory
 import fi.espoo.evaka.daycare.ClubTerm
 import fi.espoo.evaka.daycare.PreschoolTerm
@@ -86,21 +87,21 @@ enum class PlacementType : DatabaseEnum {
                 setOf(AbsenceCategory.BILLABLE, AbsenceCategory.NONBILLABLE)
         }
 
-    fun messagingCategories(): Set<MessagingCategory>? =
+    private fun messagingCategory(): MessagingCategory? =
         when (this) {
-            CLUB -> setOf(MessagingCategory.MESSAGING_CLUB)
+            CLUB -> MessagingCategory.MESSAGING_CLUB
             DAYCARE,
             DAYCARE_PART_TIME,
             DAYCARE_FIVE_YEAR_OLDS,
             DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
-            SCHOOL_SHIFT_CARE -> setOf(MessagingCategory.MESSAGING_DAYCARE)
+            SCHOOL_SHIFT_CARE -> MessagingCategory.MESSAGING_DAYCARE
             PRESCHOOL,
             PRESCHOOL_DAYCARE,
             PRESCHOOL_DAYCARE_ONLY,
             PRESCHOOL_CLUB,
             PREPARATORY,
             PREPARATORY_DAYCARE,
-            PREPARATORY_DAYCARE_ONLY -> setOf(MessagingCategory.MESSAGING_PRESCHOOL)
+            PREPARATORY_DAYCARE_ONLY -> MessagingCategory.MESSAGING_PRESCHOOL
             TEMPORARY_DAYCARE,
             TEMPORARY_DAYCARE_PART_DAY -> null
         }
@@ -171,7 +172,7 @@ enum class PlacementType : DatabaseEnum {
             entries.filter { it.absenceCategories().contains(AbsenceCategory.NONBILLABLE) }
 
         fun fromMessagingCategories(categories: List<MessagingCategory>): List<PlacementType> {
-            return PlacementType.entries.filter { it.messagingCategories()?.any { category -> category in categories } == true }
+            return PlacementType.entries.filter { categories.contains(it.messagingCategory()) }
         }
     }
 }
@@ -182,6 +183,7 @@ enum class ScheduleType {
     TERM_BREAK, // Preschool/club term break -> no activity
 }
 
+@ConstList("messagingCategory")
 enum class MessagingCategory {
     MESSAGING_CLUB,
     MESSAGING_DAYCARE,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementType.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementType.kt
@@ -86,6 +86,25 @@ enum class PlacementType : DatabaseEnum {
                 setOf(AbsenceCategory.BILLABLE, AbsenceCategory.NONBILLABLE)
         }
 
+    fun messagingCategories(): Set<MessagingCategory>? =
+        when (this) {
+            CLUB -> setOf(MessagingCategory.MESSAGING_CLUB)
+            DAYCARE,
+            DAYCARE_PART_TIME,
+            DAYCARE_FIVE_YEAR_OLDS,
+            DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
+            SCHOOL_SHIFT_CARE -> setOf(MessagingCategory.MESSAGING_DAYCARE)
+            PRESCHOOL,
+            PRESCHOOL_DAYCARE,
+            PRESCHOOL_DAYCARE_ONLY,
+            PRESCHOOL_CLUB,
+            PREPARATORY,
+            PREPARATORY_DAYCARE,
+            PREPARATORY_DAYCARE_ONLY -> setOf(MessagingCategory.MESSAGING_PRESCHOOL)
+            TEMPORARY_DAYCARE,
+            TEMPORARY_DAYCARE_PART_DAY -> null
+        }
+
     fun scheduleType(
         date: LocalDate,
         clubTerms: List<ClubTerm>,
@@ -150,6 +169,10 @@ enum class PlacementType : DatabaseEnum {
             entries.filter { it.absenceCategories().contains(AbsenceCategory.BILLABLE) }
         val withNonbillableAbsences =
             entries.filter { it.absenceCategories().contains(AbsenceCategory.NONBILLABLE) }
+
+        fun fromMessagingCategories(categories: List<MessagingCategory>): List<PlacementType> {
+            return PlacementType.entries.filter { it.messagingCategories()?.any { category -> category in categories } == true }
+        }
     }
 }
 
@@ -157,4 +180,10 @@ enum class ScheduleType {
     RESERVATION_REQUIRED, // Daycare -> reservations required
     FIXED_SCHEDULE, // Preschool/club -> reservations not required
     TERM_BREAK, // Preschool/club term break -> no activity
+}
+
+enum class MessagingCategory {
+    MESSAGING_CLUB,
+    MESSAGING_DAYCARE,
+    MESSAGING_PRESCHOOL,
 }


### PR DESCRIPTION
Lisättiin sijoitustyyppi filtteriksi massaviestintään. Sijoitustyypit ryhmiteltiin kolmeen kategoriaan: kerho, esiopetus ja  varhaiskasvatus. Slack-drafti ryhmittelystä:

<img width="493" alt="massaviestinta-filter-sijoitus" src="https://github.com/user-attachments/assets/bb9876d1-279a-4419-9c79-f0bc01634565" />


Näyttää ui:ssa tältä:


https://github.com/user-attachments/assets/18002e16-4c4c-4737-afcb-e1f79c4be722

