### PR TITLE
Korjataan AD-kirjautumisen hiljainen virhekäsittely

### DIFF
--- a/apigw/src/shared/routes/saml.ts
+++ b/apigw/src/shared/routes/saml.ts
@@ -53,6 +53,7 @@ export class SamlError extends Error {
   constructor(message: string, options?: Options) {
     super(message, options)
     this.name = 'SamlError'
+    this.options = options
   }
 }
 


### PR DESCRIPTION
## Ennen tätä muutosta:
- SamlError-konstruktori ei asettanut options-parametria this.options-propertyyn
- Kaikki SAML-virheet logitettiin virheenkäsittelijässä, vaikka ne oli alustettu silent: true -flagilla
- "InResponseTo is missing from response" -tyyppiset virheet aiheuttivat turhia hälytyksiä, vaikka ne oli tarkoitettu hiljaisiksi

## Tämän muutoksen jälkeen:
- SamlError-konstruktori asettaa options-parametrin oikein this.options-propertyyn

Tämä korjaa regressiovirheen, joka tuli commitissa 3bd9acf1ac488348c08c4d778f84931b86fc43d9 "erasable syntax" -refaktoroinnin yhteydessä.