### PR TITLE
Korjataan Nekku-erikoisruokavaliovalinnat poistumaan, jos vastaavat kentät eivät ole enää valittavissa

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuQueries.kt
@@ -312,6 +312,16 @@ WHERE
 fun Database.Transaction.setSpecialDietOptions(
     specialDietOptions: List<Pair<String, List<NekkuSpecialDietOption>>>
 ) {
+    executeBatch(specialDietOptions) {
+        sql(
+            """
+                    DELETE FROM nekku_special_diet_choices
+                    WHERE field_id = ${bind { (fieldId, _ ) -> fieldId }}
+                    AND value != ALL(${bind { (_, option) -> option.map { it.value } }})
+                """
+                .trimIndent()
+        )
+    }
 
     val deletedSpecialOptionsCount =
         executeBatch(specialDietOptions) {

--- a/service/src/main/resources/db/migration/V534__fix_nekku_special_diet_choices.sql
+++ b/service/src/main/resources/db/migration/V534__fix_nekku_special_diet_choices.sql
@@ -1,0 +1,16 @@
+ALTER TABLE nekku_special_diet_choices
+DROP CONSTRAINT nekku_special_diet_choices_diet_id_fkey;
+ALTER TABLE nekku_special_diet_choices
+DROP CONSTRAINT nekku_special_diet_choices_field_id_fkey;
+
+ALTER TABLE nekku_special_diet_choices
+ADD CONSTRAINT fk$diet_id
+FOREIGN KEY (diet_id)
+REFERENCES nekku_special_diet (id)
+ON DELETE CASCADE;
+
+ALTER TABLE nekku_special_diet_choices
+ADD CONSTRAINT fk$field_id
+FOREIGN KEY (field_id)
+REFERENCES nekku_special_diet_field (id)
+ON DELETE CASCADE;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -529,3 +529,4 @@ V530__child_document_decision_number.sql
 V531__nekku_order_report.sql
 V532__absence_application.sql
 V533__remove_nekku_customer_number_constraint.sql
+V534__fix_nekku_special_diet_choices.sql


### PR DESCRIPTION
Korjataan ongelma, jossa Nekku-erikoisruokavaliokenttien poistaminen epäonnistuu, jos niitä on käytetty jonkun lapsen erikoisruokavaliossa. Nyt erikoisruokavaliokenttien päivitys onnistuu ja poistetut valinnat poistuvat myös lapsilta.