### PR TITLE
Korjataan päivämäärävalitsimen ylimääräinen merkki

### DIFF
--- a/frontend/src/lib-components/molecules/date-picker/DatePickerLowLevel.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerLowLevel.tsx
@@ -269,7 +269,6 @@ export default React.memo(function DatePickerLowLevel({
                   />
                 </DayPickerDiv>
               </DayPickerPositioner>
-              )
             </FocusLock>,
             document.getElementById('datepicker-container') ?? document.body
           )


### PR DESCRIPTION
Kun päivämäärävalitsin avataan, näkyy sivulla ylimääräinen `)`-merkki.