### PR TITLE
Korjaus kalenteritapahtumista tuleviin Nekku-tilausvähennyksiin

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/nekku/NekkuQueryIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/nekku/NekkuQueryIntegrationTest.kt
@@ -546,6 +546,18 @@ class NekkuQueryIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) 
                 eventType = CalendarEventType.DAYCARE_EVENT,
                 nekkuUnorderedMeals = listOf(NekkuProductMealTime.BREAKFAST),
             )
+        val event4 =
+            DevCalendarEvent(
+                title = "Aiempi tapaus",
+                description = "Tätä ei mukaan vähennyksiin",
+                period = LocalDate.of(2025, 5, 12).toFiniteDateRange(),
+                modifiedAt =
+                    HelsinkiDateTime.of(LocalDate.of(2025, 5, 2), LocalTime.of(12, 34, 56)),
+                modifiedBy = employee.evakaUserId,
+                eventType = CalendarEventType.DAYCARE_EVENT,
+                nekkuUnorderedMeals = listOf(NekkuProductMealTime.BREAKFAST),
+            )
+
         val eventAttendee1 =
             DevCalendarEventAttendee(
                 calendarEventId = event1.id,
@@ -567,6 +579,13 @@ class NekkuQueryIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) 
                 groupId = group.id,
                 childId = child2.id,
             )
+        val eventAttendee4 =
+            DevCalendarEventAttendee(
+                calendarEventId = event4.id,
+                unitId = daycare.id,
+                groupId = group.id,
+                childId = child1.id,
+            )
 
         db.transaction { tx ->
             tx.insert(area)
@@ -578,9 +597,11 @@ class NekkuQueryIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) 
             tx.insert(event1)
             tx.insert(event2)
             tx.insert(event3)
+            tx.insert(event4)
             tx.insert(eventAttendee1)
             tx.insert(eventAttendee2)
             tx.insert(eventAttendee3)
+            tx.insert(eventAttendee4)
 
             val result =
                 tx.getChildSpecificEventOrderReductions(group.id, LocalDate.of(2025, 5, 14))

--- a/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuQueries.kt
@@ -1042,7 +1042,9 @@ FROM (
     SELECT cea.child_id as child_id, UNNEST(ce.nekku_unordered_meals) AS meal
     FROM calendar_event ce
     JOIN calendar_event_attendee cea ON ce.id = cea.calendar_event_id
-    WHERE cea.group_id = ${bind(groupId)} AND child_id IS NOT NULL
+    WHERE cea.group_id = ${bind(groupId)}
+    AND cea.child_id IS NOT NULL
+    AND ${bind(date)} <@ ce.period
 )
 GROUP BY child_id
         """


### PR DESCRIPTION
Jos kalenteritapahtuman osallistujaksi oli määritelty yksittäinen lapsi, tapahtuman Nekku-tilausvähennys kohdistui kaikkiin lapsen tilauksiin eikä vain tapahtuman päivään. Korjattu vähennys kohdistumaan oikeaan päivään.