### PR TITLE
Korjataan automaattinen vuoron päättäminen uusille syykoodeille

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/attendance/StaffAttendanceQueries.kt
@@ -634,7 +634,7 @@ WITH missing_planned_departures AS (
     FROM staff_attendance_realtime realtime
           JOIN staff_attendance_plan plan ON realtime.employee_id = plan.employee_id
                 AND realtime.departed IS NULL
-                AND realtime.type IN ('OTHER_WORK', 'TRAINING')
+                AND realtime.type IN ('OTHER_WORK', 'TRAINING', 'SICKNESS', 'CHILD_SICKNESS')
                 AND tstzrange(plan.start_time, plan.end_time, '[)') @> realtime.arrived
                 AND plan.end_time < ${bind(now)}
 )


### PR DESCRIPTION
Päätetään SICKNESS ja CHILD_SICKNESS -syykoodeja käytettäessä työvuoro automaattisesti suunnitelman mukaan samalla tavoin kuin TRAINING ja OTHER_WORK -koodien kanssa.