### PR TITLE
Arkistointi: Poimitaan luontipäivämäärä prosessihistorian aikaleimasta

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/document/archival/DocumentMetadataUtils.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/archival/DocumentMetadataUtils.kt
@@ -299,9 +299,15 @@ private fun createFormat(filename: String): StandardMetadataType.Format {
     }
 }
 
-private fun createCreation(documentMetadata: DocumentMetadata): StandardMetadataType.Creation {
+fun createCreation(
+    documentMetadata: DocumentMetadata,
+    caseProcess: CaseProcess?,
+): StandardMetadataType.Creation {
     return StandardMetadataType.Creation().apply {
-        created = documentMetadata.createdAt?.asXMLGregorianCalendar()
+        created =
+            (caseProcess?.history?.find { it.state == CaseProcessState.INITIAL }?.enteredAt
+                    ?: documentMetadata.createdAt)
+                ?.asXMLGregorianCalendar()
         originatingSystem = "Varhaiskasvatuksen toiminnanohjausjärjestelmä"
     }
 }
@@ -384,7 +390,7 @@ fun createDocumentMetadata(
                         birthDate,
                     )
                 format = createFormat(filename)
-                creation = createCreation(documentMetadata)
+                creation = createCreation(documentMetadata, caseProcess)
                 policies = createPolicies(documentMetadata, document.template.type)
                 caseFile = createCaseFile(documentMetadata, caseProcess, document)
                 creation.created = getCaseFinishDate(documentMetadata, caseProcess, document)


### PR DESCRIPTION
## Ennen tätä muutosta
Arkistoinnin metadatassa käytettiin itse asiakirjan luontipäivää joka on migratoiduissa asiakirjoissa migraation ajopäivä, ei itse asiakirjan luontipäivä.
## Tämän muutoksen jälkeen
Asiakirjan luontipäivä haetaan ensisijaisesti prosessihistorian tilasiirtymästä INITIAL tilaan. Näin myös migratoiduille asiakirjoille saadaan metadataan oikea luontipäivä.