### PR TITLE
Asiakirjojen arkistoon vienti erillisessä async job bulk-poolissa

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -484,7 +484,6 @@ sealed interface AsyncJob : AsyncJobPayload {
                 AsyncJobPool.Id(AsyncJob::class, "main"),
                 AsyncJobPool.Config(concurrency = 4),
                 setOf(
-                    ArchiveChildDocument::class,
                     CreateAssistanceNeedDecisionPdf::class,
                     CreateAssistanceNeedPreschoolDecisionPdf::class,
                     CreateChildDocumentPdf::class,
@@ -585,6 +584,12 @@ sealed interface AsyncJob : AsyncJobPayload {
                 AsyncJobPool.Id(AsyncJob::class, "varda"),
                 AsyncJobPool.Config(concurrency = 1),
                 setOf(VardaUpdateChild::class),
+            )
+        val bulk =
+            AsyncJobRunner.Pool(
+                AsyncJobPool.Id(AsyncJob::class, "bulk"),
+                AsyncJobPool.Config(concurrency = 4),
+                setOf(ArchiveChildDocument::class),
             )
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -39,6 +39,7 @@ class AsyncJobConfig {
                     Duration.ofSeconds(1).takeIf { env.activeProfiles.contains("production") }
                 ),
                 AsyncJob.nightly,
+                AsyncJob.bulk,
             ),
             jdbi,
             tracer,

--- a/service/src/main/resources/db/scripts/archive_closed_child_documents.sql
+++ b/service/src/main/resources/db/scripts/archive_closed_child_documents.sql
@@ -1,0 +1,51 @@
+-- SPDX-FileCopyrightText: 2017-2025 City of Espoo
+--
+-- SPDX-License-Identifier: LGPL-2.1-or-later
+
+-- Schedules async jobs to archive child documents from closed templates
+-- marked for external archiving that haven't been archived yet.
+--
+-- Archiving strategy: Distributes the job limit evenly across all eligible document types,
+-- selecting the oldest unarchived documents first from each type to ensure balanced processing.
+
+-- A configurable limit for how many archive jobs to schedule in one run.
+\set job_limit 100
+
+INSERT INTO async_job(type, payload, retry_count, retry_interval)
+SELECT 'ArchiveChildDocument',
+       jsonb_build_object(
+               'user', NULL,
+               'documentId', document_id
+       ),
+       3,
+       interval '5 minutes'
+FROM (
+    WITH
+    -- Select all templates which validity period has ended and are marked as externally archived.
+    eligible_templates AS (
+        SELECT id, validity FROM document_template
+        WHERE upper(validity) <= current_date AND archive_externally = true
+    ),
+    -- Calculate how many documents to fetch per template.
+    docs_per_template AS (
+        SELECT coalesce(ceil(:job_limit::numeric / count(*)), 0) FROM eligible_templates
+    ),
+    -- For each eligible template, select document instances to schedule the archive jobs for.
+    ranked_documents AS (
+        SELECT
+            cd.id as document_id,
+            dt.validity as template_validity,
+            row_number() OVER (PARTITION BY cd.template_id ORDER BY cd.created) as rn
+        FROM
+            child_document cd
+        JOIN
+            eligible_templates dt ON cd.template_id = dt.id
+        WHERE
+            cd.archived_at IS NULL
+    )
+    SELECT document_id
+    FROM ranked_documents
+    WHERE rn <= (SELECT * FROM docs_per_template)
+    ORDER BY rn, template_validity
+    LIMIT :job_limit
+) documents;

--- a/service/src/main/resources/db/scripts/archive_closed_child_documents_simple.sql
+++ b/service/src/main/resources/db/scripts/archive_closed_child_documents_simple.sql
@@ -1,0 +1,26 @@
+-- SPDX-FileCopyrightText: 2017-2025 City of Espoo
+--
+-- SPDX-License-Identifier: LGPL-2.1-or-later
+
+-- Schedules async jobs to archive child documents from closed templates
+-- marked for external archiving that haven't been archived yet.
+
+
+-- A configurable limit for how many archive jobs to schedule in one run.
+\set job_limit 100
+
+INSERT INTO async_job(type, payload, retry_count, retry_interval)
+SELECT 'ArchiveChildDocument',
+       jsonb_build_object(
+               'user', NULL,
+               'documentId', cd.id
+       ),
+       3,
+       interval '5 minutes'
+FROM child_document cd
+JOIN document_template dt ON cd.template_id = dt.id
+WHERE upper(dt.validity) <= current_date
+  AND dt.archive_externally = true
+  AND cd.archived_at IS NULL
+ORDER BY cd.created
+LIMIT :job_limit;


### PR DESCRIPTION
## Ennen tätä muutosta
Asiakirjojen vienti ulkoiseen arkistoon tapahtui "main"-async job poolissa, ja ainoa työkalu asiakirjan viemiseen arkistoon oli yksittäisen asiakirjan sivulla oleva "Arkistoi"-nappi.

## Tämän muutoksen jälkeen
Koska suurten asiakirjamäärien vienti arkistoon kestää tunnin tai pidempään, ajetaan ne erillisessä "bulk"-poolissa. Näin normaalit async jobit, kuten "VTJ-synkronointi", ajautuvat edelleen ilman odottelua.

Lisätty myös SQL-skriptit, joilla käynnistetään suljettujen asiakirjojen vienti.
