### PR TITLE
Korjataan kuntalaisen saavutettavuusselosteen näkyvyys

### DIFF
--- a/frontend/src/citizen-frontend/AccessibilityStatement.tsx
+++ b/frontend/src/citizen-frontend/AccessibilityStatement.tsx
@@ -21,7 +21,9 @@ export default React.memo(function AccessibilityStatement() {
       <Main>
         <Container>
           <ReturnButton label={t.common.return} />
-          <ContentArea opaque>{t.accessibilityStatement}</ContentArea>
+          <ContentArea opaque data-qa="accessibility-statement">
+            {t.accessibilityStatement}
+          </ContentArea>
         </Container>
       </Main>
       <Footer />

--- a/frontend/src/citizen-frontend/router.tsx
+++ b/frontend/src/citizen-frontend/router.tsx
@@ -46,7 +46,7 @@ const routes: CitizenRoute[] = [
   { path: '/login/form', component: LoginFormPage, auth: null },
   { path: '/login', component: LoginPage, auth: null },
   { path: '/map', component: MapPage, auth: null },
-  { path: '/accessibility', component: AccessibilityStatement },
+  { path: '/accessibility', component: AccessibilityStatement, auth: null },
   { path: '/applications', component: Applications },
   { path: '/applications/new', component: Applications },
   { path: '/applications/new/:childId', component: ApplicationCreation },

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-links.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-links.spec.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2017-2025 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import config from '../../config'
+import { testAdult } from '../../dev-api/fixtures'
+import {
+  resetServiceState,
+  upsertWeakCredentials
+} from '../../generated/api-clients'
+import { Page } from '../../utils/page'
+import { enduserLogin, enduserLoginWeak } from '../../utils/user'
+
+describe('Citizen links', () => {
+  let page: Page
+  const credentials = {
+    username: 'test@example.com',
+    password: 'TestPassword456!'
+  }
+
+  beforeEach(async () => {
+    await resetServiceState()
+    await testAdult.saveAdult({
+      updateMockVtjWithDependants: []
+    })
+    await upsertWeakCredentials({
+      id: testAdult.id,
+      body: credentials
+    })
+
+    page = await Page.open()
+  })
+
+  const initConfigurations = [
+    [
+      'direct login',
+      async (page: Page) => enduserLogin(page, testAdult)
+    ] as const,
+    [
+      'weak login',
+      async (page: Page) => enduserLoginWeak(page, credentials)
+    ] as const
+  ]
+
+  describe('without login', () => {
+    test('accessibility page can be accessed', async () => {
+      await page.goto(`${config.enduserUrl}/accessibility`)
+      await page.findByDataQa('accessibility-statement').waitUntilVisible()
+    })
+  })
+
+  describe.each(initConfigurations)(`Interactions with %s`, (_name, login) => {
+    test('accessibility page can be accessed', async () => {
+      await login(page)
+      await page.goto(`${config.enduserUrl}/accessibility`)
+      await page.findByDataQa('accessibility-statement').waitUntilVisible()
+    })
+  })
+})


### PR DESCRIPTION
Saavutettavuusselosteen router-määrityksestä jäänyt puuttumaan `auth: null`, jotta näkyisi ilman kirjautumistakin