### PR TITLE
Lisätään yksikön johtajalle ja ryhmän henkilökunnalle oikeus palauttaa lähetetty kuntalaisen lomake luonnokseksi

### DIFF
--- a/frontend/src/e2e-test/pages/employee/documents/child-document.ts
+++ b/frontend/src/e2e-test/pages/employee/documents/child-document.ts
@@ -26,6 +26,7 @@ export class ChildDocumentPage {
   archiveTooltip: Element
   acceptDecisionButton: Element
   sendingConfirmationModal: Modal
+
   constructor(private readonly page: Page) {
     this.status = page.findByDataQa('document-state-chip')
     this.savingIndicator = page.findByDataQa('saving-spinner')
@@ -76,6 +77,11 @@ export class ChildDocumentPage {
 
   async goToNextStatus() {
     await this.page.findByDataQa('next-status-button').click()
+    await this.page.findByDataQa('modal-okBtn').click()
+  }
+
+  async goToPrevStatus() {
+    await this.page.findByDataQa('prev-status-button').click()
     await this.page.findByDataQa('modal-okBtn').click()
   }
 

--- a/frontend/src/employee-frontend/components/child-documents/ChildDocumentReadView.tsx
+++ b/frontend/src/employee-frontend/components/child-documents/ChildDocumentReadView.tsx
@@ -340,6 +340,7 @@ const ChildDocumentReadViewInner = React.memo(
                                 .goBackToDraftConfirmText
                             : undefined
                         }
+                        data-qa="prev-status-button"
                       />
                     )}
                 </FixedSpaceRow>

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -2414,6 +2414,7 @@ sealed interface Action {
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
                 .withUnitFeatures(PilotFeature.VASU_AND_PEDADOC)
                 .inPlacementUnitOfChildOfChildDocument(canGoToPrevStatus = true),
+            HasGroupRole(STAFF).inPlacementGroupOfChildOfChildDocument(canGoToPrevStatus = true),
             IsEmployee.andIsDecisionMakerForChildDocumentDecision(),
         ),
         DELETE(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasGroupRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasGroupRole.kt
@@ -172,6 +172,7 @@ ${if (maxLengthInDays != null) "AND absence_application.end_date - absence_appli
         editable: Boolean = false,
         deletable: Boolean = false,
         publishable: Boolean = false,
+        canGoToPrevStatus: Boolean = false,
     ) =
         rule<ChildDocumentId> { user, now ->
             sql(
@@ -184,6 +185,7 @@ WHERE employee_id = ${bind(user.id)}
 ${if (editable) "AND status = ANY(${bind(DocumentStatus.entries.filter { it.employeeEditable })}::child_document_status[])" else ""}
 ${if (deletable) "AND status = 'DRAFT' AND published_at IS NULL" else ""}
 ${if (publishable) "AND status <> 'COMPLETED'" else ""}
+${if (canGoToPrevStatus) "AND child_document.type = 'CITIZEN_BASIC' AND child_document.content -> 'answers' = '[]'::jsonb AND child_document.status <> 'COMPLETED'" else ""}
             """
                     .trimIndent()
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/actionrule/HasUnitRole.kt
@@ -744,7 +744,7 @@ WHERE TRUE
 ${if (editable) "AND status = ANY(${bind(DocumentStatus.entries.filter { it.employeeEditable })}::child_document_status[])" else ""}
 ${if (deletable) "AND status = 'DRAFT' AND published_at IS NULL" else ""}
 ${if (publishable) "AND status <> 'COMPLETED'" else ""}
-${if (canGoToPrevStatus) "AND type = 'OTHER_DECISION' AND status <> 'COMPLETED'" else ""}
+${if (canGoToPrevStatus) "AND ((type = 'OTHER_DECISION') OR (type = 'CITIZEN_BASIC' AND child_document.content -> 'answers' = '[]'::jsonb)) AND status <> 'COMPLETED'" else ""}
             """
             )
         }


### PR DESCRIPTION
Muuttaa:
- käyttöoikeuslaajennos yksikön johtajalle ja ryhmän henkilökunnalle vastauksettomien kuntalaisen lomakkeiden palauttamiseen luonnokseksi
  -  HUOM! sivuvaikutuksena oikeus tulee myös VEO:lle, tarkistettu PO:lta -> tämä OK

Palauttamisen oikeuttaminen antaa mahdollisuuden jo lähetettyjen, mutta vastaamattomien lomakkeiden palauttamiseen editoitavaksi -> henkilökunta voi vastata kuntalaisen puolesta tapauksissa, joissa kuntalainen ei käytä eVakaa.