### PR TITLE
Ei sisällytetä tarkoituksellisesti monistettuja henkilöitä raportteihin

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/DuplicatePeopleReport.kt
@@ -60,6 +60,7 @@ private fun Database.Read.getDuplicatePeople(): List<DuplicatePeopleReportRow> {
             FROM person p
             WHERE p.first_name IS NOT NULL AND p.last_name IS NOT NULL 
                 AND p.first_name <> '' AND p.last_name <> '' AND lower(last_name) <> 'testaaja'
+                AND p.duplicate_of IS NULL
         ), duplicate_keys AS (
             SELECT key
             FROM people p

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/MissingHeadOfFamilyReport.kt
@@ -96,7 +96,8 @@ FROM (
                 daterange(start_date, end_date, '[]') && ${bind(dateRange)} AND
                 type <> 'CLUB'
         ) AND
-        p.date_of_death IS NULL
+        p.duplicate_of IS NULL
+        AND p.date_of_death IS NULL
 ) s
 WHERE NOT isempty(without_head)
 ORDER BY last_name, first_name


### PR DESCRIPTION
Tarkoituksellisen monistusominaisuuden poistossa `Monistuneet kuntalaiset` ja `Puuttuvat päämiehet` raporteille sisällytettiin virheellisesti tarkoituksellisesti monistetut henkilöt. Muutos filtteröi henkilöt pois. Ongelma koskee vain kuntia (Tampere) joissa tarkoituksellinen monistaminen ollut käytössä.