### PR TITLE
Poistetaan esiopetuspaikan osoituksesta oletus palveluntarve

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PlacementToolServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/PlacementToolServiceIntegrationTest.kt
@@ -513,6 +513,7 @@ ${child.ssn!!};${unit.id}
                     .trimIndent()
                     .toByteArray(StandardCharsets.UTF_8),
             )
+        whenever(evakaEnv.placementToolServiceNeedOptionId).thenReturn(defaultServiceNeedOption.id)
 
         val validationPre =
             controller.validatePlacementToolApplications(dbInstance(), admin, clock, file)

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -438,7 +438,7 @@ sealed interface AsyncJob : AsyncJobPayload {
     data class PlacementTool(
         override val user: AuthenticatedUser,
         val data: PlacementToolData,
-        val defaultServiceNeedOption: ServiceNeedOptionId,
+        val defaultServiceNeedOption: ServiceNeedOptionId?,
         val nextPreschoolTerm: PreschoolTermId,
     ) : AsyncJob
 
@@ -447,7 +447,7 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser,
         val ssn: String,
         val preschoolId: DaycareId,
-        val defaultServiceNeedOption: ServiceNeedOptionId,
+        val defaultServiceNeedOption: ServiceNeedOptionId?,
         val nextPreschoolTerm: PreschoolTermId,
     ) : AsyncJob
 


### PR DESCRIPTION
Mahdollistetaan pelkän esiopetushakemuksen tekeminen esiopetuspaikan osoittamisessa poistamalla oletus palveluntarpeen asettaminen.

HUOM! esiopetus ja liittyvä varhaiskasvatus hakemuksen saa yhä muodostumaan asettamalla ympäristömuuttujaan `EVAKA_PLACEMENT_TOOL_SERVICE_NEED_OPTION_ID` soveltuvan palveluntarpeen id:n
<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- Lisää linkki dokumentaation relevanttiin kohtaan.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
