### PR TITLE
Lapsen id audit-lokiin

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -26,6 +26,22 @@ sealed interface AuditId {
 
         operator fun invoke(value: Collection<Id<*>>): AuditId = Many(value.toList())
     }
+
+    operator fun plus(other: AuditId): AuditId {
+        return when (this) {
+            is One ->
+                when (other) {
+                    is One -> Many(listOf(value, other.value))
+                    is Many -> Many(listOf(value) + other.value)
+                }
+
+            is Many ->
+                when (other) {
+                    is One -> Many(value + other.value)
+                    is Many -> Many(value + other.value)
+                }
+        }
+    }
 }
 
 enum class Audit(

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceController.kt
@@ -71,8 +71,7 @@ class AbsenceController(
     ) {
         val children = absences.map { it.childId }
 
-        val upserted =
-            db.connect { dbc ->
+        db.connect { dbc ->
                 dbc.transaction { tx ->
                     accessControl.requirePermissionFor(
                         tx,
@@ -120,11 +119,13 @@ class AbsenceController(
                     tx.upsertAbsences(clock.now(), user.evakaUserId, absences)
                 }
             }
-        Audit.AbsenceUpsert.log(
-            targetId = AuditId(groupId),
-            objectId = AuditId(upserted),
-            meta = mapOf("children" to children),
-        )
+            .also { absenceIdList ->
+                Audit.AbsenceUpsert.log(
+                    targetId = AuditId(groupId),
+                    objectId = AuditId(absenceIdList),
+                    meta = mapOf("children" to children),
+                )
+            }
     }
 
     @PostMapping("/{groupId}/present")

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
@@ -650,12 +650,11 @@ class ApplicationControllerCitizen(
                     )
                     tx.getSentDecision(id)
                 } ?: throw NotFound("Decision $id does not exist")
-            decisionService.getDecisionPdf(dbc, decision).let { pdfResponse ->
+            decisionService.getDecisionPdf(dbc, decision).also {
                 Audit.DecisionDownloadPdf.log(
                     targetId = AuditId(id),
                     objectId = AuditId(decision.childId),
                 )
-                pdfResponse
             }
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerV2.kt
@@ -324,9 +324,13 @@ class ApplicationControllerV2(
                 }
             }
             .also {
-                Audit.ApplicationRead.log(targetId = AuditId(applicationId))
+                Audit.ApplicationRead.log(
+                    targetId = AuditId(applicationId),
+                    objectId = AuditId(it.application.childId),
+                )
                 Audit.DecisionReadByApplication.log(
                     targetId = AuditId(applicationId),
+                    objectId = AuditId(it.application.childId),
                     meta = mapOf("count" to it.decisions.size),
                 )
             }
@@ -445,7 +449,12 @@ class ApplicationControllerV2(
                     )
                 }
             }
-            .also { Audit.PlacementPlanDraftRead.log(targetId = AuditId(applicationId)) }
+            .also {
+                Audit.PlacementPlanDraftRead.log(
+                    targetId = AuditId(applicationId),
+                    objectId = AuditId(it.child.id),
+                )
+            }
     }
 
     @GetMapping("/{applicationId}/decision-drafts")

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -562,7 +562,10 @@ class ApplicationStateService(
             }
         }
 
