### PR TITLE
Näytetään hakemuspäätöksen asianhallinnan metadata kuntalaiselle

### DIFF
--- a/frontend/src/citizen-frontend/decisions/decisions-page/ApplicationDecision.tsx
+++ b/frontend/src/citizen-frontend/decisions/decisions-page/ApplicationDecision.tsx
@@ -22,9 +22,12 @@ import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import ListGrid from 'lib-components/layout/ListGrid'
 import { H3, Label, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
+import { featureFlags } from 'lib-customizations/citizen'
 import { theme } from 'lib-customizations/common'
 
+import { applicationMetadataQuery } from '../../applications/queries'
 import { useTranslation } from '../../localization'
+import { MetadataSection } from '../../metadata/MetadataSection'
 import { PdfLink } from '../PdfLink'
 
 const preschoolInfoTypes: DecisionType[] = [
@@ -114,6 +117,15 @@ export default React.memo(function ApplicationDecision({
               <PdfLink decisionId={id} />
             </>
           )}
+      {featureFlags.showMetadataToCitizen && (
+        <>
+          <Gap size="s" />
+          <MetadataSection
+            data-qa={applicationId}
+            query={applicationMetadataQuery({ applicationId })}
+          />
+        </>
+      )}
     </CollapsibleContentArea>
   )
 })

--- a/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-decisions.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import type { ApplicationId } from 'lib-common/generated/api-types/shared'
+
 import { waitUntilEqual } from '../../utils'
 import type { Page, Element } from '../../utils/page'
 
@@ -199,6 +201,11 @@ export default class CitizenDecisionsPage {
   async assertNoChildDecisions(childId: string) {
     await this.page.findByDataQa('decisions-page').waitUntilVisible()
     await this.page.findByDataQa(`child-decisions-${childId}`).waitUntilHidden()
+  }
+
+  async viewDecisionMetadata(applicationId: ApplicationId) {
+    await this.page.findByDataQa(`metadata-toggle-${applicationId}`).click()
+    await this.page.findByDataQa('process-number-field').waitUntilVisible()
   }
 }
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-decisions.spec.ts
@@ -252,6 +252,32 @@ describe('Citizen application decisions', () => {
     // other guardian can only see the decisions but not resolve them -> not shown in counts
     await citizenDecisionsPage.assertUnresolvedDecisionsCount(0)
   })
+
+  test('Citizen can open and view decision metadata', async () => {
+    const application = applicationFixture(
+      testChild,
+      testAdult,
+      undefined,
+      'DAYCARE',
+      null,
+      [testDaycare.id],
+      true,
+      'SENT'
+    )
+    await createApplications({ body: [application] })
+    await execSimpleApplicationActions(
+      application.id,
+      [
+        'MOVE_TO_WAITING_PLACEMENT',
+        'CREATE_DEFAULT_PLACEMENT_PLAN',
+        'SEND_DECISIONS_WITHOUT_PROPOSAL'
+      ],
+      now
+    )
+    const { citizenDecisionsPage } = await openCitizenDecisionsPage(testAdult)
+
+    await citizenDecisionsPage.viewDecisionMetadata(application.id)
+  })
 })
 
 describe('Citizen assistance decisions', () => {


### PR DESCRIPTION
Päätöksen kohdalla näytetään sama metadata kuin päätökseen johtaneen hakemuksen kohdalla, koska hakemus ja päätös ovat osa samaa asianhallintaprosessia.