### PR TITLE
Korjataan puuttuvien poissaolokyselyn vastauksien huomautuset

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
@@ -338,7 +338,7 @@ describe('Employee - Unit month calendar', () => {
         .missingHolidayReservation.waitUntilHidden()
     })
 
-    test('Missing holiday questionnaire answers are shown for questionnaire dates that have no answer', async () => {
+    test('Missing holiday questionnaire answer indicators are shown for questionnaire dates that have no answer', async () => {
       await Fixture.holidayQuestionnaire({
         active: new FiniteDateRange(today, today.addWeeks(2)),
         periodOptions: [holidayRange]
@@ -366,6 +366,38 @@ describe('Employee - Unit month calendar', () => {
         await monthCalendarPage
           .absenceCell(testChild2.id, date)
           .missingQuestionnaireAnswer.waitUntilVisible()
+        date = date.addDays(1)
+      }
+    })
+
+    test('Missing holiday questionnaire indicators are not shown if placement started after questionnaire active period', async () => {
+      await Fixture.holidayQuestionnaire({
+        active: new FiniteDateRange(today.addWeeks(-2), today.addDays(-1)),
+        periodOptions: [holidayRange]
+      }).save()
+
+      await unitPage.navigateToUnit(testDaycare.id)
+      const groupsPage = await unitPage.openGroupsPage()
+      const groupSection = await groupsPage.openGroupCollapsible(
+        testDaycareGroup.id
+      )
+      const monthCalendarPage = await groupSection.openMonthCalendar()
+
+      // Today is not in a holiday period
+      await monthCalendarPage
+        .absenceCell(testChild2.id, today)
+        .waitUntilVisible()
+      await monthCalendarPage
+        .absenceCell(testChild2.id, today)
+        .missingQuestionnaireAnswer.waitUntilHidden()
+
+      // Missing holiday reservation is shown for holiday period dates
+      await monthCalendarPage.nextWeekButton.click()
+      let date = holidayStart
+      while (date <= holidayEnd) {
+        await monthCalendarPage
+          .absenceCell(testChild2.id, date)
+          .missingQuestionnaireAnswer.waitUntilHidden()
         date = date.addDays(1)
       }
     })

--- a/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/month-calendar.spec.ts
@@ -359,7 +359,7 @@ describe('Employee - Unit month calendar', () => {
         .absenceCell(testChild2.id, today)
         .missingQuestionnaireAnswer.waitUntilHidden()
 
-      // Missing holiday reservation is shown for holiday period dates
+      // Missing questionnaire answers are shown for holiday period dates
       await monthCalendarPage.nextWeekButton.click()
       let date = holidayStart
       while (date <= holidayEnd) {
@@ -370,7 +370,7 @@ describe('Employee - Unit month calendar', () => {
       }
     })
 
-    test('Missing holiday questionnaire indicators are not shown if placement started after questionnaire active period', async () => {
+    test('Missing holiday questionnaire answer indicators are not shown if placement started after questionnaire active period', async () => {
       await Fixture.holidayQuestionnaire({
         active: new FiniteDateRange(today.addWeeks(-2), today.addDays(-1)),
         periodOptions: [holidayRange]
@@ -391,7 +391,7 @@ describe('Employee - Unit month calendar', () => {
         .absenceCell(testChild2.id, today)
         .missingQuestionnaireAnswer.waitUntilHidden()
 
-      // Missing holiday reservation is shown for holiday period dates
+      // Missing questionnaire answers are not shown for holiday period dates
       await monthCalendarPage.nextWeekButton.click()
       let date = holidayStart
       while (date <= holidayEnd) {

--- a/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/absence/AbsenceService.kt
@@ -255,6 +255,9 @@ fun getGroupMonthCalendar(
                                 val childAttendances = attendances[child.id to date] ?: emptyList()
                                 val childReservations =
                                     reservations[child.id to date] ?: emptyList()
+                                val childShouldHaveAnswers =
+                                    isQuestionnaireDate &&
+                                        questionnaires.any { it.active.overlaps(placement.range) }
                                 val noAnswersForChild =
                                     answers.none {
                                         it.childId == child.id &&
@@ -333,6 +336,7 @@ fun getGroupMonthCalendar(
                                             daycare.providerType !=
                                                 ProviderType.PRIVATE_SERVICE_VOUCHER &&
                                             isQuestionnaireDate &&
+                                            childShouldHaveAnswers &&
                                             noAnswersForChild,
                                     absences =
                                         childAbsences.map { AbsenceWithModifierInfo.from(it) },


### PR DESCRIPTION
Ei näytetä puuttuvien poissaolokyselyn vastauksien huomautusia yksikön kuukausikalenterissa, jos lapsen sijoitus on alkanut kyselyn vastaamisajan päättymisen jälkeen.

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- Lisää linkki dokumentaation relevanttiin kohtaan.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
