### PR TITLE
Korjataan tuloselvityksen muistutussähköpostit

### DIFF
--- a/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/invoicing/service/IncomeQueries.kt
@@ -85,7 +85,7 @@ FROM expiring_income_with_billable_placement_day_after_expiration expiring_incom
 WHERE NOT EXISTS (
     SELECT 1 FROM income_statement
     WHERE person_id = expiring_income.person_id
-        AND status = 'SENT'::income_statement_status
+        AND (status = 'SENT'::income_statement_status OR status = 'HANDLING'::income_statement_status)
         AND sent_at > ${bind(today)} - INTERVAL '12 months'
         AND (end_date IS NULL OR ${bind(dayAfterExpiration)} <= end_date)
     
@@ -178,7 +178,7 @@ SELECT DISTINCT person_id FROM (
 WHERE NOT EXISTS (
     SELECT 1 FROM income_statement
     WHERE person_id = parent.person_id
-      AND status = 'SENT'::income_statement_status
+      AND (status = 'SENT'::income_statement_status OR status = 'HANDLING'::income_statement_status)
       AND sent_at > ${bind(today)} - INTERVAL '12 months'
 )
 """


### PR DESCRIPTION
Korjataan muistutussähköpostit, niin että sähköpostia ei lähetetä jos kuntalaisella on tuloselvitys käsittelyssä-tilassa