### PR TITLE
Lokitetaan async jobien planaykset info tasolla

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -129,7 +129,7 @@ class AsyncJobRunner<T : AsyncJobPayload>(
             jobs.forEach { job ->
                 val jobType = AsyncJobType.ofPayload(job.payload)
                 val id = tx.insertJob(job)
-                logger.debug {
+                logger.info {
                     "$name planned job $jobType(id=$id, runAt=${job.runAt}, retryCount=${job.retryCount}, retryInterval=${job.retryInterval})"
                 }
                 afterCommitHooks[jobType]?.let { tx.afterCommit(it) }


### PR DESCRIPTION
## Ennen tätä muutosta
Oli hankalaa selvittää logeilta minkä käyttäjän ja operaation seurauksena esim. `GenerateFinanceDecisions` jobi on scheduloitu, sillä debug tason logitukset filtteröidään pois monissa ympäristöissä.
## Tämän muutoksen jälkeen
Selvittäminen on helpompaa