### PR TITLE
Korjataan maksuttoman poissaolon tyyppi

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerIntegrationTest.kt
@@ -71,11 +71,13 @@ class HolidayPeriodControllerIntegrationTest : FullApplicationTest(resetDbBefore
                         testChild_1.id,
                         holidayPeriodStart.minusDays(1),
                         AbsenceType.OTHER_ABSENCE,
+                        AbsenceType.OTHER_ABSENCE,
                     ),
                     // Inside holiday period
                     FullDayAbsenseUpsert(
                         testChild_1.id,
                         holidayPeriodStart,
+                        AbsenceType.OTHER_ABSENCE,
                         AbsenceType.OTHER_ABSENCE,
                     ),
                 ),
@@ -88,6 +90,7 @@ class HolidayPeriodControllerIntegrationTest : FullApplicationTest(resetDbBefore
                     FullDayAbsenseUpsert(
                         testChild_1.id,
                         holidayPeriodStart.plusDays(1),
+                        AbsenceType.OTHER_ABSENCE,
                         AbsenceType.OTHER_ABSENCE,
                     )
                 ),

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/CreateReservationsAndAbsencesTest.kt
@@ -1235,12 +1235,14 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     FullDayAbsenseUpsert(
                         childId = child.id,
                         date = holidayPeriodStart,
-                        absenceType = AbsenceType.OTHER_ABSENCE,
+                        absenceTypeBillable = AbsenceType.OTHER_ABSENCE,
+                        absenceTypeNonbillable = AbsenceType.OTHER_ABSENCE,
                     ),
                     FullDayAbsenseUpsert(
                         childId = child.id,
                         date = holidayPeriodStart.plusDays(1),
-                        absenceType = AbsenceType.OTHER_ABSENCE,
+                        absenceTypeBillable = AbsenceType.OTHER_ABSENCE,
+                        absenceTypeNonbillable = AbsenceType.OTHER_ABSENCE,
                     ),
                 ),
             )
@@ -1307,7 +1309,8 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     FullDayAbsenseUpsert(
                         childId = child.id,
                         date = holidayPeriodStart,
-                        absenceType = AbsenceType.OTHER_ABSENCE,
+                        absenceTypeBillable = AbsenceType.OTHER_ABSENCE,
+                        absenceTypeNonbillable = AbsenceType.OTHER_ABSENCE,
                     )
                 ),
             )
@@ -1418,7 +1421,8 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     FullDayAbsenseUpsert(
                         childId = child.id,
                         date = holidayPeriodStart,
-                        absenceType = AbsenceType.OTHER_ABSENCE,
+                        absenceTypeBillable = AbsenceType.OTHER_ABSENCE,
+                        absenceTypeNonbillable = AbsenceType.OTHER_ABSENCE,
                     )
                 ),
             )
@@ -1748,7 +1752,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                 Triple(monday, AbsenceType.PLANNED_ABSENCE, AbsenceCategory.BILLABLE),
                 Triple(tuesday, AbsenceType.PLANNED_ABSENCE, AbsenceCategory.BILLABLE),
                 // No absence for wednesday
-                Triple(thursday, AbsenceType.PLANNED_ABSENCE, AbsenceCategory.NONBILLABLE),
+                Triple(thursday, AbsenceType.OTHER_ABSENCE, AbsenceCategory.NONBILLABLE),
             ),
             absences.map { Triple(it.date, it.absenceType, it.category) },
         )

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -302,6 +302,260 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                     placementType.absenceCategories().map { Tuple(it, AbsenceType.PLANNED_ABSENCE) }
                 )
         }
