### PR TITLE
Korjataan välähtävä varoitus takautuvasta tulotiedosta

### DIFF
--- a/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/income/IncomeItemEditor.tsx
@@ -196,7 +196,16 @@ const IncomeItemEditor = React.memo(function IncomeItemEditor(props: Props) {
 
   const initialForm = useMemo(
     () =>
-      isUpdate(props) ? incomeFormFromIncome(props.baseIncome) : emptyIncome,
+      isUpdate(props)
+        ? incomeFormFromIncome(
+            omit(props.baseIncome, [
+              'createdAt',
+              'createdBy',
+              'modifiedAt',
+              'modifiedBy'
+            ])
+          )
+        : emptyIncome,
     [props]
   )
   const [editedIncome, setEditedIncome] = useState<IncomeForm>(initialForm)


### PR DESCRIPTION
Ylimääräiset luokkatyyppiset kentät aiheuttivat useMemon tarpeettoman päivityksen sekä sisällön vertailussa false positiven.