### PR TITLE
Tuen päätökset-raportin parannuksia

### DIFF
--- a/frontend/src/e2e-test/pages/employee/reports.ts
+++ b/frontend/src/e2e-test/pages/employee/reports.ts
@@ -804,10 +804,10 @@ export class ChildDocumentsReport {
 }
 
 export class ChildDocumentDecisionsReport {
-  rows: ElementCollection
+  childDocumentDetails: ElementCollection
 
   constructor(private page: Page) {
-    this.rows = page.findByDataQa('report-table').findAll('tr')
+    this.childDocumentDetails = page.findAllByDataQa('child-document-details')
   }
 
   async clickDocument(nth: number): Promise<ChildDocumentPage> {
@@ -815,7 +815,7 @@ export class ChildDocumentDecisionsReport {
       this.page.onPopup((page) => res(new ChildDocumentPage(page)))
     })
 
-    await this.rows.nth(nth).click()
+    await this.childDocumentDetails.nth(nth).click()
     return childDocument
   }
 }

--- a/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
@@ -252,7 +252,7 @@ describe('Employee - Child documents', () => {
     await nav.openTab('reports')
     const reportsPage = new ReportsPage(directorPage)
     const reportPage = await reportsPage.openChildDocumentDecisionsReport()
-    await reportPage.rows.assertCount(1)
+    await reportPage.childDocumentDetails.assertCount(1)
 
     childDocument = await reportPage.clickDocument(0)
     const validity = new DateRange(
@@ -1158,7 +1158,7 @@ describe('Employee - Child documents', () => {
     await nav.openTab('reports')
     const reportsPage = new ReportsPage(page)
     const reportPage = await reportsPage.openChildDocumentDecisionsReport()
-    await reportPage.rows.assertCount(1)
+    await reportPage.childDocumentDetails.assertCount(1)
 
     const childDocument = await reportPage.clickDocument(0)
 
@@ -1259,7 +1259,7 @@ describe('Employee - Child documents', () => {
     await nav.openTab('reports')
     const reportsPage = new ReportsPage(page)
     const reportPage = await reportsPage.openChildDocumentDecisionsReport()
-    await reportPage.rows.assertCount(1)
+    await reportPage.childDocumentDetails.assertCount(1)
     const childDocument = await reportPage.clickDocument(0)
 
     /*

--- a/frontend/src/employee-frontend/components/reports/ChildDocumentDecisionsReport.tsx
+++ b/frontend/src/employee-frontend/components/reports/ChildDocumentDecisionsReport.tsx
@@ -17,6 +17,7 @@ import type HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { evakaUserId } from 'lib-common/id-type'
 import { formatPersonName } from 'lib-common/names'
 import { useQueryResult } from 'lib-common/query'
+import ExternalLink from 'lib-components/atoms/ExternalLink'
 import Title from 'lib-components/atoms/Title'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import Checkbox from 'lib-components/atoms/form/Checkbox'
@@ -287,19 +288,15 @@ export default React.memo(function ChildDocumentDecisionsReport() {
             </Thead>
             <Tbody data-qa="report-table">
               {rows.map((row) => (
-                <RelativeTr
-                  key={row.id}
-                  onClick={() =>
-                    window.open(
-                      `/employee/child-documents/${row.id}`,
-                      '_blank',
-                      'noopener,noreferrer'
-                    )
-                  }
-                >
+                <RelativeTr key={row.id}>
                   <Td>
                     {row.highlighted && <Highlight />}
-                    {row.templateName}
+                    <ExternalLink
+                      href={`/employee/child-documents/${row.id}`}
+                      text={row.templateName}
+                      newTab={true}
+                      data-qa="child-document-details"
+                    />
                   </Td>
                   <Td>{row.childName}</Td>
                   <Td>{row.modifiedAt.toLocalDate().format()}</Td>


### PR DESCRIPTION
- avataan tuen päätökset -raportti automaattisesti uudella välilehdellä
- oletusarvoisesti ei näytetä luonnoksia