### PR TITLE
Poistetaan ryhmäkohtaiset tukimuodot käytöstä

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/assistance/PreschoolAssistanceForm.tsx
+++ b/frontend/src/employee-frontend/components/child-information/assistance/PreschoolAssistanceForm.tsx
@@ -66,7 +66,10 @@ export const levelConfigs: Record<PreschoolAssistanceLevel, LevelConfig> = {
     minStartDate: LocalDate.of(2025, 8, 1),
     maxEndDate: LocalDate.of(2026, 7, 31)
   },
-  GROUP_SUPPORT: { minStartDate: LocalDate.of(2025, 8, 1) }
+  GROUP_SUPPORT: {
+    minStartDate: LocalDate.of(2025, 8, 1),
+    maxEndDate: LocalDate.of(2025, 7, 31)
+  }
 }
 
 const preschoolAssistanceForm = transformed(

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -829,7 +829,7 @@ export const fi = {
             'Lapsikohtainen tuki ja vanhan mallinen pidennetty ov - muu (Koskeen, käytössä siirtymäkautena 1.8.2025 - 31.7.2026)',
           CHILD_SUPPORT_2_AND_OLD_EXTENDED_COMPULSORY_EDUCATION:
             'Lapsikohtainen tuki ja vanhan mallinen pidennetty ov - kehitysvamma 2 (Koskeen, käytössä siirtymäkautena 1.8.2025 - 31.7.2026)',
-          GROUP_SUPPORT: 'Ryhmäkohtaiset tukimuodot'
+          GROUP_SUPPORT: 'Ryhmäkohtaiset tukimuodot (ei käytössä)'
         },
         otherAssistanceMeasureType: {
           TRANSPORT_BENEFIT: 'Kuljetusetu (esioppilailla Koski-tieto)',

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/koski/KoskiIntegrationTest.kt
@@ -538,8 +538,6 @@ class KoskiIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
                 testPeriod2027(2L to 3L),
                 PreschoolAssistanceLevel.CHILD_SUPPORT_AND_EXTENDED_COMPULSORY_EDUCATION,
             )
-        val groupSupport =
-            TestCase(testPeriod2027(4L to 5L), PreschoolAssistanceLevel.GROUP_SUPPORT)
         val childSupportWithEce2 =
             TestCase(
                 testPeriod2027(6L to 7L),
@@ -547,7 +545,7 @@ class KoskiIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             )
 
         db.transaction { tx ->
-            listOf(childSupport, childSupportWithEce, groupSupport, childSupportWithEce2).forEach {
+            listOf(childSupport, childSupportWithEce, childSupportWithEce2).forEach {
                 tx.insert(
                     DevPreschoolAssistance(
                         modifiedBy = testDecisionMaker_1.toEvakaUser(),

--- a/service/src/main/kotlin/fi/espoo/evaka/assistance/Assistance.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/assistance/Assistance.kt
@@ -79,7 +79,8 @@ enum class PreschoolAssistanceLevel(
         minStartDate = LocalDate.of(2025, 8, 1),
         maxEndDate = LocalDate.of(2026, 7, 31),
     ),
-    GROUP_SUPPORT(minStartDate = LocalDate.of(2025, 8, 1));
+    // deprecated, never used
+    GROUP_SUPPORT(minStartDate = LocalDate.of(2025, 8, 1), maxEndDate = LocalDate.of(2025, 7, 31));
 
     override val sqlType: String = "preschool_assistance_level"
 }

--- a/service/src/main/resources/db/migration/V573__group_support_removal.sql
+++ b/service/src/main/resources/db/migration/V573__group_support_removal.sql
@@ -1,0 +1,4 @@
+DELETE
+FROM preschool_assistance
+WHERE level = 'GROUP_SUPPORT'
+  AND lower(valid_during) >= '2025-08-01';

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -568,3 +568,4 @@ V569__migrate_empty_child_document_decision_annulment_reasons.sql
 V570__mark_migrated_assistance_decisions_as_read.sql
 V571__application_senttime.sql
 V572__daycare_group_timestamps.sql
+V573__group_support_removal.sql


### PR DESCRIPTION
- Uusia ryhmäkohtaisia tukimuotoja ei pysty enää lisäämään.
- Olemassaolevat 1.8.2025 tai sen jälkeen alkavat ryhmäkohtaiset tukimuodot poistetaan kannasta. (Ryhmäkohtaisia tukimuotoja pystyi lisäämään 1.8.2025 alkaen, joten käytännössä tämä tarkoittaa kaikkia ryhmäkohtaisia tukimuotoja.)