### PR TITLE
Lisätään esiopetusta järjestävät yksiköt varasijoituksiin

### DIFF
--- a/frontend/src/employee-frontend/components/applications/ApplicationsFilters.tsx
+++ b/frontend/src/employee-frontend/components/applications/ApplicationsFilters.tsx
@@ -58,7 +58,7 @@ export default React.memo(function ApplicationFilters() {
   const allUnits = useQueryResult(
     unitsQuery({
       areaIds: searchFilters.area.length > 0 ? searchFilters.area : null,
-      type: searchFilters.type,
+      type: searchFilters.type !== 'ALL' ? [searchFilters.type] : null,
       from: null
     })
   )

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeedPreschoolDecisionEditPage.tsx
@@ -1010,7 +1010,6 @@ export default React.memo(function AssistanceNeedPreschoolDecisionEditPage() {
   const unitsResult = useQueryResult(
     unitsQuery({
       areaIds: null,
-      type: 'ALL',
       from: LocalDate.todayInHelsinkiTz()
     })
   ).map((units) =>

--- a/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance-need/decision/AssistanceNeededDecisionForm.tsx
@@ -217,7 +217,6 @@ export default React.memo(function AssistanceNeedDecisionForm({
   const units = useQueryResult(
     unitsQuery({
       areaIds: null,
-      type: 'ALL',
       from: LocalDate.todayInHelsinkiTz()
     })
   )

--- a/frontend/src/employee-frontend/components/child-information/backup-care/BackupCareForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/backup-care/BackupCareForm.tsx
@@ -102,7 +102,7 @@ export default function BackupCareForm({
   const units = useQueryResult(
     unitsQuery({
       areaIds: null,
-      type: 'DAYCARE',
+      type: ['DAYCARE', 'PRESCHOOL'],
       from: LocalDate.todayInHelsinkiTz()
     })
   )

--- a/frontend/src/employee-frontend/generated/api-clients/daycare.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/daycare.ts
@@ -502,13 +502,13 @@ export async function getAreas(): Promise<AreaJSON[]> {
 */
 export async function getUnits(
   request: {
-    type: UnitTypeFilter,
+    type?: UnitTypeFilter[] | null,
     areaIds?: AreaId[] | null,
     from?: LocalDate | null
   }
 ): Promise<UnitStub[]> {
   const params = createUrlSearchParams(
-    ['type', request.type.toString()],
+    ...(request.type?.map((e): [string, string | null | undefined] => ['type', e.toString()]) ?? []),
     ...(request.areaIds?.map((e): [string, string | null | undefined] => ['areaIds', e]) ?? []),
     ['from', request.from?.formatIso()]
   )

--- a/frontend/src/employee-frontend/state/invoicing-ui.tsx
+++ b/frontend/src/employee-frontend/state/invoicing-ui.tsx
@@ -414,7 +414,7 @@ export const InvoicingUIContextProvider = React.memo(
 
     const availableAreas = useQueryResult(areasQuery(), { enabled: loggedIn })
     const allDaycareUnits = useQueryResult(
-      unitsQuery({ areaIds: null, type: 'DAYCARE', from: null }),
+      unitsQuery({ areaIds: null, type: ['DAYCARE'], from: null }),
       { enabled: loggedIn }
     )
 

--- a/frontend/src/lib-common/generated/api-types/daycare.ts
+++ b/frontend/src/lib-common/generated/api-types/daycare.ts
@@ -559,7 +559,6 @@ export interface UnitStub {
 * Generated from fi.espoo.evaka.daycare.controllers.UnitTypeFilter
 */
 export type UnitTypeFilter =
-  | 'ALL'
   | 'CLUB'
   | 'DAYCARE'
   | 'PRESCHOOL'


### PR DESCRIPTION
Korjaa täyttö- ja käyttöasteraporttia, koska yksikön toimintamuodoksi ei tarvitse pelkästään varasijoitustoiminnallisuutta varten lisätä päiväkotia.