### PR TITLE
Lisää kuntalaiselle mahdollisuus näyttää salasana sitä syötettäessä

### DIFF
--- a/frontend/src/citizen-frontend/login/WeakLoginFormPage.tsx
+++ b/frontend/src/citizen-frontend/login/WeakLoginFormPage.tsx
@@ -23,6 +23,7 @@ import {
 } from 'lib-components/layout/responsive-layout'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
+import PasswordInputF from 'lib-components/molecules/PasswordInputF'
 import { H1, Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
@@ -120,12 +121,11 @@ const WeakLoginForm = React.memo(function WeakLogin({
         </FixedSpaceColumn>
         <FixedSpaceColumn spacing="zero">
           <Label htmlFor="password">{t.password}</Label>
-          <InputFieldF
+          <PasswordInputF
             id="password"
             data-qa="password"
             autoComplete="current-password"
             bind={password}
-            type="password"
             placeholder={t.password}
             width="L"
             hideErrorsBeforeTouched={true}

--- a/frontend/src/citizen-frontend/personal-details/LoginDetailsSection.tsx
+++ b/frontend/src/citizen-frontend/personal-details/LoginDetailsSection.tsx
@@ -12,7 +12,6 @@ import type { EmailVerificationStatusResponse } from 'lib-common/generated/api-t
 import type { PasswordConstraints } from 'lib-common/generated/api-types/shared'
 import { isPasswordStructureValid } from 'lib-common/password'
 import { Button } from 'lib-components/atoms/buttons/Button'
-import { InputFieldF } from 'lib-components/atoms/form/InputField'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import {
   ExpandingInfoBox,
@@ -20,6 +19,7 @@ import {
   InlineInfoButton
 } from 'lib-components/molecules/ExpandingInfo'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
+import PasswordInputF from 'lib-components/molecules/PasswordInputF'
 import BaseModal, {
   ModalButtons
 } from 'lib-components/molecules/modals/BaseModal'
@@ -303,26 +303,24 @@ const WeakCredentialsFormModal = React.memo(function WeakCredentialsFormModal({
             value={username}
           />
           <Label htmlFor="password">{t.password}</Label>
-          <InputFieldF
+          <PasswordInputF
             data-qa="password"
             id="password"
             name="password"
             autoComplete="new-password"
             autoFocus={true}
             bind={password}
-            type="password"
             width="full"
             hideErrorsBeforeTouched={true}
             pattern={pattern}
           />
           <Label htmlFor="confirm-password">{t.confirmPassword}</Label>
-          <InputFieldF
+          <PasswordInputF
             data-qa="confirm-password"
             id="confirm-password"
             name="confirm-password"
             autoComplete="new-password"
             bind={confirmPassword}
-            type="password"
             width="full"
             hideErrorsBeforeTouched={true}
             pattern={pattern}

--- a/frontend/src/lib-components/atoms/form/InputField.tsx
+++ b/frontend/src/lib-components/atoms/form/InputField.tsx
@@ -353,7 +353,8 @@ const InputField = React.memo(function InputField({
 
 export default InputField
 
-interface InputFieldFProps extends Omit<InputProps, 'value' | 'onChange'> {
+export interface InputFieldFProps
+  extends Omit<InputProps, 'value' | 'onChange'> {
   bind: BoundFormState<string>
 }
 

--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -34,6 +34,8 @@ export interface Translations {
     search: string
     yes: string
     openExpandingInfo: string
+    showPassword: string
+    hidePassword: string
   }
   datePicker: {
     placeholder: string

--- a/frontend/src/lib-components/molecules/PasswordInputF.tsx
+++ b/frontend/src/lib-components/molecules/PasswordInputF.tsx
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2017-2025 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React, { useState } from 'react'
+import styled from 'styled-components'
+
+import { faEye, faEyeSlash } from 'lib-icons'
+
+import { Button } from '../atoms/buttons/Button'
+import type { InputFieldFProps } from '../atoms/form/InputField'
+import { InputFieldF } from '../atoms/form/InputField'
+import { useTranslations } from '../i18n'
+import { FixedSpaceRow } from '../layout/flex-helpers'
+
+interface PasswordInputProps extends Omit<InputFieldFProps, 'type'> {}
+
+export default React.memo(function PasswordInputF({
+  ...props
+}: PasswordInputProps) {
+  const [showPassword, setShowPassword] = useState(false)
+  const i18n = useTranslations()
+
+  return (
+    <PasswordInputContainer spacing="xs" alignItems="start" fullWidth>
+      <InputFieldF {...props} type={showPassword ? 'text' : 'password'} />
+      <Button
+        className="pw-toggle-button"
+        appearance="inline"
+        icon={showPassword ? faEyeSlash : faEye}
+        text=""
+        aria-label={
+          showPassword ? i18n.common.hidePassword : i18n.common.showPassword
+        }
+        onClick={() => {
+          setShowPassword(!showPassword)
+        }}
+      />
+    </PasswordInputContainer>
+  )
+})
+
+const PasswordInputContainer = styled(FixedSpaceRow)`
+  height: 60px;
+
+  .pw-toggle-button {
+    width: 40px;
+    margin: 10px 0 0 0;
+  }
+`

--- a/frontend/src/lib-components/utils/TestContextProvider.tsx
+++ b/frontend/src/lib-components/utils/TestContextProvider.tsx
@@ -37,7 +37,9 @@ export const testTranslations: Translations = {
     saving: '',
     search: '',
     yes: '',
-    openExpandingInfo: ''
+    openExpandingInfo: '',
+    showPassword: '',
+    hidePassword: ''
   },
   datePicker: {
     placeholder: '',

--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -26,7 +26,9 @@ const components: Translations = {
     saved: 'Saved',
     search: 'Search',
     yes: 'Yes',
-    openExpandingInfo: 'Open the details'
+    openExpandingInfo: 'Open the details',
+    showPassword: 'Show password',
+    hidePassword: 'Hide password'
   },
   datePicker: {
     placeholder: 'dd.mm.yyyy',

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -26,7 +26,9 @@ const components: Translations = {
     saved: 'Tallennettu',
     search: 'Hae',
     yes: 'Kyllä',
-    openExpandingInfo: 'Avaa lisätietokenttä'
+    openExpandingInfo: 'Avaa lisätietokenttä',
+    showPassword: 'Näytä salasana',
+    hidePassword: 'Piilota salasana'
   },
   datePicker: {
     placeholder: 'pp.kk.vvvv',

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -26,7 +26,9 @@ const components: Translations = {
     saved: 'Sparad',
     search: 'Sök',
     yes: 'Ja',
-    openExpandingInfo: 'Öppna detaljer'
+    openExpandingInfo: 'Öppna detaljer',
+    showPassword: 'Visa lösenord',
+    hidePassword: 'Dölj lösenord'
   },
   datePicker: {
     placeholder: 'dd.mm.åååå',


### PR DESCRIPTION
Lisää uuden komponentin salasanojen syöttämiselle, jossa mukana kirjoitetun sisällön näyttämisen kytkevä nappi. Komponentti otettu käyttöön kuntalaisen tunnuksella kirjautumisen käyttöliittymässä.

![pw-hidden](https://github.com/user-attachments/assets/c9ba85a0-5d21-48ed-b7fa-17f8c9666c70)
![pw-shown](https://github.com/user-attachments/assets/8fce3d4c-3e5b-4597-b232-9805d0e37ad2)
