### PR TITLE
Korjataan kuntalaisen kevytkirjautumistunnuksen luominen sähköposteilla joissa on isoja kirjaimia

### DIFF
--- a/apigw/src/enduser/routes/auth-weak-update-credentials.ts
+++ b/apigw/src/enduser/routes/auth-weak-update-credentials.ts
@@ -10,13 +10,7 @@ import type { RedisClient } from '../../shared/redis-client.ts'
 import { citizenWeakLoginCredentialsUpdate } from '../../shared/service-client.ts'
 
 const Request = z.object({
-  username: z
-    .string()
-    .min(1)
-    .max(128)
-    .transform((email) => email.toLowerCase())
-    .nullable(),
-  password: z.string().min(1).max(128).nullable()
+  password: z.string().min(1).max(128)
 })
 
 export const authWeakUpdateCredentials = (redisClient: RedisClient) =>
@@ -31,12 +25,11 @@ export const authWeakUpdateCredentials = (redisClient: RedisClient) =>
         res.sendStatus(401)
         return
       }
-      const { username, password } = Request.parse(req.body)
+      const { password } = Request.parse(req.body)
       const user = req.session.evaka.user
       const userIdHash = req.session.evaka.userIdHash
 
       await citizenWeakLoginCredentialsUpdate(req, user, {
-        username,
         password
       })
       logAuditEvent(

--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -175,8 +175,7 @@ export async function citizenWeakLogin(
 }
 
 interface CitizenWeakLoginCredentialsUpdateRequest {
-  username: string | null
-  password: string | null
+  password: string
 }
 
 export async function citizenWeakLoginCredentialsUpdate(

--- a/frontend/src/citizen-frontend/personal-details/LoginDetailsSection.tsx
+++ b/frontend/src/citizen-frontend/personal-details/LoginDetailsSection.tsx
@@ -281,7 +281,6 @@ const WeakCredentialsFormModal = React.memo(function WeakCredentialsFormModal({
       resolveMutation={updateWeakLoginCredentialsMutation}
       resolveAction={() => ({
         body: {
-          username: hasCredentials ? null : username,
           password: form.value().password
         }
       })}

--- a/frontend/src/e2e-test/generated/api-clients.ts
+++ b/frontend/src/e2e-test/generated/api-clients.ts
@@ -119,7 +119,7 @@ import type { StaffAttendancePlanId } from './api-types'
 import type { StaffAttendanceRealtimeId } from 'lib-common/generated/api-types/shared'
 import type { StaffMemberAttendance } from 'lib-common/generated/api-types/attendance'
 import type { UpdateIncomeStatementHandledBody } from './api-types'
-import type { UpdateWeakLoginCredentialsRequest } from 'lib-common/generated/api-types/pis'
+import type { UpsertWeakCredentialsRequest } from './api-types'
 import type { VoucherValueDecision } from './api-types'
 import { AxiosProgressEvent } from 'axios'
 import { DevApiError } from '../dev-api'
@@ -2317,7 +2317,7 @@ export async function upsertVtjDataset(
 export async function upsertWeakCredentials(
   request: {
     id: PersonId,
-    body: UpdateWeakLoginCredentialsRequest
+    body: UpsertWeakCredentialsRequest
   },
   options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<void> {
@@ -2326,7 +2326,7 @@ export async function upsertWeakCredentials(
       url: uri`/citizen/${request.id}/weak-credentials`.toString(),
       method: 'POST',
       headers: { EvakaMockedTime: options?.mockedTime?.formatIso() },
-      data: request.body satisfies JsonCompatible<UpdateWeakLoginCredentialsRequest>
+      data: request.body satisfies JsonCompatible<UpsertWeakCredentialsRequest>
     })
     return json
   } catch (e) {

--- a/frontend/src/e2e-test/generated/api-types.ts
+++ b/frontend/src/e2e-test/generated/api-types.ts
@@ -1196,6 +1196,14 @@ export interface UpdateIncomeStatementHandledBody {
 }
 
 /**
+* Generated from fi.espoo.evaka.shared.dev.DevApi.UpsertWeakCredentialsRequest
+*/
+export interface UpsertWeakCredentialsRequest {
+  password: string
+  username: string
+}
+
+/**
 * Generated from fi.espoo.evaka.invoicing.domain.VoucherValueDecision
 */
 export interface VoucherValueDecision {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-weak-credentials.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-weak-credentials.spec.ts
@@ -11,6 +11,7 @@ import {
   upsertPasswordBlacklist
 } from '../../generated/api-clients'
 import type { DevPerson } from '../../generated/api-types'
+import CitizenHeader from '../../pages/citizen/citizen-header'
 import CitizenPersonalDetailsPage, {
   WeakCredentialsModal
 } from '../../pages/citizen/citizen-personal-details'
@@ -86,6 +87,45 @@ test.describe('Citizen weak credentials', () => {
     await expect(section.username).toHaveText(email)
   })
 
+  test('a person with a mixed-case email can activate and log in case-insensitively', async ({
+    evaka
+  }) => {
+    const email = 'Test@Example.com'
+    const citizen = await Fixture.person({
+      email,
+      verifiedEmail: email
+    }).saveAdult({
+      updateMockVtjWithDependants: []
+    })
+    const validPassword = 'aifiefaeC3io?dee'
+
+    const personalDetailsPage = await openPersonalDetailsPage(evaka, citizen)
+    const section = personalDetailsPage.loginDetailsSection
+    await section.activateCredentials.click()
+
+    const modal = new WeakCredentialsModal(evaka)
+    await modal.username.assertAttributeEquals('value', email)
+    await modal.password.fill(validPassword)
+    await modal.confirmPassword.fill(validPassword)
+    await modal.ok.click()
+    await modal.ok.click()
+    await expect(section.weakLoginEnabled).toBeVisible()
+
+    await new CitizenHeader(evaka).logout()
+
+    await enduserLoginWeak(evaka, {
+      username: email.toLowerCase(),
+      password: validPassword
+    })
+
+    await new CitizenHeader(evaka).logout()
+
+    await enduserLoginWeak(evaka, {
+      username: email,
+      password: validPassword
+    })
+  })
+
   test('a person with weak credentials can change their password', async ({
     evaka
   }) => {
@@ -159,6 +199,12 @@ test.describe('Citizen weak credentials', () => {
     await expect(personalDetailsPage.loginDetailsSection.username).toHaveText(
       newEmail
     )
+
+    await new CitizenHeader(evaka).logout()
+    await enduserLoginWeak(evaka, {
+      username: newEmail,
+      password: 'aifiefaeC3io?dee'
+    })
   })
 
   test('a person with a different email can change their username - email updated elsewhere', async ({
@@ -192,6 +238,12 @@ test.describe('Citizen weak credentials', () => {
     await expect(personalDetailsPage.loginDetailsSection.username).toHaveText(
       newEmail
     )
+
+    await new CitizenHeader(evaka).logout()
+    await enduserLoginWeak(evaka, {
+      username: newEmail,
+      password: 'aifiefaeC3io?dee'
+    })
   })
 
   test('a new password must be valid and acceptable', async ({ evaka }) => {

--- a/frontend/src/lib-common/generated/api-types/pis.ts
+++ b/frontend/src/lib-common/generated/api-types/pis.ts
@@ -750,8 +750,7 @@ export interface TemporaryEmployee {
 * Generated from fi.espoo.evaka.pis.controllers.PersonalDataControllerCitizen.UpdateWeakLoginCredentialsRequest
 */
 export interface UpdateWeakLoginCredentialsRequest {
-  password: string | null
-  username: string | null
+  password: string
 }
 
 /**

--- a/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/WeakCredentialsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/evaka/pis/controller/WeakCredentialsIntegrationTest.kt
@@ -7,8 +7,11 @@ package fi.espoo.evaka.pis.controller
 import fi.espoo.evaka.FullApplicationTest
 import fi.espoo.evaka.Sensitive
 import fi.espoo.evaka.emailclient.MockEmailClient
+import fi.espoo.evaka.pis.PersonalDataUpdate
 import fi.espoo.evaka.pis.SystemController
+import fi.espoo.evaka.pis.controllers.CONFIRMATION_CODE_LENGTH
 import fi.espoo.evaka.pis.controllers.PersonalDataControllerCitizen
+import fi.espoo.evaka.pis.updatePersonalDetails
 import fi.espoo.evaka.shared.PersonId
 import fi.espoo.evaka.shared.async.AsyncJob
 import fi.espoo.evaka.shared.async.AsyncJobRunner
@@ -18,6 +21,8 @@ import fi.espoo.evaka.shared.dev.DevPerson
 import fi.espoo.evaka.shared.dev.DevPersonType
 import fi.espoo.evaka.shared.dev.insert
 import fi.espoo.evaka.shared.domain.BadRequest
+import fi.espoo.evaka.shared.domain.Conflict
+import fi.espoo.evaka.shared.domain.Forbidden
 import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.espoo.evaka.shared.domain.RealEvakaClock
 import fi.espoo.evaka.vtjclient.service.persondetails.MockPersonDetailsService
@@ -42,13 +47,26 @@ class WeakCredentialsIntegrationTest : FullApplicationTest(resetDbBeforeEach = t
     private val user = person.user(CitizenAuthLevel.STRONG)
 
     @Test
+    fun `a person without a verified email cannot activate weak credentials`() {
+        db.transaction { tx -> tx.insert(person.copy(verifiedEmail = null), DevPersonType.ADULT) }
+        MockPersonDetailsService.addPersons(person)
+
+        citizenStrongLogin()
+        val error =
+            assertThrows<BadRequest> {
+                updateWeakLoginCredentials(password = Sensitive("test123123"))
+            }
+        assertEquals("Verified email is required", error.message)
+    }
+
+    @Test
     fun `a person with a verified email can activate weak credentials and log in`() {
         db.transaction { tx -> tx.insert(person, DevPersonType.ADULT) }
         MockPersonDetailsService.addPersons(person)
 
         citizenStrongLogin()
         val password = Sensitive("test123123")
-        updateWeakLoginCredentials(username = email, password = password)
+        updateWeakLoginCredentials(password = password)
 
         asyncJobRunner.runPendingJobsSync(RealEvakaClock())
         assertEquals(0, MockEmailClient.emails.size)
@@ -58,46 +76,24 @@ class WeakCredentialsIntegrationTest : FullApplicationTest(resetDbBeforeEach = t
     }
 
     @Test
-    fun `a person can update their username to match their new email, and log in with it`() {
-        val newEmail = "new@example.com"
-        val password = Sensitive("test123123")
+    fun `username is derived from verified email and converted to lowercase automatically`() {
+        val mixedCaseEmail = "Verified@Example.Com"
         db.transaction { tx ->
-            tx.insert(person.copy(email = newEmail, verifiedEmail = newEmail), DevPersonType.ADULT)
-            tx.insert(citizenUser(person.id, email, password))
+            tx.insert(
+                person.copy(email = mixedCaseEmail, verifiedEmail = mixedCaseEmail),
+                DevPersonType.ADULT,
+            )
         }
         MockPersonDetailsService.addPersons(person)
 
-        updateWeakLoginCredentials(username = newEmail, password = null)
+        citizenStrongLogin()
+        val password = Sensitive("test123123")
+        updateWeakLoginCredentials(password = password)
 
         asyncJobRunner.runPendingJobsSync(RealEvakaClock())
         assertEquals(0, MockEmailClient.emails.size)
 
-        val identity = citizenWeakLogin(username = newEmail, password = password)
-        assertEquals(person.id, identity.id)
-    }
-
-    @Test
-    fun `username is converted to lowercase automatically`() {
-        val newEmail = "nEW@eXample.Com"
-        val password = Sensitive("test123123")
-        db.transaction { tx ->
-            tx.insert(person.copy(email = newEmail, verifiedEmail = newEmail), DevPersonType.ADULT)
-            tx.insert(citizenUser(person.id, email, password))
-        }
-        MockPersonDetailsService.addPersons(person)
-
-        updateWeakLoginCredentials(username = newEmail, password = null)
-
-        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
-        assertEquals(0, MockEmailClient.emails.size)
-
-        // In a real environment apigw converts the username to lowercase when logging in.
-        // This conversion must be in the apigw so the login rate limit is applied correctly to the
-        // lowercase username, and it can't be bypassed by just changing some letter(s) to
-        // uppercase. The service API endpoint expects a lowercase username, so in this test we have
-        // to convert it manually
-        val actualUsername = newEmail.lowercase()
-        val identity = citizenWeakLogin(username = actualUsername, password = password)
+        val identity = citizenWeakLogin(username = mixedCaseEmail.lowercase(), password = password)
         assertEquals(person.id, identity.id)
     }
 
@@ -111,7 +107,7 @@ class WeakCredentialsIntegrationTest : FullApplicationTest(resetDbBeforeEach = t
         MockPersonDetailsService.addPersons(person)
 
         val newPassword = Sensitive("test256256")
-        updateWeakLoginCredentials(username = null, password = newPassword)
+        updateWeakLoginCredentials(password = newPassword)
 
         asyncJobRunner.runPendingJobsSync(RealEvakaClock())
         assertEquals(1, MockEmailClient.emails.size)
@@ -131,10 +127,7 @@ class WeakCredentialsIntegrationTest : FullApplicationTest(resetDbBeforeEach = t
 
         citizenStrongLogin()
         val password = Sensitive("nope")
-        val error =
-            assertThrows<BadRequest> {
-                updateWeakLoginCredentials(username = email, password = password)
-            }
+        val error = assertThrows<BadRequest> { updateWeakLoginCredentials(password = password) }
         assertEquals("PASSWORD_FORMAT", error.errorCode)
 
         asyncJobRunner.runPendingJobsSync(RealEvakaClock())
@@ -154,10 +147,7 @@ class WeakCredentialsIntegrationTest : FullApplicationTest(resetDbBeforeEach = t
         MockPersonDetailsService.addPersons(person)
 
         citizenStrongLogin()
-        val error =
-            assertThrows<BadRequest> {
-                updateWeakLoginCredentials(username = email, password = password)
-            }
+        val error = assertThrows<BadRequest> { updateWeakLoginCredentials(password = password) }
         assertEquals("PASSWORD_UNACCEPTABLE", error.errorCode)
 
         asyncJobRunner.runPendingJobsSync(RealEvakaClock())
@@ -241,12 +231,104 @@ class WeakCredentialsIntegrationTest : FullApplicationTest(resetDbBeforeEach = t
         assertEquals(0, MockEmailClient.emails.size)
     }
 
-    private fun updateWeakLoginCredentials(username: String?, password: Sensitive<String>?) =
+    @Test
+    fun `username is synced when a person with weak credentials verifies a new email`() {
+        val password = Sensitive("test123123")
+        db.transaction { tx ->
+            tx.insert(person, DevPersonType.ADULT)
+            tx.insert(citizenUser(person.id, email, password))
+        }
+        MockPersonDetailsService.addPersons(person)
+
+        val newEmail = "newemail@example.com"
+        db.transaction { tx ->
+            tx.updatePersonalDetails(
+                person.id,
+                PersonalDataUpdate(
+                    preferredName = person.firstName,
+                    phone = person.phone,
+                    backupPhone = person.backupPhone,
+                    email = newEmail,
+                ),
+            )
+        }
+        sendEmailVerificationCode()
+        val verificationCode = getVerificationCodeFromEmail(newEmail)
+        val verification = getEmailVerificationStatus().latestVerification!!
+        verifyEmail(
+            PersonalDataControllerCitizen.EmailVerificationRequest(
+                verification.id,
+                verificationCode,
+            )
+        )
+
+        val identity = citizenWeakLogin(username = newEmail, password = password)
+        assertEquals(person.id, identity.id)
+
+        assertThrows<Forbidden> { citizenWeakLogin(username = email, password = password) }
+    }
+
+    @Test
+    fun `email verification fails with a conflict if the new email is already another person's weak login username`() {
+        val password = Sensitive("test123123")
+        val otherPassword = Sensitive("test12341234")
+        val otherPersonEmail = "other@example.com"
+        val otherPerson =
+            DevPerson(
+                email = otherPersonEmail,
+                verifiedEmail = otherPersonEmail,
+                firstName = "Other",
+                lastName = "Person",
+            )
+        val otherUser = otherPerson.user(CitizenAuthLevel.STRONG)
+
+        db.transaction { tx ->
+            tx.insert(person, DevPersonType.ADULT)
+            tx.insert(citizenUser(person.id, email, password))
+
+            tx.insert(otherPerson, DevPersonType.ADULT)
+            tx.insert(citizenUser(otherPerson.id, otherPersonEmail, otherPassword))
+
+            tx.updatePersonalDetails(
+                otherPerson.id,
+                PersonalDataUpdate(
+                    preferredName = otherPerson.firstName,
+                    phone = otherPerson.phone,
+                    backupPhone = otherPerson.backupPhone,
+                    email = email,
+                ),
+            )
+        }
+        MockPersonDetailsService.addPersons(person)
+
+        sendEmailVerificationCode(otherUser)
+        val verificationCode = getVerificationCodeFromEmail(email)
+        val verification = getEmailVerificationStatus(otherUser).latestVerification!!
+
+        assertThrows<Conflict> {
+            verifyEmail(
+                PersonalDataControllerCitizen.EmailVerificationRequest(
+                    verification.id,
+                    verificationCode,
+                ),
+                otherUser,
+            )
+        }
+
+        val aIdentity = citizenWeakLogin(username = email, password = password)
+        assertEquals(person.id, aIdentity.id)
+
+        assertThrows<Forbidden> { citizenWeakLogin(username = email, password = otherPassword) }
+        val bIdentity = citizenWeakLogin(username = otherPersonEmail, password = otherPassword)
+        assertEquals(otherPerson.id, bIdentity.id)
+    }
+
+    private fun updateWeakLoginCredentials(password: Sensitive<String>) =
         controller.updateWeakLoginCredentials(
             dbInstance(),
             user,
             clock,
-            PersonalDataControllerCitizen.UpdateWeakLoginCredentialsRequest(username, password),
+            PersonalDataControllerCitizen.UpdateWeakLoginCredentialsRequest(password),
         )
 
     private fun citizenStrongLogin() =
@@ -285,4 +367,22 @@ class WeakCredentialsIntegrationTest : FullApplicationTest(resetDbBeforeEach = t
             password = passwordService.encode(password),
             passwordUpdatedAt = clock.now(),
         )
+
+    private fun sendEmailVerificationCode(citizen: AuthenticatedUser.Citizen = user) {
+        controller.sendEmailVerificationCode(dbInstance(), citizen, clock)
+        asyncJobRunner.runPendingJobsSync(clock)
+    }
+
+    private fun getEmailVerificationStatus(citizen: AuthenticatedUser.Citizen = user) =
+        controller.getEmailVerificationStatus(dbInstance(), citizen, clock)
+
+    private fun getVerificationCodeFromEmail(emailAddress: String): String =
+        MockEmailClient.getEmail(emailAddress)?.let { email ->
+            Regex("[0-9]{$CONFIRMATION_CODE_LENGTH}").find(email.content.text)?.value
+        } ?: error("No verification code found for $emailAddress")
+
+    private fun verifyEmail(
+        request: PersonalDataControllerCitizen.EmailVerificationRequest,
+        citizen: AuthenticatedUser.Citizen = user,
+    ) = controller.verifyEmail(dbInstance(), citizen, clock, request)
 }

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/EmailVerificationQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/EmailVerificationQueries.kt
@@ -62,6 +62,7 @@ RETURNING id, email, expires_at, sent_at
  * - if the code is wrong or verification has expired, BadRequest is thrown
  * - if everything is ok, the e-mail address of the person is updated and the verification is
  *   consumed
+ * - the weak-login username is also synced to the new verified e-mail, if weak credentials exist
  */
 fun Database.Transaction.verifyAndUpdateEmail(
     now: HelsinkiDateTime,
@@ -93,13 +94,14 @@ WHERE id = ${bind(personId)}
 """
         )
     }
+    syncWeakLoginUsername(now, personId)
 }
 
 /**
  * Updates a person's weak login username to be the same as their verified e-mail address, if it has
  * been set.
  */
-fun Database.Transaction.syncWeakLoginUsername(now: HelsinkiDateTime, personId: PersonId) {
+private fun Database.Transaction.syncWeakLoginUsername(now: HelsinkiDateTime, personId: PersonId) {
     execute {
         sql(
             """

--- a/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/pis/controllers/PersonalDataControllerCitizen.kt
@@ -145,14 +145,9 @@ class PersonalDataControllerCitizen(
         Audit.PersonalDataUpdate.log(targetId = AuditId(user.id))
     }
 
-    data class UpdateWeakLoginCredentialsRequest(
-        val username: String?,
-        val password: Sensitive<String>?,
-    ) {
+    data class UpdateWeakLoginCredentialsRequest(val password: Sensitive<String>) {
         init {
-            if (
-                password != null && password.value.length !in PasswordConstraints.SUPPORTED_LENGTH
-            ) {
+            if (password.value.length !in PasswordConstraints.SUPPORTED_LENGTH) {
                 throw BadRequest("Invalid password")
             }
         }
@@ -166,17 +161,13 @@ class PersonalDataControllerCitizen(
         @RequestBody body: UpdateWeakLoginCredentialsRequest,
     ) {
         Audit.CitizenCredentialsUpdateAttempt.log(targetId = AuditId(user.id))
-        if (body.password != null) {
-            if (!passwordSpecification.constraints().isPasswordStructureValid(body.password)) {
-                throw BadRequest("Password is not structurally valid", "PASSWORD_FORMAT")
-            }
+        if (!passwordSpecification.constraints().isPasswordStructureValid(body.password)) {
+            throw BadRequest("Password is not structurally valid", "PASSWORD_FORMAT")
         }
-        val password = body.password?.let { passwordService.encode(it) }
+        val password = passwordService.encode(body.password)
         db.connect { dbc ->
-            if (body.password != null) {
-                if (!passwordSpecification.isPasswordAcceptable(dbc, body.password)) {
-                    throw BadRequest("Password is not acceptable", "PASSWORD_UNACCEPTABLE")
-                }
+            if (!passwordSpecification.isPasswordAcceptable(dbc, body.password)) {
+                throw BadRequest("Password is not acceptable", "PASSWORD_UNACCEPTABLE")
             }
             dbc.transaction { tx ->
                 accessControl.requirePermissionFor(
@@ -186,18 +177,15 @@ class PersonalDataControllerCitizen(
                     Action.Citizen.Person.UPDATE_WEAK_LOGIN_CREDENTIALS,
                     user.id,
                 )
-                val emails = tx.getPersonEmails(user.id)
-                if (body.username != null && emails.verifiedEmail != body.username) {
-                    throw BadRequest("Invalid username")
-                }
+                val isActivation = !tx.hasWeakCredentials(user.id)
+                val username =
+                    if (isActivation) {
+                        tx.getPersonEmails(user.id).verifiedEmail
+                            ?: throw BadRequest("Verified email is required")
+                    } else null
                 try {
                     val updateResult =
-                        tx.updateWeakLoginCredentials(
-                            clock.now(),
-                            user.id,
-                            body.username?.lowercase(),
-                            password,
-                        )
+                        tx.updateWeakLoginCredentials(clock.now(), user.id, username, password)
                     if (updateResult.passwordChanged) {
                         asyncJobRunner.plan(
                             tx,
@@ -285,9 +273,8 @@ class PersonalDataControllerCitizen(
                     Action.Citizen.Person.VERIFY_EMAIL,
                     user.id,
                 )
-                tx.verifyAndUpdateEmail(clock.now(), user.id, request.id, request.code)
                 try {
-                    tx.syncWeakLoginUsername(clock.now(), user.id)
+                    tx.verifyAndUpdateEmail(clock.now(), user.id, request.id, request.code)
                 } catch (e: Exception) {
                     throw mapPSQLException(e)
                 }

--- a/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/shared/dev/DevApi.kt
@@ -7,6 +7,7 @@ package fi.espoo.evaka.shared.dev
 import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.espoo.evaka.EvakaEnv
 import fi.espoo.evaka.ExcludeCodeGen
+import fi.espoo.evaka.Sensitive
 import fi.espoo.evaka.absence.AbsenceCategory
 import fi.espoo.evaka.absence.AbsenceType
 import fi.espoo.evaka.absence.getAbsencesOfChildByDate
@@ -125,7 +126,6 @@ import fi.espoo.evaka.pairing.initPairing
 import fi.espoo.evaka.pairing.respondPairingChallengeCreateDevice
 import fi.espoo.evaka.pis.EmailMessageType
 import fi.espoo.evaka.pis.Employee
-import fi.espoo.evaka.pis.controllers.PersonalDataControllerCitizen
 import fi.espoo.evaka.pis.getEmployees
 import fi.espoo.evaka.pis.service.PersonDTO
 import fi.espoo.evaka.pis.service.PersonService
@@ -1670,14 +1670,16 @@ UPDATE person SET email=${bind(body.email)} WHERE id=${bind(body.personId)}
         }
     }
 
+    data class UpsertWeakCredentialsRequest(val username: String, val password: Sensitive<String>)
+
     @PostMapping("/citizen/{id}/weak-credentials")
     fun upsertWeakCredentials(
         db: Database,
         clock: EvakaClock,
         @PathVariable id: PersonId,
-        @RequestBody request: PersonalDataControllerCitizen.UpdateWeakLoginCredentialsRequest,
+        @RequestBody request: UpsertWeakCredentialsRequest,
     ) {
-        val password = request.password?.let { passwordService.encode(it) }
+        val password = passwordService.encode(request.password)
         db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.updateLastStrongLogin(clock.now(), id)

--- a/service/src/main/kotlin/fi/espoo/evaka/user/CitizenUserQueries.kt
+++ b/service/src/main/kotlin/fi/espoo/evaka/user/CitizenUserQueries.kt
@@ -72,9 +72,10 @@ fun Database.Transaction.updateWeakLoginCredentials(
     now: HelsinkiDateTime,
     id: PersonId,
     username: String?, // null = don't update
-    password: EncodedPassword?, // null = don't update
-): UpdateWeakLoginCredentialsResult =
-    createUpdate {
+    password: EncodedPassword,
+): UpdateWeakLoginCredentialsResult {
+    val normalizedUsername = username?.lowercase()
+    return createUpdate {
             sql(
                 """
 WITH old AS (
@@ -84,10 +85,10 @@ WITH old AS (
 )
 UPDATE citizen_user
 SET
-    username = coalesce(${bind(username)}, username),
-    username_updated_at = coalesce(${bind(now.takeIf { username != null })}, username_updated_at),
-    password = coalesce(${bindJson(password)}, password),
-    password_updated_at = coalesce(${bind(now.takeIf { password != null })}, password_updated_at)
+    username = coalesce(${bind(normalizedUsername)}, username),
+    username_updated_at = coalesce(${bind(now.takeIf { normalizedUsername != null })}, username_updated_at),
+    password = ${bindJson(password)},
+    password_updated_at = ${bind(now)}
 FROM old
 WHERE id = ${bind(id)}
 RETURNING (old_username IS NOT NULL AND old_username != username) AS username_changed,
@@ -97,6 +98,7 @@ RETURNING (old_username IS NOT NULL AND old_username != username) AS username_ch
         }
         .executeAndReturnGeneratedKeys()
         .exactlyOne()
+}
 
 fun Database.Transaction.hasWeakCredentials(person: PersonId): Boolean =
     createQuery {


### PR DESCRIPTION
Muutetaan kevytkirjautumistunnuksen luominen siten, että käyttäjätunnus tarkastetaan ja luodaan käyttäjän vahvistetusta sähköpostista backendillä. Tällöin frontendin ei tarvitse lähettää sähköpostia takaisin backendille ja myös apigw:n lowercasesta johtuva bugi korjaantuu.