### PR TITLE
Korjataan päivämäärävalitsimen näyttö modaalien sisällä

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -80,6 +80,7 @@ function App() {
                       <GlobalDialog />
                       <LoginErrorModal />
                       <div id="modal-container" />
+                      <div id="datepicker-container" />
                     </MessageContextProvider>
                   </NotificationsContextProvider>
                 </OverlayContextProvider>

--- a/frontend/src/citizen-frontend/children/sections/placement-termination/PlacementTerminationForm.tsx
+++ b/frontend/src/citizen-frontend/children/sections/placement-termination/PlacementTerminationForm.tsx
@@ -229,7 +229,6 @@ export default React.memo(function PlacementTerminationForm({
           onChange={(terminationDate) =>
             setState((prev) => ({ ...prev, terminationDate }))
           }
-          openAbove
         />
       </div>
 

--- a/frontend/src/e2e-test/pages/employee/units/unit-week-calendar-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-week-calendar-page.ts
@@ -265,8 +265,6 @@ export class ReservationModal extends Modal {
   async addAbsence(date: LocalDate) {
     await this.selectRepetitionType('IRREGULAR')
     await this.endDate.fill(date.format())
-    // dismiss datepicker
-    await this.endDate.press('Escape')
     await this.setAbsent()
     await this.save()
   }

--- a/frontend/src/employee-frontend/App.tsx
+++ b/frontend/src/employee-frontend/App.tsx
@@ -153,6 +153,7 @@ function App() {
               <UserContextProvider>
                 <StateProvider>
                   <Content />
+                  <div id="datepicker-container" />
                 </StateProvider>
               </UserContextProvider>
             </ErrorBoundary>

--- a/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
@@ -180,7 +180,6 @@ const Modal = React.memo(function Modal({
           date={date}
           onChange={setDate}
           hideErrorsBeforeTouched
-          openAbove
           data-qa="retroactive-fee-decision-start-date"
         />
       </FixedSpaceRow>

--- a/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
@@ -196,7 +196,6 @@ const Modal = React.memo(function Modal({
           date={date}
           onChange={setDate}
           hideErrorsBeforeTouched
-          openAbove
         />
       </FixedSpaceRow>
     </AsyncFormModal>

--- a/frontend/src/employee-mobile-frontend/App.tsx
+++ b/frontend/src/employee-mobile-frontend/App.tsx
@@ -128,6 +128,7 @@ export default function App() {
                           </EnvironmentLabel>
                         )}
                       </Router>
+                      <div id="datepicker-container" />
                     </RememberContextProvider>
                   </NotificationsContextProvider>
                 </ServiceWorkerContextProvider>

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
@@ -5,14 +5,14 @@
 import { Locale, Month, Day } from 'date-fns'
 import { fi, sv, enGB } from 'date-fns/locale'
 import React, { useMemo, useState } from 'react'
-import { DayPicker, Modifiers } from 'react-day-picker'
+import { DayPicker, OnSelectHandler } from 'react-day-picker'
 
 import LocalDate from 'lib-common/local-date'
 import 'react-day-picker/style.css'
 import { capitalizeFirstLetter } from 'lib-common/string'
 
 interface Props {
-  handleDayClick: (day: Date, modifiers?: Modifiers) => void
+  onSelect: OnSelectHandler<Date | undefined>
   inputValue: string
   locale: 'fi' | 'sv' | 'en'
   minDate?: LocalDate
@@ -21,7 +21,7 @@ interface Props {
 }
 
 export default React.memo(function DatePickerDay({
-  handleDayClick,
+  onSelect,
   inputValue,
   locale,
   minDate,
@@ -48,7 +48,7 @@ export default React.memo(function DatePickerDay({
       startMonth={startMonth}
       endMonth={endMonth}
       autoFocus
-      onDayClick={handleDayClick}
+      onSelect={onSelect}
       locale={localeData}
       selected={date?.toSystemTzDate()}
       month={month}

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerInput.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerInput.tsx
@@ -16,7 +16,6 @@ export interface Props {
   info?: InputInfo
   hideErrorsBeforeTouched?: boolean
   disabled?: boolean
-  onFocus: (e: React.FocusEvent<HTMLInputElement>) => void
   onBlur: ((e: React.FocusEvent<HTMLInputElement>) => void) | undefined
   'data-qa'?: string
   id?: string
@@ -54,7 +53,6 @@ type InternalProps = Omit<Props, 'useBrowserPicker'>
 const DateInputText = React.memo(function DateInputText({
   value,
   onChange,
-  onFocus,
   onBlur,
   info,
   hideErrorsBeforeTouched,
@@ -77,7 +75,6 @@ const DateInputText = React.memo(function DateInputText({
       placeholder={i18n.datePicker.placeholder}
       value={value}
       onChange={handleChange}
-      onFocus={onFocus}
       onBlur={onBlur}
       aria-label={i18n.datePicker.description}
       info={info}
@@ -94,7 +91,6 @@ const DateInputText = React.memo(function DateInputText({
 const DateInputNative = React.memo(function DateInputNative({
   value,
   onChange,
-  onFocus,
   onBlur,
   info,
   hideErrorsBeforeTouched,
@@ -128,7 +124,6 @@ const DateInputNative = React.memo(function DateInputNative({
       placeholder={i18n.datePicker.placeholder}
       value={valueAsIsoDate}
       onChangeTarget={handleChange}
-      onFocus={onFocus}
       onBlur={onBlur}
       aria-label={i18n.datePicker.description}
       info={info}


### PR DESCRIPTION
Sen lisäksi että `DatePicker` saa nyt kokonaan oman [stacking contextin](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context), ja siten näkyy myös modaalien ulkopuolella, se myös asemoituu automaattisesti inputin yläpuolelle jos alapuolella ei ole tilaa. `react-focus-lock` palauttaa fokuksen kun päivämäärävalitsin suljetaan, joten myös saavutettavuus säilyy.

Ennen:

<img width="585" alt="Screenshot 2025-05-08 at 12 31 03" src="https://github.com/user-attachments/assets/21386e4f-652b-442c-a25a-6fea9171fd8e" />

Jälkeen:

<img width="610" alt="Screenshot 2025-05-08 at 12 31 29" src="https://github.com/user-attachments/assets/6ec58adb-acf4-4a43-b2fc-42242872b263" />
