### PR TITLE
Lisätään henkilökunnalle käyttöoikeudet esiopetuksen poissaolohakemuksiin

### DIFF
--- a/frontend/src/lib-common/generated/action.d.ts
+++ b/frontend/src/lib-common/generated/action.d.ts
@@ -104,7 +104,9 @@ export type Global =
   | 'VARDA_OPERATIONS'
   | 'WRITE_SERVICE_WORKER_APPLICATION_NOTES'
 
-export type AbsenceApplication = 'DECIDE'
+export type AbsenceApplication =
+  | 'DECIDE'
+  | 'READ'
 
 export type Application =
   | 'ACCEPT_DECISION'

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/application/AbsenceApplicationControllers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/application/AbsenceApplicationControllers.kt
@@ -88,8 +88,10 @@ class AbsenceApplicationControllerEmployee(
                             clock,
                             applications.map { it.id },
                         )
-                    applications.map {
-                        AbsenceApplicationSummaryEmployee(it, actions[it.id] ?: emptySet())
+                    applications.mapNotNull { application ->
+                        actions[application.id]
+                            ?.takeIf { it.contains(Action.AbsenceApplication.READ) }
+                            ?.let { AbsenceApplicationSummaryEmployee(application, it) }
                     }
                 }
             }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -637,9 +637,15 @@ sealed interface Action {
     enum class AbsenceApplication(
         override vararg val defaultRules: ScopedActionRule<in AbsenceApplicationId>
     ) : ScopedAction<AbsenceApplicationId> {
+        READ(
+            HasGlobalRole(ADMIN),
+            HasUnitRole(UNIT_SUPERVISOR).inPlacementUnitOfChildOfAbsenceApplication(),
+            HasGroupRole(STAFF).inPlacementGroupOfChildOfAbsenceApplication(),
+        ),
         DECIDE(
             HasGlobalRole(ADMIN),
             HasUnitRole(UNIT_SUPERVISOR).inPlacementUnitOfChildOfAbsenceApplication(),
+            HasGroupRole(STAFF).inPlacementGroupOfChildOfAbsenceApplication(maxLengthInDays = 7),
         );
 
         override fun toString(): String = "${javaClass.name}.$name"
@@ -1032,6 +1038,7 @@ sealed interface Action {
         READ_ABSENCE_APPLICATIONS(
             HasGlobalRole(ADMIN),
             HasUnitRole(UNIT_SUPERVISOR).inPlacementUnitOfChild(),
+            HasGroupRole(STAFF).inPlacementGroupOfChild(),
         ),
         CREATE_ABSENCE(
             HasGlobalRole(ADMIN),
@@ -2088,7 +2095,10 @@ sealed interface Action {
             HasGlobalRole(ADMIN, SERVICE_WORKER),
             HasUnitRole(UNIT_SUPERVISOR).inUnit(),
         ),
-        READ_ABSENCE_APPLICATIONS(HasGlobalRole(ADMIN), HasUnitRole(UNIT_SUPERVISOR).inUnit()),
+        READ_ABSENCE_APPLICATIONS(
+            HasGlobalRole(ADMIN),
+            HasUnitRole(UNIT_SUPERVISOR, STAFF).inUnit(),
+        ),
         READ_TRANSFER_APPLICATIONS(HasGlobalRole(ADMIN, SERVICE_WORKER)),
         READ_SERVICE_APPLICATIONS(
             HasGlobalRole(ADMIN),


### PR DESCRIPTION
Henkilökunta saa nähdä omien ryhmien hakemukset, mutta hyväksyä maksimissaan viikon pituiset hakemukset.

Yksikön johtaja saa hyväksyä yli viikon pituiset hakemukset.