### PR TITLE
Parannus henkilökunnan viestien lähetyksen audit-lokitukseen

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessagePushNotificationsTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessagePushNotificationsTest.kt
@@ -143,7 +143,7 @@ class MessagePushNotificationsTest : FullApplicationTest(resetDbBeforeEach = tru
         val endpoint = URI("http://localhost:$httpPort/public/mock-web-push/subscription/1234")
         upsertSubscription(device, endpoint)
 
-        val contentId =
+        val (contentId, _) =
             db.transaction { tx ->
                 messageService.sendMessageAsEmployee(
                     tx,


### PR DESCRIPTION
## Ennen tätä muutosta

Kun henkilökunnan viesti lähetettiin `MessagingNewMessageWrite` audit-lokiin tallentui vain `accountId` ja `createdId`. Ei ollut mahdollista nähdä:

 - Kuinka monta vastaanottajaa viestillä on
 - Mitä suodattimia oli valittu viestiä lähetettäessä
 - Mitä alueita, yksiköitä tai ryhmiä oli valittu vastaanottajiksi

 ## Tämän muutoksen jälkeen

`MessagingNewMessageWrite` audit-lokiin tallentuu:
### Vastaanottajatiedot:
 - `recipientCount`: Todellinen viestiin vastaanottajien määrä (yksilölliset MessageAccountId:t)
 - `originalRecipientTypes`: Alun perin valitut vastaanottajatyypit
 - `recipients.areas`: Alueiden ID:t kun alueita on valittu
 - `recipients.units`: Yksiköiden ID:t kun yksiköitä on valittu
 - `recipients.groups`: Ryhmien ID:t kun ryhmiä on valittu

### Valitut suodattimet:
 - `appliedFilters.yearsOfBirth`: Suodatetut syntymävuodet
 - `appliedFilters.shiftCare`: Vuorohoitosuodatin
 - `appliedFilters.intermittentShiftCare`: Tilapäinen vuorohoitosuodatin
 - `appliedFilters.familyDaycare`: Perhepäivähoitosuodatin
 - `appliedFilters.placementTypes`: Sijoitustyyppien suodattimet