### PR TITLE
Bump renovate minimum release age to 5 days

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,8 +10,8 @@
   semanticCommits: 'disabled',
   automergeStrategy: 'merge-commit',
 
-  // Wait for a version to be 3 days old before making a PR
-  minimumReleaseAge: '3 days',
+  // Wait for a version to be 5 days old before making a PR
+  minimumReleaseAge: '5 days',
 
   // Update during weekends
   schedule: ['* * * * 0,6'],


### PR DESCRIPTION
This makes it even more likely to accidentally upgrade to malicious package versions, as these attempts are very likely to be detected in 5 days.