### PR TITLE
Näytetään oletuspalvelusetelikertoimet viivana lapsikohtaisella tukitoimiraportilla

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/assistance-need-and-actions-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/assistance-need-and-actions-report.spec.ts
@@ -226,7 +226,7 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\ta test assistance action option\t1\t0\t0'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\ta test assistance action option\t-\t0\t0'
       )
     await report.preschoolAssistanceLevelSelect.fillAndSelectFirst(
       'Tehostettu tuki'
@@ -234,7 +234,7 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\ta test assistance action option\t1\t0\t0'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\ta test assistance action option\t-\t0\t0'
       )
     await report.preschoolAssistanceLevelSelect.fillAndSelectFirst(
       'Tehostettu tuki'
@@ -245,14 +245,14 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t0\t\t1\t0\t0'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t0\t\t-\t0\t0'
       )
 
     await report.typeSelect.fillAndSelectFirst('varhaiskasvatuksessa')
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\ta test assistance action option\t1\t0\t0'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\ta test assistance action option\t-\t0\t0'
       )
     await report.daycareAssistanceLevelSelect.fillAndSelectFirst(
       'Yleinen tuki, ei päätöstä'
@@ -260,7 +260,7 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\ta test assistance action option\t1\t0\t0'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\ta test assistance action option\t-\t0\t0'
       )
     await report.daycareAssistanceLevelSelect.fillAndSelectFirst(
       'Yleinen tuki, ei päätöstä'
@@ -271,7 +271,7 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t0\t\t1\t0\t0'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t0\t\t-\t0\t0'
       )
   })
   test('Shows assistance decision counts', async () => {
@@ -428,7 +428,7 @@ describe('Assistance need and actions report', () => {
     await report.childRows
       .nth(0)
       .assertTextEquals(
-        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\t\t1\t0\t0'
+        'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\t\t-\t0\t0'
       )
 
     await report.providerTypeSelect.fillAndSelectFirst('Palveluseteli')
@@ -539,7 +539,7 @@ describe('Assistance need and actions report', () => {
     const anteroRow =
       'Antero Onni Leevi Aatu Högfors\tKosmiset Vakiot\t10\t1\t0\t0\t0\t1\t0\t0\ta test assistance action option\t1.5\t1\t1'
     const lisaRow =
-      'Lisä Lapsi\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\t\t1\t0\t0'
+      'Lisä Lapsi\tKosmiset Vakiot\t10\t1\t0\t0\t0\t0\t0\t0\t\t-\t0\t0'
 
     //Group view count check
     await report.needsAndActionsRows

--- a/frontend/src/employee-frontend/components/reports/AssistanceNeedsAndActions.tsx
+++ b/frontend/src/employee-frontend/components/reports/AssistanceNeedsAndActions.tsx
@@ -1333,7 +1333,10 @@ const ReportByChildTable = ({
             label:
               i18n.reports.assistanceNeedsAndActions
                 .assistanceNeedVoucherCoefficient,
-            value: (row) => row.assistanceNeedVoucherCoefficient,
+            value: (row) =>
+              row.assistanceNeedVoucherCoefficient > 1
+                ? row.assistanceNeedVoucherCoefficient
+                : null,
             exclude: !report.showAssistanceNeedVoucherCoefficient
           },
           {
@@ -1521,7 +1524,11 @@ const ReportByChildTable = ({
                     </Td>
 
                     {report.showAssistanceNeedVoucherCoefficient && (
-                      <Td>{row.assistanceNeedVoucherCoefficient}</Td>
+                      <Td>
+                        {row.assistanceNeedVoucherCoefficient > 1
+                          ? row.assistanceNeedVoucherCoefficient
+                          : '-'}
+                      </Td>
                     )}
                     <Td>{row.daycareAssistanceNeedDecisionCount}</Td>
                     <Td>{row.preschoolAssistanceNeedDecisionCount}</Td>
@@ -1562,10 +1569,11 @@ const ReportByChildTable = ({
             <Td />
             {report.showAssistanceNeedVoucherCoefficient && (
               <Td>
-                {reducePropertySum(
-                  filteredRows,
-                  (r) => r.assistanceNeedVoucherCoefficient
-                )}
+                {
+                  filteredRows.filter(
+                    (r) => r.assistanceNeedVoucherCoefficient > 1
+                  ).length
+                }
               </Td>
             )}
             <Td>


### PR DESCRIPTION
Ladattavalla raportilla näytetään tyhjänä soluna. Yhteensä-rivillä näytetään lasten määrä joilla on korotettu kerroin eikä kertoimien summaa.