### PR TITLE
Korjataan esiopetuksen poissaoloraportin laskenta

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/reports/PreschoolAbsenceReportTest.kt
@@ -300,7 +300,7 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
                         // todo
                         preschoolAbsenceTypes.associateWith { type ->
                             when (type) {
-                                AbsenceType.UNKNOWN_ABSENCE -> 4
+                                AbsenceType.OTHER_ABSENCE -> 5
                                 else -> 0
                             }
                         },
@@ -335,7 +335,7 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
                         dailyPreschoolTime =
                             TimeRange(LocalTime.of(9, 0, 0), LocalTime.of(14, 0, 0)),
                         dailyPreparatoryTime =
-                            TimeRange(LocalTime.of(9, 0, 0), LocalTime.of(13, 0, 0)),
+                            TimeRange(LocalTime.of(10, 0, 0), LocalTime.of(15, 0, 0)),
                     )
                 )
             val groupAId =
@@ -576,10 +576,21 @@ internal class PreschoolAbsenceReportTest : FullApplicationTest(resetDbBeforeEac
                     id = AbsenceId(UUID.randomUUID()),
                     testChildDonald.id,
                     monday,
-                    AbsenceType.UNKNOWN_ABSENCE,
+                    AbsenceType.PLANNED_ABSENCE,
                     HelsinkiDateTime.atStartOfDay(monday),
                     EvakaUserId(admin.id.raw),
                     AbsenceCategory.NONBILLABLE,
+                )
+            )
+            tx.insert(
+                DevAbsence(
+                    id = AbsenceId(UUID.randomUUID()),
+                    testChildDonald.id,
+                    monday,
+                    AbsenceType.PLANNED_ABSENCE,
+                    HelsinkiDateTime.atStartOfDay(monday),
+                    EvakaUserId(admin.id.raw),
+                    AbsenceCategory.BILLABLE,
                 )
             )
 


### PR DESCRIPTION
Lasketaan valmistavan esiopetuksen läsnäolojen poikkeama käyttäen valmistavan opetusaikaa. Aiemmin poikkeama laskettiin virheellisesti käyttäen esiopetuksen opetusaikaa.

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- Lisää linkki dokumentaation relevanttiin kohtaan.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
