### PR TITLE
Tekninen: wrapResult vaihtaminen React queryyn yksiköissä

### DIFF
--- a/frontend/src/employee-frontend/components/unit/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/queries.ts
@@ -10,7 +10,12 @@ import {
   getUnitApplications,
   respondToPlacementProposal
 } from '../../generated/api-clients/application'
-import { getOpenGroupAttendance } from '../../generated/api-clients/attendance'
+import {
+  getOpenGroupAttendance,
+  getRealtimeStaffAttendances,
+  upsertDailyExternalRealtimeAttendances,
+  upsertDailyStaffRealtimeAttendances
+} from '../../generated/api-clients/attendance'
 import {
   addFullAclForRole,
   createDaycare,
@@ -264,3 +269,17 @@ export const respondToPlacementProposalMutation = q.parametricMutation<{
 export const openAttendanceQuery = q.query(getOpenGroupAttendance)
 
 export const nekkuManualOrderMutation = q.mutation(nekkuManualOrder)
+
+export const realtimeStaffAttendancesQuery = q.query(
+  getRealtimeStaffAttendances
+)
+
+export const upsertStaffAttendancesMutation = q.mutation(
+  upsertDailyStaffRealtimeAttendances,
+  [realtimeStaffAttendancesQuery.prefix]
+)
+
+export const upsertExternalAttendancesMutation = q.mutation(
+  upsertDailyExternalRealtimeAttendances,
+  [realtimeStaffAttendancesQuery.prefix]
+)

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/CalendarEventsSection.tsx
@@ -18,7 +18,7 @@ import styled from 'styled-components'
 import { Link, useLocation, useParams, useSearchParams } from 'wouter'
 
 import type { Result } from 'lib-common/api'
-import { combine, wrapResult } from 'lib-common/api'
+import { combine } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import type {
@@ -36,9 +36,8 @@ import type {
 } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { formatPersonName } from 'lib-common/names'
-import { useQueryResult } from 'lib-common/query'
+import { useMutationResult, useQueryResult } from 'lib-common/query'
 import type { UUID } from 'lib-common/types'
-import { useApiState } from 'lib-common/utils/useRestApi'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -65,21 +64,17 @@ import { defaultMargins, Gap } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/employee'
 import { faCalendarPlus, faQuestion, faTrash } from 'lib-icons'
 
-import {
-  createCalendarEvent,
-  deleteCalendarEvent,
-  getUnitCalendarEvents,
-  modifyCalendarEvent
-} from '../../../generated/api-clients/calendarevent'
 import { useTranslation } from '../../../state/i18n'
 import type { DayOfWeek } from '../../../types'
 import { renderResult } from '../../async-rendering'
 import { unitGroupDetailsQuery, daycareQuery } from '../queries'
 
-const createCalendarEventResult = wrapResult(createCalendarEvent)
-const getUnitCalendarEventsResult = wrapResult(getUnitCalendarEvents)
-const modifyCalendarEventResult = wrapResult(modifyCalendarEvent)
-const deleteCalendarEventResult = wrapResult(deleteCalendarEvent)
+import {
+  createCalendarEventMutation,
+  deleteCalendarEventMutation,
+  modifyCalendarEventMutation,
+  unitCalendarEventsQuery
+} from './queries'
 
 const EventsWeekContainer = styled.div`
   display: grid;
@@ -215,14 +210,12 @@ export default React.memo(function CalendarEventsSection({
   operationalDays: DayOfWeek[]
   groupId: UUID | null // null means all groups
 }) {
-  const [events, reloadEvents] = useApiState(
-    () =>
-      getUnitCalendarEventsResult({
-        unitId,
-        start: dateRange.start,
-        end: dateRange.end
-      }),
-    [unitId, dateRange]
+  const events = useQueryResult(
+    unitCalendarEventsQuery({
+      unitId,
+      start: dateRange.start,
+      end: dateRange.end
+    })
   )
 
   const groupData = useQueryResult(
@@ -283,10 +276,7 @@ export default React.memo(function CalendarEventsSection({
         <EditEventModal
           event={editingEvent}
           unitInformation={unitInformation}
-          onClose={(shouldRefresh) => {
-            if (shouldRefresh) {
-              void reloadEvents()
-            }
+          onClose={() => {
             navigate(`/units/${unitId}/calendar`)
           }}
         />
@@ -295,11 +285,8 @@ export default React.memo(function CalendarEventsSection({
       {createEventModalVisible && (
         <CreateEventModal
           unitId={unitId}
-          onClose={(shouldRefresh) => {
+          onClose={() => {
             setCreateEventModalVisible(false)
-            if (shouldRefresh) {
-              void reloadEvents()
-            }
           }}
           groupId={groupId}
         />
@@ -516,10 +503,13 @@ const CreateEventModal = React.memo(function CreateEventModal({
   groupId
 }: {
   unitId: DaycareId
-  onClose: (shouldRefresh: boolean) => void
+  onClose: () => void
   groupId: UUID | null
 }) {
   const { i18n, lang } = useTranslation()
+  const { mutateAsync: createCalendarEvent } = useMutationResult(
+    createCalendarEventMutation
+  )
 
   const unitInformation = useQueryResult(daycareQuery({ daycareId: unitId }))
 
@@ -744,7 +734,7 @@ const CreateEventModal = React.memo(function CreateEventModal({
       icon={faCalendarPlus}
       type="info"
       resolveAction={() =>
-        createCalendarEventResult({
+        createCalendarEvent({
           body: {
             unitId,
             title: form.title,
@@ -758,8 +748,8 @@ const CreateEventModal = React.memo(function CreateEventModal({
         })
       }
       resolveLabel={i18n.unit.calendar.events.create.add}
-      onSuccess={() => onClose(true)}
-      rejectAction={() => onClose(false)}
+      onSuccess={onClose}
+      rejectAction={onClose}
       rejectLabel={i18n.common.cancel}
       resolveDisabled={!formIsValid}
     >
@@ -892,9 +882,15 @@ const EditEventModal = React.memo(function EditEventModal({
 }: {
   event: CalendarEvent
   unitInformation: Result<DaycareResponse>
-  onClose: (shouldRefresh: boolean) => void
+  onClose: () => void
 }) {
   const { i18n } = useTranslation()
+  const { mutateAsync: modifyCalendarEvent } = useMutationResult(
+    modifyCalendarEventMutation
+  )
+  const { mutateAsync: deleteCalendarEvent } = useMutationResult(
+    deleteCalendarEventMutation
+  )
 
   const [form, setForm] = useState<{
     title: string
@@ -926,7 +922,7 @@ const EditEventModal = React.memo(function EditEventModal({
           title={i18n.unit.calendar.events.edit.title}
           type="info"
           width="wide"
-          close={() => onClose(false)}
+          close={onClose}
           closeLabel={i18n.common.closeModal}
           padding="L"
         >
@@ -1028,10 +1024,8 @@ const EditEventModal = React.memo(function EditEventModal({
             />
             <AsyncButton
               primary
-              onClick={() =>
-                modifyCalendarEventResult({ id: event.id, body: form })
-              }
-              onSuccess={() => onClose(true)}
+              onClick={() => modifyCalendarEvent({ id: event.id, body: form })}
+              onSuccess={onClose}
               text={i18n.unit.calendar.events.edit.saveChanges}
               data-qa="save"
             />
@@ -1046,11 +1040,11 @@ const EditEventModal = React.memo(function EditEventModal({
           title="Haluatko varmasti poistaa tapahtuman?"
           text="Tapahtuma poistetaan sekä henkilökunnan että huoltajien kalenterista."
           type="warning"
-          resolveAction={() => deleteCalendarEventResult({ id: event.id })}
+          resolveAction={() => deleteCalendarEvent({ id: event.id })}
           resolveLabel="Poista tapahtuma"
           onSuccess={() => {
             setShowDeletionModal(false)
-            onClose(true)
+            onClose()
           }}
           rejectAction={() => setShowDeletionModal(false)}
           rejectLabel="Älä poista"

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyView.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/discussion-surveys/DiscussionSurveyView.tsx
@@ -27,7 +27,7 @@ import type { UnitGroupDetails } from 'lib-common/generated/api-types/daycare'
 import type { ChildBasics } from 'lib-common/generated/api-types/placement'
 import type { DaycareId, GroupId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
-import { useMutation, useQueryResult } from 'lib-common/query'
+import { useMutationResult, useQueryResult } from 'lib-common/query'
 import type { UUID } from 'lib-common/types'
 import { scrollRefIntoView } from 'lib-common/utils/scrolling'
 import { StaticChip } from 'lib-components/atoms/Chip'
@@ -198,7 +198,7 @@ export default React.memo(function DiscussionReservationSurveyView({
 }) {
   const { i18n } = useTranslation()
   const [, navigate] = useLocation()
-  const { mutateAsync: deleteCalendarEvent } = useMutation(
+  const { mutateAsync: deleteCalendarEvent } = useMutationResult(
     deleteCalendarEventMutation
   )
 
@@ -315,21 +315,20 @@ export default React.memo(function DiscussionReservationSurveyView({
           }}
           resolve={{
             action: () => {
-              deleteCalendarEvent({ id: eventData.id, unitId, groupId })
-                .catch(() => {
+              void deleteCalendarEvent({ id: eventData.id }).then((result) => {
+                if (result.isFailure) {
                   setErrorMessage({
                     title: t.discussionReservation.deleteConfirmation.error,
                     type: 'error',
                     resolveLabel: i18n.common.close
                   })
-                })
-                .finally(() => {
-                  setDeleteConfirmModalVisible(false)
-                  navigate(
-                    `/units/${unitId}/groups/${groupId}/discussion-reservation-surveys`,
-                    { replace: true }
-                  )
-                })
+                }
+                setDeleteConfirmModalVisible(false)
+                navigate(
+                  `/units/${unitId}/groups/${groupId}/discussion-reservation-surveys`,
+                  { replace: true }
+                )
+              })
             },
             label: i18n.common.remove
           }}

--- a/frontend/src/employee-frontend/components/unit/tab-calendar/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/tab-calendar/queries.ts
@@ -2,11 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import type {
-  CalendarEventId,
-  DaycareId,
-  GroupId
-} from 'lib-common/generated/api-types/shared'
+import type { CalendarEventId } from 'lib-common/generated/api-types/shared'
 import { Queries } from 'lib-common/query'
 
 import {
@@ -18,6 +14,8 @@ import {
   getCalendarEvent,
   getGroupDiscussionReservationDays,
   getGroupDiscussionSurveys,
+  getUnitCalendarEvents,
+  modifyCalendarEvent,
   setCalendarEventTimeReservation,
   updateCalendarEvent
 } from '../../../generated/api-clients/calendarevent'
@@ -32,13 +30,15 @@ export const groupDiscussionReservationDaysQuery = q.query(
   getGroupDiscussionReservationDays
 )
 
-export const createCalendarEventMutation = q.mutation(createCalendarEvent)
+export const unitCalendarEventsQuery = q.query(getUnitCalendarEvents)
 
-export const deleteCalendarEventMutation = q.parametricMutation<{
-  unitId: DaycareId
-  groupId: GroupId
-}>()(deleteCalendarEvent, [
-  ({ unitId, groupId }) => groupDiscussionSurveysQuery({ unitId, groupId })
+export const createCalendarEventMutation = q.mutation(createCalendarEvent, [
+  unitCalendarEventsQuery.prefix
+])
+
+export const deleteCalendarEventMutation = q.mutation(deleteCalendarEvent, [
+  groupDiscussionSurveysQuery.prefix,
+  unitCalendarEventsQuery.prefix
 ])
 
 export const updateCalendarEventMutation = q.mutation(updateCalendarEvent, [
@@ -65,4 +65,8 @@ export const deleteCalendarEventTimeMutation = q.parametricMutation<{
   eventId: CalendarEventId
 }>()(deleteCalendarEventTime, [
   ({ eventId }) => discussionSurveyQuery({ id: eventId })
+])
+
+export const modifyCalendarEventMutation = q.mutation(modifyCalendarEvent, [
+  unitCalendarEventsQuery.prefix
 ])

--- a/frontend/src/employee-frontend/components/unit/tab-groups/notes/ChildDailyNoteForm.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/notes/ChildDailyNoteForm.tsx
@@ -4,7 +4,6 @@
 
 import React, { Fragment, useCallback, useState } from 'react'
 
-import { wrapResult } from 'lib-common/api'
 import type { UpdateStateFn } from 'lib-common/form-state'
 import type {
   ChildDailyNote,
@@ -16,6 +15,7 @@ import {
   childDailyNoteReminderValues
 } from 'lib-common/generated/api-types/note'
 import type { ChildId } from 'lib-common/generated/api-types/shared'
+import { useMutationResult } from 'lib-common/query'
 import { ChipWrapper, SelectionChip } from 'lib-components/atoms/Chip'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
@@ -31,16 +31,13 @@ import { H1, H2, H3, Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { faTrash } from 'lib-icons'
 
-import {
-  createChildDailyNote,
-  deleteChildDailyNote,
-  updateChildDailyNote
-} from '../../../../generated/api-clients/note'
 import { useTranslation } from '../../../../state/i18n'
 
-const createChildDailyNoteResult = wrapResult(createChildDailyNote)
-const updateChildDailyNoteResult = wrapResult(updateChildDailyNote)
-const deleteChildDailyNoteResult = wrapResult(deleteChildDailyNote)
+import {
+  createChildDailyNoteMutation,
+  deleteChildDailyNoteMutation,
+  updateChildDailyNoteMutation
+} from './queries'
 
 interface ChildDailyNoteFormData extends Omit<
   ChildDailyNoteBody,
@@ -106,6 +103,15 @@ export default React.memo(function ChildDailyNoteForm({
   onSuccess
 }: Props) {
   const { i18n } = useTranslation()
+  const { mutateAsync: createChildDailyNote } = useMutationResult(
+    createChildDailyNoteMutation
+  )
+  const { mutateAsync: updateChildDailyNote } = useMutationResult(
+    updateChildDailyNoteMutation
+  )
+  const { mutateAsync: deleteChildDailyNote } = useMutationResult(
+    deleteChildDailyNoteMutation
+  )
 
   const [form, setForm] = useState<ChildDailyNoteFormData>(
     initialFormData(note)
@@ -128,9 +134,9 @@ export default React.memo(function ChildDailyNoteForm({
     setSubmitting(true)
     const body = formDataToRequestBody(form)
     return note
-      ? updateChildDailyNoteResult({ noteId: note.id, body })
-      : createChildDailyNoteResult({ childId, body })
-  }, [childId, form, note])
+      ? updateChildDailyNote({ noteId: note.id, body })
+      : createChildDailyNote({ childId, body })
+  }, [childId, form, note, updateChildDailyNote, createChildDailyNote])
   const submitSuccess = useCallback(() => {
     setSubmitting(false)
     onSuccess()
@@ -145,13 +151,13 @@ export default React.memo(function ChildDailyNoteForm({
       return Promise.reject()
     }
     setDeleting(true)
-    return deleteChildDailyNoteResult({ noteId: note.id }).then((res) => {
+    return deleteChildDailyNote({ noteId: note.id }).then((res) => {
       setDeleting(false)
       if (res.isSuccess) {
         onRemove()
       }
     })
-  }, [note, onRemove])
+  }, [note, onRemove, deleteChildDailyNote])
 
   return (
     <>

--- a/frontend/src/employee-frontend/components/unit/tab-groups/notes/NotesModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/notes/NotesModal.tsx
@@ -6,7 +6,6 @@ import React, { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import type { Result } from 'lib-common/api'
-import { wrapResult } from 'lib-common/api'
 import type { NotesByGroupResponse } from 'lib-common/generated/api-types/note'
 import type {
   ChildId,
@@ -14,6 +13,7 @@ import type {
   GroupId,
   GroupNoteId
 } from 'lib-common/generated/api-types/shared'
+import { useMutationResult } from 'lib-common/query'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import { StickyNoteTab } from 'lib-components/employee/notes/StickyNoteTab'
@@ -25,26 +25,19 @@ import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faTimes } from 'lib-icons'
 
-import {
-  createChildStickyNote,
-  createGroupNote,
-  deleteChildStickyNote,
-  deleteGroupNote,
-  updateChildStickyNote,
-  updateGroupNote
-} from '../../../../generated/api-clients/note'
 import type { Translations } from '../../../../state/i18n'
 import { useTranslation } from '../../../../state/i18n'
 import { renderResult } from '../../../async-rendering'
 
 import ChildDailyNoteForm from './ChildDailyNoteForm'
-
-const createGroupNoteResult = wrapResult(createGroupNote)
-const updateGroupNoteResult = wrapResult(updateGroupNote)
-const deleteGroupNoteResult = wrapResult(deleteGroupNote)
-const createChildStickyNoteResult = wrapResult(createChildStickyNote)
-const updateChildStickyNoteResult = wrapResult(updateChildStickyNote)
-const deleteChildStickyNoteResult = wrapResult(deleteChildStickyNote)
+import {
+  createChildStickyNoteMutation,
+  createGroupNoteMutation,
+  deleteChildStickyNoteMutation,
+  deleteGroupNoteMutation,
+  updateChildStickyNoteMutation,
+  updateGroupNoteMutation
+} from './queries'
 
 const getLabels = (i18n: Translations, title: string, placeholder: string) => ({
   addNew: i18n.common.addNew,
@@ -100,7 +93,6 @@ interface Props {
   group: { id: GroupId; name: string }
   child?: { id: ChildId; name: string }
   notesByGroup: Result<NotesByGroupResponse>
-  reload: () => void
   onClose: () => void
 }
 
@@ -108,10 +100,27 @@ export default React.memo(function NotesModal({
   child,
   group,
   notesByGroup,
-  onClose,
-  reload
+  onClose
 }: Props) {
   const { i18n } = useTranslation()
+  const { mutateAsync: createGroupNote } = useMutationResult(
+    createGroupNoteMutation
+  )
+  const { mutateAsync: updateGroupNote } = useMutationResult(
+    updateGroupNoteMutation
+  )
+  const { mutateAsync: deleteGroupNote } = useMutationResult(
+    deleteGroupNoteMutation
+  )
+  const { mutateAsync: createChildStickyNote } = useMutationResult(
+    createChildStickyNoteMutation
+  )
+  const { mutateAsync: updateChildStickyNote } = useMutationResult(
+    updateChildStickyNoteMutation
+  )
+  const { mutateAsync: deleteChildStickyNote } = useMutationResult(
+    deleteChildStickyNoteMutation
+  )
 
   const notes = useMemo(
     () =>
@@ -160,44 +169,31 @@ export default React.memo(function NotesModal({
       ),
     [i18n]
   )
-  const reloadAndClose = useCallback(() => {
-    reload()
-    onClose()
-  }, [onClose, reload])
-
-  const reloadOnSuccess = useCallback(
-    (res: Result<unknown>) => res.map(() => reload()),
-    [reload]
-  )
   const saveGroupNote = useCallback(
     ({ id, ...body }: EditedNote<GroupNoteId>) =>
-      (id
-        ? updateGroupNoteResult({ noteId: id, body })
-        : createGroupNoteResult({ groupId: group.id, body })
-      ).then(reloadOnSuccess),
-    [group.id, reloadOnSuccess]
+      id
+        ? updateGroupNote({ noteId: id, body })
+        : createGroupNote({ groupId: group.id, body }),
+    [group.id, updateGroupNote, createGroupNote]
   )
   const removeGroupNote = useCallback(
-    (id: GroupNoteId) =>
-      deleteGroupNoteResult({ noteId: id }).then(reloadOnSuccess),
-    [reloadOnSuccess]
+    (id: GroupNoteId) => deleteGroupNote({ noteId: id }),
+    [deleteGroupNote]
   )
   const saveStickyNote = useCallback(
     ({ id, ...body }: EditedNote<ChildStickyNoteId>) => {
       if (!child?.id) {
         return Promise.reject('invalid usage: childId was not provided')
       }
-      const promise = id
-        ? updateChildStickyNoteResult({ noteId: id, body })
-        : createChildStickyNoteResult({ childId: child.id, body })
-      return promise.then(reloadOnSuccess)
+      return id
+        ? updateChildStickyNote({ noteId: id, body })
+        : createChildStickyNote({ childId: child.id, body })
     },
-    [child, reloadOnSuccess]
+    [child, updateChildStickyNote, createChildStickyNote]
   )
   const removeStickyNote = useCallback(
-    (id: ChildStickyNoteId) =>
-      deleteChildStickyNoteResult({ noteId: id }).then(reloadOnSuccess),
-    [reloadOnSuccess]
+    (id: ChildStickyNoteId) => deleteChildStickyNote({ noteId: id }),
+    [deleteChildStickyNote]
   )
 
   const tabs = useMemo(
@@ -266,8 +262,8 @@ export default React.memo(function NotesModal({
                   childId={child.id}
                   childName={child.name}
                   onCancel={onClose}
-                  onSuccess={reloadAndClose}
-                  onRemove={reload}
+                  onSuccess={onClose}
+                  onRemove={onClose}
                 />
               </ContentArea>
             )}

--- a/frontend/src/employee-frontend/components/unit/tab-groups/notes/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/notes/queries.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Queries } from 'lib-common/query'
+
+import {
+  createChildDailyNote,
+  createChildStickyNote,
+  createGroupNote,
+  deleteChildDailyNote,
+  deleteChildStickyNote,
+  deleteGroupNote,
+  getNotesByGroup,
+  updateChildDailyNote,
+  updateChildStickyNote,
+  updateGroupNote
+} from '../../../../generated/api-clients/note'
+
+const q = new Queries()
+
+export const notesByGroupQuery = q.query(getNotesByGroup)
+
+export const createChildDailyNoteMutation = q.mutation(createChildDailyNote, [
+  notesByGroupQuery.prefix
+])
+
+export const updateChildDailyNoteMutation = q.mutation(updateChildDailyNote, [
+  notesByGroupQuery.prefix
+])
+
+export const deleteChildDailyNoteMutation = q.mutation(deleteChildDailyNote, [
+  notesByGroupQuery.prefix
+])
+
+export const createGroupNoteMutation = q.mutation(createGroupNote, [
+  notesByGroupQuery.prefix
+])
+
+export const updateGroupNoteMutation = q.mutation(updateGroupNote, [
+  notesByGroupQuery.prefix
+])
+
+export const deleteGroupNoteMutation = q.mutation(deleteGroupNote, [
+  notesByGroupQuery.prefix
+])
+
+export const createChildStickyNoteMutation = q.mutation(createChildStickyNote, [
+  notesByGroupQuery.prefix
+])
+
+export const updateChildStickyNoteMutation = q.mutation(updateChildStickyNote, [
+  notesByGroupQuery.prefix
+])
+
+export const deleteChildStickyNoteMutation = q.mutation(deleteChildStickyNote, [
+  notesByGroupQuery.prefix
+])

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitMobileDevices.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/UnitMobileDevices.tsx
@@ -2,17 +2,18 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { useQueryClient } from '@tanstack/react-query'
 import sortBy from 'lodash/sortBy'
 import React, { useCallback, useContext, useState } from 'react'
 import styled from 'styled-components'
 
-import { isLoading, wrapResult } from 'lib-common/api'
+import { isLoading } from 'lib-common/api'
 import type { MobileDevice } from 'lib-common/generated/api-types/pairing'
 import type {
   DaycareId,
   MobileDeviceId
 } from 'lib-common/generated/api-types/shared'
-import { useApiState } from 'lib-common/utils/useRestApi'
+import { useMutationResult, useQueryResult } from 'lib-common/query'
 import AddButton from 'lib-components/atoms/buttons/AddButton'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import InputField from 'lib-components/atoms/form/InputField'
@@ -24,18 +25,15 @@ import { H2 } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { faPen, faQuestion, faTrash } from 'lib-icons'
 
-import {
-  deleteMobileDevice,
-  getMobileDevices,
-  putMobileDeviceName
-} from '../../../generated/api-clients/pairing'
 import { useTranslation } from '../../../state/i18n'
 import { UIContext } from '../../../state/ui'
 import { renderResult } from '../../async-rendering'
 
-const getMobileDevicesResult = wrapResult(getMobileDevices)
-const deleteMobileDeviceResult = wrapResult(deleteMobileDevice)
-const putMobileDeviceNameResult = wrapResult(putMobileDeviceName)
+import {
+  deleteMobileDeviceMutation,
+  mobileDevicesQuery,
+  putMobileDeviceNameMutation
+} from './queries'
 
 type Props = {
   unitId: DaycareId
@@ -175,9 +173,13 @@ export default React.memo(function UnitMobileDevices({
 }: Props) {
   const { i18n } = useTranslation()
 
-  const [mobileDevices, reloadMobileDevices] = useApiState(
-    () => getMobileDevicesResult({ unitId }),
-    [unitId]
+  const queryClient = useQueryClient()
+  const mobileDevices = useQueryResult(mobileDevicesQuery({ unitId }))
+  const { mutateAsync: deleteMobileDevice } = useMutationResult(
+    deleteMobileDeviceMutation
+  )
+  const { mutateAsync: putMobileDeviceName } = useMutationResult(
+    putMobileDeviceNameMutation
   )
   const [mobileId, setMobileId] = useState<MobileDeviceId | undefined>(
     undefined
@@ -188,11 +190,10 @@ export default React.memo(function UnitMobileDevices({
 
   const confirmRemoveDevice = useCallback(async () => {
     if (mobileId) {
-      await deleteMobileDeviceResult({ id: mobileId })
-      void reloadMobileDevices()
+      await deleteMobileDevice({ id: mobileId })
     }
     clearUiMode()
-  }, [clearUiMode, mobileId, reloadMobileDevices])
+  }, [clearUiMode, mobileId, deleteMobileDevice])
 
   const openRemoveMobileDeviceModal = useCallback(
     (id: MobileDeviceId) => {
@@ -210,19 +211,23 @@ export default React.memo(function UnitMobileDevices({
     [toggleUiMode, unitId]
   )
 
+  const invalidateMobileDevices = useCallback(
+    () => void queryClient.invalidateQueries(mobileDevicesQuery({ unitId })),
+    [queryClient, unitId]
+  )
+
   const openPairMobileDeviceModal = useCallback(() => {
-    startPairing({ unitId }, reloadMobileDevices)
-  }, [startPairing, unitId, reloadMobileDevices])
+    startPairing({ unitId }, invalidateMobileDevices)
+  }, [startPairing, unitId, invalidateMobileDevices])
 
   const saveMobileDevice = useCallback(
     async (name: string) => {
       if (mobileId) {
-        await putMobileDeviceNameResult({ id: mobileId, body: { name } })
-        void reloadMobileDevices()
+        await putMobileDeviceName({ id: mobileId, body: { name } })
         clearUiMode()
       }
     },
-    [clearUiMode, mobileId, reloadMobileDevices]
+    [clearUiMode, mobileId, putMobileDeviceName]
   )
 
   return (

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/queries.ts
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/queries.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Queries } from 'lib-common/query'
+
+import {
+  deleteMobileDevice,
+  getMobileDevices,
+  putMobileDeviceName
+} from '../../../generated/api-clients/pairing'
+
+const q = new Queries()
+
+export const mobileDevicesQuery = q.query(getMobileDevices)
+
+export const deleteMobileDeviceMutation = q.mutation(deleteMobileDevice, [
+  mobileDevicesQuery.prefix
+])
+
+export const putMobileDeviceNameMutation = q.mutation(putMobileDeviceName, [
+  mobileDevicesQuery.prefix
+])

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceExternalPersonModal.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames'
 import React, { useCallback } from 'react'
 import styled from 'styled-components'
 
-import { Failure, wrapResult } from 'lib-common/api'
+import { Failure } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import { boolean, localDate, localTime, string } from 'lib-common/form/fields'
 import {
@@ -27,6 +27,7 @@ import type { DaycareId, GroupId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
+import { useMutationResult } from 'lib-common/query'
 import type { UUID } from 'lib-common/types'
 import StatusIcon from 'lib-components/atoms/StatusIcon'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -48,12 +49,8 @@ import { fontWeights, H1, Label } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
 import { faPlus } from 'lib-icons'
 
-import { upsertDailyExternalRealtimeAttendances } from '../../../generated/api-clients/attendance'
 import { useTranslation } from '../../../state/i18n'
-
-const upsertDailyExternalRealtimeAttendancesResult = wrapResult(
-  upsertDailyExternalRealtimeAttendances
-)
+import { upsertExternalAttendancesMutation } from '../queries'
 
 type ExternalPersonModalProps = {
   onClose: () => void
@@ -150,6 +147,9 @@ export default React.memo(function StaffAttendanceExternalPersonModal({
   defaultGroupId
 }: ExternalPersonModalProps) {
   const { i18n, lang } = useTranslation()
+  const { mutateAsync: upsertExternalAttendances } = useMutationResult(
+    upsertExternalAttendancesMutation
+  )
 
   const form = useForm(
     externalPersonForm,
@@ -162,8 +162,8 @@ export default React.memo(function StaffAttendanceExternalPersonModal({
       return Promise.resolve(Failure.of({ message: 'Form not valid' }))
     }
 
-    return upsertDailyExternalRealtimeAttendancesResult({ body: form.value() })
-  }, [form])
+    return upsertExternalAttendances({ body: form.value() })
+  }, [form, upsertExternalAttendances])
 
   const date = useFormField(form, 'date')
   const arrivalTime = useFormField(form, 'arrivalTime')

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/StaffAttendanceTable.tsx
@@ -12,8 +12,6 @@ import uniqBy from 'lodash/uniqBy'
 import React, { useMemo, useState, useCallback } from 'react'
 import styled from 'styled-components'
 
-import type { Result } from 'lib-common/api'
-import { wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import type { ErrorKey } from 'lib-common/form-validation'
 import type {
@@ -39,6 +37,7 @@ import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import { formatPersonName } from 'lib-common/names'
+import { useMutationResult } from 'lib-common/query'
 import { presentInGroup } from 'lib-common/staff-attendance'
 import type { UUID } from 'lib-common/types'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
@@ -53,11 +52,11 @@ import { defaultMargins } from 'lib-components/white-space'
 import { colors } from 'lib-customizations/common'
 import { faCircleEllipsis } from 'lib-icons'
 
-import {
-  upsertDailyExternalRealtimeAttendances,
-  upsertDailyStaffRealtimeAttendances
-} from '../../../generated/api-clients/attendance'
 import { useTranslation } from '../../../state/i18n'
+import {
+  upsertExternalAttendancesMutation,
+  upsertStaffAttendancesMutation
+} from '../queries'
 
 import type {
   EditedAttendance,
@@ -75,13 +74,6 @@ import {
   NameWrapper
 } from './attendance-elements'
 
-const upsertDailyStaffRealtimeAttendancesResult = wrapResult(
-  upsertDailyStaffRealtimeAttendances
-)
-const upsertDailyExternalRealtimeAttendancesResult = wrapResult(
-  upsertDailyExternalRealtimeAttendances
-)
-
 type GroupFilter = (ids: UUID[]) => boolean
 
 interface Props {
@@ -89,7 +81,6 @@ interface Props {
   operationalDays: OperationalDay[]
   staffAttendances: EmployeeAttendance[]
   externalAttendances: ExternalAttendance[]
-  reloadStaffAttendances: () => Promise<Result<unknown>>
   groups: DaycareGroup[]
   groupFilter: GroupFilter | null
   defaultGroup: GroupId | null
@@ -112,7 +103,6 @@ export default React.memo(function StaffAttendanceTable({
   staffAttendances,
   externalAttendances,
   operationalDays,
-  reloadStaffAttendances,
   groups,
   groupFilter,
   defaultGroup
@@ -266,17 +256,13 @@ export default React.memo(function StaffAttendanceTable({
           unitId={unitId}
           groups={groups}
           defaultGroupId={defaultGroup}
-          reloadStaffAttendances={reloadStaffAttendances}
           onClose={closeDetailsModal}
         />
       ) : null}
       {showExternalPersonModal && (
         <StaffAttendanceExternalPersonModal
           onClose={toggleAddPersonModal}
-          onSave={async () => {
-            await reloadStaffAttendances()
-            toggleAddPersonModal()
-          }}
+          onSave={toggleAddPersonModal}
           unitId={unitId}
           groups={groups}
           defaultGroupId={defaultGroup ?? groups[0].id}
@@ -292,7 +278,6 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
   unitId,
   groups,
   defaultGroupId,
-  reloadStaffAttendances,
   onClose
 }: {
   detailsModalConfig: DetailsModalConfig
@@ -303,18 +288,19 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
   unitId: DaycareId
   groups: DaycareGroup[]
   defaultGroupId: GroupId | null
-  reloadStaffAttendances: () => Promise<Result<unknown>>
   onClose: () => void
 }) {
-  const onSuccess = useCallback(() => {
-    void reloadStaffAttendances()
-    onClose()
-  }, [onClose, reloadStaffAttendances])
+  const { mutateAsync: upsertStaffAttendances } = useMutationResult(
+    upsertStaffAttendancesMutation
+  )
+  const { mutateAsync: upsertExternalAttendances } = useMutationResult(
+    upsertExternalAttendancesMutation
+  )
   const { target, date } = detailsModalConfig
   const onSaveStaff = useCallback(
     (entries: StaffAttendanceUpsert[]) =>
       target.type === 'employee'
-        ? upsertDailyStaffRealtimeAttendancesResult({
+        ? upsertStaffAttendances({
             body: {
               unitId,
               employeeId: target.employeeId,
@@ -323,12 +309,12 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
             }
           })
         : undefined,
-    [date, target, unitId]
+    [date, target, unitId, upsertStaffAttendances]
   )
   const onSaveExternal = useCallback(
     (entries: ExternalAttendanceUpsert[]) =>
       target.type === 'external'
-        ? upsertDailyExternalRealtimeAttendancesResult({
+        ? upsertExternalAttendances({
             body: {
               unitId,
               name: target.name,
@@ -337,7 +323,7 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
             }
           })
         : undefined,
-    [date, target, unitId]
+    [date, target, unitId, upsertExternalAttendances]
   )
   return target.type === 'employee' ? (
     <StaffAttendanceDetailsModal
@@ -353,7 +339,7 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
       groups={groups}
       defaultGroupId={defaultGroupId}
       onClose={onClose}
-      onSuccess={onSuccess}
+      onSuccess={onClose}
       unitId={unitId}
     />
   ) : (
@@ -372,7 +358,7 @@ const StaffAttendanceModal = React.memo(function StaffAttendanceModal({
       groups={groups}
       defaultGroupId={defaultGroupId}
       onClose={onClose}
-      onSuccess={onSuccess}
+      onSuccess={onClose}
       unitId={unitId}
     />
   )

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
-import { combine, isLoading, wrapResult } from 'lib-common/api'
+import { combine, isLoading } from 'lib-common/api'
 import type FiniteDateRange from 'lib-common/finite-date-range'
 import type { DaycareGroup } from 'lib-common/generated/api-types/daycare'
 import type { Child } from 'lib-common/generated/api-types/reservations'
@@ -13,7 +13,6 @@ import type { DaycareId } from 'lib-common/generated/api-types/shared'
 import type LocalDate from 'lib-common/local-date'
 import { useQueryResult } from 'lib-common/query'
 import type { UUID } from 'lib-common/types'
-import { useApiState } from 'lib-common/utils/useRestApi'
 import { IconOnlyButton } from 'lib-components/atoms/buttons/IconOnlyButton'
 import {
   FixedSpaceColumn,
@@ -26,22 +25,20 @@ import colors from 'lib-customizations/common'
 import { featureFlags } from 'lib-customizations/employee'
 import { faChevronDown, faChevronUp } from 'lib-icons'
 
-import { getRealtimeStaffAttendances } from '../../../generated/api-clients/attendance'
 import { useTranslation } from '../../../state/i18n'
 import { AbsenceLegend } from '../../absences/AbsenceLegend'
 import { renderResult } from '../../async-rendering'
 import type { AttendanceGroupFilter } from '../TabCalendar'
-import { unitAttendanceReservationsQuery } from '../queries'
+import {
+  realtimeStaffAttendancesQuery,
+  unitAttendanceReservationsQuery
+} from '../queries'
 
 import type { ChildDateEditorTarget } from './ChildDateModal'
 import ChildDateModal from './ChildDateModal'
 import ChildReservationsTable from './ChildReservationsTable'
 import ReservationModalSingleChild from './ReservationModalSingleChild'
 import StaffAttendanceTable from './StaffAttendanceTable'
-
-const getRealtimeStaffAttendancesResult = wrapResult(
-  getRealtimeStaffAttendances
-)
 
 const Time = styled.span`
   font-weight: ${fontWeights.normal};
@@ -89,14 +86,12 @@ export default React.memo(function UnitAttendanceReservationsView({
     })
   )
 
-  const [staffAttendances, reloadStaffAttendances] = useApiState(
-    () =>
-      getRealtimeStaffAttendancesResult({
-        unitId,
-        start: weekRange.start,
-        end: weekRange.end
-      }),
-    [unitId, weekRange]
+  const staffAttendances = useQueryResult(
+    realtimeStaffAttendancesQuery({
+      unitId,
+      start: weekRange.start,
+      end: weekRange.end
+    })
   )
 
   const [creatingReservationChild, setCreatingReservationChild] =
@@ -159,7 +154,6 @@ export default React.memo(function UnitAttendanceReservationsView({
             operationalDays={childData.days}
             staffAttendances={staffData.staff}
             externalAttendances={staffData.extraAttendances}
-            reloadStaffAttendances={reloadStaffAttendances}
             groups={groups}
             groupFilter={null}
             defaultGroup={null}
@@ -222,7 +216,6 @@ export default React.memo(function UnitAttendanceReservationsView({
                 operationalDays={childData.days}
                 staffAttendances={staffData.staff}
                 externalAttendances={staffData.extraAttendances}
-                reloadStaffAttendances={reloadStaffAttendances}
                 groups={groups}
                 groupFilter={groupFilter}
                 defaultGroup={selectedGroup.id}


### PR DESCRIPTION
Muutetaan yksiköt käyttämään React queryä, niin että toiminnallisuus pysyy identtisenä aiempaan.

Testattavia tilanteita:
- Kalenteritapahtuman lisääminen, muokkaaminen ja poistaminen toimii oikein
- Keskusteluaikojen lisääminen, muokkaaminen ja poistaminen toimii oikein
- Keskusteluaikojen poistaminen näyttää virheen oikein
- Lapsen muistiinpanojen lisääminen, muokkaaminen ja poistaminen toimii oikein
- Mobiililaitteen lisääminen toimii oikein
- Ulkoisen työntekijän läsnäolon lisääminen ja poistaminen toimii oikein
- Yksikön läsnäolotiedot latautuvat oikein