+
+        @Test
+        fun `postReservations inserts billable planned absence and nonbillable other absence when contract days`() {
+            db.transaction { tx ->
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            type = PlacementType.PRESCHOOL_DAYCARE,
+                            childId = child.id,
+                            unitId = unit.id,
+                            startDate = monday,
+                            endDate = monday,
+                        )
+                    )
+                tx.insert(
+                    DevServiceNeed(
+                        placementId = placementId,
+                        startDate = monday,
+                        endDate = monday,
+                        optionId = snDaycareContractDays10.id,
+                        shiftCare = ShiftCareType.NONE,
+                        confirmedBy = employee.evakaUserId,
+                        confirmedAt = HelsinkiDateTime.now(),
+                    )
+                )
+            }
+
+            postReservations(
+                adult.user(CitizenAuthLevel.WEAK),
+                listOf(
+                    DailyReservationRequest.Reservations(
+                        childId = child.id,
+                        date = monday,
+                        reservation = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 10)),
+                    )
+                ),
+            )
+
+            assertThat(db.transaction { tx -> tx.getAbsencesOfChildByDate(child.id, monday) })
+                .extracting({ it.category }, { it.absenceType })
+                .containsExactlyInAnyOrder(
+                    Tuple(AbsenceCategory.BILLABLE, AbsenceType.PLANNED_ABSENCE),
+                    Tuple(AbsenceCategory.NONBILLABLE, AbsenceType.OTHER_ABSENCE),
+                )
+        }
+
+        @Test
+        fun `postReservations with absence inserts billable planned absence and nonbillable other absence when contract days`() {
+            db.transaction { tx ->
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            type = PlacementType.PRESCHOOL_DAYCARE,
+                            childId = child.id,
+                            unitId = unit.id,
+                            startDate = monday,
+                            endDate = monday,
+                        )
+                    )
+                tx.insert(
+                    DevServiceNeed(
+                        placementId = placementId,
+                        startDate = monday,
+                        endDate = monday,
+                        optionId = snDaycareContractDays10.id,
+                        shiftCare = ShiftCareType.NONE,
+                        confirmedBy = employee.evakaUserId,
+                        confirmedAt = HelsinkiDateTime.now(),
+                    )
+                )
+            }
+
+            postReservations(
+                adult.user(CitizenAuthLevel.WEAK),
+                listOf(DailyReservationRequest.Absent(childId = child.id, date = monday)),
+            )
+
+            assertThat(db.transaction { tx -> tx.getAbsencesOfChildByDate(child.id, monday) })
+                .extracting({ it.category }, { it.absenceType })
+                .containsExactlyInAnyOrder(
+                    Tuple(AbsenceCategory.BILLABLE, AbsenceType.PLANNED_ABSENCE),
+                    Tuple(AbsenceCategory.NONBILLABLE, AbsenceType.OTHER_ABSENCE),
+                )
+        }
+
+        @Test
+        fun `postAbsences inserts billable planned absence and nonbillable other absence when contract days`() {
+            db.transaction { tx ->
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            type = PlacementType.PRESCHOOL_DAYCARE,
+                            childId = child.id,
+                            unitId = unit.id,
+                            startDate = monday,
+                            endDate = monday,
+                        )
+                    )
+                tx.insert(
+                    DevServiceNeed(
+                        placementId = placementId,
+                        startDate = monday,
+                        endDate = monday,
+                        optionId = snDaycareContractDays10.id,
+                        shiftCare = ShiftCareType.NONE,
+                        confirmedBy = employee.evakaUserId,
+                        confirmedAt = HelsinkiDateTime.now(),
+                    )
+                )
+            }
+
+            postAbsences(
+                adult.user(CitizenAuthLevel.WEAK),
+                AbsenceRequest(
+                    childIds = setOf(child.id),
+                    dateRange = FiniteDateRange(monday, monday),
+                    absenceType = AbsenceType.OTHER_ABSENCE,
+                ),
+            )
+
+            assertThat(db.transaction { tx -> tx.getAbsencesOfChildByDate(child.id, monday) })
+                .extracting({ it.category }, { it.absenceType })
+                .containsExactlyInAnyOrder(
+                    Tuple(AbsenceCategory.BILLABLE, AbsenceType.PLANNED_ABSENCE),
+                    Tuple(AbsenceCategory.NONBILLABLE, AbsenceType.OTHER_ABSENCE),
+                )
+        }
+
+        @Test
+        fun `postReservations inserts billable planned absence and nonbillable other absence when contract hours`() {
+            db.transaction { tx ->
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            type = PlacementType.PRESCHOOL_DAYCARE,
+                            childId = child.id,
+                            unitId = unit.id,
+                            startDate = monday,
+                            endDate = monday,
+                        )
+                    )
+                tx.insert(
+                    DevServiceNeed(
+                        placementId = placementId,
+                        startDate = monday,
+                        endDate = monday,
+                        optionId = snDaycareHours120.id,
+                        shiftCare = ShiftCareType.NONE,
+                        confirmedBy = employee.evakaUserId,
+                        confirmedAt = HelsinkiDateTime.now(),
+                    )
+                )
+            }
+
+            postReservations(
+                adult.user(CitizenAuthLevel.WEAK),
+                listOf(
+                    DailyReservationRequest.Reservations(
+                        childId = child.id,
+                        date = monday,
+                        reservation = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 10)),
+                    )
+                ),
+            )
+
+            assertThat(db.transaction { tx -> tx.getAbsencesOfChildByDate(child.id, monday) })
+                .extracting({ it.category }, { it.absenceType })
+                .containsExactlyInAnyOrder(
+                    Tuple(AbsenceCategory.BILLABLE, AbsenceType.PLANNED_ABSENCE),
+                    Tuple(AbsenceCategory.NONBILLABLE, AbsenceType.OTHER_ABSENCE),
+                )
+        }
+
+        @Test
+        fun `postReservations with absence inserts billable planned absence and nonbillable other absence when contract hours`() {
+            db.transaction { tx ->
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            type = PlacementType.PRESCHOOL_DAYCARE,
+                            childId = child.id,
+                            unitId = unit.id,
+                            startDate = monday,
+                            endDate = monday,
+                        )
+                    )
+                tx.insert(
+                    DevServiceNeed(
+                        placementId = placementId,
+                        startDate = monday,
+                        endDate = monday,
+                        optionId = snDaycareHours120.id,
+                        shiftCare = ShiftCareType.NONE,
+                        confirmedBy = employee.evakaUserId,
+                        confirmedAt = HelsinkiDateTime.now(),
+                    )
+                )
+            }
+
+            postReservations(
+                adult.user(CitizenAuthLevel.WEAK),
+                listOf(DailyReservationRequest.Absent(childId = child.id, date = monday)),
+            )
+
+            assertThat(db.transaction { tx -> tx.getAbsencesOfChildByDate(child.id, monday) })
+                .extracting({ it.category }, { it.absenceType })
+                .containsExactlyInAnyOrder(
+                    Tuple(AbsenceCategory.BILLABLE, AbsenceType.PLANNED_ABSENCE),
+                    Tuple(AbsenceCategory.NONBILLABLE, AbsenceType.OTHER_ABSENCE),
+                )
+        }
+
+        @Test
+        fun `postAbsences inserts billable planned absence and nonbillable other absence when contract hours`() {
+            db.transaction { tx ->
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            type = PlacementType.PRESCHOOL_DAYCARE,
+                            childId = child.id,
+                            unitId = unit.id,
+                            startDate = monday,
+                            endDate = monday,
+                        )
+                    )
+                tx.insert(
+                    DevServiceNeed(
+                        placementId = placementId,
+                        startDate = monday,
+                        endDate = monday,
+                        optionId = snDaycareHours120.id,
+                        shiftCare = ShiftCareType.NONE,
+                        confirmedBy = employee.evakaUserId,
+                        confirmedAt = HelsinkiDateTime.now(),
+                    )
+                )
+            }
+
+            postAbsences(
+                adult.user(CitizenAuthLevel.WEAK),
+                AbsenceRequest(
+                    childIds = setOf(child.id),
+                    dateRange = FiniteDateRange(monday, monday),
+                    absenceType = AbsenceType.OTHER_ABSENCE,
+                ),
+            )
+
+            assertThat(db.transaction { tx -> tx.getAbsencesOfChildByDate(child.id, monday) })
+                .extracting({ it.category }, { it.absenceType })
+                .containsExactlyInAnyOrder(
+                    Tuple(AbsenceCategory.BILLABLE, AbsenceType.PLANNED_ABSENCE),
+                    Tuple(AbsenceCategory.NONBILLABLE, AbsenceType.OTHER_ABSENCE),
+                )
+        }
     }
 
     @Test
