### PR TITLE
Korjataan esiopetuksen poissaolohakemus

### DIFF
--- a/frontend/src/citizen-frontend/children/sections/absence-applications/NewAbsenceApplicationForm.tsx
+++ b/frontend/src/citizen-frontend/children/sections/absence-applications/NewAbsenceApplicationForm.tsx
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2017-2025 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import type { ReactNode } from 'react'
+import React from 'react'
+import { useLocation } from 'wouter'
+
+import type FiniteDateRange from 'lib-common/finite-date-range'
+import { boolean, localDateRange, string } from 'lib-common/form/fields'
+import {
+  mapped,
+  object,
+  required,
+  transformed,
+  validated,
+  value
+} from 'lib-common/form/form'
+import { useForm, useFormField, useFormFields } from 'lib-common/form/hooks'
+import { ValidationError, ValidationSuccess } from 'lib-common/form/types'
+import { nonBlank } from 'lib-common/form/validators'
+import type { ChildId, PersonId } from 'lib-common/generated/api-types/shared'
+import LocalDate from 'lib-common/local-date'
+import Main from 'lib-components/atoms/Main'
+import { Button } from 'lib-components/atoms/buttons/Button'
+import { MutateButton } from 'lib-components/atoms/buttons/MutateButton'
+import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
+import { CheckboxF } from 'lib-components/atoms/form/Checkbox'
+import { InputFieldF } from 'lib-components/atoms/form/InputField'
+import Container, { ContentArea } from 'lib-components/layout/Container'
+import {
+  FixedSpaceColumn,
+  FixedSpaceRow
+} from 'lib-components/layout/flex-helpers'
+import { DateRangePickerF } from 'lib-components/molecules/date-picker/DateRangePicker'
+import { H1, Label } from 'lib-components/typography'
+import { Gap } from 'lib-components/white-space'
+
+import Footer from '../../../Footer'
+import { useLang, useTranslation } from '../../../localization'
+
+import { postAbsenceApplicationMutation } from './queries'
+
+const dateRangeFunction = () =>
+  transformed(
+    object({
+      range: localDateRange(),
+      allowedDateRanges: value<FiniteDateRange[]>()
+    }),
+    (output) => {
+      if (output.range === undefined) return ValidationSuccess.of(undefined)
+      if (
+        !output.allowedDateRanges.some(
+          (dateRange) =>
+            dateRange.includes(output.range!.start) ||
+            dateRange.includes(output.range!.end)
+        )
+      )
+        return ValidationError.of('invalidDateRange')
+      return ValidationSuccess.of(output.range)
+    }
+  )
+
+const formModel = mapped(
+  object({
+    childId: required(value<ChildId>()),
+    range: required(dateRangeFunction()),
+    description: validated(string(), nonBlank),
+    confirmation: validated(boolean(), (value) =>
+      !value ? 'required' : undefined
+    )
+  }),
+  (output) => ({
+    childId: output.childId,
+    startDate: output.range.start,
+    endDate: output.range.end,
+    description: output.description
+  })
+)
+
+export const NewAbsenceApplicationForm = ({
+  childId,
+  absenceApplicationDateRanges
+}: {
+  childId: PersonId
+  absenceApplicationDateRanges: FiniteDateRange[]
+}): ReactNode => {
+  const i18n = useTranslation()
+  const [lang] = useLang()
+  const form = useForm(
+    formModel,
+    () => ({
+      childId,
+      range: {
+        range: localDateRange.fromRange(null, {
+          minDate: LocalDate.todayInHelsinkiTz()
+        }),
+        allowedDateRanges: absenceApplicationDateRanges
+      },
+      description: '',
+      confirmation: false
+    }),
+    {
+      ...i18n.validationErrors,
+      ...i18n.children.absenceApplication.newPage.validationErrors
+    }
+  )
+  const { range, description, confirmation } = useFormFields(form)
+  const innerRange = useFormField(range, 'range')
+  const [, navigate] = useLocation()
+
+  return (
+    <>
+      <Main>
+        <Container>
+          <ReturnButton label={i18n.common.return} />
+          <ContentArea opaque>
+            <H1 noMargin>{i18n.children.absenceApplication.newPage.title}</H1>
+            <Gap />
+            <FixedSpaceColumn>
+              <div>
+                <Label>{i18n.children.absenceApplication.newPage.range}</Label>
+                <DateRangePickerF
+                  bind={innerRange}
+                  locale={lang}
+                  hideErrorsBeforeTouched
+                  info={range.inputInfo()}
+                />
+                <Label>{i18n.children.absenceApplication.description}</Label>
+                <InputFieldF
+                  bind={description}
+                  hideErrorsBeforeTouched
+                  data-qa="description"
+                />
+              </div>
+              <div>{i18n.children.absenceApplication.newPage.info}</div>
+              <CheckboxF
+                bind={confirmation}
+                label={i18n.children.absenceApplication.newPage.confirmation}
+                data-qa="confirmation"
+              />
+              <FixedSpaceRow justifyContent="space-between">
+                <Button
+                  text={i18n.common.cancel}
+                  appearance="button"
+                  onClick={() => navigate(`/children/${childId}`)}
+                />
+                <MutateButton
+                  text={i18n.children.serviceApplication.send}
+                  mutation={postAbsenceApplicationMutation}
+                  appearance="button"
+                  primary
+                  disabled={!form.isValid()}
+                  onClick={() => ({
+                    body: form.value()
+                  })}
+                  onSuccess={() => navigate(`/children/${childId}`)}
+                  data-qa="create-button"
+                />
+              </FixedSpaceRow>
+            </FixedSpaceColumn>
+          </ContentArea>
+        </Container>
+      </Main>
+      <Footer />
+    </>
+  )
+}

