### PR TITLE
Varmannetaan molemmat SAML allekirjoitukset

### DIFF
--- a/apigw/src/shared/saml/index.ts
+++ b/apigw/src/shared/saml/index.ts
@@ -48,11 +48,8 @@ export function createSamlConfig(
     privateKey: privateCert,
     signatureAlgorithm: 'sha256',
     validateInResponseTo: config.validateInResponseTo,
-    // When *both* wantXXXXSigned settings are false, node-saml still
-    // requires at least the whole response *or* the assertion to be signed, so
-    // these settings don't introduce a security problem
-    wantAssertionsSigned: false,
-    wantAuthnResponseSigned: false
+    wantAssertionsSigned: true,
+    wantAuthnResponseSigned: true
   }
 }
 


### PR DESCRIPTION
## Ennen tätä muutosta
SAML kirjautumisen (Active Directory & Suomi.fi) vastausten allekirjoitustarkistus toimi löyhemmillä säännöillä:

- `wantAssertionsSigned: false` - SAML-tunnistusten allekirjoitusta ei vaadittu eksplisiittisesti
- `wantAuthnResponseSigned: false` - SAML-vastauksen allekirjoitusta ei vaadittu eksplisiittisesti
- Järjestelmä vaati vähintään joko vastauksen TAI tunnistuksen olevan allekirjoitettu

## Tämän muutoksen jälkeen
SAML-vastausten allekirjoitustarkistus tiukennettu:

- `wantAssertionsSigned: true` - SAML-tunnistusten allekirjoitus vaaditaan aina
- `wantAuthnResponseSigned: true` - SAML-vastauksen allekirjoitus vaaditaan aina

Järjestelmä vaatii nyt sekä koko SAML-vastauksen errä sen tunnistusten olevan allekirjoitettuja, mikä parantaa turvallisuutta man-in-the-middle -hyökkäyksiä vastaan.

## Muutoksen yhteensopivuus AD ja Suomi.fi kirjautumisen kanssa täytyy vielä tarkastaa