### PR TITLE
Parannetaan ilmoitusten sijoittamista kuntalaisen käyttöliittymissä

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -105,7 +105,7 @@ const Content = React.memo(function Content({
     <FullPageContainer>
       <SkipToContent target="main">{t.skipLinks.mainContent}</SkipToContent>
       <Header ariaHidden={modalOpen} />
-      <Notifications apiVersion={apiVersion} />
+      <Notifications apiVersion={apiVersion} sticky offsetTop />
       <MainContainer ariaHidden={modalOpen}>{children}</MainContainer>
       <MobileNav />
       {sessionExpirationDetected && (

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
@@ -246,7 +246,6 @@ describe.each(envs)('Citizen calendar discussion surveys (%s)', (env) => {
       title: 'Unit event / Alkuräjähdyksen päiväkoti',
       description: 'For everyone in the unit'
     })
-    await calendarPage.closeToasts()
     await dayView.close()
 
     dayView = await calendarPage.openDayView(today.addDays(1))
@@ -295,7 +294,6 @@ describe.each(envs)('Citizen calendar discussion surveys (%s)', (env) => {
 
   test('Citizen can see open discussion survey details', async () => {
     const surveyModal = await calendarPage.openDiscussionSurveyModal()
-    await calendarPage.closeToasts()
     await surveyModal.assertChildSurvey(
       groupEventId,
       testChild.id,

--- a/frontend/src/lib-components/Notifications.tsx
+++ b/frontend/src/lib-components/Notifications.tsx
@@ -20,6 +20,7 @@ import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { faExclamation, faInfo, faRedo } from 'lib-icons'
 
 import { Button } from './atoms/buttons/Button'
+import { desktopMin } from './breakpoints'
 import { useTranslations } from './i18n'
 import { FixedSpaceColumn } from './layout/flex-helpers'
 import TimedToast from './molecules/TimedToast'
@@ -125,9 +126,13 @@ export const NotificationsContextProvider = React.memo(
 )
 
 export const Notifications = React.memo(function Notifications({
-  apiVersion
+  apiVersion,
+  sticky,
+  offsetTop
 }: {
   apiVersion: string | undefined
+  sticky?: boolean
+  offsetTop?: boolean
 }) {
   const i18n = useTranslations()
   const {
@@ -149,7 +154,7 @@ export const Notifications = React.memo(function Notifications({
     addNotification
   )
   return (
-    <OuterContainer>
+    <OuterContainer sticky={sticky} offsetTop={offsetTop}>
       <ColumnContainer
         spacing="s"
         alignItems="flex-end"
@@ -195,12 +200,23 @@ export const Notifications = React.memo(function Notifications({
   )
 })
 
-const OuterContainer = styled.div`
-  position: fixed;
-  top: 0;
+const OuterContainer = styled.div<{
+  sticky?: boolean
+  offsetTop?: boolean
+}>`
+  @media (max-width: ${desktopMin}) {
+    position: ${(p) => (p.sticky ? 'sticky' : 'fixed')};
+    top: ${(p) => (p.offsetTop ? '60px' : '0')};
+  }
+
+  @media (min-width: ${desktopMin}) {
+    position: ${(p) => (p.sticky ? 'sticky' : 'fixed')};
+    top: ${(p) => (p.offsetTop ? '160px' : '0')};
+  }
+
   left: 0;
   right: 0;
-  z-index: 100;
+  z-index: 15; //behind modals and nav dropdowns, above content
   height: 0;
 `
 


### PR DESCRIPTION
Muutos pyrkii sijoittamaan ilmoitukset kuntalaisen käyttöliittymissä niin, että ne eivät peitä tärkeitä navigaatiopainikkeita ja jäävät modaaliverhon taakse.