### PR TITLE
Päiväkodin seuraavalle aukiolopäivälle pitää tehdä tarkennustilaus

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/nekku/NekkuIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/nekku/NekkuIntegrationTest.kt
@@ -35,6 +35,7 @@ import fi.espoo.evaka.shared.domain.TimeRange
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.*
+import kotlin.collections.List
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNull
@@ -1606,11 +1607,11 @@ Seuraavien ryhmien asiakasnumerot on poistettu johtuen asiakasnumeron poistumise
 
         planNekkuOrderJobs(db, asyncJobRunner, now)
 
-        assertEquals(7, getNekkuWeeklyJobs().count())
+        assertEquals(5, getNekkuWeeklyJobs().count())
     }
 
     @Test
-    fun `meal order jobs for daycare groups are planned for two week time`() {
+    fun `meal order jobs for daycare groups are planned for two week time and it does not create job for daycare that is not open`() {
 
         val client =
             TestNekkuClient(
@@ -1648,6 +1649,16 @@ Seuraavien ryhmien asiakasnumerot on poistettu johtuen asiakasnumeron poistumise
                 mealtimeBreakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
                 mealtimeLunch = TimeRange(LocalTime.of(11, 15), LocalTime.of(11, 45)),
                 mealtimeSnack = TimeRange(LocalTime.of(13, 30), LocalTime.of(13, 50)),
+                shiftCareOperationTimes =
+                    listOf(
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        null,
+                    ),
             )
         val group = DevDaycareGroup(daycareId = daycare.id, nekkuCustomerNumber = "2501K6089")
 
@@ -1668,6 +1679,8 @@ Seuraavien ryhmien asiakasnumerot on poistettu johtuen asiakasnumeron poistumise
             nowPlusTwoWeeks.toLocalDate().toString(),
             getNekkuWeeklyJobs().first().date.toString(),
         )
+
+        assertEquals(6, getNekkuWeeklyJobs().count())
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuQueries.kt
@@ -682,7 +682,7 @@ fun Database.Read.daycareOpenNextTime(groupId: GroupId, date: LocalDate): LocalD
     return date.plusDays(daysUntilNextOperationDay.toLong())
 }
 
-fun Database.Read.daycareOpen(groupId: GroupId, date: LocalDate): LocalDate? {
+fun Database.Read.isDaycareOpen(groupId: GroupId, date: LocalDate): Boolean {
 
     val operationDays =
         createQuery {
@@ -693,8 +693,8 @@ fun Database.Read.daycareOpen(groupId: GroupId, date: LocalDate): LocalDate? {
             .exactlyOne<List<Int>>()
 
     if (operationDays.contains(date.dayOfWeek.value)) {
-        return date
+        return true
     } else {
-        return null
+        return false
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuQueries.kt
@@ -692,9 +692,5 @@ fun Database.Read.isDaycareOpen(groupId: GroupId, date: LocalDate): Boolean {
             }
             .exactlyOne<List<Int>>()
 
-    if (operationDays.contains(date.dayOfWeek.value)) {
-        return true
-    } else {
-        return false
-    }
+    return operationDays.contains(date.dayOfWeek.value)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuService.kt
@@ -321,9 +321,8 @@ fun planNekkuOrderJobs(
             tx,
             range.dates().flatMap { date ->
                 nekkuGroupIds.mapNotNull { nekkuGroupId ->
-                    val orderDate = tx.daycareOpen(nekkuGroupId, date)
-                    if (orderDate != null) {
-                        AsyncJob.SendNekkuOrder(customerGroupId = nekkuGroupId, date = orderDate)
+                    if (tx.isDaycareOpen(nekkuGroupId, date)) {
+                        AsyncJob.SendNekkuOrder(customerGroupId = nekkuGroupId, date = date)
                     } else null
                 }
             },

--- a/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuService.kt
@@ -320,8 +320,11 @@ fun planNekkuOrderJobs(
         asyncJobRunner.plan(
             tx,
             range.dates().flatMap { date ->
-                nekkuGroupIds.map { nekkuGroupId ->
-                    AsyncJob.SendNekkuOrder(customerGroupId = nekkuGroupId, date = date)
+                nekkuGroupIds.mapNotNull { nekkuGroupId ->
+                    val orderDate = tx.daycareOpen(nekkuGroupId, date)
+                    if (orderDate != null) {
+                        AsyncJob.SendNekkuOrder(customerGroupId = nekkuGroupId, date = orderDate)
+                    } else null
                 }
             },
             runAt = now,


### PR DESCRIPTION
Päiväkodin seuraavalle aukiolopäivälle pitää tehdä tarkennustilaus. Korjaa myös sen jos Nekkutilauksia yritetään tehdä viikonlopulle, vaikka yksikön operaatiopäivät eivät sitä salli. Korjauksissa mukana tarkennustilaus ja viikkotilaus.