### PR TITLE
Tiukennetaan hakemuksen näkyvyyssääntöjä ei-huoltajalle

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/application/ApplicationControllerCitizen.kt
@@ -80,7 +80,8 @@ class ApplicationControllerCitizen(
                         Action.Citizen.Person.READ_APPLICATIONS,
                         user.id,
                     )
-                    val allApplications = tx.fetchApplicationSummariesForCitizen(user.id)
+                    val allApplications =
+                        tx.fetchApplicationSummariesForCitizen(user.id, clock.today())
                     val allPermittedActions: Map<ApplicationId, Set<Action.Citizen.Application>> =
                         accessControl.getPermittedActions(
                             tx,


### PR DESCRIPTION
Paperihakemuksen voi luoda henkilölle, joka ei VTJ-tietojen mukaan ole lapsen huoltaja. Tällainen henkilö ei näe hakemusta eikä päätöstä, mutta ennen tätä korjausta hän näki notifikaatiopalluran ja sai sähköpostin kun päätös oli tehty. Ei saa enää.

Varsinaisen korjauksen lisäksi lisätään huoltajuustarkastus myös hakemusten hakuun, vaikkakin tällaiset hakemukset putosivat pois siinä kohtaa kun hakemukset ryhmiteltiin lasten alle. Lisäksi parannetaan testikattavuutta.