### PR TITLE
Lisää aktiiviset esiopetuskaudet näkymään kuntalaisen esiopetushakemukselle

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -25,6 +25,7 @@ import { useLang, useTranslation } from '../../../localization'
 import { isValidPreferredStartDate } from '../validations'
 
 import { ClubTermsInfo } from './ClubTermsInfo'
+import { PreschoolTermsInfoSection } from './PreschoolTermInfoSection'
 import type { ServiceNeedSectionProps } from './ServiceNeedSection'
 
 export default React.memo(function PreferredStartSubSection({
@@ -62,6 +63,9 @@ export default React.memo(function PreferredStartSubSection({
         ))}
 
         {type === 'CLUB' && <ClubTermsInfo clubTerms={terms ?? []} />}
+        {type === 'PRESCHOOL' &&
+          featureFlags.showCitizenApplicationPreschoolTerms &&
+          terms && <PreschoolTermsInfoSection preschoolTerms={terms} />}
 
         <ExpandingInfo
           data-qa="startdate-instructions"

--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreschoolTermInfoSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreschoolTermInfoSection.tsx
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2017-2025 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+import styled from 'styled-components'
+
+import { Label } from 'lib-components/typography'
+import { Gap } from 'lib-components/white-space'
+
+import { useTranslation } from '../../../localization'
+import type { Term } from '../ApplicationEditor'
+
+const Ul = styled.ul`
+  margin: 0;
+`
+
+interface Props {
+  preschoolTerms: Term[] | undefined
+}
+
+export function PreschoolTermsInfoSection({ preschoolTerms }: Props) {
+  const i18n = useTranslation()
+  return (
+    <>
+      <Label>
+        {
+          i18n.applications.editor.serviceNeed.startDate[
+            preschoolTerms?.length === 1 ? 'preschoolTerm' : 'preschoolTerms'
+          ]
+        }
+      </Label>
+      <Gap size="s" />
+      <Ul data-qa="preschool-terms">
+        {preschoolTerms?.map((term, i) => (
+          <li key={i}>
+            <Label>{`${term.extendedTerm.start.year}-${term.extendedTerm.end.year}`}</Label>
+            <p>{`${term.extendedTerm.format()}`}</p>
+          </li>
+        ))}
+      </Ul>
+      <Gap size="m" />
+    </>
+  )
+}

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1030,6 +1030,9 @@ const en: Translations = {
           },
           clubTerm: 'Club term',
           clubTerms: 'Club terms',
+          preschoolTerm: 'Preschool term',
+          preschoolTerms: 'Preschool terms',
+
           label: {
             DAYCARE: 'Desired start date',
             PRESCHOOL: 'Start date in August',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -994,6 +994,8 @@ export default {
           },
           clubTerm: 'Kerhon toimintakausi',
           clubTerms: 'Kerhon toimintakaudet',
+          preschoolTerm: 'Esiopetuskausi',
+          preschoolTerms: 'Esiopetuskaudet',
           label: {
             DAYCARE: 'Toivottu aloituspäivä',
             PRESCHOOL: 'Toivottu aloituspäivä',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1014,6 +1014,8 @@ const sv: Translations = {
           },
           clubTerm: 'Klubbens verksamhetsperiod',
           clubTerms: 'Klubbens verksamhetsperioder',
+          preschoolTerm: 'Förskoleperiod',
+          preschoolTerms: 'Förskoleperioder',
           label: {
             DAYCARE: 'Önskat inledningsdatum',
             PRESCHOOL: 'Inledningsdatum i augusti',

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -50,7 +50,8 @@ const features: Features = {
     archiveIntegrationEnabled: true,
     aromiIntegration: true,
     citizenChildDocumentTypes: true,
-    decisionChildDocumentTypes: true
+    decisionChildDocumentTypes: true,
+    showCitizenApplicationPreschoolTerms: true
   },
   staging: {
     environmentLabel: 'Staging',
@@ -90,7 +91,8 @@ const features: Features = {
     archiveIntegrationEnabled: true,
     aromiIntegration: false,
     citizenChildDocumentTypes: true,
-    decisionChildDocumentTypes: true
+    decisionChildDocumentTypes: true,
+    showCitizenApplicationPreschoolTerms: true
   },
   prod: {
     environmentLabel: null,
@@ -127,7 +129,8 @@ const features: Features = {
     multiSelectDeparture: true,
     archiveIntegrationEnabled: false,
     aromiIntegration: false,
-    decisionChildDocumentTypes: false
+    decisionChildDocumentTypes: false,
+    showCitizenApplicationPreschoolTerms: false
   }
 }
 

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -309,6 +309,11 @@ interface BaseFeatureFlags {
    * Enable support for decision child document types
    */
   decisionChildDocumentTypes?: boolean
+
+  /**
+   * Enable showing preschool extended term data for citizen preschool application
+   */
+  showCitizenApplicationPreschoolTerms?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>


### PR DESCRIPTION
Lisää aktiiviset esiopetuskaudet kuntalaisen eo-hakemuksen palveluntarve -osioon perustuen kausien suodatusperusteeseen `extendedTerm`. Ominaisuus rajattu lipun `showCitizenApplicationPreschoolTerms` taakse kuntakohtaisten hakemusmallien sujuvaa sovittamista varten.

Espoon lippuasetukset:
- oletus: `true`
- staging: `true`
- prod: `false`

![preschool-terms](https://github.com/user-attachments/assets/1e230a30-24c0-4c67-9378-71a056e18170)
