### PR TITLE
Päivitetään päätöksen tila -tekstejä

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
@@ -260,7 +260,7 @@ describe('Employee - Child documents', () => {
       now.toLocalDate().addDays(7)
     )
     await childDocument.acceptDecision(validity)
-    await childDocument.status.assertTextEquals('Hyväksytty')
+    await childDocument.status.assertTextEquals('Myönnetty')
     await nav.assertTabNotificationsCount('reports', 0)
 
     await childDocument.annulDecision()
@@ -294,7 +294,7 @@ describe('Employee - Child documents', () => {
     await page.goto(documentUrl)
     childDocument = new ChildDocumentPage(page)
     await childDocument.rejectDecision()
-    await childDocument.status.assertTextEquals('Hylätty')
+    await childDocument.status.assertTextEquals('Ei myönnetty')
   })
 
   test('Edit mode cannot be entered for 15 minutes after another use has edited the document content', async () => {

--- a/frontend/src/lib-components/atoms/Chip.tsx
+++ b/frontend/src/lib-components/atoms/Chip.tsx
@@ -19,6 +19,7 @@ export const StaticChip = styled.div<{
   color: string
   textColor?: string
   fitContent?: boolean
+  nowrap?: boolean
 }>`
   display: inline-block;
   font-family: 'Open Sans', sans-serif;
@@ -49,6 +50,12 @@ export const StaticChip = styled.div<{
       ? css`
           width: fit-content;
           height: fit-content;
+        `
+      : ''}
+  ${(p) =>
+    p.nowrap
+      ? css`
+          white-space: nowrap;
         `
       : ''}
 `

--- a/frontend/src/lib-components/document-templates/ChildDocumentStateChip.tsx
+++ b/frontend/src/lib-components/document-templates/ChildDocumentStateChip.tsx
@@ -39,6 +39,7 @@ export function ChildDocumentStateChip({ status }: StateChipProps) {
     <StaticChip
       color={statusColors[status]}
       fitContent
+      nowrap
       data-qa="document-state-chip"
     >
       {i18n.documentTemplates.documentStates[status]}

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -69,8 +69,8 @@ const components: Translations = {
       CITIZEN_DRAFT: 'Täytettävänä huoltajalla',
       DECISION_PROPOSAL: 'Päätösesitys',
       COMPLETED: 'Valmis',
-      ACCEPTED: 'Hyväksytty',
-      REJECTED: 'Hylätty',
+      ACCEPTED: 'Myönnetty',
+      REJECTED: 'Ei myönnetty',
       ANNULLED: 'Mitätöity'
     }
   },


### PR DESCRIPTION
Muutetaan hyväksytty/hylätty -status labelit:
_hyväksytty -> myönnetty
hylätty -> ei myönnetty_

Lisätty _nowrap_ statuksen chip-komponentille.

<img width="1337" alt="Screenshot 2025-07-07 at 14 56 48" src="https://github.com/user-attachments/assets/553aa106-cdce-4e12-9a03-07659fd7dde6" />
