### PR TITLE
Lisätään tarkistus yksikön aukiololle varasijoituksen luomiseen

### DIFF
--- a/frontend/src/e2e-test/pages/employee/child-information.ts
+++ b/frontend/src/e2e-test/pages/employee/child-information.ts
@@ -484,6 +484,7 @@ export class ChildDocumentsSection extends Section {
 
 export class BackupCaresSection extends Section {
   #createBackupCareButton = this.find('[data-qa="backup-care-create-btn"]')
+  #cancelBackupCareFormButton = this.find('[data-qa="cancel-backup-care-form"]')
   #backupCareSelectUnit = new Combobox(
     this.find('[data-qa="backup-care-select-unit"]')
   )
@@ -564,6 +565,10 @@ export class BackupCaresSection extends Section {
     await modal.waitUntilVisible()
     await this.#backupCares.find('[data-qa="modal-okBtn"]').click()
     await modal.waitUntilHidden()
+  }
+
+  async cancelBackupCareForm() {
+    await this.#cancelBackupCareFormButton.click()
   }
 
   #backupCareRow(index: number) {

--- a/frontend/src/employee-frontend/components/child-information/BackupCare.tsx
+++ b/frontend/src/employee-frontend/components/child-information/BackupCare.tsx
@@ -9,7 +9,6 @@ import type { ChildId } from 'lib-common/generated/api-types/shared'
 import { useQueryResult } from 'lib-common/query'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 
-import { ChildContext } from '../../state'
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
 import { renderResult } from '../async-rendering'
@@ -17,6 +16,7 @@ import { renderResult } from '../async-rendering'
 import BackupCareForm from './backup-care/BackupCareForm'
 import BackupCareRow from './backup-care/BackupCareRow'
 import { backupCaresQuery } from './queries'
+import { ChildContext } from './state'
 
 export interface Props {
   childId: ChildId

--- a/frontend/src/employee-frontend/generated/api-clients/daycare.ts
+++ b/frontend/src/employee-frontend/generated/api-clients/daycare.ts
@@ -45,6 +45,7 @@ import type { TemporaryEmployee } from 'lib-common/generated/api-types/pis'
 import type { UnitFeatures } from 'lib-common/generated/api-types/daycare'
 import type { UnitGroupDetails } from 'lib-common/generated/api-types/daycare'
 import type { UnitNotifications } from 'lib-common/generated/api-types/daycare'
+import type { UnitOperationPeriod } from 'lib-common/generated/api-types/daycare'
 import type { UnitStub } from 'lib-common/generated/api-types/daycare'
 import type { UnitTypeFilter } from 'lib-common/generated/api-types/daycare'
 import type { UpdateFeaturesRequest } from 'lib-common/generated/api-types/daycare'
@@ -63,6 +64,7 @@ import { deserializeJsonPublicUnit } from 'lib-common/generated/api-types/daycar
 import { deserializeJsonScheduledDaycareAclRow } from 'lib-common/generated/api-types/shared'
 import { deserializeJsonStaffAttendanceForDates } from 'lib-common/generated/api-types/daycare'
 import { deserializeJsonUnitGroupDetails } from 'lib-common/generated/api-types/daycare'
+import { deserializeJsonUnitOperationPeriod } from 'lib-common/generated/api-types/daycare'
 import { uri } from 'lib-common/uri'
 
 
@@ -311,6 +313,28 @@ export async function getUnitNotifications(
     method: 'GET'
   })
   return json
+}
+
+
+/**
+* Generated from fi.espoo.evaka.daycare.controllers.DaycareController.getUnitOperationPeriods
+*/
+export async function getUnitOperationPeriods(
+  request: {
+    unitIds?: DaycareId[] | null
+  }
+): Promise<Partial<Record<DaycareId, UnitOperationPeriod>>> {
+  const params = createUrlSearchParams(
+    ...(request.unitIds?.map((e): [string, string | null | undefined] => ['unitIds', e]) ?? [])
+  )
+  const { data: json } = await client.request<JsonOf<Partial<Record<DaycareId, UnitOperationPeriod>>>>({
+    url: uri`/employee/daycares/employee/unitOperationPeriods`.toString(),
+    method: 'GET',
+    params
+  })
+  return Object.fromEntries(Object.entries(json).map(
+    ([k, v]) => [k, v !== undefined ? deserializeJsonUnitOperationPeriod(v) : v]
+  ))
 }
 
 

--- a/frontend/src/employee-frontend/queries.ts
+++ b/frontend/src/employee-frontend/queries.ts
@@ -6,7 +6,11 @@ import { Queries } from 'lib-common/query'
 
 import { getAssistanceActionOptions } from './generated/api-clients/assistance'
 import { deleteAttachment } from './generated/api-clients/attachment'
