### PR TITLE
Lisätään päätökset-raportille hakemuksen tyypin mukaan suodatus

### DIFF
--- a/frontend/src/employee-frontend/generated/api-clients/reports.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reports.ts
@@ -5,6 +5,7 @@
 // GENERATED FILE: no manual modifications
 
 import type { ApplicationStatus } from 'lib-common/generated/api-types/application'
+import type { ApplicationType } from 'lib-common/generated/api-types/application'
 import type { ApplicationsReportRow } from 'lib-common/generated/api-types/reports'
 import type { AreaId } from 'lib-common/generated/api-types/shared'
 import type { AssistanceNeedDecisionsReportRow } from 'lib-common/generated/api-types/reports'
@@ -486,12 +487,14 @@ export async function getCustomerFeesReport(
 export async function getDecisionsReport(
   request: {
     from: LocalDate,
-    to: LocalDate
+    to: LocalDate,
+    applicationType?: ApplicationType | null
   }
 ): Promise<DecisionsReportRow[]> {
   const params = createUrlSearchParams(
     ['from', request.from.formatIso()],
-    ['to', request.to.formatIso()]
+    ['to', request.to.formatIso()],
+    ['applicationType', request.applicationType?.toString()]
   )
   const { data: json } = await client.request<JsonOf<DecisionsReportRow[]>>({
     url: uri`/employee/reports/decisions`.toString(),

--- a/frontend/src/lib-common/generated/api-types/application.ts
+++ b/frontend/src/lib-common/generated/api-types/application.ts
@@ -333,10 +333,13 @@ export interface ApplicationSummary {
 /**
 * Generated from fi.espoo.evaka.application.ApplicationType
 */
-export type ApplicationType =
-  | 'CLUB'
-  | 'DAYCARE'
-  | 'PRESCHOOL'
+export const applicationTypes = [
+  'CLUB',
+  'DAYCARE',
+  'PRESCHOOL'
+] as const
+
+export type ApplicationType = typeof applicationTypes[number]
 
 /**
 * Generated from fi.espoo.evaka.application.ApplicationTypeToggle

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/ReportSmokeTests.kt
@@ -84,6 +84,13 @@ class ReportSmokeTests : FullApplicationTest(resetDbBeforeEach = false) {
                 listOf("from" to "2020-05-01", "to" to "2020-08-01"),
             )
         )
+
+        assertOkResponse(
+            http.get(
+                "/employee/reports/decisions",
+                listOf("from" to "2020-05-01", "to" to "2020-08-01", "applicationType" to "DAYCARE"),
+            )
+        )
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/Application.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.application
 
+import fi.espoo.evaka.ConstList
 import fi.espoo.evaka.identity.ExternalIdentifier
 import fi.espoo.evaka.pis.createPerson
 import fi.espoo.evaka.pis.getPersonById
@@ -164,6 +165,7 @@ data class ApplicationAttachment(
     val uploadedByPerson: PersonId?,
 )
 
+@ConstList("applicationTypes")
 enum class ApplicationType : DatabaseEnum {
     CLUB,
     DAYCARE,


### PR DESCRIPTION
Yksikkö voi tarjota sekä varhaiskasvatusta että esiopetusta. Tämän avulla hakutoiveiden määriä saa listattua erikseen näiden osalta.