### PR TITLE
Lisätään talouden päätöksien lataamiseen tiedostonimi

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/FeeDecisionQueries.kt
@@ -792,19 +792,6 @@ fun Database.Transaction.updateFeeDecisionDocumentKey(id: FeeDecisionId, key: St
         .execute()
 }
 
-fun Database.Read.getFeeDecisionDocumentKey(decisionId: FeeDecisionId): String? {
-    return createQuery {
-            sql(
-                """
-                SELECT document_key 
-                FROM fee_decision
-                WHERE id = ${bind(decisionId)}
-                """
-            )
-        }
-        .exactlyOneOrNull<String>()
-}
-
 fun Database.Transaction.setFeeDecisionType(id: FeeDecisionId, type: FeeDecisionType) {
     createUpdate {
             sql(

--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/data/VoucherValueDecisionQueries.kt
@@ -594,13 +594,6 @@ WHERE vd.id = ${bind { id -> id }} AND voucher_value_decision.id = vd.id
     }
 }
 
-fun Database.Read.getVoucherValueDecisionDocumentKey(id: VoucherValueDecisionId): String? {
-    return createQuery {
-            sql("SELECT document_key FROM voucher_value_decision WHERE id = ${bind(id)}")
-        }
-        .exactlyOneOrNull<String>()
-}
-
 fun Database.Read.getVoucherValueDecisionByLiableCitizen(
     citizenId: PersonId
 ): List<VoucherValueDecisionCitizenInfoRow> {


### PR DESCRIPTION
Tällä hetkellä kun järjestelmän kautta lataa talouden päätöksen, tulee tiedostonimeksi `download.pdf`. Muutoksen jälkeen tulee vastaava nimi kuin mikä lähetetty suomi.fi-viestit -palveluun.