### PR TITLE
Lisätään lapsikohtaiset läsnäoloajat raportille suodatus vuorohoidon perusteella

### DIFF
--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -675,6 +675,7 @@ export class ChildAttendanceReservationByChildReport {
   unitSelector: Combobox
   groupSelector: MultiSelect
   filterByTime: Checkbox
+  filterByShiftCare: Checkbox
   startTimeInput: TextInput
   endTimeInput: TextInput
   searchButton: Element
@@ -685,6 +686,9 @@ export class ChildAttendanceReservationByChildReport {
     this.unitSelector = new Combobox(page.findByDataQa('unit-select'))
     this.groupSelector = new MultiSelect(page.findByDataQa('group-select'))
     this.filterByTime = new Checkbox(page.findByDataQa('filter-by-time'))
+    this.filterByShiftCare = new Checkbox(
+      page.findByDataQa('filter-by-shift-care')
+    )
     this.searchButton = page.findByDataQa('search-button')
     this.startTimeInput = new TextInput(page.findByDataQa('start-time-filter'))
     this.endTimeInput = new TextInput(page.findByDataQa('end-time-filter'))
@@ -716,8 +720,8 @@ export class ChildAttendanceReservationByChildReport {
   async assertRows(
     expected: {
       childName: string
-      attendanceReservationStart: string
-      attendanceReservationEnd: string
+      attendanceReservationStart: string | null
+      attendanceReservationEnd: string | null
     }[]
   ) {
     const rows = this.page.findAllByDataQa('child-attendance-reservation-row')
@@ -726,12 +730,18 @@ export class ChildAttendanceReservationByChildReport {
       expected.map(async (data, index) => {
         const row = rows.nth(index)
         await row.findByDataQa('child-name').assertTextEquals(data.childName)
-        await row
-          .findByDataQa('attendance-reservation-start')
-          .assertTextEquals(data.attendanceReservationStart)
-        await row
-          .findByDataQa('attendance-reservation-end')
-          .assertTextEquals(data.attendanceReservationEnd)
+        if (data.attendanceReservationStart && data.attendanceReservationEnd) {
+          await row
+            .findByDataQa('attendance-reservation-start')
+            .assertTextEquals(data.attendanceReservationStart)
+          await row
+            .findByDataQa('attendance-reservation-end')
+            .assertTextEquals(data.attendanceReservationEnd)
+        } else {
+          await row
+            .findByDataQa('missing-reservation-text')
+            .assertTextEquals('Varaus puuttuu')
+        }
       })
     )
   }

--- a/frontend/src/e2e-test/specs/5_employee/child-attendance-reservation-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-attendance-reservation-report.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import type { DaycareId } from 'lib-common/generated/api-types/shared'
+import { evakaUserId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
@@ -34,33 +35,58 @@ const mockedTime = LocalDate.of(2024, 2, 19)
 
 beforeEach(async () => {
   await resetServiceState()
-
+  admin = await Fixture.employee().admin().save()
   await testCareArea.save()
   await testDaycare.save()
   await familyWithTwoGuardians.save()
   await createDefaultServiceNeedOptions()
+  const fullTimeServiceNeedOption1 = await Fixture.serviceNeedOption({
+    nameFi: 'Kokopäiväinen 1',
+    validPlacementType: 'DAYCARE',
+    validFrom: LocalDate.of(2020, 1, 1),
+    validTo: null
+  }).save()
   await createDaycareGroups({ body: [testDaycareGroup] })
 
   unitId = testDaycare.id
   child = familyWithTwoGuardians.children[0]
+
   const placement = await Fixture.placement({
     childId: child.id,
     unitId: unitId,
     startDate: mockedTime,
+    endDate: mockedTime.addDays(1)
+  }).save()
+
+  await Fixture.serviceNeed({
+    placementId: placement.id,
+    optionId: fullTimeServiceNeedOption1.id,
+    confirmedBy: evakaUserId(admin.id),
+    shiftCare: 'NONE',
+    startDate: mockedTime,
     endDate: mockedTime
+  }).save()
+
+  await Fixture.serviceNeed({
+    placementId: placement.id,
+    optionId: fullTimeServiceNeedOption1.id,
+    confirmedBy: evakaUserId(admin.id),
+    shiftCare: 'FULL',
+    startDate: mockedTime.addDays(1),
+    endDate: mockedTime.addDays(1)
   }).save()
 
   await Fixture.groupPlacement({
     daycareGroupId: testDaycareGroup.id,
     daycarePlacementId: placement.id,
     startDate: mockedTime,
-    endDate: mockedTime
+    endDate: mockedTime.addDays(1)
   }).save()
 
   page = await Page.open({
     mockedTime: mockedTime.toHelsinkiDateTime(LocalTime.of(12, 0))
   })
-  admin = await Fixture.employee().admin().save()
+
   await employeeLogin(page, admin)
 })
 
@@ -112,6 +138,48 @@ describe('Child attendance reservation report', () => {
         childName: `${child.lastName} ${child.firstName}`,
         attendanceReservationStart: '14:00',
         attendanceReservationEnd: '16:00'
+      }
+    ])
+  })
+
+  test('Shift care filtering works', async () => {
+    await page.goto(
+      `${config.employeeUrl}/reports/attendance-reservation-by-child`
+    )
+    const report = new ChildAttendanceReservationByChildReport(page)
+    await report.setDates(mockedTime, mockedTime)
+    await report.selectUnit(testDaycare.name)
+    await report.selectGroup(testDaycareGroup.name)
+    await report.searchButton.click()
+    await report.assertRows([
+      {
+        childName: `${child.lastName} ${child.firstName}`,
+        attendanceReservationStart: null,
+        attendanceReservationEnd: null
+      }
+    ])
+
+    await report.filterByShiftCare.click()
+    await report.assertRows([])
+
+    //next day has a shift care service need
+    await report.setDates(mockedTime.addDays(1), mockedTime.addDays(1))
+
+    await report.searchButton.click()
+    await report.assertRows([
+      {
+        childName: `${child.lastName} ${child.firstName}`,
+        attendanceReservationStart: null,
+        attendanceReservationEnd: null
+      }
+    ])
+
+    await report.filterByShiftCare.click()
+    await report.assertRows([
+      {
+        childName: `${child.lastName} ${child.firstName}`,
+        attendanceReservationStart: null,
+        attendanceReservationEnd: null
       }
     ])
   })

--- a/frontend/src/lib-common/generated/api-types/reports.ts
+++ b/frontend/src/lib-common/generated/api-types/reports.ts
@@ -179,6 +179,7 @@ export interface AttendanceReservationReportByChildItem {
   childLastName: string
   date: LocalDate
   fullDayAbsence: boolean
+  hasShiftCare: boolean
   reservation: TimeRange | null
 }
 

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4033,6 +4033,7 @@ export const fi = {
       absence: 'Poissaolo',
       noReservation: 'Varaus puuttuu',
       filterByTime: 'Suodata ajan perusteella',
+      showOnlyShiftCare: 'Näytä vain vuorohoito',
       reservationStartTime: 'Tulo',
       reservationEndTime: 'Lähtö',
       timeFilterError: 'Virhe'


### PR DESCRIPTION
Lisää raportille näyttöfiltterin, joka vaikuttaa myös CSV-raportille. Filtterin avulla voidaan näyttää pelkät vuorohoidon palveluntarpeen omaavien lasten läsnäolo/poissaolotiedot hakufilttereiden määrittelemästä datasta.

Uusi filtteri vaikuttaa suoraan näytettävään taulukkoon ilman hakunapin painallusta, joten se on sijoitettu hakunapin alapuolelle.

<img width="666" height="490" alt="Screenshot 2025-10-17 143549" src="https://github.com/user-attachments/assets/735ab4d9-5106-4654-a5e9-42ad6df6448f" />
