### PR TITLE
Lähetetään lähes kaikki sähköpostiviestit geneerisestä osoitteesta

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionIntegrationTest.kt
@@ -910,7 +910,7 @@ class AssistanceNeedDecisionIntegrationTest : FullApplicationTest(resetDbBeforeE
             getEmailFor(testAdult_4).content.subject,
         )
         assertEquals(
-            "Test email sender fi <testemail_fi@test.com>",
+            "Espoon Varhaiskasvatus <no-reply.evaka@espoo.fi>",
             getEmailFor(testAdult_4).fromAddress.address,
         )
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedPreschoolDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedPreschoolDecisionIntegrationTest.kt
@@ -486,7 +486,7 @@ class AssistanceNeedPreschoolDecisionIntegrationTest :
             getEmailFor(testAdult_2).content.subject,
         )
         assertEquals(
-            "Test email sender fi <testemail_fi@test.com>",
+            "Espoon Varhaiskasvatus <no-reply.evaka@espoo.fi>",
             getEmailFor(testAdult_2).fromAddress.address,
         )
     }

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/application/AbsenceApplicationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/application/AbsenceApplicationService.kt
@@ -58,7 +58,7 @@ class AbsenceApplicationService(
                     db,
                     guardian.id,
                     EmailMessageType.DECISION_NOTIFICATION,
-                    emailEnv.applicationReceivedSender(language),
+                    emailEnv.sender(language),
                     emailMessageProvider.absenceApplicationDecidedNotification(
                         when (application.status) {
                             AbsenceApplicationStatus.ACCEPTED -> true

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/decision/AssistanceNeedDecisionService.kt
@@ -129,7 +129,7 @@ class AssistanceNeedDecisionService(
                 OfficialLanguage.SV -> Language.sv
                 else -> Language.fi
             }
-        val fromAddress = emailEnv.applicationReceivedSender(language)
+        val fromAddress = emailEnv.sender(language)
         val content = emailMessageProvider.assistanceNeedDecisionNotification(language)
 
         Email.create(

--- a/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistanceneed/preschooldecision/AssistanceNeedPreschoolDecisionService.kt
@@ -127,7 +127,7 @@ class AssistanceNeedPreschoolDecisionService(
                 OfficialLanguage.SV -> Language.sv
                 else -> Language.fi
             }
-        val fromAddress = emailEnv.applicationReceivedSender(language)
+        val fromAddress = emailEnv.sender(language)
         val content = emailMessageProvider.assistanceNeedPreschoolDecisionNotification(language)
 
         Email.create(

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/application/ServiceApplicationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/application/ServiceApplicationService.kt
@@ -61,7 +61,7 @@ class ServiceApplicationService(
 
         logger.info { "Sending service application decided email (${application.id})." }
 
-        val fromAddress = emailEnv.applicationReceivedSender(language)
+        val fromAddress = emailEnv.sender(language)
         val content =
             emailMessageProvider.serviceApplicationDecidedNotification(
                 accepted = accepted,


### PR DESCRIPTION
eVakaan voi konfiguroida kolme sähköpostin lähetysosoitetta:
* Yleinen
* "Hakemus vastaanotettu" (esim. palveluohjauksen osoite), erilliset suomen- ja ruotsinkielisille yksiköille

Palveluohjauksen sähköpostiosoitetta käytetään nyt vain kerho-, päivähoito- ja esiopetushakemusten vastaanottokuittausviesteissä. Ennen tätä muutosta, palveluohjauksen osoitetta käytettiin lisäksi seuraavien viestien lähettämiseen:
- lapsellenne on tehty tuen päätös / eskarituen päätös (vanha tuen päätössysteemi)
- esiopetuksen poissaolohakemuks hyväksytty/hylätty
- palveluntarpeen muutoshakemus on käsitelty