### PR TITLE
Validoi luotavan tai muokattavan esiopetussijoituksen päivämäärät

### DIFF
--- a/frontend/src/e2e-test/pages/employee/placement-draft-page.ts
+++ b/frontend/src/e2e-test/pages/employee/placement-draft-page.ts
@@ -10,12 +10,23 @@ import { Combobox, DatePicker } from '../../utils/page'
 export class PlacementDraftPage {
   #restrictedDetailsWarning: Element
   startDate: DatePicker
+  endDate: DatePicker
+  preschoolDaycareStartDate: DatePicker | null = null
+  preschoolDaycareEndDate: DatePicker | null = null
   #addOtherUnitCombobox: Combobox
   constructor(private page: Page) {
     this.#restrictedDetailsWarning = page.findByDataQa(
       'restricted-details-warning'
     )
     this.startDate = new DatePicker(page.findByDataQa('start-date'))
+    this.endDate = new DatePicker(page.findByDataQa('end-date'))
+    this.preschoolDaycareStartDate = new DatePicker(
+      page.findByDataQa('preschool-daycare-start-date')
+    )
+    this.preschoolDaycareEndDate = new DatePicker(
+      page.findByDataQa('preschool-daycare-end-date')
+    )
+
     this.#addOtherUnitCombobox = new Combobox(
       page.findByDataQa('add-other-unit')
     )

