### PR TITLE
Lisätään ympäristökonfiguraatio arkistoinnin tausta-ajolle

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJob.kt
@@ -631,9 +631,9 @@ sealed interface AsyncJob : AsyncJobPayload {
                 AsyncJobPool.Config(concurrency = 1),
                 setOf(VardaUpdateChild::class),
             )
-        val bulk =
+        val archival =
             AsyncJobRunner.Pool(
-                AsyncJobPool.Id(AsyncJob::class, "bulk"),
+                AsyncJobPool.Id(AsyncJob::class, "archival"),
                 AsyncJobPool.Config(concurrency = 4),
                 setOf(
                     ArchiveDecision::class,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/async/AsyncJobRunner.kt
@@ -48,6 +48,8 @@ class AsyncJobRunner<T : AsyncJobPayload>(
     ) {
         fun withThrottleInterval(throttleInterval: Duration?) =
             copy(config = config.copy(throttleInterval = throttleInterval))
+
+        fun withConfig(config: AsyncJobPool.Config) = copy(config = config)
     }
 
     val name = "${AsyncJobRunner::class.simpleName}.${payloadType.simpleName}"

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/config/AsyncJobConfig.kt
@@ -4,6 +4,7 @@
 
 package fi.espoo.evaka.shared.config
 
+import fi.espoo.evaka.ArchivalPoolEnv
 import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -39,7 +40,7 @@ class AsyncJobConfig {
                     Duration.ofSeconds(1).takeIf { env.activeProfiles.contains("production") }
                 ),
                 AsyncJob.nightly,
-                AsyncJob.bulk,
+                AsyncJob.archival.withConfig(ArchivalPoolEnv.fromEnvironment(env).toPoolConfig()),
             ),
             jdbi,
             tracer,


### PR DESCRIPTION
Kuntakohtaisissa arkistoinneissa on noussut tarve kutsua arkistointijärjestelmän rajapintaa rajoitetulla tahdilla. Ytimen toteutus ei mahdollistanut tausta-ajojen suorituksen rajoittamista ympäristökonfiguraatiolla.

Muutos lisää env-konfiguraation arkistoinnin tausta-ajo-poolin asetusten asettamiselle. Ytimen alkuperäisiä asetuksia käytetään oletuksena, jos envissä ei ole konfiguraatioarvoja.