### PR TITLE
Disabloidaan Spring v4 management probet

### DIFF
--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -54,3 +54,5 @@ management:
   endpoint:
     health:
       enabled: true
+      probes:
+        enabled: false


### PR DESCRIPTION
Management probet muuttivat health check -endpointin responsea sen verran, etteivät kontin health checkit toimineet enää Espoon ympäristöissä.