### PR TITLE
Tekninen: wrapResult vaihtaminen React queryyn viesteissä

### DIFF
--- a/frontend/src/employee-frontend/components/messages/MessageContext.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageContext.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { useQueryClient } from '@tanstack/react-query'
 import sortBy from 'lodash/sortBy'
 import uniqBy from 'lodash/uniqBy'
 import React, {
@@ -14,10 +15,9 @@ import React, {
 import { useSearchParams } from 'wouter'
 
 import type { Result } from 'lib-common/api'
-import { Failure, Loading, wrapResult } from 'lib-common/api'
+import { Loading } from 'lib-common/api'
 import type {
   DraftContent,
-  Message,
   MessageThread,
   AuthorizedMessageAccount,
   SentMessage,
@@ -40,9 +40,8 @@ import type {
 } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { fromNullableUuid, fromUuid, tryFromUuid } from 'lib-common/id-type'
-import { constantQuery, useQueryResult } from 'lib-common/query'
+import { constantQuery, pendingQuery, useQueryResult } from 'lib-common/query'
 import type { UUID } from 'lib-common/types'
-import { useRestApi } from 'lib-common/utils/useRestApi'
 import type { GroupMessageAccount } from 'lib-components/messages/types'
 import {
   isGroupMessageAccount,
@@ -53,20 +52,18 @@ import {
 } from 'lib-components/messages/types'
 import type { SelectOption } from 'lib-components/molecules/Select'
 
-import {
-  getArchivedMessages,
-  getMessagesInFolder,
-  getDraftMessages,
-  getMessageCopies,
-  getReceivedMessages,
-  getSentMessages,
-  getThread
-} from '../../generated/api-clients/messaging'
 import { UserContext } from '../../state/user'
 
 import {
   accountsByUserQuery,
+  archivedMessagesQuery,
+  draftsQuery,
   foldersQuery,
+  messageCopiesQuery,
+  messagesInFolderQuery,
+  receivedMessagesQuery,
+  sentMessagesQuery,
+  threadQuery,
   unreadMessagesQuery
 } from './queries'
 import type { AccountView } from './types-view'
@@ -78,14 +75,6 @@ import {
   serviceWorkerMessageBoxes,
   financeMessageBoxes
 } from './types-view'
-
-const getMessageCopiesResult = wrapResult(getMessageCopies)
-const getDraftMessagesResult = wrapResult(getDraftMessages)
-const getArchivedMessagesResult = wrapResult(getArchivedMessages)
-const getMessagesInFolderResult = wrapResult(getMessagesInFolder)
-const getReceivedMessagesResult = wrapResult(getReceivedMessages)
-const getSentMessagesResult = wrapResult(getSentMessages)
-const getThreadResult = wrapResult(getThread)
 
 type RepliesByThread = Record<UUID, string>
 
@@ -106,7 +95,6 @@ export interface MessagesState {
   page: number
   setPage: (page: number) => void
   pages: number | undefined
-  setPages: (pages: number) => void
   receivedMessages: Result<MessageThread[]>
   sentMessages: Result<SentMessage[]>
   messageDrafts: Result<DraftContent[]>
@@ -117,10 +105,9 @@ export interface MessagesState {
   setSelectedThread: (threadId: UUID) => void
   selectedThread: MessageThread | undefined
   selectThread: (thread: MessageThread | undefined) => void
-  onReplySent: (reply: ThreadReply) => void
+  onReplySent: (reply: ThreadReply, accountId: MessageAccountId) => void
   setReplyContent: (threadId: UUID, content: string) => void
   getReplyContent: (threadId: UUID) => string
-  refreshMessages: (account?: UUID) => void
   unreadCountsByAccount: Result<UnreadCountByAccount[]>
   sentMessagesAsThreads: Result<MessageThread[]>
   messageCopiesAsThreads: Result<MessageThread[]>
@@ -147,7 +134,6 @@ const defaultState: MessagesState = {
   page: 1,
   setPage: () => undefined,
   pages: undefined,
-  setPages: () => undefined,
   receivedMessages: Loading.of(),
   sentMessages: Loading.of(),
   messageDrafts: Loading.of(),
@@ -161,7 +147,6 @@ const defaultState: MessagesState = {
   onReplySent: () => undefined,
   getReplyContent: () => '',
   setReplyContent: () => undefined,
-  refreshMessages: () => undefined,
   unreadCountsByAccount: Loading.of(),
   sentMessagesAsThreads: Loading.of(),
   messageCopiesAsThreads: Loading.of(),
@@ -173,21 +158,6 @@ const defaultState: MessagesState = {
 
 export const MessageContext = createContext<MessagesState>(defaultState)
 
-const appendMessageAndMoveThreadToTopOfList =
-  (threadId: UUID, message: Message) => (state: Result<MessageThread[]>) =>
-    state.map((threads) => {
-      const thread = threads.find((t) => t.id === threadId)
-      if (!thread) return threads
-      const otherThreads = threads.filter((t) => t.id !== threadId)
-      return [
-        {
-          ...thread,
-          messages: [...thread.messages, message]
-        },
-        ...otherThreads
-      ]
-    })
-
 export const MessageContextProvider = React.memo(
   function MessageContextProvider({
     children
@@ -195,6 +165,7 @@ export const MessageContextProvider = React.memo(
     children: React.JSX.Element
   }) {
     const { user } = useContext(UserContext)
+    const queryClient = useQueryClient()
     const [searchParams, setSearchParams] = useSearchParams()
     const accountId = searchParams.get('accountId')
     const messageBox = searchParams.get('messageBox')
@@ -248,25 +219,6 @@ export const MessageContextProvider = React.memo(
     )
 
     const [page, setPage] = useState<number>(1)
-    const [pages, setPages] = useState<number>()
-    const [receivedMessages, setReceivedMessages] = useState<
-      Result<MessageThread[]>
-    >(Loading.of())
-    const [messageDrafts, setMessageDrafts] = useState<Result<DraftContent[]>>(
-      Loading.of()
-    )
-    const [sentMessages, setSentMessages] = useState<Result<SentMessage[]>>(
-      Loading.of()
-    )
-    const [messageCopies, setMessageCopies] = useState<Result<MessageCopy[]>>(
-      Loading.of()
-    )
-    const [archivedMessages, setArchivedMessages] = useState<
-      Result<MessageThread[]>
-    >(Loading.of())
-    const [messagesInFolder, setMessagesInFolder] = useState<
-      Result<MessageThread[]>
-    >(Loading.of())
 
     const accounts = useQueryResult(
       user?.accessibleFeatures.messages
@@ -390,148 +342,110 @@ export const MessageContextProvider = React.memo(
       defaultState.selectedDraft
     )
 
-    const setReceivedMessagesResult = useCallback(
-      (result: Result<PagedMessageThreads>) => {
-        setReceivedMessages(result.map((r) => r.data))
-        if (result.isSuccess) {
-          setPages(result.value.pages)
-        }
-      },
-      []
-    )
-    const loadReceivedMessages = useRestApi(
-      (accountId: MessageAccountId, page: number) =>
-        getReceivedMessagesResult({ accountId, page }),
-      setReceivedMessagesResult
-    )
-
-    const loadMessageDrafts = useRestApi(
-      getDraftMessagesResult,
-      setMessageDrafts
-    )
-
-    const setSentMessagesResult = useCallback(
-      (result: Result<PagedSentMessages>) => {
-        setSentMessages(result.map((r) => r.data))
-        if (result.isSuccess) {
-          setPages(result.value.pages)
-        }
-      },
-      []
-    )
-    const loadSentMessages = useRestApi(
-      (accountId: MessageAccountId, page: number) =>
-        getSentMessagesResult({ accountId, page }),
-      setSentMessagesResult
-    )
-
-    const setMessageCopiesResult = useCallback(
-      (result: Result<PagedMessageCopies>) => {
-        setMessageCopies(result.map((r) => r.data))
-        if (result.isSuccess) {
-          setPages(result.value.pages)
-        }
-      },
-      []
-    )
-    const loadMessageCopies = useRestApi(
-      (accountId: MessageAccountId, page: number) =>
-        getMessageCopiesResult({ accountId, page }),
-      setMessageCopiesResult
-    )
-
-    const setArchivedMessagesResult = useCallback(
-      (result: Result<PagedMessageThreads>) => {
-        setArchivedMessages(result.map((r) => r.data))
-        if (result.isSuccess) {
-          setPages(result.value.pages)
-        }
-      },
-      []
-    )
-    const loadArchivedMessages = useRestApi(
-      (accountId: MessageAccountId, page: number) =>
-        getArchivedMessagesResult({ accountId, page }),
-      setArchivedMessagesResult
-    )
-
-    const setMessagesInFolderResult = useCallback(
-      (result: Result<PagedMessageThreads>) => {
-        setMessagesInFolder(result.map((r) => r.data))
-        if (result.isSuccess) {
-          setPages(result.value.pages)
-        }
-      },
-      []
-    )
-    const loadMessagesInFolder = useRestApi(
-      (
-        accountId: MessageAccountId,
-        folderId: MessageThreadFolderId,
-        page: number
-      ) => getMessagesInFolderResult({ accountId, folderId, page }),
-      setMessagesInFolderResult
-    )
-
-    const [singleThread, setSingleThread] = useState<Result<MessageThread>>()
-
-    const loadThread = useRestApi(
-      (accountId: MessageAccountId, threadId: MessageThreadId | null) =>
-        threadId
-          ? getThreadResult({ accountId, threadId })
-          : Promise.resolve(Failure.of({ message: 'threadId is null' })),
-      setSingleThread
-    )
-
-    // load messages if account, view or page changes
-    const loadMessages = useCallback(() => {
-      if (!selectedAccount) {
-        return
-      }
-
-      switch (selectedAccount.view) {
-        case 'received':
-          return void loadReceivedMessages(selectedAccount.account.id, page)
-        case 'sent':
-          return void loadSentMessages(selectedAccount.account.id, page)
-        case 'drafts':
-          return void loadMessageDrafts({
-            accountId: selectedAccount.account.id
-          })
-        case 'copies':
-          return void loadMessageCopies(selectedAccount.account.id, page)
-        case 'archive':
-          return void loadArchivedMessages(selectedAccount.account.id, page)
-        case 'thread':
-          return void loadThread(selectedAccount.account.id, threadId)
-        default:
-          return void loadMessagesInFolder(
-            selectedAccount.account.id,
-            selectedAccount.view.id,
+    const receivedMessagesRaw = useQueryResult(
+      selectedAccount?.view === 'received'
+        ? receivedMessagesQuery({
+            accountId: selectedAccount.account.id,
             page
-          )
+          })
+        : pendingQuery<PagedMessageThreads>()
+    )
+    const receivedMessages = useMemo(
+      () => receivedMessagesRaw.map((r) => r.data),
+      [receivedMessagesRaw]
+    )
+
+    const messageDrafts = useQueryResult(
+      selectedAccount?.view === 'drafts'
+        ? draftsQuery({ accountId: selectedAccount.account.id })
+        : pendingQuery<DraftContent[]>()
+    )
+
+    const sentMessagesRaw = useQueryResult(
+      selectedAccount?.view === 'sent'
+        ? sentMessagesQuery({ accountId: selectedAccount.account.id, page })
+        : pendingQuery<PagedSentMessages>()
+    )
+    const sentMessages = useMemo(
+      () => sentMessagesRaw.map((r) => r.data),
+      [sentMessagesRaw]
+    )
+
+    const messageCopiesRaw = useQueryResult(
+      selectedAccount?.view === 'copies'
+        ? messageCopiesQuery({
+            accountId: selectedAccount.account.id,
+            page
+          })
+        : pendingQuery<PagedMessageCopies>()
+    )
+    const messageCopies = useMemo(
+      () => messageCopiesRaw.map((r) => r.data),
+      [messageCopiesRaw]
+    )
+
+    const archivedMessagesRaw = useQueryResult(
+      selectedAccount?.view === 'archive'
+        ? archivedMessagesQuery({
+            accountId: selectedAccount.account.id,
+            page
+          })
+        : pendingQuery<PagedMessageThreads>()
+    )
+    const archivedMessages = useMemo(
+      () => archivedMessagesRaw.map((r) => r.data),
+      [archivedMessagesRaw]
+    )
+
+    const messagesInFolderRaw = useQueryResult(
+      selectedAccount && isFolderView(selectedAccount.view)
+        ? messagesInFolderQuery({
+            accountId: selectedAccount.account.id,
+            folderId: selectedAccount.view.id,
+            page
+          })
+        : pendingQuery<PagedMessageThreads>()
+    )
+    const messagesInFolder = useMemo(
+      () => messagesInFolderRaw.map((r) => r.data),
+      [messagesInFolderRaw]
+    )
+
+    const singleThread = useQueryResult(
+      selectedAccount?.view === 'thread' && threadId
+        ? threadQuery({
+            accountId: selectedAccount.account.id,
+            threadId
+          })
+        : pendingQuery<MessageThread>()
+    )
+
+    const pages = useMemo(() => {
+      if (!selectedAccount) return undefined
+      const view = selectedAccount.view
+      switch (view) {
+        case 'received':
+          return receivedMessagesRaw.map((r) => r.pages).getOrElse(undefined)
+        case 'sent':
+          return sentMessagesRaw.map((r) => r.pages).getOrElse(undefined)
+        case 'copies':
+          return messageCopiesRaw.map((r) => r.pages).getOrElse(undefined)
+        case 'archive':
+          return archivedMessagesRaw.map((r) => r.pages).getOrElse(undefined)
+        case 'drafts':
+        case 'thread':
+          return undefined
+        default:
+          return messagesInFolderRaw.map((r) => r.pages).getOrElse(undefined)
       }
     }, [
-      loadMessageDrafts,
-      loadReceivedMessages,
-      loadSentMessages,
-      loadMessageCopies,
-      loadArchivedMessages,
-      loadMessagesInFolder,
-      loadThread,
-      threadId,
-      page,
-      selectedAccount
+      selectedAccount,
+      receivedMessagesRaw,
+      sentMessagesRaw,
+      messageCopiesRaw,
+      archivedMessagesRaw,
+      messagesInFolderRaw
     ])
-
-    const refreshMessages = useCallback(
-      (accountId?: UUID) => {
-        if (!accountId || selectedAccount?.account.id === accountId) {
-          loadMessages()
-        }
-      },
-      [loadMessages, selectedAccount]
-    )
 
     const sentMessagesAsThreads: Result<MessageThread[]> = useMemo(
       () =>
@@ -640,7 +554,7 @@ export const MessageContextProvider = React.memo(
           ...messageCopiesAsThreads.getOrElse([]),
           ...archivedMessages.getOrElse([]),
           ...messagesInFolder.getOrElse([]),
-          singleThread?.getOrElse(undefined)
+          singleThread.getOrElse(undefined)
         ].find((t) => t?.id === threadId),
       [
         receivedMessages,
@@ -653,52 +567,6 @@ export const MessageContextProvider = React.memo(
       ]
     )
 
-    const appendMessageToSingleThread = useCallback(
-      (message: Message) =>
-        setSingleThread((prevState: Result<MessageThread> | undefined) =>
-          prevState?.map((thread) => ({
-            ...thread,
-            messages: [...thread.messages, message]
-          }))
-        ),
-      [setSingleThread]
-    )
-
-    const appendMessageToThreadInFolder = useCallback(
-      (message: Message) =>
-        setMessagesInFolder((prevState: Result<MessageThread[]>) =>
-          prevState.map((threads) =>
-            threads.map((thread) =>
-              thread.id === message.threadId
-                ? { ...thread, messages: [...thread.messages, message] }
-                : thread
-            )
-          )
-        ),
-      [setMessagesInFolder]
-    )
-
-    const onReplySent = useCallback(
-      ({ message, threadId }: ThreadReply) => {
-        if (selectedAccount?.view === 'thread') {
-          appendMessageToSingleThread(message)
-        } else if (selectedAccount && isFolderView(selectedAccount.view)) {
-          appendMessageToThreadInFolder(message)
-        } else {
-          setReceivedMessages(
-            appendMessageAndMoveThreadToTopOfList(threadId, message)
-          )
-        }
-        setSelectedThread(threadId)
-      },
-      [
-        appendMessageToSingleThread,
-        appendMessageToThreadInFolder,
-        selectedAccount,
-        setSelectedThread
-      ]
-    )
-
     const [replyContents, setReplyContents] = useState<RepliesByThread>({})
 
     const getReplyContent = useCallback(
@@ -708,6 +576,28 @@ export const MessageContextProvider = React.memo(
     const setReplyContent = useCallback((threadId: UUID, content: string) => {
       setReplyContents((state) => ({ ...state, [threadId]: content }))
     }, [])
+
+    const onReplySent = useCallback(
+      (response: ThreadReply, messageAccountId: MessageAccountId) => {
+        queryClient.setQueryData(
+          threadQuery({
+            accountId: messageAccountId,
+            threadId: response.threadId
+          }).queryKey,
+          (old: MessageThread | undefined) =>
+            old
+              ? {
+                  ...old,
+                  messages: [...old.messages, response.message]
+                }
+              : old
+        )
+        setReplyContent(response.threadId, '')
+
+        setSelectedThread(response.threadId)
+      },
+      [queryClient, setReplyContent, setSelectedThread]
+    )
 
     const selectUnit = useCallback(
       (unitId: string) => {
@@ -805,7 +695,6 @@ export const MessageContextProvider = React.memo(
         page,
         setPage,
         pages,
-        setPages,
         receivedMessages,
         sentMessages,
         messageDrafts,
@@ -819,7 +708,6 @@ export const MessageContextProvider = React.memo(
         onReplySent,
         getReplyContent,
         setReplyContent,
-        refreshMessages,
         unreadCountsByAccount,
         sentMessagesAsThreads,
         messageCopiesAsThreads,
@@ -856,7 +744,6 @@ export const MessageContextProvider = React.memo(
         onReplySent,
         getReplyContent,
         setReplyContent,
-        refreshMessages,
         unreadCountsByAccount,
         sentMessagesAsThreads,
         messageCopiesAsThreads,

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -198,7 +198,7 @@ interface Props {
   getAttachmentUrl: (attachmentId: AttachmentId, fileName: string) => string
   accounts: AuthorizedMessageAccount[]
   folders: MessageThreadFolder[]
-  onClose: (didChanges: boolean) => void
+  onClose: () => void
   onDiscard: (accountId: MessageAccountId, draftId: MessageDraftId) => void
   onSend: (
     accountId: MessageAccountId,
@@ -468,7 +468,7 @@ export default React.memo(function MessageEditor({
     if (draftWasModified && draftState === 'dirty') {
       saveDraft()
     }
-    onClose(draftWasModified)
+    onClose()
   }, [draftState, draftWasModified, onClose, saveDraft])
 
   const senderOptions = useMemo(

--- a/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessagesPage.tsx
@@ -11,8 +11,6 @@ import React, {
 } from 'react'
 import styled from 'styled-components'
 
-import type { Result } from 'lib-common/api'
-import { Failure, wrapResult } from 'lib-common/api'
 import type {
   PostMessageBody,
   SelectableRecipientsResponse
@@ -25,16 +23,16 @@ import type {
 } from 'lib-common/generated/api-types/shared'
 import { fromUuid } from 'lib-common/id-type'
 import { formatPersonName } from 'lib-common/names'
-import { useApiState } from 'lib-common/utils/useRestApi'
+import {
+  pendingQuery,
+  useMutationResult,
+  useQueryResult
+} from 'lib-common/query'
 import Container from 'lib-components/layout/Container'
 import { defaultMargins } from 'lib-components/white-space'
 
 import { getAttachmentUrl, messageAttachment } from '../../api/attachments'
-import {
-  createMessage,
-  deleteDraftMessage
-} from '../../generated/api-clients/messaging'
-import { getPersonIdentity } from '../../generated/api-clients/pis'
+import { personIdentityQuery } from '../../queries'
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
 import { headerHeight } from '../Header'
@@ -43,10 +41,7 @@ import { MessageContext } from './MessageContext'
 import MessageEditor from './MessageEditor'
 import Sidebar from './Sidebar'
 import MessageList from './ThreadListContainer'
-
-const getPersonIdentityResult = wrapResult(getPersonIdentity)
-const deleteDraftMessageResult = wrapResult(deleteDraftMessage)
-const createMessageResult = wrapResult(createMessage)
+import { createMessageMutation, deleteDraftMutation } from './queries'
 
 const PanelContainer = styled.div`
   height: calc(100vh - ${headerHeight} - ${defaultMargins.m});
@@ -67,7 +62,6 @@ export default React.memo(function MessagesPage({
     selectDefaultAccount,
     selectAccount,
     setSelectedThread,
-    refreshMessages,
     prefilledRecipient,
     prefilledTitle,
     relatedApplicationId,
@@ -77,15 +71,16 @@ export default React.memo(function MessagesPage({
   const { setErrorMessage } = useContext(UIContext)
   const { i18n } = useTranslation()
 
-  const [prefilledRecipientPerson] = useApiState(
-    (): Promise<Result<PersonJSON>> =>
-      prefilledRecipient
-        ? getPersonIdentityResult({ personId: prefilledRecipient })
-        : Promise.resolve(Failure.of({ message: 'No person id given' })),
-    [prefilledRecipient]
+  const prefilledRecipientPerson = useQueryResult(
+    prefilledRecipient
+      ? personIdentityQuery({ personId: prefilledRecipient })
+      : pendingQuery<PersonJSON>()
   )
 
-  useEffect(() => refreshMessages(), [refreshMessages])
+  const { mutateAsync: createMessage } = useMutationResult(
+    createMessageMutation
+  )
+  const { mutateAsync: deleteDraft } = useMutationResult(deleteDraftMutation)
   const [sending, setSending] = useState(false)
   const [showEditor, setShowEditor] = useState<boolean>(
     initialShowEditor ?? false
@@ -121,7 +116,7 @@ export default React.memo(function MessagesPage({
       initialFolder: MessageThreadFolderId | null
     ) => {
       setSending(true)
-      void createMessageResult({
+      void createMessage({
         accountId,
         initialFolder,
         body: {
@@ -130,7 +125,6 @@ export default React.memo(function MessagesPage({
         }
       }).then((res) => {
         if (res.isSuccess) {
-          refreshMessages(accountId)
           const senderAccount = accounts
             .map((accounts) =>
               accounts.find((acc) => acc.account.id === accountId)
@@ -162,7 +156,7 @@ export default React.memo(function MessagesPage({
       hideEditor,
       i18n.common.error.unknown,
       i18n.common.ok,
-      refreshMessages,
+      createMessage,
       selectAccount,
       setErrorMessage,
       setSelectedThread,
@@ -172,16 +166,7 @@ export default React.memo(function MessagesPage({
 
   const onDiscard = (accountId: MessageAccountId, draftId: MessageDraftId) => {
     hideEditor()
-    void deleteDraftMessageResult({ accountId, draftId }).then(() =>
-      refreshMessages(accountId)
-    )
-  }
-
-  const onHide = (didChanges: boolean) => {
-    hideEditor()
-    if (didChanges) {
-      refreshMessages()
-    }
+    void deleteDraft({ accountId, draftId })
   }
 
   const prefilledOrRecipients = useMemo(():
@@ -258,7 +243,7 @@ export default React.memo(function MessagesPage({
               getAttachmentUrl={getAttachmentUrl}
               accounts={accounts.value}
               folders={folders.value}
-              onClose={onHide}
+              onClose={hideEditor}
               onDiscard={onDiscard}
               onSend={onSend}
               saveMessageAttachment={messageAttachment}

--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -14,7 +14,6 @@ import React, {
 import styled from 'styled-components'
 import { Link, useLocation, useSearchParams } from 'wouter'
 
-import { wrapResult } from 'lib-common/api'
 import type {
   Message,
   MessageChild,
@@ -47,19 +46,17 @@ import colors from 'lib-customizations/common'
 import { faAngleLeft, faBoxArchive, faEnvelope } from 'lib-icons'
 
 import { getAttachmentUrl } from '../../api/attachments'
-import { archiveThread } from '../../generated/api-clients/messaging'
 import { useTranslation } from '../../state/i18n'
 
 import { MessageContext } from './MessageContext'
 import {
+  archiveThreadMutation,
   markLastReceivedMessageInThreadUnreadMutation,
   markThreadReadMutation,
   replyToThreadMutation
 } from './queries'
 import type { View } from './types-view'
 import { isFolderView, isStandardView } from './types-view'
-
-const archiveThreadResult = wrapResult(archiveThread)
 
 const MessageContainer = styled.div`
   background-color: ${colors.grayscale.g0};
@@ -203,7 +200,7 @@ export function SingleThreadView({
 }: Props) {
   const { i18n } = useTranslation()
   const [, navigate] = useLocation()
-  const { getReplyContent, onReplySent, setReplyContent, refreshMessages } =
+  const { getReplyContent, onReplySent, setReplyContent } =
     useContext(MessageContext)
   const [searchParams] = useSearchParams()
   const [replyEditorVisible, setReplyEditorVisible] = useState<boolean>(
@@ -248,10 +245,10 @@ export function SingleThreadView({
 
   const handleReplySent = useCallback(
     (response: ThreadReply) => {
-      onReplySent(response)
+      onReplySent(response, account.id)
       setReplyEditorVisible(false)
     },
-    [onReplySent]
+    [account.id, onReplySent]
   )
 
   const onDiscard = useCallback(() => {
@@ -265,16 +262,17 @@ export function SingleThreadView({
   const { mutateAsync: markThreadRead } = useMutationResult(
     markThreadReadMutation
   )
+  const { mutateAsync: archiveThread } = useMutationResult(
+    archiveThreadMutation
+  )
   useEffect(() => {
     const hasUnreadMessages = messages.some(
       (m) => !m.readAt && m.sender.id !== account.id
     )
     if (hasUnreadMessages) {
-      void markThreadRead({ accountId: account.id, threadId }).then(() => {
-        refreshMessages(account.id)
-      })
+      void markThreadRead({ accountId: account.id, threadId })
     }
-  }, [account.id, markThreadRead, messages, refreshMessages, threadId])
+  }, [account.id, markThreadRead, messages, threadId])
 
   const singleCustomer = useMemo(() => {
     if (messages.length === 0) return null
@@ -416,7 +414,7 @@ export function SingleThreadView({
                     data-qa="delete-thread-btn"
                     className="delete-btn"
                     onClick={() =>
-                      archiveThreadResult({ accountId: account.id, threadId })
+                      archiveThread({ accountId: account.id, threadId })
                     }
                     onSuccess={onArchived}
                     text={i18n.messages.archiveThread}

--- a/frontend/src/employee-frontend/components/messages/ThreadList.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadList.tsx
@@ -5,17 +5,16 @@
 import React from 'react'
 
 import type { Result } from 'lib-common/api'
-import { wrapResult } from 'lib-common/api'
 import type { MessageType } from 'lib-common/generated/api-types/messaging'
 import type {
   MessageAccountId,
   MessageThreadId
 } from 'lib-common/generated/api-types/shared'
 import type HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { useMutationResult } from 'lib-common/query'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { MessageCharacteristics } from 'lib-components/messages/MessageCharacteristics'
 
-import { archiveThread } from '../../generated/api-clients/messaging'
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
 import EllipsisMenu from '../common/EllipsisMenu'
@@ -30,8 +29,7 @@ import {
   Truncated,
   TypeAndDate
 } from './MessageComponents'
-
-const archiveThreadResult = wrapResult(archiveThread)
+import { archiveThreadMutation } from './queries'
 
 export type ThreadListItem = {
   id: MessageThreadId
@@ -62,6 +60,9 @@ export function ThreadList({
   onArchived
 }: Props) {
   const { i18n } = useTranslation()
+  const { mutateAsync: archiveThread } = useMutationResult(
+    archiveThreadMutation
+  )
 
   return renderResult(messages, (threads) => (
     <>
@@ -112,7 +113,7 @@ export function ThreadList({
                         id: 'archive',
                         label: i18n.common.archive,
                         onClick: () =>
-                          archiveThreadResult({
+                          archiveThread({
                             accountId,
                             threadId: item.id
                           }).then(onArchived)

--- a/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
+++ b/frontend/src/employee-frontend/components/messages/ThreadListContainer.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useContext, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import type { Result } from 'lib-common/api'
-import { Failure, Loading, Success, wrapResult } from 'lib-common/api'
+import { Failure, Loading, Success } from 'lib-common/api'
 import type {
   MessageAccount,
   MessageThread,
@@ -18,6 +18,7 @@ import type {
 } from 'lib-common/generated/api-types/shared'
 import { fromUuid } from 'lib-common/id-type'
 import { formatPersonName } from 'lib-common/names'
+import { useMutationResult } from 'lib-common/query'
 import Pagination from 'lib-components/Pagination'
 import Select from 'lib-components/atoms/dropdowns/Select'
 import { ContentArea } from 'lib-components/layout/Container'
@@ -26,17 +27,15 @@ import { AsyncFormModal } from 'lib-components/molecules/modals/FormModal'
 import { H1, H2 } from 'lib-components/typography'
 import colors from 'lib-customizations/common'
 
-import { moveThreadToFolder } from '../../generated/api-clients/messaging'
 import { useTranslation } from '../../state/i18n'
 
 import { MessageContext } from './MessageContext'
 import { SingleThreadView } from './SingleThreadView'
 import type { ThreadListItem } from './ThreadList'
 import { ThreadList } from './ThreadList'
+import { moveThreadToFolderMutation } from './queries'
 import type { View } from './types-view'
 import { isFolderView, isStandardView } from './types-view'
-
-const moveThreadToFolderResult = wrapResult(moveThreadToFolder)
 
 const MessagesContainer = styled(ContentArea)`
   overflow-y: auto;
@@ -83,7 +82,6 @@ export default React.memo(function ThreadListContainer({
     page,
     setPage,
     pages,
-    refreshMessages,
     selectedThread,
     selectThread,
     setSelectedDraft,
@@ -96,8 +94,7 @@ export default React.memo(function ThreadListContainer({
 
   const onMessageMoved = useCallback(() => {
     selectThread(undefined)
-    refreshMessages()
-  }, [refreshMessages, selectThread])
+  }, [selectThread])
 
   const hasMessages = useMemo<boolean>(() => {
     if (view === 'received' && receivedMessages.isSuccess) {
@@ -307,6 +304,9 @@ const FolderChangeModal = React.memo(function FolderChangeModal({
   onClose: () => void
 }) {
   const { i18n } = useTranslation()
+  const { mutateAsync: moveThreadToFolder } = useMutationResult(
+    moveThreadToFolderMutation
+  )
   const [folder, setFolder] = useState<MessageThreadFolder | null>(null)
   return (
     <AsyncFormModal
@@ -314,7 +314,7 @@ const FolderChangeModal = React.memo(function FolderChangeModal({
       title={i18n.messages.changeFolder.modalTitle}
       resolveAction={() =>
         folder
-          ? moveThreadToFolderResult({
+          ? moveThreadToFolder({
               accountId: accountId,
               threadId: threadId,
               folderId: folder.id

--- a/frontend/src/employee-frontend/components/messages/queries.ts
+++ b/frontend/src/employee-frontend/components/messages/queries.ts
@@ -11,13 +11,21 @@ import {
   createMessagePreflightCheck,
   deleteDraftMessage,
   getAccountsByUser,
+  getArchivedMessages,
   getDraftMessages,
   getFinanceMessagesWithPerson,
   getFolders,
+  getMessageCopies,
+  getMessagesInFolder,
+  getReceivedMessages,
+  getSelectableRecipients,
+  getSentMessages,
+  getThread,
   getUnreadMessages,
   initDraftMessage,
   markLastReceivedMessageInThreadUnread,
   markThreadRead,
+  moveThreadToFolder,
   replyToThread,
   updateDraftMessage
 } from '../../generated/api-clients/messaging'
@@ -34,13 +42,33 @@ export const createMessagePreflightCheckQuery = q.query(
   createMessagePreflightCheck
 )
 
+export const draftsQuery = q.query(getDraftMessages)
+
+export const financeThreadsQuery = q.query(getFinanceMessagesWithPerson)
+
+export const receivedMessagesQuery = q.query(getReceivedMessages)
+
+export const sentMessagesQuery = q.query(getSentMessages)
+
+export const messageCopiesQuery = q.query(getMessageCopies)
+
+export const archivedMessagesQuery = q.query(getArchivedMessages)
+
+export const messagesInFolderQuery = q.query(getMessagesInFolder)
+
+export const threadQuery = q.query(getThread)
+
+export const selectableRecipientsQuery = q.query(getSelectableRecipients)
+
 export const markThreadReadMutation = q.mutation(markThreadRead, [
-  unreadMessagesQuery
+  unreadMessagesQuery,
+  receivedMessagesQuery.prefix
 ])
 
-export const replyToThreadMutation = q.mutation(replyToThread)
-
-export const draftsQuery = q.query(getDraftMessages)
+export const markLastReceivedMessageInThreadUnreadMutation = q.mutation(
+  markLastReceivedMessageInThreadUnread,
+  [unreadMessagesQuery]
+)
 
 export const initDraftMutation = q.mutation(initDraftMessage, [draftsQuery])
 
@@ -48,21 +76,57 @@ export const saveDraftMutation = q.mutation(updateDraftMessage, [draftsQuery])
 
 export const deleteDraftMutation = q.mutation(deleteDraftMessage, [draftsQuery])
 
-export const financeThreadsQuery = q.query(getFinanceMessagesWithPerson)
+export const replyToThreadMutation = q.mutation(replyToThread, [
+  receivedMessagesQuery.prefix,
+  messagesInFolderQuery.prefix,
+  threadQuery.prefix
+])
+
+export const archiveThreadMutation = q.mutation(archiveThread, [
+  receivedMessagesQuery.prefix,
+  archivedMessagesQuery.prefix,
+  messagesInFolderQuery.prefix,
+  threadQuery.prefix
+])
+
+export const moveThreadToFolderMutation = q.mutation(moveThreadToFolder, [
+  receivedMessagesQuery.prefix,
+  messagesInFolderQuery.prefix
+])
+
+export const createMessageMutation = q.mutation(createMessage, [
+  sentMessagesQuery.prefix,
+  receivedMessagesQuery.prefix,
+  draftsQuery.prefix,
+  messageCopiesQuery.prefix,
+  archivedMessagesQuery.prefix,
+  messagesInFolderQuery.prefix,
+  threadQuery.prefix
+])
 
 export const createFinanceThreadMutation = q.parametricMutation<{
   id: PersonId
-}>()(createMessage, [({ id }) => financeThreadsQuery({ personId: id })])
+}>()(createMessage, [
+  ({ id }) => financeThreadsQuery({ personId: id }),
+  sentMessagesQuery.prefix,
+  draftsQuery.prefix
+])
 
 export const replyToFinanceThreadMutation = q.parametricMutation<{
   id: PersonId
-}>()(replyToThread, [({ id }) => financeThreadsQuery({ personId: id })])
+}>()(replyToThread, [
+  ({ id }) => financeThreadsQuery({ personId: id }),
+  receivedMessagesQuery.prefix,
+  messagesInFolderQuery.prefix,
+  threadQuery.prefix
+])
 
 export const archiveFinanceThreadMutation = q.parametricMutation<{
   id: PersonId
-}>()(archiveThread, [({ id }) => financeThreadsQuery({ personId: id })])
-
-export const markLastReceivedMessageInThreadUnreadMutation = q.mutation(
-  markLastReceivedMessageInThreadUnread,
-  [unreadMessagesQuery]
-)
+}>()(archiveThread, [
+  ({ id }) => financeThreadsQuery({ personId: id }),
+  receivedMessagesQuery.prefix,
+  archivedMessagesQuery.prefix,
+  messagesInFolderQuery.prefix,
+  threadQuery.prefix
+])

--- a/frontend/src/employee-frontend/components/person-profile/PersonFinanceNotesAndMessages.tsx
+++ b/frontend/src/employee-frontend/components/person-profile/PersonFinanceNotesAndMessages.tsx
@@ -95,7 +95,7 @@ export default React.memo(function PersonFinanceNotesAndMessages({
   const { person, permittedActions } = useContext(PersonContext)
   const { uiMode, toggleUiMode, clearUiMode, setErrorMessage } =
     useContext(UIContext)
-  const { refreshMessages, financeAccount } = useContext(MessageContext)
+  const { financeAccount } = useContext(MessageContext)
   const financeNotes = useQueryResult(financeNotesQuery({ personId: id }))
   const [text, setText] = useState<string>('')
   const financeThreads = useQueryResult(
@@ -165,7 +165,6 @@ export default React.memo(function PersonFinanceNotesAndMessages({
               createFinanceThreadMutation,
               arg
             )
-            refreshMessages(accountId)
             clearUiMode()
           }, onSuccessTimeout)
         })
@@ -187,7 +186,6 @@ export default React.memo(function PersonFinanceNotesAndMessages({
       id,
       onSuccessTimeout,
       queryClient,
-      refreshMessages,
       setErrorMessage
     ]
   )
@@ -228,9 +226,7 @@ export default React.memo(function PersonFinanceNotesAndMessages({
             onClose={() => clearUiMode()}
             onDiscard={(accountId, draftId) => {
               clearUiMode()
-              void deleteDraftResult({ accountId, draftId }).then(() => {
-                refreshMessages(accountId)
-              })
+              void deleteDraftResult({ accountId, draftId })
             }}
             onSend={onSend}
             saveMessageAttachment={messageAttachment}
@@ -340,7 +336,6 @@ export default React.memo(function PersonFinanceNotesAndMessages({
                     thread={item}
                     financeAccount={financeAccount!.account}
                     setThread={setThread}
-                    refreshMessages={refreshMessages}
                     uiMode={uiMode}
                     clearUiMode={clearUiMode}
                     toggleUiMode={toggleUiMode}
@@ -371,7 +366,6 @@ const SingleThread = React.memo(function SingleThread({
   thread,
   financeAccount,
   setThread,
-  refreshMessages,
   uiMode,
   clearUiMode,
   toggleUiMode
@@ -380,7 +374,6 @@ const SingleThread = React.memo(function SingleThread({
   thread: MessageThread
   financeAccount: TypedMessageAccount
   setThread: (thread: MessageThread) => void
-  refreshMessages: (id: MessageAccountId) => void
   uiMode: string
   clearUiMode: () => void
   toggleUiMode: (mode: string) => void
@@ -455,9 +448,7 @@ const SingleThread = React.memo(function SingleThread({
               accountId: financeAccount.id,
               threadId: thread.id
             })}
-            onSuccess={() => {
-              refreshMessages(financeAccount.id)
-            }}
+            onSuccess={() => undefined}
           />
         </FixedSpaceRow>
       </FlexRow>
@@ -483,7 +474,6 @@ const SingleThread = React.memo(function SingleThread({
               }
             })}
             onSuccess={() => {
-              refreshMessages(financeAccount.id)
               clearUiMode()
             }}
             onDiscard={() => {


### PR DESCRIPTION
Muutetaan viestit käyttämään React queryä, niin että toiminnallisuus pysyy identtisenä aiempaan.

Testattavia tilanteita:
- Lähetetty viesti ilmestyy lähetetyt kansioon
- Viestiin vastatessa, vastaus ilmestyy automaattisesti viestiketjuun
- Luonnos tallennetaan oikein
- Luonnos poistetaan oikein
- Viestiketjun voi arkistoida ja jos arkistoituun viestiketjuun lähetetään uusi viesti, niin se palaa saapuneet kansioon
- Viestiketjun merkkaaminen lukemattomaksi päivittyy oikein
- Uuden viestin lähettäminen viestiketjuun päivittyy oikein viestiketjulistaan
- Uuden viestiketjun avaaminen päivittyy oikein lähetetyt kansioon
- Talouden viestit asiakastietojen kautta lähetettynä päivittyvät oikein talouden lähetetyt kansioon