-        Audit.ApplicationCancel.log(targetId = AuditId(applicationId))
+        Audit.ApplicationCancel.log(
+            targetId = AuditId(applicationId),
+            objectId = AuditId(application.childId),
+        )
     }
 
     fun setVerified(
@@ -595,7 +598,10 @@ class ApplicationStateService(
         } else if (confidential != null) throw BadRequest("Confidentiality is already set")
 
         tx.setApplicationVerified(applicationId, true, clock.now(), user.evakaUserId)
-        Audit.ApplicationAdminDetailsUpdate.log(targetId = AuditId(applicationId))
+        Audit.ApplicationAdminDetailsUpdate.log(
+            targetId = AuditId(applicationId),
+            objectId = AuditId(application.childId),
+        )
     }
 
     fun createPlacementPlan(
@@ -759,6 +765,7 @@ class ApplicationStateService(
         }
         Audit.PlacementPlanRespond.log(
             targetId = AuditId(applicationId),
+            objectId = AuditId(application.childId),
             meta = mapOf("status" to status),
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationStateService.kt
@@ -376,7 +376,10 @@ class ApplicationStateService(
 
         tx.resetCheckedByAdminAndConfidentiality(applicationId, clock.now(), user.evakaUserId)
 
-        Audit.ApplicationSend.log(targetId = AuditId(applicationId))
+        Audit.ApplicationSend.log(
+            targetId = AuditId(applicationId),
+            objectId = AuditId(application.childId),
+        )
     }
 
     fun sendPlacementToolApplication(

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/logging/AuditIdTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/logging/AuditIdTest.kt
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2017-2025 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package fi.espoo.evaka.shared.logging
+
+import fi.espoo.evaka.AuditId
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class AuditIdTest {
+    @Test
+    fun plusCombinesTwoOneInstancesIntoMany() {
+        val one1 = AuditId.One("value1")
+        val one2 = AuditId.One("value2")
+        val result = one1 + one2
+        assertEquals(AuditId.Many(listOf("value1", "value2")), result)
+    }
+
+    @Test
+    fun plusAddsOneToMany() {
+        val many = AuditId.Many(listOf("value1", "value2"))
+        val one = AuditId.One("value3")
+        val result = many + one
+        assertEquals(AuditId.Many(listOf("value1", "value2", "value3")), result)
+    }
+
+    @Test
+    fun plusAddsManyToOne() {
+        val one = AuditId.One("value1")
+        val many = AuditId.Many(listOf("value2", "value3"))
+        val result = one + many
+        assertEquals(AuditId.Many(listOf("value1", "value2", "value3")), result)
+    }
+
+    @Test
+    fun plusCombinesTwoManyInstances() {
+        val many1 = AuditId.Many(listOf("value1", "value2"))
+        val many2 = AuditId.Many(listOf("value3", "value4"))
+        val result = many1 + many2
+        assertEquals(AuditId.Many(listOf("value1", "value2", "value3", "value4")), result)
+    }
+
+    @Test
+    fun plusHandlesEmptyOneAndOne() {
+        val one1 = AuditId.One("")
+        val one2 = AuditId.One("")
+        val result = one1 + one2
+        assertEquals(AuditId.Many(listOf("", "")), result)
+    }
+
+    @Test
+    fun plusHandlesEmptyManyAndOne() {
+        val many = AuditId.Many(emptyList())
+        val one = AuditId.One("value")
+        val result = many + one
+        assertEquals(AuditId.Many(listOf("value")), result)
+    }
+
+    @Test
+    fun plusHandlesOneAndEmptyMany() {
+        val one = AuditId.One("value")
+        val many = AuditId.Many(emptyList())
+        val result = one + many
+        assertEquals(AuditId.Many(listOf("value")), result)
+    }
+
+    @Test
+    fun plusHandlesTwoEmptyManyInstances() {
+        val many1 = AuditId.Many(emptyList())
+        val many2 = AuditId.Many(emptyList())
+        val result = many1 + many2
+        assertEquals(AuditId.Many(emptyList()), result)
+    }
+}

--- a/service/src/test/kotlin/fi/espoo/evaka/shared/logging/AuditIdTest.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/shared/logging/AuditIdTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 class AuditIdTest {
     @Test
-    fun plusCombinesTwoOneInstancesIntoMany() {
+    fun `plus combines two One instances into Many`() {
         val one1 = AuditId.One("value1")
         val one2 = AuditId.One("value2")
         val result = one1 + one2
@@ -18,7 +18,7 @@ class AuditIdTest {
     }
 
     @Test
-    fun plusAddsOneToMany() {
+    fun `plus adds One to Many`() {
         val many = AuditId.Many(listOf("value1", "value2"))
         val one = AuditId.One("value3")
         val result = many + one
@@ -26,7 +26,7 @@ class AuditIdTest {
     }
 
     @Test
-    fun plusAddsManyToOne() {
+    fun `plus adds Many to One`() {
         val one = AuditId.One("value1")
         val many = AuditId.Many(listOf("value2", "value3"))
         val result = one + many
@@ -34,7 +34,7 @@ class AuditIdTest {
     }
 
     @Test
-    fun plusCombinesTwoManyInstances() {
+    fun `plus combines two Many instances`() {
         val many1 = AuditId.Many(listOf("value1", "value2"))
         val many2 = AuditId.Many(listOf("value3", "value4"))
         val result = many1 + many2
@@ -42,7 +42,7 @@ class AuditIdTest {
     }
 
     @Test
-    fun plusHandlesEmptyOneAndOne() {
+    fun `plus handles empty One and One`() {
         val one1 = AuditId.One("")
         val one2 = AuditId.One("")
         val result = one1 + one2
@@ -50,7 +50,7 @@ class AuditIdTest {
     }
 
     @Test
-    fun plusHandlesEmptyManyAndOne() {
+    fun `plus handles empty Many and One`() {
         val many = AuditId.Many(emptyList())
         val one = AuditId.One("value")
         val result = many + one
@@ -58,7 +58,7 @@ class AuditIdTest {
     }
 
     @Test
-    fun plusHandlesOneAndEmptyMany() {
+    fun `plus handles One and empty Many`() {
         val one = AuditId.One("value")
         val many = AuditId.Many(emptyList())
         val result = one + many
@@ -66,7 +66,7 @@ class AuditIdTest {
     }
 
     @Test
-    fun plusHandlesTwoEmptyManyInstances() {
+    fun `plus handles two empty Many instances`() {
         val many1 = AuditId.Many(emptyList())
         val many2 = AuditId.Many(emptyList())
         val result = many1 + many2


### PR DESCRIPTION
Osa 1/x
Muokattu apien audit-lokitusta, lisätty lapsen/lasten id:t lokieventin `objectId`-parametriin.
Lisätty mahdollisuus yhdistää useamman tyypin AuditId saman parametrin arvoksi.