### PR TITLE
Muutetaan tuntiperustaisen maksuton poissaolo käyttämään 21 päivän kiinteää jakajaa

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -630,9 +630,8 @@ fun computeUsedService(
         absenceTypes == setOf(AbsenceType.FREE_ABSENCE) &&
             absenceCategories == placementType.absenceCategories()
     val isRefundedAbsence =
-        absenceTypes.intersect(
-            setOf(AbsenceType.FORCE_MAJEURE, AbsenceType.FREE_ABSENCE, AbsenceType.PARENTLEAVE)
-        ) == absenceTypes && absenceCategories == placementType.absenceCategories()
+        absenceTypes.intersect(setOf(AbsenceType.FORCE_MAJEURE, AbsenceType.PARENTLEAVE)) ==
+            absenceTypes && absenceCategories == placementType.absenceCategories()
 
     // days used in average calc
     val daysInMonth =

--- a/service/src/test/kotlin/fi/espoo/evaka/reservations/UsedServiceTests.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/reservations/UsedServiceTests.kt
@@ -365,44 +365,43 @@ class UsedServiceTests {
     }
 
     @Test
-    fun `average for free absence types is divided by the number of operation days`() {
+    fun `average for refunded absence types is divided by the number of operation days`() {
         val date = today.minusDays(1)
 
         val operationDatesWithCount = { n: Int ->
             (FiniteDateRange.ofMonth(date).dates().take(n - 1) + date).toSet()
         }
 
-        listOf(AbsenceType.FORCE_MAJEURE, AbsenceType.FREE_ABSENCE, AbsenceType.PARENTLEAVE)
-            .forEach { absenceType ->
-                compute(
-                        date = date,
-                        placementType = PlacementType.DAYCARE,
-                        serviceNeedHours = 120,
-                        absences = listOf(absenceType to AbsenceCategory.BILLABLE),
-                        operationDates = operationDatesWithCount(23),
-                    )
-                    .also {
-                        assertEquals((120.0 * 60 / 23).roundToLong(), it.usedServiceMinutes)
-                        assertEquals(emptyList(), it.usedServiceRanges)
-                    }
+        listOf(AbsenceType.FORCE_MAJEURE, AbsenceType.PARENTLEAVE).forEach { absenceType ->
+            compute(
+                    date = date,
+                    placementType = PlacementType.DAYCARE,
+                    serviceNeedHours = 120,
+                    absences = listOf(absenceType to AbsenceCategory.BILLABLE),
+                    operationDates = operationDatesWithCount(23),
+                )
+                .also {
+                    assertEquals((120.0 * 60 / 23).roundToLong(), it.usedServiceMinutes)
+                    assertEquals(emptyList(), it.usedServiceRanges)
+                }
 
-                compute(
-                        date = date,
-                        placementType = PlacementType.PRESCHOOL_DAYCARE,
-                        shiftCareType = ShiftCareType.FULL,
-                        serviceNeedHours = 120,
-                        absences =
-                            listOf(
-                                absenceType to AbsenceCategory.BILLABLE,
-                                absenceType to AbsenceCategory.NONBILLABLE,
-                            ),
-                        operationDates = operationDatesWithCount(31),
-                    )
-                    .also {
-                        assertEquals((120.0 * 60 / 31).roundToLong(), it.usedServiceMinutes)
-                        assertEquals(emptyList(), it.usedServiceRanges)
-                    }
-            }
+            compute(
+                    date = date,
+                    placementType = PlacementType.PRESCHOOL_DAYCARE,
+                    shiftCareType = ShiftCareType.FULL,
+                    serviceNeedHours = 120,
+                    absences =
+                        listOf(
+                            absenceType to AbsenceCategory.BILLABLE,
+                            absenceType to AbsenceCategory.NONBILLABLE,
+                        ),
+                    operationDates = operationDatesWithCount(31),
+                )
+                .also {
+                    assertEquals((120.0 * 60 / 31).roundToLong(), it.usedServiceMinutes)
+                    assertEquals(emptyList(), it.usedServiceRanges)
+                }
+        }
     }
 
     @Test
@@ -421,7 +420,7 @@ class UsedServiceTests {
                 operationDates = operationDatesWithCount(23),
             )
             .also {
-                assertEquals((120.0 * 60 / 23).roundToLong(), it.reservedMinutes)
+                assertEquals((120.0 * 60 / 21).roundToLong(), it.reservedMinutes)
                 assertEquals(0, it.usedServiceMinutes)
                 assertEquals(emptyList(), it.usedServiceRanges)
             }
@@ -439,7 +438,7 @@ class UsedServiceTests {
                 operationDates = operationDatesWithCount(31),
             )
             .also {
-                assertEquals((120.0 * 60 / 31).roundToLong(), it.reservedMinutes)
+                assertEquals((120.0 * 60 / 21).roundToLong(), it.reservedMinutes)
                 assertEquals(0, it.usedServiceMinutes)
                 assertEquals(emptyList(), it.usedServiceRanges)
             }
@@ -461,8 +460,8 @@ class UsedServiceTests {
                 operationDates = operationDatesWithCount(23),
             )
             .also {
-                assertEquals((120.0 * 60 / 23).roundToLong(), it.reservedMinutes)
-                assertEquals((120.0 * 60 / 23).roundToLong(), it.usedServiceMinutes)
+                assertEquals((120.0 * 60 / 21).roundToLong(), it.reservedMinutes)
+                assertEquals((120.0 * 60 / 21).roundToLong(), it.usedServiceMinutes)
                 assertEquals(emptyList(), it.usedServiceRanges)
             }
 
@@ -479,8 +478,8 @@ class UsedServiceTests {
                 operationDates = operationDatesWithCount(31),
             )
             .also {
-                assertEquals((120.0 * 60 / 31).roundToLong(), it.reservedMinutes)
-                assertEquals((120.0 * 60 / 31).roundToLong(), it.usedServiceMinutes)
+                assertEquals((120.0 * 60 / 21).roundToLong(), it.reservedMinutes)
+                assertEquals((120.0 * 60 / 21).roundToLong(), it.usedServiceMinutes)
                 assertEquals(emptyList(), it.usedServiceRanges)
             }
     }


### PR DESCRIPTION
Eriyttää maksuttoman poissaolon hyvitettävien poissaolojen päivälaskulogiikasta niin, että jatkossa sille käytetään kiinteää 21 päivän jakajaa keskiarvotetussa minuuttilaskennassa.