### PR TITLE
Korjataan frontend docker-kontin konteksti

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -4,7 +4,12 @@
 
 *
 !src
-src/lib-customizations/espoo
+src/lib-customizations/**/*
+!src/lib-customizations/defaults
+!src/lib-customizations/defaults/**/*
+!src/lib-customizations/*.ts
+!src/lib-customizations/*.json
+!src/lib-customizations/*.tsx
 !packages
 !public
 !vendor


### PR DESCRIPTION
Jos eVakaa käytetään git-submodulena jossain muussa kunnassa ja lokaalin kehittämisen helpottamiseksi frontendin kustomoinnit liitetään mukaan symbolisella linkillä, linkki rikkoo joissain tapauksissa docker-buildin.

Poistetaan ylimääräiset tiedostot docker-kontekstista, jotta ne eivät sotke buildia. Nämä muutokset vastaavat osittain `.gitignore`-tiedostoa.