### PR TITLE
Korjaus Varda-tietotyyppeihin

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/varda/Varda.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/Varda.kt
@@ -78,8 +78,8 @@ data class Varhaiskasvatuspaatos(
     val vuorohoito_kytkin: Boolean,
     val tilapainen_vaka_kytkin: Boolean,
     val tuntimaara_viikossa: Double,
-    val paivittainen_vaka_kytkin: Boolean,
-    val kokopaivainen_vaka_kytkin: Boolean,
+    val paivittainen_vaka_kytkin: Boolean?,
+    val kokopaivainen_vaka_kytkin: Boolean?,
     val jarjestamismuoto_koodi: String,
 ) {
     companion object {

--- a/service/src/main/kotlin/fi/espoo/evaka/varda/VardaClient.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/varda/VardaClient.kt
@@ -89,8 +89,8 @@ interface VardaReadClient {
         val vuorohoito_kytkin: Boolean,
         val tilapainen_vaka_kytkin: Boolean,
         val tuntimaara_viikossa: Double,
-        val paivittainen_vaka_kytkin: Boolean,
-        val kokopaivainen_vaka_kytkin: Boolean,
+        val paivittainen_vaka_kytkin: Boolean?,
+        val kokopaivainen_vaka_kytkin: Boolean?,
         val jarjestamismuoto_koodi: String,
     ) : VardaEntityWithValidity
 
@@ -150,9 +150,9 @@ interface VardaWriteClient {
         val alkamis_pvm: LocalDate,
         val paattymis_pvm: LocalDate?,
         val tuntimaara_viikossa: Double,
-        val kokopaivainen_vaka_kytkin: Boolean,
+        val kokopaivainen_vaka_kytkin: Boolean?,
         val tilapainen_vaka_kytkin: Boolean,
-        val paivittainen_vaka_kytkin: Boolean,
+        val paivittainen_vaka_kytkin: Boolean?,
         val vuorohoito_kytkin: Boolean,
         val jarjestamismuoto_koodi: String,
         val lahdejarjestelma: String,


### PR DESCRIPTION
Espoon Varda-integraatiossa kenttä `paivittainen_vaka_kytkin` aiheutti virheitä, koska Varda lähetti siinä null-arvoja, mutta eVakan Kotlin-tietotyyppi ei ollut nullable. Korjattu eVakan tietotyyppi [Varda-määrittelyiden](https://virkailija.opintopolku.fi/varda/julkinen/swagger) mukaiseksi. Korjattu samalla `kokopaivainen_vaka_kytkin`. Huom. `tilapainen_vaka_kytkin` ei ole määrittelyiden mukaan nullable.