### PR TITLE
Nostetaan rinnakkaisten integraatiotestiajojen määrää CI:ssä

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -484,8 +484,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_chunk_number: [1, 2, 3, 4]
-        test_chunk_count: [4] # must max value of above list
+        test_chunk_number: [1, 2, 3, 4, 5, 6]
+        test_chunk_count: [6] # must max value of above list
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Tampereen seudun koodin tuomisella ytimeen integraatiotestien määrä kasvoi ja testien ajo hidastui. Nostetaan rinnakkaisten ajojen määrää kuuteen, jotta saadaan nopeutta.