### PR TITLE
Esiopetukseen ilmoittautuessa kalenterin rajaaminen

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormClub.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormClub.tsx
@@ -19,7 +19,7 @@ export default React.memo(function ApplicationFormClub({
   setFormData,
   errors,
   verificationRequested,
-  originalPreferredStartDate,
+  isInvalidDate,
   minDate,
   maxDate,
   terms
@@ -38,7 +38,7 @@ export default React.memo(function ApplicationFormClub({
 
       <ServiceNeedSection
         status={application.status}
-        originalPreferredStartDate={originalPreferredStartDate}
+        isInvalidDate={isInvalidDate}
         minDate={minDate}
         maxDate={maxDate}
         type={applicationType}

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormDaycare.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormDaycare.tsx
@@ -25,7 +25,7 @@ export default React.memo(function ApplicationFormDaycare({
   setFormData,
   errors,
   verificationRequested,
-  originalPreferredStartDate,
+  isInvalidDate,
   minDate,
   maxDate
 }: ApplicationFormProps) {
@@ -63,9 +63,9 @@ export default React.memo(function ApplicationFormDaycare({
 
       <ServiceNeedSection
         status={application.status}
+        isInvalidDate={isInvalidDate}
         minDate={minDate}
         maxDate={maxDate}
-        originalPreferredStartDate={originalPreferredStartDate}
         type={applicationType}
         formData={formData.serviceNeed}
         updateFormData={(data) =>

--- a/frontend/src/citizen-frontend/applications/editor/ApplicationFormPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/ApplicationFormPreschool.tsx
@@ -25,7 +25,7 @@ export default React.memo(function ApplicationFormPreschool({
   setFormData,
   errors,
   verificationRequested,
-  originalPreferredStartDate,
+  isInvalidDate,
   minDate,
   maxDate,
   terms
@@ -70,7 +70,7 @@ export default React.memo(function ApplicationFormPreschool({
 
       <ServiceNeedSection
         status={application.status}
-        originalPreferredStartDate={originalPreferredStartDate}
+        isInvalidDate={isInvalidDate}
         minDate={minDate}
         maxDate={maxDate}
         type={applicationType}

--- a/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/PreferredStartSubSection.tsx
@@ -27,14 +27,13 @@ import {
 import { deleteAttachmentMutation } from '../../../attachments/queries'
 import { errorToInputInfo } from '../../../input-info-helper'
 import { useLang, useTranslation } from '../../../localization'
-import { isValidPreferredStartDate } from '../validations'
 
 import { ClubTermsInfo } from './ClubTermsInfo'
 import { PreschoolTermsInfoSection } from './PreschoolTermInfoSection'
 import type { ServiceNeedSectionProps } from './ServiceNeedSection'
 
 export default React.memo(function PreferredStartSubSection({
-  originalPreferredStartDate,
+  isInvalidDate,
   minDate,
   maxDate,
   type,
@@ -97,11 +96,7 @@ export default React.memo(function PreferredStartSubSection({
           locale={lang}
           info={errorToInputInfo(errors.preferredStartDate, t.validationErrors)}
           hideErrorsBeforeTouched={!verificationRequested}
-          isInvalidDate={(date: LocalDate) =>
-            isValidPreferredStartDate(date, originalPreferredStartDate, terms)
-              ? null
-              : t.validationErrors.unselectableDate
-          }
+          isInvalidDate={isInvalidDate}
           minDate={minDate}
           maxDate={maxDate}
           data-qa="preferredStartDate-input"

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceNeedSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceNeedSection.tsx
@@ -27,7 +27,7 @@ import ServiceTimeSubSectionPreschool from './ServiceTimeSubSectionPreschool'
 
 export type ServiceNeedSectionProps = {
   status: ApplicationStatus
-  originalPreferredStartDate: LocalDate | null
+  isInvalidDate: ((localDate: LocalDate) => string | null) | undefined
   minDate: LocalDate
   maxDate: LocalDate
   type: ApplicationType

--- a/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/service-need/ServiceTimeSubSectionPreschool.tsx
@@ -47,6 +47,7 @@ type ServiceTimeSubSectionProps = Omit<ServiceNeedSectionProps, 'type'>
 const applicationType = 'PRESCHOOL'
 
 export default React.memo(function ServiceTimeSubSectionPreschool({
+  isInvalidDate,
   minDate,
   maxDate,
   formData,
@@ -157,6 +158,7 @@ export default React.memo(function ServiceTimeSubSectionPreschool({
                   t.validationErrors
                 )}
                 hideErrorsBeforeTouched={!verificationRequested}
+                isInvalidDate={isInvalidDate}
                 minDate={minDate}
                 maxDate={maxDate}
                 initialMonth={

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -2002,7 +2002,7 @@ export const preschoolTerm2020 = Fixture.preschoolTerm({
   ),
   applicationPeriod: new FiniteDateRange(
     LocalDate.of(2020, 1, 8),
-    LocalDate.of(2020, 1, 20)
+    LocalDate.of(2021, 6, 4)
   ),
   termBreaks: []
 })
@@ -2022,9 +2022,11 @@ export const preschoolTerm2021 = Fixture.preschoolTerm({
   ),
   applicationPeriod: new FiniteDateRange(
     LocalDate.of(2021, 1, 8),
-    LocalDate.of(2021, 1, 20)
+    LocalDate.of(2022, 6, 3)
   ),
-  termBreaks: []
+  termBreaks: [
+    new FiniteDateRange(LocalDate.of(2021, 10, 18), LocalDate.of(2021, 10, 24))
+  ]
 })
 
 export const preschoolTerm2022 = Fixture.preschoolTerm({
@@ -2042,7 +2044,7 @@ export const preschoolTerm2022 = Fixture.preschoolTerm({
   ),
   applicationPeriod: new FiniteDateRange(
     LocalDate.of(2022, 1, 10),
-    LocalDate.of(2022, 1, 21)
+    LocalDate.of(2023, 6, 2)
   ),
   termBreaks: []
 })
@@ -2062,7 +2064,7 @@ export const preschoolTerm2023 = Fixture.preschoolTerm({
   ),
   applicationPeriod: new FiniteDateRange(
     LocalDate.of(2023, 1, 8),
-    LocalDate.of(2023, 1, 20)
+    LocalDate.of(2024, 6, 6)
   ),
   termBreaks: [
     new FiniteDateRange(LocalDate.of(2023, 10, 16), LocalDate.of(2023, 10, 20)),
@@ -2078,7 +2080,7 @@ export const clubTerm2020 = Fixture.clubTerm({
   ),
   applicationPeriod: new FiniteDateRange(
     LocalDate.of(2020, 1, 8),
-    LocalDate.of(2020, 1, 20)
+    LocalDate.of(2021, 6, 4)
   ),
   termBreaks: []
 })
@@ -2090,9 +2092,11 @@ export const clubTerm2021 = Fixture.clubTerm({
   ),
   applicationPeriod: new FiniteDateRange(
     LocalDate.of(2021, 1, 8),
-    LocalDate.of(2021, 1, 20)
+    LocalDate.of(2022, 6, 3)
   ),
-  termBreaks: []
+  termBreaks: [
+    new FiniteDateRange(LocalDate.of(2021, 10, 18), LocalDate.of(2021, 10, 24))
+  ]
 })
 
 export const clubTerm2022 = Fixture.clubTerm({
@@ -2102,7 +2106,7 @@ export const clubTerm2022 = Fixture.clubTerm({
   ),
   applicationPeriod: new FiniteDateRange(
     LocalDate.of(2022, 1, 8),
-    LocalDate.of(2022, 1, 20)
+    LocalDate.of(2023, 6, 3)
   ),
   termBreaks: []
 })
@@ -2114,7 +2118,7 @@ export const clubTerm2023 = Fixture.clubTerm({
   ),
   applicationPeriod: new FiniteDateRange(
     LocalDate.of(2023, 1, 8),
-    LocalDate.of(2023, 1, 20)
+    LocalDate.of(2024, 6, 3)
   ),
   termBreaks: [
     new FiniteDateRange(LocalDate.of(2023, 10, 16), LocalDate.of(2023, 10, 20)),

--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.spec.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.spec.tsx
@@ -114,6 +114,31 @@ describe('DatePicker', () => {
       expect(onChange.mock.calls.length).toEqual(0)
       onChange.mockClear()
     })
+
+    it('does NOT call onChange if value is invalid', async () => {
+      const date = LocalDate.of(2023, 9, 13)
+      const onChange = jest.fn()
+
+      render(
+        jsx(
+          <DatePicker
+            date={null}
+            onChange={onChange}
+            locale="fi"
+            isInvalidDate={(localDate) =>
+              localDate.isEqual(date) ? null : 'Invalid'
+            }
+          />
+        )
+      )
+
+      const input = get()
+      await userEvent.type(input, date.subDays(1).format())
+      await userEvent.clear(input)
+      await userEvent.type(input, date.addDays(1).format())
+      expect(onChange.mock.calls.length).toEqual(0)
+      onChange.mockClear()
+    })
   })
   describe('native datepicker (android)', () => {
     const jsx = (child: React.JSX.Element) => (
@@ -188,6 +213,31 @@ describe('DatePicker', () => {
             locale="fi"
             minDate={date}
             maxDate={date}
+          />
+        )
+      )
+
+      const input = get()
+      change(input, date.subDays(1).formatIso())
+      change(input, '')
+      change(input, date.addDays(1).formatIso())
+      expect(onChange.mock.calls.length).toEqual(0)
+      onChange.mockClear()
+    })
+
+    it('does NOT call onChange if value is invalid', () => {
+      const date = LocalDate.of(2023, 9, 13)
+      const onChange = jest.fn()
+
+      render(
+        jsx(
+          <DatePicker
+            date={null}
+            onChange={onChange}
+            locale="fi"
+            isInvalidDate={(localDate) =>
+              localDate.isEqual(date) ? null : 'Invalid'
+            }
           />
         )
       )

--- a/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePicker.tsx
@@ -19,7 +19,6 @@ export interface DatePickerProps
   extends Omit<DatePickerLowLevelProps, 'value' | 'onChange'> {
   date: LocalDate | null
   onChange: (date: LocalDate | null) => void
-  isInvalidDate?: (date: LocalDate) => string | null
 }
 
 const DatePicker = React.memo(function DatePicker({
@@ -80,6 +79,7 @@ const DatePicker = React.memo(function DatePicker({
       value={textValue}
       onChange={handleChange}
       info={internalError ?? info}
+      isInvalidDate={isInvalidDate}
       minDate={minDate}
       maxDate={maxDate}
       {...props}
@@ -92,7 +92,7 @@ export default DatePicker
 export interface DatePickerFProps
   extends Omit<
     DatePickerLowLevelProps,
-    'value' | 'onChange' | 'minDate' | 'maxDate'
+    'value' | 'onChange' | 'isInvalidDate' | 'minDate' | 'maxDate'
   > {
   bind: BoundForm<LocalDateField>
 }

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerDay.tsx
@@ -4,7 +4,7 @@
 
 import type { Locale, Month, Day } from 'date-fns'
 import { fi, sv, enGB } from 'date-fns/locale'
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import type { OnSelectHandler } from 'react-day-picker'
 import { DayPicker } from 'react-day-picker'
 
@@ -16,8 +16,7 @@ interface Props {
   onSelect: OnSelectHandler<Date | undefined>
   inputValue: string
   locale: 'fi' | 'sv' | 'en'
-  minDate?: LocalDate
-  maxDate?: LocalDate
+  isDateDisabled: (localDate: LocalDate) => boolean
   initialMonth?: LocalDate
 }
 
@@ -25,8 +24,7 @@ export default React.memo(function DatePickerDay({
   onSelect,
   inputValue,
   locale,
-  minDate,
-  maxDate,
+  isDateDisabled,
   initialMonth
 }: Props) {
   const date = useMemo(
@@ -41,6 +39,10 @@ export default React.memo(function DatePickerDay({
       date?.toSystemTzDate() ??
       LocalDate.todayInHelsinkiTz().toSystemTzDate()
   )
+  const disabled = useCallback(
+    (date: Date) => isDateDisabled(LocalDate.fromSystemTzDate(date)),
+    [isDateDisabled]
+  )
 
   return (
     <DayPicker
@@ -54,14 +56,7 @@ export default React.memo(function DatePickerDay({
       selected={date?.toSystemTzDate()}
       month={month}
       onMonthChange={setMonth}
-      disabled={(date: Date) => {
-        const localDate = LocalDate.fromSystemTzDate(date)
-        return (
-          (minDate && minDate.isAfter(localDate)) ||
-          (maxDate && maxDate.isBefore(localDate)) ||
-          false
-        )
-      }}
+      disabled={disabled}
     />
   )
 })

--- a/frontend/src/lib-components/molecules/date-picker/DatePickerLowLevel.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DatePickerLowLevel.tsx
@@ -126,6 +126,7 @@ export interface DatePickerLowLevelProps {
   id?: string
   required?: boolean
   initialMonth?: LocalDate
+  isInvalidDate?: (localDate: LocalDate) => string | null
   minDate?: LocalDate
   maxDate?: LocalDate
   useBrowserPicker?: boolean
@@ -142,6 +143,7 @@ export default React.memo(function DatePickerLowLevel({
   id,
   required,
   initialMonth,
+  isInvalidDate,
   minDate,
   maxDate,
   useBrowserPicker = nativeDatePickerEnabled,
@@ -192,6 +194,18 @@ export default React.memo(function DatePickerLowLevel({
       onBlur?.(e)
     },
     [onBlur, onChange]
+  )
+
+  const isDateDisabled = useCallback(
+    (localDate: LocalDate) => {
+      return (
+        (isInvalidDate && isInvalidDate(localDate) !== null) ||
+        (minDate && minDate.isAfter(localDate)) ||
+        (maxDate && maxDate.isBefore(localDate)) ||
+        false
+      )
+    },
+    [isInvalidDate, maxDate, minDate]
   )
 
   useFloatingPositioning({
@@ -264,8 +278,7 @@ export default React.memo(function DatePickerLowLevel({
                     inputValue={value}
                     initialMonth={initialMonth}
                     onSelect={handleDateSelect}
-                    minDate={minDate}
-                    maxDate={maxDate}
+                    isDateDisabled={isDateDisabled}
                   />
                 </DayPickerDiv>
               </DayPickerPositioner>

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePicker.spec.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePicker.spec.tsx
@@ -224,6 +224,32 @@ describe('DateRangePicker', () => {
     onChange.mockClear()
   })
 
+  it('does NOT call onChange if dates are invalid', async () => {
+    const date = LocalDate.of(2023, 9, 1)
+    const onChange = jest.fn()
+
+    render(
+      <TestContextProvider translations={translations}>
+        <DateRangePicker
+          start={null}
+          end={null}
+          onChange={onChange}
+          isInvalidDate={(localDate) =>
+            localDate.isEqual(date) ? null : 'Invalid'
+          }
+          locale="fi"
+        />
+      </TestContextProvider>
+    )
+
+    const [start, end] = screen.getAllByRole('textbox')
+    await userEvent.type(start, date.subDays(1).format())
+    await userEvent.clear(start)
+    await userEvent.type(end, date.addDays(1).format())
+    expect(onChange.mock.calls).toEqual([])
+    onChange.mockClear()
+  })
+
   it('if start passes end, sets end to start', async () => {
     const dateBefore = LocalDate.of(2023, 9, 1)
     const dateAfter = dateBefore.addDays(5)

--- a/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
+++ b/frontend/src/lib-components/molecules/date-picker/DateRangePicker.tsx
@@ -37,6 +37,7 @@ const DateRangePicker = React.memo(function DateRangePicker({
   end,
   onChange,
   onValidationResult,
+  isInvalidDate,
   minDate,
   maxDate,
   ...datePickerProps
@@ -55,19 +56,35 @@ const DateRangePicker = React.memo(function DateRangePicker({
   const validate = useCallback(
     (start: LocalDate | null, end: LocalDate | null): boolean => {
       let isValid = true
-      if (start && minDate && start.isBefore(minDate)) {
-        setInternalStartError({
-          text: i18n.datePicker.validationErrors.dateTooEarly,
-          status: 'warning'
-        })
-        isValid = false
+      if (start) {
+        if (minDate && start.isBefore(minDate)) {
+          setInternalStartError({
+            text: i18n.datePicker.validationErrors.dateTooEarly,
+            status: 'warning'
+          })
+          isValid = false
+        } else {
+          const validationError = isInvalidDate?.(start)
+          if (validationError) {
+            setInternalStartError({ text: validationError, status: 'warning' })
+            isValid = false
+          }
+        }
       }
-      if (end && maxDate && end.isAfter(maxDate)) {
-        setInternalEndError({
-          text: i18n.datePicker.validationErrors.dateTooEarly,
-          status: 'warning'
-        })
-        isValid = false
+      if (end) {
+        if (maxDate && end.isAfter(maxDate)) {
+          setInternalEndError({
+            text: i18n.datePicker.validationErrors.dateTooEarly,
+            status: 'warning'
+          })
+          isValid = false
+        } else {
+          const validationError = isInvalidDate?.(end)
+          if (validationError) {
+            setInternalEndError({ text: validationError, status: 'warning' })
+            isValid = false
+          }
+        }
       }
       if (start && end && isValid && start.isAfter(end)) {
         setInternalStartError({
@@ -90,6 +107,7 @@ const DateRangePicker = React.memo(function DateRangePicker({
     [
       i18n.datePicker.validationErrors.dateTooEarly,
       i18n.datePicker.validationErrors.dateTooLate,
+      isInvalidDate,
       minDate,
       maxDate
     ]
@@ -140,6 +158,7 @@ const DateRangePicker = React.memo(function DateRangePicker({
       onChange={handleChange}
       startInfo={internalStartError ?? datePickerProps.startInfo}
       endInfo={internalEndError ?? datePickerProps.endInfo}
+      isInvalidDate={isInvalidDate}
       minDate={minDate}
       maxDate={maxDate}
       {...datePickerProps}
@@ -160,7 +179,13 @@ const DateInputSpacer = styled.div`
 export interface DateRangePickerFProps
   extends Omit<
     DateRangePickerLowLevelProps,
-    'value' | 'onChange' | 'startInfo' | 'endInfo' | 'minDate' | 'maxDate'
+    | 'value'
+    | 'onChange'
+    | 'startInfo'
+    | 'endInfo'
+    | 'isInvalidDate'
+    | 'minDate'
+    | 'maxDate'
   > {
   bind: BoundForm<LocalDateRangeField>
   info?: InputInfo | undefined


### PR DESCRIPTION
Disabloidaan kalenterista aloituspäivän valinnalle lomakaudet tai ylipäätään esiopetuskausien (tai pidennetyn esiopetuskauden) ulkopuoliset päivät esiopetusilmoittautumisen yhteydessä.