### PR TITLE
Estetään tuen päätöksen automaattikatkaisu jos lapsi jatkaa edelleen samannimisessä yksikössä kuin päätöksen yksikkö

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionQueries.kt
@@ -422,6 +422,15 @@ WITH daycare_assistance_decision_with_new_end_date AS (
           WHERE pl.child_id = daycare_assistance_decision.child_id
           AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
           AND d.name = daycare_ad.name
+          AND pl.type IN (
+            'DAYCARE',
+            'DAYCARE_PART_TIME',
+            'DAYCARE_FIVE_YEAR_OLDS',
+            'DAYCARE_PART_TIME_FIVE_YEAR_OLDS',
+            'PRESCHOOL_DAYCARE',
+            'PRESCHOOL_DAYCARE_ONLY',
+            'PREPARATORY_DAYCARE',
+            'PREPARATORY_DAYCARE_ONLY')
       )
       AND placement.type IN (
         'DAYCARE',

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionQueries.kt
@@ -367,6 +367,12 @@ WITH preschool_assistance_decision_with_new_end_date AS (
           WHERE pl.child_id = preschool_assistance_decision.child_id
           AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
           AND d.name = daycare_ad.name
+          AND pl.type IN (
+            'PRESCHOOL',
+            'PRESCHOOL_DAYCARE',
+            'PRESCHOOL_CLUB',
+            'PREPARATORY',
+            'PREPARATORY_DAYCARE')
       )
       AND placement.type IN (
         'PRESCHOOL',

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionQueries.kt
@@ -354,10 +354,20 @@ WITH preschool_assistance_decision_with_new_end_date AS (
     SELECT preschool_assistance_decision.id, max(placement.end_date) AS new_end_date
     FROM assistance_need_preschool_decision preschool_assistance_decision
     JOIN placement ON preschool_assistance_decision.child_id = placement.child_id
-     AND preschool_assistance_decision.selected_unit = placement.unit_id
-     AND daterange(preschool_assistance_decision.valid_from, preschool_assistance_decision.valid_to, '[]') @> placement.end_date
+      AND daterange(preschool_assistance_decision.valid_from, preschool_assistance_decision.valid_to, '[]') @> placement.end_date
+    JOIN daycare daycare_pl ON placement.unit_id = daycare_pl.id
+    JOIN daycare daycare_ad ON preschool_assistance_decision.selected_unit = daycare_ad.id
     WHERE preschool_assistance_decision.status = 'ACCEPTED'
       AND preschool_assistance_decision.valid_to IS NULL
+      AND (preschool_assistance_decision.selected_unit = placement.unit_id OR daycare_pl.name = daycare_ad.name)
+      AND NOT EXISTS (
+          SELECT
+          FROM placement pl
+          JOIN daycare d ON pl.unit_id = d.id
+          WHERE pl.child_id = preschool_assistance_decision.child_id
+          AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(date)}
+          AND d.name = daycare_ad.name
+      )
       AND placement.type IN (
         'PRESCHOOL',
         'PRESCHOOL_DAYCARE',


### PR DESCRIPTION
Tämä on apukeino yksiköiden kloonaamistapauksiin, jolla säilytetään sama tuen päätös järjestelmästä johtuvista yksikön kloonaamistarpeista aiheutuville sijoitusvaihdoksille.

- aiemmin sijoituksen vaihtuminen tai päättäminen on aina päättänyt myös tuen päätöksen (vaka & eo) seuraavan yön huoltoajossa
- muutoksen jälkeen tuen päätös katkaistaan vain, jos päättyneen sijoituksen viereinen uusi voimassa oleva sijoitustyypille merkityksellinen sijoitus ei ole merkilleen samannimiseen yksikköön kuin tuen päätös