### PR TITLE
Korjaus tiedotteen vastaanottajien näkymiseen tiedotekopiolla

### DIFF
--- a/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging-by-staff.spec.ts
@@ -509,7 +509,7 @@ describe('Staff copies', () => {
     // 1. A bulletin is sent to cherry-picked groups from TWO different units
     // 2. Each unit has MULTIPLE groups with MULTIPLE children (realistic scenario)
     // 3. The bulletin is sent to only ONE group per unit (not all groups)
-    // 4. Staff from each unit only see recipient names from their own accessible unit
+    // 4. Staff from each unit only sees the recipient name that is the "root recipient" causing the message copy to exist in the group mailbox
 
     // Helper function to create a family where each child is placed in a different group
     // Creates one child per group ID provided and returns the children
@@ -661,7 +661,7 @@ describe('Staff copies', () => {
     await messagesPage.assertCopyContent(message.title, message.content)
     const copyPage1 = await messagesPage.openCopyThread()
 
-    const expectedGroupName1 = `Alkuräjähdyksen päiväkoti - Alkuryhmän toinen ryhmä (osa), Alkuräjähdyksen päiväkoti - Kosmiset vakiot, Mustan aukon päiväkoti - Korholan ryhmä, Mustan aukon päiväkoti - Korholan toinen ryhmä (osa)`
+    const expectedGroupName1 = 'Kosmiset vakiot'
     await copyPage1.assertMessageRecipients(expectedGroupName1)
 
     // Verify: Staff from second unit sees unit names only
@@ -673,7 +673,7 @@ describe('Staff copies', () => {
     await messagesPage2.assertCopyContent(message.title, message.content)
     const copyPage2 = await messagesPage2.openCopyThread()
 
-    const expectedGroupName2 = `Alkuräjähdyksen päiväkoti - Alkuryhmän toinen ryhmä (osa), Alkuräjähdyksen päiväkoti - Kosmiset vakiot, Mustan aukon päiväkoti - Korholan ryhmä, Mustan aukon päiväkoti - Korholan toinen ryhmä (osa)`
+    const expectedGroupName2 = 'Korholan ryhmä'
     await copyPage2.assertMessageRecipients(expectedGroupName2)
   })
 })


### PR DESCRIPTION
Aikaisemmassa korjauksessa havaittiin seuraavat puutteet:
- Jos tiedote lähetettiin monelle alueelle (esim. koko kuntaan), muodostui vastaanottajien listasta todella pitkä, koska se listasi vastaanottajat ryhmätasolla.
- Aloittavien lasten viestintää ei oltu huomioitu. Ts. ryhmän päättelemisessä käytetiin aina lapsen nykyistä ryhmää.
- Tiedotekopioiden järjestys oli satunnainen.
- Suorituskyky oli huono.

Muutoksen jälkeen tiedotekopioiden vastaanottajana näytetään vain yksi nimi, joka valitaan seuraavassa järjestyksessä riippuen siitä mistä postilaatikosta kopio luetaan.
1. Tiedote lähetetty koko alueelle -> alueen nimi
2. Tiedote lähetetty koko yksikköön -> yksikön nimi
3. Tiedote lähetetty koko ryhmään -> ryhmän nimi
4. Tiedote lähetetty yksittäisille lapsille -> kopiota ei lähetetä ryhmäpostilaatikoihin

Em. nimen päättely ei toimi oikein, jos alueen/yksikön/ryhmän nimeä on muutettu tiedotteen lähettämisen jälkeen.

Aikaisempi tietoturvahavainto liittyi tilanteeseen, jossa viesti on esim. lähetetty johonkin koko ryhmään, ja osalle jonkun toisen ryhmän lapsista. Tällöin koko ryhmän postilaatikossa näkyi toisen ryhmän lasten nimet vastaanottajina, vaikka kopiota ei lainkaan lähetetty osittaisen ryhmän postilaatikkoon.