### PR TITLE
Refaktoroidaan henkilön nimen formatointia

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/contact-info/ChildSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/ChildSubSection.tsx
@@ -44,20 +44,14 @@ export default React.memo(function ChildSubSection({
           <FixedSpaceColumn spacing="xs">
             <Label>{t.applications.editor.contactInfo.childFirstName}</Label>
             <PersonName
-              person={{
-                firstName: formData.childFirstName,
-                lastName: formData.childLastName
-              }}
+              person={{ firstName: formData.childFirstName }}
               format="First"
             />
           </FixedSpaceColumn>
           <FixedSpaceColumn spacing="xs">
             <Label>{t.applications.editor.contactInfo.childLastName}</Label>
             <PersonName
-              person={{
-                firstName: formData.childFirstName,
-                lastName: formData.childLastName
-              }}
+              person={{ lastName: formData.childLastName }}
               format="Last"
             />
           </FixedSpaceColumn>

--- a/frontend/src/citizen-frontend/applications/editor/contact-info/GuardianSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/contact-info/GuardianSubSection.tsx
@@ -59,20 +59,14 @@ export default React.memo(function GuardianSubSection({
         <FixedSpaceColumn spacing="xs">
           <Label>{t.applications.editor.contactInfo.guardianFirstName}</Label>
           <PersonName
-            person={{
-              firstName: formData.guardianFirstName,
-              lastName: formData.guardianLastName
-            }}
+            person={{ firstName: formData.guardianFirstName }}
             format="First"
           />
         </FixedSpaceColumn>
         <FixedSpaceColumn spacing="xs">
           <Label>{t.applications.editor.contactInfo.guardianLastName}</Label>
           <PersonName
-            person={{
-              firstName: formData.guardianFirstName,
-              lastName: formData.guardianLastName
-            }}
+            person={{ lastName: formData.guardianLastName }}
             format="Last"
           />
         </FixedSpaceColumn>

--- a/frontend/src/citizen-frontend/applications/editor/verification/UnitPreferenceSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/verification/UnitPreferenceSection.tsx
@@ -6,8 +6,8 @@ import React, { useMemo } from 'react'
 import styled from 'styled-components'
 
 import type { UnitPreferenceFormData } from 'lib-common/api-types/application/ApplicationFormData'
+import { formatPersonName } from 'lib-common/names'
 import ListGrid from 'lib-components/layout/ListGrid'
-import { usePersonName } from 'lib-components/molecules/PersonNames'
 import { H2, H3, Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
@@ -30,7 +30,11 @@ export default React.memo(function UnitPreferenceSection({
   const t = useTranslation()
   const tLocal = t.applications.editor.verification.unitPreference
   const vtjSibling = formData.vtjSiblings.find((s) => s.selected)
-  const vtjSiblingName = usePersonName(vtjSibling, 'First Last')
+  const vtjSiblingName = formatPersonName(
+    vtjSibling ?? { firstName: '', lastName: '' },
+    'First Last',
+    t.components.common
+  )
 
   const sibling = useMemo(() => {
     if (!formData.siblingBasis) return null

--- a/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/discussion-reservation-modal/DiscussionSurveyModal.tsx
@@ -260,7 +260,7 @@ const DiscussionChildElement = React.memo(function DiscussionChildElement({
     <div data-qa={`discussion-child-${childWithSurveys.childId}`}>
       <StaticChip color={colors.main.m1}>
         <PersonName
-          person={{ firstName: childWithSurveys.firstName, lastName: '' }}
+          person={{ firstName: childWithSurveys.firstName }}
           format="FirstFirst"
         />
       </StaticChip>

--- a/frontend/src/lib-common/names.ts
+++ b/frontend/src/lib-common/names.ts
@@ -2,22 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-export type PersonNameFormat =
-  | 'First Last (Preferred)'
-  | 'First Last'
-  | 'First'
-  | 'FirstFirst Last (Preferred)'
-  | 'FirstFirst Last'
-  | 'FirstFirst'
-  | 'Last First'
-  | 'Last FirstFirst'
-  | 'Last Preferred'
-  | 'Last, First'
-  | 'Last, FirstFirst'
-  | 'Last'
-  | 'Preferred Last'
-  | 'Preferred'
-
 export interface NamedPerson {
   firstName: string
   lastName: string
@@ -25,52 +9,138 @@ export interface NamedPerson {
   preferredFirstName?: string | null
 }
 
+export interface Placeholders {
+  noFirstName: string
+  noLastName: string
+}
+
+/** Format a person's name according to the specified format.
+ *
+ * If the `placeholders` parameter is given, it will be used to fill in empty first or last names.
+ */
 export function formatPersonName(
   person: NamedPerson,
-  format: PersonNameFormat
+  format:
+    | 'First Last (Preferred)'
+    | 'FirstFirst Last (Preferred)'
+    | 'Last Preferred'
+    | 'Preferred Last',
+  placeholders?: Placeholders
+): string
+export function formatPersonName(
+  person: Pick<NamedPerson, 'firstName' | 'lastName'>,
+  format:
+    | 'First Last'
+    | 'FirstFirst Last'
+    | 'Last First'
+    | 'Last FirstFirst'
+    | 'Last, First'
+    | 'Last, FirstFirst',
+  placeholders?: Placeholders
+): string
+export function formatPersonName(
+  person: Pick<NamedPerson, 'firstName'>,
+  format: 'First' | 'FirstFirst',
+  placeholders?: Placeholders
+): string
+export function formatPersonName(
+  person: Pick<NamedPerson, 'lastName'>,
+  format: 'Last',
+  placeholders?: Placeholders
+): string
+export function formatPersonName(
+  person: Pick<
+    NamedPerson,
+    'firstName' | 'preferredName' | 'preferredFirstName'
+  >,
+  format: 'Preferred',
+  placeholders?: Placeholders
+): string
+export function formatPersonName(
+  person: Partial<NamedPerson>,
+  format:
+    | 'First Last (Preferred)'
+    | 'FirstFirst Last (Preferred)'
+    | 'First Last'
+    | 'FirstFirst Last'
+    | 'Last First'
+    | 'Last FirstFirst'
+    | 'Last, First'
+    | 'Last, FirstFirst'
+    | 'First'
+    | 'FirstFirst'
+    | 'Last'
+    | 'Last Preferred'
+    | 'Preferred Last'
+    | 'Preferred',
+  placeholders: Placeholders = { noFirstName: '', noLastName: '' }
 ): string {
   const { firstName, lastName, preferredName, preferredFirstName } = person
   const preferred = preferredName || preferredFirstName
   switch (format) {
-    case 'First Last (Preferred)': {
-      return `${firstName} ${lastName}${preferred ? ` (${preferred})` : ''}`
-    }
+    case 'First Last (Preferred)':
+      return `${formatFirstName(firstName, placeholders)} ${formatLastName(lastName, placeholders)}${preferred ? ` (${preferred})` : ''}`
     case 'First Last':
-      return `${firstName} ${lastName}`
+      return `${formatFirstName(firstName, placeholders)} ${formatLastName(lastName, placeholders)}`
     case 'First':
-      return firstName
-    case 'FirstFirst Last (Preferred)': {
-      const firstFirstName = firstName.split(/\s/)[0]
-      return `${firstFirstName} ${lastName}${preferred ? ` (${preferred})` : ''}`
-    }
-    case 'FirstFirst Last': {
-      const firstFirstName = firstName.split(/\s/)[0]
-      return `${firstFirstName} ${lastName}`
-    }
+      return formatFirstName(firstName, placeholders)
+    case 'FirstFirst Last (Preferred)':
+      return `${formatFirstFirstName(firstName, placeholders)} ${formatLastName(lastName, placeholders)}${preferred ? ` (${preferred})` : ''}`
+    case 'FirstFirst Last':
+      return `${formatFirstFirstName(firstName, placeholders)} ${formatLastName(lastName, placeholders)}`
     case 'FirstFirst':
-      return firstName.split(/\s/)[0]
+      return formatFirstFirstName(firstName, placeholders)
     case 'Last First':
-      return `${lastName} ${firstName}`
-    case 'Last FirstFirst': {
-      const firstFirstName = firstName.split(/\s/)[0]
-      return `${lastName} ${firstFirstName}`
-    }
-    case 'Last Preferred': {
-      return `${lastName} ${preferred || firstName.split(/\s/)[0]}`
-    }
+      return `${formatLastName(lastName, placeholders)} ${formatFirstName(firstName, placeholders)}`
+    case 'Last FirstFirst':
+      return `${formatLastName(lastName, placeholders)} ${formatFirstFirstName(firstName, placeholders)}`
+    case 'Last Preferred':
+      return `${formatLastName(lastName, placeholders)} ${formatPreferredName(preferred, firstName, placeholders)}`
     case 'Last, First':
-      return `${lastName}, ${firstName}`
-    case 'Last, FirstFirst': {
-      const firstFirstName = firstName.split(/\s/)[0]
-      return `${lastName}, ${firstFirstName}`
-    }
+      return `${formatLastName(lastName, placeholders)}, ${formatFirstName(firstName, placeholders)}`
+    case 'Last, FirstFirst':
+      return `${formatLastName(lastName, placeholders)}, ${formatFirstFirstName(firstName, placeholders)}`
     case 'Last':
-      return lastName
-    case 'Preferred Last': {
-      return `${preferred || firstName.split(/\s/)[0]} ${lastName}`
-    }
-    case 'Preferred': {
-      return preferred || firstName.split(/\s/)[0]
-    }
+      return formatLastName(lastName, placeholders)
+    case 'Preferred Last':
+      return `${formatPreferredName(preferred, firstName, placeholders)} ${formatLastName(lastName, placeholders)}`
+    case 'Preferred':
+      return formatPreferredName(preferred, firstName, placeholders)
   }
+}
+
+function formatFirstName(
+  firstName: string | undefined,
+  placeholders: Placeholders
+): string {
+  return firstName || placeholders.noFirstName
+}
+
+function formatLastName(
+  lastName: string | undefined,
+  placeholders: Placeholders
+): string {
+  return lastName || placeholders.noLastName
+}
+
+function formatFirstFirstName(
+  firstName: string | undefined,
+  placeholders: Placeholders
+): string {
+  if (!firstName) return placeholders.noFirstName
+
+  const firstNames = firstName.split(/\s/)
+  return firstNames.length > 0 ? firstNames[0] : placeholders.noFirstName
+}
+
+function formatPreferredName(
+  preferredName: string | null | undefined,
+  firstName: string | undefined,
+  placeholders: Placeholders
+): string {
+  if (preferredName) return preferredName
+  if (!firstName) return placeholders.noFirstName
+
+  const firstNames = firstName.split(/\s/)
+  return firstNames.length > 0 ? firstNames[0] : placeholders.noFirstName
 }

--- a/frontend/src/lib-components/molecules/PersonNames.tsx
+++ b/frontend/src/lib-components/molecules/PersonNames.tsx
@@ -4,93 +4,74 @@
 
 import React from 'react'
 
-import type { NamedPerson, PersonNameFormat } from 'lib-common/names'
+import type { NamedPerson } from 'lib-common/names'
+import { formatPersonName } from 'lib-common/names'
 
-import { useTranslations, type Translations } from '../i18n'
+import { useTranslations } from '../i18n'
 
-function formatFirstName(
-  firstName: string | undefined,
-  i18n: Translations
-): string {
-  return firstName || i18n.common.noFirstName
-}
-
-function formatLastName(
-  lastName: string | undefined,
-  i18n: Translations
-): string {
-  return lastName || i18n.common.noLastName
-}
-
-function formatFirstFirstName(
-  firstName: string | undefined,
-  i18n: Translations
-): string {
-  if (!firstName) return i18n.common.noFirstName
-
-  const firstNames = firstName.split(/\s/)
-  return firstNames.length > 0 ? firstNames[0] : i18n.common.noFirstName
-}
-
-function formatNickName(
-  preferred: string | null | undefined,
-  firstName: string | undefined,
-  i18n: Translations
-): string {
-  if (preferred) return preferred
-  if (!firstName) return i18n.common.noFirstName
-
-  const firstNames = firstName.split(/\s/)
-  return firstNames.length > 0 ? firstNames[0] : i18n.common.noFirstName
-}
-
-export function usePersonName(
-  person: NamedPerson | undefined,
-  format: PersonNameFormat
-): string {
-  const i18n = useTranslations()
-  const { firstName, lastName, preferredName, preferredFirstName } =
-    person ?? {}
-  const preferred = preferredName || preferredFirstName
-  switch (format) {
-    case 'First Last (Preferred)':
-      return `${formatFirstName(firstName, i18n)} ${formatLastName(lastName, i18n)}${preferred ? ` (${preferred})` : ''}`
-    case 'First Last':
-      return `${formatFirstName(firstName, i18n)} ${formatLastName(lastName, i18n)}`
-    case 'First':
-      return formatFirstName(firstName, i18n)
-    case 'FirstFirst Last (Preferred)':
-      return `${formatFirstFirstName(firstName, i18n)} ${formatLastName(lastName, i18n)}${preferred ? ` (${preferred})` : ''}`
-    case 'FirstFirst Last':
-      return `${formatFirstFirstName(firstName, i18n)} ${formatLastName(lastName, i18n)}`
-    case 'FirstFirst':
-      return formatFirstFirstName(firstName, i18n)
-    case 'Last First':
-      return `${formatLastName(lastName, i18n)} ${formatFirstName(firstName, i18n)}`
-    case 'Last FirstFirst':
-      return `${formatLastName(lastName, i18n)} ${formatFirstFirstName(firstName, i18n)}`
-    case 'Last Preferred':
-      return `${formatLastName(lastName, i18n)} ${formatNickName(preferred, firstName, i18n)}`
-    case 'Last, First':
-      return `${formatLastName(lastName, i18n)}, ${formatFirstName(firstName, i18n)}`
-    case 'Last, FirstFirst':
-      return `${formatLastName(lastName, i18n)}, ${formatFirstFirstName(firstName, i18n)}`
-    case 'Last':
-      return formatLastName(lastName, i18n)
-    case 'Preferred Last':
-      return `${formatNickName(preferred, firstName, i18n)} ${formatLastName(lastName, i18n)}`
-    case 'Preferred':
-      return formatNickName(preferred, firstName, i18n)
-  }
-}
-
-interface PersonNameProps {
-  person: NamedPerson
-  format: PersonNameFormat
-}
+type PersonNameProps =
+  | {
+      person: NamedPerson
+      format:
+        | 'First Last (Preferred)'
+        | 'FirstFirst Last (Preferred)'
+        | 'Last Preferred'
+        | 'Preferred Last'
+    }
+  | {
+      person: Pick<NamedPerson, 'firstName' | 'lastName'>
+      format:
+        | 'First Last'
+        | 'FirstFirst Last'
+        | 'Last First'
+        | 'Last FirstFirst'
+        | 'Last, First'
+        | 'Last, FirstFirst'
+    }
+  | { person: Pick<NamedPerson, 'firstName'>; format: 'First' | 'FirstFirst' }
+  | { person: Pick<NamedPerson, 'lastName'>; format: 'Last' }
+  | {
+      person: Pick<
+        NamedPerson,
+        'firstName' | 'preferredName' | 'preferredFirstName'
+      >
+      format: 'Preferred'
+    }
 
 export function PersonName(props: PersonNameProps) {
+  const i18n = useTranslations()
   const { person, format } = props
-  const formattedName = usePersonName(person, format)
+
+  // The switch/case is required because TypeScript's type narrowing is not smart enough. This causes a type error:
+  // const formattedName = formatPersonName(person, format, i18n.common)
+
+  let formattedName: string
+  switch (format) {
+    case 'First Last (Preferred)':
+    case 'FirstFirst Last (Preferred)':
+    case 'Last Preferred':
+    case 'Preferred Last':
+      formattedName = formatPersonName(person, format, i18n.common)
+      break
+    case 'First Last':
+    case 'FirstFirst Last':
+    case 'Last First':
+    case 'Last FirstFirst':
+    case 'Last, First':
+    case 'Last, FirstFirst':
+      formattedName = formatPersonName(person, format, i18n.common)
+      break
+    case 'First':
+    case 'FirstFirst':
+      formattedName = formatPersonName(person, format, i18n.common)
+      break
+    case 'Last':
+      formattedName = formatPersonName(person, format, i18n.common)
+      break
+    case 'Preferred':
+      formattedName = formatPersonName(person, format, i18n.common)
+      break
+  }
+
   return <span translate="no">{formattedName}</span>
 }


### PR DESCRIPTION
- Only require the name fields that are actually needed by the given format
- Remove the `usePersonName` hook. Pass `placeholders` to `formatPersonName` instead.

This also allows to remove some duplication: `formatPersonName` is now the only place that actually renders names + formats to string.
