### PR TITLE
Korjataan esiopetuksen poissaolohakemuksen käsittelyn käyttöoikeudet

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/AbsenceApplicationsSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/AbsenceApplicationsSection.tsx
@@ -112,7 +112,10 @@ export const AbsenceApplicationsSection = (props: Props) => {
                   <div>{application.data.description}</div>
                 </div>
                 {application.data.status === 'WAITING_DECISION' &&
-                  application.actions.includes('DECIDE') && (
+                  application.actions.some(
+                    (action) =>
+                      action === 'DECIDE' || action === 'DECIDE_MAX_WEEK'
+                  ) && (
                     <>
                       <AlertBox
                         message={

--- a/frontend/src/lib-common/generated/action.d.ts
+++ b/frontend/src/lib-common/generated/action.d.ts
@@ -106,6 +106,7 @@ export type Global =
 
 export type AbsenceApplication =
   | 'DECIDE'
+  | 'DECIDE_MAX_WEEK'
   | 'READ'
 
 export type Application =

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/application/AbsenceApplicationControllers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/application/AbsenceApplicationControllers.kt
@@ -205,23 +205,14 @@ class AbsenceApplicationControllerEmployee(
         id: AbsenceApplicationId,
     ): AbsenceApplication {
         val application = tx.selectAbsenceApplication(id, forUpdate = true) ?: throw NotFound()
-        if (
-            !(accessControl.hasPermissionFor(
-                tx,
-                user,
-                clock,
-                Action.AbsenceApplication.DECIDE,
-                application.id,
-            ) ||
-                (accessControl.hasPermissionFor(
-                    tx,
-                    user,
-                    clock,
-                    Action.AbsenceApplication.DECIDE_MAX_WEEK,
-                    application.id,
-                ) && isMaxWeek(tx, application)))
+        accessControl.requirePermissionFor(
+            tx,
+            user,
+            clock,
+            if (isMaxWeek(tx, application)) Action.AbsenceApplication.DECIDE_MAX_WEEK
+            else Action.AbsenceApplication.DECIDE,
+            application.id,
         )
-            throw Forbidden()
         if (application.status != AbsenceApplicationStatus.WAITING_DECISION)
             throw BadRequest("Absence application ${application.id} is not waiting decision")
         return application

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -646,7 +646,11 @@ sealed interface Action {
             HasGlobalRole(ADMIN),
             HasUnitRole(UNIT_SUPERVISOR).inPlacementUnitOfChildOfAbsenceApplication(),
         ),
-        DECIDE_MAX_WEEK(HasGroupRole(STAFF).inPlacementGroupOfChildOfAbsenceApplication());
+        DECIDE_MAX_WEEK(
+            HasGlobalRole(ADMIN),
+            HasUnitRole(UNIT_SUPERVISOR).inPlacementUnitOfChildOfAbsenceApplication(),
+            HasGroupRole(STAFF).inPlacementGroupOfChildOfAbsenceApplication(),
+        );
 
         override fun toString(): String = "${javaClass.name}.$name"
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -645,8 +645,8 @@ sealed interface Action {
         DECIDE(
             HasGlobalRole(ADMIN),
             HasUnitRole(UNIT_SUPERVISOR).inPlacementUnitOfChildOfAbsenceApplication(),
-            HasGroupRole(STAFF).inPlacementGroupOfChildOfAbsenceApplication(maxLengthInDays = 7),
-        );
+        ),
+        DECIDE_MAX_WEEK(HasGroupRole(STAFF).inPlacementGroupOfChildOfAbsenceApplication());
 
         override fun toString(): String = "${javaClass.name}.$name"
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasGroupRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasGroupRole.kt
@@ -153,7 +153,7 @@ WHERE employee_id = ${bind(user.id)}
             )
         }
 
-    fun inPlacementGroupOfChildOfAbsenceApplication(maxLengthInDays: Int? = null) =
+    fun inPlacementGroupOfChildOfAbsenceApplication() =
         rule<AbsenceApplicationId> { user, now ->
             sql(
                 """
@@ -162,7 +162,6 @@ FROM absence_application
 JOIN employee_child_group_acl(${bind(now.toLocalDate())}) acl USING (child_id)
 JOIN daycare ON acl.daycare_id = daycare.id
 WHERE employee_id = ${bind(user.id)}
-${if (maxLengthInDays != null) "AND absence_application.end_date - absence_application.start_date < ${bind(maxLengthInDays)}" else ""}
             """
                     .trimIndent()
             )


### PR DESCRIPTION
Henkilökunta saa hyväksyä maksimissaan viiden päivän hakemukset huomioiden esiopetuksen toimintapäivät.