### PR TITLE
React 19

### DIFF
--- a/frontend/.yarn/patches/@fortawesome-react-fontawesome-npm-0.2.2-e1863961b2.patch
+++ b/frontend/.yarn/patches/@fortawesome-react-fontawesome-npm-0.2.2-e1863961b2.patch
@@ -1,0 +1,11 @@
+diff --git a/index.d.ts b/index.d.ts
+index a36e1b022a6a7d650079b9648bb2c7465c617930..479baf2fbf0c47f2d260854bb804db3498602cb0 100644
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -1,5 +1,5 @@
+ /// <reference types="react" />
+-import { CSSProperties, SVGAttributes, RefAttributes } from 'react'
++import { CSSProperties, SVGAttributes, RefAttributes, JSX } from 'react'
+ import {
+   Transform,
+   IconProp,

--- a/frontend/.yarn/patches/@react-leaflet-core-npm-3.0.0-4e3f2d62b5.patch
+++ b/frontend/.yarn/patches/@react-leaflet-core-npm-3.0.0-4e3f2d62b5.patch
@@ -1,5 +1,5 @@
 diff --git a/package.json b/package.json
-index 924b5880e3bbd8aaf60c143d5abfa25dbadcd8b3..ee63bf9f5ba456623d6d9320fafcd2f0fa64e621 100644
+index 86ce7f318ea90753f04632c783f35ffd09d4d6ce..879c338f18501ad8156f56a6877b6b2450b34fe9 100644
 --- a/package.json
 +++ b/package.json
 @@ -22,7 +22,8 @@

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -42,7 +42,7 @@ ENV SENTRY_NO_PROGRESS_BAR="1"
 ENV APP_BUILD="$build"
 ENV APP_COMMIT="$commit"
 
-RUN export NODE_OPTIONS="--max-old-space-size=4096" \
+RUN export NODE_OPTIONS="--max-old-space-size=8192" \
  && yarn build
 
 FROM nginx:${NGINX_VERSION}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,9 +24,9 @@
     "@fortawesome/fontawesome-svg-core": "6.7.2",
     "@fortawesome/free-regular-svg-icons": "6.7.2",
     "@fortawesome/free-solid-svg-icons": "6.7.2",
-    "@fortawesome/react-fontawesome": "0.2.2",
-    "@react-spring/rafz": "9.7.5",
-    "@react-spring/web": "9.7.5",
+    "@fortawesome/react-fontawesome": "patch:@fortawesome/react-fontawesome@npm%3A0.2.2#~/.yarn/patches/@fortawesome-react-fontawesome-npm-0.2.2-e1863961b2.patch",
+    "@react-spring/rafz": "10.0.0",
+    "@react-spring/web": "10.0.0",
     "@sentry/browser": "9.17.0",
     "@sentry/react": "9.17.0",
     "@tanstack/react-query": "5.75.5",
@@ -54,14 +54,14 @@
     "lodash": "4.17.21",
     "polished": "4.3.1",
     "punycode": "2.3.1",
-    "react": "18.3.1",
+    "react": "19.1.0",
     "react-chartjs-2": "5.3.0",
     "react-day-picker": "9.6.7",
-    "react-dom": "18.3.1",
+    "react-dom": "19.1.0",
     "react-focus-lock": "2.13.6",
     "react-focus-on": "3.9.4",
     "react-image-crop": "11.0.10",
-    "react-leaflet": "4.2.1",
+    "react-leaflet": "5.0.0",
     "react-router": "7.6.0",
     "react-select": "5.10.1",
     "seamless-scroll-polyfill": "2.3.4",
@@ -88,8 +88,8 @@
     "@types/lodash": "4.17.16",
     "@types/node": "22.15.17",
     "@types/punycode": "2.1.4",
-    "@types/react": "18.3.21",
-    "@types/react-dom": "18.3.7",
+    "@types/react": "19.1.4",
+    "@types/react-dom": "19.1.5",
     "babel-loader": "10.0.0",
     "babel-plugin-styled-components": "2.1.4",
     "concurrently": "9.1.2",
@@ -148,7 +148,7 @@
     }
   },
   "resolutions": {
-    "@react-leaflet/core@npm:^2.1.0": "patch:@react-leaflet/core@npm%3A2.1.0#~/.yarn/patches/@react-leaflet-core-npm-2.1.0-de483ca53f.patch"
+    "@react-leaflet/core@npm:^3.0.0": "patch:@react-leaflet/core@npm%3A3.0.0#~/.yarn/patches/@react-leaflet-core-npm-3.0.0-4e3f2d62b5.patch"
   },
   "engines": {
     "node": ">= 22.12.0"

--- a/frontend/src/citizen-frontend/calendar/DayElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayElem.tsx
@@ -49,7 +49,7 @@ export default React.memo(function DayElem({
   scrollToDate
 }: DayProps) {
   const [lang] = useLang()
-  const ref = useRef<HTMLButtonElement>()
+  const ref = useRef<HTMLButtonElement>(undefined)
 
   const isToday = calendarDay.date.isToday()
   const isScrollToDate = calendarDay.date.isEqual(scrollToDate)

--- a/frontend/src/employee-frontend/components/child-information/assistance/OtherAssistanceMeasureSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance/OtherAssistanceMeasureSection.tsx
@@ -85,7 +85,7 @@ export const OtherAssistanceMeasureSection = React.memo(
     )
 
     const showInfoList = Object.values(t.otherAssistanceMeasure.info).some(
-      (fn) => fn()
+      (fn) => !!fn()
     )
 
     return renderResult(rowsResult, (rows) => (

--- a/frontend/src/employee-frontend/components/common/StickyActionBar.tsx
+++ b/frontend/src/employee-frontend/components/common/StickyActionBar.tsx
@@ -17,7 +17,7 @@ export default React.memo(function StickyActionBar({
   align,
   ['data-qa']: dataQa,
   children
-}: Props & { children: React.ReactNode | React.ReactNodeArray }) {
+}: Props & { children: React.ReactNode | readonly React.ReactNode[] }) {
   return (
     <Bar data-qa={dataQa}>
       <Content align={align}>{children}</Content>

--- a/frontend/src/employee-frontend/components/reports/AttendanceReservation.tsx
+++ b/frontend/src/employee-frontend/components/reports/AttendanceReservation.tsx
@@ -368,7 +368,7 @@ export default React.memo(function AttendanceReservation() {
 
 const getTableBody = (
   rowsByTime: Map<string, AttendanceReservationReportUiRow[]>,
-  autoScrollRef: RefObject<HTMLTableRowElement>
+  autoScrollRef: RefObject<HTMLTableRowElement | null>
 ) => {
   const components: React.ReactNode[] = []
   rowsByTime.forEach((rows, time) => {

--- a/frontend/src/lib-common/utils/useDebouncedCallback.ts
+++ b/frontend/src/lib-common/utils/useDebouncedCallback.ts
@@ -25,7 +25,7 @@ export function useDebouncedCallback<
   fn: T,
   delay: number
 ): [(...args: Parameters<T>) => void, () => void, () => void] {
-  const pendingCall = useRef<PendingCall>()
+  const pendingCall = useRef<PendingCall>(undefined)
 
   const cancelTimeout = useCallback(() => {
     if (pendingCall.current) {

--- a/frontend/src/lib-common/utils/useInterval.ts
+++ b/frontend/src/lib-common/utils/useInterval.ts
@@ -7,7 +7,7 @@ import { useEffect, useRef } from 'react'
 type Callback = () => void
 
 export function useInterval(cb: Callback, delayMs: number) {
-  const callbackRef = useRef<Callback>()
+  const callbackRef = useRef<Callback>(undefined)
 
   useEffect(() => {
     callbackRef.current = cb

--- a/frontend/src/lib-components/Notifications.tsx
+++ b/frontend/src/lib-components/Notifications.tsx
@@ -267,7 +267,7 @@ function useReloadNotification(
   addNotification: (n: Notification) => void
 ) {
   const theme = useTheme()
-  const timer = useRef<number>()
+  const timer = useRef<number>(undefined)
   const [show, setShow] = useState(false)
 
   const maybeShow = useCallback(() => {

--- a/frontend/src/lib-components/atoms/ExpandableList.tsx
+++ b/frontend/src/lib-components/atoms/ExpandableList.tsx
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { ReactNodeArray, useState } from 'react'
+import React, { useState } from 'react'
 
 interface Props {
-  children: ReactNodeArray
+  children: React.ReactNode[]
   rowsToOccupy: number
   i18n: { others: string }
 }

--- a/frontend/src/lib-components/atoms/buttons/LegacyButton.tsx
+++ b/frontend/src/lib-components/atoms/buttons/LegacyButton.tsx
@@ -83,7 +83,7 @@ export const StyledButton = styled.button`
 
 export interface ButtonProps extends BaseProps {
   onClick?: (e: React.MouseEvent) => unknown
-  children?: React.ReactNode | React.ReactNodeArray
+  children?: React.ReactNode | readonly React.ReactNode[]
   text?: string
   primary?: boolean
   disabled?: boolean

--- a/frontend/src/lib-components/atoms/dropdowns/Combobox.tsx
+++ b/frontend/src/lib-components/atoms/dropdowns/Combobox.tsx
@@ -239,7 +239,7 @@ function Combobox<T>(props: ComboboxProps<T>) {
     [filterItems, items, currentFilter]
   )
 
-  const menuRef = useRef<HTMLElement>()
+  const menuRef = useRef<HTMLElement>(undefined)
 
   const onInputValueChange = useCallback(
     ({ isOpen, inputValue }: UseComboboxStateChange<T>) => {

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerLowLevel.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerLowLevel.tsx
@@ -289,8 +289,8 @@ export function useFloatingPositioning({
   floatingHeight,
   active
 }: {
-  anchorRef: React.RefObject<HTMLElement>
-  floatingRef: React.RefObject<HTMLElement>
+  anchorRef: React.RefObject<HTMLElement | null>
+  floatingRef: React.RefObject<HTMLElement | null>
   floatingHeight: number
   active: boolean
 }) {

--- a/frontend/src/lib-components/molecules/modals/BaseModal.tsx
+++ b/frontend/src/lib-components/molecules/modals/BaseModal.tsx
@@ -24,7 +24,7 @@ export interface ModalBaseProps {
   type?: ModalType
   mobileFullScreen?: boolean
   zIndex?: number
-  children?: React.ReactNode | React.ReactNodeArray
+  children?: React.ReactNode | readonly React.ReactNode[]
   'data-qa'?: string
   width?: ModalWidth
   padding?: SpacingSize

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2279,6 +2279,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fortawesome/react-fontawesome@patch:@fortawesome/react-fontawesome@npm%3A0.2.2#~/.yarn/patches/@fortawesome-react-fontawesome-npm-0.2.2-e1863961b2.patch":
+  version: 0.2.2
+  resolution: "@fortawesome/react-fontawesome@patch:@fortawesome/react-fontawesome@npm%3A0.2.2#~/.yarn/patches/@fortawesome-react-fontawesome-npm-0.2.2-e1863961b2.patch::version=0.2.2&hash=76a249"
+  dependencies:
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@fortawesome/fontawesome-svg-core": ~1 || ~6
+    react: ">=16.3"
+  checksum: 10/eaa2fce4e2cc5515f42c47b85d3ef9f99a83f85511513a30137266e980278f81ccf4fcea6803a85dca77a15c2bcadb1e2ad3bb188d8e4be76c4738fdc0f36df7
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.0.1":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -3157,91 +3169,91 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-leaflet/core@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@react-leaflet/core@npm:2.1.0"
+"@react-leaflet/core@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@react-leaflet/core@npm:3.0.0"
   peerDependencies:
     leaflet: ^1.9.0
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 10/12ce28b85cf6712a1a7b7c49466b941fc619bc7b1535308bc5711a35f7e89eb16298babfd62f6b3a92e64abf94dcf517b2bc460f59fcf20599821bc6ab3b3048
+    react: ^19.0.0
+    react-dom: ^19.0.0
+  checksum: 10/193f4928ff609a922493f05e2f301f53a3d9b8387e90fc6ab4bc4f78f97272cad000fbdf0f1d23069f67cb35d3d855734ce5a5feab98619aebfc3334be2967c7
   languageName: node
   linkType: hard
 
-"@react-leaflet/core@patch:@react-leaflet/core@npm%3A2.1.0#~/.yarn/patches/@react-leaflet-core-npm-2.1.0-de483ca53f.patch":
-  version: 2.1.0
-  resolution: "@react-leaflet/core@patch:@react-leaflet/core@npm%3A2.1.0#~/.yarn/patches/@react-leaflet-core-npm-2.1.0-de483ca53f.patch::version=2.1.0&hash=178615"
+"@react-leaflet/core@patch:@react-leaflet/core@npm%3A3.0.0#~/.yarn/patches/@react-leaflet-core-npm-3.0.0-4e3f2d62b5.patch":
+  version: 3.0.0
+  resolution: "@react-leaflet/core@patch:@react-leaflet/core@npm%3A3.0.0#~/.yarn/patches/@react-leaflet-core-npm-3.0.0-4e3f2d62b5.patch::version=3.0.0&hash=11c529"
   peerDependencies:
     leaflet: ^1.9.0
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 10/00e3a5982d41a27dd41113de55af31b47e2719151d5a4dd472115899a9ed3881b824c285f38c32a579034eefad1743332e9a27be205114fd14768ebb862835eb
+    react: ^19.0.0
+    react-dom: ^19.0.0
+  checksum: 10/1e7c91981b827fb2902cfeee5ab9a96e08c6d84121c03cd3a1df15177b1131ddb0da8fd29094749ff7d1c3bedf83bd21e2dd864432cc2cace85eb5bf2f8b9846
   languageName: node
   linkType: hard
 
-"@react-spring/animated@npm:~9.7.5":
-  version: 9.7.5
-  resolution: "@react-spring/animated@npm:9.7.5"
+"@react-spring/animated@npm:~10.0.0":
+  version: 10.0.0
+  resolution: "@react-spring/animated@npm:10.0.0"
   dependencies:
-    "@react-spring/shared": "npm:~9.7.5"
-    "@react-spring/types": "npm:~9.7.5"
+    "@react-spring/shared": "npm:~10.0.0"
+    "@react-spring/types": "npm:~10.0.0"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/f4130b7ffae25621514ff2b3873acab65c21d6acf8eab798ef1fe5ee917c07f4c75aaa19788244dce7d9a0d6586a794f59634f2809e2f6399d9766dfbd454837
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/1f1cf60d768b6d125d3c4da13a32bfc2314683dbbf5c985688c133ea6f1010718c9c77c04af79d3fe3652c9e4480471d1d7109c2ae4dd30f3c045dab3352fb4d
   languageName: node
   linkType: hard
 
-"@react-spring/core@npm:~9.7.5":
-  version: 9.7.5
-  resolution: "@react-spring/core@npm:9.7.5"
+"@react-spring/core@npm:~10.0.0":
+  version: 10.0.0
+  resolution: "@react-spring/core@npm:10.0.0"
   dependencies:
-    "@react-spring/animated": "npm:~9.7.5"
-    "@react-spring/shared": "npm:~9.7.5"
-    "@react-spring/types": "npm:~9.7.5"
+    "@react-spring/animated": "npm:~10.0.0"
+    "@react-spring/shared": "npm:~10.0.0"
+    "@react-spring/types": "npm:~10.0.0"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/b76578ffbd26f66cce7212ab3335eea488c05a533acea6bc09c5357f3d5f7a2550e4588124fc7445f5effcb91f8b2ddf049a556c9c8786556740a90780cbd73b
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/317ddb8345fc4722f70527872053c87a88c9093f1e97c9691673324fc6ebfe005f62c17afe4198c0f1c949ff2a18cd4fbc5f2c08400e41dc740db0c0cfc00a43
   languageName: node
   linkType: hard
 
-"@react-spring/rafz@npm:9.7.5, @react-spring/rafz@npm:~9.7.5":
-  version: 9.7.5
-  resolution: "@react-spring/rafz@npm:9.7.5"
-  checksum: 10/25b2dfc674603251bb4645758b4b35e7807a887fe7b58e7257edd32993abb9d7e36cd381f831d532f45278460227357112dd008ca3d07f9d8694aedd59d786b8
+"@react-spring/rafz@npm:10.0.0, @react-spring/rafz@npm:~10.0.0":
+  version: 10.0.0
+  resolution: "@react-spring/rafz@npm:10.0.0"
+  checksum: 10/d8961c853aef489fce4956084d368d994a3dcb5f9f8b848d5ccd32e7f7fb86247fae502e369e0134f97dd9dc515853b30df8ec76c8c2a39b2009db2ddc936376
   languageName: node
   linkType: hard
 
-"@react-spring/shared@npm:~9.7.5":
-  version: 9.7.5
-  resolution: "@react-spring/shared@npm:9.7.5"
+"@react-spring/shared@npm:~10.0.0":
+  version: 10.0.0
+  resolution: "@react-spring/shared@npm:10.0.0"
   dependencies:
-    "@react-spring/rafz": "npm:~9.7.5"
-    "@react-spring/types": "npm:~9.7.5"
+    "@react-spring/rafz": "npm:~10.0.0"
+    "@react-spring/types": "npm:~10.0.0"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/4e8d7927a1543745f36600396250999d2e8fdb57d73b2cb8b4d859f35ba202cf3bdcc1a64c72ca495fcc8025f739b428b1735ab5159d01fc45ea30b568be11d8
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/64a86386a9e8fbaa834be64b43bb29f378b44d63ce8c26577126f9cb5ffdd6d840f4ae8ca4d3032d89ee8fad75eea768a13ed79bc9002796e4b203dadb0c3a4c
   languageName: node
   linkType: hard
 
-"@react-spring/types@npm:~9.7.5":
-  version: 9.7.5
-  resolution: "@react-spring/types@npm:9.7.5"
-  checksum: 10/5b0edc00f31dcd3a8c5027130c9992ba286dd275112800c63f706da2b871837ca96b52f6a1f0796f38190a947d7ae7bf4916ec9b440b04a0bc0e5c57f6fd70aa
+"@react-spring/types@npm:~10.0.0":
+  version: 10.0.0
+  resolution: "@react-spring/types@npm:10.0.0"
+  checksum: 10/b0cd524db137a75f12909959c5d97d7f8d4f9697a56ce779e3a1b7aa54bbf31dd44535f640a60ac3150960cde512c8b893e9c54866afe361f8637f17c3dd76f9
   languageName: node
   linkType: hard
 
-"@react-spring/web@npm:9.7.5":
-  version: 9.7.5
-  resolution: "@react-spring/web@npm:9.7.5"
+"@react-spring/web@npm:10.0.0":
+  version: 10.0.0
+  resolution: "@react-spring/web@npm:10.0.0"
   dependencies:
-    "@react-spring/animated": "npm:~9.7.5"
-    "@react-spring/core": "npm:~9.7.5"
-    "@react-spring/shared": "npm:~9.7.5"
-    "@react-spring/types": "npm:~9.7.5"
+    "@react-spring/animated": "npm:~10.0.0"
+    "@react-spring/core": "npm:~10.0.0"
+    "@react-spring/shared": "npm:~10.0.0"
+    "@react-spring/types": "npm:~10.0.0"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/ecd6c410d0277649c6a6dc19156a06cc7beb92ac79eb798ee18d30ca9bdf92ccf63ad7794b384471059f03d3dc8c612b26ca6aec42769d01e2a43d07919fd02b
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/61cea16b4c295cf64390e3e03ecd7d37e59eb534159f0b53e9b0a0a31d96546923dd87bcb5c6ed1bd055573ee3f448ff695bc3743d9f3e01c57f544f0b5ba322
   languageName: node
   linkType: hard
 
@@ -3787,13 +3799,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
-  version: 15.7.3
-  resolution: "@types/prop-types@npm:15.7.3"
-  checksum: 10/90064105961cfabb9174e61e5010b4e7a471e21832118ad0258f196f4be19ad7dd0f724cc62b0e90939d0b830d4f49ba54dffde166893fd0d9be1f3b43db6981
-  languageName: node
-  linkType: hard
-
 "@types/punycode@npm:2.1.4":
   version: 2.1.4
   resolution: "@types/punycode@npm:2.1.4"
@@ -3801,12 +3806,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:18.3.7":
-  version: 18.3.7
-  resolution: "@types/react-dom@npm:18.3.7"
+"@types/react-dom@npm:19.1.5":
+  version: 19.1.5
+  resolution: "@types/react-dom@npm:19.1.5"
   peerDependencies:
-    "@types/react": ^18.0.0
-  checksum: 10/317569219366d487a3103ba1e5e47154e95a002915fdcf73a44162c48fe49c3a57fcf7f57fc6979e70d447112681e6b13c6c3c1df289db8b544df4aab2d318f3
+    "@types/react": ^19.0.0
+  checksum: 10/1bbfb77aa8b40ae1b3e2d90a3cd29987aa244a34a0e398828266276eb3f83810d10ed6cb1fddaf1469653bbe7243d9b75f6e245c21c8bb6224169c48bedfa536
   languageName: node
   linkType: hard
 
@@ -3819,22 +3824,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 19.1.1
-  resolution: "@types/react@npm:19.1.1"
+"@types/react@npm:*, @types/react@npm:19.1.4":
+  version: 19.1.4
+  resolution: "@types/react@npm:19.1.4"
   dependencies:
     csstype: "npm:^3.0.2"
-  checksum: 10/f267c2a7afddd1f463bd4cf18553ddea132c609a6dc29938c5e83ae392c75e0acdbace2d03ad26178183b10da733e476324e2f25f48bd7fa6c232de708c35563
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:18.3.21":
-  version: 18.3.21
-  resolution: "@types/react@npm:18.3.21"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10/89adc2fe391fd63b620db0aaa10b2be89fad338039415fd748e60c962e47bf2b0f1897cb5226f181eda963f37a1c8ac1bf0b3b29a0e35313bacd0355e5d6c736
+  checksum: 10/b8744e03bc3f7d4d686681ab039e0b2454fbb2110436b8b7f6ee9e6c5f8f8552231c6c273b908f69b3eae1745aeb7b075949bb3983ba8b36c3b0c2888e22726c
   languageName: node
   linkType: hard
 
@@ -6691,10 +6686,10 @@ __metadata:
     "@fortawesome/fontawesome-svg-core": "npm:6.7.2"
     "@fortawesome/free-regular-svg-icons": "npm:6.7.2"
     "@fortawesome/free-solid-svg-icons": "npm:6.7.2"
-    "@fortawesome/react-fontawesome": "npm:0.2.2"
+    "@fortawesome/react-fontawesome": "patch:@fortawesome/react-fontawesome@npm%3A0.2.2#~/.yarn/patches/@fortawesome-react-fontawesome-npm-0.2.2-e1863961b2.patch"
     "@playwright/test": "npm:1.52.0"
-    "@react-spring/rafz": "npm:9.7.5"
-    "@react-spring/web": "npm:9.7.5"
+    "@react-spring/rafz": "npm:10.0.0"
+    "@react-spring/web": "npm:10.0.0"
     "@sentry/browser": "npm:9.17.0"
     "@sentry/react": "npm:9.17.0"
     "@sentry/webpack-plugin": "npm:3.4.0"
@@ -6710,8 +6705,8 @@ __metadata:
     "@types/lodash": "npm:4.17.16"
     "@types/node": "npm:22.15.17"
     "@types/punycode": "npm:2.1.4"
-    "@types/react": "npm:18.3.21"
-    "@types/react-dom": "npm:18.3.7"
+    "@types/react": "npm:19.1.4"
+    "@types/react-dom": "npm:19.1.5"
     autosize: "npm:6.0.1"
     axios: "npm:1.9.0"
     babel-loader: "npm:10.0.0"
@@ -6764,14 +6759,14 @@ __metadata:
     postcss-preset-env: "npm:10.1.6"
     prettier: "npm:3.5.3"
     punycode: "npm:2.3.1"
-    react: "npm:18.3.1"
+    react: "npm:19.1.0"
     react-chartjs-2: "npm:5.3.0"
     react-day-picker: "npm:9.6.7"
-    react-dom: "npm:18.3.1"
+    react-dom: "npm:19.1.0"
     react-focus-lock: "npm:2.13.6"
     react-focus-on: "npm:3.9.4"
     react-image-crop: "npm:11.0.10"
-    react-leaflet: "npm:4.2.1"
+    react-leaflet: "npm:5.0.0"
     react-router: "npm:7.6.0"
     react-select: "npm:5.10.1"
     seamless-scroll-polyfill: "npm:2.3.4"
@@ -9083,7 +9078,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -10837,15 +10832,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:18.3.1":
-  version: 18.3.1
-  resolution: "react-dom@npm:18.3.1"
+"react-dom@npm:19.1.0":
+  version: 19.1.0
+  resolution: "react-dom@npm:19.1.0"
   dependencies:
-    loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.2"
+    scheduler: "npm:^0.26.0"
   peerDependencies:
-    react: ^18.3.1
-  checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
+    react: ^19.1.0
+  checksum: 10/c5b58605862c7b0bb044416b01c73647bb8e89717fb5d7a2c279b11815fb7b49b619fe685c404e59f55eb52c66831236cc565c25ee1c2d042739f4a2cc538aa2
   languageName: node
   linkType: hard
 
@@ -10919,16 +10913,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-leaflet@npm:4.2.1":
-  version: 4.2.1
-  resolution: "react-leaflet@npm:4.2.1"
+"react-leaflet@npm:5.0.0":
+  version: 5.0.0
+  resolution: "react-leaflet@npm:5.0.0"
   dependencies:
-    "@react-leaflet/core": "npm:^2.1.0"
+    "@react-leaflet/core": "npm:^3.0.0"
   peerDependencies:
     leaflet: ^1.9.0
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 10/01cee12dc32e86d0153c989894fdba1c5c50fa41ad8d712352fa616f7b0dd32844aa17bb06c66f7569133675e2946c669090b4c496610cce3fa37c22254ca89f
+    react: ^19.0.0
+    react-dom: ^19.0.0
+  checksum: 10/170bf8d83141c8406fddc8cab41608ec6938efaafa5ae08c2060f9c0739370b84ed61d809c092d9f9ea79461399519f18f1cdf06dcb0e26d61d89eda46fb30be
   languageName: node
   linkType: hard
 
@@ -11035,12 +11029,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:18.3.1":
-  version: 18.3.1
-  resolution: "react@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
+"react@npm:19.1.0":
+  version: 19.1.0
+  resolution: "react@npm:19.1.0"
+  checksum: 10/d0180689826fd9de87e839c365f6f361c561daea397d61d724687cae88f432a307d1c0f53a0ee95ddbe3352c10dac41d7ff1ad85530fb24951b27a39e5398db4
   languageName: node
   linkType: hard
 
@@ -11425,12 +11417,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.2":
-  version: 0.23.2
-  resolution: "scheduler@npm:0.23.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/e8d68b89d18d5b028223edf090092846868a765a591944760942b77ea1f69b17235f7e956696efbb62c8130ab90af7e0949bfb8eba7896335507317236966bc9
+"scheduler@npm:^0.26.0":
+  version: 0.26.0
+  resolution: "scheduler@npm:0.26.0"
+  checksum: 10/1ecf2e5d7de1a7a132796834afe14a2d589ba7e437615bd8c06f3e0786a3ac3434655e67aac8755d9b14e05754c177e49c064261de2673aaa3c926bc98caa002
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Nostetaan noden muistirajaa CI:ssä koska ilman sitä webpack kaatuu
- Päivitetään react, react-dom ja tyypitykset versioon 19
- Päivitetään react-spring versioon 10
- Päivitetään react-leaflet versioon 5 ja käytetään aiemman version pikkupatchia myös uudella versiolla
- Patchataan react-fontawesomen tyypityksiä vähän
- Korjataan oman koodin tyyppivirheet