--- a/frontend/src/citizen-frontend/children/sections/absence-applications/NewAbsenceApplicationForm.tsx
+++ b/frontend/src/citizen-frontend/children/sections/absence-applications/NewAbsenceApplicationForm.tsx
@@ -41,7 +41,7 @@ import { useLang, useTranslation } from '../../../localization'
 
 import { postAbsenceApplicationMutation } from './queries'
 
-const dateRangeFunction = () =>
+const validatedAbsenceDateRange = () =>
   transformed(
     object({
       range: localDateRange(),
@@ -64,7 +64,7 @@ const dateRangeFunction = () =>
 const formModel = mapped(
   object({
     childId: required(value<ChildId>()),
-    range: required(dateRangeFunction()),
+    range: required(validatedAbsenceDateRange()),
     description: validated(string(), nonBlank),
     confirmation: validated(boolean(), (value) =>
       !value ? 'required' : undefined

--- a/frontend/src/citizen-frontend/children/sections/absence-applications/NewAbsenceApplicationPage.tsx
+++ b/frontend/src/citizen-frontend/children/sections/absence-applications/NewAbsenceApplicationPage.tsx
@@ -3,132 +3,32 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import React from 'react'
-import { useLocation } from 'wouter'
 
-import { boolean, localDateRange, string } from 'lib-common/form/fields'
-import {
-  mapped,
-  object,
-  required,
-  validated,
-  value
-} from 'lib-common/form/form'
-import { useForm, useFormFields } from 'lib-common/form/hooks'
-import { nonBlank } from 'lib-common/form/validators'
 import type { ChildId } from 'lib-common/generated/api-types/shared'
-import LocalDate from 'lib-common/local-date'
+import { useQueryResult } from 'lib-common/query'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
-import Main from 'lib-components/atoms/Main'
-import { Button } from 'lib-components/atoms/buttons/Button'
-import { MutateButton } from 'lib-components/atoms/buttons/MutateButton'
-import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
-import { CheckboxF } from 'lib-components/atoms/form/Checkbox'
-import { InputFieldF } from 'lib-components/atoms/form/InputField'
-import Container, { ContentArea } from 'lib-components/layout/Container'
-import {
-  FixedSpaceColumn,
-  FixedSpaceRow
-} from 'lib-components/layout/flex-helpers'
-import { DateRangePickerF } from 'lib-components/molecules/date-picker/DateRangePicker'
-import { H1, Label } from 'lib-components/typography'
-import { Gap } from 'lib-components/white-space'
 
-import Footer from '../../../Footer'
-import { useLang, useTranslation } from '../../../localization'
+import { renderResult } from '../../../async-rendering'
 
-import { postAbsenceApplicationMutation } from './queries'
-
-const formModel = mapped(
-  object({
-    childId: required(value<ChildId>()),
-    range: required(localDateRange()),
-    description: validated(string(), nonBlank),
-    confirmation: validated(boolean(), (value) =>
-      !value ? 'required' : undefined
-    )
-  }),
-  (output) => ({
-    childId: output.childId,
-    startDate: output.range.start,
-    endDate: output.range.end,
-    description: output.description
-  })
-)
+import { NewAbsenceApplicationForm } from './NewAbsenceApplicationForm'
+import { getAbsenceApplicationPossibleDateRangesQuery } from './queries'
 
 export const NewAbsenceApplicationPage = () => {
   const childId = useIdRouteParam<ChildId>('childId')
-  const i18n = useTranslation()
-  const [lang] = useLang()
-  const form = useForm(
-    formModel,
-    () => ({
-      childId,
-      range: localDateRange.fromRange(null, {
-        minDate: LocalDate.todayInHelsinkiTz()
-      }),
-      description: '',
-      confirmation: false
-    }),
-    i18n.validationErrors
+  const absenceApplicationDateRanges = useQueryResult(
+    getAbsenceApplicationPossibleDateRangesQuery({ childId: childId })
   )
-  const { range, description, confirmation } = useFormFields(form)
-  const [, navigate] = useLocation()
-
   return (
     <>
-      <Main>
-        <Container>
-          <ReturnButton label={i18n.common.return} />
-          <ContentArea opaque>
-            <H1 noMargin>{i18n.children.absenceApplication.newPage.title}</H1>
-            <Gap />
-            <FixedSpaceColumn>
-              <div>
-                <Label>{i18n.children.absenceApplication.newPage.range}</Label>
-                <DateRangePickerF
-                  bind={range}
-                  locale={lang}
-                  hideErrorsBeforeTouched
-                />
-              </div>
-              <div>
-                <Label>{i18n.children.absenceApplication.description}</Label>
-                <InputFieldF
-                  bind={description}
-                  hideErrorsBeforeTouched
-                  data-qa="description"
-                />
-              </div>
-              <div>{i18n.children.absenceApplication.newPage.info}</div>
-              <CheckboxF
-                bind={confirmation}
-                label={i18n.children.absenceApplication.newPage.confirmation}
-                data-qa="confirmation"
-              />
-              <FixedSpaceRow justifyContent="space-between">
-                <Button
-                  text={i18n.common.cancel}
-                  appearance="button"
-                  onClick={() => navigate(`/children/${childId}`)}
-                />
-                <MutateButton
-                  text={i18n.children.serviceApplication.send}
-                  mutation={postAbsenceApplicationMutation}
-                  appearance="button"
-                  primary
-                  disabled={!form.isValid()}
-                  onClick={() => ({
-                    body: form.value()
-                  })}
-                  onSuccess={() => navigate(`/children/${childId}`)}
-                  data-qa="create-button"
-                />
-              </FixedSpaceRow>
-            </FixedSpaceColumn>
-          </ContentArea>
-        </Container>
-      </Main>
-      <Footer />
+      {renderResult(
+        absenceApplicationDateRanges,
+        (absenceApplicationDateRanges) => (
+          <NewAbsenceApplicationForm
+            childId={childId}
+            absenceApplicationDateRanges={absenceApplicationDateRanges}
+          />
+        )
+      )}
     </>
   )
 }

--- a/frontend/src/citizen-frontend/children/sections/absence-applications/queries.ts
+++ b/frontend/src/citizen-frontend/children/sections/absence-applications/queries.ts
@@ -6,6 +6,7 @@ import { Queries } from 'lib-common/query'
 
 import {
   deleteAbsenceApplication,
+  getAbsenceApplicationPossibleDateRanges,
   getAbsenceApplications,
   postAbsenceApplication
 } from '../../../generated/api-clients/absence'
@@ -20,4 +21,8 @@ export const postAbsenceApplicationMutation = q.mutation(
 export const deleteAbsenceApplicationMutation = q.mutation(
   deleteAbsenceApplication,
   [getAbsenceApplicationsQuery.prefix]
+)
+
+export const getAbsenceApplicationPossibleDateRangesQuery = q.query(
+  getAbsenceApplicationPossibleDateRanges
 )

--- a/frontend/src/citizen-frontend/generated/api-clients/absence.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/absence.ts
@@ -7,6 +7,7 @@
 import type { AbsenceApplicationCreateRequest } from 'lib-common/generated/api-types/absence'
 import type { AbsenceApplicationId } from 'lib-common/generated/api-types/shared'
 import type { AbsenceApplicationSummaryCitizen } from 'lib-common/generated/api-types/absence'
+import FiniteDateRange from 'lib-common/finite-date-range'
 import type { JsonCompatible } from 'lib-common/json'
 import type { JsonOf } from 'lib-common/json'
 import type { PersonId } from 'lib-common/generated/api-types/shared'
@@ -29,6 +30,26 @@ export async function deleteAbsenceApplication(
     method: 'DELETE'
   })
   return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.absence.application.AbsenceApplicationControllerCitizen.getAbsenceApplicationPossibleDateRanges
+*/
+export async function getAbsenceApplicationPossibleDateRanges(
+  request: {
+    childId: PersonId
+  }
+): Promise<FiniteDateRange[]> {
+  const params = createUrlSearchParams(
+    ['childId', request.childId]
+  )
+  const { data: json } = await client.request<JsonOf<FiniteDateRange[]>>({
+    url: uri`/citizen/absence-application/application-possible`.toString(),
+    method: 'GET',
+    params
+  })
+  return json.map((x) => FiniteDateRange.parseJson(x))
 }
 
 

--- a/frontend/src/e2e-test/pages/citizen/citizen-new-absence-application.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-new-absence-application.ts
@@ -10,6 +10,7 @@ export class CitizenNewAbsenceApplicationPage {
   endDate: DatePicker
   description: TextInput
   confirmation: Checkbox
+  dateRangeWarning: Element
   createButton: Element
 
   constructor(page: Page) {
@@ -17,6 +18,9 @@ export class CitizenNewAbsenceApplicationPage {
     this.endDate = new DatePicker(page.findByDataQa('end-date'))
     this.description = new TextInput(page.findByDataQa('description'))
     this.confirmation = new Checkbox(page.findByDataQa('confirmation'))
+    this.dateRangeWarning = page.find(
+      `span:has-text("Lapsella ei ole esiopetusta valitulla aikavälillä")`
+    )
     this.createButton = page.findByDataQa('create-button')
   }
 }

--- a/frontend/src/e2e-test/specs/absence-application/absence-application.spec.ts
+++ b/frontend/src/e2e-test/specs/absence-application/absence-application.spec.ts
@@ -462,6 +462,16 @@ describe('Absence application', () => {
     await newAbsenceApplicationPage.description.fill('test')
     await newAbsenceApplicationPage.confirmation.check()
     await newAbsenceApplicationPage.createButton.assertDisabled(false)
+    await newAbsenceApplicationPage.createButton.click()
+
+    await citizenChildPage.openCollapsible('absence-applications')
+    await citizenChildPage.assertAbsenceApplications([
+      {
+        range: '05.05.2025 - 13.05.2025',
+        status: 'Odottaa päätöstä',
+        description: 'test'
+      }
+    ])
   })
 })
 

--- a/frontend/src/e2e-test/specs/absence-application/absence-application.spec.ts
+++ b/frontend/src/e2e-test/specs/absence-application/absence-application.spec.ts
@@ -13,7 +13,7 @@ import CitizenCalendarPage from '../../pages/citizen/citizen-calendar'
 import type { CitizenChildPage } from '../../pages/citizen/citizen-children'
 import CitizenHeader from '../../pages/citizen/citizen-header'
 import { UnitPage } from '../../pages/employee/units/unit'
-import { Checkbox, DatePicker, Page, TextInput } from '../../utils/page'
+import { Page } from '../../utils/page'
 import { employeeLogin, enduserLogin } from '../../utils/user'
 
 beforeEach(() => resetServiceState())
@@ -416,23 +416,21 @@ describe('Absence application', () => {
       citizenCustomizations: { featureFlags: { absenceApplications: true } }
     })
     await enduserLogin(page, adult)
-    await page.goto(
-      `http://localhost:9099/children/${child.id}/absence-application`
+    const citizenHeader = new CitizenHeader(page)
+    const citizenChildPage = await citizenHeader.openChildPage(child.id)
+    await citizenChildPage.openCollapsible('absence-applications')
+    const newAbsenceApplicationPage =
+      await citizenChildPage.newAbsenceApplicationPage()
+    await newAbsenceApplicationPage.startDate.fill(
+      mockedTime.toLocalDate().addDays(1)
     )
-    const startDate = new DatePicker(page.findByDataQa('start-date'))
-    const endDate = new DatePicker(page.findByDataQa('end-date'))
-    const description = new TextInput(page.findByDataQa('description'))
-    const confirmation = new Checkbox(page.findByDataQa('confirmation'))
-    await startDate.fill(mockedTime.toLocalDate().addDays(1))
-    await endDate.fill(mockedTime.toLocalDate().addDays(1))
-    await description.fill('test')
-    await confirmation.check()
-    await page
-      .find(
-        `span:has-text("Lapsella ei ole esiopetusta valitulla aikavälillä")`
-      )
-      .waitUntilVisible()
-    await page.findByDataQa('create-button').assertDisabled(true)
+    await newAbsenceApplicationPage.endDate.fill(
+      mockedTime.toLocalDate().addDays(1)
+    )
+    await newAbsenceApplicationPage.description.fill('test')
+    await newAbsenceApplicationPage.confirmation.check()
+    await newAbsenceApplicationPage.dateRangeWarning.waitUntilVisible()
+    await newAbsenceApplicationPage.createButton.assertDisabled(true)
   })
 
   test('Form is valid if absence date range is partly within placement date range', async () => {
@@ -452,18 +450,18 @@ describe('Absence application', () => {
       citizenCustomizations: { featureFlags: { absenceApplications: true } }
     })
     await enduserLogin(page, adult)
-    await page.goto(
-      `http://localhost:9099/children/${child.id}/absence-application`
+    const citizenHeader = new CitizenHeader(page)
+    const citizenChildPage = await citizenHeader.openChildPage(child.id)
+    await citizenChildPage.openCollapsible('absence-applications')
+    const newAbsenceApplicationPage =
+      await citizenChildPage.newAbsenceApplicationPage()
+    await newAbsenceApplicationPage.startDate.fill(mockedTime.toLocalDate())
+    await newAbsenceApplicationPage.endDate.fill(
+      mockedTime.toLocalDate().addDays(8)
     )
-    const startDate = new DatePicker(page.findByDataQa('start-date'))
-    const endDate = new DatePicker(page.findByDataQa('end-date'))
-    const description = new TextInput(page.findByDataQa('description'))
-    const confirmation = new Checkbox(page.findByDataQa('confirmation'))
-    await startDate.fill(mockedTime.toLocalDate())
-    await endDate.fill(mockedTime.toLocalDate().addDays(8))
-    await description.fill('test')
-    await confirmation.check()
-    await page.findByDataQa('create-button').assertDisabled(false)
+    await newAbsenceApplicationPage.description.fill('test')
+    await newAbsenceApplicationPage.confirmation.check()
+    await newAbsenceApplicationPage.createButton.assertDisabled(false)
   })
 })
 

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
@@ -180,13 +180,14 @@ export const DateRangePickerF = React.memo(function DateRangePickerF({
 
   const handleChange = useCallback(
     ([newStart, newEnd]: [string, string]) => {
+      useTouched.on()
       update((prev) => ({
         ...prev,
         start: newStart,
         end: newEnd
       }))
     },
-    [update]
+    [update, useTouched]
   )
   const info = infoOverride ?? bind.inputInfo()
 

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -2631,7 +2631,11 @@ const en: Translations = {
         range: 'Aika, jonka lapsi on poissa esiopetuksesta (en)',
         info: 'Hakemuksesi lähtee esiopetuksesta vastaavalle henkilökunnalle hyväksyttäväksi. (en)',
         confirmation:
-          'Ymmärrän, että henkilökunta merkitsee lapselleni poissaolon vasta, kun hakemus on hyväksytty. (en)'
+          'Ymmärrän, että henkilökunta merkitsee lapselleni poissaolon vasta, kun hakemus on hyväksytty. (en)',
+        validationErrors: {
+          invalidDateRange:
+            'Lapsella ei ole esiopetusta valitulla aikavälillä. (en)'
+        }
       }
     },
     serviceApplication: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2820,7 +2820,10 @@ export default {
         range: 'Aika, jonka lapsi on poissa esiopetuksesta',
         info: 'Hakemuksesi lähtee esiopetuksesta vastaavalle henkilökunnalle hyväksyttäväksi.',
         confirmation:
-          'Ymmärrän, että henkilökunta merkitsee lapselleni poissaolon vasta, kun hakemus on hyväksytty.'
+          'Ymmärrän, että henkilökunta merkitsee lapselleni poissaolon vasta, kun hakemus on hyväksytty.',
+        validationErrors: {
+          invalidDateRange: 'Lapsella ei ole esiopetusta valitulla aikavälillä.'
+        }
       }
     },
     serviceApplication: {

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2873,7 +2873,11 @@ const sv: Translations = {
         range: 'Aika, jonka lapsi on poissa esiopetuksesta (sv)',
         info: 'Hakemuksesi lähtee esiopetuksesta vastaavalle henkilökunnalle hyväksyttäväksi. (sv)',
         confirmation:
-          'Ymmärrän, että henkilökunta merkitsee lapselleni poissaolon vasta, kun hakemus on hyväksytty. (sv)'
+          'Ymmärrän, että henkilökunta merkitsee lapselleni poissaolon vasta, kun hakemus on hyväksytty. (sv)',
+        validationErrors: {
+          invalidDateRange:
+            'Lapsella ei ole esiopetusta valitulla aikavälillä. (sv)'
+        }
       }
     },
     serviceApplication: {

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -51,6 +51,7 @@ enum class Audit(
     AbsenceApplicationAccept,
     AbsenceApplicationCreate,
     AbsenceApplicationDelete,
+    AbsenceApplicationPossibleRead,
     AbsenceApplicationRead,
     AbsenceApplicationReject,
     AbsenceCitizenCreate,

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/application/AbsenceApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/application/AbsenceApplicationQueries.kt
@@ -12,6 +12,7 @@ import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.Predicate
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
+import java.time.LocalDate
 
 fun Database.Transaction.insertAbsenceApplication(
     application: AbsenceApplicationCreateRequest,
@@ -129,7 +130,8 @@ RETURNING id,
         .exactlyOne<AbsenceApplication>()
 
 fun Database.Read.getChildrenWithAbsenceApplicationPossibleOnSomeDate(
-    childIds: Set<ChildId>
+    childIds: Set<ChildId>,
+    today: LocalDate,
 ): Set<ChildId> =
     createQuery {
             sql(
@@ -138,6 +140,7 @@ SELECT DISTINCT child_id
 FROM placement
 WHERE type = ANY (${bind(PlacementType.preschool)})
   AND child_id = ANY (${bind(childIds)})
+  AND daterange(start_date, end_date, '[]') && daterange(${bind(today)}, null, '[]')
         """
             )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/children/ChildControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/children/ChildControllerCitizen.kt
@@ -58,7 +58,10 @@ class ChildControllerCitizen(private val accessControl: AccessControl) {
                             clock.today(),
                         )
                     val absenceApplicationPossible =
-                        tx.getChildrenWithAbsenceApplicationPossibleOnSomeDate(childIds.toSet())
+                        tx.getChildrenWithAbsenceApplicationPossibleOnSomeDate(
+                            childIds.toSet(),
+                            clock.today(),
+                        )
                     val permittedActions =
                         accessControl.getPermittedActions<ChildId, Action.Citizen.Child>(
                             tx,


### PR DESCRIPTION
Lisätään esiopetuksen poissaolohakemukseen poissaolon aikavälin validointi. Esiopetuksen poissaoloa ei voi hakea, jos poissaolon aikaväli ei osu edes osaksi esiopetuksen sijoituksen sisälle. Poissaolohakemus linkkiä ei myöskään näytetä jos lapsella on jo loppunut esiopetuksen sijoitus.