### PR TITLE
Korjattu bugi Nekun manuaalitilauksissa

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuService.kt
@@ -426,7 +426,7 @@ fun planNekkuManualOrderJob(
     if (!isDaycareOpenOnDate(date, daycareOperationInfo))
         throw BadRequest("Group $groupId is not open on $date")
 
-    if (tx.getNekkuDaycareGroupId(date.daySpan()).none { it == groupId })
+    if (tx.getNekkuDaycareGroupId(FiniteDateRange(date, date)).none { it == groupId })
         throw BadRequest("No customer number for group $groupId or group or unit is not open")
 
     asyncJobRunner.plan(


### PR DESCRIPTION
Jos ryhmä ei ole vielä auki, Nekun manuaalitilauksen pystyi tekemään ryhmän avautumista edeltävälle päivälle