### PR TITLE
Haetaan aikuisen sivun tiedot kun niitä tarvitaan

### DIFF
--- a/frontend/src/employee-frontend/components/person-profile/FosterChildren.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/FosterChildren.tsx
@@ -16,11 +16,10 @@ import LocalDate from 'lib-common/local-date'
 import { cancelMutation, useQueryResult } from 'lib-common/query'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import DateRangePicker from 'lib-components/molecules/date-picker/DateRangePicker'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
-import { H2, Label, P } from 'lib-components/typography'
+import { Label, P } from 'lib-components/typography'
 
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
@@ -39,17 +38,12 @@ import { PersonContext } from './state'
 
 interface Props {
   id: PersonId
-  open: boolean
 }
 
-export default React.memo(function FosterChildren({
-  id,
-  open: startOpen
-}: Props) {
+export default React.memo(function FosterChildren({ id }: Props) {
   const { i18n } = useTranslation()
   const { permittedActions } = useContext(PersonContext)
   const { uiMode, toggleUiMode, clearUiMode } = useContext(UIContext)
-  const [open, setOpen] = useState(startOpen)
   const [editing, setEditing] = useState<{
     id: FosterParentId
     validDuring: DateRange
@@ -103,99 +97,88 @@ export default React.memo(function FosterChildren({
           close={stopDeleting}
         />
       )}
-      <CollapsibleContentArea
-        title={<H2>{i18n.personProfile.fosterChildren.sectionTitle}</H2>}
-        open={open}
-        toggleOpen={() => setOpen(!open)}
-        opaque
-        paddingVertical="L"
-        data-qa="person-foster-children-collapsible"
-      >
-        {permittedActions.has('CREATE_FOSTER_PARENT_RELATIONSHIP') && (
-          <AddButtonRow
-            text={i18n.personProfile.fridgeChildAdd}
-            onClick={() => {
-              toggleUiMode('add-foster-child')
-            }}
-            disabled={!!uiMode}
-            data-qa="add-foster-child-button"
-          />
-        )}
-        {renderResult(fosterChildren, (fosterChildren) => (
-          <Table>
-            <Thead>
-              <Tr>
-                <Th>{i18n.common.form.name}</Th>
-                <Th>{i18n.common.form.socialSecurityNumber}</Th>
-                <Th>{i18n.common.form.age}</Th>
-                <Th>{i18n.common.form.startDate}</Th>
-                <Th>{i18n.common.form.endDate}</Th>
-                <Th>{i18n.common.form.lastModified}</Th>
-                <Th />
-              </Tr>
-            </Thead>
-            <Tbody>
-              {orderBy(
-                fosterChildren,
-                [({ child }) => child.lastName, ({ child }) => child.firstName],
-                ['asc', 'asc']
-              ).map(
-                ({
-                  relationshipId,
-                  child,
-                  modifiedAt,
-                  modifiedBy,
-                  validDuring
-                }) => (
-                  <Tr
-                    key={relationshipId}
-                    data-qa={`foster-child-row-${child.id}`}
-                  >
-                    <NameTd data-qa="name">
-                      <Link to={`/child-information/${child.id}`}>
-                        {child.firstName} {child.lastName}
-                      </Link>
-                    </NameTd>
-                    <Td>{child.socialSecurityNumber}</Td>
-                    <Td>
-                      {LocalDate.todayInHelsinkiTz().differenceInYears(
-                        child.dateOfBirth
-                      )}
-                    </Td>
-                    <Td data-qa="start">{validDuring.start.format()}</Td>
-                    <Td data-qa="end">{validDuring.end?.format() ?? ''}</Td>
-                    <Td>
-                      <Tooltip
-                        tooltip={i18n.common.form.lastModifiedBy(
-                          modifiedBy.name
-                        )}
-                        position="left"
-                      >
-                        {modifiedAt.format()}
-                      </Tooltip>
-                    </Td>
-                    <Td>
-                      <Toolbar
-                        disableAll={!!uiMode}
-                        onEdit={() => startEditing(relationshipId, validDuring)}
-                        onDelete={() => startDeleting(relationshipId)}
-                        editable={true}
-                        deletable={true}
-                        dateRange={{
-                          startDate: validDuring.start,
-                          endDate: validDuring.end
-                        }}
-                        dataQaEdit="edit"
-                        dataQaDelete="delete"
-                      />
-                    </Td>
-                  </Tr>
-                )
-              )}
-            </Tbody>
-          </Table>
-        ))}
-      </CollapsibleContentArea>
+      {permittedActions.has('CREATE_FOSTER_PARENT_RELATIONSHIP') && (
+        <AddButtonRow
+          text={i18n.personProfile.fridgeChildAdd}
+          onClick={() => {
+            toggleUiMode('add-foster-child')
+          }}
+          disabled={!!uiMode}
+          data-qa="add-foster-child-button"
+        />
+      )}
+      {renderResult(fosterChildren, (fosterChildren) => (
+        <Table>
+          <Thead>
+            <Tr>
+              <Th>{i18n.common.form.name}</Th>
+              <Th>{i18n.common.form.socialSecurityNumber}</Th>
+              <Th>{i18n.common.form.age}</Th>
+              <Th>{i18n.common.form.startDate}</Th>
+              <Th>{i18n.common.form.endDate}</Th>
+              <Th>{i18n.common.form.lastModified}</Th>
+              <Th />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {orderBy(
+              fosterChildren,
+              [({ child }) => child.lastName, ({ child }) => child.firstName],
+              ['asc', 'asc']
+            ).map(
+              ({
+                relationshipId,
+                child,
+                modifiedAt,
+                modifiedBy,
+                validDuring
+              }) => (
+                <Tr
+                  key={relationshipId}
+                  data-qa={`foster-child-row-${child.id}`}
+                >
+                  <NameTd data-qa="name">
+                    <Link to={`/child-information/${child.id}`}>
+                      {child.firstName} {child.lastName}
+                    </Link>
+                  </NameTd>
+                  <Td>{child.socialSecurityNumber}</Td>
+                  <Td>
+                    {LocalDate.todayInHelsinkiTz().differenceInYears(
+                      child.dateOfBirth
+                    )}
+                  </Td>
+                  <Td data-qa="start">{validDuring.start.format()}</Td>
+                  <Td data-qa="end">{validDuring.end?.format() ?? ''}</Td>
+                  <Td>
+                    <Tooltip
+                      tooltip={i18n.common.form.lastModifiedBy(modifiedBy.name)}
+                      position="left"
+                    >
+                      {modifiedAt.format()}
+                    </Tooltip>
+                  </Td>
+                  <Td>
+                    <Toolbar
+                      disableAll={!!uiMode}
+                      onEdit={() => startEditing(relationshipId, validDuring)}
+                      onDelete={() => startDeleting(relationshipId)}
+                      editable={true}
+                      deletable={true}
+                      dateRange={{
+                        startDate: validDuring.start,
+                        endDate: validDuring.end
+                      }}
+                      dataQaEdit="edit"
+                      dataQaDelete="delete"
+                    />
+                  </Td>
+                </Tr>
+              )
+            )}
+          </Tbody>
+        </Table>
+      ))}
     </>
   )
 })

--- a/frontend/src/employee-frontend/components/person-profile/PersonApplications.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonApplications.tsx
@@ -6,28 +6,23 @@ import orderBy from 'lodash/orderBy'
 import React, { useState } from 'react'
 import { Link } from 'react-router'
 
-import { wrapResult } from 'lib-common/api'
 import {
   ApplicationType,
   PersonApplicationSummary
 } from 'lib-common/generated/api-types/application'
 import { PersonId } from 'lib-common/generated/api-types/shared'
-import { useApiState } from 'lib-common/utils/useRestApi'
+import { useQueryResult } from 'lib-common/query'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { H2 } from 'lib-components/typography'
 import { faFileAlt } from 'lib-icons'
 
-import { getGuardianApplicationSummaries } from '../../generated/api-clients/application'
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
 
 import { DateTd, NameTd, StatusTd } from './common'
-
-const getGuardianApplicationSummariesResult = wrapResult(
-  getGuardianApplicationSummaries
-)
+import { guardianApplicationSummariesQuery } from './queries'
 
 interface Props {
   id: PersonId
@@ -40,9 +35,8 @@ export default React.memo(function PersonApplications({
 }: Props) {
   const { i18n } = useTranslation()
   const [open, setOpen] = useState(startOpen)
-  const [applications] = useApiState(
-    () => getGuardianApplicationSummariesResult({ guardianId: id }),
-    [id]
+  const applications = useQueryResult(
+    guardianApplicationSummariesQuery({ guardianId: id })
   )
 
   return (

--- a/frontend/src/employee-frontend/components/person-profile/PersonApplications.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonApplications.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import orderBy from 'lodash/orderBy'
-import React, { useState } from 'react'
+import React from 'react'
 import { Link } from 'react-router'
 
 import {
@@ -13,9 +13,7 @@ import {
 import { PersonId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
-import { H2 } from 'lib-components/typography'
 import { faFileAlt } from 'lib-icons'
 
 import { useTranslation } from '../../state/i18n'
@@ -26,97 +24,75 @@ import { guardianApplicationSummariesQuery } from './queries'
 
 interface Props {
   id: PersonId
-  open: boolean
 }
 
-export default React.memo(function PersonApplications({
-  id,
-  open: startOpen
-}: Props) {
+export default React.memo(function PersonApplications({ id }: Props) {
   const { i18n } = useTranslation()
-  const [open, setOpen] = useState(startOpen)
   const applications = useQueryResult(
     guardianApplicationSummariesQuery({ guardianId: id })
   )
 
-  return (
-    <div>
-      <CollapsibleContentArea
-        title={<H2>{i18n.personProfile.applications}</H2>}
-        open={open}
-        toggleOpen={() => setOpen(!open)}
-        opaque
-        paddingVertical="L"
-        data-qa="person-applications-collapsible"
-      >
-        {renderResult(applications, (applications) => (
-          <Table data-qa="table-of-applications">
-            <Thead>
-              <Tr>
-                <Th>{i18n.personProfile.application.child}</Th>
-                <Th>{i18n.personProfile.application.preferredUnit}</Th>
-                <Th>{i18n.personProfile.application.startDate}</Th>
-                <Th>{i18n.personProfile.application.sentDate}</Th>
-                <Th>{i18n.personProfile.application.type}</Th>
-                <Th>{i18n.personProfile.application.status}</Th>
-                <Th>{i18n.personProfile.application.open}</Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {orderBy(
-                applications,
-                ['preferredStartDate', 'preferredUnitName'],
-                ['desc', 'desc']
-              ).map((application: PersonApplicationSummary) => (
-                <Tr
-                  key={application.applicationId}
-                  data-qa="table-application-row"
-                >
-                  <NameTd data-qa="application-child-name">
-                    <Link to={`/child-information/${application.childId}`}>
-                      {application.childName}
-                    </Link>
-                  </NameTd>
-                  <Td data-qa="application-preferred-unit-id">
-                    <Link to={`/units/${application.preferredUnitId ?? ''}`}>
-                      {application.preferredUnitName}
-                    </Link>
-                  </Td>
-                  <DateTd data-qa="application-start-date">
-                    {application.preferredStartDate?.format()}
-                  </DateTd>
-                  <DateTd data-qa="application-sent-date">
-                    {application.sentDate?.format()}
-                  </DateTd>
-                  <Td data-qa="application-type">
-                    {
-                      i18n.personProfile.application.types[
-                        inferApplicationType(application)
-                      ]
-                    }
-                  </Td>
-                  <StatusTd>
-                    {i18n.personProfile.application.statuses[
-                      application.status
-                    ] ?? application.status}
-                  </StatusTd>
-                  <Td>
-                    <Link to={`/applications/${application.applicationId}`}>
-                      <IconOnlyButton
-                        onClick={() => undefined}
-                        icon={faFileAlt}
-                        aria-label={i18n.personProfile.application.open}
-                      />
-                    </Link>
-                  </Td>
-                </Tr>
-              ))}
-            </Tbody>
-          </Table>
+  return renderResult(applications, (applications) => (
+    <Table data-qa="table-of-applications">
+      <Thead>
+        <Tr>
+          <Th>{i18n.personProfile.application.child}</Th>
+          <Th>{i18n.personProfile.application.preferredUnit}</Th>
+          <Th>{i18n.personProfile.application.startDate}</Th>
+          <Th>{i18n.personProfile.application.sentDate}</Th>
+          <Th>{i18n.personProfile.application.type}</Th>
+          <Th>{i18n.personProfile.application.status}</Th>
+          <Th>{i18n.personProfile.application.open}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {orderBy(
+          applications,
+          ['preferredStartDate', 'preferredUnitName'],
+          ['desc', 'desc']
+        ).map((application: PersonApplicationSummary) => (
+          <Tr key={application.applicationId} data-qa="table-application-row">
+            <NameTd data-qa="application-child-name">
+              <Link to={`/child-information/${application.childId}`}>
+                {application.childName}
+              </Link>
+            </NameTd>
+            <Td data-qa="application-preferred-unit-id">
+              <Link to={`/units/${application.preferredUnitId ?? ''}`}>
+                {application.preferredUnitName}
+              </Link>
+            </Td>
+            <DateTd data-qa="application-start-date">
+              {application.preferredStartDate?.format()}
+            </DateTd>
+            <DateTd data-qa="application-sent-date">
+              {application.sentDate?.format()}
+            </DateTd>
+            <Td data-qa="application-type">
+              {
+                i18n.personProfile.application.types[
+                  inferApplicationType(application)
+                ]
+              }
+            </Td>
+            <StatusTd>
+              {i18n.personProfile.application.statuses[application.status] ??
+                application.status}
+            </StatusTd>
+            <Td>
+              <Link to={`/applications/${application.applicationId}`}>
+                <IconOnlyButton
+                  onClick={() => undefined}
+                  icon={faFileAlt}
+                  aria-label={i18n.personProfile.application.open}
+                />
+              </Link>
+            </Td>
+          </Tr>
         ))}
-      </CollapsibleContentArea>
-    </div>
-  )
+      </Tbody>
+    </Table>
+  ))
 })
 
 export type InferredApplicationType =

--- a/frontend/src/employee-frontend/components/person-profile/PersonDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonDecisions.tsx
@@ -6,21 +6,18 @@ import orderBy from 'lodash/orderBy'
 import React, { useState } from 'react'
 import { Link } from 'react-router'
 
-import { wrapResult } from 'lib-common/api'
 import { Decision } from 'lib-common/generated/api-types/decision'
 import { PersonId } from 'lib-common/generated/api-types/shared'
-import { useApiState } from 'lib-common/utils/useRestApi'
+import { useQueryResult } from 'lib-common/query'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { H2 } from 'lib-components/typography'
 
-import { getDecisionsByGuardian } from '../../generated/api-clients/decision'
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
 
 import { DateTd, NameTd, StatusTd } from './common'
-
-const getDecisionsByGuardianResult = wrapResult(getDecisionsByGuardian)
+import { decisionsByGuardianQuery } from './queries'
 
 interface Props {
   id: PersonId
@@ -33,10 +30,7 @@ const PersonDecisions = React.memo(function PersonDecisions({
 }: Props) {
   const { i18n } = useTranslation()
   const [open, setOpen] = useState(startOpen)
-  const [decisionsResponse] = useApiState(
-    () => getDecisionsByGuardianResult({ id }),
-    [id]
-  )
+  const decisionsResponse = useQueryResult(decisionsByGuardianQuery({ id }))
 
   return (
     <div>

--- a/frontend/src/employee-frontend/components/person-profile/PersonDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonDecisions.tsx
@@ -3,15 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import orderBy from 'lodash/orderBy'
-import React, { useState } from 'react'
+import React from 'react'
 import { Link } from 'react-router'
 
 import { Decision } from 'lib-common/generated/api-types/decision'
 import { PersonId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
-import { H2 } from 'lib-components/typography'
 
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
@@ -21,76 +19,58 @@ import { decisionsByGuardianQuery } from './queries'
 
 interface Props {
   id: PersonId
-  open: boolean
 }
 
-const PersonDecisions = React.memo(function PersonDecisions({
-  id,
-  open: startOpen
-}: Props) {
+const PersonDecisions = React.memo(function PersonDecisions({ id }: Props) {
   const { i18n } = useTranslation()
-  const [open, setOpen] = useState(startOpen)
   const decisionsResponse = useQueryResult(decisionsByGuardianQuery({ id }))
 
-  return (
-    <div>
-      <CollapsibleContentArea
-        title={<H2>{i18n.personProfile.decision.decisions}</H2>}
-        open={open}
-        toggleOpen={() => setOpen(!open)}
-        opaque
-        paddingVertical="L"
-        data-qa="person-decisions-collapsible"
-      >
-        {renderResult(decisionsResponse, (decisionsResponse) => (
-          <Table data-qa="table-of-decisions">
-            <Thead>
-              <Tr>
-                <Th>{i18n.personProfile.application.child}</Th>
-                <Th>{i18n.personProfile.decision.decisionUnit}</Th>
-                <Th>{i18n.personProfile.decision.startDate}</Th>
-                <Th>{i18n.personProfile.decision.sentDate}</Th>
-                <Th>{i18n.personProfile.application.type}</Th>
-                <Th>{i18n.personProfile.decision.status}</Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {orderBy(
-                decisionsResponse.decisions,
-                ['startDate', 'preferredUnitName', 'childName'],
-                ['desc', 'desc']
-              ).map((decision: Decision) => (
-                <Tr key={decision.id} data-qa="table-decision-row">
-                  <NameTd data-qa="decision-child-name">
-                    <Link to={`/child-information/${decision.childId}`}>
-                      {decision.childName}
-                    </Link>
-                  </NameTd>
-                  <Td data-qa="decision-preferred-unit-id">
-                    <Link to={`/units/${decision.unit.id}`}>
-                      {decision.unit.name}
-                    </Link>
-                  </Td>
-                  <DateTd data-qa="decision-start-date">
-                    {decision.startDate.format()}
-                  </DateTd>
-                  <DateTd data-qa="decision-sent-date">
-                    {decision.sentDate?.format() ?? ''}
-                  </DateTd>
-                  <Td data-qa="decision-type">
-                    {i18n.personProfile.application.types[decision.type]}
-                  </Td>
-                  <StatusTd data-qa="decision-status">
-                    {i18n.personProfile.decision.statuses[decision.status]}
-                  </StatusTd>
-                </Tr>
-              ))}
-            </Tbody>
-          </Table>
+  return renderResult(decisionsResponse, (decisionsResponse) => (
+    <Table data-qa="table-of-decisions">
+      <Thead>
+        <Tr>
+          <Th>{i18n.personProfile.application.child}</Th>
+          <Th>{i18n.personProfile.decision.decisionUnit}</Th>
+          <Th>{i18n.personProfile.decision.startDate}</Th>
+          <Th>{i18n.personProfile.decision.sentDate}</Th>
+          <Th>{i18n.personProfile.application.type}</Th>
+          <Th>{i18n.personProfile.decision.status}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {orderBy(
+          decisionsResponse.decisions,
+          ['startDate', 'preferredUnitName', 'childName'],
+          ['desc', 'desc']
+        ).map((decision: Decision) => (
+          <Tr key={decision.id} data-qa="table-decision-row">
+            <NameTd data-qa="decision-child-name">
+              <Link to={`/child-information/${decision.childId}`}>
+                {decision.childName}
+              </Link>
+            </NameTd>
+            <Td data-qa="decision-preferred-unit-id">
+              <Link to={`/units/${decision.unit.id}`}>
+                {decision.unit.name}
+              </Link>
+            </Td>
+            <DateTd data-qa="decision-start-date">
+              {decision.startDate.format()}
+            </DateTd>
+            <DateTd data-qa="decision-sent-date">
+              {decision.sentDate?.format() ?? ''}
+            </DateTd>
+            <Td data-qa="decision-type">
+              {i18n.personProfile.application.types[decision.type]}
+            </Td>
+            <StatusTd data-qa="decision-status">
+              {i18n.personProfile.decision.statuses[decision.status]}
+            </StatusTd>
+          </Tr>
         ))}
-      </CollapsibleContentArea>
-    </div>
-  )
+      </Tbody>
+    </Table>
+  ))
 })
 
 export default PersonDecisions

--- a/frontend/src/employee-frontend/components/person-profile/PersonDependants.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonDependants.tsx
@@ -3,16 +3,14 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import orderBy from 'lodash/orderBy'
-import React, { useState } from 'react'
+import React from 'react'
 import { Link } from 'react-router'
 
 import { PersonWithChildrenDTO } from 'lib-common/generated/api-types/pis'
 import { PersonId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import { getAge } from 'lib-common/utils/local-date'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
-import { H2 } from 'lib-components/typography'
 
 import { personDependantsQuery } from '../../queries'
 import { useTranslation } from '../../state/i18n'
@@ -23,72 +21,50 @@ import { NameTd } from './common'
 
 interface Props {
   id: PersonId
-  open: boolean
 }
 
-export default React.memo(function PersonDependants({
-  id,
-  open: startOpen
-}: Props) {
+export default React.memo(function PersonDependants({ id }: Props) {
   const { i18n } = useTranslation()
-  const [open, setOpen] = useState(startOpen)
   const dependants = useQueryResult(personDependantsQuery({ personId: id }))
 
-  return (
-    <div>
-      <CollapsibleContentArea
-        title={<H2>{i18n.personProfile.dependants}</H2>}
-        open={open}
-        toggleOpen={() => setOpen(!open)}
-        opaque
-        paddingVertical="L"
-        data-qa="person-dependants-collapsible"
-      >
-        {renderResult(dependants, (dependants) => (
-          <Table data-qa="table-of-dependants">
-            <Thead>
-              <Tr>
-                <Th>{i18n.personProfile.name}</Th>
-                <Th>{i18n.personProfile.ssn}</Th>
-                <Th>{i18n.personProfile.age}</Th>
-                <Th>{i18n.personProfile.streetAddress}</Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {orderBy(dependants, ['dateOfBirth'], ['asc']).map(
-                (dependant: PersonWithChildrenDTO) => (
-                  <Tr
-                    key={dependant.id}
-                    data-qa={`table-dependant-row-${dependant.id}`}
-                  >
-                    <NameTd data-qa="dependant-name">
-                      <Link to={`/child-information/${dependant.id}`}>
-                        {formatName(
-                          dependant.firstName,
-                          dependant.lastName,
-                          i18n,
-                          true
-                        )}
-                      </Link>
-                    </NameTd>
-                    <Td data-qa="dependant-ssn">
-                      {dependant.socialSecurityNumber}
-                    </Td>
-                    <Td data-qa="dependant-age">
-                      {getAge(dependant.dateOfBirth)}
-                    </Td>
-                    <Td data-qa="dependant-street-address">
-                      {printableAddresses(dependant.address)}
-                    </Td>
-                  </Tr>
-                )
-              )}
-            </Tbody>
-          </Table>
-        ))}
-      </CollapsibleContentArea>
-    </div>
-  )
+  return renderResult(dependants, (dependants) => (
+    <Table data-qa="table-of-dependants">
+      <Thead>
+        <Tr>
+          <Th>{i18n.personProfile.name}</Th>
+          <Th>{i18n.personProfile.ssn}</Th>
+          <Th>{i18n.personProfile.age}</Th>
+          <Th>{i18n.personProfile.streetAddress}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {orderBy(dependants, ['dateOfBirth'], ['asc']).map(
+          (dependant: PersonWithChildrenDTO) => (
+            <Tr
+              key={dependant.id}
+              data-qa={`table-dependant-row-${dependant.id}`}
+            >
+              <NameTd data-qa="dependant-name">
+                <Link to={`/child-information/${dependant.id}`}>
+                  {formatName(
+                    dependant.firstName,
+                    dependant.lastName,
+                    i18n,
+                    true
+                  )}
+                </Link>
+              </NameTd>
+              <Td data-qa="dependant-ssn">{dependant.socialSecurityNumber}</Td>
+              <Td data-qa="dependant-age">{getAge(dependant.dateOfBirth)}</Td>
+              <Td data-qa="dependant-street-address">
+                {printableAddresses(dependant.address)}
+              </Td>
+            </Tr>
+          )
+        )}
+      </Tbody>
+    </Table>
+  ))
 })
 
 function printableAddresses(address: PersonWithChildrenDTO['address']) {

--- a/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
@@ -8,38 +8,30 @@ import { Link } from 'react-router'
 import styled from 'styled-components'
 
 import { PersonContext } from 'employee-frontend/components/person-profile/state'
-import { wrapResult } from 'lib-common/api'
 import { FeeDecision } from 'lib-common/generated/api-types/invoicing'
 import { PersonId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatCents } from 'lib-common/money'
-import { useApiState } from 'lib-common/utils/useRestApi'
+import { cancelMutation, useQueryResult } from 'lib-common/query'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
-import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
+import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
 import { H2, Label } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import { faPlus } from 'lib-icons'
 
-import {
-  generateRetroactiveFeeDecisions,
-  getHeadOfFamilyFeeDecisions
-} from '../../generated/api-clients/invoicing'
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
 import { renderResult } from '../async-rendering'
 
 import { DateTd, StatusTd } from './common'
-
-const getHeadOfFamilyFeeDecisionsResult = wrapResult(
-  getHeadOfFamilyFeeDecisions
-)
-const generateRetroactiveFeeDecisionsResult = wrapResult(
-  generateRetroactiveFeeDecisions
-)
+import {
+  generateRetroactiveFeeDecisionsMutation,
+  headOfFamilyFeeDecisionsQuery
+} from './queries'
 
 interface Props {
   id: PersonId
@@ -54,10 +46,7 @@ export default React.memo(function PersonFeeDecisions({
   const { uiMode, toggleUiMode, clearUiMode } = useContext(UIContext)
   const { permittedActions } = useContext(PersonContext)
   const [open, setOpen] = useState(startOpen)
-  const [feeDecisions, reloadFeeDecisions] = useApiState(
-    () => getHeadOfFamilyFeeDecisionsResult({ id }),
-    [id]
-  )
+  const feeDecisions = useQueryResult(headOfFamilyFeeDecisionsQuery({ id }))
 
   const openRetroactiveDecisionsModal = useCallback(
     () => toggleUiMode('create-retroactive-fee-decision'),
@@ -74,11 +63,7 @@ export default React.memo(function PersonFeeDecisions({
       data-qa="person-fee-decisions-collapsible"
     >
       {uiMode === 'create-retroactive-fee-decision' ? (
-        <Modal
-          headOfFamily={id}
-          clear={clearUiMode}
-          loadDecisions={reloadFeeDecisions}
-        />
+        <Modal headOfFamily={id} clear={clearUiMode} />
       ) : null}
       {permittedActions.has('GENERATE_RETROACTIVE_FEE_DECISIONS') && (
         <AddButtonRow
@@ -136,40 +121,31 @@ const StyledLabel = styled(Label)`
 
 const Modal = React.memo(function Modal({
   headOfFamily,
-  clear,
-  loadDecisions
+  clear
 }: {
   headOfFamily: PersonId
   clear: () => void
-  loadDecisions: () => void
 }) {
   const { i18n, lang } = useTranslation()
   const [date, setDate] = useState<LocalDate | null>(null)
 
-  const resolve = useCallback(() => {
-    if (date) {
-      return generateRetroactiveFeeDecisionsResult({
-        id: headOfFamily,
-        body: { from: date }
-      })
-    }
-    return
-  }, [headOfFamily, date])
-
-  const onSuccess = useCallback(() => {
-    clear()
-    loadDecisions()
-  }, [clear, loadDecisions])
-
   return (
-    <AsyncFormModal
+    <MutateFormModal
       icon={faPlus}
       type="info"
       title={i18n.personProfile.feeDecisions.createRetroactive}
-      resolveAction={resolve}
+      resolveMutation={generateRetroactiveFeeDecisionsMutation}
+      resolveAction={() =>
+        date !== null
+          ? {
+              id: headOfFamily,
+              body: { from: date }
+            }
+          : cancelMutation
+      }
       resolveLabel={i18n.common.create}
       resolveDisabled={!date}
-      onSuccess={onSuccess}
+      onSuccess={clear}
       rejectAction={clear}
       rejectLabel={i18n.common.cancel}
     >
@@ -183,6 +159,6 @@ const Modal = React.memo(function Modal({
           data-qa="retroactive-fee-decision-start-date"
         />
       </FixedSpaceRow>
-    </AsyncFormModal>
+    </MutateFormModal>
   )
 })

--- a/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFeeDecisions.tsx
@@ -14,12 +14,11 @@ import LocalDate from 'lib-common/local-date'
 import { formatCents } from 'lib-common/money'
 import { cancelMutation, useQueryResult } from 'lib-common/query'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
-import { H2, Label } from 'lib-components/typography'
+import { Label } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import { faPlus } from 'lib-icons'
 
@@ -35,17 +34,12 @@ import {
 
 interface Props {
   id: PersonId
-  open: boolean
 }
 
-export default React.memo(function PersonFeeDecisions({
-  id,
-  open: startOpen
-}: Props) {
+export default React.memo(function PersonFeeDecisions({ id }: Props) {
   const { i18n } = useTranslation()
   const { uiMode, toggleUiMode, clearUiMode } = useContext(UIContext)
   const { permittedActions } = useContext(PersonContext)
-  const [open, setOpen] = useState(startOpen)
   const feeDecisions = useQueryResult(headOfFamilyFeeDecisionsQuery({ id }))
 
   const openRetroactiveDecisionsModal = useCallback(
@@ -54,14 +48,7 @@ export default React.memo(function PersonFeeDecisions({
   )
 
   return (
-    <CollapsibleContentArea
-      title={<H2>{i18n.personProfile.feeDecisions.title}</H2>}
-      open={open}
-      toggleOpen={() => setOpen(!open)}
-      opaque
-      paddingVertical="L"
-      data-qa="person-fee-decisions-collapsible"
-    >
+    <>
       {uiMode === 'create-retroactive-fee-decision' ? (
         <Modal headOfFamily={id} clear={clearUiMode} />
       ) : null}
@@ -111,7 +98,7 @@ export default React.memo(function PersonFeeDecisions({
           </Tbody>
         </Table>
       ))}
-    </CollapsibleContentArea>
+    </>
   )
 })
 

--- a/frontend/src/employee-frontend/components/person-profile/PersonFridgeChild.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFridgeChild.tsx
@@ -8,14 +8,12 @@ import { Link } from 'react-router'
 
 import { ParentshipWithPermittedActions } from 'lib-common/generated/api-types/pis'
 import { ParentshipId, PersonId } from 'lib-common/generated/api-types/shared'
-import { useMutationResult } from 'lib-common/query'
+import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { getAge } from 'lib-common/utils/local-date'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
-import { H2 } from 'lib-components/typography'
 import { faQuestion } from 'lib-icons'
 
 import Toolbar from '../../components/common/Toolbar'
@@ -26,25 +24,26 @@ import { formatName } from '../../utils'
 import { renderResult } from '../async-rendering'
 
 import { ButtonsTd, DateTd, NameTd } from './common'
-import { deleteParentshipMutation, retryParentshipMutation } from './queries'
+import {
+  deleteParentshipMutation,
+  parentshipsQuery,
+  retryParentshipMutation
+} from './queries'
 import { PersonContext } from './state'
 
 interface Props {
   id: PersonId
-  open: boolean
 }
 
-export default React.memo(function PersonFridgeChild({
-  id,
-  open: startOpen
-}: Props) {
+export default React.memo(function PersonFridgeChild({ id }: Props) {
   const { i18n } = useTranslation()
-  const { fridgeChildren, permittedActions } = useContext(PersonContext)
+  const { permittedActions } = useContext(PersonContext)
   const { uiMode, toggleUiMode, clearUiMode, setErrorMessage } =
     useContext(UIContext)
-  const [open, setOpen] = useState(startOpen)
   const [selectedParentshipId, setSelectedParentshipId] =
     useState<ParentshipId>()
+
+  const fridgeChildren = useQueryResult(parentshipsQuery({ headOfChildId: id }))
 
   const getFridgeChildById = (id: ParentshipId | undefined) =>
     fridgeChildren
@@ -94,139 +93,126 @@ export default React.memo(function PersonFridgeChild({
           }}
         />
       ) : null}
-      <CollapsibleContentArea
-        title={<H2>{i18n.personProfile.fridgeChildOfHead}</H2>}
-        open={open}
-        toggleOpen={() => setOpen(!open)}
-        opaque
-        paddingVertical="L"
-        data-qa="person-children-collapsible"
-      >
-        <AddButtonRow
-          text={i18n.personProfile.fridgeChildAdd}
-          onClick={() => {
-            toggleUiMode('add-fridge-child')
-          }}
-          data-qa="add-child-button"
-          disabled={!permittedActions.has('CREATE_PARENTSHIP')}
-        />
-        {renderResult(fridgeChildren, (parentships) => (
-          <Table data-qa="table-of-children">
-            <Thead>
-              <Tr>
-                <Th>{i18n.common.form.name}</Th>
-                <Th>{i18n.common.form.socialSecurityNumber}</Th>
-                <Th>{i18n.common.form.age}</Th>
-                <Th>{i18n.common.form.startDate}</Th>
-                <Th>{i18n.common.form.endDate}</Th>
-                <Th>{i18n.common.form.lastModified}</Th>
-                <Th />
-              </Tr>
-            </Thead>
-            <Tbody>
-              {orderBy(
-                parentships,
-                ['startDate', 'endDate'],
-                ['desc', 'desc']
-              ).map(
-                (
-                  {
-                    data: fridgeChild,
-                    permittedActions
-                  }: ParentshipWithPermittedActions,
-                  i: number
-                ) => {
-                  const modifiedAt =
-                    fridgeChild.creationModificationMetadata.modifiedAt ||
-                    fridgeChild.creationModificationMetadata.createdAt
-                  const modifiedByName =
-                    fridgeChild.creationModificationMetadata.modifiedByName ||
-                    fridgeChild.creationModificationMetadata.createdByName
+      <AddButtonRow
+        text={i18n.personProfile.fridgeChildAdd}
+        onClick={() => {
+          toggleUiMode('add-fridge-child')
+        }}
+        data-qa="add-child-button"
+        disabled={!permittedActions.has('CREATE_PARENTSHIP')}
+      />
+      {renderResult(fridgeChildren, (parentships) => (
+        <Table data-qa="table-of-children">
+          <Thead>
+            <Tr>
+              <Th>{i18n.common.form.name}</Th>
+              <Th>{i18n.common.form.socialSecurityNumber}</Th>
+              <Th>{i18n.common.form.age}</Th>
+              <Th>{i18n.common.form.startDate}</Th>
+              <Th>{i18n.common.form.endDate}</Th>
+              <Th>{i18n.common.form.lastModified}</Th>
+              <Th />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {orderBy(
+              parentships,
+              ['startDate', 'endDate'],
+              ['desc', 'desc']
+            ).map(
+              (
+                {
+                  data: fridgeChild,
+                  permittedActions
+                }: ParentshipWithPermittedActions,
+                i: number
+              ) => {
+                const modifiedAt =
+                  fridgeChild.creationModificationMetadata.modifiedAt ||
+                  fridgeChild.creationModificationMetadata.createdAt
+                const modifiedByName =
+                  fridgeChild.creationModificationMetadata.modifiedByName ||
+                  fridgeChild.creationModificationMetadata.createdByName
 
-                  return (
-                    <Tr
-                      key={`${fridgeChild.child.id}-${i}`}
-                      data-qa="table-fridge-child-row"
-                    >
-                      <NameTd>
-                        <Link to={`/child-information/${fridgeChild.child.id}`}>
-                          {formatName(
-                            fridgeChild.child.firstName,
-                            fridgeChild.child.lastName,
-                            i18n,
-                            true
-                          )}
-                        </Link>
-                      </NameTd>
-                      <Td>
-                        {fridgeChild.child.socialSecurityNumber ??
-                          fridgeChild.child.dateOfBirth.format()}
-                      </Td>
-                      <Td data-qa="child-age">
-                        {getAge(fridgeChild.child.dateOfBirth)}
-                      </Td>
-                      <DateTd>{fridgeChild.startDate.format()}</DateTd>
-                      <DateTd>{fridgeChild.endDate.format()}</DateTd>
-                      <Td>
-                        {modifiedAt ? (
-                          <Tooltip
-                            tooltip={
-                              modifiedByName
-                                ? i18n.common.form.lastModifiedBy(
-                                    modifiedByName
-                                  )
-                                : null
-                            }
-                            position="left"
-                          >
-                            {modifiedAt.format()}
-                          </Tooltip>
-                        ) : (
-                          i18n.common.unknown
+                return (
+                  <Tr
+                    key={`${fridgeChild.child.id}-${i}`}
+                    data-qa="table-fridge-child-row"
+                  >
+                    <NameTd>
+                      <Link to={`/child-information/${fridgeChild.child.id}`}>
+                        {formatName(
+                          fridgeChild.child.firstName,
+                          fridgeChild.child.lastName,
+                          i18n,
+                          true
                         )}
-                      </Td>
-                      <ButtonsTd>
-                        <Toolbar
-                          dateRange={fridgeChild}
-                          onRetry={
-                            fridgeChild.conflict
-                              ? () => {
-                                  void retryParentship({
-                                    headOfChildId: id,
-                                    id: fridgeChild.id
-                                  })
-                                }
-                              : undefined
+                      </Link>
+                    </NameTd>
+                    <Td>
+                      {fridgeChild.child.socialSecurityNumber ??
+                        fridgeChild.child.dateOfBirth.format()}
+                    </Td>
+                    <Td data-qa="child-age">
+                      {getAge(fridgeChild.child.dateOfBirth)}
+                    </Td>
+                    <DateTd>{fridgeChild.startDate.format()}</DateTd>
+                    <DateTd>{fridgeChild.endDate.format()}</DateTd>
+                    <Td>
+                      {modifiedAt ? (
+                        <Tooltip
+                          tooltip={
+                            modifiedByName
+                              ? i18n.common.form.lastModifiedBy(modifiedByName)
+                              : null
                           }
-                          editable={permittedActions.includes('UPDATE')}
-                          onEdit={() => {
-                            setSelectedParentshipId(fridgeChild.id)
-                            toggleUiMode(`edit-fridge-child-${fridgeChild.id}`)
-                          }}
-                          deletable={
-                            fridgeChild.conflict
-                              ? permittedActions.includes(
-                                  'DELETE_CONFLICTED_PARENTSHIP'
-                                )
-                              : permittedActions.includes('DELETE')
-                          }
-                          onDelete={() => {
-                            setSelectedParentshipId(fridgeChild.id)
-                            toggleUiMode(
-                              `remove-fridge-child-${fridgeChild.id}`
-                            )
-                          }}
-                          conflict={fridgeChild.conflict}
-                        />
-                      </ButtonsTd>
-                    </Tr>
-                  )
-                }
-              )}
-            </Tbody>
-          </Table>
-        ))}
-      </CollapsibleContentArea>
+                          position="left"
+                        >
+                          {modifiedAt.format()}
+                        </Tooltip>
+                      ) : (
+                        i18n.common.unknown
+                      )}
+                    </Td>
+                    <ButtonsTd>
+                      <Toolbar
+                        dateRange={fridgeChild}
+                        onRetry={
+                          fridgeChild.conflict
+                            ? () => {
+                                void retryParentship({
+                                  headOfChildId: id,
+                                  id: fridgeChild.id
+                                })
+                              }
+                            : undefined
+                        }
+                        editable={permittedActions.includes('UPDATE')}
+                        onEdit={() => {
+                          setSelectedParentshipId(fridgeChild.id)
+                          toggleUiMode(`edit-fridge-child-${fridgeChild.id}`)
+                        }}
+                        deletable={
+                          fridgeChild.conflict
+                            ? permittedActions.includes(
+                                'DELETE_CONFLICTED_PARENTSHIP'
+                              )
+                            : permittedActions.includes('DELETE')
+                        }
+                        onDelete={() => {
+                          setSelectedParentshipId(fridgeChild.id)
+                          toggleUiMode(`remove-fridge-child-${fridgeChild.id}`)
+                        }}
+                        conflict={fridgeChild.conflict}
+                      />
+                    </ButtonsTd>
+                  </Tr>
+                )
+              }
+            )}
+          </Tbody>
+        </Table>
+      ))}
     </div>
   )
 })

--- a/frontend/src/employee-frontend/components/person-profile/PersonFridgePartner.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFridgePartner.tsx
@@ -12,10 +12,8 @@ import { PartnershipId, PersonId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
-import { H2 } from 'lib-components/typography'
 import { faQuestion } from 'lib-icons'
 
 import Toolbar from '../../components/common/Toolbar'
@@ -41,18 +39,15 @@ const TopBar = styled.div`
 
 interface Props {
   id: PersonId
-  open: boolean
 }
 
 const PersonFridgePartner = React.memo(function PersonFridgePartner({
-  id,
-  open: startOpen
+  id
 }: Props) {
   const { i18n } = useTranslation()
   const { permittedActions } = useContext(PersonContext)
   const { uiMode, toggleUiMode, clearUiMode, setErrorMessage } =
     useContext(UIContext)
-  const [open, setOpen] = useState(startOpen)
 
   const partnerships = useQueryResult(partnershipsQuery({ personId: id }))
   const [selectedPartnershipId, setSelectedPartnershipId] =
@@ -113,131 +108,122 @@ const PersonFridgePartner = React.memo(function PersonFridgePartner({
           }}
         />
       ) : null}
-      <CollapsibleContentArea
-        title={<H2>{i18n.personProfile.partner}</H2>}
-        open={open}
-        toggleOpen={() => setOpen(!open)}
-        opaque
-        paddingVertical="L"
-        data-qa="person-partners-collapsible"
-      >
-        <TopBar>
-          <span className="subtitle">({i18n.personProfile.partnerInfo})</span>
-          <AddButton
-            flipped
-            text={i18n.personProfile.partnerAdd}
-            onClick={() => {
-              setSelectedPartnershipId(undefined)
-              toggleUiMode('add-fridge-partner')
-            }}
-            data-qa="add-partner-button"
-            disabled={!permittedActions.has('CREATE_PARTNERSHIP')}
-          />
-        </TopBar>
-        {renderResult(partnerships, (partnerships) => (
-          <Table data-qa="table-of-partners">
-            <Thead>
-              <Tr>
-                <Th>{i18n.common.form.name}</Th>
-                <Th>{i18n.common.form.socialSecurityNumber}</Th>
-                <Th>{i18n.common.form.startDate}</Th>
-                <Th>{i18n.common.form.endDate}</Th>
-                <Th>{i18n.common.form.lastModified}</Th>
-                <Th />
-                <Th />
-              </Tr>
-            </Thead>
-            <Tbody>
-              {orderBy(
-                partnerships,
-                ['startDate', 'endDate'],
-                ['desc', 'desc']
-              ).map(({ permittedActions, data: fridgePartner }, i) =>
-                fridgePartner.partners
-                  .filter((p) => p.id !== id)
-                  .map((partner: PersonJSON) => {
-                    const modifiedAt =
-                      fridgePartner?.creationModificationMetadata?.modifiedAt ||
-                      fridgePartner?.creationModificationMetadata?.createdAt
-                    const modifiedByName =
-                      fridgePartner?.creationModificationMetadata
-                        ?.modifiedByName ||
-                      fridgePartner?.creationModificationMetadata?.createdByName
+      <TopBar>
+        <span className="subtitle">({i18n.personProfile.partnerInfo})</span>
+        <AddButton
+          flipped
+          text={i18n.personProfile.partnerAdd}
+          onClick={() => {
+            setSelectedPartnershipId(undefined)
+            toggleUiMode('add-fridge-partner')
+          }}
+          data-qa="add-partner-button"
+          disabled={!permittedActions.has('CREATE_PARTNERSHIP')}
+        />
+      </TopBar>
+      {renderResult(partnerships, (partnerships) => (
+        <Table data-qa="table-of-partners">
+          <Thead>
+            <Tr>
+              <Th>{i18n.common.form.name}</Th>
+              <Th>{i18n.common.form.socialSecurityNumber}</Th>
+              <Th>{i18n.common.form.startDate}</Th>
+              <Th>{i18n.common.form.endDate}</Th>
+              <Th>{i18n.common.form.lastModified}</Th>
+              <Th />
+              <Th />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {orderBy(
+              partnerships,
+              ['startDate', 'endDate'],
+              ['desc', 'desc']
+            ).map(({ permittedActions, data: fridgePartner }, i) =>
+              fridgePartner.partners
+                .filter((p) => p.id !== id)
+                .map((partner: PersonJSON) => {
+                  const modifiedAt =
+                    fridgePartner?.creationModificationMetadata?.modifiedAt ||
+                    fridgePartner?.creationModificationMetadata?.createdAt
+                  const modifiedByName =
+                    fridgePartner?.creationModificationMetadata
+                      ?.modifiedByName ||
+                    fridgePartner?.creationModificationMetadata?.createdByName
 
-                    return (
-                      <Tr
-                        key={`${partner.id}-${i}`}
-                        data-qa="table-fridge-partner-row"
-                      >
-                        <NameTd>
-                          <Link to={`/profile/${partner.id}`}>
-                            {formatName(
-                              partner.firstName,
-                              partner.lastName,
-                              i18n,
-                              true
-                            )}
-                          </Link>
-                        </NameTd>
-                        <Td>{partner.socialSecurityNumber}</Td>
-                        <DateTd>{fridgePartner.startDate.format()}</DateTd>
-                        <DateTd>{fridgePartner.endDate?.format()}</DateTd>
-                        <Td>
-                          {modifiedAt ? (
-                            <Tooltip
-                              tooltip={
-                                modifiedByName
-                                  ? i18n.common.form.lastModifiedBy(
-                                      modifiedByName
-                                    )
-                                  : null
-                              }
-                              position="left"
-                            >
-                              {modifiedAt.format()}
-                            </Tooltip>
-                          ) : (
-                            i18n.common.unknown
+                  return (
+                    <Tr
+                      key={`${partner.id}-${i}`}
+                      data-qa="table-fridge-partner-row"
+                    >
+                      <NameTd>
+                        <Link to={`/profile/${partner.id}`}>
+                          {formatName(
+                            partner.firstName,
+                            partner.lastName,
+                            i18n,
+                            true
                           )}
-                        </Td>
-                        <ButtonsTd>
-                          <Toolbar
-                            dateRange={fridgePartner}
-                            conflict={fridgePartner.conflict}
-                            onRetry={
-                              fridgePartner.conflict
-                                ? () => {
-                                    void retryPartnership({
-                                      personId: id,
-                                      partnershipId: fridgePartner.id
-                                    })
-                                  }
-                                : undefined
+                        </Link>
+                      </NameTd>
+                      <Td>{partner.socialSecurityNumber}</Td>
+                      <DateTd>{fridgePartner.startDate.format()}</DateTd>
+                      <DateTd>{fridgePartner.endDate?.format()}</DateTd>
+                      <Td>
+                        {modifiedAt ? (
+                          <Tooltip
+                            tooltip={
+                              modifiedByName
+                                ? i18n.common.form.lastModifiedBy(
+                                    modifiedByName
+                                  )
+                                : null
                             }
-                            onEdit={() => {
-                              setSelectedPartnershipId(fridgePartner.id)
-                              toggleUiMode(
-                                `edit-fridge-partner-${fridgePartner.id}`
-                              )
-                            }}
-                            onDelete={() => {
-                              setSelectedPartnershipId(fridgePartner.id)
-                              toggleUiMode(
-                                `remove-fridge-partner-${fridgePartner.id}`
-                              )
-                            }}
-                            editable={permittedActions.includes('UPDATE')}
-                            deletable={permittedActions.includes('DELETE')}
-                          />
-                        </ButtonsTd>
-                      </Tr>
-                    )
-                  })
-              )}
-            </Tbody>
-          </Table>
-        ))}
-      </CollapsibleContentArea>
+                            position="left"
+                          >
+                            {modifiedAt.format()}
+                          </Tooltip>
+                        ) : (
+                          i18n.common.unknown
+                        )}
+                      </Td>
+                      <ButtonsTd>
+                        <Toolbar
+                          dateRange={fridgePartner}
+                          conflict={fridgePartner.conflict}
+                          onRetry={
+                            fridgePartner.conflict
+                              ? () => {
+                                  void retryPartnership({
+                                    personId: id,
+                                    partnershipId: fridgePartner.id
+                                  })
+                                }
+                              : undefined
+                          }
+                          onEdit={() => {
+                            setSelectedPartnershipId(fridgePartner.id)
+                            toggleUiMode(
+                              `edit-fridge-partner-${fridgePartner.id}`
+                            )
+                          }}
+                          onDelete={() => {
+                            setSelectedPartnershipId(fridgePartner.id)
+                            toggleUiMode(
+                              `remove-fridge-partner-${fridgePartner.id}`
+                            )
+                          }}
+                          editable={permittedActions.includes('UPDATE')}
+                          deletable={permittedActions.includes('DELETE')}
+                        />
+                      </ButtonsTd>
+                    </Tr>
+                  )
+                })
+            )}
+          </Tbody>
+        </Table>
+      ))}
     </div>
   )
 })

--- a/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
@@ -13,8 +13,7 @@ import { IncomeId, PersonId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import Pagination from 'lib-components/Pagination'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
-import { H2, H3, H4 } from 'lib-components/typography'
+import { H3, H4 } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 
@@ -41,30 +40,18 @@ import { PersonContext } from './state'
 
 interface Props {
   id: PersonId
-  open: boolean
 }
 
-export default React.memo(function PersonIncome({
-  id,
-  open: startOpen
-}: Props) {
+export default React.memo(function PersonIncome({ id }: Props) {
   const { i18n } = useTranslation()
   const { permittedActions } = useContext(PersonContext)
-  const [open, setOpen] = useState(startOpen)
 
   const children = useQueryResult(
     incomeStatementChildrenQuery({ guardianId: id })
   )
 
   return (
-    <CollapsibleContentArea
-      title={<H2>{i18n.personProfile.income.title}</H2>}
-      open={open}
-      toggleOpen={() => setOpen(!open)}
-      opaque
-      paddingVertical="L"
-      data-qa="person-income-collapsible"
-    >
+    <>
       <H4>{i18n.personProfile.incomeStatement.title}</H4>
       <IncomeStatements personId={id} />
       <Gap size="L" />
@@ -83,7 +70,7 @@ export default React.memo(function PersonIncome({
       <Gap size="L" />
       <H3>{i18n.personProfile.income.title}</H3>
       <Incomes personId={id} permittedActions={permittedActions} />
-    </CollapsibleContentArea>
+    </>
   )
 })
 

--- a/frontend/src/employee-frontend/components/person-profile/PersonInvoiceCorrections.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonInvoiceCorrections.tsx
@@ -43,7 +43,6 @@ import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import { SelectF } from 'lib-components/atoms/dropdowns/Select'
 import { InputFieldF } from 'lib-components/atoms/form/InputField'
 import TextArea, { TextAreaF } from 'lib-components/atoms/form/TextArea'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import {
   FixedSpaceColumn,
@@ -52,7 +51,7 @@ import {
 import { ConfirmedMutation } from 'lib-components/molecules/ConfirmedMutation'
 import { DateRangePickerF } from 'lib-components/molecules/date-picker/DateRangePicker'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
-import { H2, H4, Label, P } from 'lib-components/typography'
+import { H4, Label, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { faCommentAlt, fasCommentAltLines, faTrash } from 'lib-icons'
 
@@ -64,6 +63,7 @@ import {
   createInvoiceCorrectionMutation,
   deleteInvoiceCorrectionMutation,
   invoiceCorrectionsQuery,
+  parentshipsQuery,
   updateInvoiceCorrectionNoteMutation
 } from './queries'
 import { PersonContext } from './state'
@@ -74,17 +74,15 @@ interface EditTarget {
 }
 
 export default React.memo(function PersonInvoiceCorrections({
-  id,
-  open: startOpen
+  id
 }: {
   id: PersonId
-  open: boolean
 }) {
   const { i18n } = useTranslation()
-  const { fridgeChildren, permittedActions } = useContext(PersonContext)
-  const [open, setOpen] = useState(startOpen)
+  const { permittedActions } = useContext(PersonContext)
   const invoiceCodes = useQueryResult(invoiceCodesQuery())
   const corrections = useQueryResult(invoiceCorrectionsQuery({ personId: id }))
+  const fridgeChildren = useQueryResult(parentshipsQuery({ headOfChildId: id }))
 
   const [editTarget, setEditTarget] = useState<EditTarget | null>(null)
 
@@ -129,47 +127,36 @@ export default React.memo(function PersonInvoiceCorrections({
     [invoiceCodes]
   )
 
-  return (
-    <CollapsibleContentArea
-      title={<H2>{i18n.personProfile.invoiceCorrections.title}</H2>}
-      open={open}
-      toggleOpen={() => setOpen(!open)}
-      opaque
-      paddingVertical="L"
-      data-qa="person-invoice-corrections-collapsible"
-    >
-      {renderResult(
-        combine(children, groupedCorrections, products, unitIds, unitDetails),
-        ([children, groupedCorrections, products, unitIds, unitDetails]) => (
-          <FixedSpaceColumn spacing="L">
-            {children.length === 0 ? (
-              <div>{i18n.invoiceCorrections.noChildren}</div>
-            ) : (
-              children.map((child) => (
-                <ChildSection
-                  key={child.id}
-                  personId={id}
-                  permittedPersonActions={permittedActions}
-                  child={child}
-                  corrections={groupedCorrections[child.id] ?? []}
-                  products={products}
-                  unitIds={unitIds}
-                  unitDetails={unitDetails}
-                  editTarget={editTarget}
-                  onStartCreate={() =>
-                    setEditTarget({ childId: child.id, correctionId: null })
-                  }
-                  onStartEdit={(correctionId) =>
-                    setEditTarget({ childId: child.id, correctionId })
-                  }
-                  onEditorCancel={() => setEditTarget(null)}
-                />
-              ))
-            )}
-          </FixedSpaceColumn>
-        )
-      )}
-    </CollapsibleContentArea>
+  return renderResult(
+    combine(children, groupedCorrections, products, unitIds, unitDetails),
+    ([children, groupedCorrections, products, unitIds, unitDetails]) => (
+      <FixedSpaceColumn spacing="L">
+        {children.length === 0 ? (
+          <div>{i18n.invoiceCorrections.noChildren}</div>
+        ) : (
+          children.map((child) => (
+            <ChildSection
+              key={child.id}
+              personId={id}
+              permittedPersonActions={permittedActions}
+              child={child}
+              corrections={groupedCorrections[child.id] ?? []}
+              products={products}
+              unitIds={unitIds}
+              unitDetails={unitDetails}
+              editTarget={editTarget}
+              onStartCreate={() =>
+                setEditTarget({ childId: child.id, correctionId: null })
+              }
+              onStartEdit={(correctionId) =>
+                setEditTarget({ childId: child.id, correctionId })
+              }
+              onEditorCancel={() => setEditTarget(null)}
+            />
+          ))
+        )}
+      </FixedSpaceColumn>
+    )
   )
 })
 

--- a/frontend/src/employee-frontend/components/person-profile/PersonInvoices.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonInvoices.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import orderBy from 'lodash/orderBy'
-import React, { useContext, useState } from 'react'
+import React, { useContext } from 'react'
 import { Link } from 'react-router'
 
 import { PersonContext } from 'employee-frontend/components/person-profile/state'
@@ -12,10 +12,8 @@ import { PersonId } from 'lib-common/generated/api-types/shared'
 import { formatCents } from 'lib-common/money'
 import { useQueryResult } from 'lib-common/query'
 import { MutateButton } from 'lib-components/atoms/buttons/MutateButton'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
-import { H2 } from 'lib-components/typography'
 import { faRefresh } from 'lib-icons'
 
 import { useTranslation } from '../../state/i18n'
@@ -30,66 +28,52 @@ import {
 
 interface Props {
   id: PersonId
-  open: boolean
 }
 
-export default React.memo(function PersonInvoices({
-  id,
-  open: startOpen
-}: Props) {
+export default React.memo(function PersonInvoices({ id }: Props) {
   const { i18n } = useTranslation()
   const user = useContext(UserContext)
   const { permittedActions } = useContext(PersonContext)
-  const [open, setOpen] = useState(startOpen)
   const invoices = useQueryResult(headOfFamilyInvoicesQuery({ id }))
 
   return (
     <div>
-      <CollapsibleContentArea
-        title={<H2>{i18n.personProfile.invoices}</H2>}
-        open={open}
-        toggleOpen={() => setOpen(!open)}
-        opaque
-        paddingVertical="L"
-        data-qa="person-invoices-collapsible"
-      >
-        {user?.user?.accessibleFeatures.replacementInvoices &&
-        permittedActions.has('CREATE_REPLACEMENT_DRAFT_INVOICES') ? (
-          <FixedSpaceColumn alignItems="flex-end">
-            <MutateButton
-              icon={faRefresh}
-              appearance="inline"
-              mutation={createReplacementDraftsForHeadOfFamilyMutation}
-              onClick={() => ({ headOfFamilyId: id })}
-              text={i18n.personProfile.invoice.createReplacementDrafts}
-            />
-          </FixedSpaceColumn>
-        ) : null}
-        {renderResult(invoices, (invoices) => (
-          <Table data-qa="table-of-invoices">
-            <Thead>
-              <Tr>
-                <Th>{i18n.personProfile.invoice.validity}</Th>
-                <Th>{i18n.personProfile.invoice.price}</Th>
-                <Th>{i18n.personProfile.invoice.status}</Th>
+      {user?.user?.accessibleFeatures.replacementInvoices &&
+      permittedActions.has('CREATE_REPLACEMENT_DRAFT_INVOICES') ? (
+        <FixedSpaceColumn alignItems="flex-end">
+          <MutateButton
+            icon={faRefresh}
+            appearance="inline"
+            mutation={createReplacementDraftsForHeadOfFamilyMutation}
+            onClick={() => ({ headOfFamilyId: id })}
+            text={i18n.personProfile.invoice.createReplacementDrafts}
+          />
+        </FixedSpaceColumn>
+      ) : null}
+      {renderResult(invoices, (invoices) => (
+        <Table data-qa="table-of-invoices">
+          <Thead>
+            <Tr>
+              <Th>{i18n.personProfile.invoice.validity}</Th>
+              <Th>{i18n.personProfile.invoice.price}</Th>
+              <Th>{i18n.personProfile.invoice.status}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {orderBy(invoices, ['sentAt'], ['desc']).map((invoice) => (
+              <Tr key={invoice.id} data-qa="table-invoice-row">
+                <Td>
+                  <Link to={`/finance/invoices/${invoice.id}`}>
+                    {formatInvoicePeriod(invoice, i18n)}
+                  </Link>
+                </Td>
+                <Td>{formatCents(invoice.totalPrice)}</Td>
+                <StatusTd>{i18n.invoice.status[invoice.status]}</StatusTd>
               </Tr>
-            </Thead>
-            <Tbody>
-              {orderBy(invoices, ['sentAt'], ['desc']).map((invoice) => (
-                <Tr key={invoice.id} data-qa="table-invoice-row">
-                  <Td>
-                    <Link to={`/finance/invoices/${invoice.id}`}>
-                      {formatInvoicePeriod(invoice, i18n)}
-                    </Link>
-                  </Td>
-                  <Td>{formatCents(invoice.totalPrice)}</Td>
-                  <StatusTd>{i18n.invoice.status[invoice.status]}</StatusTd>
-                </Tr>
-              ))}
-            </Tbody>
-          </Table>
-        ))}
-      </CollapsibleContentArea>
+            ))}
+          </Tbody>
+        </Table>
+      ))}
     </div>
   )
 })

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -52,20 +52,6 @@ interface SectionProps {
   open: boolean
 }
 
-function requireOneOfPermittedActions(
-  Component: React.FunctionComponent<SectionProps>,
-  ...actions: Action.Person[]
-): React.FunctionComponent<SectionProps> {
-  return function Section({ id, open }: SectionProps) {
-    const { permittedActions } = useContext<PersonState>(PersonContext)
-    if (actions.some((action) => permittedActions.has(action))) {
-      return <Component id={id} open={open} />
-    } else {
-      return null
-    }
-  }
-}
-
 function section({
   component: Component,
   enabled = true,
@@ -179,10 +165,12 @@ const components = {
     title: (i18n) => i18n.personProfile.decision.decisions,
     dataQa: 'person-decisions-collapsible'
   }),
-  'notes-and-messages': requireOneOfPermittedActions(
-    PersonFinanceNotesAndMessages,
-    'READ_FINANCE_NOTES'
-  )
+  'notes-and-messages': section({
+    component: PersonFinanceNotesAndMessages,
+    requireOneOfPermittedActions: ['READ_FINANCE_NOTES'],
+    title: (i18n) => i18n.personProfile.financeNotesAndMessages.title,
+    dataQa: 'person-finance-notes-and-messages-collapsible'
+  })
 }
 
 const layouts: Layouts<typeof components> = {

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -113,11 +113,12 @@ const components = {
     title: (i18n) => i18n.personProfile.familyOverview.title,
     dataQa: 'family-overview-collapsible'
   }),
-  income: requireOneOfPermittedActions(
-    PersonIncome,
-    'READ_INCOME_STATEMENTS',
-    'READ_INCOME'
-  ),
+  income: section({
+    component: PersonIncome,
+    requireOneOfPermittedActions: ['READ_INCOME_STATEMENTS', 'READ_INCOME'],
+    title: (i18n) => i18n.personProfile.income.title,
+    dataQa: 'person-income-collapsible'
+  }),
   'fee-decisions': requireOneOfPermittedActions(
     PersonFeeDecisions,
     'READ_FEE_DECISIONS'

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -161,10 +161,12 @@ const components = {
     title: (i18n) => i18n.personProfile.dependants,
     dataQa: 'person-dependants-collapsible'
   }),
-  fosterChildren: requireOneOfPermittedActions(
-    FosterChildren,
-    'READ_FOSTER_CHILDREN'
-  ),
+  fosterChildren: section({
+    component: FosterChildren,
+    requireOneOfPermittedActions: ['READ_FOSTER_CHILDREN'],
+    title: (i18n) => i18n.personProfile.fosterChildren.sectionTitle,
+    dataQa: 'person-foster-children-collapsible'
+  }),
   applications: requireOneOfPermittedActions(
     PersonApplications,
     'READ_APPLICATIONS'

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -137,10 +137,12 @@ const components = {
     title: (i18n) => i18n.personProfile.invoiceCorrections.title,
     dataQa: 'person-invoice-corrections-collapsible'
   }),
-  voucherValueDecisions: requireOneOfPermittedActions(
-    PersonVoucherValueDecisions,
-    'READ_VOUCHER_VALUE_DECISIONS'
-  ),
+  voucherValueDecisions: section({
+    component: PersonVoucherValueDecisions,
+    requireOneOfPermittedActions: ['READ_VOUCHER_VALUE_DECISIONS'],
+    title: (i18n) => i18n.personProfile.voucherValueDecisions.title,
+    dataQa: 'person-voucher-value-decisions-collapsible'
+  }),
   partners: requireOneOfPermittedActions(
     PersonFridgePartner,
     'READ_PARTNERSHIPS'

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -131,10 +131,12 @@ const components = {
     title: (i18n) => i18n.personProfile.invoices,
     dataQa: 'person-invoices-collapsible'
   }),
-  invoiceCorrections: requireOneOfPermittedActions(
-    PersonInvoiceCorrections,
-    'READ_INVOICE_CORRECTIONS'
-  ),
+  invoiceCorrections: section({
+    component: PersonInvoiceCorrections,
+    requireOneOfPermittedActions: ['READ_INVOICE_CORRECTIONS'],
+    title: (i18n) => i18n.personProfile.invoiceCorrections.title,
+    dataQa: 'person-invoice-corrections-collapsible'
+  }),
   voucherValueDecisions: requireOneOfPermittedActions(
     PersonVoucherValueDecisions,
     'READ_VOUCHER_VALUE_DECISIONS'
@@ -143,10 +145,12 @@ const components = {
     PersonFridgePartner,
     'READ_PARTNERSHIPS'
   ),
-  'fridge-children': requireOneOfPermittedActions(
-    PersonFridgeChild,
-    'READ_PARENTSHIPS'
-  ),
+  'fridge-children': section({
+    component: PersonFridgeChild,
+    requireOneOfPermittedActions: ['READ_PARENTSHIPS'],
+    title: (i18n) => i18n.personProfile.fridgeChildOfHead,
+    dataQa: 'person-children-collapsible'
+  }),
   dependants: requireOneOfPermittedActions(PersonDependants, 'READ_DEPENDANTS'),
   fosterChildren: requireOneOfPermittedActions(
     FosterChildren,

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -143,10 +143,12 @@ const components = {
     title: (i18n) => i18n.personProfile.voucherValueDecisions.title,
     dataQa: 'person-voucher-value-decisions-collapsible'
   }),
-  partners: requireOneOfPermittedActions(
-    PersonFridgePartner,
-    'READ_PARTNERSHIPS'
-  ),
+  partners: section({
+    component: PersonFridgePartner,
+    requireOneOfPermittedActions: ['READ_PARTNERSHIPS'],
+    title: (i18n) => i18n.personProfile.partner,
+    dataQa: 'person-partners-collapsible'
+  }),
   'fridge-children': section({
     component: PersonFridgeChild,
     requireOneOfPermittedActions: ['READ_PARENTSHIPS'],

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -119,10 +119,12 @@ const components = {
     title: (i18n) => i18n.personProfile.income.title,
     dataQa: 'person-income-collapsible'
   }),
-  'fee-decisions': requireOneOfPermittedActions(
-    PersonFeeDecisions,
-    'READ_FEE_DECISIONS'
-  ),
+  'fee-decisions': section({
+    component: PersonFeeDecisions,
+    requireOneOfPermittedActions: ['READ_FEE_DECISIONS'],
+    title: (i18n) => i18n.personProfile.feeDecisions.title,
+    dataQa: 'person-fee-decisions-collapsible'
+  }),
   invoices: requireOneOfPermittedActions(PersonInvoices, 'READ_INVOICES'),
   invoiceCorrections: requireOneOfPermittedActions(
     PersonInvoiceCorrections,

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -125,7 +125,12 @@ const components = {
     title: (i18n) => i18n.personProfile.feeDecisions.title,
     dataQa: 'person-fee-decisions-collapsible'
   }),
-  invoices: requireOneOfPermittedActions(PersonInvoices, 'READ_INVOICES'),
+  invoices: section({
+    component: PersonInvoices,
+    requireOneOfPermittedActions: ['READ_INVOICES'],
+    title: (i18n) => i18n.personProfile.invoices,
+    dataQa: 'person-invoices-collapsible'
+  }),
   invoiceCorrections: requireOneOfPermittedActions(
     PersonInvoiceCorrections,
     'READ_INVOICE_CORRECTIONS'

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -167,10 +167,12 @@ const components = {
     title: (i18n) => i18n.personProfile.fosterChildren.sectionTitle,
     dataQa: 'person-foster-children-collapsible'
   }),
-  applications: requireOneOfPermittedActions(
-    PersonApplications,
-    'READ_APPLICATIONS'
-  ),
+  applications: section({
+    component: PersonApplications,
+    requireOneOfPermittedActions: ['READ_APPLICATIONS'],
+    title: (i18n) => i18n.personProfile.applications,
+    dataQa: 'person-applications-collapsible'
+  }),
   decisions: requireOneOfPermittedActions(PersonDecisions, 'READ_DECISIONS'),
   'notes-and-messages': requireOneOfPermittedActions(
     PersonFinanceNotesAndMessages,

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -173,7 +173,12 @@ const components = {
     title: (i18n) => i18n.personProfile.applications,
     dataQa: 'person-applications-collapsible'
   }),
-  decisions: requireOneOfPermittedActions(PersonDecisions, 'READ_DECISIONS'),
+  decisions: section({
+    component: PersonDecisions,
+    requireOneOfPermittedActions: ['READ_DECISIONS'],
+    title: (i18n) => i18n.personProfile.decision.decisions,
+    dataQa: 'person-decisions-collapsible'
+  }),
   'notes-and-messages': requireOneOfPermittedActions(
     PersonFinanceNotesAndMessages,
     'READ_FINANCE_NOTES'

--- a/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonProfile.tsx
@@ -155,7 +155,12 @@ const components = {
     title: (i18n) => i18n.personProfile.fridgeChildOfHead,
     dataQa: 'person-children-collapsible'
   }),
-  dependants: requireOneOfPermittedActions(PersonDependants, 'READ_DEPENDANTS'),
+  dependants: section({
+    component: PersonDependants,
+    requireOneOfPermittedActions: ['READ_DEPENDANTS'],
+    title: (i18n) => i18n.personProfile.dependants,
+    dataQa: 'person-dependants-collapsible'
+  }),
   fosterChildren: requireOneOfPermittedActions(
     FosterChildren,
     'READ_FOSTER_CHILDREN'

--- a/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
@@ -13,12 +13,11 @@ import LocalDate from 'lib-common/local-date'
 import { formatCents } from 'lib-common/money'
 import { cancelMutation, useQueryResult } from 'lib-common/query'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
-import { H2, Label } from 'lib-components/typography'
+import { Label } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import { faPlus } from 'lib-icons'
 
@@ -33,17 +32,12 @@ import {
 
 interface Props {
   id: PersonId
-  open: boolean
 }
 
-export default React.memo(function PersonVoucherValueDecisions({
-  id,
-  open: startOpen
-}: Props) {
+export default React.memo(function PersonVoucherValueDecisions({ id }: Props) {
   const { i18n } = useTranslation()
   const { uiMode, toggleUiMode, clearUiMode } = useContext(UIContext)
   const { permittedActions } = useContext(PersonContext)
-  const [open, setOpen] = useState(startOpen)
   const voucherValueDecisions = useQueryResult(
     headOfFamilyVoucherValueDecisionsQuery({ headOfFamilyId: id })
   )
@@ -54,14 +48,7 @@ export default React.memo(function PersonVoucherValueDecisions({
   )
 
   return (
-    <CollapsibleContentArea
-      title={<H2>{i18n.personProfile.voucherValueDecisions.title}</H2>}
-      open={open}
-      toggleOpen={() => setOpen(!open)}
-      opaque
-      paddingVertical="L"
-      data-qa="person-voucher-value-decisions-collapsible"
-    >
+    <>
       {uiMode === 'create-retroactive-value-decisions' ? (
         <Modal headOfFamily={id} clear={clearUiMode} />
       ) : null}
@@ -129,7 +116,7 @@ export default React.memo(function PersonVoucherValueDecisions({
           </Tbody>
         </Table>
       ))}
-    </CollapsibleContentArea>
+    </>
   )
 })
 

--- a/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonVoucherValueDecisions.tsx
@@ -8,35 +8,28 @@ import { Link } from 'react-router'
 import styled from 'styled-components'
 
 import { PersonContext } from 'employee-frontend/components/person-profile/state'
-import { wrapResult } from 'lib-common/api'
 import { PersonId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatCents } from 'lib-common/money'
-import { useApiState } from 'lib-common/utils/useRestApi'
+import { cancelMutation, useQueryResult } from 'lib-common/query'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
-import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
+import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
 import { H2, Label } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 import { faPlus } from 'lib-icons'
 
-import {
-  generateRetroactiveVoucherValueDecisions,
-  getHeadOfFamilyVoucherValueDecisions
-} from '../../generated/api-clients/invoicing'
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
 import { renderResult } from '../async-rendering'
 
-const getHeadOfFamilyVoucherValueDecisionsResult = wrapResult(
-  getHeadOfFamilyVoucherValueDecisions
-)
-const generateRetroactiveVoucherValueDecisionsResult = wrapResult(
-  generateRetroactiveVoucherValueDecisions
-)
+import {
+  generateRetroactiveVoucherValueDecisionsMutation,
+  headOfFamilyVoucherValueDecisionsQuery
+} from './queries'
 
 interface Props {
   id: PersonId
@@ -51,9 +44,8 @@ export default React.memo(function PersonVoucherValueDecisions({
   const { uiMode, toggleUiMode, clearUiMode } = useContext(UIContext)
   const { permittedActions } = useContext(PersonContext)
   const [open, setOpen] = useState(startOpen)
-  const [voucherValueDecisions, reloadDecisions] = useApiState(
-    () => getHeadOfFamilyVoucherValueDecisionsResult({ headOfFamilyId: id }),
-    [id]
+  const voucherValueDecisions = useQueryResult(
+    headOfFamilyVoucherValueDecisionsQuery({ headOfFamilyId: id })
   )
 
   const openRetroactiveDecisionsModal = useCallback(
@@ -71,11 +63,7 @@ export default React.memo(function PersonVoucherValueDecisions({
       data-qa="person-voucher-value-decisions-collapsible"
     >
       {uiMode === 'create-retroactive-value-decisions' ? (
-        <Modal
-          headOfFamily={id}
-          clear={clearUiMode}
-          loadDecisions={reloadDecisions}
-        />
+        <Modal headOfFamily={id} clear={clearUiMode} />
       ) : null}
       {permittedActions.has('GENERATE_RETROACTIVE_VOUCHER_VALUE_DECISIONS') && (
         <AddButtonRow
@@ -151,40 +139,31 @@ const StyledLabel = styled(Label)`
 
 const Modal = React.memo(function Modal({
   headOfFamily,
-  clear,
-  loadDecisions
+  clear
 }: {
   headOfFamily: PersonId
   clear: () => void
-  loadDecisions: () => void
 }) {
   const { i18n, lang } = useTranslation()
   const [date, setDate] = useState<LocalDate | null>(null)
 
-  const resolve = useCallback(() => {
-    if (date) {
-      return generateRetroactiveVoucherValueDecisionsResult({
-        id: headOfFamily,
-        body: { from: date }
-      })
-    }
-    return
-  }, [headOfFamily, date])
-
-  const onSuccess = useCallback(() => {
-    clear()
-    loadDecisions()
-  }, [clear, loadDecisions])
-
   return (
-    <AsyncFormModal
+    <MutateFormModal
       icon={faPlus}
       type="info"
       title={i18n.personProfile.voucherValueDecisions.createRetroactive}
-      resolveAction={resolve}
+      resolveMutation={generateRetroactiveVoucherValueDecisionsMutation}
+      resolveAction={() =>
+        date !== null
+          ? {
+              id: headOfFamily,
+              body: { from: date }
+            }
+          : cancelMutation
+      }
       resolveLabel={i18n.common.create}
       resolveDisabled={!date}
-      onSuccess={onSuccess}
+      onSuccess={clear}
       rejectAction={clear}
       rejectLabel={i18n.common.cancel}
     >
@@ -198,6 +177,6 @@ const Modal = React.memo(function Modal({
           hideErrorsBeforeTouched
         />
       </FixedSpaceRow>
-    </AsyncFormModal>
+    </MutateFormModal>
   )
 })

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeList.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeList.tsx
@@ -46,6 +46,7 @@ interface Props {
   deleteIncome: (incomeId: IncomeId) => Promise<Result<unknown>>
   onSuccessfulUpdate: () => void
   onFailedUpdate: (value: Failure<unknown>) => void
+  onCancelEdit: () => void
 }
 
 const IncomeList = React.memo(function IncomeList({
@@ -64,7 +65,8 @@ const IncomeList = React.memo(function IncomeList({
   updateIncome,
   deleteIncome,
   onSuccessfulUpdate,
-  onFailedUpdate
+  onFailedUpdate,
+  onCancelEdit
 }: Props) {
   const { i18n } = useTranslation()
 
@@ -167,7 +169,7 @@ const IncomeList = React.memo(function IncomeList({
                   baseIncome={item}
                   incomeTypeOptions={incomeTypeOptions}
                   coefficientMultipliers={coefficientMultipliers}
-                  cancel={onSuccessfulUpdate}
+                  cancel={onCancelEdit}
                   update={(income) => updateIncome(item.id, income)}
                   onSuccess={onSuccessfulUpdate}
                   onFailure={onFailedUpdate}

--- a/frontend/src/employee-frontend/components/person-profile/queries.ts
+++ b/frontend/src/employee-frontend/components/person-profile/queries.ts
@@ -2,6 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import {
+  getIncomeStatementChildren,
+  getIncomeStatements
+} from 'employee-frontend/generated/api-clients/incomestatement'
+import { getChildPlacementPeriods } from 'employee-frontend/generated/api-clients/placement'
 import { PersonId } from 'lib-common/generated/api-types/shared'
 import { Queries } from 'lib-common/query'
 
@@ -12,13 +17,18 @@ import {
   updateFinanceNote
 } from '../../generated/api-clients/finance'
 import {
+  createIncome,
   createInvoiceCorrection,
   createReplacementDraftsForHeadOfFamily,
+  deleteIncome,
   deleteInvoiceCorrection,
   getHeadOfFamilyInvoices,
   getIncomeMultipliers,
+  getIncomeNotifications,
   getIncomeTypeOptions,
+  getPersonIncomes,
   getPersonInvoiceCorrections,
+  updateIncome,
   updateInvoiceCorrectionNote
 } from '../../generated/api-clients/invoicing'
 import {
@@ -198,3 +208,30 @@ export const deleteFinanceNoteMutation = q.parametricMutation<{
 }>()(deleteFinanceNote, [({ id }) => financeNotesQuery({ personId: id })])
 
 export const incomeTypeOptionsQuery = q.query(getIncomeTypeOptions)
+
+export const childPlacementPeriodsQuery = q.query(getChildPlacementPeriods)
+
+export const personIncomesQuery = q.query(getPersonIncomes)
+
+export const createIncomeMutation = q.mutation(createIncome, [
+  ({ body }) => personIncomesQuery({ personId: body.personId }),
+  ({ body }) => familyByPersonQuery({ id: body.personId })
+])
+
+export const updateIncomeMutation = q.mutation(updateIncome, [
+  ({ body }) => personIncomesQuery({ personId: body.personId }),
+  ({ body }) => familyByPersonQuery({ id: body.personId })
+])
+
+export const deleteIncomeMutation = q.parametricMutation<{
+  personId: PersonId
+}>()(deleteIncome, [
+  ({ personId }) => personIncomesQuery({ personId }),
+  ({ personId }) => familyByPersonQuery({ id: personId })
+])
+
+export const incomeNotificationsQuery = q.query(getIncomeNotifications)
+
+export const incomeStatementsQuery = q.query(getIncomeStatements)
+
+export const incomeStatementChildrenQuery = q.query(getIncomeStatementChildren)

--- a/frontend/src/employee-frontend/components/person-profile/queries.ts
+++ b/frontend/src/employee-frontend/components/person-profile/queries.ts
@@ -23,8 +23,10 @@ import {
   deleteIncome,
   deleteInvoiceCorrection,
   generateRetroactiveFeeDecisions,
+  generateRetroactiveVoucherValueDecisions,
   getHeadOfFamilyFeeDecisions,
   getHeadOfFamilyInvoices,
+  getHeadOfFamilyVoucherValueDecisions,
   getIncomeMultipliers,
   getIncomeNotifications,
   getIncomeTypeOptions,
@@ -245,4 +247,13 @@ export const headOfFamilyFeeDecisionsQuery = q.query(
 export const generateRetroactiveFeeDecisionsMutation = q.mutation(
   generateRetroactiveFeeDecisions,
   [({ id }) => headOfFamilyFeeDecisionsQuery({ id })]
+)
+
+export const headOfFamilyVoucherValueDecisionsQuery = q.query(
+  getHeadOfFamilyVoucherValueDecisions
+)
+
+export const generateRetroactiveVoucherValueDecisionsMutation = q.mutation(
+  generateRetroactiveVoucherValueDecisions,
+  [({ id }) => headOfFamilyVoucherValueDecisionsQuery({ headOfFamilyId: id })]
 )

--- a/frontend/src/employee-frontend/components/person-profile/queries.ts
+++ b/frontend/src/employee-frontend/components/person-profile/queries.ts
@@ -22,6 +22,8 @@ import {
   createReplacementDraftsForHeadOfFamily,
   deleteIncome,
   deleteInvoiceCorrection,
+  generateRetroactiveFeeDecisions,
+  getHeadOfFamilyFeeDecisions,
   getHeadOfFamilyInvoices,
   getIncomeMultipliers,
   getIncomeNotifications,
@@ -235,3 +237,12 @@ export const incomeNotificationsQuery = q.query(getIncomeNotifications)
 export const incomeStatementsQuery = q.query(getIncomeStatements)
 
 export const incomeStatementChildrenQuery = q.query(getIncomeStatementChildren)
+
+export const headOfFamilyFeeDecisionsQuery = q.query(
+  getHeadOfFamilyFeeDecisions
+)
+
+export const generateRetroactiveFeeDecisionsMutation = q.mutation(
+  generateRetroactiveFeeDecisions,
+  [({ id }) => headOfFamilyFeeDecisionsQuery({ id })]
+)

--- a/frontend/src/employee-frontend/components/person-profile/queries.ts
+++ b/frontend/src/employee-frontend/components/person-profile/queries.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { getGuardianApplicationSummaries } from 'employee-frontend/generated/api-clients/application'
 import {
   getIncomeStatementChildren,
   getIncomeStatements
@@ -256,4 +257,8 @@ export const headOfFamilyVoucherValueDecisionsQuery = q.query(
 export const generateRetroactiveVoucherValueDecisionsMutation = q.mutation(
   generateRetroactiveVoucherValueDecisions,
   [({ id }) => headOfFamilyVoucherValueDecisionsQuery({ headOfFamilyId: id })]
+)
+
+export const guardianApplicationSummariesQuery = q.query(
+  getGuardianApplicationSummaries
 )

--- a/frontend/src/employee-frontend/components/person-profile/queries.ts
+++ b/frontend/src/employee-frontend/components/person-profile/queries.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { getGuardianApplicationSummaries } from 'employee-frontend/generated/api-clients/application'
+import { getDecisionsByGuardian } from 'employee-frontend/generated/api-clients/decision'
 import {
   getIncomeStatementChildren,
   getIncomeStatements
@@ -262,3 +263,5 @@ export const generateRetroactiveVoucherValueDecisionsMutation = q.mutation(
 export const guardianApplicationSummariesQuery = q.query(
   getGuardianApplicationSummaries
 )
+
+export const decisionsByGuardianQuery = q.query(getDecisionsByGuardian)

--- a/frontend/src/employee-frontend/components/person-profile/state.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/state.tsx
@@ -7,26 +7,23 @@ import React, { createContext, useMemo } from 'react'
 import { Loading, Result } from 'lib-common/api'
 import { Action } from 'lib-common/generated/action'
 import {
-  FamilyOverview,
   ParentshipWithPermittedActions,
   PersonJSON
 } from 'lib-common/generated/api-types/pis'
 import { PersonId } from 'lib-common/generated/api-types/shared'
 import { pendingQuery, useQueryResult } from 'lib-common/query'
 
-import { familyByPersonQuery, parentshipsQuery, personQuery } from './queries'
+import { parentshipsQuery, personQuery } from './queries'
 
 export interface PersonState {
   person: Result<PersonJSON>
   permittedActions: Set<Action.Person>
-  family: Result<FamilyOverview>
   fridgeChildren: Result<ParentshipWithPermittedActions[]>
 }
 
 const defaultState: PersonState = {
   person: Loading.of(),
   permittedActions: new Set(),
-  family: Loading.of(),
   fridgeChildren: Loading.of()
 }
 
@@ -55,12 +52,6 @@ export const PersonContextProvider = React.memo(function PersonContextProvider({
     [personResponse]
   )
 
-  const family = useQueryResult(
-    permittedActions.has('READ_FAMILY_OVERVIEW')
-      ? familyByPersonQuery({ id })
-      : pendingQuery<FamilyOverview>()
-  )
-
   const fridgeChildren = useQueryResult(
     permittedActions.has('READ_PARENTSHIPS')
       ? parentshipsQuery({ headOfChildId: id })
@@ -71,10 +62,9 @@ export const PersonContextProvider = React.memo(function PersonContextProvider({
     () => ({
       person,
       permittedActions,
-      family,
       fridgeChildren
     }),
-    [person, permittedActions, family, fridgeChildren]
+    [person, permittedActions, fridgeChildren]
   )
 
   return (

--- a/frontend/src/employee-frontend/components/person-profile/state.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/state.tsx
@@ -6,25 +6,20 @@ import React, { createContext, useMemo } from 'react'
 
 import { Loading, Result } from 'lib-common/api'
 import { Action } from 'lib-common/generated/action'
-import {
-  ParentshipWithPermittedActions,
-  PersonJSON
-} from 'lib-common/generated/api-types/pis'
+import { PersonJSON } from 'lib-common/generated/api-types/pis'
 import { PersonId } from 'lib-common/generated/api-types/shared'
-import { pendingQuery, useQueryResult } from 'lib-common/query'
+import { useQueryResult } from 'lib-common/query'
 
-import { parentshipsQuery, personQuery } from './queries'
+import { personQuery } from './queries'
 
 export interface PersonState {
   person: Result<PersonJSON>
   permittedActions: Set<Action.Person>
-  fridgeChildren: Result<ParentshipWithPermittedActions[]>
 }
 
 const defaultState: PersonState = {
   person: Loading.of(),
-  permittedActions: new Set(),
-  fridgeChildren: Loading.of()
+  permittedActions: new Set()
 }
 
 const emptyPermittedActions = new Set<Action.Person>()
@@ -52,19 +47,12 @@ export const PersonContextProvider = React.memo(function PersonContextProvider({
     [personResponse]
   )
 
-  const fridgeChildren = useQueryResult(
-    permittedActions.has('READ_PARENTSHIPS')
-      ? parentshipsQuery({ headOfChildId: id })
-      : pendingQuery<ParentshipWithPermittedActions[]>()
-  )
-
   const value = useMemo<PersonState>(
     () => ({
       person,
-      permittedActions,
-      fridgeChildren
+      permittedActions
     }),
-    [person, permittedActions, fridgeChildren]
+    [person, permittedActions]
   )
 
   return (


### PR DESCRIPTION
Sen sijaan että aikuisen sivulla haettaisiin piilossa olevien osioiden data heti, haetaan data vasta kun osiot avataan. Muutetaan myös moni paikka käyttämään react-queryä, joka on esiehto tälle toiminnallisuudelle.

Alla olevista kuvista näkee HTTP requestien määrät kun aikuisen sivu avataan pääkäyttäjän roolilla (talouden muistiinpanot ja viestit sekä perheen tietojen kooste ovat auki oletuksena).

**Ennen:**

<img width="390" alt="Screenshot 2025-05-13 at 13 03 08" src="https://github.com/user-attachments/assets/d60de2d4-f95b-438a-939d-409b49fd5543" />

**Jälkeen:**

<img width="453" alt="Screenshot 2025-05-14 at 9 24 45" src="https://github.com/user-attachments/assets/034e1231-df12-4fad-8ce6-5d5c8df502ef" />
