### PR TITLE
Korjataan static-bucketin virheidenkäsittely

### DIFF
--- a/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -255,7 +255,7 @@ server {
     proxy_pass              $staticEndpoint$uri;
 
     proxy_intercept_errors  on;
-    error_page 404 = @indexPage;
+    error_page 403 404 = @indexPage;
   }
   {{ end }}
 


### PR DESCRIPTION
Jos static-bucket on konfiguroitu osoitteeseen `https://<bucket-name>.s3.<region>.amazonaws.com`, vastaa S3 olemattomiin tiedostoihin 403 Forbidden.