### PR TITLE
Trimmaa Aromin vastuuyksikkökoodi ennen tallennusta

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
@@ -94,8 +94,8 @@ export default React.memo(function GroupModal({ unitId }: Props) {
                 initialCaretakers: form.initialCaretakers,
                 aromiCustomerId:
                   form.aromiCustomerId !== null &&
-                  form.aromiCustomerId.length > 0
-                    ? form.aromiCustomerId
+                  form.aromiCustomerId.trim().length > 0
+                    ? form.aromiCustomerId.trim()
                     : null
               }
             }
@@ -162,7 +162,8 @@ export default React.memo(function GroupModal({ unitId }: Props) {
               }
               data-qa="new-group-aromi-id-input"
             />
-            {form.aromiCustomerId === null && (
+            {(form.aromiCustomerId === null ||
+              form.aromiCustomerId.trim().length === 0) && (
               <>
                 <Gap size="s" />
                 <MessageBox

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupUpdateModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/group/GroupUpdateModal.tsx
@@ -66,7 +66,12 @@ export default React.memo(function GroupUpdateModal({
               body: {
                 ...data,
                 startDate: data.startDate,
-                name: data.name.trim()
+                name: data.name.trim(),
+                aromiCustomerId:
+                  data.aromiCustomerId !== null &&
+                  data.aromiCustomerId.trim().length > 0
+                    ? data.aromiCustomerId.trim()
+                    : null
               }
             }
           : cancelMutation
@@ -148,7 +153,8 @@ export default React.memo(function GroupUpdateModal({
                   }))
                 }}
               />
-              {data.aromiCustomerId === null && (
+              {(data.aromiCustomerId === null ||
+                data.aromiCustomerId.trim().length === 0) && (
                 <>
                   <Gap size="s" />
                   <MessageBox


### PR DESCRIPTION
Toteuttaa trimmauksen Aromin vastuuyksikkökoodin arvolle sekä uuden ryhmän luonnissa että ryhmää muokatessa siten, että:
- tallennettu versio ei sisällä koskaan välilyöntejä syötetyn arvon alussa tai lopussa
- koodikenttään voi syöttää tai liittää vapaasti tekstiä välilyönnit mukaanlukien
- tyhjän koodiarvon varoituslaatikko näkyy myös, jos trimmauksen jälkeinen arvo = tyhjä arvo