### PR TITLE
Content-Security-Policy -otsakkeen Sentry-osoitteet konfiguroitavaksi

### DIFF
--- a/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
+++ b/frontend/proxy/files/etc/nginx/conf.d/nginx.conf.template
@@ -159,6 +159,7 @@ server {
   set $enduserUrl "{{ .Env.ENDUSER_GW_URL }}";
   set $internalUrl "{{ .Env.INTERNAL_GW_URL }}";
   set $httpScheme "{{ env.Getenv "HTTP_SCHEME" "https" }}";
+  set $cspConnectSrcSentry "{{ env.Getenv "CSP_CONNECT_SRC_SENTRY" "https://o4507111645052928.ingest.de.sentry.io/ https://o318158.ingest.sentry.io" }}";
   {{ if env.Getenv "STATIC_FILES_ENDPOINT_URL" "" }}
   set $staticEndpoint "{{ .Env.STATIC_FILES_ENDPOINT_URL }}";
   {{ end }}
@@ -175,7 +176,7 @@ server {
   add_header Report-To '{"group","csp-endpoint","max_age":31536000,"endpoints":[{"url":"$httpScheme://$host/api/csp"}]}';
 
   set $loadFailedInlineScript "'sha256-PR1ssrSqCny+dZsLWihNXCvJD0eBdn4ItWwveZE1M+0='"; # SHA256 calculated from the script contents
-  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' https://o4507111645052928.ingest.de.sentry.io/ https://o318158.ingest.sentry.io https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
+  set $contentSecurityPolicyBase "block-all-mixed-content; upgrade-insecure-requests; default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'self' $cspConnectSrcSentry https://api.digitransit.fi; object-src 'none'; report-uri /api/csp; report-to csp-endpoint";
   add_header Content-Security-Policy "${contentSecurityPolicyBase}; script-src 'self' ${loadFailedInlineScript}; frame-ancestors 'none'; form-action 'self';";
 
   # Tracing


### PR DESCRIPTION
# Mitä

Tämä PR muuttaa Content-Security-Policy -otsakkeesta `connect-src` kohdasta Sentryn osoitteet konfiguroitaviksi ympäristömuuttujalla.

Jos ympäristömuuttujaa ei ole asetettu, käytetään nykyisiä arvoja, säilyttäen taaksepäinyhteensopivuus.

# Miksi

Sentryn DSN-osoitteet ovat konfiguroitavissa `lib-customizations`:n `appConfigs.env.sentry.dsn` kautta, mutta CSP:n `connect-src` kirjoitushetkellä ei ole.

Sentry-konfiguraatio tarvitsee toimiakseen molempia.

Miksi muutos vain CSP:n Sentry-osaan? Pienempi muutos on selkeämpi. Tile-server osoitteet eivät ole konfiguroitavissa, joten niitä ei kirjoitushetkellä ole tarvetta konfiguroida myöskään CSP:ssä (vaikkakin lahjoituksilla pyörivän [OpenStreetMapin tile-serverin](https://operations.osmfoundation.org/policies/tiles/) käyttö saattaa aiheuttaa tulevaisuudessa tarvetta konfiguroinnille). Myös tarve Digitransitin konfiguraatiolle instanssikohtaisesti on epätodennäköistä. Koko CSP:n muuttaminen ympäristömuuttujaksi laajentaisi tarpeettoman paljon rajapintaa eVaka coren ja instanssien välillä, jolloin mahdolliset muutokset coressa olisivat tasoa "breaking changes" eli ylläpitäjiltä toimia vaativia.

## Kuvakaappauksia

### Ilman ympäristömuuttujaa

<img width="578" height="49" alt="image" src="https://github.com/user-attachments/assets/98b71dea-fc0a-4726-a97b-78ebc9259964" />

<img width="927" height="76" alt="image" src="https://github.com/user-attachments/assets/2781a9e8-1609-42f1-9c61-b2fce5458b3e" />

### Ympäristömuuttujan kanssa

<img width="537" height="40" alt="image" src="https://github.com/user-attachments/assets/2410a870-6dc1-47be-9bc2-0cf86072a460" />

<img width="922" height="75" alt="image" src="https://github.com/user-attachments/assets/e169362f-b21f-4fc2-8b35-13c0f4350956" />

