### PR TITLE
Estetään vanhan mallisten tuen päätösten avaaminen

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/AssistanceNeedDecisionSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/AssistanceNeedDecisionSection.tsx
@@ -1,30 +1,25 @@
-// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+// SPDX-FileCopyrightText: 2017-2025 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import orderBy from 'lodash/orderBy'
-import React, { useContext, useRef, useState } from 'react'
-import styled from 'styled-components'
-import { useLocation } from 'wouter'
+import React, { useState } from 'react'
 
 import { wrapResult } from 'lib-common/api'
-import DateRange from 'lib-common/date-range'
 import type {
   AssistanceNeedDecisionId,
   ChildId
 } from 'lib-common/generated/api-types/shared'
-import LocalDate from 'lib-common/local-date'
 import type { UUID } from 'lib-common/types'
 import { useApiState } from 'lib-common/utils/useRestApi'
 import Title from 'lib-components/atoms/Title'
-import AddButton from 'lib-components/atoms/buttons/AddButton'
 import { Table, Tbody, Th, Thead, Tr } from 'lib-components/layout/Table'
+import { InfoBox } from 'lib-components/molecules/MessageBoxes'
 import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { P } from 'lib-components/typography'
 import { faQuestion } from 'lib-icons'
 
 import {
-  createAssistanceNeedDecision,
   deleteAssistanceNeedDecision,
   getAssistanceNeedDecisions
 } from '../../generated/api-clients/assistanceneed'
@@ -32,27 +27,11 @@ import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
 
 import AssistanceNeedDecisionSectionRow from './AssistanceNeedDecisionSectionRow'
-import { ChildContext } from './state'
-import type { ChildState } from './state'
 
-const createAssistanceNeedDecisionResult = wrapResult(
-  createAssistanceNeedDecision
-)
 const getAssistanceNeedDecisionsResult = wrapResult(getAssistanceNeedDecisions)
 const deleteAssistanceNeedDecisionResult = wrapResult(
   deleteAssistanceNeedDecision
 )
