### PR TITLE
Korjaus tulotietojen lukemiseen Jackson 3 päivityksen jälkeen

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/domain/Incomes.kt
@@ -85,8 +85,8 @@ fun decisionIncomesEqual(income1: DecisionIncome?, income2: DecisionIncome?): Bo
 data class IncomeValue(
     val amount: Int,
     val coefficient: IncomeCoefficient,
-    val multiplier: Int,
-    val monthlyAmount: Int,
+    val multiplier: Int = 1,
+    val monthlyAmount: Int = 0,
 )
 
 enum class IncomeEffect : DatabaseEnum {


### PR DESCRIPTION
Syynä on, että kannassa on JSON-muotoista tulotietodataa, josta puuttuu Kotlin-puolella pakolliseksi määriteltyjä kenttiä. Jackson 2 luki nämä eri tavalla, eikä ole löytynyt asetusta jolla Jackson 2 -tyylinen lukutapa olisi mahdollista palauttaa.