### PR TITLE
Feature flag muut dokumentit -toiminnolle

### DIFF
--- a/service/src/main/resources/db/migration/V553__other_decision_pilot_feature_flag.sql
+++ b/service/src/main/resources/db/migration/V553__other_decision_pilot_feature_flag.sql
@@ -1,0 +1,1 @@
+ALTER TYPE pilot_feature ADD VALUE 'OTHER_DECISION';

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -548,3 +548,4 @@ V549__placement_indexes.sql
 V550__new_preschool_assistance_levels_v2.sql
 V551__daycare_nekku_order_reduction_percentage.sql
 V552__child_document_published_modified_metadata.sql
+V553__other_decision_pilot_feature_flag.sql


### PR DESCRIPTION
Muut dokumentit halutaan erottaa toiminnallisesti nykyisistä pedagogisista dokumenteista jotta voidaan yksikkökohtaisesti määrätä mitä dokumentteja kussakin yksikössä voidaan tuottaa. Tämä PR lisää uuden tietokanta-ENUM arvon tälle lipulle. Varsinaisessa muutoksen toteuttavassa prssä tämä otetaan käyttöön. Tietokantamuutos on erotettu omaan PRn jotta toiminnallisuutta voidaan testata testiympäristössä jo ennen masteriin mergaamista