### PR TITLE
Audit-lokiin objectId pakolliseksi valittuihin tapahtumiin

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -64,7 +64,6 @@ enum class Audit(
     ApplicationConfirmDecisionsMailed,
     ApplicationCreate,
     ApplicationDelete,
-    ApplicationRead,
     ApplicationReadMetadata,
     ApplicationReadNotifications,
     ApplicationReadDuplicates,
@@ -631,6 +630,38 @@ enum class Audit(
                 "eventCode" to eventCode,
                 "targetId" to targetId?.value,
                 "objectId" to objectId?.value,
+                "securityLevel" to securityLevel,
+                "securityEvent" to securityEvent,
+            ) + if (meta.isNotEmpty()) mapOf("meta" to meta) else emptyMap()
+        ) {
+            eventCode
+        }
+    }
+}
+
+// Audit events that are enforced to be logged with child id(s)
+enum class ChildAudit(
+    private val securityEvent: Boolean = false,
+    private val securityLevel: String = "low",
+) {
+    ApplicationRead;
+
+    private val eventCode = name
+
+    class UseNamedArguments private constructor()
+
+    fun log(
+        // This is a hack to force passing all real parameters by name
+        @Suppress("UNUSED_PARAMETER") vararg forceNamed: Array<out UseNamedArguments>,
+        targetId: AuditId? = null,
+        childId: AuditId,
+        meta: Map<String, Any?> = emptyMap(),
+    ) {
+        logger.audit(
+            mapOf(
+                "eventCode" to eventCode,
+                "targetId" to targetId?.value,
+                "objectId" to childId.value,
                 "securityLevel" to securityLevel,
                 "securityEvent" to securityEvent,
             ) + if (meta.isNotEmpty()) mapOf("meta" to meta) else emptyMap()

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -653,15 +653,17 @@ enum class ChildAudit(
     fun log(
         // This is a hack to force passing all real parameters by name
         @Suppress("UNUSED_PARAMETER") vararg forceNamed: Array<out UseNamedArguments>,
-        targetId: AuditId? = null,
         childId: AuditId,
+        targetId: AuditId? = null,
+        objectId: AuditId? = null,
         meta: Map<String, Any?> = emptyMap(),
     ) {
+        val combinedObjectIds = objectId?.let { childId + it } ?: childId
         logger.audit(
             mapOf(
                 "eventCode" to eventCode,
                 "targetId" to targetId?.value,
-                "objectId" to childId.value,
+                "objectId" to combinedObjectIds.value,
                 "securityLevel" to securityLevel,
                 "securityEvent" to securityEvent,
             ) + if (meta.isNotEmpty()) mapOf("meta" to meta) else emptyMap()


### PR DESCRIPTION
Erillinen `ChildAudit`-lokitustapa eventteihin joissa on korkeampi tarve seurata lapsen tietojen käsittelyä. Pohjana `Audit` enum classin `log`-funktio, johon vaihdettu tarkoituksen ohjaamiseksi `objectId`-parametrin nimeksi `childId`. Lopulliseen lokitukseen mapataan kuitenkin `childId` parametriin `objectId`.