### PR TITLE
Korjataan yksikön hakuprosessi-välilehden näkyminen henkilökunnalle

### DIFF
--- a/frontend/src/employee-frontend/components/UnitPage.tsx
+++ b/frontend/src/employee-frontend/components/UnitPage.tsx
@@ -157,6 +157,9 @@ export default React.memo(function UnitPage() {
       ) ||
         unitInformation.value.permittedActions.includes(
           'READ_SERVICE_APPLICATIONS'
+        ) ||
+        unitInformation.value.permittedActions.includes(
+          'READ_ABSENCE_APPLICATIONS'
         ))
         ? [
             {


### PR DESCRIPTION
Hakuprosessi-välilehti sisältää nykyään myös esiopetuksen poissaolohakemukset, joihin henkilökunnalla pitäisi olla näkyvyys. Tämä korjaa välilehden näkymisen henkilökunnalle. Lapsen sivulla poissaolohakemukset näkyvät jo oikein.