### PR TITLE
Korjataan viestiketjun merkitseminen luetuksi

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -64,7 +64,6 @@ import {
   getSentMessages,
   getThread,
   getUnreadMessages,
-  markThreadRead,
   getFolders
 } from '../../generated/api-clients/messaging'
 import { UserContext } from '../../state/user'
@@ -89,7 +88,6 @@ const getAccountsByUserResult = wrapResult(getAccountsByUser)
 const getReceivedMessagesResult = wrapResult(getReceivedMessages)
 const getSentMessagesResult = wrapResult(getSentMessages)
 const getUnreadMessagesResult = wrapResult(getUnreadMessages)
-const markThreadReadResult = wrapResult(markThreadRead)
 const getThreadResult = wrapResult(getThread)
 
 type RepliesByThread = Record<UUID, string>
@@ -637,22 +635,8 @@ export const MessageContextProvider = React.memo(
     const selectThread = useCallback(
       (thread: MessageThread | undefined) => {
         setSelectedThread(thread?.id)
-        if (!selectedAccount) throw new Error('Should never happen')
-
-        const accountId = selectedAccount.account.id
-        const hasUnreadMessages = thread?.messages.some(
-          (m) => !m.readAt && m.sender.id !== accountId
-        )
-        if (thread && hasUnreadMessages) {
-          void markThreadReadResult({ accountId, threadId: thread.id }).then(
-            () => {
-              refreshMessages(accountId)
-              void refreshUnreadCounts()
-            }
-          )
-        }
       },
-      [setSelectedThread, selectedAccount, refreshMessages, refreshUnreadCounts]
+      [setSelectedThread]
     )
     const selectedThread = useMemo(
       () =>

--- a/frontend/src/employee-frontend/components/person-profile/PersonFinanceNotesAndMessages.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFinanceNotesAndMessages.tsx
@@ -72,7 +72,6 @@ import {
   draftsQuery,
   financeFoldersQuery,
   financeThreadsQuery,
-  markThreadReadMutation,
   replyToFinanceThreadMutation
 } from '../messages/queries'
 
@@ -98,7 +97,7 @@ export default React.memo(function PersonFinanceNotesAndMessages({
   const { refreshMessages, financeAccount } = useContext(MessageContext)
   const financeNotes = useQueryResult(financeNotesQuery({ personId: id }))
   const [text, setText] = useState<string>('')
-  const financeMessages = useQueryResult(
+  const financeThreads = useQueryResult(
     financeAccount ? financeThreadsQuery({ personId: id }) : constantQuery([])
   )
   const messageFolders = useQueryResult(financeFoldersQuery())
@@ -109,29 +108,6 @@ export default React.memo(function PersonFinanceNotesAndMessages({
       ? draftsQuery({ accountId: financeAccount?.account.id })
       : constantQuery([])
   )
-
-  const { mutateAsync: markThreadRead } = useMutationResult(
-    markThreadReadMutation
-  )
-
-  const financeThreads = useMemo(() => {
-    if (financeMessages.isSuccess && financeAccount) {
-      financeMessages.value.forEach((thread) => {
-        if (
-          thread.messages.some(
-            (m) => !m.readAt && m.sender.id !== financeAccount?.account.id
-          )
-        ) {
-          void markThreadRead({
-            accountId: financeAccount.account.id,
-            threadId: thread.id
-          })
-        }
-      })
-      refreshMessages(financeAccount.account.id)
-    }
-    return financeMessages
-  }, [financeAccount, financeMessages, markThreadRead, refreshMessages])
 
   const onSuccessTimeout = isAutomatedTest ? 10 : 800 // same as used in async-button-behaviour
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageQueriesTest.kt
@@ -179,7 +179,7 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals("Newest thread", thread.title)
 
         // when the thread is marked read for person 1
-        db.transaction { it.markThreadRead(clock, accounts.person1.id, thread1Id) }
+        db.transaction { it.markThreadRead(clock.now(), accounts.person1.id, thread1Id) }
 
         // then the message has correct readAt
         val person1Threads =

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageController.kt
@@ -989,7 +989,7 @@ class MessageController(
     ) {
         db.connect { dbc ->
             requireMessageAccountAccess(dbc, user, clock, accountId)
-            dbc.transaction { it.markThreadRead(clock, accountId, threadId) }
+            dbc.transaction { it.markThreadRead(clock.now(), accountId, threadId) }
         }
         Audit.MessagingMarkMessagesReadWrite.log(targetId = AuditId(listOf(accountId, threadId)))
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageControllerCitizen.kt
@@ -100,7 +100,7 @@ class MessageControllerCitizen(
     ) {
         db.connect { dbc ->
                 val accountId = dbc.read { it.getCitizenMessageAccount(user.id) }
-                dbc.transaction { it.markThreadRead(clock, accountId, threadId) }
+                dbc.transaction { it.markThreadRead(clock.now(), accountId, threadId) }
                 accountId
             }
             .also { accountId ->

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageQueries.kt
@@ -14,7 +14,6 @@ import fi.espoo.evaka.shared.*
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.Predicate
 import fi.espoo.evaka.shared.db.PredicateSql
-import fi.espoo.evaka.shared.domain.EvakaClock
 import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import fi.espoo.evaka.shared.domain.NotFound
@@ -130,11 +129,10 @@ GROUP BY acc.id, acc.daycare_group_id
 }
 
 fun Database.Transaction.markThreadRead(
-    clock: EvakaClock,
+    now: HelsinkiDateTime,
     accountId: MessageAccountId,
     threadId: MessageThreadId,
 ): Int {
-    val now = clock.now()
     return createUpdate {
             sql(
                 """

--- a/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/messaging/MessageService.kt
@@ -329,6 +329,7 @@ class MessageService(
                     )
                 tx.insertRecipients(listOf(messageId to recipientAccountIds))
                 asyncJobRunner.scheduleMarkMessagesAsSent(tx, contentId, now)
+                tx.markThreadRead(now, senderAccount, threadId)
                 if (applicationId != null) {
                     tx.createApplicationNote(
                         now = now,


### PR DESCRIPTION
`Asiakastietosivun avaus ei tulisi merkata talouden viestejä luetuksi. `

-> poistettu toteutus.

`Sen sijaan jos viestiketjun avaa viestintäpuolelle joko talouden viestintä kohdasta tai hakemuksen sivupalkista, viestiketjun tulee merkkaantua luetuksi.`

-> siirretty merkitseminen luetuksi viestiketjun vaihdosta viestiketjun sivulle. Eli nyt mikä tahansa linkki suoraan yksittäiseen viestiketjuun merkitsee sen luetuksi.

  `Lisäksi jos jommassa kummassa näkymässä (hakemuksen viestit / asiakkaan talouden viestit) vastaa viestiin "inline editorilla" viestiketjun tulee merkaantua henkilökunnan puolella luetuksi.`

-> lisätty viestiketjun automaattinen merkitseminen luetuksi kun viestiin vastataan.