### PR TITLE
Korjataan nimettömän henkilön näyttäminen perheen tietojen koosteessa

### DIFF
--- a/frontend/src/employee-frontend/components/person-profile/PersonFamilyOverview.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFamilyOverview.tsx
@@ -15,10 +15,10 @@ import type {
 } from 'lib-common/generated/api-types/pis'
 import type { PersonId } from 'lib-common/generated/api-types/shared'
 import { formatCents } from 'lib-common/money'
-import { formatPersonName } from 'lib-common/names'
 import { useQueryResult } from 'lib-common/query'
 import { getAge } from 'lib-common/utils/local-date'
 import { Table, Tbody, Td, Th, Thead, Tr } from 'lib-components/layout/Table'
+import { PersonName } from 'lib-components/molecules/PersonNames'
 
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
@@ -30,7 +30,8 @@ type FamilyOverviewPersonRole = 'HEAD' | 'PARTNER' | 'CHILD'
 
 interface FamilyOverviewRow {
   personId: string
-  name: string
+  firstName: string
+  lastName: string
   role: FamilyOverviewPersonRole
   age: number
   restrictedDetailsEnabled: boolean
@@ -63,7 +64,8 @@ function mapPersonToRow(
   const age = getAge(dateOfBirth)
   return {
     personId,
-    name: formatPersonName({ firstName, lastName }, 'Last First'),
+    firstName,
+    lastName,
     role,
     age,
     restrictedDetailsEnabled,
@@ -160,7 +162,8 @@ export default React.memo(function FamilyOverview({ id }: Props) {
                 {getMembers(family)?.map(
                   ({
                     personId,
-                    name,
+                    firstName,
+                    lastName,
                     role,
                     age,
                     restrictedDetailsEnabled,
@@ -174,10 +177,18 @@ export default React.memo(function FamilyOverview({ id }: Props) {
                       <Td>
                         {role === 'CHILD' ? (
                           <Link to={`/child-information/${personId}`}>
-                            {name}
+                            <PersonName
+                              person={{ firstName, lastName }}
+                              format="Last First"
+                            />
                           </Link>
                         ) : (
-                          <Link to={`/profile/${personId}`}>{name}</Link>
+                          <Link to={`/profile/${personId}`}>
+                            <PersonName
+                              person={{ firstName, lastName }}
+                              format="Last First"
+                            />
+                          </Link>
                         )}
                       </Td>
                       <Td>{i18n.personProfile.familyOverview.role[role]}</Td>


### PR DESCRIPTION
Ennen:

<img width="859" alt="Screenshot 2025-06-12 at 13 18 44" src="https://github.com/user-attachments/assets/6785b81d-5801-49d8-9df0-4c152d251a13" />

Jälkeen:

<img width="816" alt="Screenshot 2025-06-12 at 13 19 26" src="https://github.com/user-attachments/assets/ffa413bd-f4f7-4442-8642-e503d2d0ca8e" />
