### PR TITLE
Korjataan yksikön karttakoordinaattien tyhjennys

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/daycare/DaycareEditIntegrationTest.kt
@@ -154,6 +154,19 @@ class DaycareEditIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
     }
 
     @Test
+    fun `updateDaycare with location null`() {
+        val fieldsWithLocationNull = fields.copy(location = null)
+        daycareController.updateDaycare(
+            dbInstance(),
+            admin,
+            RealEvakaClock(),
+            testDaycare.id,
+            fieldsWithLocationNull,
+        )
+        getAndAssertDaycareFields(testDaycare.id, fieldsWithLocationNull)
+    }
+
+    @Test
     fun testUpdatePreschool() {
         val preschoolFields =
             fields.copy(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/db/JdbiExtensions.kt
@@ -96,6 +96,8 @@ val coordinateArgumentFactory =
             if (it != null) {
                 y = it.lat
                 x = it.lon
+            } else {
+                isNull = true
             }
         }
     }


### PR DESCRIPTION
Jos karttakoordinaatit-kentän tyhjensi ja tallensi, tallentui tietokantaan `0, 0`.