### PR TITLE
Sisällytetään polyfillit käytön perusteella

### DIFF
--- a/frontend/src/citizen-frontend/index.tsx
+++ b/frontend/src/citizen-frontend/index.tsx
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import 'core-js/stable'
 import * as Sentry from '@sentry/browser'
 import React from 'react'
 import { createRoot } from 'react-dom/client'

--- a/frontend/src/employee-frontend/index.tsx
+++ b/frontend/src/employee-frontend/index.tsx
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import 'lib-common/assets/fonts/fonts.css'
-import 'core-js/stable'
 import * as Sentry from '@sentry/browser'
 import {
   Chart,

--- a/frontend/src/employee-mobile-frontend/index.tsx
+++ b/frontend/src/employee-mobile-frontend/index.tsx
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import 'lib-common/assets/fonts/fonts.css'
-import 'core-js/stable'
 import * as Sentry from '@sentry/browser'
 import React from 'react'
 import { createRoot } from 'react-dom/client'

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -144,8 +144,8 @@ function baseConfig({ isDevelopment }, { name, publicPath, entry }) {
                   [
                     '@babel/preset-env',
                     {
-                      corejs: '3.37',
-                      useBuiltIns: 'entry'
+                      corejs: '3.42',
+                      useBuiltIns: 'usage'
                     }
                   ]
                 ],

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5214,9 +5214,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
-  version: 1.0.30001715
-  resolution: "caniuse-lite@npm:1.0.30001715"
-  checksum: 10/5608cdaf609eb5fe3a86ab6c1c2f3943dbdab813041725f4747f5432b05e6e19fc606faa8a9b75c329b37b772c91c47e8db483e76a6b715b59c289ce53dcba68
+  version: 1.0.30001718
+  resolution: "caniuse-lite@npm:1.0.30001718"
+  checksum: 10/e172a4c156f743cc947e659f353ad9edb045725cc109a02cc792dcbf98569356ebfa4bb4356e3febf87427aab0951c34c1ee5630629334f25ae6f76de7d86fd0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Aiemmin tuotantobuildeihin otettiin mukaan *kaikki* polyfillit, jotka tarvittiin toteuttamaan stabiilit ES- ja web-ominaisuudet [package.jsonissa listatuille tuetuille selaimille](https://github.com/espoon-voltti/evaka/blob/b65c71034efd7004c9842c5ef331f42aa59ea2ee/frontend/package.json#L159-L171):

* Kaikissa fronteissa `import 'core-js/stable'`
* `@babel/present-env`-konffi: `useBuiltins: 'entry'`

Nyt sen sijaan sisällytetään polyfillit vain niille ominaisuuksille joita koodissa oikeasti käytetään:

* Ei eksplisiittisiä `core-js` importteja
* `@babel/present-env`-konffi: `useBuiltins: 'usage'`

Tämä on valmistelua vite-tuotantobuildia varten, koska vitessä polyfillaus toimii näin.