### PR TITLE
Ilmoita läsnäolo -modaalin saavutettavuusparannuksia

### DIFF
--- a/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useState, useCallback, useRef } from 'react'
+import React, { useState, useRef } from 'react'
 import styled from 'styled-components'
 
 import type { PreferredUnit } from 'lib-common/generated/api-types/application'
@@ -22,6 +22,7 @@ import { Gap } from 'lib-components/white-space'
 import { getMaxPreferredUnits } from 'lib-customizations/citizen'
 import colors from 'lib-customizations/common'
 
+import { useTimedScreenReaderMessage } from '../../../calendar/hooks'
 import { useTranslation } from '../../../localization'
 
 import PreferredUnitBox from './PreferredUnitBox'
@@ -45,24 +46,9 @@ export default React.memo(function UnitsSubSection({
   const [displayFinnish, setDisplayFinnish] = useState(true)
   const [displaySwedish, setDisplaySwedish] = useState(false)
   const [isUnitSelectionInvalid, setIsUnitSelectionInvalid] = useState(false)
-  const [screenReaderMessage, setScreenReaderMessage] = useState<string | null>(
-    null
-  )
+  const [screenReaderMessage, showTimedScreenReaderMessage] =
+    useTimedScreenReaderMessage()
   const maxUnits = getMaxPreferredUnits(applicationType)
-  const [isMessageTimerOn, setIsMessageTimerOn] = useState(false)
-  const showTimedScreenReaderMessage = useCallback(
-    (message: string) => {
-      setScreenReaderMessage(message)
-      if (!isMessageTimerOn) {
-        setIsMessageTimerOn(true)
-        setTimeout(() => {
-          setScreenReaderMessage(null)
-          setIsMessageTimerOn(false)
-        }, 5000)
-      }
-    },
-    [isMessageTimerOn]
-  )
 
   return (
     <>

--- a/frontend/src/citizen-frontend/calendar/hooks.ts
+++ b/frontend/src/citizen-frontend/calendar/hooks.ts
@@ -149,3 +149,27 @@ export function useExtendedReservationsRange(dateRange: FiniteDateRange) {
 
   return { reservations, loading: fetchedReservations.isLoading }
 }
+
+export const useTimedScreenReaderMessage = (): [
+  string | null,
+  (message: string) => void
+] => {
+  const [screenReaderMessage, setScreenReaderMessage] = useState<string | null>(
+    null
+  )
+  const [isMessageTimerOn, setIsMessageTimerOn] = useState(false)
+  const showTimedScreenReaderMessage = useCallback(
+    (message: string) => {
+      setScreenReaderMessage(message)
+      if (!isMessageTimerOn) {
+        setIsMessageTimerOn(true)
+        setTimeout(() => {
+          setScreenReaderMessage(null)
+          setIsMessageTimerOn(false)
+        }, 5000)
+      }
+    },
+    [isMessageTimerOn]
+  )
+  return [screenReaderMessage, showTimedScreenReaderMessage]
+}

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -370,6 +370,8 @@ const TimeRanges = React.memo(function TimeRanges({
             bind={firstTimeRange}
             hideErrorsBeforeTouched={!showAllErrors}
             dataQaPrefix={dataQaPrefix ? `${dataQaPrefix}-time-0` : undefined}
+            ariaDescriptionStart={i18n.calendar.reservationModal.startAria}
+            ariaDescriptionEnd={i18n.calendar.reservationModal.endAria}
             onFocus={onFocus}
           />
         </MiddleCell>

--- a/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
+++ b/frontend/src/citizen-frontend/calendar/reservation-modal/TimeInputs.tsx
@@ -12,6 +12,7 @@ import {
   useFormField,
   useFormUnion
 } from 'lib-common/form/hooks'
+import { ScreenReaderOnly } from 'lib-components/atoms/ScreenReaderOnly'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import Radio from 'lib-components/atoms/form/Radio'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
@@ -24,6 +25,7 @@ import { faPlus, fasUserMinus, faTrash, faUserMinus } from 'lib-icons'
 import { useTranslation } from '../../localization'
 import { focusElementOnNextFrame } from '../../utils/focus'
 import TimeRangeInput from '../TimeRangeInput'
+import { useTimedScreenReaderMessage } from '../hooks'
 
 import type { LimitedLocalTimeRangeField, ReadOnlyState } from './form'
 import {
@@ -345,6 +347,8 @@ const TimeRanges = React.memo(function TimeRanges({
   const i18n = useTranslation()
   const firstTimeRange = useFormElem(bind, 0)
   const secondTimeRange = useFormElem(bind, 1)
+  const [screenReaderMessage, showTimedScreenReaderMessage] =
+    useTimedScreenReaderMessage()
 
   if (firstTimeRange === undefined) {
     throw new Error('BUG: at least one time range expected')
@@ -408,6 +412,9 @@ const TimeRanges = React.memo(function TimeRanges({
           </FixedSpaceRow>
         </RightCell>
       </FixedSpaceRow>
+      <ScreenReaderOnly aria-live="polite" aria-atomic={true}>
+        {screenReaderMessage}
+      </ScreenReaderOnly>
       {secondTimeRange !== undefined ? (
         <FixedSpaceRow fullWidth alignItems="center">
           {label !== undefined ? <LeftCell /> : null}
@@ -428,7 +435,12 @@ const TimeRanges = React.memo(function TimeRanges({
           <RightCell>
             <IconOnlyButton
               icon={faTrash}
-              onClick={() => bind.update((prev) => prev.slice(0, 1))}
+              onClick={() => {
+                bind.update((prev) => prev.slice(0, 1))
+                showTimedScreenReaderMessage(
+                  i18n.calendar.reservationModal.secondTimeRange.deleteSuccess
+                )
+              }}
               aria-label={i18n.calendar.reservationModal.secondTimeRange.delete}
             />
           </RightCell>

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -507,6 +507,7 @@ const en: Translations = {
       secondTimeRange: {
         add: 'Add second time range',
         delete: 'Delete second time range',
+        deleteSuccess: 'Second time range deleted',
         start: 'Second time range start',
         end: 'Second time range end'
       },

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -504,6 +504,8 @@ const en: Translations = {
       },
       start: 'Start',
       end: 'End',
+      startAria: 'Time range start',
+      endAria: 'Time range end',
       secondTimeRange: {
         add: 'Add second time range',
         delete: 'Delete second time range',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -509,6 +509,7 @@ export default {
       secondTimeRange: {
         add: 'Lisää toinen aikaväli',
         delete: 'Poista toinen aikaväli',
+        deleteSuccess: 'Toinen aikaväli poistettu',
         start: 'Toisen aikavälin alku',
         end: 'Toisen aikavälin loppu'
       },

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -506,6 +506,8 @@ export default {
       },
       start: 'Alkaa',
       end: 'Päättyy',
+      startAria: 'Ilmoita aloitusaika',
+      endAria: 'Ilmoita loppumisaika',
       secondTimeRange: {
         add: 'Lisää toinen aikaväli',
         delete: 'Poista toinen aikaväli',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -498,6 +498,7 @@ const sv: Translations = {
       secondTimeRange: {
         add: 'Lägg till ett andra tidsintervall',
         delete: 'Radera andra tidsintervallet',
+        deleteSuccess: 'Andra tidsintervallet raderat',
         start: 'Andra tidsintervall start',
         end: 'Andra tidsintervall slut'
       },

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -495,6 +495,8 @@ const sv: Translations = {
       },
       start: 'Börjar',
       end: 'Slutar',
+      startAria: 'Tidsintervallets början',
+      endAria: 'Slut på tidsintervallet',
       secondTimeRange: {
         add: 'Lägg till ett andra tidsintervall',
         delete: 'Radera andra tidsintervallet',


### PR DESCRIPTION
1. Kun painetaan “poista” (toisen aikavälin poisto), ruudunlukijalle ei lausuta poiston onnistumisesta mitään. Ruudunlukijalle voisi välittää esim. “Toinen aikaväli poistettu”.
2. Sanoo nyt “alkaa-muokkaa”  ja “päättyy-muokkaa”. Voisi olla parempi että sanoisi “ ilmoita aloitusaika-muokkaa” ja “ ilmoitus loppumisaika - muokkaa ”.