### PR TITLE
Poista vanhentunut X-XSS-Protection header

### DIFF
--- a/apigw/src/pino-cli/test-utils/fixtures/log-messages.ts
+++ b/apigw/src/pino-cli/test-utils/fixtures/log-messages.ts
@@ -60,7 +60,6 @@ export const validPinoAccessLogMessage: PinoAccessLog = {
       'strict-transport-security': 'max-age=15552000; includeSubDomains',
       'x-download-options': 'noopen',
       'x-content-type-options': 'nosniff',
-      'x-xss-protection': '1; mode=block',
       'x-content-length': '19924',
       'set-cookie':
         'nuora.local.sid=s%3AdtmQbMKjkuf2SAllngYu5_esQ9kr7WE9.%2Bx9t0JU5wGadEPEyfm7r0FqiuWOcIrYOvwIjIabuGN8; Path=/; Expires=Wed, 30 Jan 2019 11:56:43 GMT; HttpOnly'

--- a/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -171,7 +171,6 @@ server {
   # a location bloc as it overrides the parent headers
   add_header Strict-Transport-Security 'max-age=31536000; includeSubdomains; preload';
   add_header X-Content-Type-Options nosniff;
-  add_header X-XSS-Protection '1; mode=block';
   add_header X-DNS-Prefetch-Control off;
   add_header Report-To '{"group","csp-endpoint","max_age":31536000,"endpoints":[{"url":"$httpScheme://$host/api/csp"}]}';
 
@@ -355,7 +354,6 @@ server {
 
     add_header Strict-Transport-Security 'max-age=31536000; includeSubdomains; preload';
     add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection '1; mode=block';
     add_header X-DNS-Prefetch-Control off;
 
     rewrite ^ $httpScheme://{{ .Env.SERVICE_DOMAIN }}$uri?lang=sv redirect;


### PR DESCRIPTION
X-XSS-Protection on poistunt käytöstä ja nykyaikaiset selaimet eivät tue enää sitä:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection

<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- Lisää linkki dokumentaation relevanttiin kohtaan.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
-->
