### PR TITLE
Katkaistaan henkilökunnan aukijääneet sisäänkirjaukset joka tunti

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/job/ScheduledJobs.kt
@@ -102,7 +102,10 @@ enum class ScheduledJob(
     ),
     EndOfDayStaffAttendanceUpkeep(
         ScheduledJobs::endOfDayStaffAttendanceUpkeep,
-        ScheduledJobSettings(enabled = true, schedule = JobSchedule.daily(LocalTime.of(0, 0))),
+        ScheduledJobSettings(
+            enabled = true,
+            schedule = JobSchedule.cron("0 55 * * * *"),
+        ), // every hour at minute 55
     ),
     EndOfDayReservationUpkeep(
         ScheduledJobs::endOfDayReservationUpkeep,


### PR DESCRIPTION
- Lisäksi lisätään testi sille että jos sisäänkirjautuu minuutinkin ennen suunnitelman alkua automaattikatkaisu ei käytä suunnitelman loppuajankohtaa vaan sisäänkirjautuminen + 12h