### PR TITLE
Korjataan viestieditorin muut vastaanottajat osion saavutettavuus

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -330,9 +330,12 @@ export default React.memo(function MessageEditor({
             {showSecondaryRecipientSelection && (
               <>
                 <Gap size="xs" />
-                <div>
+                <div
+                  role="group"
+                  aria-labelledby="message-editor-secondary-recipients"
+                >
                   <label>
-                    <Bold>
+                    <Bold id="message-editor-secondary-recipients">
                       {i18n.messages.messageEditor.secondaryRecipients}
                     </Bold>
                   </label>

--- a/frontend/src/lib-components/messages/ToggleableRecipient.tsx
+++ b/frontend/src/lib-components/messages/ToggleableRecipient.tsx
@@ -50,6 +50,8 @@ export function ToggleableRecipient({
     ? () => onToggleRecipient(id, !selected)
     : undefined
   const i18n = useTranslations()
+  const label =
+    type === 'GROUP' ? `${name} (${i18n.messages.staffAnnotation})` : name
   return (
     <Recipient
       onClick={onClick}
@@ -57,12 +59,12 @@ export function ToggleableRecipient({
       toggleable={toggleable}
       disabled={!toggleable}
       data-qa={dataQa}
+      aria-label={label}
+      aria-pressed={selected}
     >
       {selected ? (
         <>
-          {type === 'GROUP'
-            ? `${name} (${i18n.messages.staffAnnotation})`
-            : name}
+          {label}
           {toggleable && <FontAwesomeIcon icon={faTimes} />}
         </>
       ) : (


### PR DESCRIPTION
Muutoksen jälkeen ruudunlukija toimii seuraavasti:
1. käyttäjä navigoi ensimmäiseen muuhun vastaanottajaan (tab)
2. "Muut vastaanottajat panel" -> "Etunimi Sukunimi toggle button not pressed"
3. käyttäjä valitsee vastaanottajan (space/enter)
4. "pressed"
5. käyttäjä poistaa valinnan (space/enter)
6. "not pressed"