### PR TITLE
Sijoituksen viimeiseen päivään irtisanominen ei näy huoltajan irtisanomana

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizenIntegrationTest.kt
@@ -56,6 +56,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.boot.test.system.OutputCaptureExtension
@@ -693,16 +695,25 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
         )
     }
 
-    @Test
-    fun `terminating PRESCHOOL_DAYCARE followed by DAYCARE on the change date updates PRESCHOOL_DAYCARE termination date`() {
+    @ParameterizedTest
+    @ValueSource(longs = [1, 10])
+    fun `terminating PRESCHOOL_DAYCARE on the end date updates PRESCHOOL_DAYCARE termination date`(
+        daycareStartsAfterDays: Long
+    ) {
         /*
+        1st run:
         |--- PRESCHOOL_DAYCARE ---||--------- DAYCARE --------||--- PRESCHOOL_DAYCARE ---|
+               terminationDate   x
+        |--- PRESCHOOL_DAYCARE ---|                            |------ PRESCHOOL---------|
+
+        2nd run:
+        |--- PRESCHOOL_DAYCARE ---|     |---- DAYCARE --------||--- PRESCHOOL_DAYCARE ---|
                terminationDate   x
         |--- PRESCHOOL_DAYCARE ---|                            |------ PRESCHOOL---------|
         */
         val startPreschool = today.minusWeeks(2)
         val endPreschool = startPreschool.plusMonths(1)
-        val startDaycare = endPreschool.plusDays(1)
+        val startDaycare = endPreschool.plusDays(daycareStartsAfterDays)
         val endDaycare = startDaycare.plusMonths(1)
         val startNextPreschoolDaycare = endDaycare.plusDays(1)
         val endNextPreschoolDaycare = startNextPreschoolDaycare.plusMonths(1)

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
@@ -145,6 +145,22 @@ class PlacementControllerCitizen(
                                     )
                                 }
                         }
+                        // Make sure termination bookkeeping happens when the whole placement gets
+                        // removed, and the previous placement is untouched
+                        val allPlacements =
+                            terminatablePlacementGroup.placements +
+                                terminatablePlacementGroup.additionalPlacements
+                        if (allPlacements.any { it.startDate == terminationDate.plusDays(1) }) {
+                            val endingPlacement =
+                                allPlacements.find { it.endDate == terminationDate }
+                            if (endingPlacement != null) {
+                                tx.updatePlacementTermination(
+                                    endingPlacement.id,
+                                    clock.today(),
+                                    user.evakaUserId,
+                                )
+                            }
+                        }
 
                         val cancelableTransferApplicationIds =
                             tx.cancelAllActiveTransferApplications(childId, clock, user.evakaUserId)

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
@@ -145,12 +145,13 @@ class PlacementControllerCitizen(
                                     )
                                 }
                         }
-                        // Make sure termination bookkeeping happens when the whole placement gets
-                        // removed, and the previous placement is untouched
+                        // Make sure termination bookkeeping happens when no placement is terminated
+                        // from the middle i.e. some placements have been completely deleted and the
+                        // termination date is the end date of some placement.
                         val allPlacements =
                             terminatablePlacementGroup.placements +
                                 terminatablePlacementGroup.additionalPlacements
-                        if (allPlacements.any { it.startDate == terminationDate.plusDays(1) }) {
+                        if (allPlacements.any { it.startDate > terminationDate }) {
                             val endingPlacement =
                                 allPlacements.find { it.endDate == terminationDate }
                             if (endingPlacement != null) {

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizen.kt
@@ -124,7 +124,6 @@ class PlacementControllerCitizen(
                             terminateBilledDaycare(
                                 tx,
                                 user,
-                                clock.today(),
                                 terminatablePlacementGroup,
                                 terminationDate,
                                 childId,
@@ -139,7 +138,6 @@ class PlacementControllerCitizen(
                                 .forEach {
                                     cancelOrTerminatePlacement(
                                         tx,
-                                        clock.today(),
                                         it,
                                         terminationDate,
                                         user,

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -833,7 +833,6 @@ WHERE placement_id = ${bind(id)}
 }
 
 fun Database.Transaction.terminatePlacementFrom(
-    terminationRequestedDate: LocalDate,
     placementId: PlacementId,
     terminationDate: LocalDate,
     terminatedBy: EvakaUserId,
@@ -848,7 +847,7 @@ fun Database.Transaction.terminatePlacementFrom(
             sql(
                 """
 UPDATE placement
-SET termination_requested_date = ${bind(terminationRequestedDate)},
+SET termination_requested_date = ${bind(now.toLocalDate())},
     terminated_by = ${bind(terminatedBy)},
     end_date = ${bind(terminationDate)}
 WHERE id = ${bind(placementId)}

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementTermination.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementTermination.kt
@@ -156,7 +156,7 @@ fun terminateBilledDaycare(
     unitId: DaycareId,
     now: HelsinkiDateTime,
 ) {
-    // additional placements after termination date are always cancelled
+    // additional placements after termination date are always canceled
     terminatablePlacementGroup.additionalPlacements
         .filter { it.endDate.isAfter(terminationDate) }
         .forEach { cancelOrTerminatePlacement(tx, it, terminationDate, user, now) }
@@ -166,6 +166,7 @@ fun terminateBilledDaycare(
             (it.type == PRESCHOOL_DAYCARE || it.type == PREPARATORY_DAYCARE) &&
                 it.endDate.isAfter(terminationDate)
         }
+
     // placements which have already been updated on the earlier iteration
     val placementsToSkip = mutableListOf<ChildPlacement>()
     for (placement in preschoolOrPreparatoryWithDaycare) {

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementTermination.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementTermination.kt
@@ -236,19 +236,8 @@ fun terminateBilledDaycare(
             }
         } else {
             tx.movePlacementEndDateEarlier(
-                Placement(
-                    id = placement.id,
-                    type = placement.type,
-                    childId = placement.childId,
-                    unitId = placement.unitId,
-                    startDate = placement.startDate,
-                    endDate = placement.endDate,
-                    terminationRequestedDate = placement.terminationRequestedDate,
-                    terminationRequestedBy = placement.terminatedBy?.id,
-                    placeGuarantee = false,
-                    modifiedAt = null,
-                    modifiedBy = null,
-                ),
+                placement.id,
+                placement.endDate,
                 terminationDate,
                 now,
                 user.evakaUserId,


### PR DESCRIPTION
Korjattu ongelma, jossa "Huoltaja irtisanonut" -merkintä ei näkynyt, jos huoltaja irtisanoi sijoituksen viimeiselle päivälle ja lapsella alkoi heti seuraavana päivänä uusi sijoitus (ts. seuraavana päivänä alkanut sijoitus on se joka varsinaisesti irtisanottiin). Tyypillinen tällainen tilanne on keväällä esiopetuksen ja sitä seuraavan liittyvän varhaiskasvatuksen saumakohdassa.