### PR TITLE
Tekninen: wrapResult vaihtaminen React queryyn mobiilissa

### DIFF
--- a/frontend/src/employee-mobile-frontend/child-attendance/queries.ts
+++ b/frontend/src/employee-mobile-frontend/child-attendance/queries.ts
@@ -8,8 +8,10 @@ import { Queries } from 'lib-common/query'
 import { futureAbsencesOfChild } from '../generated/api-clients/absence'
 import {
   cancelFullDayAbsence,
+  deleteAbsenceRange,
   getAttendanceStatuses,
   getExpectedAbsencesOnDepartures,
+  postAbsenceRange,
   postArrivals,
   postDepartures,
   postFullDayAbsence,
@@ -94,3 +96,11 @@ export const uploadChildImageMutation = q.parametricMutation<{
 export const deleteChildImageMutation = q.parametricMutation<{
   unitId: DaycareId
 }>()(deleteImage, [({ unitId }) => childrenQuery(unitId)])
+
+export const postAbsenceRangeMutation = q.mutation(postAbsenceRange, [
+  ({ childId }) => getFutureAbsencesByChildQuery({ childId })
+])
+
+export const deleteAbsenceRangeMutation = q.mutation(deleteAbsenceRange, [
+  ({ childId }) => getFutureAbsencesByChildQuery({ childId })
+])

--- a/frontend/src/employee-mobile-frontend/pairing/queries.ts
+++ b/frontend/src/employee-mobile-frontend/pairing/queries.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Queries } from 'lib-common/query'
+
+import {
+  getPairingStatus,
+  postPairingChallenge
+} from '../generated/api-clients/pairing'
+
+const q = new Queries()
+
+export const postPairingChallengeMutation = q.mutation(postPairingChallenge)
+export const getPairingStatusMutation = q.mutation(getPairingStatus)


### PR DESCRIPTION
Muutetaan mobiili käyttämään React queryä, niin että toiminnallisuus pysyy identtisenä aiempaan.

Testattavia tilanteita:
- Henkilökohtaisen mobiililaitteen lisääminen toimii oikein
- Lapsen tulevien poissaolojen lisääminen toimii oikein