### PR TITLE
Tieto päiväkirjalle jos huoltajat eivät ole vastanneet poissaolokyselyyn

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-month-calendar-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-month-calendar-page.ts
@@ -131,6 +131,7 @@ export class AbsenceCell extends Element {
   }
 
   missingHolidayReservation = this.findByDataQa('missing-holiday-reservation')
+  missingQuestionnaireAnswer = this.findByDataQa('missing-questionnaire-answer')
 
   async select() {
     await this.locator.click()

--- a/frontend/src/employee-frontend/components/absences/MonthCalendarCell.tsx
+++ b/frontend/src/employee-frontend/components/absences/MonthCalendarCell.tsx
@@ -18,6 +18,7 @@ import type { UUID } from 'lib-common/types'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { absenceColors } from 'lib-customizations/common'
 import colors from 'lib-customizations/common'
+import { featureFlags } from 'lib-customizations/employee'
 
 import type { SelectedCell } from './GroupMonthCalendar'
 import UnitCalendarDayCellTooltip from './UnitCalendarDayCellTooltip'
@@ -130,6 +131,7 @@ interface AbsenceCellPartsProps {
   requiresBackupCare: boolean
   isSelected: boolean
   isMissingHolidayReservation: boolean
+  isMissingQuestionnaireAnswer: boolean
   intermittentShiftCare: boolean
   toggle: (parts: CellPart[]) => void
 }
@@ -144,6 +146,7 @@ const AbsenceCellParts = React.memo(function AbsenceCellParts({
   requiresBackupCare,
   isSelected,
   isMissingHolidayReservation,
+  isMissingQuestionnaireAnswer,
   intermittentShiftCare,
   toggle
 }: AbsenceCellPartsProps) {
@@ -182,7 +185,11 @@ const AbsenceCellParts = React.memo(function AbsenceCellParts({
         />
       ))}
       {!isSelected && isMissingHolidayReservation ? (
-        <MissingHolidayReservationMarker data-qa="missing-holiday-reservation" />
+        <MissingHolidayInfoMarker data-qa="missing-holiday-reservation" />
+      ) : featureFlags.missingHolidayReservationMarkerEnabled === true &&
+        !isSelected &&
+        isMissingQuestionnaireAnswer ? (
+        <MissingHolidayInfoMarker data-qa="missing-questionnaire-answer" />
       ) : null}
     </AbsenceCellDiv>
   )
@@ -203,7 +210,7 @@ export const AbsenceCellDiv = styled(DisabledCell)<{ $isSelected: boolean }>`
     `};
 `
 
-const MissingHolidayReservationMarker = styled.div`
+const MissingHolidayInfoMarker = styled.div`
   position: absolute;
   height: ${cellSize}px;
   width: ${cellSize}px;
@@ -300,6 +307,7 @@ export default React.memo(function MonthCalendarCell({
             reservations={day.reservations}
             backupCare={day.backupCare}
             isMissingHolidayReservation={day.missingHolidayReservation}
+            isMissingQuestionnaireAnswer={day.missingHolidayQuestionnaireAnswer}
             requiresBackupCare={requiresBackupCare}
           />
         ) : undefined
@@ -319,6 +327,7 @@ export default React.memo(function MonthCalendarCell({
         requiresBackupCare={requiresBackupCare}
         isSelected={isSelected}
         isMissingHolidayReservation={day.missingHolidayReservation}
+        isMissingQuestionnaireAnswer={day.missingHolidayQuestionnaireAnswer}
         intermittentShiftCare={intermittentShiftCare}
         toggle={toggle}
       />

--- a/frontend/src/employee-frontend/components/absences/UnitCalendarDayCellTooltip.tsx
+++ b/frontend/src/employee-frontend/components/absences/UnitCalendarDayCellTooltip.tsx
@@ -20,6 +20,7 @@ interface UnitCalendarMonthlyDayCellTooltipProps {
   reservations: ChildReservation[]
   backupCare: boolean
   isMissingHolidayReservation: boolean
+  isMissingQuestionnaireAnswer: boolean
   requiresBackupCare: boolean
 }
 
@@ -30,6 +31,7 @@ export default React.memo(function UnitCalendarMonthlyDayCellTooltip({
   reservations,
   backupCare,
   isMissingHolidayReservation,
+  isMissingQuestionnaireAnswer,
   requiresBackupCare
 }: UnitCalendarMonthlyDayCellTooltipProps) {
   const { i18n } = useTranslation()
@@ -70,6 +72,21 @@ export default React.memo(function UnitCalendarMonthlyDayCellTooltip({
     () => (
       <div>
         {i18n.absences.missingHolidayReservation}
+        {dailyServiceTimeTooltip !== undefined ? (
+          <div>
+            <br />
+            {dailyServiceTimeTooltip}
+          </div>
+        ) : undefined}
+      </div>
+    ),
+    [i18n, dailyServiceTimeTooltip]
+  )
+
+  const missingQuestionnaireAnswerTooltip = useMemo(
+    () => (
+      <div>
+        {i18n.absences.missingHolidayQuestionnaireAnswer}
         {dailyServiceTimeTooltip !== undefined ? (
           <div>
             <br />
@@ -123,6 +140,8 @@ export default React.memo(function UnitCalendarMonthlyDayCellTooltip({
         absencesTooltip
       ) : isMissingHolidayReservation ? (
         missingHolidayReservationTooltip
+      ) : isMissingQuestionnaireAnswer ? (
+        missingQuestionnaireAnswerTooltip
       ) : requiresBackupCare ? (
         requiresBackupCareTooltip
       ) : reservations.length > 0 || dailyServiceTimes !== null ? (

--- a/frontend/src/lib-common/generated/api-types/absence.ts
+++ b/frontend/src/lib-common/generated/api-types/absence.ts
@@ -202,6 +202,7 @@ export interface GroupMonthCalendarDayChild {
   backupCare: boolean
   childId: PersonId
   dailyServiceTimes: ServiceTimesPresenceStatus
+  missingHolidayQuestionnaireAnswer: boolean
   missingHolidayReservation: boolean
   reservations: ChildReservation[]
   scheduleType: ScheduleType

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3566,6 +3566,8 @@ export const fi = {
       NO_ABSENCE: 'Ei poissaoloa'
     },
     missingHolidayReservation: 'Huoltaja ei ole vahvistanut loma-ajan varausta',
+    missingHolidayQuestionnaireAnswer:
+      'Huoltaja ei ole vastannut poissaolokyselyyn',
     shiftCare: 'Ilta-/vuorohoito',
     requiresBackupCare: 'Odottaa varasijoitusta',
     additionalLegendItems: {
@@ -5363,7 +5365,7 @@ export const fi = {
       'Kyselyyn voi vastata jos lapsella yhtäjaksoinen sijoitus',
     period: 'Poissaolokausi',
     absenceTypeThreshold: 'Yhtenäisen poissaolon minimipituus',
-    days: 'päivää'
+    days: 'päivää',
   },
   terms: {
     term: 'Lukukausi',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -5365,7 +5365,7 @@ export const fi = {
       'Kyselyyn voi vastata jos lapsella yhtäjaksoinen sijoitus',
     period: 'Poissaolokausi',
     absenceTypeThreshold: 'Yhtenäisen poissaolon minimipituus',
-    days: 'päivää',
+    days: 'päivää'
   },
   terms: {
     term: 'Lukukausi',

--- a/frontend/src/lib-customizations/espoo/featureFlags.tsx
+++ b/frontend/src/lib-customizations/espoo/featureFlags.tsx
@@ -51,7 +51,8 @@ const features: Features = {
     aromiIntegration: true,
     citizenChildDocumentTypes: true,
     decisionChildDocumentTypes: true,
-    showCitizenApplicationPreschoolTerms: true
+    showCitizenApplicationPreschoolTerms: true,
+    missingHolidayReservationMarkerEnabled: false
   },
   staging: {
     environmentLabel: 'Staging',
@@ -92,7 +93,8 @@ const features: Features = {
     aromiIntegration: false,
     citizenChildDocumentTypes: true,
     decisionChildDocumentTypes: true,
-    showCitizenApplicationPreschoolTerms: true
+    showCitizenApplicationPreschoolTerms: true,
+    missingHolidayReservationMarkerEnabled: false
   },
   prod: {
     environmentLabel: null,
@@ -130,7 +132,8 @@ const features: Features = {
     archiveIntegrationEnabled: false,
     aromiIntegration: false,
     decisionChildDocumentTypes: false,
-    showCitizenApplicationPreschoolTerms: false
+    showCitizenApplicationPreschoolTerms: false,
+    missingHolidayReservationMarkerEnabled: false
   }
 }
 

--- a/frontend/src/lib-customizations/types.d.ts
+++ b/frontend/src/lib-customizations/types.d.ts
@@ -314,6 +314,11 @@ interface BaseFeatureFlags {
    * Enable showing preschool extended term data for citizen preschool application
    */
   showCitizenApplicationPreschoolTerms?: boolean
+
+  /**
+   * Enable missing holiday questionnaire answer indicator
+   */
+  missingHolidayReservationMarkerEnabled?: boolean
 }
 
 export type FeatureFlags = DeepReadonly<BaseFeatureFlags>

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/absence/AbsenceServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/absence/AbsenceServiceIntegrationTest.kt
@@ -23,6 +23,7 @@ import fi.espoo.evaka.shared.EmployeeId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
+import fi.espoo.evaka.shared.config.testFeatureConfig
 import fi.espoo.evaka.shared.data.DateSet
 import fi.espoo.evaka.shared.dev.DevAbsence
 import fi.espoo.evaka.shared.dev.DevBackupCare
@@ -95,6 +96,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
             scheduleType = ScheduleType.RESERVATION_REQUIRED,
             shiftCare = ShiftCareType.NONE,
             missingHolidayReservation = false,
+            missingHolidayQuestionnaireAnswer = false,
             absences = listOf(),
             reservations = listOf(),
             dailyServiceTimes = ServiceTimesPresenceStatus.Unknown,
@@ -128,7 +130,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         val today = now.toLocalDate()
         val result =
             db.read {
-                getGroupMonthCalendar(it, today, testDaycareGroup.id, today.year, today.monthValue)
+                getGroupMonthCalendar(
+                    it,
+                    today,
+                    testDaycareGroup.id,
+                    today.year,
+                    today.monthValue,
+                    testFeatureConfig,
+                )
             }
 
         assertEquals(
@@ -177,6 +186,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     placementStart.year,
                     placementStart.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -281,6 +291,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     firstOfMonth.year,
                     firstOfMonth.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -339,6 +350,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     roundTheClockGroupId,
                     placementDate.year,
                     placementDate.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -438,6 +450,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     placementStart.year,
                     placementStart.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -505,6 +518,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     placementStart.year,
                     placementStart.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -600,6 +614,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     placementStart.year,
                     placementStart.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -763,6 +778,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     placementStart.year,
                     placementStart.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -814,6 +830,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     placementStart.year,
                     placementStart.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -876,6 +893,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     placementStart.year,
                     placementStart.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -949,6 +967,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     absenceDate.year,
                     absenceDate.monthValue,
+                    testFeatureConfig,
                 )
             }
         val child =
@@ -1000,6 +1019,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     absenceDate.year,
                     absenceDate.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -1035,6 +1055,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     absenceDate.year,
                     absenceDate.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -1063,6 +1084,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     absenceDate.year,
                     absenceDate.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -1187,6 +1209,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     firstOfJanuary2020.year,
                     firstOfJanuary2020.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -1208,6 +1231,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     firstOfJanuary2020.year,
                     firstOfJanuary2020.monthValue,
+                    testFeatureConfig,
                 )
             }
 
@@ -1230,7 +1254,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(40), result.children.map { it.reservationTotalHours })
     }
@@ -1257,7 +1288,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(60), result.children.map { it.reservationTotalHours })
     }
@@ -1276,7 +1314,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(12), result.children.map { it.reservationTotalHours })
     }
@@ -1295,7 +1340,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(12), result.children.map { it.reservationTotalHours })
     }
@@ -1317,7 +1369,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(12), result.children.map { it.reservationTotalHours })
     }
@@ -1339,7 +1398,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(12), result.children.map { it.reservationTotalHours })
     }
@@ -1362,7 +1428,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(40), result.children.map { it.reservationTotalHours })
     }
@@ -1384,7 +1457,16 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         insertBackupPlacement(testChild_1.id, backupUnit, backupGroup, backupPeriod)
 
         val result =
-            db.read { getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), backupGroup, 2019, 8) }
+            db.read {
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    backupGroup,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
+            }
         assertEquals(listOf(16), result.children.map { it.reservationTotalHours })
     }
 
@@ -1414,7 +1496,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
 
         // 1 operational day * 0 h + 1 operational day * 8 h
@@ -1446,7 +1535,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         // 22 operational days * 8h
         assertEquals(listOf(176), result.children.map { it.reservationTotalHours })
@@ -1473,7 +1569,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         // 8-16 + 8-14 (saturday is not included because the unit is not operational on saturdays)
         assertEquals(listOf(14), result.children.map { it.reservationTotalHours })
@@ -1501,7 +1604,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         // 21 operational days * 8h + 12h
         assertEquals(listOf(180), result.children.map { it.reservationTotalHours })
@@ -1526,7 +1636,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         // 21-9 + 9-15 (overlapping 2 hours are left out)
         assertEquals(listOf(18), result.children.map { it.reservationTotalHours })
@@ -1558,7 +1675,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         // the start and end of absence date overlaps with two reservations but only one reservation
         // is left out
@@ -1583,7 +1707,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(21 + 20 * 8), result.children.map { it.reservationTotalHours })
     }
@@ -1630,7 +1761,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(
             listOf(
@@ -1664,7 +1802,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(40), result.children.map { it.attendanceTotalHours })
     }
@@ -1691,7 +1836,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(60), result.children.map { it.attendanceTotalHours })
     }
@@ -1711,7 +1863,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(12), result.children.map { it.attendanceTotalHours })
     }
@@ -1731,7 +1890,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(12), result.children.map { it.attendanceTotalHours })
     }
@@ -1754,7 +1920,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(24), result.children.map { it.attendanceTotalHours })
     }
@@ -1777,7 +1950,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(40), result.children.map { it.attendanceTotalHours })
     }
@@ -1799,7 +1979,16 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
         insertAttendances(testChild_1.id, backupUnit, attendances)
 
         val result =
-            db.read { getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), backupGroup, 2019, 8) }
+            db.read {
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    backupGroup,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
+            }
         assertEquals(listOf(16), result.children.map { it.attendanceTotalHours })
     }
 
@@ -1811,7 +2000,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(0), result.children.map { it.attendanceTotalHours })
     }
@@ -1840,7 +2036,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 1), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 1),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(listOf(6), result.children.map { it.attendanceTotalHours })
     }
@@ -1873,7 +2076,14 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
 
         val result =
             db.read {
-                getGroupMonthCalendar(it, LocalDate.of(2019, 8, 31), testDaycareGroup.id, 2019, 8)
+                getGroupMonthCalendar(
+                    it,
+                    LocalDate.of(2019, 8, 31),
+                    testDaycareGroup.id,
+                    2019,
+                    8,
+                    testFeatureConfig,
+                )
             }
         assertEquals(1, result.children.size)
         assertEquals(
@@ -1930,6 +2140,7 @@ class AbsenceServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = tr
                     testDaycareGroup.id,
                     placementDate.year,
                     placementDate.monthValue,
+                    testFeatureConfig,
                 )
             }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceController.kt
@@ -50,7 +50,7 @@ class AbsenceController(
                         Action.Group.READ_ABSENCES,
                         groupId,
                     )
-                    getGroupMonthCalendar(it, clock.today(), groupId, year, month)
+                    getGroupMonthCalendar(it, clock.today(), groupId, year, month, featureConfig)
                 }
             }
             .also {

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceService.kt
@@ -330,8 +330,7 @@ fun getGroupMonthCalendar(
                                             childReservations.isEmpty() &&
                                             childAbsences.isEmpty(),
                                     missingHolidayQuestionnaireAnswer =
-                                            isQuestionnaireDate &&
-                                            childAnswers.isEmpty(),
+                                        isQuestionnaireDate && childAnswers.isEmpty(),
                                     absences =
                                         childAbsences.map { AbsenceWithModifierInfo.from(it) },
                                     reservations = childReservations,

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaireQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaireQueries.kt
@@ -303,3 +303,18 @@ WHERE questionnaire_id = ${bind(id)} AND child_id = ANY(${bind(childIds)})
             )
         }
         .toList<HolidayQuestionnaireAnswer>()
+
+fun Database.Read.getQuestionnaireAnswers(
+    ids: List<HolidayQuestionnaireId>,
+    childIds: List<ChildId>,
+): List<HolidayQuestionnaireAnswer> =
+    createQuery {
+            sql(
+                """
+SELECT questionnaire_id, child_id, fixed_period, open_ranges
+FROM holiday_questionnaire_answer
+WHERE questionnaire_id = ANY(${bind(ids)}) AND child_id = ANY(${bind(childIds)})
+            """
+            )
+        }
+        .toList<HolidayQuestionnaireAnswer>()

--- a/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaires.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/holidayperiod/HolidayQuestionnaires.kt
@@ -39,6 +39,8 @@ sealed class HolidayQuestionnaire(val type: QuestionnaireType) {
      */
     abstract val conditions: QuestionnaireConditions
 
+    abstract fun getPeriods(): List<FiniteDateRange>
+
     @JsonTypeName("FIXED_PERIOD")
     data class FixedPeriodQuestionnaire(
         override val id: HolidayQuestionnaireId,
@@ -51,7 +53,9 @@ sealed class HolidayQuestionnaire(val type: QuestionnaireType) {
         @Nested("condition") override val conditions: QuestionnaireConditions,
         val periodOptions: List<FiniteDateRange>,
         @Json val periodOptionLabel: Translatable,
-    ) : HolidayQuestionnaire(QuestionnaireType.FIXED_PERIOD)
+    ) : HolidayQuestionnaire(QuestionnaireType.FIXED_PERIOD) {
+        override fun getPeriods(): List<FiniteDateRange> = periodOptions
+    }
 
     @JsonTypeName("OPEN_RANGES")
     data class OpenRangesQuestionnaire(
@@ -65,7 +69,9 @@ sealed class HolidayQuestionnaire(val type: QuestionnaireType) {
         @Nested("condition") override val conditions: QuestionnaireConditions,
         val period: FiniteDateRange,
         val absenceTypeThreshold: Int,
-    ) : HolidayQuestionnaire(QuestionnaireType.OPEN_RANGES)
+    ) : HolidayQuestionnaire(QuestionnaireType.OPEN_RANGES) {
+        override fun getPeriods(): List<FiniteDateRange> = listOf(period)
+    }
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")


### PR DESCRIPTION
Yksikön kuukausikalenteriin lisätty loma-ajan puuttuvien varausten huomautusta vastaava merkintä puuttuville poissaolokyselyn vastauksille. Ominaisuus fronttilipun takana.

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- Lisää linkki dokumentaation relevanttiin kohtaan.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
