### PR TITLE
Muutetaan sijoituksen tyypin käyttöliittymäteksti

### DIFF
--- a/frontend/src/employee-frontend/components/reports/ServiceNeeds.tsx
+++ b/frontend/src/employee-frontend/components/reports/ServiceNeeds.tsx
@@ -107,7 +107,7 @@ const ServiceNeedsInner = (props: { areas: AreaJSON[] }) => {
           <SelectF bind={providerType} placeholder={i18n.common.all} />
         </FilterRow>
         <FilterRow>
-          <FilterLabel>{i18n.reports.common.unitType}</FilterLabel>
+          <FilterLabel>{i18n.reports.common.placementType}</FilterLabel>
           <SelectF bind={placementType} placeholder={i18n.common.all} />
         </FilterRow>
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -3816,6 +3816,7 @@ export const fi = {
         PRIVATE_SERVICE_VOUCHER: 'Palveluseteli',
         EXTERNAL_PURCHASED: 'Ostopalvelu (muu)'
       },
+      placementType: 'Sijoitustyyppi',
       period: 'Ajanjakso',
       date: 'Päivämäärä',
       clock: 'Klo',


### PR DESCRIPTION
Jatkoa muutokselle https://github.com/espoon-voltti/evaka/pull/7434. Lasten palveluntarpeet ja iät yksiköissä -raportista löytyi vielä yksi muutettava teksti.