### PR TITLE
Korjataan päivämääräkenttien tyhjentäminen hakemus- ja taloushauissa

### DIFF
--- a/frontend/src/employee-frontend/components/common/Filters.tsx
+++ b/frontend/src/employee-frontend/components/common/Filters.tsx
@@ -49,7 +49,6 @@ import {
   FixedSpaceColumn,
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
-import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
 import DatePickerLowLevel from 'lib-components/molecules/date-picker/DatePickerLowLevel'
 import { Label } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -500,10 +499,10 @@ export function FeeDecisionDistinctionsFilter({
 }
 
 interface FeeDecisionDateFilterProps {
-  startDate: LocalDate | null
-  setStartDate: (startDate: LocalDate | null) => void
-  endDate: LocalDate | null
-  setEndDate: (endDate: LocalDate | null) => void
+  startDate: string
+  setStartDate: (startDate: string) => void
+  endDate: string
+  setEndDate: (endDate: string) => void
   searchByStartDate: boolean
   setSearchByStartDate: (searchByStartDate: boolean) => void
 }
@@ -518,25 +517,31 @@ export function FeeDecisionDateFilter({
 }: FeeDecisionDateFilterProps) {
   const { i18n } = useTranslation()
 
+  const showWarning = useMemo(() => {
+    const start = LocalDate.parseFiOrNull(startDate)
+    const end = LocalDate.parseFiOrNull(endDate)
+    return start && end && start.isAfter(end)
+  }, [startDate, endDate])
+
   return (
     <>
       <Label>{i18n.filters.validityPeriod}</Label>
       <FlexRow>
-        <DatePicker
-          date={startDate}
+        <DatePickerLowLevel
+          value={startDate}
           onChange={setStartDate}
           locale="fi"
           data-qa="fee-decisions-start-date"
         />
         <Gap horizontal size="xs" />
-        <DatePicker
-          date={endDate}
+        <DatePickerLowLevel
+          value={endDate}
           onChange={setEndDate}
           locale="fi"
           data-qa="fee-decisions-start-date"
         />
       </FlexRow>
-      {startDate && endDate && startDate.isAfter(endDate) ? (
+      {showWarning ? (
         <>
           <Gap size="xs" />
           <span>
@@ -600,10 +605,10 @@ export const ValueDecisionStatusFilter = React.memo(
 )
 
 interface ValueDecisionDateFilterProps {
-  startDate: LocalDate | null
-  setStartDate: (startDate: LocalDate | null) => void
-  endDate: LocalDate | null
-  setEndDate: (endDate: LocalDate | null) => void
+  startDate: string
+  setStartDate: (startDate: string) => void
+  endDate: string
+  setEndDate: (endDate: string) => void
   searchByStartDate: boolean
   setSearchByStartDate: (searchByStartDate: boolean) => void
 }
@@ -618,25 +623,31 @@ export function ValueDecisionDateFilter({
 }: ValueDecisionDateFilterProps) {
   const { i18n } = useTranslation()
 
+  const showWarning = useMemo(() => {
+    const start = LocalDate.parseFiOrNull(startDate)
+    const end = LocalDate.parseFiOrNull(endDate)
+    return start && end && start.isAfter(end)
+  }, [startDate, endDate])
+
   return (
     <>
       <Label>{i18n.filters.validityPeriod}</Label>
       <FlexRow>
-        <DatePicker
-          date={startDate}
+        <DatePickerLowLevel
+          value={startDate}
           onChange={setStartDate}
           locale="fi"
           data-qa="value-decisions-start-date"
         />
         <Gap horizontal size="xs" />
-        <DatePicker
-          date={endDate}
+        <DatePickerLowLevel
+          value={endDate}
           onChange={setEndDate}
           locale="fi"
           data-qa="value-decisions-end-date"
         />
       </FlexRow>
-      {startDate && endDate && startDate.isAfter(endDate) ? (
+      {showWarning ? (
         <>
           <Gap size="xs" />
           <span>
@@ -744,10 +755,10 @@ export function InvoiceStatusFilter({
 }
 
 interface InvoiceDateFilterProps {
-  startDate: LocalDate | null
-  setStartDate: (startDate: LocalDate | null) => void
-  endDate: LocalDate | null
-  setEndDate: (endDate: LocalDate | null) => void
+  startDate: string
+  setStartDate: (startDate: string) => void
+  endDate: string
+  setEndDate: (endDate: string) => void
   searchByStartDate: boolean
   setUseCustomDatesForInvoiceSending: (
     useCustomDatesForInvoiceSending: boolean
@@ -764,25 +775,31 @@ export function InvoiceDateFilter({
 }: InvoiceDateFilterProps) {
   const { i18n } = useTranslation()
 
+  const showWarning = useMemo(() => {
+    const start = LocalDate.parseFiOrNull(startDate)
+    const end = LocalDate.parseFiOrNull(endDate)
+    return start && end && start.isAfter(end)
+  }, [startDate, endDate])
+
   return (
     <>
       <Label>{i18n.filters.invoiceDate}</Label>
       <FlexRow>
-        <DatePicker
-          date={startDate}
+        <DatePickerLowLevel
+          value={startDate}
           onChange={setStartDate}
           locale="fi"
           data-qa="invoices-start-date"
         />
         <Gap horizontal size="xs" />
-        <DatePicker
-          date={endDate}
+        <DatePickerLowLevel
+          value={endDate}
           onChange={setEndDate}
           locale="fi"
           data-qa="invoices-end-date"
         />
       </FlexRow>
-      {startDate && endDate && startDate.isAfter(endDate) ? (
+      {showWarning ? (
         <>
           <Gap size="xs" />
           <span>
@@ -1276,10 +1293,10 @@ export function TransferApplicationsFilter({
 
 interface DateFilterProps {
   title: string
-  startDate: LocalDate | null
-  setStartDate: (startDate: LocalDate | null) => void
-  endDate: LocalDate | null
-  setEndDate: (endDate: LocalDate | null) => void
+  startDate: string
+  setStartDate: (startDate: string) => void
+  endDate: string
+  setEndDate: (endDate: string) => void
 }
 
 export function DateFilter({
@@ -1291,25 +1308,31 @@ export function DateFilter({
 }: DateFilterProps) {
   const { i18n } = useTranslation()
 
+  const showWarning = useMemo(() => {
+    const start = LocalDate.parseFiOrNull(startDate)
+    const end = LocalDate.parseFiOrNull(endDate)
+    return start && end && start.isAfter(end)
+  }, [startDate, endDate])
+
   return (
     <>
       <Label>{title}</Label>
       <FlexRow>
-        <DatePicker
-          date={startDate}
+        <DatePickerLowLevel
+          value={startDate}
           onChange={setStartDate}
           locale="fi"
           data-qa="start-date-filter-input"
         />
         <Gap horizontal size="xs" />
-        <DatePicker
-          date={endDate}
+        <DatePickerLowLevel
+          value={endDate}
           onChange={setEndDate}
           locale="fi"
           data-qa="end-date-filter-input"
         />
       </FlexRow>
-      {startDate && endDate && startDate.isAfter(endDate) ? (
+      {showWarning ? (
         <>
           <Gap size="xs" />
           <span>

--- a/frontend/src/employee-frontend/components/common/Filters.tsx
+++ b/frontend/src/employee-frontend/components/common/Filters.tsx
@@ -36,7 +36,7 @@ import type {
   DaycareId,
   EmployeeId
 } from 'lib-common/generated/api-types/shared'
-import type LocalDate from 'lib-common/local-date'
+import LocalDate from 'lib-common/local-date'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -50,6 +50,7 @@ import {
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
 import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
+import DatePickerLowLevel from 'lib-components/molecules/date-picker/DatePickerLowLevel'
 import { Label } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors, { applicationBasisColors } from 'lib-customizations/common'
@@ -931,10 +932,10 @@ export function ApplicationStatusFilter({
 }
 
 interface ApplicationDateFilterProps {
-  startDate: LocalDate | null
-  setStartDate: (startDate: LocalDate | null) => void
-  endDate: LocalDate | null
-  setEndDate: (endDate: LocalDate | null) => void
+  startDate: string
+  setStartDate: (startDate: string) => void
+  endDate: string
+  setEndDate: (endDate: string) => void
   toggled: ApplicationDateType[]
   toggle: (applicationDateType: ApplicationDateType) => () => void
 }
@@ -953,6 +954,12 @@ export function ApplicationDateFilter({
 
   const dates: ApplicationDateType[] = ['DUE', 'START', 'ARRIVAL']
 
+  const showWarning = useMemo(() => {
+    const start = LocalDate.parseFiOrNull(startDate)
+    const end = LocalDate.parseFiOrNull(endDate)
+    return start && end && start.isAfter(end)
+  }, [startDate, endDate])
+
   return (
     <>
       <Label>{i18n.common.date}</Label>
@@ -970,21 +977,21 @@ export function ApplicationDateFilter({
       </FixedSpaceColumn>
       <Gap size="s" />
       <FlexRow>
-        <DatePicker
-          date={startDate}
+        <DatePickerLowLevel
+          value={startDate}
           onChange={setStartDate}
           locale="fi"
           data-qa="applications-start-date"
         />
         <span>-</span>
-        <DatePicker
-          date={endDate}
+        <DatePickerLowLevel
+          value={endDate}
           onChange={setEndDate}
           locale="fi"
           data-qa="applications-end-date"
         />
       </FlexRow>
-      {startDate && endDate && startDate.isAfter(endDate) ? (
+      {showWarning && (
         <>
           <Gap size="xs" />
           <span>
@@ -996,7 +1003,7 @@ export function ApplicationDateFilter({
             />
           </span>
         </>
-      ) : null}
+      )}
     </>
   )
 }

--- a/frontend/src/employee-frontend/components/common/Filters.tsx
+++ b/frontend/src/employee-frontend/components/common/Filters.tsx
@@ -127,8 +127,8 @@ export function Filters({
 
   return (
     <FiltersContainer
-      onKeyDown={() => {
-        if (onSearch) onSearch()
+      onKeyDown={(e) => {
+        if (onSearch && e.key === 'Enter') onSearch()
       }}
     >
       {setFreeText && (

--- a/frontend/src/employee-frontend/components/fee-decisions/FeeDecisionFilters.tsx
+++ b/frontend/src/employee-frontend/components/fee-decisions/FeeDecisionFilters.tsx
@@ -15,7 +15,6 @@ import type {
   DaycareId,
   EmployeeId
 } from 'lib-common/generated/api-types/shared'
-import type LocalDate from 'lib-common/local-date'
 import { formatPersonName } from 'lib-common/names'
 import { useQueryResult } from 'lib-common/query'
 import { Gap } from 'lib-components/white-space'
@@ -144,14 +143,14 @@ function FeeDecisionFilters() {
     }
   }
 
-  const setStartDate = (startDate: LocalDate | null) => {
+  const setStartDate = (startDate: string) => {
     setSearchFilters({
       ...searchFilters,
       startDate: startDate
     })
   }
 
-  const setEndDate = (endDate: LocalDate | null) => {
+  const setEndDate = (endDate: string) => {
     setSearchFilters({
       ...searchFilters,
       endDate: endDate

--- a/frontend/src/employee-frontend/components/income-statements/IncomeStatementFilters.tsx
+++ b/frontend/src/employee-frontend/components/income-statements/IncomeStatementFilters.tsx
@@ -6,8 +6,7 @@ import React, { Fragment, useCallback, useContext } from 'react'
 
 import type { ProviderType } from 'lib-common/generated/api-types/daycare'
 import type { DaycareId } from 'lib-common/generated/api-types/shared'
-import type LocalDate from 'lib-common/local-date'
-import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
+import DatePickerLowLevel from 'lib-components/molecules/date-picker/DatePickerLowLevel'
 import { Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 
@@ -59,19 +58,19 @@ export default React.memo(function IncomeStatementsFilters() {
   )
 
   const setSentStartDate = useCallback(
-    (sentStartDate: LocalDate | null) =>
+    (sentStartDate: string) =>
       setSearchFilters((old) => ({ ...old, sentStartDate })),
     [setSearchFilters]
   )
 
   const setSentEndDate = useCallback(
-    (sentEndDate: LocalDate | null) =>
+    (sentEndDate: string) =>
       setSearchFilters((old) => ({ ...old, sentEndDate })),
     [setSearchFilters]
   )
 
   const setPlacementValidDate = useCallback(
-    (placementValidDate: LocalDate | null) =>
+    (placementValidDate: string) =>
       setSearchFilters((old) => ({ ...old, placementValidDate })),
     [setSearchFilters]
   )
@@ -125,8 +124,8 @@ export default React.memo(function IncomeStatementsFilters() {
           />
           <Gap size="L" />
           <Label>{i18n.filters.incomeStatementPlacementValidDate}</Label>
-          <DatePicker
-            date={searchFilters.placementValidDate}
+          <DatePickerLowLevel
+            value={searchFilters.placementValidDate}
             onChange={setPlacementValidDate}
             locale="fi"
           />

--- a/frontend/src/employee-frontend/components/invoices/InvoiceFilters.tsx
+++ b/frontend/src/employee-frontend/components/invoices/InvoiceFilters.tsx
@@ -9,7 +9,6 @@ import type {
   InvoiceStatus
 } from 'lib-common/generated/api-types/invoicing'
 import type { DaycareId } from 'lib-common/generated/api-types/shared'
-import type LocalDate from 'lib-common/local-date'
 import { Gap } from 'lib-components/white-space'
 
 import { useTranslation } from '../../state/i18n'
@@ -98,14 +97,12 @@ export default React.memo(function InvoiceFilters({
   )
 
   const setStartDate = useCallback(
-    (startDate: LocalDate | null) =>
-      setSearchFilters((old) => ({ ...old, startDate })),
+    (startDate: string) => setSearchFilters((old) => ({ ...old, startDate })),
     [setSearchFilters]
   )
 
   const setEndDate = useCallback(
-    (endDate: LocalDate | null) =>
-      setSearchFilters((old) => ({ ...old, endDate })),
+    (endDate: string) => setSearchFilters((old) => ({ ...old, endDate })),
     [setSearchFilters]
   )
 

--- a/frontend/src/employee-frontend/components/invoices/InvoicesPage.tsx
+++ b/frontend/src/employee-frontend/components/invoices/InvoicesPage.tsx
@@ -260,23 +260,25 @@ const SendModal = React.memo(function SendModal({
       sendType === 'DRAFT'
         ? sendInvoicesByDateMutation
         : resendInvoicesByDateMutation,
-      () => ({
-        body: {
-          dueDate,
-          invoiceDate,
-          areas: searchFilters.area,
-          from:
-            searchFilters.startDate &&
-            searchFilters.useCustomDatesForInvoiceSending
-              ? searchFilters.startDate
-              : LocalDate.todayInSystemTz().withDate(1),
-          to:
-            searchFilters.endDate &&
-            searchFilters.useCustomDatesForInvoiceSending
-              ? searchFilters.endDate
-              : LocalDate.todayInSystemTz().lastDayOfMonth()
+      () => {
+        const startDate = LocalDate.parseFiOrNull(searchFilters.startDate)
+        const endDate = LocalDate.parseFiOrNull(searchFilters.endDate)
+        return {
+          body: {
+            dueDate,
+            invoiceDate,
+            areas: searchFilters.area,
+            from:
+              startDate && searchFilters.useCustomDatesForInvoiceSending
+                ? startDate
+                : LocalDate.todayInSystemTz().withDate(1),
+            to:
+              endDate && searchFilters.useCustomDatesForInvoiceSending
+                ? endDate
+                : LocalDate.todayInSystemTz().lastDayOfMonth()
+          }
         }
-      })
+      }
     ],
     [
       sendType === 'DRAFT' ? sendInvoicesMutation : resendInvoicesMutation,

--- a/frontend/src/employee-frontend/components/payments/PaymentFilters.tsx
+++ b/frontend/src/employee-frontend/components/payments/PaymentFilters.tsx
@@ -3,18 +3,24 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { Fragment, useCallback, useContext, useEffect } from 'react'
+import React, {
+  Fragment,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo
+} from 'react'
 
 import type {
   PaymentDistinctiveParams,
   PaymentStatus
 } from 'lib-common/generated/api-types/invoicing'
 import type { DaycareId } from 'lib-common/generated/api-types/shared'
-import type LocalDate from 'lib-common/local-date'
+import LocalDate from 'lib-common/local-date'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
 import Radio from 'lib-components/atoms/form/Radio'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
-import DatePicker from 'lib-components/molecules/date-picker/DatePicker'
+import DatePickerLowLevel from 'lib-components/molecules/date-picker/DatePickerLowLevel'
 import { Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
@@ -95,13 +101,13 @@ export default React.memo(function PaymentFilters() {
   )
 
   const setPaymentDateStart = useCallback(
-    (paymentDateStart: LocalDate | null) =>
+    (paymentDateStart: string) =>
       setSearchFilters((old) => ({ ...old, paymentDateStart })),
     [setSearchFilters]
   )
 
   const setPaymentDateEnd = useCallback(
-    (paymentDateEnd: LocalDate | null) =>
+    (paymentDateEnd: string) =>
       setSearchFilters((old) => ({ ...old, paymentDateEnd })),
     [setSearchFilters]
   )
@@ -193,10 +199,10 @@ export function PaymentStatusFilter({
 }
 
 interface PaymentDateFilterProps {
-  startDate: LocalDate | null
-  setStartDate: (startDate: LocalDate | null) => void
-  endDate: LocalDate | null
-  setEndDate: (endDate: LocalDate | null) => void
+  startDate: string
+  setStartDate: (startDate: string) => void
+  endDate: string
+  setEndDate: (endDate: string) => void
 }
 
 export function PaymentDateFilter({
@@ -207,15 +213,25 @@ export function PaymentDateFilter({
 }: PaymentDateFilterProps) {
   const { i18n } = useTranslation()
 
+  const showWarning = useMemo(() => {
+    const start = LocalDate.parseFiOrNull(startDate)
+    const end = LocalDate.parseFiOrNull(endDate)
+    return start && end && start.isAfter(end)
+  }, [startDate, endDate])
+
   return (
     <>
       <Label>{i18n.filters.paymentDate}</Label>
       <FlexRow>
-        <DatePicker date={startDate} onChange={setStartDate} locale="fi" />
+        <DatePickerLowLevel
+          value={startDate}
+          onChange={setStartDate}
+          locale="fi"
+        />
         <Gap horizontal size="xs" />
-        <DatePicker date={endDate} onChange={setEndDate} locale="fi" />
+        <DatePickerLowLevel value={endDate} onChange={setEndDate} locale="fi" />
       </FlexRow>
-      {startDate && endDate && startDate.isAfter(endDate) ? (
+      {showWarning ? (
         <>
           <Gap size="xs" />
           <span>

--- a/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionFilters.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decisions/VoucherValueDecisionFilters.tsx
@@ -15,7 +15,6 @@ import type {
   DaycareId,
   EmployeeId
 } from 'lib-common/generated/api-types/shared'
-import type LocalDate from 'lib-common/local-date'
 import { formatPersonName } from 'lib-common/names'
 import { useQueryResult } from 'lib-common/query'
 import { Gap } from 'lib-components/white-space'
@@ -132,14 +131,14 @@ export default React.memo(function VoucherValueDecisionFilters() {
     }
   }
 
-  const setStartDate = (startDate: LocalDate | null) => {
+  const setStartDate = (startDate: string) => {
     setSearchFilters({
       ...searchFilters,
       startDate: startDate
     })
   }
 
-  const setEndDate = (endDate: LocalDate | null) => {
+  const setEndDate = (endDate: string) => {
     setSearchFilters({
       ...searchFilters,
       endDate: endDate


### PR DESCRIPTION
Ennen muutosta:
- tyhjennä valinnat napin painaminen tyhjensi päivämäärätkin oikeasti, mutta vanhat arvot näkyivät edelleen hakukentissä
- kaikki näppäimistön painallukset laukaisivat haun

Muutoksen jälkeen:
- tyhjennä valinnat napin painaminen tyhjentää myös päivämääräkentät oikein
- vain entterin tai hae-napin painaminen laukaisee haun