### PR TITLE
Korjaus Digitransit osoitehakuun

### DIFF
--- a/frontend/src/citizen-frontend/map/SearchInput.tsx
+++ b/frontend/src/citizen-frontend/map/SearchInput.tsx
@@ -46,8 +46,8 @@ export default React.memo(function SearchInput({
   const debouncedInputString = useDebounce(inputString, 500)
 
   const addressOptions = useQueryResult(
-    debouncedInputString.length > 0
-      ? addressOptionsQuery(debouncedInputString)
+    debouncedInputString.trim().length > 0
+      ? addressOptionsQuery(debouncedInputString.trim())
       : constantQuery([])
   )
 


### PR DESCRIPTION
Korjataan Digitransit osoitehaun bugi, jossa osoitetta yritetään hakea välilyönti hakuehtona. Osoitehaun hakuehto trimmataan  ja osoitehakua ei suoriteta tyhjällä hakuehdolla.