### PR TITLE
Merkitse viesti lukemattomaksi (työntekijä)

### DIFF
--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -31,6 +31,7 @@ export default class MessagesPage {
   #unitAccount: Element
   #draftMessagesBoxRow: TextInput
   unitReceived: Element
+  markUnreadButton: Element
   constructor(private readonly page: Page) {
     this.newMessageButton = page.findByDataQa('new-message-btn')
     this.#personalAccount = page.findByDataQa('personal-account')
@@ -51,6 +52,7 @@ export default class MessagesPage {
     this.unitReceived = this.#unitAccount.findByDataQa(
       'message-box-row-received'
     )
+    this.markUnreadButton = page.findByDataQa('mark-unread-btn')
   }
 
   async openSentMessages(nth = 0) {
@@ -88,6 +90,10 @@ export default class MessagesPage {
 
   async openReplyEditor() {
     await this.#openReplyEditorButton.click()
+  }
+
+  async openFirstThread() {
+    await this.receivedMessage.click()
   }
 
   async openFirstThreadReplyEditor() {

--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -132,6 +132,7 @@ export interface MessagesState {
   prefilledTitle: string | null
   relatedApplicationId: ApplicationId | null
   accountAllowsNewMessage: () => boolean
+  refreshUnreadCounts: () => void
 }
 
 const defaultState: MessagesState = {
@@ -172,7 +173,8 @@ const defaultState: MessagesState = {
   prefilledRecipient: null,
   prefilledTitle: null,
   relatedApplicationId: null,
-  accountAllowsNewMessage: () => false
+  accountAllowsNewMessage: () => false,
+  refreshUnreadCounts: () => undefined
 }
 
 export const MessageContext = createContext<MessagesState>(defaultState)
@@ -845,7 +847,8 @@ export const MessageContextProvider = React.memo(
         prefilledRecipient,
         prefilledTitle,
         relatedApplicationId,
-        accountAllowsNewMessage
+        accountAllowsNewMessage,
+        refreshUnreadCounts
       }),
       [
         accounts,
@@ -882,7 +885,8 @@ export const MessageContextProvider = React.memo(
         prefilledRecipient,
         prefilledTitle,
         relatedApplicationId,
-        accountAllowsNewMessage
+        accountAllowsNewMessage,
+        refreshUnreadCounts
       ]
     )
 

--- a/frontend/src/employee-frontend/components/messages/queries.ts
+++ b/frontend/src/employee-frontend/components/messages/queries.ts
@@ -13,6 +13,7 @@ import {
   getDraftMessages,
   getFinanceMessagesWithPerson,
   initDraftMessage,
+  markLastReceivedMessageInThreadUnread,
   markThreadRead,
   replyToThread,
   updateDraftMessage
@@ -49,3 +50,7 @@ export const replyToFinanceThreadMutation = q.parametricMutation<{
 export const archiveFinanceThreadMutation = q.parametricMutation<{
   id: PersonId
 }>()(archiveThread, [({ id }) => financeThreadsQuery({ personId: id })])
+
+export const markLastReceivedMessageInThreadUnreadMutation = q.mutation(
+  markLastReceivedMessageInThreadUnread
+)

--- a/frontend/src/employee-frontend/generated/api-clients/messaging.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/messaging.ts
@@ -354,6 +354,23 @@ export async function initDraftMessage(
 
 
 /**
+* Generated from fi.espoo.evaka.messaging.MessageController.markLastReceivedMessageInThreadUnread
+*/
+export async function markLastReceivedMessageInThreadUnread(
+  request: {
+    accountId: MessageAccountId,
+    threadId: MessageThreadId
+  }
+): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/employee/messages/${request.accountId}/threads/${request.threadId}/last-received-message/unread`.toString(),
+    method: 'PUT'
+  })
+  return json
+}
+
+
+/**
 * Generated from fi.espoo.evaka.messaging.MessageController.markThreadRead
 */
 export async function markThreadRead(

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4763,6 +4763,7 @@ export const fi = {
     emptyInbox: 'Tämä kansio on tyhjä',
     replyToThread: 'Vastaa viestiin',
     archiveThread: 'Arkistoi viestiketju',
+    markUnread: 'Merkitse lukemattomaksi',
     changeFolder: {
       button: 'Vaihda kansiota',
       modalTitle: 'Valitse kansio',


### PR DESCRIPTION
Lisätään myös työntekijän puolelle mahdollisuus merkitä säikeen viimeinen luettu viesti lukemattomaksi.


<img width="1160" alt="Screenshot 2025-05-07 at 12 50 50" src="https://github.com/user-attachments/assets/99cb17a2-cefe-41a0-aeff-73efabb1887b" />
