### PR TITLE
Muutetaan tulotietojen muistutusviestit haitariin

### DIFF
--- a/frontend/src/e2e-test/pages/employee/guardian-information.ts
+++ b/frontend/src/e2e-test/pages/employee/guardian-information.ts
@@ -342,7 +342,13 @@ export class IncomeSection extends Section {
   #childIncomeStatementsTitles = this.findAllByDataQa(
     'child-income-statement-title'
   )
+  async toggleNotificationsCollapsible() {
+    await this.incomeNotificationsHeader.click()
+  }
 
+  incomeNotificationsHeader = this.findByDataQa(
+    'income-notifications-collapsible-header'
+  )
   incomeNotificationRows = this.findAllByDataQa('income-notification-sent-info')
   incomeNotifications = this.findAllByDataQa('income-notifications')
   confirmRetroactive = new Checkbox(this.findByDataQa('confirm-retroactive'))

--- a/frontend/src/e2e-test/specs/5_employee/income.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/income.spec.ts
@@ -324,6 +324,7 @@ describe('Income', () => {
     }).save()
 
     await page.reload()
+    await incomesSection.toggleNotificationsCollapsible()
     await waitUntilEqual(() => incomesSection.incomeNotificationRows.count(), 3)
     await incomesSection.incomeNotificationRows
       .nth(0)

--- a/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
@@ -46,6 +46,10 @@ interface Props {
   id: PersonId
 }
 
