### PR TITLE
Parannuksia tuloselvityslomakkeen puuttuvien tietojen korostukseen

### DIFF
--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementComponents.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementComponents.tsx
@@ -43,7 +43,7 @@ export const LabelWithError = React.memo(function LabelWithError({
   errorText: string
 }) {
   return (
-    <FixedSpaceRow>
+    <FixedSpaceRow aria-invalid={showError}>
       <Label>{label}</Label>
       {showError ? <LabelError text={errorText} /> : null}
     </FixedSpaceRow>

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementComponents.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementComponents.tsx
@@ -60,8 +60,9 @@ export interface IncomeStatementFormAPI {
 
 export const ActionContainer = styled.div`
   display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+  flex-direction: row;
+  justify-content: space-between;
+  flex-wrap: wrap;
   padding: ${defaultMargins.s} 0;
   background-color: ${(p) => p.theme.colors.grayscale.g0};
 
@@ -74,8 +75,6 @@ export const ActionContainer = styled.div`
   }
 
   @media (min-width: ${tabletMin}) {
-    flex-direction: row;
-
     > * {
       margin: ${defaultMargins.s} ${defaultMargins.m};
     }

--- a/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
+++ b/frontend/src/citizen-frontend/income-statements/IncomeStatementEditor.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { combine, Loading, Result } from 'lib-common/api'
@@ -113,16 +113,14 @@ export default React.memo(function IncomeStatementEditor() {
     [state]
   )
 
-  useEffect(() => {
-    if (
-      (showFormErrors === 'SAVE' &&
-        validatedBody.isSuccess &&
-        validatedBody.value) ||
-      (showFormErrors === 'DRAFT' && draftBody.isSuccess && draftBody.value)
-    ) {
-      setShowFormErrors('NONE')
-    }
-  }, [showFormErrors, validatedBody, draftBody])
+  if (
+    (showFormErrors === 'SAVE' &&
+      validatedBody.isSuccess &&
+      validatedBody.value) ||
+    (showFormErrors === 'DRAFT' && draftBody.isSuccess && draftBody.value)
+  ) {
+    setShowFormErrors('NONE')
+  }
 
   return renderResult(
     combine(state, draftBody, validatedBody),

--- a/frontend/src/e2e-test/pages/citizen/citizen-income.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-income.ts
@@ -25,7 +25,6 @@ export default class CitizenIncomePage {
   validToDate: TextInput
   incomeStartDateInfo: Element
   incomeEndDateInfo: Element
-  incomeValidMaxRangeInfo: Element
   constructor(
     private readonly page: Page,
     env: EnvType
@@ -45,7 +44,6 @@ export default class CitizenIncomePage {
     this.validToDate = new TextInput(page.findByDataQa('income-end-date'))
     this.incomeStartDateInfo = page.findByDataQa('income-start-date-info')
     this.incomeEndDateInfo = page.findByDataQa('income-end-date-info')
-    this.incomeValidMaxRangeInfo = page.findByDataQa('date-range-info')
   }
 
   async createNewIncomeStatement() {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-income-statement.spec.ts
@@ -100,11 +100,12 @@ describe.each(envs)('Income statements', (env) => {
 
       // End date can be max 1y from start date so a warning is shown
       await incomeStatementsPage.setValidToDate('25.12.2045')
-      await incomeStatementsPage.incomeValidMaxRangeInfo.waitUntilVisible()
+      await incomeStatementsPage.incomeEndDateInfo.assertTextEquals(
+        'Valitse aikaisempi päivä'
+      )
 
       await incomeStatementsPage.setValidToDate(endDate)
       await incomeStatementsPage.incomeEndDateInfo.waitUntilHidden()
-      await incomeStatementsPage.incomeValidMaxRangeInfo.waitUntilHidden()
       await incomeStatementsPage.submit()
       await assertIncomeStatementCreated(startDate, now, env)
     })

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2368,8 +2368,6 @@ const en: Translations = {
       choose: 'Please select an option',
       chooseAtLeastOne: 'Select at least one option',
       deleteFailed: 'The income statement could not be deleted',
-      dateRangeInvalid:
-        'Income information can be valid for a maximum of one year',
       attachmentMissing: 'Attachment is missing'
     },
     table: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2599,7 +2599,6 @@ export default {
       choose: 'Valitse vaihtoehto',
       chooseAtLeastOne: 'Valitse vähintään yksi vaihtoehto',
       deleteFailed: 'Tuloselvitystä ei voitu poistaa',
-      dateRangeInvalid: `Tulotiedot voivat olla voimassa korkeintaan vuoden`,
       attachmentMissing: 'Liite puuttuu'
     },
     table: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2615,7 +2615,6 @@ const sv: Translations = {
       choose: 'Välj ett alternativ',
       chooseAtLeastOne: 'Välj minst ett alternativ',
       deleteFailed: 'Inkomstutredningen kunde inte raderas',
-      dateRangeInvalid: 'Inkomstuppgifter kan vara giltiga i högst ett år',
       attachmentMissing: 'Bilaga saknas'
     },
     table: {


### PR DESCRIPTION
- Sallitaan *Tallenna ja jatka myöhemmin* ja *Lähetä* -nappien painaminen aina.
- Jos lomake on tilassa, jossa em. toimintoa ei voi suorittaa, ruutu skrollaa napin painalluksesta ensimmäiseen virheelliseen kenttään.
- Piilotetaan *Lomakkeelta puuttuu...* teksti heti kun lomakkeella ei enää ole virheitä.
- Kun voimassaolon päättymispäivä on pakollinen, sen pitää olla vuoden sisällä alkupäivästä. Tähän liittyen lisättiin esto, että yli vuoden päässä olevia päättymispäiviä ei pysty valitsemaan.
- Poistettiin em. liittyen infolaatikko, koska lomaketta ei enää saa tilaan, jossa päättymispäivä olisi yli vuoden päässä. Jos käsin syöttämällä antaa virheellisen päättymispäivän, tästä tulee päivämäärävalitsinkomponentin oma virheilmoitus "Valitse aikaisempi päivä".
- Korjattu alareunan toimintopalkin komponenttien rivitys kapeahkoilla näytöillä.