### PR TITLE
Korjataan asiakirjapohjan exportin salassapitotiedot

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/document/DocumentTemplateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/document/DocumentTemplateIntegrationTest.kt
@@ -319,6 +319,23 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     }
 
     @Test
+    fun `template can be exported`() {
+        val request = testCreationRequest.copy(placementTypes = setOf(PlacementType.DAYCARE))
+        val created = controller.createTemplate(dbInstance(), employeeUser, now, request)
+        controller.updateDraftTemplateContent(
+            dbInstance(),
+            employeeUser,
+            now,
+            created.id,
+            testContent,
+        )
+
+        val exported = controller.exportTemplate(dbInstance(), employeeUser, now, created.id)
+
+        assertEquals(request.toExported(testContent), exported.body)
+    }
+
+    @Test
     fun `active templates endpoint returns valid templates`() {
         val template =
             controller.createTemplate(
@@ -661,3 +678,19 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
         }
     }
 }
+
+private fun DocumentTemplateBasicsRequest.Regular.toExported(content: DocumentTemplateContent) =
+    ExportedDocumentTemplate(
+        name,
+        type,
+        placementTypes,
+        language,
+        confidentiality,
+        legalBasis,
+        validity,
+        processDefinitionNumber,
+        archiveDurationMonths,
+        archiveExternally,
+        endDecisionWhenUnitChanges,
+        content,
+    )

--- a/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplate.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/document/DocumentTemplate.kt
@@ -448,7 +448,7 @@ data class ExportedDocumentTemplate(
     val type: ChildDocumentType,
     val placementTypes: Set<PlacementType>,
     val language: UiLanguage,
-    val confidentiality: DocumentConfidentiality?,
+    @Nested("confidentiality") val confidentiality: DocumentConfidentiality?,
     val legalBasis: String,
     val validity: DateRange,
     val processDefinitionNumber: String?,


### PR DESCRIPTION
`confidentiality` oli json-tiedostossa aina `null`.