### PR TITLE
Korjaus Nekun erityisruokavalioiden kenttätyyppien käsittelyyn

### DIFF
--- a/frontend/src/lib-common/generated/api-types/nekku.ts
+++ b/frontend/src/lib-common/generated/api-types/nekku.ts
@@ -46,7 +46,11 @@ export interface NekkuSpecialDietOptionWithFieldId {
 */
 export const nekku_special_diet_type = [
   'TEXT',
-  'CHECKBOXLIST'
+  'CHECKBOXLIST',
+  'CHECKBOX',
+  'RADIO',
+  'TEXTAREA',
+  'EMAIL'
 ] as const
 
 export type NekkuSpecialDietType = typeof nekku_special_diet_type[number]

--- a/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuService.kt
@@ -270,7 +270,7 @@ class NekkuHttpClient(private val env: NekkuEnv, private val jsonMapper: JsonMap
             return try {
                 jsonMapper.readValue<T>(body.string())
             } catch (e: Exception) {
-                logger.error(e) { "Failed to parse Nekku API response" }
+                logger.error(e) { "Failed to parse Nekku API response: ${body.string()}" }
                 throw IOException("Failed to parse Nekku API response", e)
             }
         }
@@ -754,7 +754,11 @@ data class NekkuSpecialDietsFieldWithoutOptions(
 @ConstList("nekku_special_diet_type")
 enum class NekkuSpecialDietType : DatabaseEnum {
     TEXT,
-    CHECKBOXLIST;
+    CHECKBOXLIST,
+    CHECKBOX,
+    RADIO,
+    TEXTAREA,
+    EMAIL;
 
     override val sqlType: String = "nekku_special_diet_type"
 }
@@ -765,6 +769,18 @@ enum class NekkuApiSpecialDietType(@JsonValue val jsonValue: String) {
     },
     CheckBoxLst("checkboxlst") {
         override fun toEvaka(): NekkuSpecialDietType = NekkuSpecialDietType.CHECKBOXLIST
+    },
+    Checkbox("checkbox") {
+        override fun toEvaka(): NekkuSpecialDietType = NekkuSpecialDietType.CHECKBOX
+    },
+    Radio("radio") {
+        override fun toEvaka(): NekkuSpecialDietType = NekkuSpecialDietType.RADIO
+    },
+    Textarea("textarea") {
+        override fun toEvaka(): NekkuSpecialDietType = NekkuSpecialDietType.TEXTAREA
+    },
+    Email("email") {
+        override fun toEvaka(): NekkuSpecialDietType = NekkuSpecialDietType.EMAIL
     };
 
     abstract fun toEvaka(): NekkuSpecialDietType

--- a/service/src/main/resources/db/migration/V525__nekku_special_diet_type_additions.sql
+++ b/service/src/main/resources/db/migration/V525__nekku_special_diet_type_additions.sql
@@ -1,0 +1,4 @@
+ALTER TYPE public.nekku_special_diet_type ADD VALUE 'CHECKBOX';
+ALTER TYPE public.nekku_special_diet_type ADD VALUE 'RADIO';
+ALTER TYPE public.nekku_special_diet_type ADD VALUE 'TEXTAREA';
+ALTER TYPE public.nekku_special_diet_type ADD VALUE 'EMAIL';

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -520,3 +520,4 @@ V521__document_template_archiveable.sql
 V522__other_decision_document_type_changes.sql
 V523__other_decision.sql
 V524__sfi_events.sql
+V525__nekku_special_diet_type_additions.sql


### PR DESCRIPTION
Varaudutaan deserialisoimaan ja tallentamaan kantaan myös muut Nekun tuntemat erityisruokavalion kenttätyypit kuin aiemmin käsitellyt kaksi, vaikka normaalitilanteessa varhaiskasvatuksen erityisruokavaliossa ei pitäisi muita olla