### PR TITLE
Tekninen: wrapResult vaihtaminen React queryyn taloudessa

### DIFF
--- a/frontend/src/employee-frontend/components/fee-decision-details/Actions.tsx
+++ b/frontend/src/employee-frontend/components/fee-decision-details/Actions.tsx
@@ -4,31 +4,27 @@
 
 import React, { useCallback } from 'react'
 
-import { wrapResult } from 'lib-common/api'
 import type {
   FeeDecisionDetailed,
   FeeDecisionType
 } from 'lib-common/generated/api-types/invoicing'
+import { useMutationResult } from 'lib-common/query'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { featureFlags } from 'lib-customizations/employee'
 
-import {
-  confirmFeeDecisionDrafts,
-  setFeeDecisionSent,
-  setFeeDecisionType
-} from '../../generated/api-clients/invoicing'
 import { useTranslation } from '../../state/i18n'
 
-const confirmFeeDecisionDraftsResult = wrapResult(confirmFeeDecisionDrafts)
-const setFeeDecisionSentResult = wrapResult(setFeeDecisionSent)
-const setFeeDecisionTypeResult = wrapResult(setFeeDecisionType)
+import {
+  confirmFeeDecisionDraftsMutation,
+  setFeeDecisionSentMutation,
+  setFeeDecisionTypeMutation
+} from './queries'
 
 interface Props {
   decision: FeeDecisionDetailed
   goToDecisions: () => void
-  loadDecision: () => Promise<void>
   modified: boolean
   setModified: (value: boolean) => void
   newDecisionType: FeeDecisionType
@@ -38,28 +34,36 @@ interface Props {
 const Actions = React.memo(function Actions({
   decision,
   goToDecisions,
-  loadDecision,
   modified,
   setModified,
   newDecisionType,
   onHandlerSelectModal
 }: Props) {
   const { i18n } = useTranslation()
+  const { mutateAsync: setFeeDecisionType } = useMutationResult(
+    setFeeDecisionTypeMutation
+  )
+  const { mutateAsync: confirmFeeDecisionDrafts } = useMutationResult(
+    confirmFeeDecisionDraftsMutation
+  )
+  const { mutateAsync: setFeeDecisionSent } = useMutationResult(
+    setFeeDecisionSentMutation
+  )
   const updateType = useCallback(
     () =>
-      setFeeDecisionTypeResult({
+      setFeeDecisionType({
         id: decision.id,
         body: { type: newDecisionType }
       }),
-    [decision.id, newDecisionType]
+    [decision.id, newDecisionType, setFeeDecisionType]
   )
   const confirmDecision = useCallback(
-    () => confirmFeeDecisionDraftsResult({ body: [decision.id] }),
-    [decision.id]
+    () => confirmFeeDecisionDrafts({ body: [decision.id] }),
+    [decision.id, confirmFeeDecisionDrafts]
   )
   const markSent = useCallback(
-    () => setFeeDecisionSentResult({ body: [decision.id] }),
-    [decision.id]
+    () => setFeeDecisionSent({ body: [decision.id] }),
+    [decision.id, setFeeDecisionSent]
   )
 
   const isDraft = decision.status === 'DRAFT'
@@ -80,7 +84,7 @@ const Actions = React.memo(function Actions({
             textInProgress={i18n.common.saving}
             textDone={i18n.common.saved}
             onClick={updateType}
-            onSuccess={() => loadDecision().then(() => setModified(false))}
+            onSuccess={() => setModified(false)}
             disabled={!modified}
             data-qa="decision-actions-save"
           />
@@ -97,7 +101,7 @@ const Actions = React.memo(function Actions({
               primary
               text={i18n.feeDecisions.buttons.createDecision(1)}
               onClick={confirmDecision}
-              onSuccess={loadDecision}
+              onSuccess={() => undefined}
               disabled={modified}
               data-qa="decision-actions-confirm-decision"
             />
@@ -109,7 +113,7 @@ const Actions = React.memo(function Actions({
           primary
           text={i18n.feeDecisions.buttons.markSent}
           onClick={markSent}
-          onSuccess={loadDecision}
+          onSuccess={() => undefined}
           data-qa="decision-actions-mark-sent"
         />
       ) : null}

--- a/frontend/src/employee-frontend/components/fee-decision-details/FeeDecisionDetailsPage.tsx
+++ b/frontend/src/employee-frontend/components/fee-decision-details/FeeDecisionDetailsPage.tsx
@@ -5,15 +5,10 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Redirect } from 'wouter'
 
-import type { Result } from 'lib-common/api'
-import { Loading, wrapResult } from 'lib-common/api'
-import type {
-  FeeDecisionResponse,
-  FeeDecisionType
-} from 'lib-common/generated/api-types/invoicing'
+import type { FeeDecisionType } from 'lib-common/generated/api-types/invoicing'
 import type { FeeDecisionId } from 'lib-common/generated/api-types/shared'
 import { formatPersonName } from 'lib-common/names'
-import { useQueryResult } from 'lib-common/query'
+import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
@@ -21,10 +16,6 @@ import InfoModal from 'lib-components/molecules/modals/InfoModal'
 import { Gap } from 'lib-components/white-space'
 import { faQuestion } from 'lib-icons'
 
-import {
-  confirmFeeDecisionDrafts,
-  getFeeDecision
-} from '../../generated/api-clients/invoicing'
 import { useTranslation } from '../../state/i18n'
 import { useTitle } from '../../utils/useTitle'
 import MetadataSection from '../archive-metadata/MetadataSection'
@@ -36,9 +27,7 @@ import Actions from './Actions'
 import ChildSection from './ChildSection'
 import Heading from './Heading'
 import Summary from './Summary'
-
-const confirmFeeDecisionDraftsResult = wrapResult(confirmFeeDecisionDrafts)
-const getFeeDecisionResult = wrapResult(getFeeDecision)
+import { confirmFeeDecisionDraftsMutation, feeDecisionQuery } from './queries'
 
 const FeeDecisionMetadataSection = React.memo(
   function FeeDecisionMetadataSection({
@@ -55,19 +44,14 @@ export default React.memo(function FeeDecisionDetailsPage() {
   const [showHandlerSelectModal, setShowHandlerSelectModal] = useState(false)
   const id = useIdRouteParam<FeeDecisionId>('id')
   const { i18n } = useTranslation()
-  const [decisionResponse, setDecisionResponse] = useState<
-    Result<FeeDecisionResponse>
-  >(Loading.of())
+  const decisionResponse = useQueryResult(feeDecisionQuery({ id }))
+  const { mutateAsync: confirmFeeDecisionDrafts } = useMutationResult(
+    confirmFeeDecisionDraftsMutation
+  )
   const [modified, setModified] = useState<boolean>(false)
   const [newDecisionType, setNewDecisionType] =
     useState<FeeDecisionType>('NORMAL')
   const [confirmingBack, setConfirmingBack] = useState<boolean>(false)
-
-  const loadDecision = useCallback(
-    () => getFeeDecisionResult({ id }).then(setDecisionResponse),
-    [id]
-  )
-  useEffect(() => void loadDecision(), [id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (decisionResponse.isSuccess) {
@@ -115,12 +99,11 @@ export default React.memo(function FeeDecisionDetailsPage() {
               {showHandlerSelectModal && (
                 <FinanceDecisionHandlerSelectModal
                   onResolve={async (decisionHandlerId) => {
-                    const result = await confirmFeeDecisionDraftsResult({
+                    const result = await confirmFeeDecisionDrafts({
                       decisionHandlerId,
                       body: [decision.id]
                     })
                     if (result.isSuccess) {
-                      await loadDecision()
                       setShowHandlerSelectModal(false)
                     }
                     return result
@@ -155,7 +138,6 @@ export default React.memo(function FeeDecisionDetailsPage() {
                 <Actions
                   decision={decision}
                   goToDecisions={goBack}
-                  loadDecision={loadDecision}
                   modified={modified}
                   setModified={setModified}
                   newDecisionType={newDecisionType}

--- a/frontend/src/employee-frontend/components/fee-decision-details/queries.ts
+++ b/frontend/src/employee-frontend/components/fee-decision-details/queries.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Queries } from 'lib-common/query'
+
+import {
+  confirmFeeDecisionDrafts,
+  getFeeDecision,
+  setFeeDecisionSent,
+  setFeeDecisionType
+} from '../../generated/api-clients/invoicing'
+
+const q = new Queries()
+
+export const feeDecisionQuery = q.query(getFeeDecision)
+
+export const setFeeDecisionTypeMutation = q.mutation(setFeeDecisionType, [
+  feeDecisionQuery.prefix
+])
+
+export const confirmFeeDecisionDraftsMutation = q.mutation(
+  confirmFeeDecisionDrafts,
+  [feeDecisionQuery.prefix]
+)
+
+export const setFeeDecisionSentMutation = q.mutation(setFeeDecisionSent, [
+  feeDecisionQuery.prefix
+])

--- a/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsEditor.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeeThresholdsEditor.tsx
@@ -6,13 +6,13 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import type { Failure, Result } from 'lib-common/api'
-import { wrapResult } from 'lib-common/api'
 import DateRange from 'lib-common/date-range'
 import { throwIfNull } from 'lib-common/form-validation'
 import type { FeeThresholds } from 'lib-common/generated/api-types/invoicing'
 import type { FeeThresholdsId } from 'lib-common/generated/api-types/shared'
 import LocalDate from 'lib-common/local-date'
 import { isValidCents, parseCents, parseCentsOrThrow } from 'lib-common/money'
+import { useMutationResult } from 'lib-common/query'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import InputField from 'lib-components/atoms/form/InputField'
@@ -29,10 +29,6 @@ import { defaultMargins } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { faQuestion } from 'lib-icons'
 
-import {
-  createFeeThresholds,
-  updateFeeThresholds
-} from '../../generated/api-clients/invoicing'
 import type { Translations } from '../../state/i18n'
 import type {
   FamilySize,
@@ -41,9 +37,10 @@ import type {
 import { familySizes } from '../../types/finance-basics'
 
 import type { FormState } from './FeesSection'
-
-const createFeeThresholdsResult = wrapResult(createFeeThresholds)
-const updateFeeThresholdsResult = wrapResult(updateFeeThresholds)
+import {
+  createFeeThresholdsMutation,
+  updateFeeThresholdsMutation
+} from './queries'
 
 interface FeeThresholdsWithId {
   id: string
@@ -55,16 +52,20 @@ export default React.memo(function FeeThresholdsEditor({
   id,
   initialState,
   close,
-  reloadData,
   existingThresholds
 }: {
   i18n: Translations
   id: FeeThresholdsId | undefined
   initialState: FormState
   close: () => void
-  reloadData: () => void
   existingThresholds: Result<FeeThresholdsWithId[]>
 }) {
+  const { mutateAsync: createFeeThresholds } = useMutationResult(
+    createFeeThresholdsMutation
+  )
+  const { mutateAsync: updateFeeThresholds } = useMutationResult(
+    updateFeeThresholdsMutation
+  )
   const [editorState, setEditorState] = useState<FormState>(initialState)
   const validationResult = validateForm(
     i18n,
@@ -436,16 +437,13 @@ export default React.memo(function FeeThresholdsEditor({
             }
 
             return id === undefined
-              ? createFeeThresholdsResult({ body: validationResult.payload })
-              : updateFeeThresholdsResult({
+              ? createFeeThresholds({ body: validationResult.payload })
+              : updateFeeThresholds({
                   id,
                   body: validationResult.payload
                 })
           }}
-          onSuccess={() => {
-            close()
-            reloadData()
-          }}
+          onSuccess={close}
           onFailure={handleSaveErrors}
           disabled={'errors' in validationResult}
           data-qa="save"
@@ -469,13 +467,12 @@ export default React.memo(function FeeThresholdsEditor({
                 return
               }
               await (id === undefined
-                ? createFeeThresholdsResult({ body: validationResult.payload })
-                : updateFeeThresholdsResult({
+                ? createFeeThresholds({ body: validationResult.payload })
+                : updateFeeThresholds({
                     id,
                     body: validationResult.payload
                   }))
               close()
-              reloadData()
             },
             label: i18n.financeBasics.fees.modals.saveRetroactive.resolve
           }}

--- a/frontend/src/employee-frontend/components/finance-basics/FeesSection.tsx
+++ b/frontend/src/employee-frontend/components/finance-basics/FeesSection.tsx
@@ -4,23 +4,21 @@
 
 import React, { useCallback, useMemo, useState } from 'react'
 
-import { isLoading, wrapResult } from 'lib-common/api'
+import { isLoading } from 'lib-common/api'
 import type { FeeThresholds } from 'lib-common/generated/api-types/invoicing'
 import type LocalDate from 'lib-common/local-date'
 import { formatCents } from 'lib-common/money'
-import { useApiState } from 'lib-common/utils/useRestApi'
+import { useQueryResult } from 'lib-common/query'
 import { AddButtonRow } from 'lib-components/atoms/buttons/AddButton'
 import { CollapsibleContentArea } from 'lib-components/layout/Container'
 import { H2 } from 'lib-components/typography'
 
-import { getFeeThresholds } from '../../generated/api-clients/invoicing'
 import { useTranslation } from '../../state/i18n'
 import { renderResult } from '../async-rendering'
 
 import FeeThresholdsEditor from './FeeThresholdsEditor'
 import { FeeThresholdsItem } from './FeeThresholdsItem'
-
-const getFeeThresholdsResult = wrapResult(getFeeThresholds)
+import { feeThresholdsQuery } from './queries'
 
 export default React.memo(function FeesSection() {
   const { i18n } = useTranslation()
@@ -28,7 +26,7 @@ export default React.memo(function FeesSection() {
   const [open, setOpen] = useState(true)
   const toggleOpen = useCallback(() => setOpen((isOpen) => !isOpen), [setOpen])
 
-  const [data, loadData] = useApiState(() => getFeeThresholdsResult(), [])
+  const data = useQueryResult(feeThresholdsQuery())
 
   const [editorState, setEditorState] = useState<EditorState>({})
   const closeEditor = useCallback(() => setEditorState({}), [setEditorState])
@@ -90,7 +88,6 @@ export default React.memo(function FeesSection() {
           id={undefined}
           initialState={editorState.form}
           close={closeEditor}
-          reloadData={loadData}
           existingThresholds={data}
         />
       ) : null}
@@ -104,7 +101,6 @@ export default React.memo(function FeesSection() {
                 id={feeThresholds.id}
                 initialState={editorState.form}
                 close={closeEditor}
-                reloadData={loadData}
                 existingThresholds={data}
               />
             ) : (

--- a/frontend/src/employee-frontend/components/finance-basics/queries.ts
+++ b/frontend/src/employee-frontend/components/finance-basics/queries.ts
@@ -5,8 +5,11 @@
 import { Queries } from 'lib-common/query'
 
 import {
+  createFeeThresholds,
   createVoucherValue,
+  getFeeThresholds,
   getVoucherValues,
+  updateFeeThresholds,
   updateVoucherValue
 } from '../../generated/api-clients/invoicing'
 import { deleteVoucherValue } from '../../generated/api-clients/invoicing'
@@ -25,4 +28,14 @@ export const updateVoucherValueMutation = q.mutation(updateVoucherValue, [
 
 export const deleteVoucherValueMutation = q.mutation(deleteVoucherValue, [
   voucherValuesQuery
+])
+
+export const feeThresholdsQuery = q.query(getFeeThresholds)
+
+export const createFeeThresholdsMutation = q.mutation(createFeeThresholds, [
+  feeThresholdsQuery.prefix
+])
+
+export const updateFeeThresholdsMutation = q.mutation(updateFeeThresholds, [
+  feeThresholdsQuery.prefix
 ])

--- a/frontend/src/employee-frontend/components/finance-decisions/FinanceDecisionHandlerSelectModal.tsx
+++ b/frontend/src/employee-frontend/components/finance-decisions/FinanceDecisionHandlerSelectModal.tsx
@@ -6,23 +6,19 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import type { Result } from 'lib-common/api'
-import { wrapResult } from 'lib-common/api'
 import type { EmployeeId } from 'lib-common/generated/api-types/shared'
 import { formatPersonName } from 'lib-common/names'
+import { useQueryResult } from 'lib-common/query'
 import type { UUID } from 'lib-common/types'
-import { useApiState } from 'lib-common/utils/useRestApi'
 import Select from 'lib-components/atoms/dropdowns/Select'
 import FormModal from 'lib-components/molecules/modals/FormModal'
 import { Label } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { faArrowRight } from 'lib-icons'
 
-import { getSelectableFinanceDecisionHandlers } from '../../generated/api-clients/invoicing'
 import { useTranslation } from '../../state/i18n'
 
-const getSelectableFinanceDecisionHandlersResult = wrapResult(
-  getSelectableFinanceDecisionHandlers
-)
+import { selectableFinanceDecisionHandlersQuery } from './queries'
 
 interface Props {
   onResolve: (
@@ -43,9 +39,8 @@ export default React.memo(function FinanceDecisionHandlerSelectModal(
   const { i18n, lang } = useTranslation()
   const [selectedFinanceDecisionHandler, setFinanceDecisionHandler] =
     useState<EmployeeId>()
-  const [financeDecisionHandlersResult] = useApiState(
-    getSelectableFinanceDecisionHandlersResult,
-    []
+  const financeDecisionHandlersResult = useQueryResult(
+    selectableFinanceDecisionHandlersQuery()
   )
   const [error, setError] = useState<string>()
 

--- a/frontend/src/employee-frontend/components/finance-decisions/queries.ts
+++ b/frontend/src/employee-frontend/components/finance-decisions/queries.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Queries } from 'lib-common/query'
+
+import { getSelectableFinanceDecisionHandlers } from '../../generated/api-clients/invoicing'
+
+const q = new Queries()
+
+export const selectableFinanceDecisionHandlersQuery = q.query(
+  getSelectableFinanceDecisionHandlers
+)

--- a/frontend/src/employee-frontend/components/invoice/AbsencesModal.tsx
+++ b/frontend/src/employee-frontend/components/invoice/AbsencesModal.tsx
@@ -5,7 +5,6 @@
 import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 
-import { wrapResult } from 'lib-common/api'
 import type {
   Absence,
   AbsenceCategory,
@@ -13,7 +12,7 @@ import type {
 } from 'lib-common/generated/api-types/absence'
 import type { ChildId } from 'lib-common/generated/api-types/shared'
 import type LocalDate from 'lib-common/local-date'
-import { useApiState } from 'lib-common/utils/useRestApi'
+import { useQueryResult } from 'lib-common/query'
 import Title from 'lib-components/atoms/Title'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { PersonName } from 'lib-components/molecules/PersonNames'
@@ -22,7 +21,6 @@ import { fontWeights } from 'lib-components/typography'
 import { absenceTypes } from 'lib-customizations/employee'
 import { faAbacus } from 'lib-icons'
 
-import { getAbsencesOfChild } from '../../generated/api-clients/absence'
 import type { Lang, Translations } from '../../state/i18n'
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
@@ -30,7 +28,7 @@ import PeriodPicker from '../absences/PeriodPicker'
 import { renderResult } from '../async-rendering'
 import ColorInfoItem from '../common/ColorInfoItem'
 
-const getAbsencesOfChildResult = wrapResult(getAbsencesOfChild)
+import { absencesOfChildQuery } from './queries'
 
 const Section = styled.section``
 
@@ -72,14 +70,12 @@ export default React.memo(function AbsencesModal({ child, date }: Props) {
   const { i18n, lang } = useTranslation()
   const { clearUiMode } = useContext(UIContext)
   const [selectedDate, setSelectedDate] = useState<LocalDate>(date)
-  const [absences] = useApiState(
-    () =>
-      getAbsencesOfChildResult({
-        childId: child.id,
-        year: selectedDate.getYear(),
-        month: selectedDate.getMonth()
-      }),
-    [child.id, selectedDate]
+  const absences = useQueryResult(
+    absencesOfChildQuery({
+      childId: child.id,
+      year: selectedDate.getYear(),
+      month: selectedDate.getMonth()
+    })
   )
 
   return (

--- a/frontend/src/employee-frontend/components/invoice/queries.ts
+++ b/frontend/src/employee-frontend/components/invoice/queries.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Queries } from 'lib-common/query'
+
+import { getAbsencesOfChild } from '../../generated/api-clients/absence'
+
+const q = new Queries()
+
+export const absencesOfChildQuery = q.query(getAbsencesOfChild)

--- a/frontend/src/employee-frontend/components/voucher-value-decision/VoucherValueDecisionActionBar.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decision/VoucherValueDecisionActionBar.tsx
@@ -4,39 +4,29 @@
 
 import React, { useCallback, useContext } from 'react'
 
-import { wrapResult } from 'lib-common/api'
 import type {
   VoucherValueDecisionDetailed,
   VoucherValueDecisionType
 } from 'lib-common/generated/api-types/invoicing'
+import { useMutationResult } from 'lib-common/query'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { LegacyButton } from 'lib-components/atoms/buttons/LegacyButton'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { featureFlags } from 'lib-customizations/employee'
 
-import {
-  markVoucherValueDecisionSent,
-  sendVoucherValueDecisionDrafts,
-  setVoucherValueDecisionType
-} from '../../generated/api-clients/invoicing'
 import { useTranslation } from '../../state/i18n'
 import { UIContext } from '../../state/ui'
 import StickyActionBar from '../common/StickyActionBar'
 
-const sendVoucherValueDecisionDraftsResult = wrapResult(
-  sendVoucherValueDecisionDrafts
-)
-const setVoucherValueDecisionTypeResult = wrapResult(
-  setVoucherValueDecisionType
-)
-const markVoucherValueDecisionSentResult = wrapResult(
-  markVoucherValueDecisionSent
-)
+import {
+  markVoucherValueDecisionSentMutation,
+  sendVoucherValueDecisionDraftsMutation,
+  setVoucherValueDecisionTypeMutation
+} from './queries'
 
 type Props = {
   decision: VoucherValueDecisionDetailed
   goToDecisions: () => void
-  loadDecision: () => Promise<void>
   modified: boolean
   setModified: (value: boolean) => void
   newDecisionType: VoucherValueDecisionType
@@ -46,7 +36,6 @@ type Props = {
 export default React.memo(function VoucherValueDecisionActionBar({
   decision,
   goToDecisions,
-  loadDecision,
   modified,
   setModified,
   newDecisionType,
@@ -54,21 +43,26 @@ export default React.memo(function VoucherValueDecisionActionBar({
 }: Props) {
   const { i18n } = useTranslation()
   const { setErrorMessage, clearErrorMessage } = useContext(UIContext)
+  const { mutateAsync: setVoucherValueDecisionType } = useMutationResult(
+    setVoucherValueDecisionTypeMutation
+  )
+  const { mutateAsync: sendVoucherValueDecisionDrafts } = useMutationResult(
+    sendVoucherValueDecisionDraftsMutation
+  )
+  const { mutateAsync: markVoucherValueDecisionSent } = useMutationResult(
+    markVoucherValueDecisionSentMutation
+  )
   const updateType = useCallback(
     () =>
-      setVoucherValueDecisionTypeResult({
+      setVoucherValueDecisionType({
         id: decision.id,
         body: { type: newDecisionType }
       }),
-    [decision.id, newDecisionType]
-  )
-  const reloadDecision = useCallback(
-    () => loadDecision().then(() => setModified(false)),
-    [loadDecision, setModified]
+    [decision.id, newDecisionType, setVoucherValueDecisionType]
   )
   const sendDecision = useCallback(
-    () => sendVoucherValueDecisionDraftsResult({ body: [decision.id] }),
-    [decision.id]
+    () => sendVoucherValueDecisionDrafts({ body: [decision.id] }),
+    [decision.id, sendVoucherValueDecisionDrafts]
   )
 
   const isDraft = decision.status === 'DRAFT'
@@ -91,7 +85,7 @@ export default React.memo(function VoucherValueDecisionActionBar({
             onClick={updateType}
             onSuccess={() => {
               clearErrorMessage()
-              void reloadDecision()
+              setModified(false)
             }}
             onFailure={() => {
               setErrorMessage({
@@ -119,10 +113,7 @@ export default React.memo(function VoucherValueDecisionActionBar({
               disabled={modified}
               text={i18n.common.send}
               onClick={sendDecision}
-              onSuccess={() => {
-                clearErrorMessage()
-                void loadDecision()
-              }}
+              onSuccess={clearErrorMessage}
               onFailure={(result) => {
                 setErrorMessage({
                   title: i18n.common.error.unknown,
@@ -146,10 +137,10 @@ export default React.memo(function VoucherValueDecisionActionBar({
             primary
             text={i18n.valueDecisions.buttons.markSent}
             onClick={() =>
-              markVoucherValueDecisionSentResult({ body: [decision.id] })
+              markVoucherValueDecisionSent({ body: [decision.id] })
             }
+            onSuccess={() => undefined}
             disabled={modified}
-            onSuccess={loadDecision}
           />
         </StickyActionBar>
       )}

--- a/frontend/src/employee-frontend/components/voucher-value-decision/VoucherValueDecisionPage.tsx
+++ b/frontend/src/employee-frontend/components/voucher-value-decision/VoucherValueDecisionPage.tsx
@@ -5,24 +5,15 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Redirect } from 'wouter'
 
-import type { Result } from 'lib-common/api'
-import { Loading, wrapResult } from 'lib-common/api'
-import type {
-  VoucherValueDecisionResponse,
-  VoucherValueDecisionType
-} from 'lib-common/generated/api-types/invoicing'
+import type { VoucherValueDecisionType } from 'lib-common/generated/api-types/invoicing'
 import type { VoucherValueDecisionId } from 'lib-common/generated/api-types/shared'
 import { formatPersonName } from 'lib-common/names'
-import { useQueryResult } from 'lib-common/query'
+import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { useIdRouteParam } from 'lib-common/useRouteParams'
 import ReturnButton from 'lib-components/atoms/buttons/ReturnButton'
 import { Container, ContentArea } from 'lib-components/layout/Container'
 import { Gap } from 'lib-components/white-space'
 
-import {
-  getVoucherValueDecision,
-  sendVoucherValueDecisionDrafts
-} from '../../generated/api-clients/invoicing'
 import { useTranslation } from '../../state/i18n'
 import { useTitle } from '../../utils/useTitle'
 import MetadataSection from '../archive-metadata/MetadataSection'
@@ -34,11 +25,10 @@ import VoucherValueDecisionActionBar from './VoucherValueDecisionActionBar'
 import VoucherValueDecisionChildSection from './VoucherValueDecisionChildSection'
 import VoucherValueDecisionHeading from './VoucherValueDecisionHeading'
 import VoucherValueDecisionSummary from './VoucherValueDecisionSummary'
-
-const getVoucherValueDecisionResult = wrapResult(getVoucherValueDecision)
-const sendVoucherValueDecisionDraftsResult = wrapResult(
-  sendVoucherValueDecisionDrafts
-)
+import {
+  sendVoucherValueDecisionDraftsMutation,
+  voucherValueDecisionQuery
+} from './queries'
 
 const VoucherValueDecisionMetadataSection = React.memo(
   function VoucherValueDecisionMetadataSection({
@@ -57,25 +47,20 @@ export default React.memo(function VoucherValueDecisionPage() {
   const [showHandlerSelectModal, setShowHandlerSelectModal] = useState(false)
   const id = useIdRouteParam<VoucherValueDecisionId>('id')
   const { i18n } = useTranslation()
-  const [decisionResponse, setDecisionResponse] = useState<
-    Result<VoucherValueDecisionResponse>
-  >(Loading.of())
+  const decisionResponse = useQueryResult(voucherValueDecisionQuery({ id }))
+  const { mutateAsync: sendVoucherValueDecisionDrafts } = useMutationResult(
+    sendVoucherValueDecisionDraftsMutation
+  )
   const [modified, setModified] = useState<boolean>(false)
   const [newDecisionType, setNewDecisionType] =
     useState<VoucherValueDecisionType>('NORMAL')
-
-  const loadDecision = useCallback(
-    () => getVoucherValueDecisionResult({ id }).then(setDecisionResponse),
-    [id]
-  )
-  useEffect(() => void loadDecision(), [loadDecision])
 
   useEffect(() => {
     if (decisionResponse.isSuccess) {
       const decision = decisionResponse.value.data
       setNewDecisionType(decision.decisionType)
     }
-  }, [decisionResponse, i18n])
+  }, [decisionResponse])
 
   useTitle(
     decisionResponse.map(
@@ -112,12 +97,11 @@ export default React.memo(function VoucherValueDecisionPage() {
             {showHandlerSelectModal && (
               <FinanceDecisionHandlerSelectModal
                 onResolve={async (decisionHandlerId) => {
-                  const result = await sendVoucherValueDecisionDraftsResult({
+                  const result = await sendVoucherValueDecisionDrafts({
                     decisionHandlerId,
                     body: [decision.id]
                   })
                   if (result.isSuccess) {
-                    await loadDecision()
                     setShowHandlerSelectModal(false)
                   }
                   return result
@@ -142,7 +126,6 @@ export default React.memo(function VoucherValueDecisionPage() {
               <VoucherValueDecisionActionBar
                 decision={decision}
                 goToDecisions={goBack}
-                loadDecision={loadDecision}
                 modified={modified}
                 setModified={setModified}
                 newDecisionType={newDecisionType}

--- a/frontend/src/employee-frontend/components/voucher-value-decision/queries.ts
+++ b/frontend/src/employee-frontend/components/voucher-value-decision/queries.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2017-2024 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { Queries } from 'lib-common/query'
+
+import {
+  getVoucherValueDecision,
+  markVoucherValueDecisionSent,
+  sendVoucherValueDecisionDrafts,
+  setVoucherValueDecisionType
+} from '../../generated/api-clients/invoicing'
+
+const q = new Queries()
+
+export const voucherValueDecisionQuery = q.query(getVoucherValueDecision)
+
+export const setVoucherValueDecisionTypeMutation = q.mutation(
+  setVoucherValueDecisionType,
+  [voucherValueDecisionQuery.prefix]
+)
+
+export const sendVoucherValueDecisionDraftsMutation = q.mutation(
+  sendVoucherValueDecisionDrafts,
+  [voucherValueDecisionQuery.prefix]
+)
+
+export const markVoucherValueDecisionSentMutation = q.mutation(
+  markVoucherValueDecisionSent,
+  [voucherValueDecisionQuery.prefix]
+)


### PR DESCRIPTION
Muutetaan talous käyttämään React queryä, niin että toiminnallisuus pysyy identtisenä aiempaan.

Testattavia tilanteita:
- Maksupäätökset toimivat oikein
- Arvopäätökset toimivat oikein
- Asiakasmaksujen muutokset toimivat oikein
- Poissaolokoosteet toimivat oikein