--- a/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
@@ -382,7 +382,7 @@ describe('Application transitions', () => {
         testChild2,
         familyWithTwoGuardians.guardian,
         undefined,
-        'DAYCARE',
+        'PRESCHOOL',
         null,
         [testDaycare.id],
         true,
@@ -414,7 +414,6 @@ describe('Application transitions', () => {
 
     const planStartDate = preferredStartDate.addDays(1)
     await placementDraftPage.startDate.fill(planStartDate)
-
     await placementDraftPage.assertOccupancies(testDaycare.id, {
       max3Months: '14,3 %',
       max6Months: '14,3 %',
@@ -431,6 +430,36 @@ describe('Application transitions', () => {
     })
 
     await placementDraftPage.placeToUnit(testPreschool.id)
+
+    // TODO test placement dates here
+    const preschoolTermValidationWarning = page.findByDataQa(
+      'preschool-term-warning'
+    )
+    await preschoolTermValidationWarning
+      .findText('Sijoituksen tulee olla esiopetuskaudella')
+      .waitUntilVisible()
+
+    await placementDraftPage.preschoolDaycareEndDate?.fill(
+      preschoolTerm2021.extendedTerm.end
+    )
+    await preschoolTermValidationWarning
+      .findText('Sijoituksen tulee olla esiopetuskaudella')
+      .waitUntilHidden()
+
+    await placementDraftPage.endDate?.fill(
+      preschoolTerm2021.finnishPreschool.end.addDays(1)
+    )
+    await preschoolTermValidationWarning
+      .findText('Sijoituksen tulee olla esiopetuskaudella')
+      .waitUntilVisible()
+
+    await placementDraftPage.endDate?.fill(
+      preschoolTerm2021.finnishPreschool.end
+    )
+    await preschoolTermValidationWarning
+      .findText('Sijoituksen tulee olla esiopetuskaudella')
+      .waitUntilHidden()
+
     await placementDraftPage.submit()
 
     await applicationListView.filterByApplicationStatus('WAITING_DECISION')

--- a/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/application-transitions.spec.ts
@@ -431,16 +431,8 @@ describe('Application transitions', () => {
 
     await placementDraftPage.placeToUnit(testPreschool.id)
 
-    // TODO test placement dates here
     const preschoolTermValidationWarning = page.findByDataQa(
       'preschool-term-warning'
-    )
-    await preschoolTermValidationWarning
-      .findText('Sijoituksen tulee olla esiopetuskaudella')
-      .waitUntilVisible()
-
-    await placementDraftPage.preschoolDaycareEndDate?.fill(
-      preschoolTerm2021.extendedTerm.end
     )
     await preschoolTermValidationWarning
       .findText('Sijoituksen tulee olla esiopetuskaudella')
@@ -455,6 +447,20 @@ describe('Application transitions', () => {
 
     await placementDraftPage.endDate?.fill(
       preschoolTerm2021.finnishPreschool.end
+    )
+    await preschoolTermValidationWarning
+      .findText('Sijoituksen tulee olla esiopetuskaudella')
+      .waitUntilHidden()
+
+    await placementDraftPage.preschoolDaycareEndDate?.fill(
+      LocalDate.of(2022, 8, 1)
+    )
+    await preschoolTermValidationWarning
+      .findText('Sijoituksen tulee olla esiopetuskaudella')
+      .waitUntilVisible()
+
+    await placementDraftPage.preschoolDaycareEndDate?.fill(
+      LocalDate.of(2022, 7, 31)
     )
     await preschoolTermValidationWarning
       .findText('Sijoituksen tulee olla esiopetuskaudella')

--- a/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
@@ -324,7 +324,7 @@ describe('Child Information placement create (feature flag place guarantee = fal
 
     // Placement starts a day before the term
     await start.fill(preschoolTerms.finnishPreschool.start.subDays(1))
-    await modal.findText('Sijoitus ei ole esiopetuskaudella').waitUntilVisible()
+    await modal.findText('Sijoituksen tulee olla esiopetuskaudella').waitUntilVisible()
     await modal.submitButton.assertDisabled(true)
 
     // A day before preschool term the extended term is valid so placement can be created
@@ -334,7 +334,7 @@ describe('Child Information placement create (feature flag place guarantee = fal
     // Placement starts a day before the term
     await start.fill(preschoolTerms.extendedTerm.start.subDays(1))
     await modal
-      .findText('Sijoitus ei ole liittyvällä esiopetuskaudella')
+      .findText('Sijoituksen tulee olla esiopetuskaudella')
       .waitUntilVisible()
   })
 

--- a/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
@@ -21,7 +21,8 @@ import {
   familyWithTwoGuardians,
   Fixture,
   testCareArea,
-  testDaycare
+  testDaycare,
+  preschoolTerm2023
 } from '../../dev-api/fixtures'
 import {
   createDaycareGroups,
@@ -31,7 +32,14 @@ import {
   terminatePlacement
 } from '../../generated/api-clients'
 import ChildInformationPage from '../../pages/employee/child-information'
-import { Combobox, Modal, Page } from '../../utils/page'
+import {
+  Checkbox,
+  Combobox,
+  DatePicker,
+  Modal,
+  Page,
+  Select
+} from '../../utils/page'
 import { employeeLogin } from '../../utils/user'
 
 beforeEach(async (): Promise<void> => resetServiceState())
@@ -231,6 +239,7 @@ describe('Child Information placement create (feature flag place guarantee = fal
     await employeeLogin(page, admin)
 
     const childPlacements = await openChildPlacements(page, childId)
+
     await childPlacements.createNewPlacement({
       unitName,
       startDate: mockedTime.toLocalDate().subDays(1).format(),
@@ -273,6 +282,60 @@ describe('Child Information placement create (feature flag place guarantee = fal
     await unitSelect.fillAndSelectFirst(unitName)
     await modal.findByDataQa('create-placement-end-date').assertTextEquals('')
     await modal.submitButton.assertDisabled(true)
+  })
+
+  test('placement create dialog shows errors on dates outside preschool and extended terms', async () => {
+    const preschoolTerms = await preschoolTerm2023.save()
+
+    const admin = await Fixture.employee().admin().save()
+    const area = await Fixture.careArea().save()
+    const unit = await Fixture.daycare({ areaId: area.id }).save()
+    const unitName = unit.name
+    const child = await Fixture.person().saveChild({ updateMockVtj: true })
+    const childId = child.id
+
+    const page = await openPage()
+    await employeeLogin(page, admin)
+
+    await openChildPlacements(page, childId)
+    await page.findByDataQa('create-new-placement-button').click()
+
+    const modal = new Modal(page.findByDataQa('modal'))
+
+    const placementTypeSelect = new Select(
+      modal.find('[data-qa="placement-type-select"]')
+    )
+    await placementTypeSelect.selectOption('PRESCHOOL')
+
+    const unitSelect = new Combobox(modal.find('[data-qa="unit-select"]'))
+    await unitSelect.fillAndSelectFirst(unitName)
+    const start = new DatePicker(
+      modal.findByDataQa('create-placement-start-date')
+    )
+    await start.click()
+    await start.fill(preschoolTerms.finnishPreschool.start)
+
+    const end = new DatePicker(modal.findByDataQa('create-placement-end-date'))
+    await end.fill(preschoolTerms.finnishPreschool.end)
+
+    await new Checkbox(modal.findByDataQa('confirm-retroactive')).check()
+
+    await modal.submitButton.assertDisabled(false)
+
+    // Placement starts a day before the term
+    await start.fill(preschoolTerms.finnishPreschool.start.subDays(1))
+    await modal.findText('Sijoitus ei ole esiopetuskaudella').waitUntilVisible()
+    await modal.submitButton.assertDisabled(true)
+
+    // A day before preschool term the extended term is valid so placement can be created
+    await placementTypeSelect.selectOption('PRESCHOOL_DAYCARE')
+    await modal.submitButton.assertDisabled(false)
+
+    // Placement starts a day before the term
+    await start.fill(preschoolTerms.extendedTerm.start.subDays(1))
+    await modal
+      .findText('Sijoitus ei ole liittyvällä esiopetuskaudella')
+      .waitUntilVisible()
   })
 
   async function openPage() {

--- a/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-information-placements.spec.ts
@@ -324,16 +324,35 @@ describe('Child Information placement create (feature flag place guarantee = fal
 
     // Placement starts a day before the term
     await start.fill(preschoolTerms.finnishPreschool.start.subDays(1))
-    await modal.findText('Sijoituksen tulee olla esiopetuskaudella').waitUntilVisible()
+    await modal
+      .findText('Sijoituksen tulee olla esiopetuskaudella')
+      .waitUntilVisible()
     await modal.submitButton.assertDisabled(true)
 
     // A day before preschool term the extended term is valid so placement can be created
     await placementTypeSelect.selectOption('PRESCHOOL_DAYCARE')
     await modal.submitButton.assertDisabled(false)
 
-    // Placement starts a day before the term
+    // Placement starts a day before the term so it is invalid
     await start.fill(preschoolTerms.extendedTerm.start.subDays(1))
     await modal
+      .findText('Sijoituksen tulee olla esiopetuskaudella')
+      .waitUntilVisible()
+    await modal.submitButton.assertDisabled(true)
+
+    // Create a valid placement
+    await start.fill(preschoolTerms.extendedTerm.start)
+    await modal.submitButton.click()
+
+    const placements = page.findByDataQa('child-placements-collapsible')
+    await placements.findByDataQa('btn-edit-placement').click()
+
+    const editedStart = new DatePicker(
+      placements.findByDataQa('placement-start-date-input')
+    )
+    await editedStart.fill(preschoolTerms.extendedTerm.start.subDays(1))
+
+    await placements
       .findText('Sijoituksen tulee olla esiopetuskaudella')
       .waitUntilVisible()
   })

--- a/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
@@ -49,13 +49,6 @@ function CreatePlacementModal({ childId }: Props) {
   const { clearUiMode } = useContext(UIContext)
   const units = useQueryResult(daycaresQuery({ includeClosed: true }))
   const preschoolTermsResult = useQueryResult(getPreschoolTermsQuery())
-  const preschoolTerms = useMemo(
-    () =>
-      preschoolTermsResult
-        .map((preschoolTerms) => preschoolTerms)
-        .getOrElse([]),
-    [preschoolTermsResult]
-  )
 
   const [form, setForm] = useState<Form>({
     type: 'DAYCARE',
@@ -105,6 +98,9 @@ function CreatePlacementModal({ childId }: Props) {
 
   const datesAreInsideSomePreschoolTerm = useMemo(() => {
     if (form.startDate && form.endDate) {
+      const preschoolTerms = preschoolTermsResult
+        .map((preschoolTerms) => preschoolTerms)
+        .getOrElse([])
       return preschoolTerms.some(
         (term) =>
           (term.finnishPreschool.asDateRange().includes(form.startDate!) &&
@@ -114,10 +110,13 @@ function CreatePlacementModal({ childId }: Props) {
       )
     }
     return false
-  }, [form, preschoolTerms])
+  }, [form, preschoolTermsResult])
 
   const datesAreInsideSomeExtendedPreschoolTerm = useMemo(() => {
     if (form.startDate && form.endDate) {
+      const preschoolTerms = preschoolTermsResult
+        .map((preschoolTerms) => preschoolTerms)
+        .getOrElse([])
       return preschoolTerms.some(
         (term) =>
           term.extendedTerm.asDateRange().includes(form.startDate!) &&
@@ -125,7 +124,7 @@ function CreatePlacementModal({ childId }: Props) {
       )
     }
     return false
-  }, [form, preschoolTerms])
+  }, [form, preschoolTermsResult])
 
   const errors = useMemo(() => {
     const errors: string[] = []
@@ -226,7 +225,7 @@ function CreatePlacementModal({ childId }: Props) {
       rejectLabel={i18n.common.cancel}
     >
       <FixedSpaceColumn>
-        <section>
+        <section data-qa="placement-type-select">
           <div className="bold">{i18n.childInformation.placements.type}</div>
 
           <Select

--- a/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/CreatePlacementModal.tsx
@@ -29,8 +29,9 @@ import { UIContext } from '../../../state/ui'
 import RetroactiveConfirmation, {
   isChangeRetroactive
 } from '../../common/RetroactiveConfirmation'
-import { daycaresQuery } from '../../unit/queries'
+import {daycaresQuery, getPreschoolTermsQuery} from '../../unit/queries'
 import { createPlacementMutation } from '../queries'
+import {getPreschoolTerms} from "../../../generated/api-clients/daycare";
 
 export interface Props {
   childId: ChildId
@@ -48,6 +49,8 @@ function CreatePlacementModal({ childId }: Props) {
   const { i18n } = useTranslation()
   const { clearUiMode } = useContext(UIContext)
   const units = useQueryResult(daycaresQuery({ includeClosed: true }))
+  const prechoolTerms = useQueryResult(getPreschoolTermsQuery())
+
   const [form, setForm] = useState<Form>({
     type: 'DAYCARE',
     unit: null,

--- a/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
+++ b/frontend/src/employee-frontend/components/child-information/placements/PlacementRow.tsx
@@ -277,11 +277,7 @@ export default React.memo(function PlacementRow({
             (term.swedishPreschool.asDateRange().includes(startDate) &&
               term.swedishPreschool.asDateRange().includes(endDate))
         )
-        if (datesAreInsideSomePreschoolTerm) {
-          setPreschoolDatesTermWarning(false)
-        } else {
-          setPreschoolDatesTermWarning(true)
-        }
+        setPreschoolDatesTermWarning(!datesAreInsideSomePreschoolTerm)
       })
     }
 
@@ -296,11 +292,7 @@ export default React.memo(function PlacementRow({
             term.extendedTerm.asDateRange().includes(startDate) &&
             term.extendedTerm.asDateRange().includes(endDate)
         )
-        if (datesAreInsideSomeExtendedPreschoolTerm) {
-          setPreschoolDatesTermWarning(false)
-        } else {
-          setPreschoolDatesTermWarning(true)
-        }
+        setPreschoolDatesTermWarning(!datesAreInsideSomeExtendedPreschoolTerm)
       })
     }
   }
@@ -427,7 +419,9 @@ export default React.memo(function PlacementRow({
                   </div>
                 )}
               </div>
-            ) : null}
+            ) : (
+              placement.endDate.format()
+            )}
           </DataValue>
         </DataRow>
         {editing && retroactive && (

--- a/frontend/src/employee-frontend/components/placement-draft/PlacementDraft.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/PlacementDraft.tsx
@@ -248,7 +248,7 @@ export default React.memo(function PlacementDraft() {
         ? LocalDate.of(formState.period.end.year, 7, 31)
         : LocalDate.of(formState.period.start.year + 1, 7, 31)
 
-      const validExtenderPreschoolDaycarePeriod = new FiniteDateRange(
+      const validExtendedPreschoolDaycarePeriod = new FiniteDateRange(
         previousAugust1StBeforePreschoolPlacementStart,
         nextJuly31StAfterPreschoolPlacementEnd
       )
@@ -256,9 +256,10 @@ export default React.memo(function PlacementDraft() {
       const preschoolDaycarePeriodIsValid =
         formState.hasPreschoolDaycarePeriod &&
         formState.preschoolDaycarePeriod !== null &&
-        validExtenderPreschoolDaycarePeriod.contains(
+        validExtendedPreschoolDaycarePeriod.contains(
           formState.preschoolDaycarePeriod
-        )
+        ) &&
+        formState.period.overlaps(formState.preschoolDaycarePeriod) // must overlap with placement period at least 1 day
 
       setPreschoolDatesAreValid(
         preschoolPeriodIsValid && preschoolDaycarePeriodIsValid

--- a/frontend/src/employee-frontend/components/placement-draft/PlacementDraft.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/PlacementDraft.tsx
@@ -208,6 +208,46 @@ export default React.memo(function PlacementDraft() {
     )
   }, [applicationId, redirectToMainPage])
 
+  const validatePreschoolPeriods = useCallback(
+    (
+      placementType: PlacementType,
+      periodType: 'period' | 'preschoolDaycarePeriod',
+      period: FiniteDateRange
+    ) => {
+      if (preschoolTermsResult.isSuccess) {
+        if (
+          placementType === 'PRESCHOOL' ||
+          placementType === 'PREPARATORY' ||
+          placementType === 'PRESCHOOL_DAYCARE' ||
+          placementType === 'PRESCHOOL_DAYCARE_ONLY' ||
+          placementType === 'PREPARATORY_DAYCARE'
+        ) {
+          if (periodType === 'period') {
+            preschoolTermsResult.map((preschoolTerms) => {
+              const datesAreInsideSomePreschoolTerm = preschoolTerms.some(
+                (term) =>
+                  term.finnishPreschool.asDateRange().contains(period) ||
+                  term.swedishPreschool.asDateRange().contains(period)
+              )
+              setPreschoolDatesTermWarning(!datesAreInsideSomePreschoolTerm)
+            })
+          } else {
+            preschoolTermsResult.map((preschoolTerms) => {
+              const datesAreInsideSomeExtendedPreschoolTerm =
+                preschoolTerms.some((term) =>
+                  term.extendedTerm.asDateRange().contains(period)
+                )
+              setPreschoolDatesTermWarning(
+                !datesAreInsideSomeExtendedPreschoolTerm
+              )
+            })
+          }
+        }
+      }
+    },
+    [preschoolTermsResult, setPreschoolDatesTermWarning]
+  )
+
   useEffect(() => {
     if (placementDraft.isSuccess) {
       void getApplicationUnitsResult({
@@ -273,46 +313,6 @@ export default React.memo(function PlacementDraft() {
     }
     return null
   }
-
-  const validatePreschoolPeriods = useCallback(
-    (
-      placementType: PlacementType,
-      periodType: 'period' | 'preschoolDaycarePeriod',
-      period: FiniteDateRange
-    ) => {
-      if (preschoolTermsResult.isSuccess) {
-        if (
-          placementType === 'PRESCHOOL' ||
-          placementType === 'PREPARATORY' ||
-          placementType === 'PRESCHOOL_DAYCARE' ||
-          placementType === 'PRESCHOOL_DAYCARE_ONLY' ||
-          placementType === 'PREPARATORY_DAYCARE'
-        ) {
-          if (periodType === 'period') {
-            preschoolTermsResult.map((preschoolTerms) => {
-              const datesAreInsideSomePreschoolTerm = preschoolTerms.some(
-                (term) =>
-                  term.finnishPreschool.asDateRange().contains(period) ||
-                  term.swedishPreschool.asDateRange().contains(period)
-              )
-              setPreschoolDatesTermWarning(!datesAreInsideSomePreschoolTerm)
-            })
-          } else {
-            preschoolTermsResult.map((preschoolTerms) => {
-              const datesAreInsideSomeExtendedPreschoolTerm =
-                preschoolTerms.some((term) =>
-                  term.extendedTerm.asDateRange().contains(period)
-                )
-              setPreschoolDatesTermWarning(
-                !datesAreInsideSomeExtendedPreschoolTerm
-              )
-            })
-          }
-        }
-      }
-    },
-    [preschoolTermsResult, setPreschoolDatesTermWarning]
-  )
 
   const updatePlacementDate =
     (
@@ -450,7 +450,7 @@ export default React.memo(function PlacementDraft() {
               )}
             />
             {preschoolDatesTermWarning && (
-              <div>
+              <div data-qa="preschool-term-warning">
                 <WarningContainer>
                   <InputWarning
                     text={

--- a/frontend/src/employee-frontend/components/placement-draft/PlacementDraftRow.tsx
+++ b/frontend/src/employee-frontend/components/placement-draft/PlacementDraftRow.tsx
@@ -136,6 +136,7 @@ export default React.memo(function PlacementDraftSection({
             onChange={updateEnd}
             minDate={formState.period?.start ?? today}
             locale="fi"
+            data-qa="end-date"
           />
         </DateRowItem>
         <DateRowItem>
@@ -159,6 +160,7 @@ export default React.memo(function PlacementDraftSection({
               onChange={updatePreschoolStart}
               minDate={today}
               locale="fi"
+              data-qa="preschool-daycare-start-date"
             />
             <DatePickerSpacer />
             <DatePicker
@@ -166,6 +168,7 @@ export default React.memo(function PlacementDraftSection({
               onChange={updatePreschoolEnd}
               minDate={formState.preschoolDaycarePeriod?.start ?? today}
               locale="fi"
+              data-qa="preschool-daycare-end-date"
             />
           </DateRowItem>
           {formState.preschoolDaycarePeriod !== null &&

--- a/frontend/src/employee-frontend/components/unit/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/queries.ts
@@ -65,6 +65,7 @@ import {
   postReservations
 } from '../../generated/api-clients/reservations'
 import { getUndecidedServiceApplications } from '../../generated/api-clients/serviceneed'
+import { getPreschoolTerms } from '../../generated/api-clients/daycare'
 
 const q = new Queries()
 
@@ -182,6 +183,9 @@ export const deleteGroupPlacementMutation = q.parametricMutation<{
   ({ unitId }) => unitNotificationsQuery({ daycareId: unitId }),
   unitGroupDetailsQuery.prefix
 ])
+
+export const getPreschoolTermsQuery = q.query(getPreschoolTerms)
+
 
 export const transferGroupMutation = q.parametricMutation<{
   unitId: DaycareId

--- a/frontend/src/employee-frontend/components/unit/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/queries.ts
@@ -42,6 +42,7 @@ import {
   updateTemporaryEmployee,
   updateUnitClosingDate
 } from '../../generated/api-clients/daycare'
+import { getPreschoolTerms } from '../../generated/api-clients/daycare'
 import {
   getNekkuUnitNumbers,
   nekkuManualOrder
@@ -65,7 +66,6 @@ import {
   postReservations
 } from '../../generated/api-clients/reservations'
 import { getUndecidedServiceApplications } from '../../generated/api-clients/serviceneed'
-import { getPreschoolTerms } from '../../generated/api-clients/daycare'
 
 const q = new Queries()
 
@@ -185,7 +185,6 @@ export const deleteGroupPlacementMutation = q.parametricMutation<{
 ])
 
 export const getPreschoolTermsQuery = q.query(getPreschoolTerms)
-
 
 export const transferGroupMutation = q.parametricMutation<{
   unitId: DaycareId

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -1604,9 +1604,9 @@ export const fi = {
         temporaryDaycareWarning: 'HUOM! Älä käytä varasijoitusta tehdessäsi!',
         startDateMissing: 'Alkupäivä on pakollinen tieto',
         unitMissing: 'Yksikkö puuttuu',
-        preschoolTermNotOpen: 'Sijoitus ei ole esiopetuskaudella',
+        preschoolTermNotOpen: 'Sijoituksen tulee olla esiopetuskaudella',
         preschoolExtendedTermNotOpen:
-          'Sijoitus ei ole liittyvällä esiopetuskaudella',
+          'Sijoituksen tulee olla esiopetuskaudella',
         placeGuarantee: {
           title: 'Varhaiskasvatuspaikkatakuu',
           info: 'Tulevaisuuden sijoitus liittyy varhaiskasvatuspaikkatakuuseen'

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -1604,6 +1604,9 @@ export const fi = {
         temporaryDaycareWarning: 'HUOM! Älä käytä varasijoitusta tehdessäsi!',
         startDateMissing: 'Alkupäivä on pakollinen tieto',
         unitMissing: 'Yksikkö puuttuu',
+        preschoolTermNotOpen: 'Sijoitus ei ole esiopetuskaudella',
+        preschoolExtendedTermNotOpen:
+          'Sijoitus ei ole liittyvällä esiopetuskaudella',
         placeGuarantee: {
           title: 'Varhaiskasvatuspaikkatakuu',
           info: 'Tulevaisuuden sijoitus liittyy varhaiskasvatuspaikkatakuuseen'


### PR DESCRIPTION
Tarkistaa että muokattavan tai luotavan esikoulusijoituksen päivämäärät osuvat jollekin esiopetus- tai liittyvälle kaudelle
- Lapsen profiilisivun sijoitusnäkymän sijoituksen muokkausnäkymässä muokatessa tai uutta sijoitusta luotaessa
- Hakemusta sijoitettaessa