@@ -1938,7 +2192,7 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                 DevAbsence(
                     childId = child.id,
                     date = monday,
-                    absenceType = AbsenceType.PLANNED_ABSENCE,
+                    absenceType = AbsenceType.OTHER_ABSENCE,
                     modifiedBy = adult.evakaUserId(),
                     absenceCategory = AbsenceCategory.NONBILLABLE,
                 )
@@ -2022,7 +2276,7 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                 DevAbsence(
                     childId = child.id,
                     date = monday,
-                    absenceType = AbsenceType.PLANNED_ABSENCE,
+                    absenceType = AbsenceType.OTHER_ABSENCE,
                     modifiedBy = adult.evakaUserId(),
                     absenceCategory = AbsenceCategory.NONBILLABLE,
                 )
@@ -2053,7 +2307,7 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             )
             .extracting({ it.date }, { it.absenceType }, { it.category })
             .containsExactlyInAnyOrder(
-                Tuple(monday, AbsenceType.PLANNED_ABSENCE, AbsenceCategory.NONBILLABLE),
+                Tuple(monday, AbsenceType.SICKLEAVE, AbsenceCategory.NONBILLABLE),
                 Tuple(monday, AbsenceType.PLANNED_ABSENCE, AbsenceCategory.BILLABLE),
                 Tuple(tuesday, AbsenceType.SICKLEAVE, AbsenceCategory.NONBILLABLE),
                 Tuple(tuesday, AbsenceType.SICKLEAVE, AbsenceCategory.BILLABLE),

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceQueries.kt
@@ -112,7 +112,8 @@ RETURNING id
 data class FullDayAbsenseUpsert(
     val childId: ChildId,
     val date: LocalDate,
-    val absenceType: AbsenceType,
+    val absenceTypeBillable: AbsenceType,
+    val absenceTypeNonbillable: AbsenceType,
     val questionnaireId: HolidayQuestionnaireId? = null,
 )
 
@@ -133,7 +134,10 @@ SELECT
     ${bind { it.childId }},
     ${bind { it.date }},
     category,
-    ${bind { it.absenceType }},
+    CASE category
+        WHEN 'BILLABLE' THEN ${bind { it.absenceTypeBillable }}
+        WHEN 'NONBILLABLE' THEN ${bind { it.absenceTypeNonbillable }}
+    END,
     ${bind(now)},
     ${bind(userId)},
     ${bind { it.questionnaireId }}

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -150,7 +150,8 @@ class HolidayPeriodControllerCitizen(
                             FullDayAbsenseUpsert(
                                 childId = childId,
                                 date = it,
-                                absenceType = questionnaire.absenceType,
+                                absenceTypeBillable = questionnaire.absenceType,
+                                absenceTypeNonbillable = questionnaire.absenceType,
                                 questionnaireId = questionnaire.id,
                             )
                         } ?: emptySequence()
@@ -200,16 +201,18 @@ class HolidayPeriodControllerCitizen(
                     body.openRanges.entries.flatMap { (childId, ranges) ->
                         ranges.flatMap { range ->
                             range.dates().map {
+                                val absenceType =
+                                    when {
+                                        range.durationInDays() >=
+                                            questionnaire.absenceTypeThreshold ->
+                                            questionnaire.absenceType
+                                        else -> AbsenceType.OTHER_ABSENCE
+                                    }
                                 FullDayAbsenseUpsert(
                                     childId = childId,
                                     date = it,
-                                    absenceType =
-                                        when {
-                                            range.durationInDays() >=
-                                                questionnaire.absenceTypeThreshold ->
-                                                questionnaire.absenceType
-                                            else -> AbsenceType.OTHER_ABSENCE
-                                        },
+                                    absenceTypeBillable = absenceType,
+                                    absenceTypeNonbillable = absenceType,
                                     questionnaireId = questionnaire.id,
                                 )
                             }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationControllerCitizen.kt
@@ -411,6 +411,7 @@ class ReservationControllerCitizen(
                                             } else {
                                                 body.absenceType
                                             },
+                                            body.absenceType,
                                         )
                                     }
                             }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -369,6 +369,7 @@ fun createReservationsAndAbsences(
                 if (plannedAbsenceEnabled && reservableRange.includes(it.date))
                     AbsenceType.PLANNED_ABSENCE
                 else AbsenceType.OTHER_ABSENCE,
+                AbsenceType.OTHER_ABSENCE,
             )
         }
     val upsertedFullDayAbsences =
