### PR TITLE
Korjaus "työvuoro tänään" päällekkäisyyteen status-tiedon kanssa.

### DIFF
--- a/frontend/src/employee-mobile-frontend/staff-attendance/StaffMemberPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/StaffMemberPage.tsx
@@ -26,7 +26,7 @@ import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import ExpandingInfo from 'lib-components/molecules/ExpandingInfo'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 import { H4, Label } from 'lib-components/typography'
-import { defaultMargins } from 'lib-components/white-space'
+import { defaultMargins, Gap } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/employeeMobile'
 import { faCalendar } from 'lib-icons'
 
@@ -142,6 +142,7 @@ export default React.memo(function StaffMemberPage({
         ) : (
           <>
             <EmployeeCardBackground staff={toStaff(staffMember)} />
+            <Gap size="s" />
             <FixedSpaceColumn>
               {featureFlags.staffAttendanceTypes ? (
                 <>


### PR DESCRIPTION
Korjaus "työvuoro tänään" päällekkäisyyteen status-tiedon kanssa.

Korjauksen jälkeen ei pitäisi enää "Poissa" mennä "Työvuoro tänään" tekstin kanssa päällekkäin.

<img width="420" height="487" alt="image" src="https://github.com/user-attachments/assets/6d459e0b-cf1b-4003-9e0a-7765e254f6b7" />
