### PR TITLE
Käytetään Viteä tuotantobuildiin

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -6,6 +6,7 @@
 !src
 src/lib-customizations/espoo
 !packages
+!public
 !vendor
 !*.json
 !*.lock

--- a/frontend/.yarn/patches/unplugin-npm-1.0.1-70bc9bb0e2.patch
+++ b/frontend/.yarn/patches/unplugin-npm-1.0.1-70bc9bb0e2.patch
@@ -1,0 +1,19 @@
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index b19d2e120c6d50c4fb0e2c24591606229ea38880..37b22167e883fc9089a895d8925ec6a28885922f 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -1,4 +1,4 @@
+-import { SourceMapInput, EmittedAsset, AcornNode, Plugin, PluginContextMeta } from 'rollup';
++import { SourceMapInput, EmittedAsset, Plugin, PluginContextMeta } from 'rollup';
+ export { Plugin as RollupPlugin } from 'rollup';
+ import { Compiler, WebpackPluginInstance } from 'webpack';
+ export { Compiler as WebpackCompiler } from 'webpack';
+@@ -21,7 +21,7 @@ interface UnpluginBuildContext {
+     addWatchFile: (id: string) => void;
+     emitFile: (emittedFile: EmittedAsset) => void;
+     getWatchFiles: () => string[];
+-    parse: (input: string, options?: any) => AcornNode;
++    parse: (input: string, options?: any) => any;
+ }
+ interface UnpluginOptions {
+     name: string;

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -42,8 +42,7 @@ ENV SENTRY_NO_PROGRESS_BAR="1"
 ENV APP_BUILD="$build"
 ENV APP_COMMIT="$commit"
 
-RUN export NODE_OPTIONS="--max-old-space-size=8192" \
- && yarn build
+RUN yarn build
 
 FROM nginx:${NGINX_VERSION}
 ARG CACHE_BUST
@@ -98,9 +97,14 @@ COPY ./proxy/files/etc/ /etc/
 ENTRYPOINT ["/bin/proxy-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]
 
-COPY --from=builder /project/dist/bundle/citizen-frontend /static/
-COPY --from=builder /project/dist/bundle/employee-frontend /static/employee
-COPY --from=builder /project/dist/bundle/employee-mobile-frontend /static/employee/mobile
+RUN mkdir /static
+COPY --from=builder /project/dist/bundle/favicon.ico /static
+COPY --from=builder /project/dist/bundle/assets /static/assets
+COPY --from=builder /project/dist/bundle/employee /static/employee
+COPY --from=builder /project/dist/bundle/src/citizen-frontend/index-vite.html /static/index.html
+COPY --from=builder /project/dist/bundle/src/employee-frontend/index-vite.html /static/employee/index.html
+COPY --from=builder /project/dist/bundle/src/employee-mobile-frontend/index-vite.html /static/employee/mobile/index.html
+
 COPY --from=builder /project/src/maintenance-page-frontend /static/maintenance-page
 
 # Add build and commit environment variables and labels

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,6 +78,7 @@
     "@eslint/js": "9.28.0",
     "@evaka/eslint-plugin": "link:eslint-plugin",
     "@playwright/test": "1.52.0",
+    "@sentry/vite-plugin": "3.4.0",
     "@sentry/webpack-plugin": "3.5.0",
     "@testing-library/dom": "10.4.0",
     "@testing-library/jest-dom": "6.6.3",
@@ -152,7 +153,8 @@
     }
   },
   "resolutions": {
-    "@react-leaflet/core@npm:^3.0.0": "patch:@react-leaflet/core@npm%3A3.0.0#~/.yarn/patches/@react-leaflet-core-npm-3.0.0-4e3f2d62b5.patch"
+    "@react-leaflet/core@npm:^3.0.0": "patch:@react-leaflet/core@npm%3A3.0.0#~/.yarn/patches/@react-leaflet-core-npm-3.0.0-4e3f2d62b5.patch",
+    "unplugin@npm:1.0.1": "patch:unplugin@npm%3A1.0.1#~/.yarn/patches/unplugin-npm-1.0.1-70bc9bb0e2.patch"
   },
   "engines": {
     "node": ">= 22.12.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,6 +92,7 @@
     "@types/punycode": "2.1.4",
     "@types/react": "19.1.6",
     "@types/react-dom": "19.1.6",
+    "@vitejs/plugin-legacy": "6.1.1",
     "@vitejs/plugin-react": "4.5.1",
     "babel-loader": "10.0.0",
     "babel-plugin-styled-components": "2.1.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "yarn lint --fix",
     "type-check": "tsc --build --force .",
     "type-check:watch": "yarn type-check --watch --preserveWatchOutput",
-    "build": "webpack --mode production",
+    "build": "vite build",
     "build:dev": "node build.js --dev",
     "build:serve": "node build.js --dev --watch --serve",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest src/*-frontend src/lib-* eslint-plugin",

--- a/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -179,7 +179,7 @@ server {
   add_header X-DNS-Prefetch-Control off;
   add_header Report-To '{"group","csp-endpoint","max_age":31536000,"endpoints":[{"url":"$httpScheme://$host/api/csp"}]}';
 
-  set $loadFailedInlineScript "'sha256-z1vaAvxob9VDuw7klCB049Y2Xr6lf7KjhDrsLvsvcPU='"; # SHA256 calculated from the script contents
+  set $loadFailedInlineScript "'sha256-PR1ssrSqCny+dZsLWihNXCvJD0eBdn4ItWwveZE1M+0='"; # SHA256 calculated from the script contents
   set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o4507111645052928.ingest.de.sentry.io/ https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
   add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' ${loadFailedInlineScript}; frame-ancestors 'none'; form-action 'self';";
 
@@ -222,7 +222,7 @@ server {
 
   # STATIC FILE ROUTING
 
-  location ~ ^/employee/mobile/service-worker.js(\.map)? {
+  location ~ ^/employee/mobile/service-worker.js {
     expires        off;
     add_header     Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
     proxy_no_cache 1
@@ -230,7 +230,7 @@ server {
   }
 
   location / {
-    location ~ /employee/mobile/manifest\.([a-z0-9]+)\.json$ {
+    location ~ /employee/mobile/manifest\.json$ {
       auth_basic off;
     }
 

--- a/frontend/src/lib-customizations/espoo/appConfigs.ts
+++ b/frontend/src/lib-customizations/espoo/appConfigs.ts
@@ -11,71 +11,30 @@ type AppConfigs = {
   default: BaseAppConfig
 } & Record<Env, BaseAppConfig>
 
-const employeeConfigs: AppConfigs = {
+const sentryDsn =
+  'https://7f01c64aa4c21cdb5edfdf50ce1f4395@o4507111645052928.ingest.de.sentry.io/4507412540883024'
+
+const appConfigs: AppConfigs = {
   default: {
     sentry: {
-      dsn: 'https://d2af0931b75ee492c4c1f4da85e035ea@o4507111645052928.ingest.de.sentry.io/4507412723990608',
+      dsn: sentryDsn,
       enabled: false
     }
   },
   staging: {
     sentry: {
-      dsn: 'https://d2af0931b75ee492c4c1f4da85e035ea@o4507111645052928.ingest.de.sentry.io/4507412723990608',
+      dsn: sentryDsn,
       enabled: true
     }
   },
   prod: {
     sentry: {
-      dsn: 'https://d2af0931b75ee492c4c1f4da85e035ea@o4507111645052928.ingest.de.sentry.io/4507412723990608',
+      dsn: sentryDsn,
       enabled: true
     }
   }
 }
 
-const employeeMobileConfigs: AppConfigs = {
-  default: {
-    sentry: {
-      dsn: 'https://2e084169f4249f5096edc78d65d4c7bc@o4507111645052928.ingest.de.sentry.io/4507412751122512',
-      enabled: false
-    }
-  },
-  staging: {
-    sentry: {
-      dsn: 'https://2e084169f4249f5096edc78d65d4c7bc@o4507111645052928.ingest.de.sentry.io/4507412751122512',
-      enabled: true
-    }
-  },
-  prod: {
-    sentry: {
-      dsn: 'https://2e084169f4249f5096edc78d65d4c7bc@o4507111645052928.ingest.de.sentry.io/4507412751122512',
-      enabled: true
-    }
-  }
-}
+const appConfig = appConfigs[env()]
 
-const citizenConfigs: AppConfigs = {
-  default: {
-    sentry: {
-      dsn: 'https://7f01c64aa4c21cdb5edfdf50ce1f4395@o4507111645052928.ingest.de.sentry.io/4507412540883024',
-      enabled: false
-    }
-  },
-  staging: {
-    sentry: {
-      dsn: 'https://7f01c64aa4c21cdb5edfdf50ce1f4395@o4507111645052928.ingest.de.sentry.io/4507412540883024',
-      enabled: true
-    }
-  },
-  prod: {
-    sentry: {
-      dsn: 'https://7f01c64aa4c21cdb5edfdf50ce1f4395@o4507111645052928.ingest.de.sentry.io/4507412540883024',
-      enabled: true
-    }
-  }
-}
-
-const employeeConfig = employeeConfigs[env()]
-const employeeMobileConfig = employeeMobileConfigs[env()]
-const citizenConfig = citizenConfigs[env()]
-
-export { employeeConfig, employeeMobileConfig, citizenConfig }
+export { appConfig }

--- a/frontend/src/lib-customizations/espoo/citizen.tsx
+++ b/frontend/src/lib-customizations/espoo/citizen.tsx
@@ -9,7 +9,7 @@ import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { P } from 'lib-components/typography'
 import type { CitizenCustomizations } from 'lib-customizations/types'
 
-import { citizenConfig } from './appConfigs'
+import { appConfig } from './appConfigs'
 import EspooLogo from './assets/EspooLogoPrimary.svg'
 import featureFlags from './featureFlags'
 import mapConfig from './mapConfig'
@@ -21,7 +21,7 @@ const MultiLineCheckboxLabel = styled(FixedSpaceColumn).attrs({
 `
 
 const customizations: CitizenCustomizations = {
-  appConfig: citizenConfig,
+  appConfig,
   langs: ['fi', 'sv', 'en'],
   translations: {
     fi: {

--- a/frontend/src/lib-customizations/espoo/employee.tsx
+++ b/frontend/src/lib-customizations/espoo/employee.tsx
@@ -10,12 +10,12 @@ import {
 } from 'lib-common/generated/api-types/assistance'
 import type { EmployeeCustomizations } from 'lib-customizations/types'
 
-import { employeeConfig } from './appConfigs'
+import { appConfig } from './appConfigs'
 import Logo from './assets/EspooLogoPrimary.svg'
 import featureFlags from './featureFlags'
 
 const customizations: EmployeeCustomizations = {
-  appConfig: employeeConfig,
+  appConfig,
   translations: {
     fi: {
       common: {

--- a/frontend/src/lib-customizations/espoo/employeeMobile.tsx
+++ b/frontend/src/lib-customizations/espoo/employeeMobile.tsx
@@ -4,11 +4,11 @@
 
 import type { EmployeeMobileCustomizations } from 'lib-customizations/types'
 
-import { employeeMobileConfig } from './appConfigs'
+import { appConfig } from './appConfigs'
 import featureFlags from './featureFlags'
 
 const customizations: EmployeeMobileCustomizations = {
-  appConfig: employeeMobileConfig,
+  appConfig,
   featureFlags,
   translations: {
     fi: {}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3475,6 +3475,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/babel-plugin-component-annotate@npm:3.4.0":
+  version: 3.4.0
+  resolution: "@sentry/babel-plugin-component-annotate@npm:3.4.0"
+  checksum: 10/7b8122fd49ac9dbb28a31be1e96a3e4f80910ce7d192360041beeea0f992382aaa80d499f87041178af28e834a66a1881cd83fb1324d88212b45929d66b16711
+  languageName: node
+  linkType: hard
+
 "@sentry/babel-plugin-component-annotate@npm:3.5.0":
   version: 3.5.0
   resolution: "@sentry/babel-plugin-component-annotate@npm:3.5.0"
@@ -3492,6 +3499,22 @@ __metadata:
     "@sentry-internal/replay-canvas": "npm:9.27.0"
     "@sentry/core": "npm:9.27.0"
   checksum: 10/ceb8392b45f25acb0de0b208d477ed649709dd2e180546255e83cfb5d00a36b770f22a18a65f6360a857569d2648ebb6af166c1f0f9b7580dbe051b653e0af83
+  languageName: node
+  linkType: hard
+
+"@sentry/bundler-plugin-core@npm:3.4.0":
+  version: 3.4.0
+  resolution: "@sentry/bundler-plugin-core@npm:3.4.0"
+  dependencies:
+    "@babel/core": "npm:^7.18.5"
+    "@sentry/babel-plugin-component-annotate": "npm:3.4.0"
+    "@sentry/cli": "npm:2.42.2"
+    dotenv: "npm:^16.3.1"
+    find-up: "npm:^5.0.0"
+    glob: "npm:^9.3.2"
+    magic-string: "npm:0.30.8"
+    unplugin: "npm:1.0.1"
+  checksum: 10/e3d9b33dc734c8869b56937fb999e2e17a1549ccba8f00cd1e3b33d55a22ea712b1b13cd777593f78ec762267a7f78cb21e7b2751bfc2e0b985c2ba00ae04aa5
   languageName: node
   linkType: hard
 
@@ -3614,6 +3637,16 @@ __metadata:
   peerDependencies:
     react: ^16.14.0 || 17.x || 18.x || 19.x
   checksum: 10/639769cb4a5f793e66c829a584e9b14f6b2bbd4af2d911c0af0efe6bb7244f8b9f9595dd76deeac1e94c9b8830b3a869db08a9f59dc4461bde562f17230da465
+  languageName: node
+  linkType: hard
+
+"@sentry/vite-plugin@npm:3.4.0":
+  version: 3.4.0
+  resolution: "@sentry/vite-plugin@npm:3.4.0"
+  dependencies:
+    "@sentry/bundler-plugin-core": "npm:3.4.0"
+    unplugin: "npm:1.0.1"
+  checksum: 10/be70dbb44b49c252dfd1ede55a08818d71f131dbfd84fb676b50ec0f640ae69602bf127d0e1488e9bd8db0bf1b6d8f5a5c51dd427856b70e9eef5c466258de65
   languageName: node
   linkType: hard
 
@@ -6957,6 +6990,7 @@ __metadata:
     "@react-spring/web": "npm:10.0.1"
     "@sentry/browser": "npm:9.27.0"
     "@sentry/react": "npm:9.27.0"
+    "@sentry/vite-plugin": "npm:3.4.0"
     "@sentry/webpack-plugin": "npm:3.5.0"
     "@tanstack/react-query": "npm:5.80.6"
     "@testing-library/dom": "npm:10.4.0"
@@ -12944,6 +12978,18 @@ __metadata:
     webpack-sources: "npm:^3.2.3"
     webpack-virtual-modules: "npm:^0.5.0"
   checksum: 10/59f0d29c634adbc56e7e770f9753bff9ec52c479ff837b798354ec5d1b2e8cb971412645df43eb14a698db5bff4db23634c1506657e24d1ba86f4a8f27c1bf87
+  languageName: node
+  linkType: hard
+
+"unplugin@patch:unplugin@npm%3A1.0.1#~/.yarn/patches/unplugin-npm-1.0.1-70bc9bb0e2.patch":
+  version: 1.0.1
+  resolution: "unplugin@patch:unplugin@npm%3A1.0.1#~/.yarn/patches/unplugin-npm-1.0.1-70bc9bb0e2.patch::version=1.0.1&hash=eb4286"
+  dependencies:
+    acorn: "npm:^8.8.1"
+    chokidar: "npm:^3.5.3"
+    webpack-sources: "npm:^3.2.3"
+    webpack-virtual-modules: "npm:^0.5.0"
+  checksum: 10/d1b54b3699ef76ac62f763f6807a7441d21ef3d6fc47e6845748402a88def193c77ee6f77113887486d91bdcd225467a50e29bb1e0f0c7dc13a93eac8b362de0
   languageName: node
   linkType: hard
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1153,7 +1153,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:7.27.2":
+"@babel/preset-env@npm:7.27.2, @babel/preset-env@npm:^7.26.9":
   version: 7.27.2
   resolution: "@babel/preset-env@npm:7.27.2"
   dependencies:
@@ -3096,6 +3096,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
+  checksum: 10/4ed6123217569a1484419ac53f6ea0d9f3b57e5b57ab30d7c267bdb27792a27eb0e4b08e84a2680aa55cc2f2b411ffd6ec3db01c44fdc6dc43aca4b55f8374fd
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:0.3.9":
   version: 0.3.9
   resolution: "@jridgewell/trace-mapping@npm:0.3.9"
@@ -4242,6 +4249,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitejs/plugin-legacy@npm:6.1.1":
+  version: 6.1.1
+  resolution: "@vitejs/plugin-legacy@npm:6.1.1"
+  dependencies:
+    "@babel/core": "npm:^7.26.10"
+    "@babel/preset-env": "npm:^7.26.9"
+    browserslist: "npm:^4.24.4"
+    browserslist-to-esbuild: "npm:^2.1.1"
+    core-js: "npm:^3.41.0"
+    magic-string: "npm:^0.30.17"
+    regenerator-runtime: "npm:^0.14.1"
+    systemjs: "npm:^6.15.1"
+  peerDependencies:
+    terser: ^5.16.0
+    vite: ^6.0.0
+  checksum: 10/b4e9368d10e8b454ed5167f040912799f15ead831acff941cc0f513c241c4800086c5f3f234c4efc6c376c70fc57e7b1150ab7a1fd90b6ab0f01f285e95c2d01
+  languageName: node
+  linkType: hard
+
 "@vitejs/plugin-react@npm:4.5.1":
   version: 4.5.1
   resolution: "@vitejs/plugin-react@npm:4.5.1"
@@ -5115,6 +5141,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist-to-esbuild@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "browserslist-to-esbuild@npm:2.1.1"
+  dependencies:
+    meow: "npm:^13.0.0"
+  peerDependencies:
+    browserslist: "*"
+  bin:
+    browserslist-to-esbuild: cli/index.js
+  checksum: 10/5e91b23ba5ac47412b7456bbb74ee11b35d1083163e9e8e001e48f3a975c65758a4559ab532812d8518877a1d8f68c5b649b88a08722b9543b38e633e6943f7d
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.24.0, browserslist@npm:^4.24.4, browserslist@npm:^4.25.0":
   version: 4.25.0
   resolution: "browserslist@npm:4.25.0"
@@ -5615,6 +5654,13 @@ __metadata:
   version: 3.42.0
   resolution: "core-js@npm:3.42.0"
   checksum: 10/07e10c475cdb45608559778c4d8d1561204aa57c937a3e77ebc7359a95a350f8acfdbeab59c6a6532eb3b47262be0d05aba150a00b79659a91bedda4f59d9d5f
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3.41.0":
+  version: 3.43.0
+  resolution: "core-js@npm:3.43.0"
+  checksum: 10/514952992863266b1a6a2d3c985e905461d37fe72d131d9320d5dbf01ac7e746f6fc53004b548347518cc832f7d2602b9a228acf6b5183e5cbede9dd296d73d3
   languageName: node
   linkType: hard
 
@@ -6926,6 +6972,7 @@ __metadata:
     "@types/punycode": "npm:2.1.4"
     "@types/react": "npm:19.1.6"
     "@types/react-dom": "npm:19.1.6"
+    "@vitejs/plugin-legacy": "npm:6.1.1"
     "@vitejs/plugin-react": "npm:4.5.1"
     autosize: "npm:6.0.1"
     axios: "npm:1.9.0"
@@ -9368,6 +9415,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.30.17":
+  version: 0.30.17
+  resolution: "magic-string@npm:0.30.17"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
+  checksum: 10/2f71af2b0afd78c2e9012a29b066d2c8ba45a9cd0c8070f7fd72de982fb1c403b4e3afdb1dae00691d56885ede66b772ef6bedf765e02e3a7066208fe2fec4aa
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^3.0.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
@@ -9444,6 +9500,13 @@ __metadata:
   version: 6.0.0
   resolution: "memoize-one@npm:6.0.0"
   checksum: 10/28feaf7e9a870efef1187df110b876ce42deaf86c955f4111d72d23b96e44eed573469316e6ad0d2cc7fa3b1526978215617b126158015f957242c7493babca9
+  languageName: node
+  linkType: hard
+
+"meow@npm:^13.0.0":
+  version: 13.2.0
+  resolution: "meow@npm:13.2.0"
+  checksum: 10/4eff5bc921fed0b8a471ad79069d741a0210036d717547d0c7f36fdaf84ef7a3036225f38b6a53830d84dc9cbf8b944b097fde62381b8b5b215119e735ce1063
   languageName: node
   linkType: hard
 
@@ -11348,6 +11411,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "regenerator-runtime@npm:0.14.1"
+  checksum: 10/5db3161abb311eef8c45bcf6565f4f378f785900ed3945acf740a9888c792f75b98ecb77f0775f3bf95502ff423529d23e94f41d80c8256e8fa05ed4b07cf471
+  languageName: node
+  linkType: hard
+
 "regexp.prototype.flags@npm:^1.5.3":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
@@ -12323,6 +12393,13 @@ __metadata:
   dependencies:
     "@pkgr/core": "npm:^0.2.4"
   checksum: 10/9bb2cf11edaf31ba781f1c719dd58087323201bda6392254538aef4dea216aa02a32e25f06643bcfa1c1a2c95e0d84186d82cfb66f9a0ab3a2be4816c696a8a3
+  languageName: node
+  linkType: hard
+
+"systemjs@npm:^6.15.1":
+  version: 6.15.1
+  resolution: "systemjs@npm:6.15.1"
+  checksum: 10/9454c32515cdf7b033cac547233b161d6154abc020a1a97afc8654a01d63cf2bc51101869807aa7f8529aae98475a2cb4522c1e31da6d33832c8e12f00ee4e18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Suurin käyttäjiin mahdollisesti vaikuttava muutos on, että lopullinen JavaScript-koodi käyttää ES-moduuleita, joita kaikki yleisimmät selaimet ovat tukeneet viimeistään vuodesta 2020. (Näin vanhojen selainten käyttö olisi itsessäänkin jo tietoturvariski käyttäjälle.)

`yarn build` nopeutuu Viten johdosta useista minuuteista kymmeniin sekunteihin. Sen myötä myös esim. docker-composen pystytys lokaalisti sekä frontin CI build nopeutuvat huomattavasti. `yarn build`:in muistinkäyttö myös pysyy NodeJS:n rajoissa eikä muistiasetuksia tarvitse korottaa.

Siirtymäajan jälkeen voidaan poistaa webpackin konfiguraatio ja siihen liittyvät riippuvuudet. Viten konfigurointi on paljon yksinkertaisempaa kuin webpackin, mikä osaltaan myös helpottaa jatkossa ylläpitoa.