### PR TITLE
Piilotetaan tapahtumakalenteri, jos varaukset eivät ole yksikössä päällä

### DIFF
--- a/frontend/src/employee-frontend/components/unit/TabCalendar.tsx
+++ b/frontend/src/employee-frontend/components/unit/TabCalendar.tsx
@@ -317,7 +317,8 @@ const CalendarContent = React.memo(function CalendarContent({
 
       {unitInformation.permittedActions.includes('READ_CALENDAR_EVENTS') &&
       (selectedGroup.type === 'group' ||
-        (selectedGroup.type === 'all-children' && mode === 'week')) ? (
+        (selectedGroup.type === 'all-children' && mode === 'week')) &&
+      reservationEnabled ? (
         <>
           <HorizontalLine dashed slim />
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -5177,7 +5177,7 @@ export const fi = {
     pilotFeatures: {
       MESSAGING: 'Viestintä',
       MOBILE: 'Mobiili',
-      RESERVATIONS: 'Varaukset',
+      RESERVATIONS: 'Kuntalaisen kalenteri',
       VASU_AND_PEDADOC: 'Pedagogiset asiakirjat ja pedagoginen dokumentointi',
       MOBILE_MESSAGING: 'Mobiili­viestintä',
       PLACEMENT_TERMINATION: 'Paikan irtisanominen',


### PR DESCRIPTION
Lisäksi "Varaukset" ominaisuus toimintojen avauksissa nimettiin uudelleen -> "Kuntalaisen kalenteri"