### PR TITLE
Migratoidaan vanhat poissaolokyselyn vastaukset ja lisätään rajoituksia

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/SchemaConventionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/SchemaConventionsTest.kt
@@ -380,11 +380,6 @@ class SchemaConventionsTest : PureJdbiTest(resetDbBeforeEach = false) {
         val permittedViolations =
             setOf(
                 Column(ColumnRef("fridge_partner", "modified_by"), "uuid", nullable = true),
-                Column(
-                    ColumnRef("holiday_questionnaire_answer", "modified_by"),
-                    "uuid",
-                    nullable = true,
-                ),
                 Column(ColumnRef("placement", "modified_by"), "uuid", nullable = true),
             )
         val violations =

--- a/service/src/main/resources/db/migration/V541__holiday_questionnaire_constraints.sql
+++ b/service/src/main/resources/db/migration/V541__holiday_questionnaire_constraints.sql
@@ -1,0 +1,14 @@
+-- Update any rows that would violate the new constraint
+UPDATE holiday_questionnaire_answer
+SET open_ranges = '{}'
+WHERE open_ranges IS NULL;
+
+-- Add not null constraints
+ALTER TABLE holiday_questionnaire_answer
+    ALTER COLUMN modified_by SET NOT NULL;
+ALTER TABLE holiday_questionnaire_answer
+    ALTER COLUMN questionnaire_id SET NOT NULL;
+ALTER TABLE holiday_questionnaire_answer
+    ALTER COLUMN child_id SET NOT NULL;
+ALTER TABLE holiday_questionnaire_answer
+    ALTER COLUMN open_ranges SET NOT NULL;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -536,3 +536,4 @@ V537__child_document_archive_deletion_constraint.sql
 V538__archived_process_migrated.sql
 V539__add_info_column_to_nekku_order.sql
 V540__new_preschool_assistance_levels.sql
+V541__holiday_questionnaire_constraints.sql


### PR DESCRIPTION
Yksikön kuukausikalenterin muutoksesta ilmentyi ongelma kalenterin tietojen lataamisessa, jos kalenterissa näytettävän kuukauden ajalla listattavalle lapselle oli poissolokyselyn vastauksessa `open_ranges` kentän arvona tyhjän listan sijaan `null`. Uusiin vastauksiin tällaista tilannetta ei muodostu, mutta vanhat vastaukset ovat jääneet migratoimatta.

Migratoidaan siis kaikkiin nykyisiin vastauksiin `null` -> tyhjä lista ja lisätään `not null` rajoite. Lisätään samalla sama rajoite muokkaaja, kyselyn id ja lapsen id kenttiin.

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- Lisää linkki dokumentaation relevanttiin kohtaan.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
