### PR TITLE
Päivitetään pedagogisen dokumentoinnin selitysteksti

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/PedagogicalDocuments.tsx
+++ b/frontend/src/employee-frontend/components/child-information/PedagogicalDocuments.tsx
@@ -21,7 +21,6 @@ import {
 import { P } from 'lib-components/typography'
 import { defaultMargins } from 'lib-components/white-space'
 
-import { ChildContext } from '../../state'
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
 
@@ -30,6 +29,7 @@ import {
   childPedagogicalDocumentsQuery,
   createPedagogicalDocumentMutation
 } from './queries'
+import { ChildContext } from './state'
 
 interface Props {
   childId: ChildId
@@ -78,7 +78,7 @@ export default React.memo(function PedagogicalDocuments({ childId }: Props) {
       )}
 
       {!!i18n.childInformation.pedagogicalDocument.explanation && (
-        <P noMargin>
+        <P>
           {i18n.childInformation.pedagogicalDocument.explanation}
           <InfoButtonWithMargin
             onClick={() =>

--- a/frontend/src/lib-customizations/espoo/employee.tsx
+++ b/frontend/src/lib-customizations/espoo/employee.tsx
@@ -32,7 +32,7 @@ const customizations: EmployeeCustomizations = {
         },
         pedagogicalDocument: {
           explanation:
-            'Pedagogisen dokumentoinnin ominaisuutta käytetään toiminnasta kertovien kuvien ja digitaalisten dokumenttien jakamiseen.',
+            'Pedagogisen dokumentoinnin ominaisuutta käytetään toiminnasta kertovien kuvien ja digitaalisten dokumenttien jakamiseen. Pedagogisiin dokumentteihin ei saa liittää lapsen terveystietoja tai lausuntoja.',
           explanationInfo:
             'Pedagogisen dokumentoinnin prosessi tapahtuu pääsääntöisesti ennen dokumentin jakamista huoltajille. Tarkastele dokumentteja yhdessä lasten ja kasvattajatiimin kanssa. Nosta yhteisistä havainnoista kehittämiskohteita käytännön pedagogiselle työlle, sen tavoitteille ja sisällöille, jotta pedagoginen toiminta vastaa mahdollisimman hyvin yksittäisen lapsen ja lapsiryhmän tarpeita, vahvuuksia ja mielenkiinnon kohteita. Erityistä huomiota kiinnitetään aikuisen toimintaan. Pedagoginen dokumentointi luo pohjan lapsilähtöisen pedagogiikan toteuttamiselle.',
           documentInfo:


### PR DESCRIPTION
Lisätään tieto siitä, että pedagogisiin dokumentteihin ei saa lisätä lapsen terveystietoja tai lausuntoja. Lisäksi lisätään tekstiin marginaali, koska ilman sitä osa infonappulasta leikkaantuu pois.