### PR TITLE
Korjataan viestieditorin kohdistus lapsen valinnassa

### DIFF
--- a/frontend/src/citizen-frontend/messages/MessageEditor.tsx
+++ b/frontend/src/citizen-frontend/messages/MessageEditor.tsx
@@ -190,14 +190,6 @@ export default React.memo(function MessageEditor({
 
   const chipGroupContainerRef = React.useRef<HTMLDivElement>(null)
 
-  const ChipContainer = styled(FixedSpaceFlexWrap)`
-    margin-bottom: -${defaultMargins.xxs};
-
-    > * {
-      margin-bottom: ${defaultMargins.xxs};
-    }
-  `
-
   return (
     <ModalAccessibilityWrapper>
       <FocusLock>
@@ -464,6 +456,14 @@ export default React.memo(function MessageEditor({
     </ModalAccessibilityWrapper>
   )
 })
+
+const ChipContainer = styled(FixedSpaceFlexWrap)`
+  margin-bottom: -${defaultMargins.xxs};
+
+  > * {
+    margin-bottom: ${defaultMargins.xxs};
+  }
+`
 
 const Container = styled.div`
   width: 100%;


### PR DESCRIPTION
Ruudunlukija-firefox -yhdistelmällä focus hyppää päätasolle lapsen valinnan jälkeen. Siirrettiin containerin luonti editorin ulkopuolelle, jolloin `styled`-kääre ei tee uutta instanssia joka rendauksella.