### PR TITLE
Muutettu Nekun aterian nimi illallisesta päivälliseksi

### DIFF
--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4356,7 +4356,7 @@ export const fi = {
         BREAKFAST: 'Aamupala',
         LUNCH: 'Lounas',
         SNACK: 'Välipala',
-        DINNER: 'Illallinen',
+        DINNER: 'Päivällinen',
         SUPPER: 'Iltapala'
       },
       mealTypeValues: {


### PR DESCRIPTION
Ateria joka on Nekussa päivällinen oli nimetty eVakassa illalliseksi. Vaihdettu eVakassakin päivälliseksi sekaannusten välttämiseksi.