### PR TITLE
Poistetaan mahdollisesti arkaluontoiset tiedot eskarin poissaolohakemuksen ilmoitussähköpostista

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/absence/AbsenceApplicationControllersTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/absence/AbsenceApplicationControllersTest.kt
@@ -210,7 +210,7 @@ class AbsenceApplicationControllersTest : FullApplicationTest(resetDbBeforeEach 
             assertThat(MockEmailClient.emails)
                 .extracting({ it.toAddress }, { it.content.subject })
                 .containsExactly(
-                    Tuple("test@example.com", "Esiopetuksen poissaolohakemus hyväksytty")
+                    Tuple("test@example.com", "Esiopetuksen poissaolohakemus käsitelty")
                 )
 
             assertThrows<BadRequest> {
@@ -516,7 +516,9 @@ class AbsenceApplicationControllersTest : FullApplicationTest(resetDbBeforeEach 
             asyncJobRunner.runPendingJobsSync(clock)
             assertThat(MockEmailClient.emails)
                 .extracting({ it.toAddress }, { it.content.subject })
-                .containsExactly(Tuple("test@example.com", "Esiopetuksen poissaolohakemus hylätty"))
+                .containsExactly(
+                    Tuple("test@example.com", "Esiopetuksen poissaolohakemus käsitelty")
+                )
 
             assertThrows<BadRequest> {
                 absenceApplicationControllerCitizen.deleteAbsenceApplication(

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -789,23 +789,9 @@ $unsubscribeEn
         startDate: LocalDate,
         endDate: LocalDate,
     ): EmailContent {
-        val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
-        val range = "${formatter.format(startDate)} - ${formatter.format(endDate)}"
         return EmailContent.fromHtml(
-            subject =
-                if (accepted) "Esiopetuksen poissaolohakemus hyväksytty"
-                else "Esiopetuksen poissaolohakemus hylätty",
-            html =
-                if (accepted)
-                    """
-                <p>Lapsesi esiopetuksen poissaolohakemus ajalle $range on hyväksytty ja poissaolot on merkitty eVakaan. Lue lisää eVakasta.</p>
-            """
-                        .trimIndent()
-                else
-                    """
-                <p>Lapsesi esiopetuksen poissaolohakemus ajalle $range on hylätty. Lue lisää eVakasta.</p>
-            """
-                        .trimIndent(),
+            subject = "Esiopetuksen poissaolohakemus käsitelty",
+            html = "<p>Lapsesi esiopetuksen poissaolohakemus käsitelty. Lue lisää eVakasta.</p>",
         )
     }
 


### PR DESCRIPTION
**Aiemmat viestin sisällöt:**

```
Subject: Esiopetuksen poissaolohakemus hyväksytty

Lapsesi esiopetuksen poissaolohakemus ajalle PP.KK.VVVV - PP.KK.VVVV on
hyväksytty ja poissaolot on merkitty eVakaan. Lue lisää eVakasta.
```

tai

```
Subject: Esiopetuksen poissaolohakemus hylätty

Lapsesi esiopetuksen poissaolohakemus ajalle PP.KK.VVVV - PP.KK.VVVV on
hylätty. Lue lisää eVakasta.
```

**Uusi sisältö:**

```
Subject: Esiopetuksen poissaolohakemus käsitelty

Lapsesi esiopetuksen poissaolohakemus käsitelty. Lue lisää eVakasta.
```