### PR TITLE
Piiloitetaan pedagogiset dokumentit huoltajalta lapsen sijoituksen loputtua

### DIFF
--- a/frontend/src/citizen-frontend/navigation/utils.ts
+++ b/frontend/src/citizen-frontend/navigation/utils.ts
@@ -57,10 +57,7 @@ export function useChildrenWithOwnPage() {
   const { data } = useQuery(childrenQuery())
   return useMemo(() => {
     if (!data) return []
-    return data.filter(
-      (child) =>
-        child.upcomingPlacementType !== null || child.hasPedagogicalDocuments
-    )
+    return data.filter((child) => child.upcomingPlacementType !== null)
   }, [data])
 }
 

--- a/frontend/src/lib-common/generated/api-types/children.ts
+++ b/frontend/src/lib-common/generated/api-types/children.ts
@@ -26,7 +26,6 @@ export interface ChildAndPermittedActions {
   duplicateOf: PersonId | null
   firstName: string
   group: Group | null
-  hasPedagogicalDocuments: boolean
   id: PersonId
   imageId: ChildImageId | null
   lastName: string

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/children/ChildControllerCitizenTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/children/ChildControllerCitizenTest.kt
@@ -319,7 +319,6 @@ class ChildControllerCitizenTest : FullApplicationTest(resetDbBeforeEach = true)
                 group = null,
                 unit = null,
                 upcomingPlacementType = PlacementType.DAYCARE,
-                hasPedagogicalDocuments = false,
                 permittedActions =
                     setOf(
                         Action.Citizen.Child.CREATE_ABSENCE,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerCitizenIntegrationTest.kt
@@ -465,9 +465,6 @@ class ChildDocumentControllerCitizenIntegrationTest :
 
     @Test
     fun `guardian can't get documents if child's placement has ended`() {
-        publishDocument(documentId)
-        asyncJobRunner.runPendingJobsSync(clock)
-
         val template =
             DevDocumentTemplate(
                     type = ChildDocumentType.CITIZEN_BASIC,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/childdocument/ChildDocumentControllerCitizenIntegrationTest.kt
@@ -15,14 +15,20 @@ import fi.espoo.evaka.document.getTemplate
 import fi.espoo.evaka.shared.ChildDocumentId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DocumentTemplateId
+import fi.espoo.evaka.shared.EmployeeId
+import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
 import fi.espoo.evaka.shared.auth.CitizenAuthLevel
 import fi.espoo.evaka.shared.auth.UserRole
+import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevChildDocument
+import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevDocumentTemplate
+import fi.espoo.evaka.shared.dev.DevEmployee
 import fi.espoo.evaka.shared.dev.DevGuardian
+import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insert
@@ -365,6 +371,14 @@ class ChildDocumentControllerCitizenIntegrationTest :
                 tx.insert(testAdult_2, DevPersonType.ADULT)
                 tx.insert(DevGuardian(testAdult_2.id, testChild_2.id))
                 tx.insert(
+                    DevPlacement(
+                        childId = testChild_2.id,
+                        unitId = testDaycare.id,
+                        startDate = clock.today(),
+                        endDate = clock.today().plusDays(5),
+                    )
+                )
+                tx.insert(
                     DevChildDocument(
                         status = DocumentStatus.CITIZEN_DRAFT,
                         childId = testChild_2.id,
@@ -447,6 +461,74 @@ class ChildDocumentControllerCitizenIntegrationTest :
         assertEquals(listOf(summary2), getDocumentsByChild(testChild_2.id, user = citizen2))
         assertEquals(listOf(summary2), getUnansweredChildDocuments(user = citizen2))
         assertThrows<Forbidden> { getDocumentsByChild(testChild_1.id, user = citizen2) }
+    }
+
+    @Test
+    fun `guardian can't get documents if child's placement has ended`() {
+        publishDocument(documentId)
+        asyncJobRunner.runPendingJobsSync(clock)
+
+        val template =
+            DevDocumentTemplate(
+                    type = ChildDocumentType.CITIZEN_BASIC,
+                    name = "Medialupa",
+                    validity = DateRange(clock.today(), clock.today()),
+                    content = templateContent,
+                )
+                .also { db.transaction { tx -> tx.insert(it) } }
+
+        val adult =
+            DevPerson(PersonId(UUID.randomUUID())).also {
+                db.transaction { tx -> tx.insert(it, DevPersonType.ADULT) }
+            }
+        val child =
+            DevPerson(PersonId(UUID.randomUUID())).also {
+                db.transaction { tx -> tx.insert(it, DevPersonType.CHILD) }
+            }
+        db.transaction { tx -> tx.insert(DevGuardian(adult.id, child.id)) }
+
+        val adultUser = AuthenticatedUser.Citizen(adult.id, CitizenAuthLevel.STRONG)
+        val employee =
+            DevEmployee(EmployeeId(UUID.randomUUID())).also {
+                db.transaction { tx -> tx.insert(it) }
+            }
+        val employeeUser = AuthenticatedUser.Employee(employee.id, setOf(UserRole.ADMIN))
+
+        val careArea =
+            DevCareArea(shortName = "test_care_area").also {
+                db.transaction { tx -> tx.insert(it) }
+            }
+        val daycare =
+            DevDaycare(areaId = careArea.id).also { db.transaction { tx -> tx.insert(it) } }
+
+        db.transaction { tx ->
+            tx.insert(
+                DevChildDocument(
+                    status = DocumentStatus.CITIZEN_DRAFT,
+                    childId = child.id,
+                    templateId = template.id,
+                    content = documentContent,
+                    publishedContent = documentContent,
+                    modifiedAt = clock.now(),
+                    contentModifiedAt = clock.now(),
+                    contentModifiedBy = employeeUser.id,
+                    publishedAt = clock.now(),
+                    answeredAt = null,
+                    answeredBy = null,
+                )
+            )
+
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = daycare.id,
+                    startDate = clock.today().minusDays(1),
+                    endDate = clock.today().minusDays(1),
+                )
+            )
+        }
+
+        assertThrows<Forbidden> { getDocumentsByChild(child.id, adultUser) }
     }
 
     @Test

--- a/service/src/main/kotlin/fi/espoo/evaka/children/Children.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/children/Children.kt
@@ -28,7 +28,6 @@ data class Child(
     @Nested("group") val group: Group?,
     @Nested("unit") val unit: Unit?,
     val upcomingPlacementType: PlacementType?,
-    val hasPedagogicalDocuments: Boolean,
 )
 
 data class ChildAndPermittedActions(
@@ -41,7 +40,6 @@ data class ChildAndPermittedActions(
     @Nested("group") val group: Group?,
     @Nested("unit") val unit: Unit?,
     val upcomingPlacementType: PlacementType?,
-    val hasPedagogicalDocuments: Boolean,
     val permittedActions: Set<Action.Citizen.Child>,
     val serviceApplicationCreationPossible: Boolean,
     val absenceApplicationCreationPossible: Boolean,
@@ -63,7 +61,6 @@ data class ChildAndPermittedActions(
                 group = child.group,
                 unit = child.unit,
                 upcomingPlacementType = child.upcomingPlacementType,
-                hasPedagogicalDocuments = child.hasPedagogicalDocuments,
                 permittedActions = permittedActions,
                 serviceApplicationCreationPossible = serviceApplicationCreationPossible,
                 absenceApplicationCreationPossible = absenceApplicationCreationPossible,

--- a/service/src/main/kotlin/fi/espoo/evaka/children/ChildrenQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/children/ChildrenQueries.kt
@@ -31,8 +31,7 @@ SELECT
     u.id AS unit_id,
     u.name AS unit_name,
     upcoming_pl.type AS upcoming_placement_type,
-    upcoming_pl.type IS NOT NULL AS has_upcoming_placements,
-    EXISTS (SELECT 1 FROM pedagogical_document doc WHERE p.id = doc.child_id) has_pedagogical_documents
+    upcoming_pl.type IS NOT NULL AS has_upcoming_placements
 FROM children c
 INNER JOIN person p ON c.child_id = p.id
 LEFT JOIN child_images img ON p.id = img.child_id

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/security/Action.kt
@@ -462,8 +462,8 @@ sealed interface Action {
                 IsCitizen(allowWeakLogin = false).fosterParentOfChild(),
             ),
             READ_PEDAGOGICAL_DOCUMENTS(
-                IsCitizen(allowWeakLogin = false).guardianOfChild(),
-                IsCitizen(allowWeakLogin = false).fosterParentOfChild(),
+                IsCitizen(allowWeakLogin = false).guardianOfChildWithActiveOrUpcomingPlacement(),
+                IsCitizen(allowWeakLogin = false).fosterParentOfChildWithActiveOrUpcomingPlacement(),
             ),
             CREATE_ABSENCE_APPLICATION(
                 IsCitizen(allowWeakLogin = true).guardianOfChild(),
@@ -491,8 +491,8 @@ sealed interface Action {
                 IsCitizen(allowWeakLogin = true).fosterParentOfChild(),
             ),
             READ_CHILD_DOCUMENTS(
-                IsCitizen(allowWeakLogin = false).guardianOfChild(),
-                IsCitizen(allowWeakLogin = false).fosterParentOfChild(),
+                IsCitizen(allowWeakLogin = false).guardianOfChildWithActiveOrUpcomingPlacement(),
+                IsCitizen(allowWeakLogin = false).fosterParentOfChildWithActiveOrUpcomingPlacement(),
             ),
             CREATE_CALENDAR_EVENT_TIME_RESERVATION(
                 IsCitizen(allowWeakLogin = true).guardianOfChild(),


### PR DESCRIPTION
Muutetaan huoltajan oikeuksia siten, että heillä on pääsy pedagogisiin dokumentteihin vain jos lapsella on aktiivinen tai tuleva sijoitus. Sijoituksen päätyttyä huoltaja ei pysty lukemaan tai lataamaan pedagogisia dokumentteja tai liitteitä