### PR TITLE
Mahdollistetaan käyttäjän kevytkirjautumisen deaktivointi kannan tasolla

### DIFF
--- a/service/src/main/resources/db/migration/V547__relax_weak_credentials_check.sql
+++ b/service/src/main/resources/db/migration/V547__relax_weak_credentials_check.sql
@@ -1,0 +1,7 @@
+ALTER TABLE citizen_user
+    DROP CONSTRAINT check$weak_credentials,
+    ADD CONSTRAINT check$weak_credentials CHECK ((username IS NULL) = (password IS NULL)),
+    ADD CONSTRAINT check$weak_credentials_updated CHECK (
+        (username IS NULL OR username_updated_at IS NOT NULL) AND
+        (username_updated_at IS NULL) = (password_updated_at IS NULL)
+    );

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -542,3 +542,4 @@ V543__case_process.sql
 V544__child_document_decision_unit.sql
 V545__case_identifier.sql
 V546__end_decision_when_unit_changes_config.sql
+V547__relax_weak_credentials_check.sql


### PR DESCRIPTION
Käyttäjän kevytkirjautumisen voi nyt estää näin:

```
UPDATE citizen_user SET
  username = NULL, username_updated_at = current_timestamp,
  password = NULL, password_updated_at = current_timestamp
WHERE id = <person_id>;
```

Myöhemmin tälle voidaan kehittää käyttöliittymä.
