### PR TITLE
Lähetetään yksikön johtajalle sähköposti jos ryhmän Nekku-asiakasnumero poistuu

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -391,6 +391,14 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class SendNekkuCustomerNumberNullificationWarningEmail(
+        val unitId: DaycareId,
+        val employeeId: EmployeeId,
+        val groupNames: List<String>,
+    ) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     data class SendServiceApplicationDecidedEmail(val serviceApplicationId: ServiceApplicationId) :
         AsyncJob {
         override val user: AuthenticatedUser? = null
@@ -507,6 +515,7 @@ sealed interface AsyncJob : AsyncJobPayload {
                     SendPendingDecisionEmail::class,
                     SendServiceApplicationDecidedEmail::class,
                     SendSpecialDietNullificationWarningEmail::class,
+                    SendNekkuCustomerNumberNullificationWarningEmail::class,
                 ),
             )
         val urgent =


### PR DESCRIPTION
Jos Nekun asiakasnumeroita päivitättäessä havaitaan että jollekin ryhmälle asetettu asiakasnumero on poistunut Nekusta, yksikön johtajalle lähetetään sähköpostissa tieto tilanteesta ja ryhmistä joita se koskee