### PR TITLE
Huomioidaan opetustauot esiopetuksen poissaolohakemuksessa

### DIFF
--- a/frontend/src/e2e-test/specs/absence-application/absence-application.spec.ts
+++ b/frontend/src/e2e-test/specs/absence-application/absence-application.spec.ts
@@ -223,6 +223,14 @@ describe('Absence application', () => {
   })
 
   test('accepted flow', async () => {
+    const mockedDate = mockedTime.toLocalDate()
+    const termRange = new FiniteDateRange(mockedDate, mockedDate.addYears(1))
+    await Fixture.preschoolTerm({
+      extendedTerm: termRange,
+      finnishPreschool: termRange,
+      swedishPreschool: termRange,
+      applicationPeriod: termRange.withStart(mockedDate.subMonths(2))
+    }).save()
     const area = await Fixture.careArea().save()
     const unit = await Fixture.daycare({ areaId: area.id }).save()
     const unitSupervisor = await Fixture.employee()
@@ -284,6 +292,14 @@ describe('Absence application', () => {
   })
 
   test('rejected flow', async () => {
+    const mockedDate = mockedTime.toLocalDate()
+    const termRange = new FiniteDateRange(mockedDate, mockedDate.addYears(1))
+    await Fixture.preschoolTerm({
+      extendedTerm: termRange,
+      finnishPreschool: termRange,
+      swedishPreschool: termRange,
+      applicationPeriod: termRange.withStart(mockedDate.subMonths(2))
+    }).save()
     const area = await Fixture.careArea().save()
     const unit = await Fixture.daycare({ areaId: area.id }).save()
     const unitSupervisor = await Fixture.employee()
@@ -349,6 +365,14 @@ describe('Absence application', () => {
   })
 
   test('delete flow', async () => {
+    const mockedDate = mockedTime.toLocalDate()
+    const termRange = new FiniteDateRange(mockedDate, mockedDate.addYears(1))
+    await Fixture.preschoolTerm({
+      extendedTerm: termRange,
+      finnishPreschool: termRange,
+      swedishPreschool: termRange,
+      applicationPeriod: termRange.withStart(mockedDate.subMonths(2))
+    }).save()
     const area = await Fixture.careArea().save()
     const unit = await Fixture.daycare({ areaId: area.id }).save()
     const unitSupervisor = await Fixture.employee()
@@ -399,7 +423,15 @@ describe('Absence application', () => {
     await applicationProcessTab.assertAbsenceApplications([])
   })
 
-  test('Form is invalid if absence date range is not on placement date range', async () => {
+  test('Form is invalid if absence date range is not on possible absence application date range', async () => {
+    const mockedDate = mockedTime.toLocalDate()
+    const termRange = new FiniteDateRange(mockedDate, mockedDate.addYears(1))
+    await Fixture.preschoolTerm({
+      extendedTerm: termRange,
+      finnishPreschool: termRange,
+      swedishPreschool: termRange,
+      applicationPeriod: termRange.withStart(mockedDate.subMonths(2))
+    }).save()
     const area = await Fixture.careArea().save()
     const unit = await Fixture.daycare({ areaId: area.id }).save()
     await Fixture.family({ guardian: adult, children: [child] }).save()
@@ -433,7 +465,15 @@ describe('Absence application', () => {
     await newAbsenceApplicationPage.createButton.assertDisabled(true)
   })
 
-  test('Form is valid if absence date range is partly within placement date range', async () => {
+  test('Form is valid if absence date range is partly within possible absence application date range', async () => {
+    const mockedDate = mockedTime.toLocalDate()
+    const termRange = new FiniteDateRange(mockedDate, mockedDate.addYears(1))
+    await Fixture.preschoolTerm({
+      extendedTerm: termRange,
+      finnishPreschool: termRange,
+      swedishPreschool: termRange,
+      applicationPeriod: termRange.withStart(mockedDate.subMonths(2))
+    }).save()
     const area = await Fixture.careArea().save()
     const unit = await Fixture.daycare({ areaId: area.id }).save()
     await Fixture.family({ guardian: adult, children: [child] }).save()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/absence/AbsenceApplicationControllersTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/absence/AbsenceApplicationControllersTest.kt
@@ -553,7 +553,7 @@ class AbsenceApplicationControllersTest : FullApplicationTest(resetDbBeforeEach 
             }
 
             assertEquals(
-                DateSet.of(
+                setOf<FiniteDateRange>(
                     FiniteDateRange(LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31)),
                     FiniteDateRange(LocalDate.of(2023, 2, 1), LocalDate.of(2023, 2, 28)),
                 ),
@@ -586,7 +586,7 @@ class AbsenceApplicationControllersTest : FullApplicationTest(resetDbBeforeEach 
             }
 
             assertEquals(
-                DateSet.empty(),
+                setOf<FiniteDateRange>(),
                 db.transaction { tx -> tx.getAbsenceApplicationDateRanges(child.id, clock.today()) },
             )
         }
@@ -626,11 +626,100 @@ class AbsenceApplicationControllersTest : FullApplicationTest(resetDbBeforeEach 
             }
 
             assertEquals(
-                DateSet.of(
+                setOf<FiniteDateRange>(
                     FiniteDateRange(LocalDate.of(2022, 8, 1), LocalDate.of(2022, 8, 31)),
                     FiniteDateRange(LocalDate.of(2022, 9, 1), LocalDate.of(2022, 9, 30)),
                 ),
                 db.transaction { tx -> tx.getAbsenceApplicationDateRanges(child.id, clock.today()) },
+            )
+        }
+
+        @Test
+        fun `Term breaks are not included in the absence application date ranges`() {
+            db.transaction { tx ->
+                val termRange = FiniteDateRange(clock.today(), clock.today().plusMonths(2))
+                tx.insert(
+                    DevPreschoolTerm(
+                        finnishPreschool = termRange,
+                        swedishPreschool = termRange,
+                        extendedTerm = termRange,
+                        applicationPeriod = termRange.copy(start = clock.today().minusMonths(2)),
+                        termBreaks =
+                            DateSet.of(
+                                FiniteDateRange(
+                                    LocalDate.of(2022, 8, 20),
+                                    LocalDate.of(2022, 8, 25),
+                                ),
+                                FiniteDateRange(
+                                    LocalDate.of(2022, 9, 10),
+                                    LocalDate.of(2022, 9, 15),
+                                ),
+                                FiniteDateRange(
+                                    LocalDate.of(2022, 10, 1),
+                                    LocalDate.of(2022, 10, 5),
+                                ),
+                            ),
+                    )
+                )
+                tx.insert(
+                    DevPlacement(
+                        type = PlacementType.PRESCHOOL,
+                        childId = child.id,
+                        unitId = unit.id,
+                        startDate = termRange.start,
+                        endDate = termRange.end,
+                    )
+                )
+            }
+
+            assertEquals(
+                DateSet.of(
+                    FiniteDateRange(LocalDate.of(2022, 8, 10), LocalDate.of(2022, 8, 19)),
+                    FiniteDateRange(LocalDate.of(2022, 8, 26), LocalDate.of(2022, 9, 9)),
+                    FiniteDateRange(LocalDate.of(2022, 9, 16), LocalDate.of(2022, 9, 30)),
+                    FiniteDateRange(LocalDate.of(2022, 10, 6), LocalDate.of(2022, 10, 10)),
+                ),
+                absenceApplicationControllerCitizen.getAbsenceApplicationPossibleDateRanges(
+                    dbInstance(),
+                    adult.user(CitizenAuthLevel.STRONG),
+                    clock,
+                    child.id,
+                ),
+            )
+        }
+
+        @Test
+        fun `Absence application date ranges include only the placement range`() {
+            db.transaction { tx ->
+                val termRange = FiniteDateRange(clock.today(), clock.today().plusMonths(2))
+                tx.insert(
+                    DevPreschoolTerm(
+                        finnishPreschool = termRange,
+                        swedishPreschool = termRange,
+                        extendedTerm = termRange,
+                        applicationPeriod = termRange.copy(start = clock.today().minusMonths(2)),
+                        termBreaks = DateSet.empty(),
+                    )
+                )
+                tx.insert(
+                    DevPlacement(
+                        type = PlacementType.PRESCHOOL,
+                        childId = child.id,
+                        unitId = unit.id,
+                        startDate = termRange.start.plusDays(10),
+                        endDate = termRange.end.minusMonths(1),
+                    )
+                )
+            }
+
+            assertEquals(
+                DateSet.of(FiniteDateRange(LocalDate.of(2022, 8, 20), LocalDate.of(2022, 9, 10))),
+                absenceApplicationControllerCitizen.getAbsenceApplicationPossibleDateRanges(
+                    dbInstance(),
+                    adult.user(CitizenAuthLevel.STRONG),
+                    clock,
+                    child.id,
+                ),
             )
         }
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/application/AbsenceApplicationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/application/AbsenceApplicationQueries.kt
@@ -9,9 +9,9 @@ import fi.espoo.evaka.shared.AbsenceApplicationId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EvakaUserId
-import fi.espoo.evaka.shared.data.DateSet
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.Predicate
+import fi.espoo.evaka.shared.domain.FiniteDateRange
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
 
@@ -147,21 +147,22 @@ WHERE type = ANY (${bind(PlacementType.preschool)})
         }
         .toSet()
 
-fun Database.Read.getAbsenceApplicationDateRanges(childId: ChildId, today: LocalDate): DateSet =
-    DateSet.of(
-        createQuery {
-                sql(
-                    """
+fun Database.Read.getAbsenceApplicationDateRanges(
+    childId: ChildId,
+    today: LocalDate,
+): Set<FiniteDateRange> =
+    createQuery {
+            sql(
+                """
 SELECT daterange(start_date, end_date, '[]') AS range
 FROM placement
 WHERE type = ANY (${bind(PlacementType.preschool)})
     AND child_id = ${bind(childId)}
     AND daterange(start_date, end_date, '[]') && daterange(${bind(today)}, null, '[]')
           """
-                )
-            }
-            .toSet()
-    )
+            )
+        }
+        .toSet()
 
 private fun Database.Read.absenceApplicationSummaryQuery(predicate: Predicate) = createQuery {
     sql(


### PR DESCRIPTION
Muutetaan esiopetuksen poissaolohakemuksen poissaolon aikavälin validointia ottamaan huomioon opetustauot. Poissaoloa ei voi hakea, jos hakemus aikaväli osuu kokonaan opetustauolle tai opetuskauden ulkopuolelle.