### PR TITLE
Lisätään yöllinen ajo poistuneen vuorohoidon tarpeen jälkeiseen varausten siivoamiseen tulevaisuudesta

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -684,8 +684,8 @@ fun Database.Read.getReservationEnabledPlacementRangesByChild(
         }
         .useSequence { rows -> rows.groupBy({ it.first }, { it.second }) }
 
-fun Database.Transaction.deleteInvalidatedShiftCareReservationsByDate(today: LocalDate): Int {
-    val futureHolidays = getHolidays(FiniteDateRange(today, today.plusMonths(6)))
+fun Database.Transaction.deleteInvalidatedShiftCareReservationsAfterDate(date: LocalDate): Int {
+    val futureHolidays = getHolidays(FiniteDateRange(date, date.plusMonths(6)))
     return createUpdate {
             sql(
                 """
@@ -701,8 +701,8 @@ fun Database.Transaction.deleteInvalidatedShiftCareReservationsByDate(today: Loc
                                       AND daterange(sn.start_date, sn.end_date, '[]') @> ar.date
                             WHERE (sn.shift_care IS NULL OR sn.shift_care = 'NONE') 
                             AND (ar.date = ANY (${bind(futureHolidays)})
-                                OR (ar.date >= ${bind(today)}
-                                    AND d.operation_times[extract(isodow FROM ar.date)] IS NULL
+                                OR (ar.date >= ${bind(date)}
+                                    AND d.operation_days[extract(isodow FROM ar.date)] IS NULL
                                 ))
                         )
                     """

--- a/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reservations/ReservationQueries.kt
@@ -702,7 +702,7 @@ fun Database.Transaction.deleteInvalidatedShiftCareReservationsAfterDate(date: L
                             WHERE (sn.shift_care IS NULL OR sn.shift_care = 'NONE') 
                             AND (ar.date = ANY (${bind(futureHolidays)})
                                 OR (ar.date >= ${bind(date)}
-                                    AND d.operation_days[extract(isodow FROM ar.date)] IS NULL
+                                    AND NOT (extract(isodow FROM ar.date) = ANY (d.operation_days))
                                 ))
                         )
                     """

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -36,7 +36,7 @@ import fi.espoo.evaka.pis.deactivateInactiveEmployees
 import fi.espoo.evaka.reports.freezeVoucherValueReportRows
 import fi.espoo.evaka.reservations.MissingHolidayReservationsReminders
 import fi.espoo.evaka.reservations.MissingReservationsReminders
-import fi.espoo.evaka.reservations.deleteInvalidatedShiftCareReservationsByDate
+import fi.espoo.evaka.reservations.deleteInvalidatedShiftCareReservationsAfterDate
 import fi.espoo.evaka.sficlient.SfiAsyncJobs
 import fi.espoo.evaka.sficlient.SfiMessagesClient
 import fi.espoo.evaka.shared.FeatureConfig
@@ -299,7 +299,7 @@ enum class ScheduledJob(
      */
     RemoveInvalidatedShiftCareReservations(
         ScheduledJobs::removeInvalidatedShiftCareReservations,
-        ScheduledJobSettings(enabled = true, schedule = JobSchedule.nightly()),
+        ScheduledJobSettings(enabled = false, schedule = JobSchedule.nightly()),
     ),
 }
 
@@ -645,8 +645,8 @@ WHERE id IN (SELECT id FROM attendances_to_end)
 
     fun removeInvalidatedShiftCareReservations(db: Database.Connection, clock: EvakaClock) {
         db.transaction {
-            val removalCounts = it.deleteInvalidatedShiftCareReservationsByDate(clock.today())
-            logger.info { "Removed $removalCounts invalidated shift care reservations." }
+            val removalCount = it.deleteInvalidatedShiftCareReservationsAfterDate(clock.today())
+            logger.info { "Removed $removalCount invalidated shift care reservations." }
         }
     }
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -299,7 +299,7 @@ enum class ScheduledJob(
      */
     RemoveInvalidatedShiftCareReservations(
         ScheduledJobs::removeInvalidatedShiftCareReservations,
-        ScheduledJobSettings(enabled = false, schedule = JobSchedule.nightly()),
+        ScheduledJobSettings(enabled = true, schedule = JobSchedule.nightly()),
     ),
 }
 


### PR DESCRIPTION
Lisää ajastetun ajon siivouskyselyille, jotka poistavat sellaiset vuorohoitoyksiköiden tulevaisuuden varaukset, jotka eivät enää perustu vuorohoitopalveluntarpeeseen. Tällaisia varauksia voi jäädä järjestelmään, jos vuorohoidon palveluntarve katkaistaan, korvataan vuorohoidottomalla palveluntarpeella tai  palveluntarpeen vuorohoitomerkintä poistetaan takautuvasti.

Poistettavat varaukset:
- arkipyhille osuvat varaukset
- yksikön normaaliaukiolopäivien ulkopuoliset varaukset
  - pelkästään normaaliaukiolotunnit ylittävää varausta EI poisteta
