### PR TITLE
Tekninen: Ajetaan Linkity-jobit yöllisessä ajossa

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/espoo/EspooScheduledJobs.kt
@@ -39,15 +39,11 @@ enum class EspooScheduledJob(
     ),
     PlanStaffAttendancePlanJobs(
         EspooScheduledJobs::planStaffAttendancePlanJobs,
-        ScheduledJobSettings(
-            enabled = true,
-            schedule = JobSchedule.daily(LocalTime.of(1, 30)),
-            retryCount = 1,
-        ),
+        ScheduledJobSettings(enabled = true, schedule = JobSchedule.nightly(), retryCount = 1),
     ),
     SendStaffAttendancesToLinkity(
         EspooScheduledJobs::sendStaffAttendancesToLinkity,
-        ScheduledJobSettings(enabled = true, schedule = JobSchedule.daily(LocalTime.of(2, 30))),
+        ScheduledJobSettings(enabled = true, schedule = JobSchedule.nightly()),
     ),
 }
 


### PR DESCRIPTION
Myös oletuksena yöllisessä ajossa olevien jobien ajoaikatauluja voi säätää ympäristömuuttujilla. Näin ollen Linkity-jobit voidaan siirtää yöllisiin ajoihin.