### PR TITLE
Lisätään constraintteja `message_account`-tauluun

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/messaging/MessageIntegrationTest.kt
@@ -2553,7 +2553,6 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
 
             val groupAccount =
                 db.transaction { tx -> tx.createDaycareGroupMessageAccount(group.id) }
-            val municipalAccount = db.transaction { tx -> tx.createMunicipalMessageAccount() }
 
             // Message thread beyond employee access limit (1 week before daycare group acl
             // creation)

--- a/service/src/main/resources/db/migration/V574__message_account_constraints.sql
+++ b/service/src/main/resources/db/migration/V574__message_account_constraints.sql
@@ -1,0 +1,9 @@
+CREATE UNIQUE INDEX only_one_municipal_account ON message_account (type) WHERE type = 'MUNICIPAL';
+
+ALTER TABLE message_account ADD CONSTRAINT check$message_account_foreign_keys CHECK (
+    (type = 'PERSONAL' AND employee_id IS NOT NULL AND daycare_group_id IS NULL AND person_id IS NULL) OR
+    (type = 'GROUP' AND employee_id IS NULL AND daycare_group_id IS NOT NULL AND person_id IS NULL) OR
+    (type = 'CITIZEN' AND employee_id IS NULL AND daycare_group_id IS NULL AND person_id IS NOT NULL) OR
+    (type <> 'PERSONAL' AND type <> 'GROUP' AND type <> 'CITIZEN' AND employee_id IS NULL AND daycare_group_id IS NULL AND person_id IS NULL)
+);
+ALTER TABLE message_account DROP CONSTRAINT message_account_created_for_fk;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -569,3 +569,4 @@ V570__mark_migrated_assistance_decisions_as_read.sql
 V571__application_senttime.sql
 V572__daycare_group_timestamps.sql
 V573__group_support_removal.sql
+V574__message_account_constraints.sql


### PR DESCRIPTION
- Ensure only one `MUNICIPAL` account exists. This constraint used to be there since migration V282, but was accidentally dropped by re-creating the `type` column in V295.

- Ensure that the correct foreign key is set based on account type. This replaces the previous check constraint that only ensured that at most one foreign key column has a value.
