### PR TITLE
Tekninen: Poistetaan jq apigw-imagesta

### DIFF
--- a/apigw/Dockerfile
+++ b/apigw/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update \
       ca-certificates \
       curl \
       unzip \
-      jq \
  && curl -sSfL https://github.com/espoon-voltti/s3-downloader/releases/download/v1.4.1/s3downloader-linux-amd64 \
        -o /bin/s3download \
  && chmod +x /bin/s3download \


### PR DESCRIPTION
Aiheutti ECR-hälyn eikä ole enää käytössä. Käytetty aikoinaan HOST_IP:n päättelyssä.