-import { getAreas, getUnits } from './generated/api-clients/daycare'
+import {
+  getAreas,
+  getUnitOperationPeriods,
+  getUnits
+} from './generated/api-clients/daycare'
 import {
   getPairingStatus,
   postPairing,
@@ -47,6 +51,8 @@ export const personDependantsQuery = q.query(getPersonDependants)
 export const areasQuery = q.query(getAreas)
 
 export const unitsQuery = q.query(getUnits)
+
+export const unitOperationPeriodsQuery = q.query(getUnitOperationPeriods)
 
 export const financeDecisionHandlersQuery = q.query(getFinanceDecisionHandlers)
 

--- a/frontend/src/lib-common/generated/api-types/daycare.ts
+++ b/frontend/src/lib-common/generated/api-types/daycare.ts
@@ -547,6 +547,14 @@ export interface UnitNotifications {
 }
 
 /**
+* Generated from fi.espoo.evaka.daycare.UnitOperationPeriod
+*/
+export interface UnitOperationPeriod {
+  closingDate: LocalDate | null
+  openingDate: LocalDate | null
+}
+
+/**
 * Generated from fi.espoo.evaka.daycare.UnitStub
 */
 export interface UnitStub {
@@ -828,5 +836,14 @@ export function deserializeJsonUnitGroupDetails(json: JsonOf<UnitGroupDetails>):
     missingGroupPlacements: json.missingGroupPlacements.map(e => deserializeJsonMissingGroupPlacement(e)),
     placements: json.placements.map(e => deserializeJsonDaycarePlacementWithDetails(e)),
     recentlyTerminatedPlacements: json.recentlyTerminatedPlacements.map(e => deserializeJsonTerminatedPlacement(e))
+  }
+}
+
+
+export function deserializeJsonUnitOperationPeriod(json: JsonOf<UnitOperationPeriod>): UnitOperationPeriod {
+  return {
+    ...json,
+    closingDate: (json.closingDate != null) ? LocalDate.parseIso(json.closingDate) : null,
+    openingDate: (json.openingDate != null) ? LocalDate.parseIso(json.openingDate) : null
   }
 }

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -1738,7 +1738,9 @@ export const fi = {
       validationNoMatchingPlacement:
         'Varasijoitus ei ole minkään lapsen sijoituksen aikana.',
       validationChildAlreadyInOtherUnit:
-        'Lapsi on jo kirjattu sisään toiseen yksikköön.'
+        'Lapsi on jo kirjattu sisään toiseen yksikköön.',
+      validationBackupCareNotOpen:
+        'Yksikkö ei ole avoinna koko varasijoituksen ajan.'
     },
     backupPickups: {
       title: 'Varahakijat',

--- a/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/Audit.kt
@@ -603,6 +603,7 @@ enum class Audit(
     UnitRead,
     UnitDailyReservationStatistics,
     UnitSearch,
+    UnitOperationPeriodsRead,
     UnitUpdate,
     UnitView,
     UnitsReportRead,

--- a/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/backupcare/BackupCareController.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.backupcare
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.attendance.getOngoingAttendanceInAnyUnitForChild
+import fi.espoo.evaka.daycare.isDaycareOpenForPeriod
 import fi.espoo.evaka.placement.childPlacementsHasConsecutiveRange
 import fi.espoo.evaka.placement.clearCalendarEventAttendees
 import fi.espoo.evaka.placement.getPlacementsForChildDuring
@@ -93,6 +94,11 @@ class BackupCareController(private val accessControl: AccessControl) {
                         if (!tx.childPlacementsHasConsecutiveRange(childId, body.period)) {
                             throw BadRequest(
                                 "The new backup care period is not contained within a placement"
+                            )
+                        }
+                        if (!tx.isDaycareOpenForPeriod(body.unitId, body.period)) {
+                            throw BadRequest(
+                                "The unit is not open during the whole backup care period"
                             )
                         }
                         tx.getPlacementsForChildDuring(childId, body.period.start, body.period.end)

--- a/service/src/main/kotlin/fi/espoo/evaka/daycare/CareArea.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/daycare/CareArea.kt
@@ -154,3 +154,5 @@ data class UnitFeatures(
     val providerType: ProviderType,
     val type: List<CareType>,
 )
+
+data class UnitOperationPeriod(val openingDate: LocalDate?, val closingDate: LocalDate?)


### PR DESCRIPTION
Tarkistetaan yksikön aukiolo varasijoitusta tehdessä. Yksikön tulee olla auki koko varasijoituksen ajan, jotta sijoituksen voi tehdä.

Yksikölle voi olla määriteltynä avaus- ja sulkeutumispäivämäärä:
- Jos yksiköllä on avaus- ja sulkeutumispäivämäärä, tarkistetaan että varasijoitus on näiden päivämäärien sisällä
- Jos yksiköllä ei ole avauspäivämäärää, tarkistetaan että varasijoitus loppuu ennen sulkeutumispäivämäärää
- Jos yksiköllä ei ole sulkeutumispäivämäärää, tarkistetaan että varasijoitus alkaa avauspäivämäärän jälkeen
- Jos yksiköllä ei ole avaus- ja sulkeutumispäivämäärää, oletetaan että yksikkö on auki riippumatta varasijoituksen ajankohdasta