### PR TITLE
Korjauksia metadatamigraatioon

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/process/MigrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/process/MigrationTest.kt
@@ -273,7 +273,7 @@ class MigrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         process.history.last().also {
             assertEquals(ArchivedProcessState.COMPLETED, it.state)
             assertEquals(clock.now(), it.enteredAt)
-            assertEquals(AuthenticatedUser.SystemInternalUser.evakaUserId, it.enteredBy.id)
+            assertEquals(adult.evakaUserId(), it.enteredBy.id)
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/process/Migration.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/process/Migration.kt
@@ -90,6 +90,7 @@ private data class ApplicationMigrationData(
     val modifiedAt: HelsinkiDateTime,
     val statusModifiedAt: HelsinkiDateTime?,
     val decisionResolved: HelsinkiDateTime?,
+    val decisionResolvedBy: EvakaUserId?,
 )
 
 private fun migrateApplicationMetadata(
@@ -111,7 +112,8 @@ private fun migrateApplicationMetadata(
                             a.status,
                             a.modified_at,
                             a.status_modified_at,
-                            d.resolved AS decision_resolved
+                            d.resolved AS decision_resolved,
+                            d.resolved_by AS decision_resolved_by
                         FROM application a
                         LEFT JOIN decision d ON d.application_id = a.id
                         WHERE process_id IS NULL AND sentdate IS NOT NULL
@@ -153,7 +155,7 @@ private fun migrateApplicationMetadata(
                         application.decisionResolved
                             ?: application.statusModifiedAt
                             ?: application.modifiedAt,
-                    userId = systemInternalUser,
+                    userId = application.decisionResolvedBy ?: systemInternalUser,
                 )
             } else if (application.status == ApplicationStatus.CANCELLED) {
                 tx.insertProcessHistoryRow(


### PR DESCRIPTION
- Vanhan datan osalta kaikilla käyttäjillä ei välttämättä vielä ole `evaka_user`-riviä johon `archived_process_history`-taulusta viitataan, joten luodaan puuttuvat käyttäjät lennossa.
- Käytetään useampaa aikaleimaa kun päätellään milloin hakemus on siirtynyt `COMPLETED`-tilaan.
- Käytetään päätöksen hyväksyjää (kuntalainen tai henkilökunta) hakemuksen `COMPLETED`-tilaan siirtäjänä.
- Siirretään mitätöidyt maksu- ja arvopäätökset aina `COMPLETED`-tilaan