### PR TITLE
Tuetaan tukitoimivaihtoehtojen muuttumista

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -1759,6 +1759,10 @@ export class Fixture {
       descriptionFi: 'a description',
       nameFi: 'a test assistance action option',
       value: 'TEST_ASSISTANCE_ACTION_OPTION',
+      category: 'DAYCARE',
+      displayOrder: null,
+      validFrom: null,
+      validTo: null,
       ...initial
     }
     return {

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -14,6 +14,7 @@ import type { ApplicationType } from 'lib-common/generated/api-types/application
 import type { ArchivedProcessId } from 'lib-common/generated/api-types/shared'
 import type { AreaId } from 'lib-common/generated/api-types/shared'
 import type { AssistanceActionId } from 'lib-common/generated/api-types/shared'
+import type { AssistanceActionOptionCategory } from 'lib-common/generated/api-types/assistanceaction'
 import type { AssistanceFactorId } from 'lib-common/generated/api-types/shared'
 import type { AssistanceLevel } from 'lib-common/generated/api-types/assistanceneed'
 import type { AssistanceNeedDecisionEmployee } from 'lib-common/generated/api-types/assistanceneed'
@@ -238,9 +239,13 @@ export interface DevAssistanceAction {
 * Generated from fi.espoo.evaka.shared.dev.DevAssistanceActionOption
 */
 export interface DevAssistanceActionOption {
+  category: AssistanceActionOptionCategory
   descriptionFi: string | null
+  displayOrder: number | null
   id: AssistanceActionOptionId
   nameFi: string
+  validFrom: LocalDate | null
+  validTo: LocalDate | null
   value: string
 }
 
@@ -1306,6 +1311,15 @@ export function deserializeJsonDevAssistanceAction(json: JsonOf<DevAssistanceAct
     endDate: LocalDate.parseIso(json.endDate),
     modifiedAt: HelsinkiDateTime.parseIso(json.modifiedAt),
     startDate: LocalDate.parseIso(json.startDate)
+  }
+}
+
+
+export function deserializeJsonDevAssistanceActionOption(json: JsonOf<DevAssistanceActionOption>): DevAssistanceActionOption {
+  return {
+    ...json,
+    validFrom: (json.validFrom != null) ? LocalDate.parseIso(json.validFrom) : null,
+    validTo: (json.validTo != null) ? LocalDate.parseIso(json.validTo) : null
   }
 }
 

--- a/frontend/src/employee-frontend/components/child-information/assistance/AssistanceActionRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance/AssistanceActionRow.tsx
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import sortBy from 'lodash/sortBy'
 import type { MutableRefObject } from 'react'
+import { useMemo } from 'react'
 import React, { useContext, useRef, useState } from 'react'
 
 import DateRange from 'lib-common/date-range'
@@ -53,6 +55,16 @@ export default React.memo(function AssistanceActionRow({
 
   const { mutateAsync: deleteAssistanceAction } = useMutationResult(
     deleteAssistanceActionMutation
+  )
+
+  const sortedOptions = useMemo(
+    () =>
+      sortBy(assistanceActionOptions, [
+        (o) => (o.category === 'DAYCARE' ? 1 : 2),
+        (o) => o.displayOrder,
+        (o) => o.nameFi
+      ]),
+    [assistanceActionOptions]
   )
 
   return (
@@ -119,7 +131,7 @@ export default React.memo(function AssistanceActionRow({
                 label: i18n.childInformation.assistanceAction.fields.actions,
                 value: (
                   <ul>
-                    {assistanceActionOptions.map(
+                    {sortedOptions.map(
                       (option) =>
                         assistanceAction.actions.includes(option.value) && (
                           <li key={option.value}>{option.nameFi}</li>

--- a/frontend/src/employee-frontend/components/common/LabelValueList.tsx
+++ b/frontend/src/employee-frontend/components/common/LabelValueList.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import type { Property } from 'csstype'
 import type { ReactNode } from 'react'
 import React, { Fragment } from 'react'
 import styled, { css } from 'styled-components'
@@ -23,18 +24,21 @@ type Props = {
   horizontalSpacing?: Spacing
   labelWidth?: LabelWidth
   contents: (Content | false)[]
+  alignItems?: Property.AlignItems
 }
 
 const LabelValueList = React.memo(function LabelValueList({
   spacing,
   horizontalSpacing,
   contents,
+  alignItems,
   labelWidth = '25%'
 }: Props) {
   return (
     <GridContainer
       spacing={spacing}
       horizontalSpacing={horizontalSpacing}
+      alignItems={alignItems}
       labelWidth={labelWidth}
       size={contents.length}
     >
@@ -63,6 +67,7 @@ const GridContainer = styled.div<{
   horizontalSpacing?: Spacing
   size: number
   labelWidth: LabelWidth
+  alignItems?: Property.AlignItems
 }>`
   display: grid;
   grid-template-columns: ${(p) => p.labelWidth} auto;
@@ -72,7 +77,7 @@ const GridContainer = styled.div<{
       ${horizontalSpacing === 'small' ? '1em' : '4em'};
   `};
   justify-items: start;
-  align-items: baseline;
+  align-items: ${(p) => p.alignItems ?? 'baseline'};
 `
 
 const GridLabel = styled(LabelLike)<{ index: number }>`

--- a/frontend/src/employee-frontend/generated/api-clients/assistance.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/assistance.ts
@@ -22,6 +22,7 @@ import type { PreschoolAssistanceId } from 'lib-common/generated/api-types/share
 import type { PreschoolAssistanceUpdate } from 'lib-common/generated/api-types/assistance'
 import { client } from '../../api/client'
 import { deserializeJsonAssistanceAction } from 'lib-common/generated/api-types/assistanceaction'
+import { deserializeJsonAssistanceActionOption } from 'lib-common/generated/api-types/assistanceaction'
 import { deserializeJsonAssistanceResponse } from 'lib-common/generated/api-types/assistance'
 import { uri } from 'lib-common/uri'
 
@@ -204,7 +205,7 @@ export async function getAssistanceActionOptions(): Promise<AssistanceActionOpti
     url: uri`/employee/assistance-action-options`.toString(),
     method: 'GET'
   })
-  return json
+  return json.map(e => deserializeJsonAssistanceActionOption(e))
 }
 
 

--- a/frontend/src/employee-frontend/generated/api-clients/reports.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/reports.ts
@@ -92,6 +92,8 @@ import YearMonth from 'lib-common/year-month'
 import { client } from '../../api/client'
 import { createUrlSearchParams } from 'lib-common/api'
 import { deserializeJsonAssistanceNeedDecisionsReportRow } from 'lib-common/generated/api-types/reports'
+import { deserializeJsonAssistanceNeedsAndActionsReport } from 'lib-common/generated/api-types/reports'
+import { deserializeJsonAssistanceNeedsAndActionsReportByChild } from 'lib-common/generated/api-types/reports'
 import { deserializeJsonAttendanceReservationReportByChildGroup } from 'lib-common/generated/api-types/reports'
 import { deserializeJsonAttendanceReservationReportRow } from 'lib-common/generated/api-types/reports'
 import { deserializeJsonChildAttendanceReportRow } from 'lib-common/generated/api-types/reports'
@@ -192,7 +194,7 @@ export async function getAssistanceNeedsAndActionsReport(
     method: 'GET',
     params
   })
-  return json
+  return deserializeJsonAssistanceNeedsAndActionsReport(json)
 }
 
 
@@ -220,7 +222,7 @@ export async function getAssistanceNeedsAndActionsReportByChild(
     method: 'GET',
     params
   })
-  return json
+  return deserializeJsonAssistanceNeedsAndActionsReportByChild(json)
 }
 
 

--- a/frontend/src/lib-common/generated/api-types/assistanceaction.ts
+++ b/frontend/src/lib-common/generated/api-types/assistanceaction.ts
@@ -26,10 +26,24 @@ export interface AssistanceAction {
 * Generated from fi.espoo.evaka.assistanceaction.AssistanceActionOption
 */
 export interface AssistanceActionOption {
+  category: AssistanceActionOptionCategory
   descriptionFi: string | null
+  displayOrder: number | null
   nameFi: string
+  validFrom: LocalDate | null
+  validTo: LocalDate | null
   value: string
 }
+
+/**
+* Generated from fi.espoo.evaka.assistanceaction.AssistanceActionOptionCategory
+*/
+export const assistanceActionOptionCategories = [
+  'DAYCARE',
+  'PRESCHOOL'
+] as const
+
+export type AssistanceActionOptionCategory = typeof assistanceActionOptionCategories[number]
 
 /**
 * Generated from fi.espoo.evaka.assistanceaction.AssistanceActionRequest
@@ -55,6 +69,15 @@ export function deserializeJsonAssistanceAction(json: JsonOf<AssistanceAction>):
     ...json,
     endDate: LocalDate.parseIso(json.endDate),
     startDate: LocalDate.parseIso(json.startDate)
+  }
+}
+
+
+export function deserializeJsonAssistanceActionOption(json: JsonOf<AssistanceActionOption>): AssistanceActionOption {
+  return {
+    ...json,
+    validFrom: (json.validFrom != null) ? LocalDate.parseIso(json.validFrom) : null,
+    validTo: (json.validTo != null) ? LocalDate.parseIso(json.validTo) : null
   }
 }
 

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -38,6 +38,7 @@ import TimeRange from '../../time-range'
 import type { TitaniaErrorsId } from './shared'
 import type { UUID } from '../../types'
 import type { VoucherValueDecisionId } from './shared'
+import { deserializeJsonAssistanceActionOption } from './assistanceaction'
 import { deserializeJsonDocumentContent } from './document'
 
 /**
@@ -1255,6 +1256,22 @@ export function deserializeJsonAssistanceNeedDecisionsReportRow(json: JsonOf<Ass
     ...json,
     decisionMade: (json.decisionMade != null) ? LocalDate.parseIso(json.decisionMade) : null,
     sentForDecision: LocalDate.parseIso(json.sentForDecision)
+  }
+}
+
+
+export function deserializeJsonAssistanceNeedsAndActionsReport(json: JsonOf<AssistanceNeedsAndActionsReport>): AssistanceNeedsAndActionsReport {
+  return {
+    ...json,
+    actions: json.actions.map(e => deserializeJsonAssistanceActionOption(e))
+  }
+}
+
+
+export function deserializeJsonAssistanceNeedsAndActionsReportByChild(json: JsonOf<AssistanceNeedsAndActionsReportByChild>): AssistanceNeedsAndActionsReportByChild {
+  return {
+    ...json,
+    actions: json.actions.map(e => deserializeJsonAssistanceActionOption(e))
   }
 }
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -838,6 +838,11 @@ export const fi = {
       fields: {
         dateRange: 'Tukitoimien voimassaoloaika',
         actions: 'Tukitoimet',
+        actionsByCategory: {
+          DAYCARE: 'Varhaiskasvatuksen tukitoimet',
+          PRESCHOOL: 'Esiopetuksen tukitoimet',
+          OTHER: 'Muut tukitoimet'
+        },
         actionTypes: {
           OTHER: 'Muu tukitoimi'
         },

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -856,7 +856,11 @@ export const fi = {
         hardConflict:
           'Tukitoimet menevät päällekkäin toisen ajanjakson alkupäivämäärän kanssa.',
         autoCutWarning:
-          'Aiemmat päällekkäiset tukitoimet katkaistaan automaattisesti.'
+          'Aiemmat päällekkäiset tukitoimet katkaistaan automaattisesti.',
+        startBeforeMinDate: (date: LocalDate) =>
+          `Tämä tukitoimi voi alkaa aikaisintaan ${date.format()}`,
+        endAfterMaxDate: (date: LocalDate) =>
+          `Tämän tukitoimen voi myöntää korkeintaan ${date.format()} saakka`
       }
     },
     childDocuments: {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/TestFixtures.kt
@@ -589,16 +589,22 @@ fun Database.Transaction.insertAssistanceActionOptions() {
     execute {
         sql(
             """
-INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
-    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10),
-    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20),
-    ('SMALLER_GROUP', 'Pedagogisesti vahvistettu ryhmä', 30),
-    ('SPECIAL_GROUP', 'Erityisryhmä', 40),
-    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', 50),
-    ('PART_TIME_SPECIAL_EDUCATION', 'Osa-aikainen erityisopetus esiopetuksessa', 55),
-    ('RESOURCE_PERSON', 'Resurssihenkilö', 60),
-    ('RATIO_DECREASE', 'Suhdeluvun väljennys', 70),
-    ('PERIODICAL_VEO_SUPPORT', 'Lisäresurssi hankerahoituksella', 80);
+INSERT INTO assistance_action_option (value, name_fi, display_order, category, valid_from, valid_to) VALUES
+    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10, 'DAYCARE', NULL, NULL),
+    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20, 'DAYCARE', NULL, NULL),
+    ('SMALLER_GROUP', 'Pedagogisesti vahvistettu ryhmä', 30, 'DAYCARE', NULL, NULL),
+    ('SPECIAL_GROUP', 'Erityisryhmä', 40, 'DAYCARE', NULL, NULL),
+    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', 50, 'DAYCARE', NULL, NULL),
+    ('RESOURCE_PERSON', 'Resurssihenkilö', 60, 'DAYCARE', NULL, NULL),
+    ('RATIO_DECREASE', 'Suhdeluvun väljennys', 70, 'DAYCARE', NULL, NULL),
+    ('PERIODICAL_VEO_SUPPORT', 'Lisäresurssi hankerahoituksella', 80, 'DAYCARE', NULL, NULL),
+
+    ('PART_TIME_SPECIAL_EDUCATION', 'Osa-aikainen erityisopetus esiopetuksessa', 0, 'PRESCHOOL', NULL, '2025-07-31'::date),
+    ('FULL_VEO_SUPPORT_IN_SMALLER_GROUP', 'Kokoaikainen erityisopettajan antama opetus pienryhmässä', 10, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('REGULAR_VEO_SUPPORT_PARTIALLY_IN_SMALLER_GROUP', 'Säännöllinen erityisopettajan antama opetus osittain pienryhmässä ja muun opetuksen yhteydessä', 20, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('PERSONAL_ASSISTANT', 'Lapsikohtainen avustaja', 30, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('ASSISTIVE_DEVICES', 'Apuvälineet', 40, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('INTERPRETATION_SERVICES', 'Tulkitsemispalvelut', 50, 'PRESCHOOL', '2025-08-01'::date, NULL);
 """
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceAction.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceAction.kt
@@ -4,8 +4,10 @@
 
 package fi.espoo.evaka.assistanceaction
 
+import fi.espoo.evaka.ConstList
 import fi.espoo.evaka.shared.AssistanceActionId
 import fi.espoo.evaka.shared.ChildId
+import fi.espoo.evaka.shared.db.DatabaseEnum
 import fi.espoo.evaka.shared.security.Action
 import java.time.LocalDate
 
@@ -30,8 +32,20 @@ data class AssistanceActionResponse(
     val permittedActions: Set<Action.AssistanceAction>,
 )
 
+@ConstList("assistanceActionOptionCategories")
+enum class AssistanceActionOptionCategory : DatabaseEnum {
+    DAYCARE,
+    PRESCHOOL;
+
+    override val sqlType: String = "assistance_action_option_category"
+}
+
 data class AssistanceActionOption(
     val value: String,
     val nameFi: String,
     val descriptionFi: String?,
+    val category: AssistanceActionOptionCategory,
+    val displayOrder: Int?,
+    val validFrom: LocalDate?,
+    val validTo: LocalDate?,
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceaction/AssistanceActionQueries.kt
@@ -163,7 +163,10 @@ AND option_id NOT IN (SELECT id FROM assistance_action_option WHERE value = ANY(
 fun Database.Read.getAssistanceActionOptions(): List<AssistanceActionOption> =
     createQuery {
             sql(
-                "SELECT value, name_fi, description_fi FROM assistance_action_option ORDER BY display_order"
+                """
+                    SELECT value, name_fi, description_fi, category, display_order, valid_from, valid_to 
+                    FROM assistance_action_option 
+                """
             )
         }
         .toList()

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -1673,8 +1673,8 @@ fun Database.Transaction.insert(row: DevAssistanceActionOption): AssistanceActio
     createUpdate {
             sql(
                 """
-INSERT INTO assistance_action_option(id, value, name_fi, description_fi)
-VALUES (${bind(row.id)}, ${bind(row.value)}, ${bind(row.nameFi)}, ${bind(row.descriptionFi)})        
+INSERT INTO assistance_action_option(id, value, name_fi, description_fi, category, display_order, valid_from, valid_to)
+VALUES (${bind(row.id)}, ${bind(row.value)}, ${bind(row.nameFi)}, ${bind(row.descriptionFi)}, ${bind(row.category)}, ${bind(row.displayOrder)}, ${bind(row.validFrom)}, ${bind(row.validTo)})        
 """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -22,6 +22,7 @@ import fi.espoo.evaka.application.fetchApplicationDetails
 import fi.espoo.evaka.assistance.DaycareAssistanceLevel
 import fi.espoo.evaka.assistance.OtherAssistanceMeasureType
 import fi.espoo.evaka.assistance.PreschoolAssistanceLevel
+import fi.espoo.evaka.assistanceaction.AssistanceActionOptionCategory
 import fi.espoo.evaka.assistanceneed.decision.AssistanceLevel
 import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionEmployee
 import fi.espoo.evaka.assistanceneed.decision.AssistanceNeedDecisionGuardian
@@ -2599,7 +2600,11 @@ data class DevAssistanceActionOption(
     val id: AssistanceActionOptionId,
     val value: String = "TEST_ASSISTANCE_ACTION_OPTION",
     val nameFi: String = "testAssistanceActionOption",
-    val descriptionFi: String?,
+    val descriptionFi: String? = null,
+    val category: AssistanceActionOptionCategory = AssistanceActionOptionCategory.DAYCARE,
+    val displayOrder: Int? = null,
+    val validFrom: LocalDate? = null,
+    val validTo: LocalDate? = null,
 )
 
 val feeThresholds2020 =

--- a/service/src/main/resources/db/migration/V542__assistance_action_option_validity.sql
+++ b/service/src/main/resources/db/migration/V542__assistance_action_option_validity.sql
@@ -1,0 +1,18 @@
+CREATE TYPE assistance_action_option_category AS ENUM (
+    'DAYCARE',
+    'PRESCHOOL'
+);
+
+ALTER TABLE assistance_action_option
+    ADD COLUMN valid_from date,
+    ADD COLUMN valid_to date,
+    ADD COLUMN category assistance_action_option_category NOT NULL DEFAULT 'DAYCARE';
+
+ALTER TABLE assistance_action_option ALTER COLUMN category DROP DEFAULT;
+
+ALTER TABLE assistance_action_option ADD CONSTRAINT check_validity
+    CHECK (valid_from IS NULL OR valid_to IS NULL OR valid_from <= valid_to);
+
+-- drop unused legacy column and type
+ALTER TABLE assistance_action DROP COLUMN measures;
+DROP TYPE assistance_measure;

--- a/service/src/main/resources/dev-data/dev-data.sql
+++ b/service/src/main/resources/dev-data/dev-data.sql
@@ -40,16 +40,22 @@ INSERT INTO daycare_caretaker (group_id, amount, start_date, end_date) VALUES
 
 INSERT INTO message_account (daycare_group_id, type) SELECT id, 'GROUP'::message_account_type as type FROM daycare_group;
 
-INSERT INTO assistance_action_option (value, name_fi, display_order) VALUES
-    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10),
-    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20),
-    ('SMALLER_GROUP', 'Pedagogisesti vahvistettu ryhmä', 30),
-    ('SPECIAL_GROUP', 'Erityisryhmä', 40),
-    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', 50),
-    ('PART_TIME_SPECIAL_EDUCATION', 'Osa-aikainen erityisopetus esiopetuksessa', 55),
-    ('RESOURCE_PERSON', 'Resurssihenkilö', 60),
-    ('RATIO_DECREASE', 'Suhdeluvun väljennys', 70),
-    ('PERIODICAL_VEO_SUPPORT', 'Lisäresurssi hankerahoituksella', 80);
+INSERT INTO assistance_action_option (value, name_fi, display_order, category, valid_from, valid_to) VALUES
+    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', 10, 'DAYCARE', NULL, NULL),
+    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', 20, 'DAYCARE', NULL, NULL),
+    ('SMALLER_GROUP', 'Pedagogisesti vahvistettu ryhmä', 30, 'DAYCARE', NULL, NULL),
+    ('SPECIAL_GROUP', 'Erityisryhmä', 40, 'DAYCARE', NULL, NULL),
+    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', 50, 'DAYCARE', NULL, NULL),
+    ('RESOURCE_PERSON', 'Resurssihenkilö', 60, 'DAYCARE', NULL, NULL),
+    ('RATIO_DECREASE', 'Suhdeluvun väljennys', 70, 'DAYCARE', NULL, NULL),
+    ('PERIODICAL_VEO_SUPPORT', 'Lisäresurssi hankerahoituksella', 80, 'DAYCARE', NULL, NULL),
+
+    ('PART_TIME_SPECIAL_EDUCATION', 'Osa-aikainen erityisopetus esiopetuksessa', 0, 'PRESCHOOL', NULL, '2025-07-31'::date),
+    ('FULL_VEO_SUPPORT_IN_SMALLER_GROUP', 'Kokoaikainen erityisopettajan antama opetus pienryhmässä', 10, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('REGULAR_VEO_SUPPORT_PARTIALLY_IN_SMALLER_GROUP', 'Säännöllinen erityisopettajan antama opetus osittain pienryhmässä ja muun opetuksen yhteydessä', 20, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('PERSONAL_ASSISTANT', 'Lapsikohtainen avustaja', 30, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('ASSISTIVE_DEVICES', 'Apuvälineet', 40, 'PRESCHOOL', '2025-08-01'::date, NULL),
+    ('INTERPRETATION_SERVICES', 'Tulkitsemispalvelut', 50, 'PRESCHOOL', '2025-08-01'::date, NULL);
 
 UPDATE daycare SET enabled_pilot_features = '{MESSAGING, MOBILE, RESERVATIONS, VASU_AND_PEDADOC, MOBILE_MESSAGING}';
 

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -537,3 +537,4 @@ V538__archived_process_migrated.sql
 V539__add_info_column_to_nekku_order.sql
 V540__new_preschool_assistance_levels.sql
 V541__holiday_questionnaire_constraints.sql
+V542__assistance_action_option_validity.sql


### PR DESCRIPTION
Kannassa oleviin kuntakohtaisiin tukitoimivaihtoehtoihin on lisätty kategoria (vaka/esiopetus) käyttöliittymässä ryhmittelyä varten sekä optionaaliset voimassaolon alku ja loppupäivät.

Oletuksena kategoria on vanhoille tukitoimille DAYCARE. Muuta se tarvittaessa. Esim Espoossa:
```
UPDATE assistance_action_option
SET category = 'PRESCHOOL'
WHERE value = 'PART_TIME_SPECIAL_EDUCATION';
```

Jos joku tukitoimi poistuu käytöstä, aseta päättymispäivä. Esim espoossa:
```
UPDATE assistance_action_option
SET valid_to = '2025-07-31'::date
WHERE value = 'PART_TIME_SPECIAL_EDUCATION';
```

Luo uudet lakimuutoksen mukaiset sekä mahdolliset muut kuntakohtaiset tukitoimet:
```
INSERT INTO assistance_action_option (value, name_fi, display_order, category, valid_from, valid_to) VALUES
    ('FULL_VEO_SUPPORT_IN_SMALLER_GROUP', 'Kokoaikainen erityisopettajan antama opetus pienryhmässä', 10, 'PRESCHOOL', '2025-08-01'::date, NULL),
    ('REGULAR_VEO_SUPPORT_PARTIALLY_IN_SMALLER_GROUP', 'Säännöllinen erityisopettajan antama opetus osittain pienryhmässä ja muun opetuksen yhteydessä', 20, 'PRESCHOOL', '2025-08-01'::date, NULL),
    ('PERSONAL_ASSISTANT', 'Lapsikohtainen avustaja', 30, 'PRESCHOOL', '2025-08-01'::date, NULL),
    ('ASSISTIVE_DEVICES', 'Apuvälineet', 40, 'PRESCHOOL', '2025-08-01'::date, NULL),
    ('INTERPRETATION_SERVICES', 'Tulkitsemispalvelut', 50, 'PRESCHOOL', '2025-08-01'::date, NULL);
```

Infotekstit voi edelleen syöttää halutessaan `description_fi` kenttään.