### PR TITLE
Käytetään yhtä lähettäjän osoitetta kaikkeen sähköpostinlähetykseen

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailIntegrationTest.kt
@@ -172,7 +172,10 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest(resetDbBefor
         assertEquals(1, sentMails.size)
 
         val sentMail = sentMails[0]
-        assertEquals("Test email sender sv <testemail_sv@test.com>", sentMail.fromAddress.address)
+        assertEquals(
+            "Esbo småbarnspedagogik <no-reply.evaka@espoo.fi>",
+            sentMail.fromAddress.address,
+        )
         assertEquals(guardian.email, sentMail.toAddress)
         assertEquals(guardian.id.toString(), sentMail.traceId)
         assertEquals(
@@ -412,7 +415,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest(resetDbBefor
         assertEmail(
             MockEmailClient.getEmail("working@test.fi"),
             "working@test.fi",
-            "Test email sender fi <testemail_fi@test.com>",
+            "Espoon Varhaiskasvatus <no-reply.evaka@espoo.fi>",
             "Olemme vastaanottaneet hakemuksenne / Vi har tagit emot din ansökan / We have received your application",
             "Varhaiskasvatushakemuksella on <strong>neljän (4) kuukauden hakuaika",
             "Varhaiskasvatushakemuksella on neljän (4) kuukauden hakuaika",
@@ -428,7 +431,7 @@ class ApplicationReceivedEmailIntegrationTest : FullApplicationTest(resetDbBefor
         assertEmail(
             MockEmailClient.getEmail("Working.Email@Test.Com"),
             "Working.Email@Test.Com",
-            "Test email sender sv <testemail_sv@test.com>",
+            "Esbo småbarnspedagogik <no-reply.evaka@espoo.fi>",
             "Olemme vastaanottaneet hakemuksenne / Vi har tagit emot din ansökan / We have received your application",
             "Ansökan om småbarnspedagogik har en <strong>ansökningstid på fyra (4) månader",
             "Ansökan om småbarnspedagogik har en ansökningstid på fyra (4) månader",

--- a/service/src/integrationTest/resources/application-integration-test.yaml
+++ b/service/src/integrationTest/resources/application-integration-test.yaml
@@ -16,13 +16,6 @@ evaka:
     sender_name:
       fi: Espoon Varhaiskasvatus
       sv: Esbo småbarnspedagogik
-    application_received:
-      sender_address:
-        fi: testemail_fi@test.com
-        sv: testemail_sv@test.com
-      sender_name:
-        fi: Test email sender fi
-        sv: Test email sender sv
   async_job_runner:
     disable_runner: true
   fee_decision:

--- a/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/EvakaEnv.kt
@@ -161,31 +161,11 @@ data class EmailEnv(
     val senderNameFi: String,
     val senderNameSv: String,
     val subjectPostfix: String?,
-    val applicationReceivedSenderAddressFi: String,
-    val applicationReceivedSenderAddressSv: String,
-    val applicationReceivedSenderAddressArnFi: String?,
-    val applicationReceivedSenderAddressArnSv: String?,
-    val applicationReceivedSenderNameFi: String,
-    val applicationReceivedSenderNameSv: String,
 ) {
     fun sender(language: Language): FromAddress =
         when (language) {
             Language.sv -> FromAddress("$senderNameSv <$senderAddress>", senderAddressArn)
             else -> FromAddress("$senderNameFi <$senderAddress>", senderAddressArn)
-        }
-
-    fun applicationReceivedSender(language: Language): FromAddress =
-        when (language) {
-            Language.sv ->
-                FromAddress(
-                    "$applicationReceivedSenderNameSv <$applicationReceivedSenderAddressSv>",
-                    applicationReceivedSenderAddressArnSv,
-                )
-            else ->
-                FromAddress(
-                    "$applicationReceivedSenderNameFi <$applicationReceivedSenderAddressFi>",
-                    applicationReceivedSenderAddressArnFi,
-                )
         }
 
     companion object {
@@ -206,18 +186,6 @@ data class EmailEnv(
                 senderNameFi = env.lookup("evaka.email.sender_name.fi"),
                 senderNameSv = env.lookup("evaka.email.sender_name.sv"),
                 subjectPostfix = env.lookup("evaka.email.subject_postfix") ?: getLegacyPostfix(),
-                applicationReceivedSenderAddressFi =
-                    env.lookup("evaka.email.application_received.sender_address.fi") ?: "",
-                applicationReceivedSenderAddressSv =
-                    env.lookup("evaka.email.application_received.sender_address.sv") ?: "",
-                applicationReceivedSenderAddressArnFi =
-                    env.lookup("evaka.email.application_received.sender_address_arn.fi"),
-                applicationReceivedSenderAddressArnSv =
-                    env.lookup("evaka.email.application_received.sender_address_arn.sv"),
-                applicationReceivedSenderNameFi =
-                    env.lookup("evaka.email.application_received.sender_name.fi") ?: "",
-                applicationReceivedSenderNameSv =
-                    env.lookup("evaka.email.application_received.sender_name.sv") ?: "",
             )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationReceivedEmailService.kt
@@ -30,7 +30,7 @@ class ApplicationReceivedEmailService(
         type: ApplicationType,
         sentWithinPreschoolApplicationPeriod: Boolean? = null,
     ) {
-        val fromAddress = emailEnv.applicationReceivedSender(language)
+        val fromAddress = emailEnv.sender(language)
         val content =
             when (type) {
                 ApplicationType.CLUB -> emailMessageProvider.clubApplicationReceived(language)

--- a/service/src/main/resources/application-espoo_evaka.yaml
+++ b/service/src/main/resources/application-espoo_evaka.yaml
@@ -8,13 +8,6 @@ evaka:
     sender_name:
       fi: "Espoon Varhaiskasvatus"
       sv: "Esbo småbarnspedagogik"
-    application_received:
-      sender_address:
-        fi: "vaka.palveluohjaus@espoo.fi"
-        sv: "dagis@esbo.fi"
-      sender_name:
-        fi: "Varhaiskasvatuksen palveluohjaus"
-        sv: "Servicesakkunnig / Esbo stad"
   oph:
     municipality_code: "049"
     organizer_oid: "1.2.246.562.10.90008375488"


### PR DESCRIPTION
`EVAKA_EMAIL_APPLICATION_RECEIVED_*` ympäristömuuttujat jäävät pois käytöstä ja kaikkien sähköpostien lähetysosoitteena käytetään `EVAKA_EMAIL_SENDER_*`-ympäristömuuttujissa määriteltyjä nimiä ja osoitetta.