-
-export const TitleRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin: 30px 0;
-
-  .title {
-    margin: 0;
-  }
-`
 
 export interface Props {
   id: ChildId
@@ -62,23 +41,17 @@ export default React.memo(function AssistanceNeedDecisionSection({
   id
 }: Props) {
   const { i18n } = useTranslation()
-  const { permittedActions } = useContext<ChildState>(ChildContext)
-  const refSectionTop = useRef(null)
 
   const [assistanceNeedDecisions, reloadDecisions] = useApiState(
     () => getAssistanceNeedDecisionsResult({ childId: id }),
     [id]
   )
 
-  const [, navigate] = useLocation()
-
-  const [isCreatingDecision, setIsCreatingDecision] = useState(false)
-
   const [removingDecision, setRemovingDecision] =
     useState<AssistanceNeedDecisionId>()
 
   return (
-    <div ref={refSectionTop}>
+    <div>
       {!!removingDecision && (
         <DeleteDecisionModal
           onClose={(shouldRefresh) => {
@@ -92,93 +65,13 @@ export default React.memo(function AssistanceNeedDecisionSection({
         />
       )}
 
-      <TitleRow>
-        <Title size={4}>
-          {i18n.childInformation.assistanceNeedDecision.sectionTitle}
-        </Title>
-        {permittedActions.has('CREATE_ASSISTANCE_NEED_DECISION') && (
-          <AddButton
-            flipped
-            text={i18n.childInformation.assistanceNeedDecision.create}
-            onClick={() => {
-              setIsCreatingDecision(true)
-              void createAssistanceNeedDecisionResult({
-                childId: id,
-                body: {
-                  decision: {
-                    assistanceLevels: [],
-                    careMotivation: null,
-                    decisionMade: null,
-                    decisionMaker: {
-                      employeeId: null,
-                      title: null
-                    },
-                    decisionNumber: null,
-                    expertResponsibilities: null,
-                    guardianInfo: [],
-                    guardiansHeardOn: null,
-                    language: 'FI',
-                    motivationForDecision: null,
-                    otherRepresentativeDetails: null,
-                    otherRepresentativeHeard: false,
-                    pedagogicalMotivation: null,
-                    preparedBy1: {
-                      employeeId: null,
-                      title: null,
-                      phoneNumber: null
-                    },
-                    preparedBy2: {
-                      employeeId: null,
-                      title: null,
-                      phoneNumber: null
-                    },
-                    selectedUnit: null,
-                    sentForDecision: null,
-                    serviceOptions: {
-                      consultationSpecialEd: false,
-                      fullTimeSpecialEd: false,
-                      interpretationAndAssistanceServices: false,
-                      partTimeSpecialEd: false,
-                      specialAides: false
-                    },
-                    servicesMotivation: null,
-                    status: 'DRAFT',
-                    structuralMotivationDescription: null,
-                    structuralMotivationOptions: {
-                      additionalStaff: false,
-                      childAssistant: false,
-                      groupAssistant: false,
-                      smallGroup: false,
-                      smallerGroup: false,
-                      specialGroup: false
-                    },
-                    validityPeriod: new DateRange(
-                      LocalDate.todayInHelsinkiTz(),
-                      null
-                    ),
-                    endDateNotKnown: false,
-                    viewOfGuardians: null
-                  }
-                }
-              }).then((decision) => {
-                void reloadDecisions()
-                setIsCreatingDecision(false)
-
-                decision.map(({ id: decisionId }) =>
-                  navigate(
-                    `/child-information/${id}/assistance-need-decision/${
-                      decisionId ?? ''
-                    }/edit`
-                  )
-                )
-              })
-            }}
-            disabled={isCreatingDecision}
-            data-qa="assistance-need-decision-create-btn"
-          />
-        )}
-      </TitleRow>
+      <Title size={4}>
+        {i18n.childInformation.assistanceNeedDecision.sectionTitle}
+      </Title>
       <P>{i18n.childInformation.assistanceNeedDecision.description}</P>
+      <InfoBox
+        message={i18n.childInformation.assistanceNeedDecision.deprecated}
+      />
       {renderResult(assistanceNeedDecisions, (decisions) =>
         decisions.length === 0 ? null : (
           <Table data-qa="table-of-assistance-need-decisions">

--- a/frontend/src/employee-frontend/components/child-information/AssistanceNeedPreschoolDecisionSection.tsx
+++ b/frontend/src/employee-frontend/components/child-information/AssistanceNeedPreschoolDecisionSection.tsx
@@ -1,10 +1,9 @@
-// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+// SPDX-FileCopyrightText: 2017-2025 City of Espoo
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import orderBy from 'lodash/orderBy'
-import React, { useContext, useRef, useState } from 'react'
-import { useLocation } from 'wouter'
+import React, { useState } from 'react'
 
 import type {
   AssistanceNeedPreschoolDecisionId,
@@ -12,8 +11,8 @@ import type {
 } from 'lib-common/generated/api-types/shared'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import Title from 'lib-components/atoms/Title'
-import AddButton from 'lib-components/atoms/buttons/AddButton'
 import { Table, Tbody, Th, Thead, Tr } from 'lib-components/layout/Table'
+import { InfoBox } from 'lib-components/molecules/MessageBoxes'
 import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
 import { P } from 'lib-components/typography'
 import { faQuestion } from 'lib-icons'
@@ -21,15 +20,11 @@ import { faQuestion } from 'lib-icons'
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
 
-import { TitleRow } from './AssistanceNeedDecisionSection'
 import AssistanceNeedPreschoolDecisionSectionRow from './AssistanceNeedPreschoolDecisionSectionRow'
 import {
   assistanceNeedPreschoolDecisionBasicsQuery,
-  createAssistanceNeedPreschoolDecisionMutation,
   deleteAssistanceNeedPreschoolDecisionMutation
 } from './queries'
-import { ChildContext } from './state'
-import type { ChildState } from './state'
 
 export interface Props {
   childId: ChildId
@@ -39,13 +34,6 @@ export default React.memo(function AssistanceNeedPreschoolDecisionSection({
   childId
 }: Props) {
   const { i18n } = useTranslation()
-  const { permittedActions } = useContext<ChildState>(ChildContext)
-  const refSectionTop = useRef(null)
-
-  const { mutateAsync: createDecision, isPending: creatingDecision } =
-    useMutationResult(createAssistanceNeedPreschoolDecisionMutation)
-
-  const [, navigate] = useLocation()
 
   const assistanceNeedDecisions = useQueryResult(
     assistanceNeedPreschoolDecisionBasicsQuery({ childId })
@@ -55,7 +43,7 @@ export default React.memo(function AssistanceNeedPreschoolDecisionSection({
     useState<AssistanceNeedPreschoolDecisionId>()
 
   return (
-    <div ref={refSectionTop}>
+    <div>
       {!!removingDecision && (
         <DeleteDecisionModal
           onClose={() => {
@@ -66,27 +54,13 @@ export default React.memo(function AssistanceNeedPreschoolDecisionSection({
         />
       )}
 
-      <TitleRow>
-        <Title size={4}>
-          {i18n.childInformation.assistanceNeedPreschoolDecision.sectionTitle}
-        </Title>
-        {permittedActions.has('CREATE_ASSISTANCE_NEED_PRESCHOOL_DECISION') && (
-          <AddButton
-            flipped
-            text={i18n.childInformation.assistanceNeedDecision.create}
-            onClick={async () => {
-              const res = await createDecision({ childId })
-              if (res.isSuccess) {
-                navigate(
-                  `/child-information/${childId}/assistance-need-preschool-decisions/${res.value.id}/edit`
-                )
-              }
-            }}
-            disabled={creatingDecision}
-          />
-        )}
-      </TitleRow>
+      <Title size={4}>
+        {i18n.childInformation.assistanceNeedPreschoolDecision.sectionTitle}
+      </Title>
       <P>{i18n.childInformation.assistanceNeedDecision.description}</P>
+      <InfoBox
+        message={i18n.childInformation.assistanceNeedDecision.deprecated}
+      />
       {renderResult(assistanceNeedDecisions, (decisions) =>
         decisions.length === 0 ? null : (
           <Table data-qa="table-of-assistance-need-decisions">

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -1217,6 +1217,8 @@ export const fi = {
       pageTitle: 'Päätös tuesta varhaiskasvatuksessa',
       annulmentReason: 'Päätöksen mitätöinnin perustelu',
       sectionTitle: 'Päätökset tuesta varhaiskasvatuksessa',
+      deprecated:
+        'Täältä löydät toistaiseksi vanhan malliset tuen päätökset. Uudet päätökset tehdään osiossa Lapsen asiakirjat > Muut päätökset.',
       description:
         'Hyväksytyt ja hylätyt päätökset tuesta näkyvät huoltajalle eVakassa.',
       table: {


### PR DESCRIPTION
Ennen tämän muutoksen käyttöönottoa kannattaa olla luotuna `Muu päätös` tyyppiset asiakirjapohjat, joilla tuen päätökset jatkossa tehdään. 

Jo avatut vanhan malliset tuen päätökset käsitellään loppuun ja migratoidaan lähiaikoina uuteen formaattiin: https://github.com/espoon-voltti/evaka/pull/7355