### PR TITLE
Korjataan päättyneiden lomakepohjien suodatus

### DIFF
--- a/frontend/src/employee-frontend/components/document-templates/template-editor/DocumentTemplatesPage.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/DocumentTemplatesPage.tsx
@@ -258,8 +258,7 @@ export default React.memo(function DocumentTemplatesPage() {
           if (
             !past.value() &&
             template.validity.end &&
-            template.validity.end.isBefore(today) &&
-            template.published
+            template.validity.end.isBefore(today)
           )
             return false
           if (type.value() !== undefined && type.value() !== template.type)

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -5286,7 +5286,7 @@ export const fi = {
         active: 'Käytössä',
         draft: 'Luonnos',
         future: 'Tulossa käyttöön',
-        past: 'Poistunut käytöstä',
+        past: 'Päättyneet',
         type: 'Asiakirjan tyyppi',
         all: 'Kaikki',
         language: 'Kieli'


### PR DESCRIPTION
**Ennen tätä muutosta:**

Poistunut käytöstä -suodatin ei suodattanut pois luonnoksia.

<img width="866" height="245" alt="Screenshot 2025-08-08 at 12 26 11" src="https://github.com/user-attachments/assets/50f93a3c-d5b7-4f7d-8a79-1dd660dd9e50" />

**Tämän muutoksen jälkeen:**

Päättyneet-suodatin suodattaa pois myös luonnokset.

<img width="810" height="243" alt="Screenshot 2025-08-08 at 12 26 49" src="https://github.com/user-attachments/assets/8214d844-39d1-40f0-97fc-19cc114aa381" />
