### PR TITLE
Korjataan yksiköt-sivun uudelleenohjaus ainokaiseen yksikköön

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/units.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/units.spec.ts
@@ -237,4 +237,24 @@ describe('Employee - Units', () => {
       .unitRow(closedUnit.id)
       .assertFields({ name: closedUnit.name })
   })
+
+  test('Units list is shown when there is only one open unit and some closed units', async () => {
+    const area = await Fixture.careArea().save()
+    const closedUnit = await Fixture.daycare({
+      areaId: area.id,
+      name: 'Wanha päiväkoti',
+      openingDate: LocalDate.of(1900, 1, 1),
+      closingDate: LocalDate.of(2000, 1, 1)
+    }).save()
+    const unitSupervisor = await Fixture.employee()
+      .unitSupervisor(unitFixture.id)
+      .unitSupervisor(closedUnit.id)
+      .save()
+
+    await employeeLogin(page, unitSupervisor)
+    const unitsPage = await UnitsPage.open(page)
+    await unitsPage.assertRowCount(1)
+    await unitsPage.showClosedUnits(true)
+    await unitsPage.assertRowCount(2)
+  })
 })

--- a/frontend/src/employee-frontend/components/Units.tsx
+++ b/frontend/src/employee-frontend/components/Units.tsx
@@ -61,7 +61,7 @@ export default React.memo(function Units() {
     setIncludeClosed
   } = useContext<UnitsState>(UnitsContext)
   const [, navigate] = useLocation()
-  const units = useQueryResult(daycaresQuery({ includeClosed }))
+  const units = useQueryResult(daycaresQuery({ includeClosed: true }))
 
   const sortBy = (column: SearchColumn) => {
     if (sortColumn === column) {


### PR DESCRIPTION
Jos käyttäjällä on käyttöoikeus vain yhteen voimassaolevaan yksikköön ja yhteen tai useampaan suljettuun yksikköön, ei tehdä uudelleenohjausta voimassaolevaan yksikköön jotta pääsee navigoimaan myös suljettuihin yksiköihin.