@@ -399,7 +400,11 @@ fun createReservationsAndAbsences(
                         req.childId,
                         req.date,
                         it,
-                        if (plannedAbsenceEnabled && reservableRange.includes(req.date)) {
+                        if (
+                            plannedAbsenceEnabled &&
+                                reservableRange.includes(req.date) &&
+                                it == AbsenceCategory.BILLABLE
+                        ) {
                             AbsenceType.PLANNED_ABSENCE
                         } else {
                             AbsenceType.OTHER_ABSENCE


### PR DESCRIPTION
Huoltaja voi ilmoittaa kolmea eri poissaolotyyppiä:
1) Sairaus (`SICKLEAVE`)
2) Poissaolo (`OTHER_ABSENCE`)
3) Vuorotyöpoissaolo (`PLANNED_ABSENCE`), käytössä vain Espoolla.

Jos lapsella on palveluntarpeena sopimuspäivät tai tuntiperustainen, tallentuu poissaoloksi tällä hetkellä "Sopimuksen mukainen poissaolo" (`PLANNED_ABSENCE`) kun valitaan poissaolotyypiksi vaihtoehto 2. Lisäksi jos lapsi on esiopetuksessa ja täydentävässä varhaiskasvatuksessa, tallentuu kyseinen poissaolo sekä esiopetukseen (`NONBILLABLE`) että varhaiskasvatukseen (`BILLABLE`). Sopimuksen mukaisen poissaolon tallennus esiopetukseen on väärin, jonka tämä muutospyyntö korjaa.

Vaihtoehto 3 pitäisi edelleen toimia samalla tavalla kuin ennenkin eli valittu Vuorotyöpoissaolo tallentuu sekä esiopetukseen että liittyvään varhaiskasvatukseen poissaolotyypillä `PLANNED_ABSENCE`.

Laskutukseen tällä muutoksella ei ole vaikutusta, koska laskutukseen otetaan vain `BILLABLE`-kategorian poissaoloja.