### PR TITLE
Korjataan tooltipin näyttäminen liian kapeana

### DIFF
--- a/frontend/src/lib-components/atoms/Tooltip.tsx
+++ b/frontend/src/lib-components/atoms/Tooltip.tsx
@@ -252,17 +252,16 @@ function useFloatingPositioning({
 
     const anchorRect = anchor.getBoundingClientRect()
 
-    const tooltipMaxWidth =
+    const baseTooltipMaxWidth = 128 // based on previous tooltip measures
+    const calculatedMaxWidth =
       (['top', 'bottom'].includes(position)
         ? width === 'large'
           ? 400
-          : 140
-        : margin) +
-      anchorRect.width +
-      'px'
+          : baseTooltipMaxWidth
+        : margin) + anchorRect.width
 
     Object.assign(floating.style, {
-      maxWidth: tooltipMaxWidth
+      maxWidth: Math.max(baseTooltipMaxWidth, calculatedMaxWidth) + 'px'
     })
 
     const location: TooltipLocation = {
@@ -272,37 +271,26 @@ function useFloatingPositioning({
       bottom: null
     }
 
+    const verticalLeft =
+      anchorRect.left - floating.offsetWidth / 2 + anchorRect.width / 2 + 'px'
+    const horizontalTop =
+      anchorRect.top - floating.offsetHeight / 2 + anchorRect.height / 2 + 'px'
+
     switch (position) {
       case 'top':
         location.bottom = viewportHeight - anchorRect.top + 3 * margin + 'px'
-        location.left =
-          anchorRect.left -
-          floating.offsetWidth / 2 +
-          anchorRect.width / 2 +
-          'px'
+        location.left = verticalLeft
         break
       case 'bottom':
         location.top = anchorRect.bottom + 3 * margin + 'px'
-        location.left =
-          anchorRect.left -
-          floating.offsetWidth / 2 +
-          anchorRect.width / 2 +
-          'px'
+        location.left = verticalLeft
         break
       case 'left':
-        location.top =
-          anchorRect.top -
-          floating.offsetHeight / 2 +
-          anchorRect.height / 2 +
-          'px'
+        location.top = horizontalTop
         location.right = viewportWidth - anchorRect.left + 4 * margin + 'px'
         break
       case 'right':
-        location.top =
-          anchorRect.top -
-          floating.offsetHeight / 2 +
-          anchorRect.height / 2 +
-          'px'
+        location.top = horizontalTop
         location.left = anchorRect.right + 4 * margin + 'px'
         break
     }


### PR DESCRIPTION
Tooltipin osoittaessa oikealle tai vasemmalle oli mahdollista että sen suurin leveys perustui parent-elementin leveyteen. Jos elementtin on esim. pieni ikoni, tämä rajasi leveyden liian kapeaksi. Asetettiin vähimmäisleveys myös vaakatasossa osoittaville tooltipeille.

**_Ennen muutosta:_**


<img width="1356" height="676" alt="Screenshot 2025-09-01 at 10 53 59" src="https://github.com/user-attachments/assets/c84192bd-892b-4209-8800-ae6944126166" />


**_Muutoksen jälkeen:_**


<img width="1372" height="390" alt="Screenshot 2025-09-01 at 12 16 40" src="https://github.com/user-attachments/assets/3b878cb9-db3b-4435-a88b-bec3023c9266" />


pari muuta tooltip-otosta lisäksi:
<img width="1327" height="513" alt="Screenshot 2025-09-01 at 12 06 40" src="https://github.com/user-attachments/assets/1d3a1d93-fec9-47df-bf7a-15c6f706a911" />
<img width="1363" height="681" alt="Screenshot 2025-09-01 at 12 01 46" src="https://github.com/user-attachments/assets/f17ea3da-6df6-4264-bb86-e4384558e6f3" />
<img width="1414" height="432" alt="Screenshot 2025-09-01 at 12 01 10" src="https://github.com/user-attachments/assets/cc58d3ae-a93e-479b-97d6-f7950ffc3795" />
<img width="1359" height="564" alt="Screenshot 2025-09-01 at 12 00 11" src="https://github.com/user-attachments/assets/56f84329-5c3d-4f14-8d7e-39b8969deb14" />



