### PR TITLE
Lasten tuen tarpeet ja tukitoimet -raportin lisäykset

### DIFF
--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -512,10 +512,12 @@ export class AssistanceNeedsAndActionsReport {
   needsAndActionsRows: ElementCollection
   childRows: ElementCollection
   careAreaSelect: Combobox
+  providerTypeSelect: Combobox
   unitSelect: Combobox
   typeSelect: Combobox
   daycareAssistanceLevelSelect: MultiSelect
   preschoolAssistanceLevelSelect: MultiSelect
+  placementTypeSelect: MultiSelect
 
   constructor(private page: Page) {
     this.needsAndActionsRows = page.findAllByDataQa(
@@ -525,11 +527,17 @@ export class AssistanceNeedsAndActionsReport {
     this.careAreaSelect = new Combobox(page.findByDataQa('care-area-filter'))
     this.unitSelect = new Combobox(page.findByDataQa('unit-filter'))
     this.typeSelect = new Combobox(this.page.findByDataQa(`type-filter`))
+    this.providerTypeSelect = new Combobox(
+      this.page.findByDataQa('provider-type-filter')
+    )
     this.daycareAssistanceLevelSelect = new MultiSelect(
       this.page.findByDataQa('daycare-assistance-level-filter')
     )
     this.preschoolAssistanceLevelSelect = new MultiSelect(
       this.page.findByDataQa('preschool-assistance-level-filter')
+    )
+    this.placementTypeSelect = new MultiSelect(
+      this.page.findByDataQa('placement-type-filter')
     )
   }
 

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-and-actions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-and-actions-report.spec.ts
@@ -144,13 +144,15 @@ describe('Assistance need and actions report', () => {
     await report.typeSelect.fillAndSelectFirst('esiopetuksessa')
     await report.needsAndActionsRows
       .nth(0)
-      .assertTextEquals('Superkeskus\n' + '\t\t1\t0\t0\t0\t0\t0\t0\t1\t0\t0\t0')
+      .assertTextEquals(
+        'Superkeskus\n' + '\t\t1\t0\t0\t0\t0\t0\t0\t1\t0\t0\t0\t0\t0'
+      )
     await report.preschoolAssistanceLevelSelect.fillAndSelectFirst(
       'Tehostettu tuki'
     )
     await report.needsAndActionsRows
       .nth(0)
-      .assertTextEquals('Superkeskus\n' + '\t\t1\t1\t0\t0\t0')
+      .assertTextEquals('Superkeskus\n' + '\t\t1\t1\t0\t0\t0\t0\t0')
     await report.preschoolAssistanceLevelSelect.fillAndSelectFirst(
       'Tehostettu tuki'
     )
@@ -159,18 +161,20 @@ describe('Assistance need and actions report', () => {
     )
     await report.needsAndActionsRows
       .nth(0)
-      .assertTextEquals('Superkeskus\n' + '\t\t0\t0\t0\t0\t0')
+      .assertTextEquals('Superkeskus\n' + '\t\t0\t0\t0\t0\t0\t0\t0')
 
     await report.typeSelect.fillAndSelectFirst('varhaiskasvatuksessa')
     await report.needsAndActionsRows
       .nth(0)
-      .assertTextEquals('Superkeskus\n' + '\t\t1\t0\t0\t0\t0\t0\t0\t1\t0\t0\t0')
+      .assertTextEquals(
+        'Superkeskus\n' + '\t\t1\t0\t0\t0\t0\t0\t0\t1\t0\t0\t0\t0\t0'
+      )
     await report.daycareAssistanceLevelSelect.fillAndSelectFirst(
       'Yleinen tuki, ei päätöstä'
     )
     await report.needsAndActionsRows
       .nth(0)
-      .assertTextEquals('Superkeskus\n' + '\t\t1\t1\t0\t0\t0')
+      .assertTextEquals('Superkeskus\n' + '\t\t1\t1\t0\t0\t0\t0\t0')
     await report.daycareAssistanceLevelSelect.fillAndSelectFirst(
       'Yleinen tuki, ei päätöstä'
     )
@@ -179,7 +183,7 @@ describe('Assistance need and actions report', () => {
     )
     await report.needsAndActionsRows
       .nth(0)
-      .assertTextEquals('Superkeskus\n' + '\t\t0\t0\t0\t0\t0')
+      .assertTextEquals('Superkeskus\n' + '\t\t0\t0\t0\t0\t0\t0\t0')
   })
   test('Shows actions only if child has selected assistance', async () => {
     const validDuring = new FiniteDateRange(mockedTime, mockedTime)

--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-and-actions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-and-actions-report.spec.ts
@@ -3,8 +3,12 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
-import { DaycareId, PersonId } from 'lib-common/generated/api-types/shared'
-import { evakaUserId } from 'lib-common/id-type'
+import {
+  DaycareId,
+  GroupId,
+  PersonId
+} from 'lib-common/generated/api-types/shared'
+import { evakaUserId, randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
@@ -103,13 +107,15 @@ describe('Assistance need and actions report', () => {
     const report = new AssistanceNeedsAndActionsReport(page)
     await report.needsAndActionsRows
       .nth(0)
-      .assertTextEquals('Superkeskus\n' + '\t\t1\t0\t0\t0\t1\t0\t0\t1\t0\t0\t1')
+      .assertTextEquals(
+        'Superkeskus\n' + '\t\t1\t0\t0\t0\t1\t0\t0\t1\t0\t0\t1\t0\t0'
+      )
     await report.selectCareAreaFilter('Superkeskus')
     await report.openUnit('Alkuräjähdyksen päiväkoti')
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t1\t0\t0\ta test assistance action option\t1.5'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t1\t0\t0\ta test assistance action option\t1.5\t0\t0'
       )
   })
   test('Counts actions only if child has selected assistance', async () => {
@@ -220,7 +226,7 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\ta test assistance action option\t1'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\ta test assistance action option\t1\t0\t0'
       )
     await report.preschoolAssistanceLevelSelect.fillAndSelectFirst(
       'Tehostettu tuki'
@@ -228,7 +234,7 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\ta test assistance action option\t1'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\ta test assistance action option\t1\t0\t0'
       )
     await report.preschoolAssistanceLevelSelect.fillAndSelectFirst(
       'Tehostettu tuki'
@@ -239,14 +245,14 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t0\t\t1'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t0\t\t1\t0\t0'
       )
 
     await report.typeSelect.fillAndSelectFirst('varhaiskasvatuksessa')
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\ta test assistance action option\t1'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\ta test assistance action option\t1\t0\t0'
       )
     await report.daycareAssistanceLevelSelect.fillAndSelectFirst(
       'Yleinen tuki, ei päätöstä'
@@ -254,7 +260,7 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\ta test assistance action option\t1'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\ta test assistance action option\t1\t0\t0'
       )
     await report.daycareAssistanceLevelSelect.fillAndSelectFirst(
       'Yleinen tuki, ei päätöstä'
@@ -265,7 +271,303 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t0\t\t1'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t0\t\t1\t0\t0'
       )
+  })
+  test('Shows assistance decision counts', async () => {
+    const validDuring = new FiniteDateRange(mockedTime, mockedTime)
+    await Fixture.daycareAssistance({
+      childId,
+      validDuring
+    }).save()
+
+    await Fixture.otherAssistanceMeasure({
+      childId,
+      validDuring
+    }).save()
+
+    await Fixture.assistanceActionOption({
+      value: 'ASSISTANCE_SERVICE_CHILD'
+    }).save()
+
+    await Fixture.assistanceAction({
+      childId,
+      updatedBy: evakaUserId(admin.id),
+      startDate: validDuring.start,
+      endDate: validDuring.end,
+      actions: ['ASSISTANCE_SERVICE_CHILD']
+    }).save()
+
+    await Fixture.assistanceNeedVoucherCoefficient({
+      childId,
+      validityPeriod: new FiniteDateRange(validDuring.start, validDuring.end),
+      coefficient: 1.5
+    }).save()
+    await Fixture.assistanceNeedDecision({
+      childId,
+      validityPeriod: validDuring.asDateRange(),
+      status: 'ACCEPTED',
+      decisionMaker: {
+        employeeId: admin.id,
+        title: 'regional director',
+        name: null,
+        phoneNumber: null
+      },
+      sentForDecision: validDuring.start,
+      selectedUnit: unitId
+    }).save()
+
+    await Fixture.assistanceNeedPreschoolDecision({
+      childId: childId
+    })
+      .withRequiredFieldsFilled(testDaycare.id, admin.id, admin.id)
+      .with({
+        status: 'ACCEPTED',
+        sentForDecision: validDuring.start,
+        decisionMade: validDuring.start,
+        unreadGuardianIds: []
+      })
+      .withForm({
+        type: 'NEW',
+        validFrom: validDuring.start,
+        validTo: validDuring.end
+      })
+      .save()
+
+    await page.goto(
+      `${config.employeeUrl}/reports/assistance-needs-and-actions`
+    )
+    const report = new AssistanceNeedsAndActionsReport(page)
+    await report.needsAndActionsRows
+      .nth(0)
+      .assertTextEquals(
+        'Superkeskus\n' + '\t\t1\t0\t0\t0\t1\t0\t0\t1\t0\t0\t1\t1\t1'
+      )
+    await report.selectCareAreaFilter('Superkeskus')
+    await report.openUnit('Alkuräjähdyksen päiväkoti')
+    await report.childRows
+      .nth(0)
+      .assertTextEquals(
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t1\t0\t0\ta test assistance action option\t1.5\t1\t1'
+      )
+  })
+
+  test('Provider type filtering works', async () => {
+    const validDuring = new FiniteDateRange(mockedTime, mockedTime)
+    await Fixture.daycareAssistance({
+      childId,
+      validDuring
+    }).save()
+
+    const voucherDaycare = await Fixture.daycare({
+      id: randomId<DaycareId>(),
+      areaId: testCareArea.id,
+      name: 'Voucher daycare',
+      type: ['CENTRE'],
+      dailyPreschoolTime: null,
+      dailyPreparatoryTime: null,
+      costCenter: '31501',
+      visitingAddress: {
+        streetAddress: 'Kamreerintie 2',
+        postalCode: '02210',
+        postOffice: 'Espoo'
+      },
+      decisionCustomization: {
+        daycareName: 'Päiväkoti 2 päätöksellä',
+        preschoolName: 'Päiväkoti 2 päätöksellä',
+        handler: 'Käsittelijä 2',
+        handlerAddress: 'Käsittelijän 2 osoite'
+      },
+      providerType: 'PRIVATE_SERVICE_VOUCHER',
+      enabledPilotFeatures: ['MESSAGING', 'MOBILE', 'RESERVATIONS']
+    }).save()
+
+    await Fixture.daycareGroup({
+      id: randomId<GroupId>(),
+      name: 'Voucher group',
+      daycareId: voucherDaycare.id
+    }).save()
+
+    const municipalAndTotalGroupRowExpectation =
+      'Superkeskus\n' + '\t\t1\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0'
+    const voucherGroupRowExpectation =
+      'Superkeskus\n' + '\t\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0'
+    await page.goto(
+      `${config.employeeUrl}/reports/assistance-needs-and-actions`
+    )
+    const report = new AssistanceNeedsAndActionsReport(page)
+    await report.needsAndActionsRows
+      .nth(0)
+      .assertTextEquals(municipalAndTotalGroupRowExpectation)
+
+    await report.providerTypeSelect.fillAndSelectFirst('Palveluseteli')
+    await report.unitSelect.click()
+    await report.unitSelect.assertOptions(['Kaikki', voucherDaycare.name])
+
+    await report.needsAndActionsRows
+      .nth(0)
+      .assertTextEquals(voucherGroupRowExpectation)
+
+    await report.providerTypeSelect.fillAndSelectFirst('Kunnallinen')
+    await report.unitSelect.click()
+    await report.unitSelect.assertOptions(['Kaikki', testDaycare.name])
+    await report.needsAndActionsRows
+      .nth(0)
+      .assertTextEquals(municipalAndTotalGroupRowExpectation)
+
+    await report.providerTypeSelect.fillAndSelectFirst('Kaikki')
+    await report.selectCareAreaFilter('Superkeskus')
+    await report.unitSelect.click()
+    await report.unitSelect.assertOptions([
+      'Kaikki',
+      testDaycare.name,
+      voucherDaycare.name
+    ])
+
+    await report.openUnit('Alkuräjähdyksen päiväkoti')
+    await report.childRows
+      .nth(0)
+      .assertTextEquals(
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\t\t1\t0\t0'
+      )
+
+    await report.providerTypeSelect.fillAndSelectFirst('Palveluseteli')
+    await report.childRows.assertCount(0)
+  })
+
+  test('Placement type filtering works', async () => {
+    const validDuring = new FiniteDateRange(mockedTime, mockedTime)
+    await Fixture.daycareAssistance({
+      childId,
+      validDuring
+    }).save()
+
+    await Fixture.otherAssistanceMeasure({
+      childId,
+      validDuring
+    }).save()
+
+    await Fixture.assistanceActionOption({
+      value: 'ASSISTANCE_SERVICE_CHILD'
+    }).save()
+
+    await Fixture.assistanceAction({
+      childId,
+      updatedBy: evakaUserId(admin.id),
+      startDate: validDuring.start,
+      endDate: validDuring.end,
+      actions: ['ASSISTANCE_SERVICE_CHILD']
+    }).save()
+
+    await Fixture.assistanceNeedVoucherCoefficient({
+      childId,
+      validityPeriod: new FiniteDateRange(validDuring.start, validDuring.end),
+      coefficient: 1.5
+    }).save()
+    await Fixture.assistanceNeedDecision({
+      childId,
+      validityPeriod: validDuring.asDateRange(),
+      status: 'ACCEPTED',
+      decisionMaker: {
+        employeeId: admin.id,
+        title: 'regional director',
+        name: null,
+        phoneNumber: null
+      },
+      sentForDecision: validDuring.start,
+      selectedUnit: unitId
+    }).save()
+
+    await Fixture.assistanceNeedPreschoolDecision({
+      childId: childId
+    })
+      .withRequiredFieldsFilled(testDaycare.id, admin.id, admin.id)
+      .with({
+        status: 'ACCEPTED',
+        sentForDecision: validDuring.start,
+        decisionMade: validDuring.start,
+        unreadGuardianIds: []
+      })
+      .withForm({
+        type: 'NEW',
+        validFrom: validDuring.start,
+        validTo: validDuring.end
+      })
+      .save()
+
+    const child2 = await Fixture.person({
+      id: randomId<PersonId>(),
+      ssn: '071013A960A',
+      firstName: 'Lisä',
+      lastName: 'Lapsi',
+      email: '',
+      phone: '',
+      language: 'fi',
+      dateOfBirth: LocalDate.of(2013, 10, 7),
+      streetAddress: 'Kamreerintie 4',
+      postalCode: '02100',
+      postOffice: 'Espoo',
+      nationalities: ['FI'],
+      restrictedDetailsEnabled: false,
+      restrictedDetailsEndDate: null
+    }).saveChild()
+
+    const placement2 = await Fixture.placement({
+      childId: child2.id,
+      unitId: unitId,
+      startDate: mockedTime,
+      endDate: mockedTime,
+      type: 'PRESCHOOL'
+    }).save()
+
+    await Fixture.groupPlacement({
+      daycareGroupId: testDaycareGroup.id,
+      daycarePlacementId: placement2.id,
+      startDate: mockedTime,
+      endDate: mockedTime
+    }).save()
+    await Fixture.daycareAssistance({
+      childId: child2.id,
+      validDuring
+    }).save()
+
+    await page.goto(
+      `${config.employeeUrl}/reports/assistance-needs-and-actions`
+    )
+    const report = new AssistanceNeedsAndActionsReport(page)
+
+    const anteroRow =
+      'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t1\t0\t0\ta test assistance action option\t1.5\t1\t1'
+    const lisaRow =
+      'Lisä Lapsi\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\t\t1\t0\t0'
+
+    //Group view count check
+    await report.needsAndActionsRows
+      .nth(0)
+      .assertTextEquals(
+        'Superkeskus\n' + '\t\t2\t0\t0\t0\t1\t0\t0\t1\t0\t0\t1\t1\t1'
+      )
+    await report.placementTypeSelect.click()
+    await report.placementTypeSelect.selectItem('DAYCARE')
+    await report.needsAndActionsRows
+      .nth(0)
+      .assertTextEquals(
+        'Superkeskus\n' + '\t\t1\t0\t0\t0\t1\t0\t0\t1\t0\t0\t1\t1\t1'
+      )
+
+    //Child view row checks
+    await report.selectCareAreaFilter('Superkeskus')
+    await report.openUnit('Alkuräjähdyksen päiväkoti')
+    await report.childRows.nth(0).assertTextEquals(anteroRow)
+    await report.placementTypeSelect.click()
+    await report.placementTypeSelect.selectItem('PRESCHOOL')
+    await report.openUnit('Alkuräjähdyksen päiväkoti')
+    await report.childRows.nth(0).assertTextEquals(anteroRow)
+    await report.childRows.nth(1).assertTextEquals(lisaRow)
+    await report.placementTypeSelect.click()
+    //remove selection
+    await report.placementTypeSelect.selectItem('DAYCARE')
+    await report.openUnit('Alkuräjähdyksen päiväkoti')
+    await report.childRows.nth(0).assertTextEquals(lisaRow)
   })
 })

--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedsAndActions.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedsAndActions.tsx
@@ -5,6 +5,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import add from 'lodash/add'
 import mergeWith from 'lodash/mergeWith'
+import orderBy from 'lodash/orderBy'
 import sortBy from 'lodash/sortBy'
 import React, { useMemo, useState } from 'react'
 import { Link } from 'react-router'
@@ -58,12 +59,17 @@ import {
   permittedReportsQuery
 } from './queries'
 
+interface PlacementTypeWithLabel {
+  label: string
+  value: PlacementType
+}
+
 type AssistanceNeedsAndActionsReportFilters = {
   date: LocalDate | null
   daycareAssistanceLevels: DaycareAssistanceLevel[]
   preschoolAssistanceLevels: PreschoolAssistanceLevel[]
   otherAssistanceMeasureTypes: OtherAssistanceMeasureType[]
-  placementTypes: PlacementType[]
+  placementTypes: PlacementTypeWithLabel[]
 }
 
 const types = ['DAYCARE', 'PRESCHOOL'] as const
@@ -523,7 +529,13 @@ export default React.memo(function AssistanceNeedsAndActions() {
           </FilterLabel>
           <Wrapper>
             <MultiSelect
-              options={placementTypes}
+              options={orderBy(
+                placementTypes.map((pt) => ({
+                  label: i18n.placement.type[pt],
+                  value: pt
+                })),
+                [(item) => item.label]
+              )}
               onChange={(selectedItems) =>
                 setFilters({
                   ...filters,
@@ -531,8 +543,8 @@ export default React.memo(function AssistanceNeedsAndActions() {
                 })
               }
               value={filters.placementTypes}
-              getOptionId={(type) => type}
-              getOptionLabel={(type) => i18n.placement.type[type]}
+              getOptionId={(o) => o.value}
+              getOptionLabel={(o) => o.label}
               placeholder={i18n.common.all}
               data-qa="placement-type-filter"
             />
@@ -696,7 +708,7 @@ const ReportByGroup = (props: {
               ? props.selectedPreschoolColumns
               : undefined,
           otherAssistanceMeasureTypes: props.selectedOtherColumns,
-          placementTypes: props.filters.placementTypes
+          placementTypes: props.filters.placementTypes.map((o) => o.value)
         })
       : constantQuery(null)
   )
@@ -1133,7 +1145,7 @@ const ReportByChild = (props: {
               ? props.selectedPreschoolColumns
               : undefined,
           otherAssistanceMeasureTypes: props.selectedOtherColumns,
-          placementTypes: props.filters.placementTypes
+          placementTypes: props.filters.placementTypes.map((o) => o.value)
         })
       : constantQuery(null)
   )

--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedsAndActions.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedsAndActions.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lib-common/generated/api-types/assistance'
 import { AssistanceActionOption } from 'lib-common/generated/api-types/assistanceaction'
 import { Daycare, ProviderType } from 'lib-common/generated/api-types/daycare'
+import { PlacementType } from 'lib-common/generated/api-types/placement'
 import {
   AssistanceNeedsAndActionsReport,
   AssistanceNeedsAndActionsReportByChild,
@@ -37,6 +38,7 @@ import {
   daycareAssistanceLevels,
   featureFlags,
   otherAssistanceMeasureTypes,
+  placementTypes,
   preschoolAssistanceLevels,
   unitProviderTypes
 } from 'lib-customizations/employee'
@@ -61,6 +63,7 @@ type AssistanceNeedsAndActionsReportFilters = {
   daycareAssistanceLevels: DaycareAssistanceLevel[]
   preschoolAssistanceLevels: PreschoolAssistanceLevel[]
   otherAssistanceMeasureTypes: OtherAssistanceMeasureType[]
+  placementTypes: PlacementType[]
 }
 
 const types = ['DAYCARE', 'PRESCHOOL'] as const
@@ -286,7 +289,8 @@ export default React.memo(function AssistanceNeedsAndActions() {
       date: LocalDate.todayInSystemTz(),
       daycareAssistanceLevels: [],
       preschoolAssistanceLevels: [],
-      otherAssistanceMeasureTypes: []
+      otherAssistanceMeasureTypes: [],
+      placementTypes: []
     })
   const areasResult = useQueryResult(areasQuery())
   const sortedAreas = useMemo(
@@ -515,6 +519,27 @@ export default React.memo(function AssistanceNeedsAndActions() {
         ))}
         <FilterRow>
           <FilterLabel>
+            {i18n.reports.assistanceNeedsAndActions.placementType}
+          </FilterLabel>
+          <Wrapper>
+            <MultiSelect
+              options={placementTypes}
+              onChange={(selectedItems) =>
+                setFilters({
+                  ...filters,
+                  placementTypes: selectedItems
+                })
+              }
+              value={filters.placementTypes}
+              getOptionId={(type) => type}
+              getOptionLabel={(type) => i18n.placement.type[type]}
+              placeholder={i18n.common.all}
+              data-qa="placement-type-filter"
+            />
+          </Wrapper>
+        </FilterRow>
+        <FilterRow>
+          <FilterLabel>
             {i18n.reports.assistanceNeedsAndActions.type}
           </FilterLabel>
           <Wrapper>
@@ -670,7 +695,8 @@ const ReportByGroup = (props: {
             props.columnFilters.type === 'PRESCHOOL'
               ? props.selectedPreschoolColumns
               : undefined,
-          otherAssistanceMeasureTypes: props.selectedOtherColumns
+          otherAssistanceMeasureTypes: props.selectedOtherColumns,
+          placementTypes: props.filters.placementTypes
         })
       : constantQuery(null)
   )
@@ -1106,7 +1132,8 @@ const ReportByChild = (props: {
             props.columnFilters.type === 'PRESCHOOL'
               ? props.selectedPreschoolColumns
               : undefined,
-          otherAssistanceMeasureTypes: props.selectedOtherColumns
+          otherAssistanceMeasureTypes: props.selectedOtherColumns,
+          placementTypes: props.filters.placementTypes
         })
       : constantQuery(null)
   )

--- a/frontend/src/employee-frontend/generated/api-clients/reports.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reports.ts
@@ -164,14 +164,16 @@ export async function getAssistanceNeedsAndActionsReport(
     date: LocalDate,
     daycareAssistanceLevels?: DaycareAssistanceLevel[] | null,
     preschoolAssistanceLevels?: PreschoolAssistanceLevel[] | null,
-    otherAssistanceMeasureTypes?: OtherAssistanceMeasureType[] | null
+    otherAssistanceMeasureTypes?: OtherAssistanceMeasureType[] | null,
+    placementTypes?: PlacementType[] | null
   }
 ): Promise<AssistanceNeedsAndActionsReport> {
   const params = createUrlSearchParams(
     ['date', request.date.formatIso()],
     ...(request.daycareAssistanceLevels?.map((e): [string, string | null | undefined] => ['daycareAssistanceLevels', e.toString()]) ?? []),
     ...(request.preschoolAssistanceLevels?.map((e): [string, string | null | undefined] => ['preschoolAssistanceLevels', e.toString()]) ?? []),
-    ...(request.otherAssistanceMeasureTypes?.map((e): [string, string | null | undefined] => ['otherAssistanceMeasureTypes', e.toString()]) ?? [])
+    ...(request.otherAssistanceMeasureTypes?.map((e): [string, string | null | undefined] => ['otherAssistanceMeasureTypes', e.toString()]) ?? []),
+    ...(request.placementTypes?.map((e): [string, string | null | undefined] => ['placementTypes', e.toString()]) ?? [])
   )
   const { data: json } = await client.request<JsonOf<AssistanceNeedsAndActionsReport>>({
     url: uri`/employee/reports/assistance-needs-and-actions`.toString(),
@@ -190,14 +192,16 @@ export async function getAssistanceNeedsAndActionsReportByChild(
     date: LocalDate,
     daycareAssistanceLevels?: DaycareAssistanceLevel[] | null,
     preschoolAssistanceLevels?: PreschoolAssistanceLevel[] | null,
-    otherAssistanceMeasureTypes?: OtherAssistanceMeasureType[] | null
+    otherAssistanceMeasureTypes?: OtherAssistanceMeasureType[] | null,
+    placementTypes?: PlacementType[] | null
   }
 ): Promise<AssistanceNeedsAndActionsReportByChild> {
   const params = createUrlSearchParams(
     ['date', request.date.formatIso()],
     ...(request.daycareAssistanceLevels?.map((e): [string, string | null | undefined] => ['daycareAssistanceLevels', e.toString()]) ?? []),
     ...(request.preschoolAssistanceLevels?.map((e): [string, string | null | undefined] => ['preschoolAssistanceLevels', e.toString()]) ?? []),
-    ...(request.otherAssistanceMeasureTypes?.map((e): [string, string | null | undefined] => ['otherAssistanceMeasureTypes', e.toString()]) ?? [])
+    ...(request.otherAssistanceMeasureTypes?.map((e): [string, string | null | undefined] => ['otherAssistanceMeasureTypes', e.toString()]) ?? []),
+    ...(request.placementTypes?.map((e): [string, string | null | undefined] => ['placementTypes', e.toString()]) ?? [])
   )
   const { data: json } = await client.request<JsonOf<AssistanceNeedsAndActionsReportByChild>>({
     url: uri`/employee/reports/assistance-needs-and-actions/by-child`.toString(),

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -112,14 +112,17 @@ export interface AssistanceNeedsAndActionsReportRow {
   assistanceNeedVoucherCoefficientCount: number
   careAreaName: string
   daycareAssistanceCounts: Partial<Record<DaycareAssistanceLevel, number>>
+  daycareAssistanceNeedDecisionCount: number
   groupId: GroupId
   groupName: string
   noActionCount: number
   otherActionCount: number
   otherAssistanceMeasureCounts: Partial<Record<OtherAssistanceMeasureType, number>>
   preschoolAssistanceCounts: Partial<Record<PreschoolAssistanceLevel, number>>
+  preschoolAssistanceNeedDecisionCount: number
   unitId: DaycareId
   unitName: string
+  unitProviderType: ProviderType
 }
 
 /**
@@ -134,13 +137,16 @@ export interface AssistanceNeedsAndActionsReportRowByChild {
   childId: PersonId
   childLastName: string
   daycareAssistanceCounts: Partial<Record<DaycareAssistanceLevel, number>>
+  daycareAssistanceNeedDecisionCount: number
   groupId: GroupId
   groupName: string
   otherAction: string
   otherAssistanceMeasureCounts: Partial<Record<OtherAssistanceMeasureType, number>>
   preschoolAssistanceCounts: Partial<Record<PreschoolAssistanceLevel, number>>
+  preschoolAssistanceNeedDecisionCount: number
   unitId: DaycareId
   unitName: string
+  unitProviderType: ProviderType
 }
 
 /**

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4152,6 +4152,7 @@ export const fi = {
         DAYCARE: 'varhaiskasvatuksessa',
         PRESCHOOL: 'esiopetuksessa'
       },
+      placementType: 'Sijoitusmuoto',
       level: 'Tuen taso ja muut toimet',
       showZeroRows: 'Näytä nollarivit',
       groupingTypes: {

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4152,7 +4152,7 @@ export const fi = {
         DAYCARE: 'varhaiskasvatuksessa',
         PRESCHOOL: 'esiopetuksessa'
       },
-      placementType: 'Sijoitusmuoto',
+      placementType: 'Toimintamuoto',
       level: 'Tuen taso ja muut toimet',
       showZeroRows: 'Näytä nollarivit',
       groupingTypes: {

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4162,7 +4162,10 @@ export const fi = {
       basisMissing: 'Peruste puuttuu',
       action: 'Tukitoimi',
       actionMissing: 'Tukitoimi puuttuu',
-      assistanceNeedVoucherCoefficient: 'Korotettu PS-kerroin'
+      assistanceNeedVoucherCoefficient: 'Korotettu PS-kerroin',
+      daycareAssistanceNeedDecisions:
+        'Aktiiviset varhaiskasvatuksen tuen päätökset',
+      preschoolAssistanceNeedDecisions: 'Aktiiviset esiopetuksen tuen päätökset'
     },
     occupancies: {
       title: 'Täyttö- ja käyttöasteet',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReportControllerTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReportControllerTest.kt
@@ -6,10 +6,20 @@ package fi.espoo.evaka.reports
 
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.assistance.DaycareAssistanceLevel
+import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionEmployee
+import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionStatus
+import fi.espoo.evaka.assistanceneed.decision.ServiceOptions
+import fi.espoo.evaka.assistanceneed.decision.StructuralMotivationOptions
+import fi.espoo.evaka.assistanceneed.preschooldecision.AssistanceNeedPreschoolDecisionForm
+import fi.espoo.evaka.assistanceneed.preschooldecision.AssistanceNeedPreschoolDecisionType
+import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.insertAssistanceActionOptions
+import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.UserRole
 import fi.espoo.evaka.shared.dev.DevAssistanceAction
+import fi.espoo.evaka.shared.dev.DevAssistanceNeedDecision
+import fi.espoo.evaka.shared.dev.DevAssistanceNeedPreschoolDecision
 import fi.espoo.evaka.shared.dev.DevAssistanceNeedVoucherCoefficient
 import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
@@ -21,9 +31,13 @@ import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insert
+import fi.espoo.evaka.shared.dev.insertTestAssistanceNeedDecision
+import fi.espoo.evaka.shared.dev.insertTestAssistanceNeedPreschoolDecision
+import fi.espoo.evaka.shared.domain.DateRange
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.MockEvakaClock
+import fi.espoo.evaka.shared.domain.OfficialLanguage
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalTime
@@ -53,156 +67,23 @@ class AssistanceNeedsAndActionsReportControllerTest :
     fun `daycare assistance works`() {
         val date = LocalDate.of(2023, 10, 5)
         val clock = MockEvakaClock(HelsinkiDateTime.of(date, LocalTime.of(14, 15)))
+        val area = DevCareArea()
+        val unit = DevDaycare(areaId = area.id)
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(unit)
+        }
 
-        val unitId =
-            db.transaction { tx ->
-                val areaId = tx.insert(DevCareArea())
-                tx.insert(DevDaycare(areaId = areaId))
-            }
-        val group1Id =
-            db.transaction { tx ->
-                tx.insert(DevDaycareGroup(daycareId = unitId, name = "Group 1", startDate = date))
-            }
-        val group2Id =
-            db.transaction { tx ->
-                tx.insert(DevDaycareGroup(daycareId = unitId, name = "Group 2", startDate = date))
-            }
-        val group3Id =
-            db.transaction { tx ->
-                tx.insert(DevDaycareGroup(daycareId = unitId, name = "Group 3", startDate = date))
-            }
+        val groups =
+            listOf(
+                DevDaycareGroup(daycareId = unit.id, name = "Group 1", startDate = date),
+                DevDaycareGroup(daycareId = unit.id, name = "Group 2", startDate = date),
+                DevDaycareGroup(daycareId = unit.id, name = "Group 3", startDate = date),
+            )
 
-        val child1Id =
-            db.transaction { tx ->
-                val childId =
-                    tx.insert(
-                        DevPerson(firstName = "Test 1", dateOfBirth = date.minusYears(3)),
-                        DevPersonType.CHILD,
-                    )
-                val placementId =
-                    tx.insert(
-                        DevPlacement(
-                            childId = childId,
-                            unitId = unitId,
-                            startDate = date,
-                            endDate = date,
-                        )
-                    )
-                tx.insert(
-                    DevDaycareGroupPlacement(
-                        daycarePlacementId = placementId,
-                        daycareGroupId = group1Id,
-                        startDate = date,
-                        endDate = date,
-                    )
-                )
-                tx.insert(
-                    DevDaycareAssistance(
-                        childId = childId,
-                        validDuring = FiniteDateRange(date, date),
-                        level = DaycareAssistanceLevel.GENERAL_SUPPORT,
-                    )
-                )
-                tx.insert(
-                    DevAssistanceAction(
-                        childId = childId,
-                        startDate = date,
-                        endDate = date,
-                        actions = setOf("ASSISTANCE_SERVICE_CHILD"),
-                    )
-                )
-                tx.insert(
-                    DevAssistanceNeedVoucherCoefficient(
-                        childId = childId,
-                        validityPeriod = FiniteDateRange(date, date),
-                        coefficient = BigDecimal(1.50),
-                    )
-                )
-                childId
-            }
-        val child2Id =
-            db.transaction { tx ->
-                val childId =
-                    tx.insert(
-                        DevPerson(firstName = "Test 2", dateOfBirth = date.minusYears(3)),
-                        DevPersonType.CHILD,
-                    )
-                val placementId =
-                    tx.insert(
-                        DevPlacement(
-                            childId = childId,
-                            unitId = unitId,
-                            startDate = date,
-                            endDate = date,
-                        )
-                    )
-                tx.insert(
-                    DevDaycareGroupPlacement(
-                        daycarePlacementId = placementId,
-                        daycareGroupId = group1Id,
-                        startDate = date,
-                        endDate = date,
-                    )
-                )
-                tx.insert(
-                    DevDaycareAssistance(
-                        childId = childId,
-                        validDuring = FiniteDateRange(date, date),
-                        level = DaycareAssistanceLevel.GENERAL_SUPPORT,
-                    )
-                )
-                tx.insert(
-                    DevAssistanceAction(
-                        childId = childId,
-                        startDate = date,
-                        endDate = date,
-                        otherAction = "other action test",
-                    )
-                )
-                childId
-            }
-        val child3Id =
-            db.transaction { tx ->
-                val childId =
-                    tx.insert(
-                        DevPerson(firstName = "Test 3", dateOfBirth = date.minusYears(3)),
-                        DevPersonType.CHILD,
-                    )
-                val placementId =
-                    tx.insert(
-                        DevPlacement(
-                            childId = childId,
-                            unitId = unitId,
-                            startDate = date,
-                            endDate = date,
-                        )
-                    )
-                tx.insert(
-                    DevDaycareGroupPlacement(
-                        daycarePlacementId = placementId,
-                        daycareGroupId = group2Id,
-                        startDate = date,
-                        endDate = date,
-                    )
-                )
-                tx.insert(
-                    DevDaycareAssistance(
-                        childId = childId,
-                        validDuring = FiniteDateRange(date, date),
-                        level = DaycareAssistanceLevel.GENERAL_SUPPORT,
-                    )
-                )
-                tx.insert(
-                    DevAssistanceAction(
-                        childId = childId,
-                        startDate = date,
-                        endDate = date,
-                        actions = setOf("ASSISTANCE_SERVICE_CHILD"),
-                    )
-                )
-                childId
-            }
+        db.transaction { tx -> groups.forEach { group -> tx.insert(group) } }
 
+        val children = insertAssistanceData(unit = unit, groups = groups, date = date)
         val groupReport =
             controller.getAssistanceNeedsAndActionsReport(
                 dbInstance(),
@@ -217,10 +98,10 @@ class AssistanceNeedsAndActionsReportControllerTest :
             listOf(
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group1Id,
-                    groupName = "Group 1",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
                     actionCounts = mapOf("ASSISTANCE_SERVICE_CHILD" to 1),
                     otherActionCount = 1,
                     noActionCount = 0,
@@ -228,13 +109,16 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficientCount = 1,
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group2Id,
-                    groupName = "Group 2",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[1].id,
+                    groupName = groups[1].name,
                     actionCounts = mapOf("ASSISTANCE_SERVICE_CHILD" to 1),
                     otherActionCount = 0,
                     noActionCount = 0,
@@ -242,13 +126,16 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficientCount = 0,
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group3Id,
-                    groupName = "Group 3",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[2].id,
+                    groupName = groups[2].name,
                     actionCounts = emptyMap(),
                     otherActionCount = 0,
                     noActionCount = 0,
@@ -256,6 +143,9 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficientCount = 0,
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
             ),
             groupReport.rows,
@@ -275,10 +165,10 @@ class AssistanceNeedsAndActionsReportControllerTest :
             listOf(
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group1Id,
-                    groupName = "Group 1",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
                     actionCounts = emptyMap(),
                     otherActionCount = 0,
                     noActionCount = 0,
@@ -286,13 +176,16 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficientCount = 1,
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group2Id,
-                    groupName = "Group 2",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[1].id,
+                    groupName = groups[1].name,
                     actionCounts = emptyMap(),
                     otherActionCount = 0,
                     noActionCount = 0,
@@ -300,13 +193,16 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficientCount = 0,
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group3Id,
-                    groupName = "Group 3",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[2].id,
+                    groupName = groups[2].name,
                     actionCounts = emptyMap(),
                     otherActionCount = 0,
                     noActionCount = 0,
@@ -314,6 +210,9 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficientCount = 0,
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
             ),
             emptyGroupReport.rows,
@@ -333,13 +232,13 @@ class AssistanceNeedsAndActionsReportControllerTest :
             listOf(
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group1Id,
-                    groupName = "Group 1",
-                    childId = child1Id,
-                    childLastName = "Person",
-                    childFirstName = "Test 1",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
+                    childId = children[0].id,
+                    childLastName = children[0].lastName,
+                    childFirstName = children[0].firstName,
                     childAge = 3,
                     actions = setOf("ASSISTANCE_SERVICE_CHILD"),
                     otherAction = "",
@@ -347,16 +246,19 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficient = BigDecimal("1.50"),
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group1Id,
-                    groupName = "Group 1",
-                    childId = child2Id,
-                    childLastName = "Person",
-                    childFirstName = "Test 2",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
+                    childId = children[1].id,
+                    childLastName = children[1].lastName,
+                    childFirstName = children[1].firstName,
                     childAge = 3,
                     actions = emptySet(),
                     otherAction = "other action test",
@@ -364,16 +266,19 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficient = BigDecimal("1.0"),
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group2Id,
-                    groupName = "Group 2",
-                    childId = child3Id,
-                    childLastName = "Person",
-                    childFirstName = "Test 3",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[1].id,
+                    groupName = groups[1].name,
+                    childId = children[2].id,
+                    childLastName = children[2].lastName,
+                    childFirstName = children[2].firstName,
                     childAge = 3,
                     actions = setOf("ASSISTANCE_SERVICE_CHILD"),
                     otherAction = "",
@@ -381,6 +286,9 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficient = BigDecimal("1.0"),
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
             ),
             childReport.rows,
@@ -400,13 +308,13 @@ class AssistanceNeedsAndActionsReportControllerTest :
             listOf(
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group1Id,
-                    groupName = "Group 1",
-                    childId = child1Id,
-                    childLastName = "Person",
-                    childFirstName = "Test 1",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
+                    childId = children[0].id,
+                    childLastName = children[0].lastName,
+                    childFirstName = children[0].firstName,
                     childAge = 3,
                     actions = emptySet(),
                     otherAction = "",
@@ -414,16 +322,19 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficient = BigDecimal("1.50"),
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group1Id,
-                    groupName = "Group 1",
-                    childId = child2Id,
-                    childLastName = "Person",
-                    childFirstName = "Test 2",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
+                    childId = children[1].id,
+                    childLastName = children[1].lastName,
+                    childFirstName = children[1].firstName,
                     childAge = 3,
                     actions = emptySet(),
                     otherAction = "",
@@ -431,16 +342,19 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficient = BigDecimal("1.0"),
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
                 AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
                     careAreaName = "Test Care Area",
-                    unitId = unitId,
-                    unitName = "Test Daycare",
-                    groupId = group2Id,
-                    groupName = "Group 2",
-                    childId = child3Id,
-                    childLastName = "Person",
-                    childFirstName = "Test 3",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[1].id,
+                    groupName = groups[1].name,
+                    childId = children[2].id,
+                    childLastName = children[2].lastName,
+                    childFirstName = children[2].firstName,
                     childAge = 3,
                     actions = emptySet(),
                     otherAction = "",
@@ -448,9 +362,677 @@ class AssistanceNeedsAndActionsReportControllerTest :
                     preschoolAssistanceCounts = emptyMap(),
                     otherAssistanceMeasureCounts = emptyMap(),
                     assistanceNeedVoucherCoefficient = BigDecimal("1.0"),
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
                 ),
             ),
             emptyChildReport.rows,
         )
+    }
+
+    @Test
+    fun `assistance decision counting works`() {
+        val date = LocalDate.of(2023, 10, 5)
+        val clock = MockEvakaClock(HelsinkiDateTime.of(date, LocalTime.of(14, 15)))
+        val area = DevCareArea()
+        val unit = DevDaycare(areaId = area.id)
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(unit)
+        }
+
+        val groups =
+            listOf(
+                DevDaycareGroup(daycareId = unit.id, name = "Group 1", startDate = date),
+                DevDaycareGroup(daycareId = unit.id, name = "Group 2", startDate = date),
+                DevDaycareGroup(daycareId = unit.id, name = "Group 3", startDate = date),
+            )
+
+        db.transaction { tx -> groups.forEach { group -> tx.insert(group) } }
+        val children = insertAssistanceData(unit = unit, groups = groups, date = date)
+
+        db.transaction { tx ->
+            tx.insertTestAssistanceNeedDecision(
+                childId = children[0].id,
+                DevAssistanceNeedDecision(
+                    decisionNumber = 10000,
+                    childId = children[0].id,
+                    validityPeriod = DateRange(date.minusYears(1), null),
+                    status = AssistanceNeedDecisionStatus.ACCEPTED,
+                    language = OfficialLanguage.FI,
+                    decisionMade = date.minusYears(1),
+                    sentForDecision = date.minusYears(1),
+                    selectedUnit = null,
+                    preparedBy1 =
+                        AssistanceNeedDecisionEmployee(
+                            employeeId = admin.id,
+                            title = "title",
+                            name = "admin",
+                            phoneNumber = "111",
+                        ),
+                    preparedBy2 = null,
+                    decisionMaker =
+                        AssistanceNeedDecisionEmployee(
+                            employeeId = admin.id,
+                            title = "title",
+                            name = "admin",
+                            phoneNumber = "111",
+                        ),
+                    pedagogicalMotivation = null,
+                    structuralMotivationOptions =
+                        StructuralMotivationOptions(
+                            smallerGroup = false,
+                            specialGroup = false,
+                            smallGroup = false,
+                            groupAssistant = false,
+                            childAssistant = false,
+                            additionalStaff = false,
+                        ),
+                    structuralMotivationDescription = null,
+                    careMotivation = null,
+                    serviceOptions =
+                        ServiceOptions(
+                            consultationSpecialEd = false,
+                            partTimeSpecialEd = false,
+                            fullTimeSpecialEd = false,
+                            interpretationAndAssistanceServices = false,
+                            specialAides = false,
+                        ),
+                    servicesMotivation = null,
+                    expertResponsibilities = null,
+                    guardiansHeardOn = null,
+                    guardianInfo = emptySet(),
+                    viewOfGuardians = null,
+                    otherRepresentativeHeard = false,
+                    otherRepresentativeDetails = null,
+                    assistanceLevels = emptySet(),
+                    motivationForDecision = null,
+                    unreadGuardianIds = null,
+                    annulmentReason = "",
+                    endDateNotKnown = false,
+                ),
+            )
+            tx.insertTestAssistanceNeedDecision(
+                childId = children[1].id,
+                DevAssistanceNeedDecision(
+                    decisionNumber = 10000,
+                    childId = children[1].id,
+                    validityPeriod = DateRange(date.minusYears(1), null),
+                    status = AssistanceNeedDecisionStatus.ACCEPTED,
+                    language = OfficialLanguage.FI,
+                    decisionMade = date.minusYears(1),
+                    sentForDecision = date.minusYears(1),
+                    selectedUnit = null,
+                    preparedBy1 =
+                        AssistanceNeedDecisionEmployee(
+                            employeeId = admin.id,
+                            title = "title",
+                            name = "admin",
+                            phoneNumber = "111",
+                        ),
+                    preparedBy2 = null,
+                    decisionMaker =
+                        AssistanceNeedDecisionEmployee(
+                            employeeId = admin.id,
+                            title = "title",
+                            name = "admin",
+                            phoneNumber = "111",
+                        ),
+                    pedagogicalMotivation = null,
+                    structuralMotivationOptions =
+                        StructuralMotivationOptions(
+                            smallerGroup = false,
+                            specialGroup = false,
+                            smallGroup = false,
+                            groupAssistant = false,
+                            childAssistant = false,
+                            additionalStaff = false,
+                        ),
+                    structuralMotivationDescription = null,
+                    careMotivation = null,
+                    serviceOptions =
+                        ServiceOptions(
+                            consultationSpecialEd = false,
+                            partTimeSpecialEd = false,
+                            fullTimeSpecialEd = false,
+                            interpretationAndAssistanceServices = false,
+                            specialAides = false,
+                        ),
+                    servicesMotivation = null,
+                    expertResponsibilities = null,
+                    guardiansHeardOn = null,
+                    guardianInfo = emptySet(),
+                    viewOfGuardians = null,
+                    otherRepresentativeHeard = false,
+                    otherRepresentativeDetails = null,
+                    assistanceLevels = emptySet(),
+                    motivationForDecision = null,
+                    unreadGuardianIds = null,
+                    annulmentReason = "",
+                    endDateNotKnown = false,
+                ),
+            )
+            tx.insertTestAssistanceNeedPreschoolDecision(
+                DevAssistanceNeedPreschoolDecision(
+                    decisionNumber = 10001,
+                    childId = children[1].id,
+                    status = AssistanceNeedDecisionStatus.ACCEPTED,
+                    decisionMade = date.minusYears(1),
+                    sentForDecision = date.minusYears(1),
+                    unreadGuardianIds = emptySet(),
+                    annulmentReason = "",
+                    form =
+                        AssistanceNeedPreschoolDecisionForm(
+                            validFrom = date.minusYears(1),
+                            validTo = null,
+                            type = AssistanceNeedPreschoolDecisionType.NEW,
+                            language = OfficialLanguage.FI,
+                            extendedCompulsoryEducation = false,
+                            extendedCompulsoryEducationInfo = "",
+                            grantedAssistanceService = false,
+                            grantedInterpretationService = false,
+                            grantedAssistiveDevices = false,
+                            grantedServicesBasis = "",
+                            selectedUnit = unit.id,
+                            primaryGroup = "",
+                            decisionBasis = "",
+                            basisDocumentPedagogicalReport = false,
+                            basisDocumentPsychologistStatement = false,
+                            basisDocumentSocialReport = false,
+                            basisDocumentDoctorStatement = false,
+                            basisDocumentPedagogicalReportDate = null,
+                            basisDocumentPsychologistStatementDate = null,
+                            basisDocumentSocialReportDate = null,
+                            basisDocumentDoctorStatementDate = null,
+                            basisDocumentOtherOrMissing = false,
+                            basisDocumentOtherOrMissingInfo = "",
+                            basisDocumentsInfo = "",
+                            guardiansHeardOn = null,
+                            guardianInfo = emptySet(),
+                            otherRepresentativeHeard = false,
+                            otherRepresentativeDetails = "",
+                            viewOfGuardians = "",
+                            preparer1EmployeeId = admin.id,
+                            preparer1Title = "",
+                            preparer1PhoneNumber = "",
+                            preparer2EmployeeId = null,
+                            preparer2Title = "",
+                            preparer2PhoneNumber = "",
+                            decisionMakerEmployeeId = admin.id,
+                            decisionMakerTitle = "",
+                        ),
+                )
+            )
+        }
+
+        val groupReport =
+            controller.getAssistanceNeedsAndActionsReport(
+                dbInstance(),
+                admin,
+                clock,
+                date,
+                DaycareAssistanceLevel.entries,
+            )
+        assertEquals(
+            listOf(
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
+                    actionCounts = mapOf("ASSISTANCE_SERVICE_CHILD" to 1),
+                    otherActionCount = 1,
+                    noActionCount = 0,
+                    daycareAssistanceCounts = mapOf(DaycareAssistanceLevel.GENERAL_SUPPORT to 2),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficientCount = 1,
+                    daycareAssistanceNeedDecisionCount = 2,
+                    preschoolAssistanceNeedDecisionCount = 1,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[1].id,
+                    groupName = groups[1].name,
+                    actionCounts = mapOf("ASSISTANCE_SERVICE_CHILD" to 1),
+                    otherActionCount = 0,
+                    noActionCount = 0,
+                    daycareAssistanceCounts = mapOf(DaycareAssistanceLevel.GENERAL_SUPPORT to 1),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficientCount = 0,
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[2].id,
+                    groupName = groups[2].name,
+                    actionCounts = emptyMap(),
+                    otherActionCount = 0,
+                    noActionCount = 0,
+                    daycareAssistanceCounts = emptyMap(),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficientCount = 0,
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+            ),
+            groupReport.rows,
+        )
+
+        val childReport =
+            controller.getAssistanceNeedsAndActionsReportByChild(
+                dbInstance(),
+                admin,
+                clock,
+                date,
+                DaycareAssistanceLevel.entries,
+            )
+        assertEquals(
+            listOf(
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
+                    childId = children[0].id,
+                    childLastName = children[0].lastName,
+                    childFirstName = children[0].firstName,
+                    childAge = 3,
+                    actions = setOf("ASSISTANCE_SERVICE_CHILD"),
+                    otherAction = "",
+                    daycareAssistanceCounts = mapOf(DaycareAssistanceLevel.GENERAL_SUPPORT to 1),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficient = BigDecimal("1.50"),
+                    daycareAssistanceNeedDecisionCount = 1,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
+                    childId = children[1].id,
+                    childLastName = children[1].lastName,
+                    childFirstName = children[1].firstName,
+                    childAge = 3,
+                    actions = emptySet(),
+                    otherAction = "other action test",
+                    daycareAssistanceCounts = mapOf(DaycareAssistanceLevel.GENERAL_SUPPORT to 1),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficient = BigDecimal("1.0"),
+                    daycareAssistanceNeedDecisionCount = 1,
+                    preschoolAssistanceNeedDecisionCount = 1,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[1].id,
+                    groupName = groups[1].name,
+                    childId = children[2].id,
+                    childLastName = children[2].lastName,
+                    childFirstName = children[2].firstName,
+                    childAge = 3,
+                    actions = setOf("ASSISTANCE_SERVICE_CHILD"),
+                    otherAction = "",
+                    daycareAssistanceCounts = mapOf(DaycareAssistanceLevel.GENERAL_SUPPORT to 1),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficient = BigDecimal("1.0"),
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+            ),
+            childReport.rows,
+        )
+    }
+
+    @Test
+    fun `placement type filtering works`() {
+        val date = LocalDate.of(2023, 10, 5)
+        val clock = MockEvakaClock(HelsinkiDateTime.of(date, LocalTime.of(14, 15)))
+        val area = DevCareArea()
+        val unit = DevDaycare(areaId = area.id)
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(unit)
+        }
+
+        val groups =
+            listOf(
+                DevDaycareGroup(daycareId = unit.id, name = "Group 1", startDate = date),
+                DevDaycareGroup(daycareId = unit.id, name = "Group 2", startDate = date),
+                DevDaycareGroup(daycareId = unit.id, name = "Group 3", startDate = date),
+            )
+
+        db.transaction { tx -> groups.forEach { group -> tx.insert(group) } }
+        val children =
+            insertAssistanceData(
+                unit = unit,
+                groups = groups,
+                date = date,
+                placementType = PlacementType.PRESCHOOL_DAYCARE,
+            )
+
+        val daycareReport =
+            controller.getAssistanceNeedsAndActionsReport(
+                dbInstance(),
+                admin,
+                clock,
+                date,
+                DaycareAssistanceLevel.entries,
+                placementTypes = listOf(PlacementType.DAYCARE),
+            )
+
+        val preschoolDaycareReport =
+            controller.getAssistanceNeedsAndActionsReport(
+                dbInstance(),
+                admin,
+                clock,
+                date,
+                DaycareAssistanceLevel.entries,
+                placementTypes = listOf(PlacementType.PRESCHOOL_DAYCARE),
+            )
+
+        fun getEmptyGroupExpectation(group: DevDaycareGroup) =
+            AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
+                careAreaName = "Test Care Area",
+                unitId = unit.id,
+                unitName = unit.name,
+                groupId = group.id,
+                groupName = group.name,
+                actionCounts = emptyMap(),
+                otherActionCount = 0,
+                noActionCount = 0,
+                daycareAssistanceCounts = emptyMap(),
+                preschoolAssistanceCounts = emptyMap(),
+                otherAssistanceMeasureCounts = emptyMap(),
+                assistanceNeedVoucherCoefficientCount = 0,
+                daycareAssistanceNeedDecisionCount = 0,
+                preschoolAssistanceNeedDecisionCount = 0,
+                unitProviderType = ProviderType.MUNICIPAL,
+            )
+
+        assertEquals(
+            listOf(
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
+                    actionCounts = mapOf("ASSISTANCE_SERVICE_CHILD" to 1),
+                    otherActionCount = 1,
+                    noActionCount = 0,
+                    daycareAssistanceCounts = mapOf(DaycareAssistanceLevel.GENERAL_SUPPORT to 2),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficientCount = 1,
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRow(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[1].id,
+                    groupName = groups[1].name,
+                    actionCounts = mapOf("ASSISTANCE_SERVICE_CHILD" to 1),
+                    otherActionCount = 0,
+                    noActionCount = 0,
+                    daycareAssistanceCounts = mapOf(DaycareAssistanceLevel.GENERAL_SUPPORT to 1),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficientCount = 0,
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+                getEmptyGroupExpectation(groups[2]),
+            ),
+            preschoolDaycareReport.rows,
+        )
+
+        assertEquals(groups.map { getEmptyGroupExpectation(it) }, daycareReport.rows)
+
+        val daycareChildReport =
+            controller.getAssistanceNeedsAndActionsReportByChild(
+                dbInstance(),
+                admin,
+                clock,
+                date,
+                DaycareAssistanceLevel.entries,
+                placementTypes = listOf(PlacementType.DAYCARE),
+            )
+        val preschoolDaycareChildReport =
+            controller.getAssistanceNeedsAndActionsReportByChild(
+                dbInstance(),
+                admin,
+                clock,
+                date,
+                DaycareAssistanceLevel.entries,
+                placementTypes = listOf(PlacementType.DAYCARE, PlacementType.PRESCHOOL_DAYCARE),
+            )
+
+        assertEquals(
+            listOf(
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
+                    childId = children[0].id,
+                    childLastName = children[0].lastName,
+                    childFirstName = children[0].firstName,
+                    childAge = 3,
+                    actions = setOf("ASSISTANCE_SERVICE_CHILD"),
+                    otherAction = "",
+                    daycareAssistanceCounts = mapOf(DaycareAssistanceLevel.GENERAL_SUPPORT to 1),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficient = BigDecimal("1.50"),
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[0].id,
+                    groupName = groups[0].name,
+                    childId = children[1].id,
+                    childLastName = children[1].lastName,
+                    childFirstName = children[1].firstName,
+                    childAge = 3,
+                    actions = emptySet(),
+                    otherAction = "other action test",
+                    daycareAssistanceCounts = mapOf(DaycareAssistanceLevel.GENERAL_SUPPORT to 1),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficient = BigDecimal("1.0"),
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+                AssistanceNeedsAndActionsReportController.AssistanceNeedsAndActionsReportRowByChild(
+                    careAreaName = "Test Care Area",
+                    unitId = unit.id,
+                    unitName = unit.name,
+                    groupId = groups[1].id,
+                    groupName = groups[1].name,
+                    childId = children[2].id,
+                    childLastName = children[2].lastName,
+                    childFirstName = children[2].firstName,
+                    childAge = 3,
+                    actions = setOf("ASSISTANCE_SERVICE_CHILD"),
+                    otherAction = "",
+                    daycareAssistanceCounts = mapOf(DaycareAssistanceLevel.GENERAL_SUPPORT to 1),
+                    preschoolAssistanceCounts = emptyMap(),
+                    otherAssistanceMeasureCounts = emptyMap(),
+                    assistanceNeedVoucherCoefficient = BigDecimal("1.0"),
+                    daycareAssistanceNeedDecisionCount = 0,
+                    preschoolAssistanceNeedDecisionCount = 0,
+                    unitProviderType = ProviderType.MUNICIPAL,
+                ),
+            ),
+            preschoolDaycareChildReport.rows,
+        )
+
+        assertEquals(0, daycareChildReport.rows.size)
+    }
+
+    private fun insertAssistanceData(
+        unit: DevDaycare,
+        date: LocalDate,
+        groups: List<DevDaycareGroup>,
+        placementType: PlacementType = PlacementType.DAYCARE,
+    ): List<DevPerson> {
+        val child1 =
+            db.transaction { tx ->
+                val child = DevPerson(firstName = "Test 1", dateOfBirth = date.minusYears(3))
+                tx.insert(child, DevPersonType.CHILD)
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            childId = child.id,
+                            unitId = unit.id,
+                            startDate = date,
+                            endDate = date,
+                            type = placementType,
+                        )
+                    )
+                tx.insert(
+                    DevDaycareGroupPlacement(
+                        daycarePlacementId = placementId,
+                        daycareGroupId = groups[0].id,
+                        startDate = date,
+                        endDate = date,
+                    )
+                )
+                tx.insert(
+                    DevDaycareAssistance(
+                        childId = child.id,
+                        validDuring = FiniteDateRange(date, date),
+                        level = DaycareAssistanceLevel.GENERAL_SUPPORT,
+                    )
+                )
+                tx.insert(
+                    DevAssistanceAction(
+                        childId = child.id,
+                        startDate = date,
+                        endDate = date,
+                        actions = setOf("ASSISTANCE_SERVICE_CHILD"),
+                    )
+                )
+                tx.insert(
+                    DevAssistanceNeedVoucherCoefficient(
+                        childId = child.id,
+                        validityPeriod = FiniteDateRange(date, date),
+                        coefficient = BigDecimal(1.50),
+                    )
+                )
+                child
+            }
+        val child2 =
+            db.transaction { tx ->
+                val child = DevPerson(firstName = "Test 2", dateOfBirth = date.minusYears(3))
+                tx.insert(child, DevPersonType.CHILD)
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            childId = child.id,
+                            unitId = unit.id,
+                            startDate = date,
+                            endDate = date,
+                            type = placementType,
+                        )
+                    )
+                tx.insert(
+                    DevDaycareGroupPlacement(
+                        daycarePlacementId = placementId,
+                        daycareGroupId = groups[0].id,
+                        startDate = date,
+                        endDate = date,
+                    )
+                )
+                tx.insert(
+                    DevDaycareAssistance(
+                        childId = child.id,
+                        validDuring = FiniteDateRange(date, date),
+                        level = DaycareAssistanceLevel.GENERAL_SUPPORT,
+                    )
+                )
+                tx.insert(
+                    DevAssistanceAction(
+                        childId = child.id,
+                        startDate = date,
+                        endDate = date,
+                        otherAction = "other action test",
+                    )
+                )
+                child
+            }
+        val child3 =
+            db.transaction { tx ->
+                val child = DevPerson(firstName = "Test 3", dateOfBirth = date.minusYears(3))
+                tx.insert(child, DevPersonType.CHILD)
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            childId = child.id,
+                            unitId = unit.id,
+                            startDate = date,
+                            endDate = date,
+                            type = placementType,
+                        )
+                    )
+                tx.insert(
+                    DevDaycareGroupPlacement(
+                        daycarePlacementId = placementId,
+                        daycareGroupId = groups[1].id,
+                        startDate = date,
+                        endDate = date,
+                    )
+                )
+                tx.insert(
+                    DevDaycareAssistance(
+                        childId = child.id,
+                        validDuring = FiniteDateRange(date, date),
+                        level = DaycareAssistanceLevel.GENERAL_SUPPORT,
+                    )
+                )
+                tx.insert(
+                    DevAssistanceAction(
+                        childId = child.id,
+                        startDate = date,
+                        endDate = date,
+                        actions = setOf("ASSISTANCE_SERVICE_CHILD"),
+                    )
+                )
+                child
+            }
+        return listOf(child1, child2, child3)
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReportController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReportController.kt
@@ -11,12 +11,14 @@ import fi.espoo.evaka.assistance.PreschoolAssistanceLevel
 import fi.espoo.evaka.assistanceaction.AssistanceActionOption
 import fi.espoo.evaka.assistanceaction.getAssistanceActionOptions
 import fi.espoo.evaka.daycare.domain.ProviderType
+import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.db.Database
+import fi.espoo.evaka.shared.db.Predicate
 import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.security.AccessControl
 import fi.espoo.evaka.shared.security.Action
@@ -44,26 +46,31 @@ class AssistanceNeedsAndActionsReportController(
         @RequestParam daycareAssistanceLevels: List<DaycareAssistanceLevel> = emptyList(),
         @RequestParam preschoolAssistanceLevels: List<PreschoolAssistanceLevel> = emptyList(),
         @RequestParam otherAssistanceMeasureTypes: List<OtherAssistanceMeasureType> = emptyList(),
+        @RequestParam placementTypes: List<PlacementType> = emptyList(),
     ): AssistanceNeedsAndActionsReport {
         return db.connect { dbc ->
-                dbc.read {
+                dbc.read { tx ->
                     val filter =
                         accessControl.requireAuthorizationFilter(
-                            it,
+                            tx,
                             user,
                             clock,
                             Action.Unit.READ_ASSISTANCE_NEEDS_AND_ACTIONS_REPORT,
                         )
-                    it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                    tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                    val placementPredicate =
+                        if (placementTypes.isEmpty()) Predicate.alwaysTrue()
+                        else Predicate { where("$it.type = ANY (${bind(placementTypes)})") }
                     AssistanceNeedsAndActionsReport(
-                        actions = it.getAssistanceActionOptions(),
+                        actions = tx.getAssistanceActionOptions(),
                         rows =
-                            it.getReportRows(
+                            tx.getReportRows(
                                 date,
                                 filter,
                                 daycareAssistanceLevels,
                                 preschoolAssistanceLevels,
                                 otherAssistanceMeasureTypes,
+                                placementPredicate,
                             ),
                         showAssistanceNeedVoucherCoefficient =
                             !featureConfig.valueDecisionCapacityFactorEnabled,
@@ -110,26 +117,31 @@ class AssistanceNeedsAndActionsReportController(
         @RequestParam daycareAssistanceLevels: List<DaycareAssistanceLevel> = emptyList(),
         @RequestParam preschoolAssistanceLevels: List<PreschoolAssistanceLevel> = emptyList(),
         @RequestParam otherAssistanceMeasureTypes: List<OtherAssistanceMeasureType> = emptyList(),
+        @RequestParam placementTypes: List<PlacementType> = emptyList(),
     ): AssistanceNeedsAndActionsReportByChild {
         return db.connect { dbc ->
-                dbc.read {
+                dbc.read { tx ->
                     val filter =
                         accessControl.requireAuthorizationFilter(
-                            it,
+                            tx,
                             user,
                             clock,
                             Action.Unit.READ_ASSISTANCE_NEEDS_AND_ACTIONS_REPORT_BY_CHILD,
                         )
-                    it.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                    tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
+                    val placementPredicate =
+                        if (placementTypes.isEmpty()) Predicate.alwaysTrue()
+                        else Predicate { where("$it.type = ANY (${bind(placementTypes)})") }
                     AssistanceNeedsAndActionsReportByChild(
-                        actions = it.getAssistanceActionOptions(),
+                        actions = tx.getAssistanceActionOptions(),
                         rows =
-                            it.getReportRowsByChild(
+                            tx.getReportRowsByChild(
                                 date,
                                 filter,
                                 daycareAssistanceLevels,
                                 preschoolAssistanceLevels,
                                 otherAssistanceMeasureTypes,
+                                placementPredicate,
                             ),
                         showAssistanceNeedVoucherCoefficient =
                             !featureConfig.valueDecisionCapacityFactorEnabled,
@@ -179,6 +191,7 @@ private fun Database.Read.getReportRows(
     daycareAssistanceLevels: List<DaycareAssistanceLevel>,
     preschoolAssistanceLevels: List<PreschoolAssistanceLevel>,
     otherAssistanceMeasureTypes: List<OtherAssistanceMeasureType>,
+    placementPredicate: Predicate,
 ) =
     createQuery {
             sql(
@@ -209,6 +222,7 @@ WITH action_counts AS (
             EXISTS (SELECT FROM preschool_assistance WHERE child_id = aa.child_id AND valid_during @> ${bind(date)} AND level = ANY(${bind(preschoolAssistanceLevels)})) OR
             EXISTS (SELECT FROM other_assistance_measure WHERE child_id = aa.child_id AND valid_during @> ${bind(date)} AND type = ANY(${bind(otherAssistanceMeasureTypes)}))
         )
+        AND ${predicate(placementPredicate.forTable("pl"))}
         GROUP BY GROUPING SETS ((1, 2), (1, 3), (1, 4))
     ) action_stats
     GROUP BY daycare_group_id
@@ -227,6 +241,7 @@ WITH action_counts AS (
         WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> ${bind(date)}
         AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
         AND da.valid_during @> ${bind(date)}
+        AND ${predicate(placementPredicate.forTable("pl"))} 
         GROUP BY 1, 2
     ) daycare_assistance_stats
     GROUP BY daycare_group_id
@@ -245,6 +260,7 @@ WITH action_counts AS (
         WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> ${bind(date)}
         AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
         AND pa.valid_during @> ${bind(date)}
+        AND ${predicate(placementPredicate.forTable("pl"))}
         GROUP BY 1, 2
     ) daycare_assistance_stats
     GROUP BY daycare_group_id
@@ -263,6 +279,7 @@ WITH action_counts AS (
         WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> ${bind(date)}
         AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
         AND oam.valid_during @> ${bind(date)}
+        AND ${predicate(placementPredicate.forTable("pl"))}
         GROUP BY 1, 2
     ) daycare_assistance_stats
     GROUP BY daycare_group_id
@@ -276,6 +293,7 @@ WITH action_counts AS (
     WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> ${bind(date)}
     AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
     AND vc.validity_period @> ${bind(date)}
+    AND ${predicate(placementPredicate.forTable("pl"))}
     GROUP BY daycare_group_id
 ), daycare_assistance_need_decision_count AS (
     SELECT dgp.daycare_group_id,
@@ -288,6 +306,7 @@ WITH action_counts AS (
     WHERE daterange(dgp.start_date, dgp.end_date, '[]') @> ${bind(date)}
     AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
     AND decision.validity_period @> ${bind(date)}
+    AND ${predicate(placementPredicate.forTable("pl"))}
     GROUP BY dgp.daycare_group_id
 ), preschool_assistance_need_decision_count AS (
     SELECT dgp.daycare_group_id,
@@ -300,6 +319,7 @@ WITH action_counts AS (
     WHERE daterange(dgp.start_date, dgp.end_date, '[]') @> ${bind(date)}
     AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
     AND daterange(decision.valid_from, decision.valid_to, '[]') @> ${bind(date)}
+    AND ${predicate(placementPredicate.forTable("pl"))}
     GROUP BY dgp.daycare_group_id
 )
 
@@ -343,6 +363,7 @@ private fun Database.Read.getReportRowsByChild(
     daycareAssistanceLevels: List<DaycareAssistanceLevel>,
     preschoolAssistanceLevels: List<PreschoolAssistanceLevel>,
     otherAssistanceMeasureTypes: List<OtherAssistanceMeasureType>,
+    placementPredicate: Predicate,
 ) =
     createQuery {
             sql(
@@ -366,6 +387,7 @@ WITH actions AS (
         EXISTS (SELECT FROM preschool_assistance WHERE child_id = aa.child_id AND valid_during @> ${bind(date)} AND level = ANY(${bind(preschoolAssistanceLevels)})) OR
         EXISTS (SELECT FROM other_assistance_measure WHERE child_id = aa.child_id AND valid_during @> ${bind(date)} AND type = ANY(${bind(otherAssistanceMeasureTypes)}))
     )
+    AND ${predicate(placementPredicate.forTable("pl"))}
     GROUP BY gpl.id, aa.child_id, aa.other_action
 ), daycare_assistance_counts AS (
     SELECT
@@ -384,6 +406,7 @@ WITH actions AS (
         WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> ${bind(date)}
         AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
         AND da.valid_during @> ${bind(date)}
+        AND ${predicate(placementPredicate.forTable("pl"))}
         GROUP BY 1, 2, 3
     ) daycare_assistance_stats
     GROUP BY daycare_group_id, child_id
@@ -404,6 +427,7 @@ WITH actions AS (
         WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> ${bind(date)}
         AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
         AND pa.valid_during @> ${bind(date)}
+        AND ${predicate(placementPredicate.forTable("pl"))}
         GROUP BY 1, 2, 3
     ) daycare_assistance_stats
     GROUP BY daycare_group_id, child_id
@@ -424,6 +448,7 @@ WITH actions AS (
         WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> ${bind(date)}
         AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
         AND oam.valid_during @> ${bind(date)}
+        AND ${predicate(placementPredicate.forTable("pl"))}
         GROUP BY 1, 2, 3
     ) daycare_assistance_stats
     GROUP BY daycare_group_id, child_id
@@ -438,6 +463,7 @@ WITH actions AS (
         WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> ${bind(date)}
         AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
         AND vc.validity_period @> ${bind(date)}
+        AND ${predicate(placementPredicate.forTable("pl"))}
 ), daycare_assistance_need_decision_count AS (
     SELECT dgp.daycare_group_id,
            pl.child_id,
@@ -450,6 +476,7 @@ WITH actions AS (
     WHERE daterange(dgp.start_date, dgp.end_date, '[]') @> ${bind(date)}
     AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
     AND decision.validity_period @> ${bind(date)}
+    AND ${predicate(placementPredicate.forTable("pl"))}
     GROUP BY dgp.daycare_group_id, pl.child_id
 ), preschool_assistance_need_decision_count AS (
     SELECT dgp.daycare_group_id,
@@ -463,6 +490,7 @@ WITH actions AS (
     WHERE daterange(dgp.start_date, dgp.end_date, '[]') @> ${bind(date)}
     AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
     AND daterange(decision.valid_from, decision.valid_to, '[]') @> ${bind(date)}
+    AND ${predicate(placementPredicate.forTable("pl"))}
     GROUP BY dgp.daycare_group_id, pl.child_id
 ) 
 SELECT
@@ -503,6 +531,7 @@ LEFT JOIN assistance_need_voucher_coefficient ON g.id = assistance_need_voucher_
 LEFT JOIN daycare_assistance_need_decision_count dand ON g.id = dand.daycare_group_id AND child.id = dand.child_id
 LEFT JOIN preschool_assistance_need_decision_count pand ON g.id = pand.daycare_group_id AND child.id = pand.child_id
 WHERE ${predicate(unitFilter.forTable("u"))}
+AND ${predicate(placementPredicate.forTable("p"))}
 ORDER BY ca.name, u.name, g.name, child.last_name, child.first_name
         """
                     .trimIndent()

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReportController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/AssistanceNeedsAndActionsReportController.kt
@@ -10,6 +10,7 @@ import fi.espoo.evaka.assistance.OtherAssistanceMeasureType
 import fi.espoo.evaka.assistance.PreschoolAssistanceLevel
 import fi.espoo.evaka.assistanceaction.AssistanceActionOption
 import fi.espoo.evaka.assistanceaction.getAssistanceActionOptions
+import fi.espoo.evaka.daycare.domain.ProviderType
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.FeatureConfig
 import fi.espoo.evaka.shared.GroupId
@@ -86,6 +87,7 @@ class AssistanceNeedsAndActionsReportController(
         val careAreaName: String,
         val unitId: DaycareId,
         val unitName: String,
+        val unitProviderType: ProviderType,
         val groupId: GroupId,
         val groupName: String,
         @Json val actionCounts: Map<AssistanceActionOptionValue, Int>,
@@ -95,6 +97,8 @@ class AssistanceNeedsAndActionsReportController(
         @Json val preschoolAssistanceCounts: Map<PreschoolAssistanceLevel, Int>,
         @Json val otherAssistanceMeasureCounts: Map<OtherAssistanceMeasureType, Int>,
         val assistanceNeedVoucherCoefficientCount: Int,
+        val daycareAssistanceNeedDecisionCount: Int,
+        val preschoolAssistanceNeedDecisionCount: Int,
     )
 
     @GetMapping("/employee/reports/assistance-needs-and-actions/by-child")
@@ -149,6 +153,7 @@ class AssistanceNeedsAndActionsReportController(
         val careAreaName: String,
         val unitId: DaycareId,
         val unitName: String,
+        val unitProviderType: ProviderType,
         val groupId: GroupId,
         val groupName: String,
         val childId: PersonId,
@@ -161,6 +166,8 @@ class AssistanceNeedsAndActionsReportController(
         @Json val preschoolAssistanceCounts: Map<PreschoolAssistanceLevel, Int>,
         @Json val otherAssistanceMeasureCounts: Map<OtherAssistanceMeasureType, Int>,
         val assistanceNeedVoucherCoefficient: BigDecimal,
+        val daycareAssistanceNeedDecisionCount: Int,
+        val preschoolAssistanceNeedDecisionCount: Int,
     )
 }
 
@@ -270,11 +277,37 @@ WITH action_counts AS (
     AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
     AND vc.validity_period @> ${bind(date)}
     GROUP BY daycare_group_id
-) 
+), daycare_assistance_need_decision_count AS (
+    SELECT dgp.daycare_group_id,
+           count(decision.id) AS count
+    FROM daycare_group_placement dgp
+    JOIN placement pl ON pl.id = dgp.daycare_placement_id
+    JOIN assistance_need_decision decision ON
+        pl.child_id = decision.child_id
+        AND decision.status = 'ACCEPTED'
+    WHERE daterange(dgp.start_date, dgp.end_date, '[]') @> ${bind(date)}
+    AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
+    AND decision.validity_period @> ${bind(date)}
+    GROUP BY dgp.daycare_group_id
+), preschool_assistance_need_decision_count AS (
+    SELECT dgp.daycare_group_id,
+           count(decision.id) AS count
+    FROM daycare_group_placement dgp
+    JOIN placement pl ON pl.id = dgp.daycare_placement_id
+    JOIN assistance_need_preschool_decision decision ON
+        pl.child_id = decision.child_id
+        AND decision.status = 'ACCEPTED'
+    WHERE daterange(dgp.start_date, dgp.end_date, '[]') @> ${bind(date)}
+    AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
+    AND daterange(decision.valid_from, decision.valid_to, '[]') @> ${bind(date)}
+    GROUP BY dgp.daycare_group_id
+)
+
 SELECT
     ca.name AS care_area_name,
     u.id AS unit_id,
     u.name AS unit_name,
+    u.provider_type AS unit_provider_type,
     g.id AS group_id,
     initcap(g.name) AS group_name,
     coalesce(action_counts, '{}') AS action_counts,
@@ -283,7 +316,9 @@ SELECT
     coalesce(daycare_assistance_counts, '{}') AS daycare_assistance_counts,
     coalesce(preschool_assistance_counts, '{}') AS preschool_assistance_counts,
     coalesce(other_assistance_measure_counts, '{}') AS other_assistance_measure_counts,
-    coalesce(assistance_need_voucher_coefficient_counts.count, 0) AS assistance_need_voucher_coefficient_count
+    coalesce(assistance_need_voucher_coefficient_counts.count, 0) AS assistance_need_voucher_coefficient_count,
+    coalesce(dand.count, 0) AS daycare_assistance_need_decision_count,
+    coalesce(pand.count, 0) AS preschool_assistance_need_decision_count
 FROM daycare u
 JOIN care_area ca ON u.care_area_id = ca.id
 JOIN daycare_group g ON g.daycare_id = u.id AND daterange(g.start_date, g.end_date, '[]') @> ${bind(date)}
@@ -292,6 +327,8 @@ LEFT JOIN daycare_assistance_counts ON g.id = daycare_assistance_counts.daycare_
 LEFT JOIN preschool_assistance_counts ON g.id = preschool_assistance_counts.daycare_group_id
 LEFT JOIN other_assistance_measure_counts ON g.id = other_assistance_measure_counts.daycare_group_id
 LEFT JOIN assistance_need_voucher_coefficient_counts ON g.id = assistance_need_voucher_coefficient_counts.daycare_group_id
+LEFT JOIN daycare_assistance_need_decision_count dand ON g.id = dand.daycare_group_id
+LEFT JOIN preschool_assistance_need_decision_count pand ON g.id = pand.daycare_group_id
 WHERE ${predicate(unitFilter.forTable("u"))}
 ORDER BY ca.name, u.name, g.name
         """
@@ -401,11 +438,38 @@ WITH actions AS (
         WHERE daterange(gpl.start_date, gpl.end_date, '[]') @> ${bind(date)}
         AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
         AND vc.validity_period @> ${bind(date)}
+), daycare_assistance_need_decision_count AS (
+    SELECT dgp.daycare_group_id,
+           pl.child_id,
+           count(decision.id) AS count
+    FROM daycare_group_placement dgp
+    JOIN placement pl ON pl.id = dgp.daycare_placement_id
+    JOIN assistance_need_decision decision ON
+        pl.child_id = decision.child_id
+        AND decision.status = 'ACCEPTED'
+    WHERE daterange(dgp.start_date, dgp.end_date, '[]') @> ${bind(date)}
+    AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
+    AND decision.validity_period @> ${bind(date)}
+    GROUP BY dgp.daycare_group_id, pl.child_id
+), preschool_assistance_need_decision_count AS (
+    SELECT dgp.daycare_group_id,
+           pl.child_id,
+           count(decision.id) AS count
+    FROM daycare_group_placement dgp
+    JOIN placement pl ON pl.id = dgp.daycare_placement_id
+    JOIN assistance_need_preschool_decision decision ON
+        pl.child_id = decision.child_id
+        AND decision.status = 'ACCEPTED'
+    WHERE daterange(dgp.start_date, dgp.end_date, '[]') @> ${bind(date)}
+    AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
+    AND daterange(decision.valid_from, decision.valid_to, '[]') @> ${bind(date)}
+    GROUP BY dgp.daycare_group_id, pl.child_id
 ) 
 SELECT
     ca.name AS care_area_name,
     u.id AS unit_id,
     u.name AS unit_name,
+    u.provider_type AS unit_provider_type,
     g.id AS group_id,
     initcap(g.name) AS group_name,
     child.id AS child_id,
@@ -417,7 +481,9 @@ SELECT
     coalesce(daycare_assistance_counts, '{}') AS daycare_assistance_counts,
     coalesce(preschool_assistance_counts, '{}') AS preschool_assistance_counts,
     coalesce(other_assistance_measure_counts, '{}') AS other_assistance_measure_counts,
-    coalesce(assistance_need_voucher_coefficient.coefficient, 1.0) AS assistance_need_voucher_coefficient
+    coalesce(assistance_need_voucher_coefficient.coefficient, 1.0) AS assistance_need_voucher_coefficient,
+    coalesce(dand.count, 0) AS daycare_assistance_need_decision_count,
+    coalesce(pand.count, 0) AS preschool_assistance_need_decision_count
 FROM daycare u
 JOIN care_area ca ON u.care_area_id = ca.id
 JOIN daycare_group g ON g.daycare_id = u.id AND daterange(g.start_date, g.end_date, '[]') @> ${bind(date)}
@@ -434,6 +500,8 @@ LEFT JOIN other_assistance_measure_counts ON g.id = other_assistance_measure_cou
     AND child.id = other_assistance_measure_counts.child_id
 LEFT JOIN assistance_need_voucher_coefficient ON g.id = assistance_need_voucher_coefficient.daycare_group_id 
    AND child.id = assistance_need_voucher_coefficient.child_id
+LEFT JOIN daycare_assistance_need_decision_count dand ON g.id = dand.daycare_group_id AND child.id = dand.child_id
+LEFT JOIN preschool_assistance_need_decision_count pand ON g.id = pand.daycare_group_id AND child.id = pand.child_id
 WHERE ${predicate(unitFilter.forTable("u"))}
 ORDER BY ca.name, u.name, g.name, child.last_name, child.first_name
         """


### PR DESCRIPTION
Raportille lisätty:
- 2 laskurisaraketta kaikkiin näkymiin:
  - Aktiiviset varhaiskasvatuksen tuen päätökset 
  - Aktiiviset esiopetuksen tuen päätökset
- näkymäfiltteri yksikön järjestämismuodon mukaan
- monivalinta-hakufiltteri toimintamuodon (sijoitustyyppi) mukaan
  - käyttää mukautuksen sijoitustyyppilistausta 

Lisätty integraatiotestit hakumuutoksille ja e2e testit kaikille muutoksille.