### PR TITLE
Korjataan kohdistus kun viestiketju suljetaan

### DIFF
--- a/frontend/src/citizen-frontend/messages/ThreadList.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadList.tsx
@@ -43,7 +43,7 @@ const hasUnreadMessages = (
 
 interface Props {
   accountId: MessageAccountId
-  selectThread: (threadId: MessageThreadId | undefined) => void
+  selectThread: (threadId: MessageThreadId) => void
   closeThread: () => void
   setEditorVisible: (value: boolean) => void
   newMessageButtonEnabled: boolean

--- a/frontend/src/citizen-frontend/messages/ThreadList.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadList.tsx
@@ -44,6 +44,7 @@ const hasUnreadMessages = (
 interface Props {
   accountId: MessageAccountId
   selectThread: (threadId: MessageThreadId | undefined) => void
+  closeThread: () => void
   setEditorVisible: (value: boolean) => void
   newMessageButtonEnabled: boolean
 }
@@ -51,6 +52,7 @@ interface Props {
 export default React.memo(function ThreadList({
   accountId,
   selectThread,
+  closeThread,
   setEditorVisible,
   newMessageButtonEnabled
 }: Props) {
@@ -66,7 +68,7 @@ export default React.memo(function ThreadList({
         <MobileOnly>
           <ReturnButton
             label={t.common.return}
-            onClick={() => selectThread(undefined)}
+            onClick={closeThread}
             margin={defaultMargins.s}
           />
         </MobileOnly>

--- a/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
+++ b/frontend/src/citizen-frontend/messages/ThreadListItem.tsx
@@ -11,6 +11,7 @@ import type {
   CitizenMessageThread,
   MessageAccount
 } from 'lib-common/generated/api-types/messaging'
+import type { MessageThreadId } from 'lib-common/generated/api-types/shared'
 import { ScreenReaderOnly } from 'lib-components/atoms/ScreenReaderOnly'
 import {
   FixedSpaceColumn,
@@ -31,6 +32,9 @@ import { getAttachmentUrl } from '../attachments/attachments'
 import { useTranslation } from '../localization'
 
 import { isRegularThread } from './utils'
+
+export const messageThreadIdAttr = (messageThreadId: MessageThreadId) =>
+  `message-thread-${messageThreadId}`
 
 interface Props {
   thread: CitizenMessageThread
@@ -82,6 +86,7 @@ export default React.memo(function ThreadListItem({
       onKeyDown={(e) => e.key === 'Enter' && onClick()}
       data-qa="thread-list-item"
       tabIndex={0}
+      id={messageThreadIdAttr(thread.id)}
     >
       <FixedSpaceColumn>
         <Header isRead={!hasUnreadMessages}>


### PR DESCRIPTION
Näppäimistönavigoinnilla viestieditoriin tulee näkyviin apunäppäimiä, kuten “Takaisin listaan”. Painettaessa tätä nappia intuitiivinen kohdistuksen kohde olisi listassa se viesti josta nappia painettiin.