### PR TITLE
Logitetaan Suomi.fi / SAML kirjautumisen peruutus info-tasolla

### DIFF
--- a/apigw/src/shared/saml/error-utils.ts
+++ b/apigw/src/shared/saml/error-utils.ts
@@ -56,7 +56,7 @@ function parseErrorMessage(status: StatusObject): string {
 
 export const samlErrorSchema = z.object({
   message: z.string(),
-  statusXml: z.string()
+  xmlStatus: z.string()
 })
 
 export type SamlError = z.infer<typeof samlErrorSchema>
@@ -65,8 +65,8 @@ export function parseDescriptionFromSamlError(
   error: SamlError,
   req: Request
 ): string | undefined {
-  if (!error.statusXml) {
-    logDebug('No statusXml found from SAML error', req, { error })
+  if (!error.xmlStatus) {
+    logDebug('No xmlStatus found from SAML error', req, { error })
     return
   }
 
@@ -75,7 +75,7 @@ export function parseDescriptionFromSamlError(
     parseAttributeValue: true
   })
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const statusObject: StatusObject = parser.parse(error.statusXml)
+  const statusObject: StatusObject = parser.parse(error.xmlStatus)
 
   if (!statusObject) {
     logError(


### PR DESCRIPTION
## Ennen tätä muutosta

apigw:n `samlErrorSchema` (zod) odotti SAML-virheeltä kenttää nimeltä `statusXml`, mutta `@node-saml/node-saml`-kirjaston `SamlStatusError` paljastaa status-XML:n kentässä `xmlStatus`.

Skeema ei siis koskaan vastannut todellisuutta, ja `routes/saml.ts`:n “hiljennetty” haara oli käytännössä kuollutta koodia.

Seurauksena jokainen IDP:n puolella tapahtunut status-epäonnistuminen sisäänkirjautumisessa päätyi oletushaaraan, joka logittaa error-tason rivin sovelluslokiin. Käytännössä tämä tarkoitti, että hälytyskanava laukesi joka kerta, kun käyttäjä perui Suomi.fi-tunnistautumisen IDP:llä — vaikka kyse on täysin normaalista käyttäjän toiminnasta.

Tyyppitarkistus ei huomannut virhettä, koska alkuperäinen paikallinen `PassportSamlError { statusXml?: string }` -rajapinta (passport-saml@1.5.0 -ajalta, jolloin kenttä oikeasti oli `statusXml`) oli rakenteellisesti yhteensopiva uudempien kirjastojen `ErrorWithXmlStatus` / `SamlStatusError` -luokkien kanssa. Optionaalinen kenttä on aina tyyppikelpoinen `undefined`:na.

Nimeämismuutos tapahtui upstreamissa `passport-saml` 1.x → 3.x -päivityksessä jo tammikuussa 2022, ja marraskuun 2024 zod-migraatio kopioi väärän nimen sellaisenaan eteenpäin.

## Tämän muutoksen jälkeen

`samlErrorSchema` (sekä `parseDescriptionFromSamlError`:n sisäinen kenttäviittaus) käyttää oikeaa nimeä `xmlStatus`, joten aiemmin kuollut hiljentävä haara toimii nyt alkuperäisen tarkoituksensa mukaisesti:

- Sisäänkirjautuminen, `SamlStatusError` (esim. käyttäjä perui Suomi.fi-tunnistautumisen)  
  → skeema täsmää  
  → sovelluslokiin ei enää kirjoiteta error-tason riviä  

Audit-lokiin kirjoitetaan edelleen rikastettu kuvaus (primary/secondary status + viesti).