### PR TITLE
Suorituskykyparannuksia Nekku-tilausraporttiin

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/nekku/NekkuQueries.kt
@@ -1051,3 +1051,15 @@ GROUP BY child_id
             )
         }
         .toMap { columnPair("child_id", "reductions") }
+
+fun Database.Transaction.cleanNekkuOrderReportRows(cutOffDate: LocalDate) =
+    createUpdate {
+            sql(
+                """
+                DELETE FROM nekku_orders_report
+                WHERE delivery_date < ${bind(cutOffDate)}
+            """
+                    .trimIndent()
+            )
+        }
+        .execute()

--- a/service/src/main/kotlin/fi/espoo/evaka/reports/NekkuOrderReport.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/reports/NekkuOrderReport.kt
@@ -76,9 +76,7 @@ class NekkuOrderReportController(private val accessControl: AccessControl) {
 
         val effectiveGroupIds = groupIds ?: tx.getDaycareGroupIds(unitId)
 
-        val dateList = generateDateList(start, end)
-
-        val orderRows = tx.getNekkuReportRows(unitId, effectiveGroupIds, dateList)
+        val orderRows = tx.getNekkuReportRows(unitId, effectiveGroupIds, start, end)
 
         return orderRows
     }
@@ -87,7 +85,8 @@ class NekkuOrderReportController(private val accessControl: AccessControl) {
 fun Database.Read.getNekkuReportRows(
     daycareId: DaycareId,
     groupIds: List<GroupId>,
-    dates: List<LocalDate>,
+    start: LocalDate,
+    end: LocalDate,
 ): List<NekkuOrderRow> {
     return createQuery {
             sql(
@@ -107,7 +106,7 @@ fun Database.Read.getNekkuReportRows(
                 ON nor.group_id = dg.id
                 WHERE nor.daycare_id = ${bind(daycareId)}
                 AND nor.group_id =ANY(${bind ( groupIds)})
-                AND nor.delivery_date =ANY(${bind ( dates)})
+                AND nor.delivery_date BETWEEN ${bind(start)} AND ${bind(end)}
                 ORDER BY nor.delivery_date, nor.group_id, nor.meal_time, nor.meal_sku
             """
             )

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -426,6 +426,10 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class CleanNekkuOrdersReport(val cutOffDate: LocalDate) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     data class SendAbsenceApplicationDecidedEmail(val absenceApplicationId: AbsenceApplicationId) :
         AsyncJob {
         override val user: AuthenticatedUser? = null
@@ -555,6 +559,7 @@ sealed interface AsyncJob : AsyncJobPayload {
                     SyncNekkuCustomers::class,
                     SyncNekkuProducts::class,
                     SyncNekkuSpecialDiets::class,
+                    CleanNekkuOrdersReport::class,
                     UpdateFromVtj::class,
                     UploadToKoski::class,
                     VTJRefresh::class,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -190,6 +190,10 @@ enum class ScheduledJob(
             schedule = JobSchedule.cron("0 0 5 * * *"), // daily 5:00 am
         ),
     ),
+    CleanNekkuOrdersReport(
+        ScheduledJobs::cleanNekkuOrdersReport,
+        ScheduledJobSettings(enabled = false, schedule = JobSchedule.cron("0 0 1 * * *")),
+    ),
     SendAromiOrders(
         ScheduledJobs::sendAromiOrders,
         ScheduledJobSettings(enabled = false, schedule = JobSchedule.nightly()),
@@ -491,6 +495,10 @@ WHERE id IN (SELECT id FROM attendances_to_end)
 
     fun sendNekkuSpecifyOrders(db: Database.Connection, clock: EvakaClock) {
         nekkuService.planNekkuSpecifyOrders(db, clock)
+    }
+
+    fun cleanNekkuOrdersReport(db: Database.Connection, clock: EvakaClock) {
+        nekkuService.planCleanNekkuOrdersReport(db, clock)
     }
 
     fun sendAromiOrders(db: Database.Connection, clock: EvakaClock) {

--- a/service/src/main/resources/db/migration/V567__nekku_orders_report_index.sql
+++ b/service/src/main/resources/db/migration/V567__nekku_orders_report_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx$nekku_order_report_filters ON nekku_orders_report (daycare_id, group_id, delivery_date);

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -562,3 +562,4 @@ V563__staff_attendance_realtime_constraint_change.sql
 V564__add_nekku_order_time.sql
 V565__placement_draft_start_date.sql
 V566__new_preschool_assistance_levels_v3.sql
+V567__nekku_orders_report_index.sql


### PR DESCRIPTION
Nekku-tilausraportin suorityskykyä parantavia muutoksia:

- Muutettu raportin kyselyä hieman tehokkaammaksi
- Lisätty raportin käyttämään nekku_orders_report -tauluun soveltuva indeksi
- Siivotaan tietokannasta raportin kolmea kuukautta vanhemmat rivit