### PR TITLE
Ruudunlukijakorjauksia viestieditoriin (kuntalainen)

### DIFF
--- a/frontend/src/lib-components/atoms/Chip.tsx
+++ b/frontend/src/lib-components/atoms/Chip.tsx
@@ -116,20 +116,20 @@ export const SelectionChip = React.memo(function SelectionChip({
             <FontAwesomeIcon icon={faCheck} />
           </IconWrapper>
         )}
-        <StyledLabel
+        <StyledSpan
           className={classNames({ disabled })}
           aria-hidden="true"
           onClick={preventDefault}
           translate={translate}
         >
           {text}
-        </StyledLabel>
+        </StyledSpan>
       </SelectionChipInnerWrapper>
     </SelectionChipWrapper>
   )
 })
 
-const StyledLabel = styled.label`
+const StyledSpan = styled.span`
   cursor: pointer;
   &.disabled {
     cursor: not-allowed;

--- a/frontend/src/lib-components/atoms/ScreenReaderOnly.tsx
+++ b/frontend/src/lib-components/atoms/ScreenReaderOnly.tsx
@@ -18,3 +18,20 @@ export const ScreenReaderOnly = isAutomatedTest
       height: 1px;
       overflow: hidden;
     `
+
+export const ScreenReaderOnlyInline = isAutomatedTest
+  ? styled.div`
+      display: none;
+    `
+  : styled.span`
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      border: 0;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      margin: -1px;
+      padding: 0;
+      white-space: nowrap; /* prevent line breaks */
+    `

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -660,7 +660,8 @@ const en: Translations = {
       search: 'Search',
       noResults: 'No results, select a child or children first',
       messageSendError: 'Failed to send the message',
-      messageSentNotification: 'Message sent'
+      messageSentNotification: 'Message sent',
+      required: 'Required field'
     },
     confirmDelete: {
       title: 'Do you really want to delete the message thread?',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -662,7 +662,8 @@ export default {
       search: 'Haku',
       noResults: 'Ei tuloksia, valitse ensin lapsi tai lapsia',
       messageSendError: 'Viestin lähetys epäonnistui',
-      messageSentNotification: 'Viesti lähetetty'
+      messageSentNotification: 'Viesti lähetetty',
+      required: 'Pakollinen kenttä'
     },
     confirmDelete: {
       title: 'Haluatko varmasti poistaa viestiketjun?',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -649,7 +649,8 @@ const sv: Translations = {
       search: 'Sök',
       noResults: 'Inga resultat, välj ett barn eller flera barn först',
       messageSendError: 'Misslyckades med att skicka meddelande',
-      messageSentNotification: 'Meddelande skickat'
+      messageSentNotification: 'Meddelande skickat',
+      required: 'Obligatoriskt fält'
     },
     confirmDelete: {
       title: 'Vill du verkligen radera meddelandetråden?',


### PR DESCRIPTION
Ruudunlukija lausuu "*"-merkin "tähti" sijaan "Pakollinen kenttä". Vastaanottajien valintaan käytettävä MultiSelect koostuu monesta kerroksesta ja pelkkä required-attribuutti ei tule selvästi esiin ruudunlukijalle.

Modaalissa oli myös pari "orphaned labelia", niitä paritettu.

Chip-komponentissa ollut label korvattu spanilla, korjaa orphaned label -ongelman.
