### PR TITLE
Lisää ohjeteksti lasten asiakirjan luonnospalautuksen vahvistusikkunaan

### DIFF
--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentReadView.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentReadView.tsx
@@ -334,6 +334,12 @@ const ChildDocumentReadViewInner = React.memo(
                           i18n.childInformation.childDocuments.editor
                             .goToPrevStatusConfirmTitle[prevStatus]
                         }
+                        confirmationText={
+                          prevStatus === 'DRAFT'
+                            ? i18n.childInformation.childDocuments.editor
+                                .goBackToDraftConfirmText
+                            : undefined
+                        }
                       />
                     )}
                 </FixedSpaceRow>

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -941,6 +941,8 @@ export const fi = {
             'Haluatko varmasti palauttaa päätöksen päätösesitykseksi?', // not applicable,
           COMPLETED: 'Haluatko varmasti palauttaa asiakirjan valmiiksi?' // not applicable,
         },
+        goBackToDraftConfirmText:
+          'Luonnosvaiheessa voit muokata lomakkeen tietoja.',
         deleteDraft: 'Poista luonnos',
         deleteDraftConfirmTitle: 'Haluatko varmasti poistaa luonnoksen?',
         fullyPublished: 'Asiakirjan viimeisin versio on julkaistu',


### PR DESCRIPTION
Lisää ohjetekstin vahvistusikkunaan kun työntekijä palauttaa lasten asiakirjan takaisin luonnokseksi:
![draft-confirm-text-addition](https://github.com/user-attachments/assets/9be5983b-3d1c-41bd-8880-90b3ca59fc0d)
