### PR TITLE
Muutetaan tuntiperusteisten varausten päivittäiskeskiarvolaskenta pyöristämään alaspäin

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -44,7 +44,6 @@ import fi.espoo.evaka.shared.utils.mapOfNotNullValues
 import fi.espoo.evaka.user.EvakaUser
 import java.time.LocalDate
 import java.time.LocalTime
-import kotlin.math.roundToLong
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 sealed interface DailyReservationRequest {
@@ -642,7 +641,7 @@ fun computeUsedService(
         } else {
             21
         }
-    val dailyAverage = serviceNeedHours.toDouble() * 60 / daysInMonth
+    val dailyAverageRoundedDown = (serviceNeedHours.toDouble() * 60 / daysInMonth).toLong()
 
     // Five-year-olds get 4 hours for free
     val freeMinutes =
@@ -654,14 +653,14 @@ fun computeUsedService(
     if (operationDates.contains(date) && isFreeAbsence) {
         return if (isDateInFuture) {
             UsedServiceResult(
-                reservedMinutes = dailyAverage.roundToLong(),
+                reservedMinutes = dailyAverageRoundedDown,
                 usedServiceMinutes = 0,
                 usedServiceRanges = emptyList(),
             )
         } else
             UsedServiceResult(
-                reservedMinutes = dailyAverage.roundToLong(),
-                usedServiceMinutes = maxOf(0, dailyAverage.roundToLong() - freeMinutes),
+                reservedMinutes = dailyAverageRoundedDown,
+                usedServiceMinutes = maxOf(0, dailyAverageRoundedDown - freeMinutes),
                 usedServiceRanges = emptyList(),
             )
     }
@@ -712,7 +711,7 @@ fun computeUsedService(
     if (operationDates.contains(date) && reservations.isEmpty() && endedAttendances.isEmpty()) {
         return UsedServiceResult(
             reservedMinutes = 0,
-            usedServiceMinutes = maxOf(0, dailyAverage.roundToLong() - freeMinutes),
+            usedServiceMinutes = maxOf(0, dailyAverageRoundedDown - freeMinutes),
             usedServiceRanges = emptyList(),
         )
     }

--- a/service/src/test/kotlin/fi/espoo/evaka/reservations/UsedServiceTests.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/reservations/UsedServiceTests.kt
@@ -103,7 +103,7 @@ class UsedServiceTests {
     @Test
     fun `uses hours divided by 21 if no absences, reservations or attendances exist`() {
         compute(absences = listOf(), reservations = listOf(), attendances = listOf()).also {
-            assertEquals(it.usedServiceMinutes, (120.0 * 60 / 21).roundToLong())
+            assertEquals(it.usedServiceMinutes, (120.0 * 60 / 21).toLong())
             assertEquals(it.usedServiceRanges, emptyList())
         }
 
@@ -115,7 +115,7 @@ class UsedServiceTests {
             )
             .also {
                 // Five-year-olds get 4 hours for free
-                assertEquals((120.0 * 60 / 21).roundToLong() - 4 * 60, it.usedServiceMinutes)
+                assertEquals((120.0 * 60 / 21).toLong() - 4 * 60, it.usedServiceMinutes)
                 assertEquals(emptyList(), it.usedServiceRanges)
             }
     }
@@ -177,7 +177,7 @@ class UsedServiceTests {
     @Test
     fun `uses hours divided by 21 if other than planned absences exist without reservation`() {
         compute(absences = listOf(AbsenceType.OTHER_ABSENCE to AbsenceCategory.BILLABLE)).also {
-            assertEquals(it.usedServiceMinutes, (120.0 * 60 / 21).roundToLong())
+            assertEquals(it.usedServiceMinutes, (120.0 * 60 / 21).toLong())
             assertEquals(it.usedServiceRanges, emptyList())
         }
     }
@@ -456,13 +456,13 @@ class UsedServiceTests {
         compute(
                 date = date,
                 placementType = PlacementType.DAYCARE,
-                serviceNeedHours = 120,
+                serviceNeedHours = 85,
                 absences = listOf(AbsenceType.FREE_ABSENCE to AbsenceCategory.BILLABLE),
                 operationDates = operationDatesWithCount(23),
             )
             .also {
-                assertEquals((120.0 * 60 / 23).roundToLong(), it.reservedMinutes)
-                assertEquals((120.0 * 60 / 23).roundToLong(), it.usedServiceMinutes)
+                assertEquals((85.0 * 60 / 23).toLong(), it.reservedMinutes)
+                assertEquals((85.0 * 60 / 23).toLong(), it.usedServiceMinutes)
                 assertEquals(emptyList(), it.usedServiceRanges)
             }
 
@@ -479,8 +479,8 @@ class UsedServiceTests {
                 operationDates = operationDatesWithCount(31),
             )
             .also {
-                assertEquals((120.0 * 60 / 31).roundToLong(), it.reservedMinutes)
-                assertEquals((120.0 * 60 / 31).roundToLong(), it.usedServiceMinutes)
+                assertEquals((120.0 * 60 / 31).toLong(), it.reservedMinutes)
+                assertEquals((120.0 * 60 / 31).toLong(), it.usedServiceMinutes)
                 assertEquals(emptyList(), it.usedServiceRanges)
             }
     }


### PR DESCRIPTION
Ylöspäin pyöristäminen aiheutti jämäminuutteja, jotka näkyivät huoltajille sopimusylityksinä poissaolokuukausina. Alaspäin pyöristämällä pienennetään pyöristysvääristymän aiheuttamaa vahinkoa. 