### PR TITLE
Tallennetaan sijoituksen lisääjä ja sekä lisäämisen syy

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -39,6 +39,7 @@ import type {
   AreaId,
   DaycareId,
   EmployeeId,
+  EvakaUserId,
   FeeDecisionId,
   GroupId,
   PersonId,
@@ -157,6 +158,7 @@ import type {
   NekkuCustomer,
   NekkuSpecialDiet,
   PlacementPlan,
+  PlacementSource,
   ReservationInsert,
   VoucherValueDecision
 } from '../generated/api-types'
@@ -692,6 +694,11 @@ export class Fixture {
       placeGuarantee: false,
       terminatedBy: null,
       terminationRequestedDate: null,
+      createdAt: HelsinkiDateTime.now(),
+      createdBy: systemInternalUser.id,
+      source: 'MANUAL',
+      modifiedAt: HelsinkiDateTime.now(),
+      modifiedBy: systemInternalUser.id,
       ...initial
     }
     return {
@@ -3218,9 +3225,14 @@ export function createDaycarePlacementFixture(
   startDate = LocalDate.of(2022, 5, 1),
   endDate = LocalDate.of(2023, 8, 31),
   type: PlacementType = 'DAYCARE',
-  placeGuarantee = false
+  placeGuarantee = false,
+  createdAt = HelsinkiDateTime.now(),
+  createdBy = systemInternalUser.id,
+  source: PlacementSource = 'MANUAL',
+  modifiedAt: HelsinkiDateTime | null = HelsinkiDateTime.now(),
+  modifiedBy: EvakaUserId | null = systemInternalUser.id
 ): DevPlacement {
-  return {
+  return Fixture.placement({
     id,
     type,
     childId,
@@ -3228,9 +3240,14 @@ export function createDaycarePlacementFixture(
     startDate,
     endDate,
     placeGuarantee,
+    createdAt,
+    createdBy,
+    source,
+    modifiedAt,
+    modifiedBy,
     terminationRequestedDate: null,
     terminatedBy: null
-  }
+  })
 }
 
 export const DecisionIncomeFixture = (total: number): DecisionIncome => ({

--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -697,6 +697,8 @@ export class Fixture {
       createdAt: HelsinkiDateTime.now(),
       createdBy: systemInternalUser.id,
       source: 'MANUAL',
+      sourceApplicationId: null,
+      sourceServiceApplicationId: null,
       modifiedAt: HelsinkiDateTime.now(),
       modifiedBy: systemInternalUser.id,
       ...initial

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -104,6 +104,7 @@ import type { PreschoolAssistanceLevel } from 'lib-common/generated/api-types/as
 import type { PreschoolTermId } from 'lib-common/generated/api-types/shared'
 import type { ProviderType } from 'lib-common/generated/api-types/daycare'
 import type { PushNotificationCategory } from 'lib-common/generated/api-types/webpush'
+import type { ServiceApplicationId } from 'lib-common/generated/api-types/shared'
 import type { ServiceNeedId } from 'lib-common/generated/api-types/shared'
 import type { ServiceNeedOptionId } from 'lib-common/generated/api-types/shared'
 import type { ServiceOptions } from 'lib-common/generated/api-types/assistanceneed'
@@ -928,6 +929,8 @@ export interface DevPlacement {
   modifiedBy: EvakaUserId | null
   placeGuarantee: boolean
   source: PlacementSource | null
+  sourceApplicationId: ApplicationId | null
+  sourceServiceApplicationId: ServiceApplicationId | null
   startDate: LocalDate
   terminatedBy: EvakaUserId | null
   terminationRequestedDate: LocalDate | null

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -920,9 +920,14 @@ export interface DevPersonalMobileDevice {
 */
 export interface DevPlacement {
   childId: PersonId
+  createdAt: HelsinkiDateTime
+  createdBy: EvakaUserId | null
   endDate: LocalDate
   id: PlacementId
+  modifiedAt: HelsinkiDateTime | null
+  modifiedBy: EvakaUserId | null
   placeGuarantee: boolean
+  source: PlacementSource | null
   startDate: LocalDate
   terminatedBy: EvakaUserId | null
   terminationRequestedDate: LocalDate | null
@@ -1167,6 +1172,15 @@ export interface PlacementPlan {
   preschoolDaycarePeriodStart: LocalDate | null
   unitId: DaycareId
 }
+
+/**
+* Generated from fi.espoo.evaka.placement.PlacementSource
+*/
+export type PlacementSource =
+  | 'APPLICATION'
+  | 'SERVICE_APPLICATION'
+  | 'PLACEMENT_TERMINATION'
+  | 'MANUAL'
 
 /**
 * Generated from fi.espoo.evaka.reservations.ReservationInsert
@@ -1656,7 +1670,9 @@ export function deserializeJsonDevPerson(json: JsonOf<DevPerson>): DevPerson {
 export function deserializeJsonDevPlacement(json: JsonOf<DevPlacement>): DevPlacement {
   return {
     ...json,
+    createdAt: HelsinkiDateTime.parseIso(json.createdAt),
     endDate: LocalDate.parseIso(json.endDate),
+    modifiedAt: (json.modifiedAt != null) ? HelsinkiDateTime.parseIso(json.modifiedAt) : null,
     startDate: LocalDate.parseIso(json.startDate),
     terminationRequestedDate: (json.terminationRequestedDate != null) ? LocalDate.parseIso(json.terminationRequestedDate) : null
   }

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { randomId } from 'lib-common/id-type'
 
 import { execSimpleApplicationActions } from '../../dev-api'
 import {
@@ -19,7 +18,6 @@ import {
 } from '../../dev-api/fixtures'
 import {
   createApplications,
-  createDaycarePlacements,
   getApplication,
   resetServiceState,
   runJobs,
@@ -177,21 +175,13 @@ describe('Citizen daycare applications', () => {
   })
 
   test('Notification on transfer application is visible', async () => {
-    await createDaycarePlacements({
-      body: [
-        {
-          id: randomId(),
-          type: 'DAYCARE',
-          childId: testChild.id,
-          unitId: testDaycare.id,
-          startDate: mockedDate.subYears(1),
-          endDate: mockedDate.addYears(1),
-          placeGuarantee: false,
-          terminatedBy: null,
-          terminationRequestedDate: null
-        }
-      ]
-    })
+    await Fixture.placement({
+      type: 'DAYCARE',
+      childId: testChild.id,
+      unitId: testDaycare.id,
+      startDate: mockedDate.subYears(1),
+      endDate: mockedDate.addYears(1)
+    }).save()
 
     await header.selectTab('applications')
     await applicationsPage.assertTransferNotificationIsShown(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/application/ApplicationStateServiceIntegrationTests.kt
@@ -29,6 +29,7 @@ import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementPlan
 import fi.espoo.evaka.placement.PlacementPlanConfirmationStatus
 import fi.espoo.evaka.placement.PlacementPlanRejectReason
+import fi.espoo.evaka.placement.PlacementSource
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getPlacementPlan
 import fi.espoo.evaka.placement.getPlacementsForChild
@@ -1942,6 +1943,13 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             // then
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.ACTIVE, application.status)
+
+            // application is recorded as the placement's source
+            val placements = tx.getPlacementsForChild(testChild_6.id)
+            placements.single().also { placement ->
+                assertEquals(placement.source, PlacementSource.APPLICATION)
+                assertEquals(placement.sourceApplicationId, applicationId)
+            }
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
@@ -7,8 +7,6 @@ package fi.espoo.evaka.holidayperiod
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.absence.AbsenceType
 import fi.espoo.evaka.pis.service.insertGuardian
-import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.placement.insertPlacement
 import fi.espoo.evaka.serviceneed.ShiftCareType
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.HolidayQuestionnaireId
@@ -20,6 +18,7 @@ import fi.espoo.evaka.shared.dev.DevCareArea
 import fi.espoo.evaka.shared.dev.DevDaycare
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
+import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.DevServiceNeed
 import fi.espoo.evaka.shared.dev.insert
 import fi.espoo.evaka.shared.dev.insertServiceNeedOptions
@@ -101,14 +100,13 @@ class HolidayPeriodControllerCitizenIntegrationTest :
             tx.insertGuardian(parent.id, child1.id)
 
             val placement =
-                tx.insertPlacement(
-                    PlacementType.DAYCARE,
-                    child1.id,
-                    daycare.id,
-                    mockToday.minusYears(2),
-                    mockToday.plusYears(1),
-                    false,
+                DevPlacement(
+                    childId = child1.id,
+                    unitId = daycare.id,
+                    startDate = mockToday.minusYears(2),
+                    endDate = mockToday.plusYears(1),
                 )
+            tx.insert(placement)
             tx.insertServiceNeedOptions()
             tx.insert(
                 DevServiceNeed(
@@ -153,30 +151,30 @@ class HolidayPeriodControllerCitizenIntegrationTest :
             // child1 has a placement that covers the whole period
             // child2 has no placement
             // child3 has a placement that covers the period partly
-            tx.insertPlacement(
-                PlacementType.DAYCARE,
-                child3.id,
-                daycare.id,
-                condition.start,
-                condition.end.minusDays(1),
-                false,
+            tx.insert(
+                DevPlacement(
+                    childId = child3.id,
+                    unitId = daycare.id,
+                    startDate = condition.start,
+                    endDate = condition.end.minusDays(1),
+                )
             )
             // child4 has two placements that cover the period together
-            tx.insertPlacement(
-                PlacementType.DAYCARE,
-                child4.id,
-                daycare.id,
-                condition.start,
-                condition.start.plusDays(5),
-                false,
+            tx.insert(
+                DevPlacement(
+                    childId = child4.id,
+                    unitId = daycare.id,
+                    startDate = condition.start,
+                    endDate = condition.start.plusDays(5),
+                )
             )
-            tx.insertPlacement(
-                PlacementType.DAYCARE,
-                child4.id,
-                daycare.id,
-                condition.start.plusDays(6),
-                condition.end,
-                false,
+            tx.insert(
+                DevPlacement(
+                    childId = child4.id,
+                    unitId = daycare.id,
+                    startDate = condition.start.plusDays(6),
+                    endDate = condition.end,
+                )
             )
         }
         createFixedPeriodQuestionnaire(
@@ -323,13 +321,13 @@ class HolidayPeriodControllerCitizenIntegrationTest :
         val firstOption = freePeriodQuestionnaire.periodOptions[0]
         db.transaction { tx ->
             tx.insertGuardian(parent.id, child2.id)
-            tx.insertPlacement(
-                PlacementType.DAYCARE,
-                child2.id,
-                daycare.id,
-                firstOption.start.plusDays(1),
-                firstOption.end,
-                false,
+            tx.insert(
+                DevPlacement(
+                    childId = child2.id,
+                    unitId = daycare.id,
+                    startDate = firstOption.start.plusDays(1),
+                    endDate = firstOption.end,
+                )
             )
         }
         val id =
@@ -352,13 +350,13 @@ class HolidayPeriodControllerCitizenIntegrationTest :
         val firstOption = freePeriodQuestionnaire.periodOptions[0]
         db.transaction { tx ->
             tx.insertGuardian(parent.id, child2.id)
-            tx.insertPlacement(
-                PlacementType.DAYCARE,
-                child2.id,
-                daycare.id,
-                firstOption.start,
-                firstOption.end.minusDays(1),
-                false,
+            tx.insert(
+                DevPlacement(
+                    childId = child2.id,
+                    unitId = daycare.id,
+                    startDate = firstOption.start,
+                    endDate = firstOption.end.minusDays(1),
+                )
             )
         }
         val id =
@@ -472,14 +470,13 @@ class HolidayPeriodControllerCitizenIntegrationTest :
             tx.insertGuardian(parent.id, child2.id)
 
             val placement =
-                tx.insertPlacement(
-                    PlacementType.DAYCARE,
-                    child2.id,
-                    daycareId,
-                    mockToday.minusYears(2),
-                    mockToday.plusYears(1),
-                    false,
+                DevPlacement(
+                    childId = child2.id,
+                    unitId = daycareId,
+                    startDate = mockToday.minusYears(2),
+                    endDate = mockToday.plusYears(1),
                 )
+            tx.insert(placement)
             tx.insert(
                 DevServiceNeed(
                     placementId = placement.id,

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/invoicing/FeeDecisionIntegrationTest.kt
@@ -33,7 +33,6 @@ import fi.espoo.evaka.invoicing.domain.UnitData
 import fi.espoo.evaka.pis.EmailMessageType
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.placement.insertPlacement
 import fi.espoo.evaka.sficlient.MockSfiMessagesClient
 import fi.espoo.evaka.sficlient.SfiAsyncJobs
 import fi.espoo.evaka.sficlient.getSfiGetEventsContinuationTokens
@@ -53,6 +52,7 @@ import fi.espoo.evaka.shared.dev.DevIncomeStatement
 import fi.espoo.evaka.shared.dev.DevParentship
 import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
+import fi.espoo.evaka.shared.dev.DevPlacement
 import fi.espoo.evaka.shared.dev.insert
 import fi.espoo.evaka.shared.dev.insertTestPartnership
 import fi.espoo.evaka.shared.domain.BadRequest
@@ -495,26 +495,26 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
         val testDecisionWithOneStartingChild = testDecisions[0]
         val firstPlacementStartingThisMonthChild = testDecisionWithOneStartingChild.children[0]
         db.transaction {
-            it.insertPlacement(
-                PlacementType.DAYCARE,
-                firstPlacementStartingThisMonthChild.child.id,
-                firstPlacementStartingThisMonthChild.placement.unitId,
-                LocalDate.now(),
-                LocalDate.now(),
-                false,
+            it.insert(
+                DevPlacement(
+                    childId = firstPlacementStartingThisMonthChild.child.id,
+                    unitId = firstPlacementStartingThisMonthChild.placement.unitId,
+                    startDate = LocalDate.now(),
+                    endDate = LocalDate.now(),
+                )
             )
         }
 
         val testDecisionWithNoStartingChild = testDecisions[3]
         val previousPlacementChild = testDecisionWithNoStartingChild.children[0]
         db.transaction {
-            it.insertPlacement(
-                PlacementType.DAYCARE,
-                previousPlacementChild.child.id,
-                previousPlacementChild.placement.unitId,
-                LocalDate.now().minusMonths(1),
-                LocalDate.now(),
-                false,
+            it.insert(
+                DevPlacement(
+                    childId = previousPlacementChild.child.id,
+                    unitId = previousPlacementChild.placement.unitId,
+                    startDate = LocalDate.now().minusMonths(1),
+                    endDate = LocalDate.now(),
+                )
             )
         }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/FiveYearOldDaycarePlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/FiveYearOldDaycarePlacementsIntegrationTest.kt
@@ -59,6 +59,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
                     placeGuarantee = true,
                     now = now,
                     userId = user.evakaUserId,
+                    source = PlacementSource.MANUAL,
                 )
             }
 
@@ -100,6 +101,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
                     placeGuarantee = false,
                     now = now,
                     userId = user.evakaUserId,
+                    source = PlacementSource.MANUAL,
                 )
             }
 
@@ -128,6 +130,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
                     placeGuarantee = false,
                     now = now,
                     userId = user.evakaUserId,
+                    source = PlacementSource.MANUAL,
                 )
             }
 
@@ -156,6 +159,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
                         placeGuarantee = false,
                         now = now,
                         userId = user.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -203,6 +207,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
                         placeGuarantee = false,
                         now = now,
                         userId = user.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -250,6 +255,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
                         placeGuarantee = false,
                         now = now,
                         userId = user.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -297,6 +303,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
                         placeGuarantee = false,
                         now = now,
                         userId = user.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -344,6 +351,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
                         placeGuarantee = false,
                         now = now,
                         userId = user.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -387,6 +395,7 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
                         placeGuarantee = false,
                         now = now,
                         userId = user.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/FiveYearOldDaycarePlacementsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/FiveYearOldDaycarePlacementsIntegrationTest.kt
@@ -303,7 +303,10 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
                         placeGuarantee = false,
                         now = now,
                         userId = user.evakaUserId,
-                        source = PlacementSource.MANUAL,
+
+                        // use a non-default source to allow testing that it's copied to the new
+                        // placement
+                        source = PlacementSource.PLACEMENT_TERMINATION,
                     )
                 }
                 .first()
@@ -326,11 +329,13 @@ class FiveYearOldDaycarePlacementsIntegrationTest : FullApplicationTest(resetDbB
             assertEquals(PlacementType.DAYCARE, placement.type)
             assertEquals(newStartDate, placement.startDate)
             assertEquals(LocalDate.of(yearChildTurnsFive, 7, 31), placement.endDate)
+            assertEquals(PlacementSource.PLACEMENT_TERMINATION, placement.source)
         }
         placements.last().let { placement ->
             assertEquals(PlacementType.DAYCARE_FIVE_YEAR_OLDS, placement.type)
             assertEquals(LocalDate.of(yearChildTurnsFive, 8, 1), placement.startDate)
             assertEquals(originalEndDate, placement.endDate)
+            assertEquals(PlacementSource.PLACEMENT_TERMINATION, placement.source)
         }
     }
 

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerCitizenIntegrationTest.kt
@@ -424,6 +424,11 @@ class PlacementControllerCitizenIntegrationTest : FullApplicationTest(resetDbBef
         assertEquals(placementTerminationDate.plusDays(1), remainderOfPreschool.startDate)
         assertEquals(endPreschool, remainderOfPreschool.endDate)
 
+        // ChildPlacement doesn't contain source info (yet?)
+        db.read { it.getPlacement(remainderOfPreschool.id) }!!.also {
+                assertEquals(PlacementSource.PLACEMENT_TERMINATION, it.source)
+            }
+
         assertEquals(
             0,
             db.read {

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementControllerIntegrationTest.kt
@@ -315,6 +315,8 @@ class PlacementControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
         val newPlacement =
             placements.find { it.id != testPlacement.id && it.id != activePlacement.id }!!
 
+        assertEquals(PlacementSource.MANUAL, newPlacement.source)
+
         val secondGroupPlacementId =
             placementController.createGroupPlacement(
                 dbInstance(),
@@ -424,6 +426,8 @@ class PlacementControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
         assertEquals(3, placements.size)
         val newPlacement =
             placements.find { it.id != testPlacement.id && it.id != activePlacement.id }!!
+
+        assertEquals(PlacementSource.MANUAL, newPlacement.source)
 
         val secondGroupPlacementId =
             placementController.createGroupPlacement(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
@@ -92,16 +92,17 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                     )
                 )
 
-            oldPlacement =
-                tx.insertPlacement(
-                    PlacementType.DAYCARE,
-                    childId,
-                    unitId,
-                    placementStart,
-                    placementEnd,
-                    false,
+            val daycarePlacementId =
+                tx.insert(
+                    DevPlacement(
+                        childId = childId,
+                        unitId = unitId,
+                        startDate = placementStart,
+                        endDate = placementEnd,
+                        placeGuarantee = false,
+                    )
                 )
-            daycarePlacementId = oldPlacement.id
+            oldPlacement = tx.getPlacement(daycarePlacementId)!!
 
             groupPlacementId =
                 tx.insert(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/placement/PlacementServiceIntegrationTest.kt
@@ -138,6 +138,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -167,6 +168,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                     placeGuarantee = false,
                     now = now,
                     userId = testDecisionMaker_1.evakaUserId,
+                    source = PlacementSource.MANUAL,
                 )
             }
 
@@ -197,6 +199,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -231,6 +234,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -285,6 +289,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -324,6 +329,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -371,6 +377,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -403,6 +410,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -442,6 +450,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -474,6 +483,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -506,6 +516,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -545,6 +556,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -563,6 +575,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -591,33 +604,40 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     fun `adding a new placement does not delete future placements`() {
         // insert a future PRESCHOOL placement
         val (futurePreparatoryDaycare, futureDaycareInPreparatoryTerm, futurePreparatory) =
-            db.transaction {
+            db.transaction { tx ->
                 listOf(
-                    it.insertPlacement(
-                        PlacementType.PREPARATORY_DAYCARE,
-                        childId,
-                        unitId,
-                        LocalDate.of(year + 1, 8, 1),
-                        LocalDate.of(year + 2, 6, 30),
-                        false,
-                    ),
-                    it.insertPlacement(
-                        PlacementType.DAYCARE,
-                        childId,
-                        unitId,
-                        LocalDate.of(year + 2, 7, 1),
-                        LocalDate.of(year + 2, 7, 31),
-                        false,
-                    ),
-                    it.insertPlacement(
-                        PlacementType.PREPARATORY_DAYCARE,
-                        childId,
-                        unitId,
-                        LocalDate.of(year + 2, 9, 1),
-                        LocalDate.of(year + 3, 4, 11),
-                        false,
-                    ),
-                )
+                        tx.insert(
+                            DevPlacement(
+                                type = PlacementType.PREPARATORY_DAYCARE,
+                                childId = childId,
+                                unitId = unitId,
+                                startDate = LocalDate.of(year + 1, 8, 1),
+                                endDate = LocalDate.of(year + 2, 6, 30),
+                                placeGuarantee = false,
+                            )
+                        ),
+                        tx.insert(
+                            DevPlacement(
+                                type = PlacementType.DAYCARE,
+                                childId = childId,
+                                unitId = unitId,
+                                startDate = LocalDate.of(year + 2, 7, 1),
+                                endDate = LocalDate.of(year + 2, 7, 31),
+                                placeGuarantee = false,
+                            )
+                        ),
+                        tx.insert(
+                            DevPlacement(
+                                type = PlacementType.PREPARATORY_DAYCARE,
+                                childId = childId,
+                                unitId = unitId,
+                                startDate = LocalDate.of(year + 2, 9, 1),
+                                endDate = LocalDate.of(year + 3, 4, 11),
+                                placeGuarantee = false,
+                            )
+                        ),
+                    )
+                    .map { tx.getPlacement(it)!! }
             }
 
         val newPlacement =
@@ -636,6 +656,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -673,6 +694,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -715,6 +737,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -794,6 +817,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -831,6 +855,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                 placeGuarantee = false,
                 now = now,
                 userId = testDecisionMaker_1.evakaUserId,
+                source = PlacementSource.MANUAL,
             )
         }
 
@@ -882,6 +907,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -924,6 +950,7 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                         placeGuarantee = false,
                         now = now,
                         userId = testDecisionMaker_1.evakaUserId,
+                        source = PlacementSource.MANUAL,
                     )
                 }
                 .first()
@@ -1006,6 +1033,8 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                     unitId = daycare2.id,
                     startDate = daycarePlacementStartDate,
                     endDate = daycarePlacementEndDate,
+                    modifiedAt = null,
+                    modifiedBy = null,
                 )
             )
         }
@@ -1082,6 +1111,8 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                     unitId = daycare2.id,
                     startDate = daycarePlacementStartDate,
                     endDate = daycarePlacementEndDate,
+                    modifiedAt = null,
+                    modifiedBy = null,
                 )
             )
         }
@@ -1236,35 +1267,39 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     @Test
     fun `only missing group placements after evaka launch are included`() {
         val evakaLaunch = LocalDate.of(2020, 3, 1)
-        val placement =
+        val startDate = evakaLaunch.minusYears(1)
+        val endDate = evakaLaunch.plusYears(1)
+        val placementId =
             db.transaction { tx ->
-                val placement =
-                    tx.insertPlacement(
-                        PlacementType.DAYCARE,
-                        testChild_1.id,
-                        daycare1.id,
-                        evakaLaunch.minusYears(1),
-                        evakaLaunch.plusYears(1),
-                        false,
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            type = PlacementType.DAYCARE,
+                            childId = testChild_1.id,
+                            unitId = daycare1.id,
+                            startDate = startDate,
+                            endDate = endDate,
+                            placeGuarantee = false,
+                        )
                     )
                 tx.insert(
                     DevDaycareGroupPlacement(
-                        daycarePlacementId = placement.id,
+                        daycarePlacementId = placementId,
                         daycareGroupId = groupId1,
                         startDate = evakaLaunch,
                         endDate = evakaLaunch.plusMonths(6),
                     )
                 )
-                placement
+                placementId
             }
 
         val (group, backup) = db.read { tx -> getMissingGroupPlacements(tx, daycare1.id) }
         assertEquals(
             listOf(
                 MissingGroupPlacement(
-                    placement.id,
-                    placement.type,
-                    FiniteDateRange(placement.startDate, placement.endDate),
+                    placementId,
+                    PlacementType.DAYCARE,
+                    FiniteDateRange(startDate, endDate),
                     testChild_1.id,
                     testChild_1.firstName,
                     testChild_1.lastName,
@@ -1282,23 +1317,27 @@ class PlacementServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     @Test
     fun `only missing backup care group placements after evaka launch are included`() {
         val evakaLaunch = LocalDate.of(2020, 3, 1)
+        val startDate = evakaLaunch.minusYears(1)
+        val endDate = evakaLaunch.plusYears(1)
         val backupCareId =
             db.transaction { tx ->
-                val placement =
-                    tx.insertPlacement(
-                        PlacementType.DAYCARE,
-                        testChild_1.id,
-                        daycare1.id,
-                        evakaLaunch.minusYears(1),
-                        evakaLaunch.plusYears(1),
-                        false,
+                val placementId =
+                    tx.insert(
+                        DevPlacement(
+                            type = PlacementType.DAYCARE,
+                            childId = testChild_1.id,
+                            unitId = daycare1.id,
+                            startDate = startDate,
+                            endDate = endDate,
+                            placeGuarantee = false,
+                        )
                     )
                 tx.insert(
                     DevDaycareGroupPlacement(
-                        daycarePlacementId = placement.id,
+                        daycarePlacementId = placementId,
                         daycareGroupId = groupId1,
-                        startDate = placement.startDate,
-                        endDate = placement.endDate,
+                        startDate = startDate,
+                        endDate = endDate,
                     )
                 )
                 tx.insert(

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/application/ServiceApplicationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/serviceneed/application/ServiceApplicationIntegrationTest.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.serviceneed.application
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.emailclient.MockEmailClient
 import fi.espoo.evaka.insertServiceNeedOptions
+import fi.espoo.evaka.placement.PlacementSource
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.placement.getPlacementsForChild
 import fi.espoo.evaka.serviceneed.ShiftCareType
@@ -456,6 +457,8 @@ class ServiceApplicationIntegrationTest : FullApplicationTest(resetDbBeforeEach 
             assertEquals(it.endDate, placement.endDate)
             assertEquals(it.type, snDaycarePartDay25.validPlacementType)
             assertEquals(it.unitId, placement.unitId)
+            assertEquals(it.source, PlacementSource.SERVICE_APPLICATION)
+            assertEquals(it.sourceServiceApplicationId, application.id)
         }
 
         // service need was updated

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/SchemaConventionsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/db/SchemaConventionsTest.kt
@@ -70,7 +70,6 @@ class SchemaConventionsTest : PureJdbiTest(resetDbBeforeEach = false) {
                 "pairing",
                 "payment",
                 "person",
-                "placement",
                 "placement_plan",
                 "preschool_assistance",
                 "preschool_term",
@@ -140,7 +139,6 @@ class SchemaConventionsTest : PureJdbiTest(resetDbBeforeEach = false) {
                 "pairing",
                 "payment",
                 "person",
-                "placement",
                 "placement_plan",
                 "preschool_assistance",
                 "preschool_term",
@@ -359,6 +357,7 @@ class SchemaConventionsTest : PureJdbiTest(resetDbBeforeEach = false) {
                 ),
                 Column(ColumnRef("child_document", "created_by"), "uuid", nullable = true),
                 Column(ColumnRef("fridge_partner", "created_by"), "uuid", nullable = true),
+                Column(ColumnRef("placement", "created_by"), "uuid", nullable = true),
             )
         val violations =
             columns
@@ -455,8 +454,6 @@ class SchemaConventionsTest : PureJdbiTest(resetDbBeforeEach = false) {
                 // million)
                 ColumnRef("password_blacklist", "source"),
                 ColumnRef("payment", "sent_by"),
-                ColumnRef("placement", "modified_by"),
-                ColumnRef("placement", "terminated_by"),
                 ColumnRef("preschool_assistance", "modified_by"),
             )
         val violations =

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/shared/job/ScheduledJobsTest.kt
@@ -22,7 +22,6 @@ import fi.espoo.evaka.note.child.sticky.getChildStickyNotesForChild
 import fi.espoo.evaka.pis.service.getGuardianChildIds
 import fi.espoo.evaka.pis.service.insertGuardian
 import fi.espoo.evaka.placement.PlacementType
-import fi.espoo.evaka.placement.insertPlacement
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.auth.AuthenticatedUser
@@ -426,13 +425,13 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
 
         val validNoteId =
             db.transaction {
-                it.insertPlacement(
-                    type = PlacementType.DAYCARE,
-                    childId = testChild_2.id,
-                    unitId = testDaycare.id,
-                    startDate = LocalDate.now().minusDays(100),
-                    endDate = LocalDate.now().plusDays(100),
-                    false,
+                it.insert(
+                    DevPlacement(
+                        childId = testChild_2.id,
+                        unitId = testDaycare.id,
+                        startDate = LocalDate.now().minusDays(100),
+                        endDate = LocalDate.now().plusDays(100),
+                    )
                 )
                 it.createChildDailyNote(
                     testChild_2.id,

--- a/service/src/main/kotlin/fi/espoo/evaka/espoo/bi/EspooBi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/espoo/bi/EspooBi.kt
@@ -63,7 +63,7 @@ JOIN person USING (id)
         csvQuery<BiPlacement> {
             sql(
                 """
-SELECT id, created, updated, child_id AS child, unit_id AS unit, start_date, end_date, FALSE AS is_backup, type
+SELECT id, created_at AS created, updated_at AS updated, child_id AS child, unit_id AS unit, start_date, end_date, FALSE AS is_backup, type
 FROM placement
 
 UNION ALL

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/Placement.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/Placement.kt
@@ -5,10 +5,12 @@
 package fi.espoo.evaka.placement
 
 import fi.espoo.evaka.children.Unit
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceApplicationId
 import fi.espoo.evaka.shared.db.DatabaseEnum
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
@@ -36,6 +38,8 @@ data class Placement(
     val createdAt: HelsinkiDateTime,
     val createdBy: EvakaUserId?,
     val source: PlacementSource?,
+    val sourceApplicationId: ApplicationId?,
+    val sourceServiceApplicationId: ServiceApplicationId?,
     val modifiedAt: HelsinkiDateTime?,
     val modifiedBy: EvakaUserId?,
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/Placement.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/Placement.kt
@@ -9,9 +9,19 @@ import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.db.DatabaseEnum
 import fi.espoo.evaka.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
 import org.jdbi.v3.core.mapper.Nested
+
+enum class PlacementSource : DatabaseEnum {
+    APPLICATION,
+    SERVICE_APPLICATION,
+    PLACEMENT_TERMINATION,
+    MANUAL;
+
+    override val sqlType: String = "placement_source"
+}
 
 data class Placement(
     val id: PlacementId,
@@ -23,6 +33,9 @@ data class Placement(
     val terminationRequestedDate: LocalDate?,
     val terminationRequestedBy: EvakaUserId?,
     val placeGuarantee: Boolean,
+    val createdAt: HelsinkiDateTime,
+    val createdBy: EvakaUserId?,
+    val source: PlacementSource?,
     val modifiedAt: HelsinkiDateTime?,
     val modifiedBy: EvakaUserId?,
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementController.kt
@@ -160,8 +160,9 @@ class PlacementController(
                             type = body.type,
                             useFiveYearsOldDaycare = useFiveYearsOldDaycare,
                             placeGuarantee = body.placeGuarantee,
-                            now = clock.now(),
+                            now = now,
                             userId = user.evakaUserId,
+                            source = PlacementSource.MANUAL,
                         )
                         .also {
                             tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlan.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlan.kt
@@ -4,9 +4,12 @@
 
 package fi.espoo.evaka.placement
 
+import fi.espoo.evaka.occupancy.OccupancyInput
 import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
+import fi.espoo.evaka.shared.Id
+import fi.espoo.evaka.shared.PlacementId
 import fi.espoo.evaka.shared.PlacementPlanId
 import fi.espoo.evaka.shared.db.DatabaseEnum
 import fi.espoo.evaka.shared.domain.FiniteDateRange
@@ -77,4 +80,18 @@ enum class PlacementPlanRejectReason : DatabaseEnum {
     REASON_3;
 
     override val sqlType: String = "placement_reject_reason"
+}
+
+class SpeculatedPlacement(
+    override val type: PlacementType,
+    override val childId: ChildId,
+    override val unitId: DaycareId,
+    override val period: FiniteDateRange,
+    override val familyUnitPlacement: Boolean,
+) : OccupancyInput {
+    override val placementId: PlacementId?
+        get() = null
+
+    override val groupingId: Id<*>
+        get() = unitId
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -271,6 +271,7 @@ class PlacementPlanService(
             placeGuarantee = false,
             now,
             userId,
+            PlacementSource.APPLICATION,
         )
 
         tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(childId, clock.today())

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementPlanService.kt
@@ -269,9 +269,10 @@ class PlacementPlanService(
             placementTypePeriods = placementTypePeriods,
             serviceNeed = serviceNeed,
             placeGuarantee = false,
-            now,
-            userId,
-            PlacementSource.APPLICATION,
+            now = now,
+            userId = userId,
+            source = PlacementSource.APPLICATION,
+            sourceApplicationId = application.id,
         )
 
         tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(childId, clock.today())

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -5,12 +5,14 @@
 package fi.espoo.evaka.placement
 
 import fi.espoo.evaka.backupcare.recreateBackupCares
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
 import fi.espoo.evaka.shared.EvakaUserId
 import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceApplicationId
 import fi.espoo.evaka.shared.data.DateSet
 import fi.espoo.evaka.shared.db.Database
 import fi.espoo.evaka.shared.db.Predicate
@@ -29,7 +31,7 @@ fun Database.Read.getPlacement(id: PlacementId): Placement? {
     return createQuery {
             sql(
                 """
-SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.created_at, p.created_by, p.source, p.modified_at, p.modified_by
+SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.created_at, p.created_by, p.source, p.source_application_id, p.source_service_application_id, p.modified_at, p.modified_by
 FROM placement p
 WHERE p.id = ${bind(id)}
 """
@@ -56,7 +58,7 @@ fun Database.Read.getPlacementsForChild(childId: ChildId): List<Placement> {
     return createQuery {
             sql(
                 """
-SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.created_at, p.created_by, p.source, p.modified_at, p.modified_by
+SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.created_at, p.created_by, p.source, p.source_application_id, p.source_service_application_id, p.modified_at, p.modified_by
 FROM placement p
 WHERE p.child_id = ${bind(childId)}
 """
@@ -69,7 +71,7 @@ fun Database.Read.getPlacements(where: Predicate): List<Placement> =
     createQuery {
             sql(
                 """
-SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.created_at, p.created_by, p.source, p.modified_at, p.modified_by
+SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.created_at, p.created_by, p.source, p.source_application_id, p.source_service_application_id, p.modified_at, p.modified_by
 FROM placement p
 WHERE ${predicate(where.forTable("p"))}
 """
@@ -125,6 +127,8 @@ fun Database.Transaction.insertPlacement(
     source: PlacementSource,
     modifiedAt: HelsinkiDateTime,
     modifiedBy: EvakaUserId,
+    sourceApplicationId: ApplicationId? = null,
+    sourceServiceApplicationId: ServiceApplicationId? = null,
 ): Placement {
     return createQuery {
             sql(
@@ -139,6 +143,8 @@ INSERT INTO placement (
     created_at,
     created_by,
     source,
+    source_application_id,
+    source_service_application_id,
     modified_at,
     modified_by
 ) VALUES (
@@ -151,6 +157,8 @@ INSERT INTO placement (
     ${bind(createdAt)},
     ${bind(createdBy)},
     ${bind(source)},
+    ${bind(sourceApplicationId)},
+    ${bind(sourceServiceApplicationId)},
     ${bind(modifiedAt)},
     ${bind(modifiedBy)}
 )
@@ -184,6 +192,8 @@ INSERT INTO placement (
     created_at,
     created_by,
     source,
+    source_application_id,
+    source_service_application_id,
     modified_at,
     modified_by
 ) VALUES (
@@ -196,6 +206,8 @@ INSERT INTO placement (
     ${bind(placement.createdAt)},
     ${bind(placement.createdBy)},
     ${bind(placement.source)},
+    ${bind(placement.sourceApplicationId)},
+    ${bind(placement.sourceServiceApplicationId)},
     ${bind(modifiedAt)},
     ${bind(modifiedBy)}
 )

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementQueries.kt
@@ -29,7 +29,7 @@ fun Database.Read.getPlacement(id: PlacementId): Placement? {
     return createQuery {
             sql(
                 """
-SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.modified_at, p.modified_by
+SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.created_at, p.created_by, p.source, p.modified_at, p.modified_by
 FROM placement p
 WHERE p.id = ${bind(id)}
 """
@@ -56,7 +56,7 @@ fun Database.Read.getPlacementsForChild(childId: ChildId): List<Placement> {
     return createQuery {
             sql(
                 """
-SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.modified_at, p.modified_by
+SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.created_at, p.created_by, p.source, p.modified_at, p.modified_by
 FROM placement p
 WHERE p.child_id = ${bind(childId)}
 """
@@ -69,7 +69,7 @@ fun Database.Read.getPlacements(where: Predicate): List<Placement> =
     createQuery {
             sql(
                 """
-SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.modified_at, p.modified_by
+SELECT p.id, p.type, p.child_id, p.unit_id, p.start_date, p.end_date, p.termination_requested_date, p.terminated_by, p.place_guarantee, p.created_at, p.created_by, p.source, p.modified_at, p.modified_by
 FROM placement p
 WHERE ${predicate(where.forTable("p"))}
 """
@@ -120,18 +120,91 @@ fun Database.Transaction.insertPlacement(
     startDate: LocalDate,
     endDate: LocalDate,
     placeGuarantee: Boolean,
+    createdAt: HelsinkiDateTime,
+    createdBy: EvakaUserId,
+    source: PlacementSource,
+    modifiedAt: HelsinkiDateTime,
+    modifiedBy: EvakaUserId,
 ): Placement {
     return createQuery {
             sql(
                 """
-INSERT INTO placement (type, child_id, unit_id, start_date, end_date, place_guarantee)
-VALUES (${bind(type)}::placement_type, ${bind(childId)}, ${bind(unitId)}, ${bind(startDate)}, ${bind(endDate)}, ${bind(placeGuarantee)})
+INSERT INTO placement (
+    type,
+    child_id,
+    unit_id,
+    start_date,
+    end_date,
+    place_guarantee,
+    created_at,
+    created_by,
+    source,
+    modified_at,
+    modified_by
+) VALUES (
+    ${bind(type)},
+    ${bind(childId)},
+    ${bind(unitId)},
+    ${bind(startDate)},
+    ${bind(endDate)},
+    ${bind(placeGuarantee)},
+    ${bind(createdAt)},
+    ${bind(createdBy)},
+    ${bind(source)},
+    ${bind(modifiedAt)},
+    ${bind(modifiedBy)}
+)
 RETURNING *
-        """
+"""
             )
         }
-        .toList<Placement>()
-        .first()
+        .mapTo<Placement>()
+        .exactlyOne()
+}
+
+/** Derive a new placement from an existing one, allowing to change the type and dates */
+fun Database.Transaction.insertDerivedPlacement(
+    placement: Placement,
+    newType: PlacementType,
+    newStartDate: LocalDate,
+    newEndDate: LocalDate,
+    modifiedAt: HelsinkiDateTime,
+    modifiedBy: EvakaUserId,
+): Placement {
+    return createQuery {
+            sql(
+                """
+INSERT INTO placement (
+    type,
+    child_id,
+    unit_id,
+    start_date,
+    end_date,
+    place_guarantee,
+    created_at,
+    created_by,
+    source,
+    modified_at,
+    modified_by
+) VALUES (
+    ${bind(newType)},
+    ${bind(placement.childId)},
+    ${bind(placement.unitId)},
+    ${bind(newStartDate)},
+    ${bind(newEndDate)},
+    ${bind(placement.placeGuarantee)},
+    ${bind(placement.createdAt)},
+    ${bind(placement.createdBy)},
+    ${bind(placement.source)},
+    ${bind(modifiedAt)},
+    ${bind(modifiedBy)}
+)
+RETURNING *
+"""
+            )
+        }
+        .mapTo<Placement>()
+        .exactlyOne()
 }
 
 data class PlacementChildAndRange(

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementService.kt
@@ -18,6 +18,7 @@ import fi.espoo.evaka.serviceneed.getServiceNeedOptions
 import fi.espoo.evaka.serviceneed.getServiceNeedsByChild
 import fi.espoo.evaka.serviceneed.getServiceNeedsByUnit
 import fi.espoo.evaka.serviceneed.insertServiceNeed
+import fi.espoo.evaka.shared.ApplicationId
 import fi.espoo.evaka.shared.BackupCareId
 import fi.espoo.evaka.shared.ChildId
 import fi.espoo.evaka.shared.DaycareId
@@ -26,6 +27,7 @@ import fi.espoo.evaka.shared.GroupId
 import fi.espoo.evaka.shared.GroupPlacementId
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.PlacementId
+import fi.espoo.evaka.shared.ServiceApplicationId
 import fi.espoo.evaka.shared.ServiceNeedId
 import fi.espoo.evaka.shared.ServiceNeedOptionId
 import fi.espoo.evaka.shared.auth.AclAuthorization
@@ -60,6 +62,8 @@ fun createPlacements(
     now: HelsinkiDateTime,
     userId: EvakaUserId,
     source: PlacementSource,
+    sourceApplicationId: ApplicationId? = null,
+    sourceServiceApplicationId: ServiceApplicationId? = null,
 ): List<Placement> {
     placementTypePeriods
         .sortedBy { it.first.start }
@@ -80,6 +84,8 @@ fun createPlacements(
                 createdAt = now,
                 createdBy = userId,
                 source = source,
+                sourceApplicationId = sourceApplicationId,
+                sourceServiceApplicationId = sourceServiceApplicationId,
                 modifiedAt = now,
                 modifiedBy = userId,
             )
@@ -113,6 +119,7 @@ fun createPlacement(
     now: HelsinkiDateTime,
     userId: EvakaUserId,
     source: PlacementSource,
+    sourceServiceApplicationId: ServiceApplicationId? = null,
 ): List<Placement> {
     val placementTypePeriods =
         if (useFiveYearsOldDaycare) {
@@ -130,6 +137,7 @@ fun createPlacement(
         now = now,
         userId = userId,
         source = source,
+        sourceServiceApplicationId = sourceServiceApplicationId,
     )
 }
 

--- a/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementTermination.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/placement/PlacementTermination.kt
@@ -251,6 +251,11 @@ fun terminateBilledDaycare(
                     startDate = terminationDate.plusDays(1),
                     endDate = placement.endDate,
                     placeGuarantee = false,
+                    createdAt = now,
+                    createdBy = user.evakaUserId,
+                    source = PlacementSource.PLACEMENT_TERMINATION,
+                    modifiedAt = now,
+                    modifiedBy = user.evakaUserId,
                 )
             }
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -668,7 +668,7 @@ fun Database.Read.getReservationEnabledPlacementRangesByChild(
     createQuery {
             sql(
                 """
-                SELECT pl.child_id, pl.created, daterange(pl.start_date, pl.end_date, '[]') AS range
+                SELECT pl.child_id, pl.created_at, daterange(pl.start_date, pl.end_date, '[]') AS range
                 FROM placement pl
                 JOIN daycare d ON pl.unit_id = d.id
                 WHERE pl.child_id = ANY(${bind(childIds)}) AND 'RESERVATIONS' = ANY(d.enabled_pilot_features)
@@ -678,7 +678,7 @@ fun Database.Read.getReservationEnabledPlacementRangesByChild(
         .map {
             column<ChildId>("child_id") to
                 ReservationEnabledPlacementRange(
-                    column<HelsinkiDateTime>("created").toLocalDate(),
+                    column<HelsinkiDateTime>("created_at").toLocalDate(),
                     column("range"),
                 )
         }

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/application/ServiceApplicationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/application/ServiceApplicationController.kt
@@ -190,6 +190,7 @@ class ServiceApplicationController(
                                     now = clock.now(),
                                     userId = user.evakaUserId,
                                     source = PlacementSource.SERVICE_APPLICATION,
+                                    sourceServiceApplicationId = id,
                                 )
                                 .also {
                                     tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(

--- a/service/src/main/kotlin/fi/espoo/evaka/serviceneed/application/ServiceApplicationController.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/serviceneed/application/ServiceApplicationController.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.serviceneed.application
 import fi.espoo.evaka.Audit
 import fi.espoo.evaka.AuditId
 import fi.espoo.evaka.absence.generateAbsencesFromIrregularDailyServiceTimes
+import fi.espoo.evaka.placement.PlacementSource
 import fi.espoo.evaka.placement.createPlacement
 import fi.espoo.evaka.placement.deleteFutureReservationsAndAbsencesOutsideValidPlacements
 import fi.espoo.evaka.serviceneed.ShiftCareType
@@ -188,6 +189,7 @@ class ServiceApplicationController(
                                     placeGuarantee = false,
                                     now = clock.now(),
                                     userId = user.evakaUserId,
+                                    source = PlacementSource.SERVICE_APPLICATION,
                                 )
                                 .also {
                                     tx.deleteFutureReservationsAndAbsencesOutsideValidPlacements(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -520,8 +520,8 @@ fun Database.Transaction.insert(row: DevPlacement): PlacementId =
     createUpdate {
             sql(
                 """
-INSERT INTO placement (id, type, child_id, unit_id, start_date, end_date, termination_requested_date, terminated_by, place_guarantee)
-VALUES (${bind(row.id)}, ${bind(row.type)}, ${bind(row.childId)}, ${bind(row.unitId)}, ${bind(row.startDate)}, ${bind(row.endDate)}, ${bind(row.terminationRequestedDate)}, ${bind(row.terminatedBy)}, ${bind(row.placeGuarantee)})
+INSERT INTO placement (id, type, child_id, unit_id, start_date, end_date, termination_requested_date, terminated_by, place_guarantee, created_at, created_by, source, modified_at, modified_by)
+VALUES (${bind(row.id)}, ${bind(row.type)}, ${bind(row.childId)}, ${bind(row.unitId)}, ${bind(row.startDate)}, ${bind(row.endDate)}, ${bind(row.terminationRequestedDate)}, ${bind(row.terminatedBy)}, ${bind(row.placeGuarantee)}, ${bind(row.createdAt)}, ${bind(row.createdBy)}, ${bind(row.source)}, ${bind(row.modifiedAt)}, ${bind(row.modifiedBy)})
 RETURNING id
 """
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DataInitializers.kt
@@ -520,8 +520,8 @@ fun Database.Transaction.insert(row: DevPlacement): PlacementId =
     createUpdate {
             sql(
                 """
-INSERT INTO placement (id, type, child_id, unit_id, start_date, end_date, termination_requested_date, terminated_by, place_guarantee, created_at, created_by, source, modified_at, modified_by)
-VALUES (${bind(row.id)}, ${bind(row.type)}, ${bind(row.childId)}, ${bind(row.unitId)}, ${bind(row.startDate)}, ${bind(row.endDate)}, ${bind(row.terminationRequestedDate)}, ${bind(row.terminatedBy)}, ${bind(row.placeGuarantee)}, ${bind(row.createdAt)}, ${bind(row.createdBy)}, ${bind(row.source)}, ${bind(row.modifiedAt)}, ${bind(row.modifiedBy)})
+INSERT INTO placement (id, type, child_id, unit_id, start_date, end_date, termination_requested_date, terminated_by, place_guarantee, created_at, created_by, source, source_application_id, source_service_application_id, modified_at, modified_by)
+VALUES (${bind(row.id)}, ${bind(row.type)}, ${bind(row.childId)}, ${bind(row.unitId)}, ${bind(row.startDate)}, ${bind(row.endDate)}, ${bind(row.terminationRequestedDate)}, ${bind(row.terminatedBy)}, ${bind(row.placeGuarantee)}, ${bind(row.createdAt)}, ${bind(row.createdBy)}, ${bind(row.source)}, ${bind(row.sourceApplicationId)}, ${bind(row.sourceServiceApplicationId)}, ${bind(row.modifiedAt)}, ${bind(row.modifiedBy)})
 RETURNING id
 """
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -2174,6 +2174,8 @@ data class DevPlacement(
     val modifiedAt: HelsinkiDateTime? = HelsinkiDateTime.now(),
     val modifiedBy: EvakaUserId? = AuthenticatedUser.SystemInternalUser.evakaUserId,
     val source: PlacementSource? = PlacementSource.MANUAL,
+    val sourceApplicationId: ApplicationId? = null,
+    val sourceServiceApplicationId: ServiceApplicationId? = null,
 )
 
 data class DevPerson(

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -136,6 +136,7 @@ import fi.espoo.evaka.pis.getEmployees
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
 import fi.espoo.evaka.placement.PlacementPlanService
+import fi.espoo.evaka.placement.PlacementSource
 import fi.espoo.evaka.placement.PlacementType
 import fi.espoo.evaka.reservations.DailyReservationRequest
 import fi.espoo.evaka.reservations.ReservationInsert
@@ -2168,6 +2169,11 @@ data class DevPlacement(
     val terminationRequestedDate: LocalDate? = null,
     val terminatedBy: EvakaUserId? = null,
     val placeGuarantee: Boolean = false,
+    val createdAt: HelsinkiDateTime = HelsinkiDateTime.now(),
+    val createdBy: EvakaUserId? = AuthenticatedUser.SystemInternalUser.evakaUserId,
+    val modifiedAt: HelsinkiDateTime? = HelsinkiDateTime.now(),
+    val modifiedBy: EvakaUserId? = AuthenticatedUser.SystemInternalUser.evakaUserId,
+    val source: PlacementSource? = PlacementSource.MANUAL,
 )
 
 data class DevPerson(

--- a/service/src/main/resources/db/migration/V548__placement_created_by_source_etc.sql
+++ b/service/src/main/resources/db/migration/V548__placement_created_by_source_etc.sql
@@ -1,0 +1,17 @@
+CREATE TYPE placement_source AS ENUM (
+    'APPLICATION',
+    'SERVICE_APPLICATION',
+    'PLACEMENT_TERMINATION',
+    'MANUAL'
+);
+
+ALTER TABLE placement RENAME COLUMN created TO created_at;
+ALTER TABLE placement ALTER COLUMN created_at DROP DEFAULT;
+
+DROP TRIGGER set_timestamp ON placement;
+ALTER TABLE placement RENAME COLUMN updated TO updated_at;
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON placement FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated_at();
+
+ALTER TABLE placement
+    ADD COLUMN created_by uuid REFERENCES evaka_user(id),
+    ADD COLUMN source placement_source;

--- a/service/src/main/resources/db/migration/V548__placement_created_by_source_etc.sql
+++ b/service/src/main/resources/db/migration/V548__placement_created_by_source_etc.sql
@@ -14,4 +14,11 @@ CREATE TRIGGER set_timestamp BEFORE UPDATE ON placement FOR EACH ROW EXECUTE PRO
 
 ALTER TABLE placement
     ADD COLUMN created_by uuid REFERENCES evaka_user(id),
-    ADD COLUMN source placement_source;
+    ADD COLUMN source placement_source,
+    ADD COLUMN source_application_id uuid REFERENCES application(id),
+    ADD COLUMN source_service_application_id uuid REFERENCES service_application(id),
+    ADD CONSTRAINT check$source_application_ref CHECK (source != 'APPLICATION' OR source_application_id IS NOT NULL),
+    ADD CONSTRAINT check$source_service_application_ref CHECK (source != 'SERVICE_APPLICATION' OR source_service_application_id IS NOT NULL);
+
+CREATE INDEX fk$placement_source_application_id ON placement (source_application_id) WHERE source_application_id IS NOT NULL;
+CREATE INDEX fk$placement_source_service_application_id ON placement (source_service_application_id) WHERE source_service_application_id IS NOT NULL;

--- a/service/src/main/resources/db/migration/V549__placement_indexes.sql
+++ b/service/src/main/resources/db/migration/V549__placement_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX fk$created_by ON placement (created_by);
+CREATE INDEX fk$modified_by ON placement (modified_by);
+CREATE INDEX fk$terminated_by ON placement (terminated_by);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -543,3 +543,5 @@ V544__child_document_decision_unit.sql
 V545__case_identifier.sql
 V546__end_decision_when_unit_changes_config.sql
 V547__relax_weak_credentials_check.sql
+V548__placement_created_by_source_etc.sql
+V549__placement_indexes.sql


### PR DESCRIPTION
Lisätään sijoitukselle luoja sekä lähde (`placement`-tauluun `created_by`, `source`, `source_application_id`, `source_service_application_id`). Nämä tiedot säilyvät joidenkin operaatioiden yli, kuten sijoituksen lyhentäminen tai jakaminen keskeltä kahtia.

Samalla uudelleennimetään `created/updated` => `created_at/updated_at` ja lisätään puuttuvia indeksejä.

Uusia kenttiä ei näytetä vielä käyttöliittymässä.