### PR TITLE
Ryhmän nimi kalenteritapahtumien sähköpostiherätteisiin

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationService.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/calendarevent/CalendarEventNotificationService.kt
@@ -147,7 +147,13 @@ class CalendarEventNotificationService(
     ) {
         val notificationData =
             dbc.read { tx -> tx.getCalendarEventsById(msg.events.toSet()) }
-                .map { CalendarEventNotificationData(HtmlSafe(it.title), it.period) }
+                .map {
+                    CalendarEventNotificationData(
+                        HtmlSafe(it.title),
+                        it.period,
+                        it.groups.map { group -> HtmlSafe(group.name) },
+                    )
+                }
                 .sortedWith(compareBy({ it.period.start }, { it.title.toString() }))
         if (notificationData.isEmpty()) {
             logger.info { "No events to notify for parent ${msg.parentId}" }

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/EvakaEmailMessageProvider.kt
@@ -604,7 +604,13 @@ $unsubscribeEn
                     if (event.period.end != event.period.start) {
                         period += "-${event.period.end.format(format)}"
                     }
-                    "<li>$period: ${event.title}</li>"
+                    val groupInfo =
+                        if (event.groupNames.isNotEmpty()) {
+                            " (${event.groupNames.joinToString(", ")})"
+                        } else {
+                            ""
+                        }
+                    "<li>$period: ${event.title}$groupInfo</li>"
                 } +
                 "</ul>"
         return EmailContent.fromHtml(

--- a/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/emailclient/IEmailMessageProvider.kt
@@ -162,7 +162,11 @@ data class MessageThreadData(
     val isCopy: Boolean,
 )
 
-data class CalendarEventNotificationData(val title: HtmlSafe<String>, val period: FiniteDateRange)
+data class CalendarEventNotificationData(
+    val title: HtmlSafe<String>,
+    val period: FiniteDateRange,
+    val groupNames: List<HtmlSafe<String>>,
+)
 
 data class DiscussionTimeReminderData(
     val date: LocalDate,

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -1536,6 +1536,7 @@ VALUES (${bind(body.id)}, ${bind(body.guardianId)})
                             CalendarEventNotificationData(
                                 HtmlSafe("Esimerkki 1"),
                                 FiniteDateRange(LocalDate.now(), LocalDate.now().plusDays(1)),
+                                listOf(HtmlSafe("Ryhmä A")),
                             ),
                             CalendarEventNotificationData(
                                 HtmlSafe("Esimerkki 2"),
@@ -1543,6 +1544,7 @@ VALUES (${bind(body.id)}, ${bind(body.guardianId)})
                                     LocalDate.now().plusDays(7),
                                     LocalDate.now().plusDays(7),
                                 ),
+                                listOf(HtmlSafe("Ryhmä B"), HtmlSafe("Ryhmä C")),
                             ),
                         ),
                     )


### PR DESCRIPTION
## Ennen tätä muutosta

Kalenteritapahtumista lähetettävissä sähköpostiherätteissä listattiin ainoastaan tapahtuman ajankohta ja otsikko. Vaikka kalenterimerkintä olisi kohdistettu tietylle ryhmälle, sähköpostin vastaanottaja ei nähnyt viestistä suoraan, mitä ryhmää merkintä koskee.

## Tämän muutoksen jälkeen

   Sähköpostiherätteisiin on lisätty tieto tapahtumaan liittyvistä ryhmistä. Mikäli kalenteritapahtuma on kohdistettu yhdelle tai useammalle ryhmälle, ryhmien nimet näytetään sähköpostissa suluissa tapahtuman otsikon perässä (esim. "Retkipäivä (Pikku Myyt)"). Jos tapahtuma ei liity tiettyyn ryhmään (esim. koko päiväkodin yhteinen tapahtuma), viesti pysyy ennallaan.