### PR TITLE
Ei yritetä lukea huoltajuustietoa jos ei ole oikeuksia

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/ChildInformation.tsx
+++ b/frontend/src/employee-frontend/components/child-information/ChildInformation.tsx
@@ -13,7 +13,7 @@ import type { ParentshipWithPermittedActions } from 'lib-common/generated/api-ty
 import type { ChildId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatPersonName } from 'lib-common/names'
-import { useQueryResult } from 'lib-common/query'
+import { constantQuery, useQueryResult } from 'lib-common/query'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import { getAge } from 'lib-common/utils/local-date'
 import Title from 'lib-components/atoms/Title'
@@ -381,7 +381,8 @@ const ChildInformation = React.memo(function ChildInformation({
   const { i18n } = useTranslation()
   const [, navigate] = useLocation()
   const { roles } = useContext(UserContext)
-  const { person, hasGuardian } = useContext<ChildState>(ChildContext)
+  const { person, hasGuardian, permittedActions } =
+    useContext<ChildState>(ChildContext)
 
   useTitle(
     person.map(
@@ -392,7 +393,12 @@ const ChildInformation = React.memo(function ChildInformation({
 
   const layout = useMemo(() => getLayout(layouts, roles), [roles])
 
-  const parentships = useQueryResult(parentshipsQuery({ childId: id }))
+  const parentships = useQueryResult(
+    permittedActions.has('READ_PARENTSHIPS')
+      ? parentshipsQuery({ childId: id })
+      : constantQuery([])
+  )
+
   const currentHeadOfChildId = useMemo(
     () => parentships.map(getCurrentHeadOfChildId).getOrElse(undefined),
     [parentships]


### PR DESCRIPTION
STAFF-roolilla ei ole oikeuksia lukea huoltajuustietoa, mutta on oikeus katsoa hakemusta. Tästä seurasi 403-virheitä /employee/parentships -endpointista.

Ennen korjausta hakemusnäkymän liikenne:
<img width="269" height="306" alt="Screenshot 2025-10-14 at 12 53 19" src="https://github.com/user-attachments/assets/e9b75d54-5f36-4893-b507-d08fcea41afc" />

Ja korjauksen jälkeen:
<img width="305" height="247" alt="Screenshot 2025-10-14 at 12 46 48" src="https://github.com/user-attachments/assets/ab267273-2adc-43d0-a5cf-533aec1aa621" />

