### PR TITLE
CVE varoituksen korjaus: Thymeleaf 3.1.4

### DIFF
--- a/service/evaka-bom/build.gradle.kts
+++ b/service/evaka-bom/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
         api("org.checkerframework:checker-qual:3.55.1")
         api("org.skyscreamer:jsonassert:1.5.3")
         api("org.thymeleaf.extras:thymeleaf-extras-java8time:3.0.4.RELEASE")
-        api("org.thymeleaf:thymeleaf:3.1.3.RELEASE")
+        api("org.thymeleaf:thymeleaf:3.1.4.RELEASE")
         api(libs.flyingsaucer.core)
         api(libs.flyingsaucer.pdf)
         api(libs.ktlint.cli.ruleset.core)


### PR DESCRIPTION
Korjaa CVE-2026-40477 ja CVE-2026-40478 (Server-Side Template Injection Thymeleafissa <= 3.1.3). eVaka käyttää Thymeleafia vain PDF-generointiin kovakoodatuilla malleilla ja muuttuja-arvoilla, joita ei tulkita lausekkeina, joten tunnettua hyökkäysvektoria ei ole, mutta päivitys poistaa OWASP-riippuvuustarkistuksen virheen.