### PR TITLE
Korjataan yksikön kalenteri-välilehden varaustaulukko

### DIFF
--- a/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
@@ -43,6 +43,7 @@ export default React.memo(function AbsenceDay({ type, staffCreated }: Props) {
 
 const AbsenceTooltip = styled(Tooltip)`
   display: flex;
+  flex-direction: column;
   justify-content: space-evenly;
   padding: 8px;
   gap: 8px;

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayReservation.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayReservation.tsx
@@ -223,7 +223,7 @@ export default React.memo(function ChildDayReservation({
 export const ReservationDateCell = styled(DateCell)`
   margin: 5px 0px 5px 0px;
   position: relative;
-  height: 38px;
+  height: 50px;
   padding-right: 12px;
 
   &:hover {

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -198,7 +198,7 @@ export default React.memo(function UnitAttendanceReservationsView({
                 />
               </FixedSpaceRow>
               {legendVisible && (
-                <FixedSpaceRow alignItems="flex-start" spacing="XL">
+                <FixedSpaceColumn alignItems="flex-start" spacing="XL">
                   <LabelValueList
                     spacing="small"
                     horizontalSpacing="small"
@@ -208,7 +208,7 @@ export default React.memo(function UnitAttendanceReservationsView({
                   <FixedSpaceColumn spacing="xs">
                     <AbsenceLegend icons showAdditionalLegendItems />
                   </FixedSpaceColumn>
-                </FixedSpaceRow>
+                </FixedSpaceColumn>
               )}
             </div>
             {realtimeStaffAttendanceEnabled &&

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/attendance-elements.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/attendance-elements.tsx
@@ -71,6 +71,7 @@ export const StyledTd = styled(Td)<StyledTdProps>`
 export const DayTd = styled(StyledTd)`
   padding: 0;
   vertical-align: top;
+  max-width: 110px;
 `
 
 export const DayTr = styled(Tr)<TrProps>`


### PR DESCRIPTION
Korjataan varaustaulukon ylileveneminen, kun yksiköllä on yli 5 toimintapäivää. Samalla korjataan myös merkintöjen selvityksistä infotekstien ylileveneminen