+const StyledCollapsibleContentArea = styled(CollapsibleContentArea)`
+  width: 50%;
+`
+
 export default React.memo(function PersonIncome({ id }: Props) {
   const { i18n } = useTranslation()
   const { permittedActions } = useContext(PersonContext)
@@ -55,10 +59,6 @@ export default React.memo(function PersonIncome({ id }: Props) {
   const children = useQueryResult(
     incomeStatementChildrenQuery({ guardianId: id })
   )
-
-  const StyledCollapsibleContentArea = styled(CollapsibleContentArea)`
-    width: 50%;
-  `
 
   return (
     <>

--- a/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
@@ -14,7 +14,6 @@ import type { IncomeId, PersonId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import Pagination from 'lib-components/Pagination'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
-import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { PersonName } from 'lib-components/molecules/PersonNames'
 import { H3 } from 'lib-components/typography'
@@ -46,15 +45,9 @@ interface Props {
   id: PersonId
 }
 
-const StyledCollapsibleContentArea = styled(CollapsibleContentArea)`
-  width: 50%;
-`
-
 export default React.memo(function PersonIncome({ id }: Props) {
   const { i18n } = useTranslation()
   const { permittedActions } = useContext(PersonContext)
-
-  const [open, setOpen] = useState(false)
 
   const children = useQueryResult(
     incomeStatementChildrenQuery({ guardianId: id })
@@ -65,21 +58,7 @@ export default React.memo(function PersonIncome({ id }: Props) {
       <H3>{i18n.personProfile.incomeStatement.title}</H3>
       <IncomeStatements personId={id} />
       <Gap size="L" />
-      <StyledCollapsibleContentArea
-        data-qa="income-notifications-collapsible"
-        aria-label={i18n.common.showMore}
-        paddingHorizontal="zero"
-        opaque
-        open={open}
-        toggleOpen={() => setOpen(!open)}
-        title={
-          <H3 noMargin>
-            {i18n.personProfile.incomeStatement.notificationsTitle}
-          </H3>
-        }
-      >
-        <IncomeNotifications personId={id} />
-      </StyledCollapsibleContentArea>
+      <IncomeNotifications personId={id} />
       <Gap size="L" />
       {renderResult(children, (children) => (
         <>

--- a/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonIncome.tsx
@@ -14,6 +14,7 @@ import type { IncomeId, PersonId } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import Pagination from 'lib-components/Pagination'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
+import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { PersonName } from 'lib-components/molecules/PersonNames'
 import { H3 } from 'lib-components/typography'
@@ -49,17 +50,36 @@ export default React.memo(function PersonIncome({ id }: Props) {
   const { i18n } = useTranslation()
   const { permittedActions } = useContext(PersonContext)
 
+  const [open, setOpen] = useState(false)
+
   const children = useQueryResult(
     incomeStatementChildrenQuery({ guardianId: id })
   )
+
+  const StyledCollapsibleContentArea = styled(CollapsibleContentArea)`
+    width: 50%;
+  `
 
   return (
     <>
       <H3>{i18n.personProfile.incomeStatement.title}</H3>
       <IncomeStatements personId={id} />
       <Gap size="L" />
-      <H3>{i18n.personProfile.incomeStatement.notificationsTitle}</H3>
-      <IncomeNotifications personId={id} />
+      <StyledCollapsibleContentArea
+        data-qa="income-notifications-collapsible"
+        aria-label={i18n.common.showMore}
+        paddingHorizontal="zero"
+        opaque
+        open={open}
+        toggleOpen={() => setOpen(!open)}
+        title={
+          <H3 noMargin>
+            {i18n.personProfile.incomeStatement.notificationsTitle}
+          </H3>
+        }
+      >
+        <IncomeNotifications personId={id} />
+      </StyledCollapsibleContentArea>
       <Gap size="L" />
       {renderResult(children, (children) => (
         <>

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeNotifications.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeNotifications.tsx
@@ -8,8 +8,10 @@ import React, { useMemo } from 'react'
 import type { PersonId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import UnorderedList from 'lib-components/atoms/UnorderedList'
+import { Button } from 'lib-components/atoms/buttons/Button'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { Label } from 'lib-components/typography'
+import { Gap } from 'lib-components/white-space'
 
 import { useTranslation } from '../../../state/i18n'
 import { renderResult } from '../../async-rendering'
@@ -32,23 +34,45 @@ export const IncomeNotifications = React.memo(function IncomeNotifications({
     [incomeNotifications]
   )
 
+  const initialNotificationAmount = 10
+  const [notificationLimit, setNotificationLimit] = React.useState(
+    initialNotificationAmount
+  )
+
   return renderResult(sortedIncomeNotifications, (notifications) =>
     notifications.length > 0 ? (
       <FixedSpaceColumn spacing="xs">
         <Label>{i18n.personProfile.incomeStatement.notificationSent}</Label>
         <UnorderedList>
-          {notifications.map((n, i) => (
-            <li key={i} data-qa="income-notification-sent-info">
-              {n.created.format()} (
-              {
-                i18n.personProfile.incomeStatement.notificationTypes[
-                  n.notificationType
-                ]
-              }
-              )
-            </li>
-          ))}
+          {notifications
+            .filter((_, i) => i < notificationLimit)
+            .map((n, i) => (
+              <li key={i} data-qa="income-notification-sent-info">
+                {n.created.format()} (
+                {
+                  i18n.personProfile.incomeStatement.notificationTypes[
+                    n.notificationType
+                  ]
+                }
+                )
+              </li>
+            ))}
         </UnorderedList>
+        <Gap size="s" />
+        {notifications.length > notificationLimit && (
+          <Button
+            text={i18n.common.showMore}
+            appearance="inline"
+            onClick={() => setNotificationLimit(notificationLimit + 10)}
+          />
+        )}
+        {notificationLimit > initialNotificationAmount && (
+          <Button
+            text={i18n.common.showLess}
+            appearance="inline"
+            onClick={() => setNotificationLimit(notificationLimit - 10)}
+          />
+        )}
       </FixedSpaceColumn>
     ) : (
       <span>{i18n.personProfile.incomeStatement.noNotifications}</span>

--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeNotifications.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeNotifications.tsx
@@ -4,18 +4,24 @@
 
 import orderBy from 'lodash/orderBy'
 import React, { useMemo } from 'react'
+import styled from 'styled-components'
 
 import type { PersonId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import UnorderedList from 'lib-components/atoms/UnorderedList'
 import { Button } from 'lib-components/atoms/buttons/Button'
+import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
-import { Label } from 'lib-components/typography'
+import { H3, Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
 import { useTranslation } from '../../../state/i18n'
 import { renderResult } from '../../async-rendering'
 import { incomeNotificationsQuery } from '../queries'
+
+const StyledCollapsibleContentArea = styled(CollapsibleContentArea)`
+  width: 50%;
+`
 
 export const IncomeNotifications = React.memo(function IncomeNotifications({
   personId
@@ -38,44 +44,59 @@ export const IncomeNotifications = React.memo(function IncomeNotifications({
   const [notificationLimit, setNotificationLimit] = React.useState(
     initialNotificationAmount
   )
+  const [open, setOpen] = React.useState(false)
 
-  return renderResult(sortedIncomeNotifications, (notifications) =>
-    notifications.length > 0 ? (
-      <FixedSpaceColumn spacing="xs">
-        <Label>{i18n.personProfile.incomeStatement.notificationSent}</Label>
-        <UnorderedList>
-          {notifications
-            .filter((_, i) => i < notificationLimit)
-            .map((n, i) => (
-              <li key={i} data-qa="income-notification-sent-info">
-                {n.created.format()} (
-                {
-                  i18n.personProfile.incomeStatement.notificationTypes[
-                    n.notificationType
-                  ]
-                }
-                )
-              </li>
-            ))}
-        </UnorderedList>
-        <Gap size="s" />
-        {notifications.length > notificationLimit && (
-          <Button
-            text={i18n.common.showMore}
-            appearance="inline"
-            onClick={() => setNotificationLimit(notificationLimit + 10)}
-          />
-        )}
-        {notificationLimit > initialNotificationAmount && (
-          <Button
-            text={i18n.common.showLess}
-            appearance="inline"
-            onClick={() => setNotificationLimit(notificationLimit - 10)}
-          />
-        )}
-      </FixedSpaceColumn>
-    ) : (
-      <span>{i18n.personProfile.incomeStatement.noNotifications}</span>
-    )
-  )
+  return renderResult(sortedIncomeNotifications, (notifications) => (
+    <StyledCollapsibleContentArea
+      data-qa="income-notifications-collapsible"
+      aria-label={i18n.common.showMore}
+      paddingHorizontal="zero"
+      opaque
+      open={open}
+      toggleOpen={() => setOpen(!open)}
+      title={
+        <H3 noMargin>
+          {i18n.personProfile.incomeStatement.notificationsTitle}
+        </H3>
+      }
+    >
+      {notifications.length > 0 ? (
+        <FixedSpaceColumn spacing="xs">
+          <Label>{i18n.personProfile.incomeStatement.notificationSent}</Label>
+          <UnorderedList>
+            {notifications
+              .filter((_, i) => i < notificationLimit)
+              .map((n, i) => (
+                <li key={i} data-qa="income-notification-sent-info">
+                  {n.created.format()} (
+                  {
+                    i18n.personProfile.incomeStatement.notificationTypes[
+                      n.notificationType
+                    ]
+                  }
+                  )
+                </li>
+              ))}
+          </UnorderedList>
+          <Gap size="s" />
+          {notifications.length > notificationLimit && (
+            <Button
+              text={i18n.common.showMore}
+              appearance="inline"
+              onClick={() => setNotificationLimit(notificationLimit + 10)}
+            />
+          )}
+          {notificationLimit > initialNotificationAmount && (
+            <Button
+              text={i18n.common.showLess}
+              appearance="inline"
+              onClick={() => setNotificationLimit(notificationLimit - 10)}
+            />
+          )}
+        </FixedSpaceColumn>
+      ) : (
+        <span>{i18n.personProfile.incomeStatement.noNotifications}</span>
+      )}
+    </StyledCollapsibleContentArea>
+  ))
 })

--- a/frontend/src/employee-frontend/components/reports/HolidayPeriodAttendanceReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/HolidayPeriodAttendanceReport.tsx
@@ -330,7 +330,7 @@ const DailyPeriodAttendanceRow = React.memo(function DailyPeriodAttendanceRow(
       <TinyTd data-qa="resize-column">
         <Button
           text=""
-          aria-label={i18n.reports.holidayPeriodAttendance.showMoreButton}
+          aria-label={i18n.common.showMore}
           onClick={() => expansion.toggle()}
           icon={isExpanded ? faChevronDown : faChevronRight}
           appearance="link"

--- a/frontend/src/employee-frontend/components/reports/HolidayQuestionnaireReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/HolidayQuestionnaireReport.tsx
@@ -334,7 +334,7 @@ const DailyQuestionnaireRow = React.memo(function DailyQuestionnaireRow(
       <TinyTd data-qa="resize-column">
         <Button
           text=""
-          aria-label={i18n.reports.holidayQuestionnaire.showMoreButton}
+          aria-label={i18n.common.showMore}
           onClick={() => expansion.toggle()}
           icon={isExpanded ? faChevronDown : faChevronRight}
           appearance="link"

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyView.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyView.tsx
@@ -175,10 +175,7 @@ const ReservationCalendarSection = React.memo(
             >
               <ExpandHorizonButton
                 onClick={expandCalendarAction}
-                text={
-                  i18n.unit.calendar.events.discussionReservation.calendar
-                    .addTimeButton
-                }
+                text={i18n.common.showMore}
                 data-qa="expand-horizon-button"
               />
             </FixedSpaceRow>

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/survey-editor/DiscussionTimesForm.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/survey-editor/DiscussionTimesForm.tsx
@@ -174,10 +174,7 @@ export default React.memo(function DiscussionTimesForm({
                 >
                   <LegacyButton
                     onClick={extendHorizonAction}
-                    text={
-                      i18n.unit.calendar.events.discussionReservation.calendar
-                        .addTimeButton
-                    }
+                    text={i18n.common.showMore}
                   />
                 </FixedSpaceRow>
                 <Gap size="m" />

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -246,7 +246,9 @@ export const fi = {
       EMPLOYEE: 'työntekijä',
       MOBILE_DEVICE: 'mobiililaite',
       UNKNOWN: 'tuntematon'
-    }
+    },
+    showMore: 'Näytä lisää',
+    showLess: 'Piilota'
   },
   header: {
     applications: 'Hakemukset',
@@ -2571,7 +2573,6 @@ export const fi = {
         },
         discussionReservation: {
           calendar: {
-            addTimeButton: 'Näytä lisää',
             eventTooltipTitle: 'Muita tapahtumia:',
             otherEventSingular: 'muu tapahtuma',
             otherEventPlural: 'muuta tapahtumaa'
@@ -4605,8 +4606,7 @@ export const fi = {
       staffColumn: 'Hlö. kunnan tarve',
       absentColumn: 'Poissa',
       noResponseColumn: 'Ei vastannut',
-      moreText: 'lisää',
-      showMoreButton: 'Näytä lisää'
+      moreText: 'lisää'
     },
     holidayQuestionnaire: {
       title: 'Poissaolokyselyraportti',
@@ -4627,8 +4627,7 @@ export const fi = {
       staffColumn: 'Hlö. kunnan tarve',
       absentColumn: 'Poissa',
       noResponseColumn: 'Ei vastannut',
-      moreText: 'lisää',
-      showMoreButton: 'Näytä lisää'
+      moreText: 'lisää'
     },
     tampereRegionalSurvey: {
       title: 'Tampereen alueen seutuselvitys',


### PR DESCRIPTION
Muutetaan tulotietojen muistutusviestit haitariin, jossa näytetään oletuksena 10 muistutusviestiä. Viestäjä näytetään lisää "Näytä lisää" napilla ja näytetään vähemmän "Piilota" napilla. Napit lisäävät ja vähentävät 10 viestiä kerrallaan.