### PR TITLE
Korjataan täydentävän varhaiskasvatuksen tuntilaskuri

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/Reservations.kt
@@ -696,9 +696,13 @@ fun computeUsedService(
         )
     }
 
+    val absenceCategoriesByType = absences.groupBy({ it.first }, { it.second })
     val isPlannedAbsence =
         absenceTypes == setOf(AbsenceType.PLANNED_ABSENCE) &&
-            absenceCategories == placementType.absenceCategories()
+            absenceCategories == placementType.absenceCategories() ||
+            absenceCategoriesByType[AbsenceType.PLANNED_ABSENCE]?.contains(
+                AbsenceCategory.BILLABLE
+            ) == true
 
     if (endedAttendances.isEmpty() && isPlannedAbsence) {
         return UsedServiceResult(

--- a/service/src/test/kotlin/fi/espoo/evaka/reservations/UsedServiceTests.kt
+++ b/service/src/test/kotlin/fi/espoo/evaka/reservations/UsedServiceTests.kt
@@ -175,6 +175,30 @@ class UsedServiceTests {
     }
 
     @Test
+    fun `returns no used service for billable planned absence`() {
+        compute(
+                placementType = PlacementType.PRESCHOOL_DAYCARE,
+                absences = listOf(AbsenceType.PLANNED_ABSENCE to AbsenceCategory.BILLABLE),
+            )
+            .also {
+                assertEquals(0, it.usedServiceMinutes)
+                assertEquals(emptyList(), it.usedServiceRanges)
+            }
+        compute(
+                placementType = PlacementType.PRESCHOOL_DAYCARE,
+                absences =
+                    listOf(
+                        AbsenceType.PLANNED_ABSENCE to AbsenceCategory.BILLABLE,
+                        AbsenceType.OTHER_ABSENCE to AbsenceCategory.NONBILLABLE,
+                    ),
+            )
+            .also {
+                assertEquals(0, it.usedServiceMinutes)
+                assertEquals(emptyList(), it.usedServiceRanges)
+            }
+    }
+
+    @Test
     fun `uses hours divided by 21 if other than planned absences exist without reservation`() {
         compute(absences = listOf(AbsenceType.OTHER_ABSENCE to AbsenceCategory.BILLABLE)).also {
             assertEquals(it.usedServiceMinutes, (120.0 * 60 / 21).toLong())


### PR DESCRIPTION
Täydentävässä varhaiskasvatuksessa poissaoloksi laitetaan "Suunniteltu poissaolo" (`PLANNED_ABSENCE`) ja esiopetukselle "Poissaolo" (`OTHER ABSENCE`). Tällöin laskurin pitäisi näyttää kyseiseltä päivältä nollaa.