### PR TITLE
Ryhmän luonnissa alkamispäivämäärä tyhjäksi oletuksena

### DIFF
--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/GroupModal.tsx
@@ -19,7 +19,6 @@ import { theme } from 'lib-customizations/common'
 import { featureFlags } from 'lib-customizations/employee'
 import { fasExclamation } from 'lib-icons'
 
-import { EVAKA_START } from '../../../../constants'
 import { useTranslation } from '../../../../state/i18n'
 import { UIContext } from '../../../../state/ui'
 import { errorToInputInfo } from '../../../../utils/validation/input-info-helper'
@@ -54,7 +53,7 @@ export default React.memo(function GroupModal({ unitId }: Props) {
 
   const initialForm: CreateGroupForm = {
     name: '',
-    startDate: EVAKA_START,
+    startDate: null,
     initialCaretakers: 3,
     aromiCustomerId: null
   }


### PR DESCRIPTION
## Ennen tätä muutosta

Kun käyttäjä luo uuden ryhmän, alkamispäivämäärä-kenttään asetetaan oletusarvoksi `2020-03-01` (EVAKA_START). Käyttäjä saattaa hyväksyä oletusarvon miettimättä, mikä oikea päivämäärä olisi.

## Tämän muutoksen jälkeen

Alkamispäivämäärä on tyhjä, mutta edelleen pakollinen. Käyttäjä joutuu tietoisesti valitsemaan oikean päivämäärän ennen kuin lomakkeen voi lähettää.

🤖 Generated with [Claude Code](https://claude.com/claude-code)