### PR TITLE
Korjataan esiopetuksen poissaolohakemuksien näkyminen henkilökunnalle

### DIFF
--- a/frontend/src/e2e-test/specs/8_access/access.spec.ts
+++ b/frontend/src/e2e-test/specs/8_access/access.spec.ts
@@ -18,16 +18,17 @@ import { employeeLogin } from '../../utils/user'
 let page: Page
 let nav: EmployeeNav
 let childInfo: ChildInformationPage
+const area = testCareArea
+const unit = testDaycare
+const child = testChild
+const placement = Fixture.placement({ childId: child.id, unitId: unit.id })
 
 beforeAll(async () => {
   await resetServiceState()
-  await testCareArea.save()
-  await testDaycare.save()
-  await testChild.saveChild()
-  await Fixture.placement({
-    childId: testChild.id,
-    unitId: testDaycare.id
-  }).save()
+  await area.save()
+  await unit.save()
+  await child.saveChild()
+  await placement.save()
 })
 beforeEach(async () => {
   page = await Page.open({
@@ -109,7 +110,7 @@ describe('Child information page', () => {
   })
 
   test('Staff sees only the units, reports and messaging tabs', async () => {
-    const staff = await Fixture.employee().staff(testDaycare.id).save()
+    const staff = await Fixture.employee().staff(unit.id).save()
     await employeeLogin(page, staff)
     await page.goto(config.employeeUrl)
     await nav.tabsVisible({
@@ -124,7 +125,7 @@ describe('Child information page', () => {
 
   test('Unit supervisor sees units, search, reports and messaging tabs', async () => {
     const unitSupervisor = await Fixture.employee()
-      .unitSupervisor(testDaycare.id)
+      .unitSupervisor(unit.id)
       .save()
     await employeeLogin(page, unitSupervisor)
     await page.goto(config.employeeUrl)
@@ -143,7 +144,7 @@ describe('Child information page sections', () => {
   test('Admin sees every collapsible section', async () => {
     const admin = await Fixture.employee().admin().save()
     await employeeLogin(page, admin)
-    await page.goto(`${config.employeeUrl}/child-information/${testChild.id}`)
+    await page.goto(`${config.employeeUrl}/child-information/${child.id}`)
     await childInfo.assertCollapsiblesVisible({
       feeAlterations: true,
       guardians: true,
@@ -164,7 +165,7 @@ describe('Child information page sections', () => {
   test('Service worker sees the correct sections', async () => {
     const serviceWorker = await Fixture.employee().serviceWorker().save()
     await employeeLogin(page, serviceWorker)
-    await page.goto(`${config.employeeUrl}/child-information/${testChild.id}`)
+    await page.goto(`${config.employeeUrl}/child-information/${child.id}`)
     await childInfo.assertCollapsiblesVisible({
       feeAlterations: false,
       guardians: true,
@@ -185,7 +186,7 @@ describe('Child information page sections', () => {
   test('Finance admin sees the correct sections', async () => {
     const financeAdmin = await Fixture.employee().financeAdmin().save()
     await employeeLogin(page, financeAdmin)
-    await page.goto(`${config.employeeUrl}/child-information/${testChild.id}`)
+    await page.goto(`${config.employeeUrl}/child-information/${child.id}`)
     await childInfo.assertCollapsiblesVisible({
       feeAlterations: true,
       guardians: true,
@@ -203,10 +204,10 @@ describe('Child information page sections', () => {
     })
   })
 
-  test('Staff sees the correct sections', async () => {
-    const staff = await Fixture.employee().staff(testDaycare.id).save()
+  test('Staff sees the correct sections with unit acl only', async () => {
+    const staff = await Fixture.employee().staff(unit.id).save()
     await employeeLogin(page, staff)
-    await page.goto(`${config.employeeUrl}/child-information/${testChild.id}`)
+    await page.goto(`${config.employeeUrl}/child-information/${child.id}`)
     await childInfo.assertCollapsiblesVisible({
       feeAlterations: false,
       guardians: false,
@@ -224,12 +225,43 @@ describe('Child information page sections', () => {
     })
   })
 
+  test('Staff sees the correct sections with group acl', async () => {
+    const group = await Fixture.daycareGroup({ daycareId: unit.id }).save()
+    await Fixture.groupPlacement({
+      daycarePlacementId: placement.id,
+      daycareGroupId: group.id,
+      startDate: placement.startDate,
+      endDate: placement.endDate
+    }).save()
+    const staff = await Fixture.employee()
+      .staff(unit.id)
+      .groupAcl(group.id)
+      .save()
+    await employeeLogin(page, staff)
+    await page.goto(`${config.employeeUrl}/child-information/${child.id}`)
+    await childInfo.assertCollapsiblesVisible({
+      feeAlterations: false,
+      guardians: false,
+      placements: true,
+      absenceApplications: true,
+      serviceApplications: false,
+      assistance: true,
+      backupCares: true,
+      familyContacts: true,
+      applications: false,
+      dailyServiceTimes: true,
+      childDocuments: true,
+      pedagogicalDocuments: true,
+      income: false
+    })
+  })
+
   test('Unit supervisor sees the correct sections', async () => {
     const unitSupervisor = await Fixture.employee()
-      .unitSupervisor(testDaycare.id)
+      .unitSupervisor(unit.id)
       .save()
     await employeeLogin(page, unitSupervisor)
-    await page.goto(`${config.employeeUrl}/child-information/${testChild.id}`)
+    await page.goto(`${config.employeeUrl}/child-information/${child.id}`)
     await childInfo.assertCollapsiblesVisible({
       feeAlterations: false,
       guardians: true,
@@ -249,10 +281,10 @@ describe('Child information page sections', () => {
 
   test('Special education teacher sees the correct sections', async () => {
     const specialEducationTeacher = await Fixture.employee()
-      .specialEducationTeacher(testDaycare.id)
+      .specialEducationTeacher(unit.id)
       .save()
     await employeeLogin(page, specialEducationTeacher)
-    await page.goto(`${config.employeeUrl}/child-information/${testChild.id}`)
+    await page.goto(`${config.employeeUrl}/child-information/${child.id}`)
     await childInfo.assertCollapsiblesVisible({
       feeAlterations: false,
       guardians: false,

--- a/frontend/src/employee-frontend/components/child-information/ChildInformation.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildInformation.tsx
@@ -308,6 +308,7 @@ const layouts: Layouts<typeof components> = {
   ['STAFF']: [
     { component: 'family-contacts', open: true },
     { component: 'placements', open: false },
+    { component: 'absenceApplications', open: false },
     { component: 'backup-care', open: false },
     { component: 'daily-service-times', open: false },
     { component: 'childDocuments', open: false },


### PR DESCRIPTION
Käyttöliittymään pitää erikseen lisätä näkyvyys uusille osioille roolikohtaisesti. Korjaa muutoksen https://github.com/espoon-voltti/evaka/pull/6997 näkymisen käyttöliittymään.