### PR TITLE
Owasp tarkistuksen vaimennuslistan siivous

### DIFF
--- a/service/owasp-suppressions.xml
+++ b/service/owasp-suppressions.xml
@@ -7,25 +7,4 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 -->
 
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress>
-       <notes><![CDATA[
-       Misidentification. The checkstyle reporter for Ktlint version x.y is not the same as the actual checkstyle library version x.y.
-       ]]></notes>
-       <packageUrl regex="true">^pkg:maven/com\.pinterest\.ktlint/ktlint\-cli\-reporter\-checkstyle@.*$</packageUrl>
-       <cpe>cpe:/a:checkstyle:checkstyle</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        Only affects applications deployed as a WAR or with an embedded Servlet container, not Tomcat
-        ]]></notes>
-        <cve>CVE-2025-41242</cve>
-    </suppress>
-
-    <suppress>
-        <notes><![CDATA[
-        Spring security annotations are not used
-        ]]></notes>
-        <cve>CVE-2025-41248</cve>
-        <cve>CVE-2025-41249</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
## Ennen tätä muutosta
Owasp checkin conffissa oli turhaan jo päivitettyjen riippuvuuksien haavoittuvuuksia vaimennettuna.
## Tämän muutoksen jälkeen
Vaimennuslista on tyhjennetty