### PR TITLE
Korjataan kesäajan maksuttomien poissaolojen luonti monen palveluntarpeen tapauksessa

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
@@ -330,6 +330,66 @@ class HolidayPeriodControllerCitizenIntegrationTest :
     }
 
     @Test
+    fun `free absences are saved on weekends for a shift care child that has an earlier non-shift-care service need on the same placement`() {
+        val id = createFixedPeriodQuestionnaire(freePeriodQuestionnaire)
+        val firstOption = freePeriodQuestionnaire.periodOptions[0]
+
+        val fullDay = TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59"))
+        db.transaction { tx ->
+            val daycareId =
+                tx.insert(
+                    DevDaycare(
+                        areaId = area.id,
+                        operationTimes =
+                            listOf(fullDay, fullDay, fullDay, fullDay, fullDay, null, null),
+                        shiftCareOperationTimes =
+                            listOf(fullDay, fullDay, fullDay, fullDay, fullDay, fullDay, fullDay),
+                        shiftCareOpenOnHolidays = true,
+                    )
+                )
+            tx.insertGuardian(parent.id, child2.id)
+
+            val placement =
+                DevPlacement(
+                    childId = child2.id,
+                    unitId = daycareId,
+                    startDate = mockToday.minusYears(2),
+                    endDate = mockToday.plusYears(1),
+                )
+            tx.insert(placement)
+            val fullTimeDaycareOption =
+                ServiceNeedOptionId(UUID.fromString("7406df92-e715-11ec-9ec2-9b7ff580dcb4"))
+            tx.insert(
+                DevServiceNeed(
+                    placementId = placement.id,
+                    startDate = placement.startDate,
+                    endDate = firstOption.start.minusDays(1),
+                    optionId = fullTimeDaycareOption,
+                    shiftCare = ShiftCareType.NONE,
+                    confirmedBy = authenticatedParent.evakaUserId,
+                )
+            )
+            tx.insert(
+                DevServiceNeed(
+                    placementId = placement.id,
+                    startDate = firstOption.start,
+                    endDate = placement.endDate,
+                    optionId = fullTimeDaycareOption,
+                    shiftCare = ShiftCareType.FULL,
+                    confirmedBy = authenticatedParent.evakaUserId,
+                )
+            )
+        }
+
+        reportFreePeriods(id, FixedPeriodsBody(mapOf(child2.id to firstOption)))
+
+        assertEquals(
+            firstOption.dates().map { Absence(child2.id, it, AbsenceType.FREE_ABSENCE) }.toList(),
+            db.read { it.getAllAbsences().filter { absence -> absence.childId == child2.id } },
+        )
+    }
+
+    @Test
     fun `free absences cannot be saved if a child is not eligible`() {
         db.transaction { tx ->
             tx.insertGuardian(parent.id, child2.id)

--- a/service/src/integrationTest/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
@@ -16,7 +16,6 @@ import evaka.core.serviceneed.ShiftCareType
 import evaka.core.shared.ChildId
 import evaka.core.shared.HolidayQuestionnaireId
 import evaka.core.shared.ServiceNeedOptionId
-import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.auth.CitizenAuthLevel
 import evaka.core.shared.db.Database
 import evaka.core.shared.dev.DevCareArea
@@ -27,7 +26,6 @@ import evaka.core.shared.dev.DevPlacement
 import evaka.core.shared.dev.DevServiceNeed
 import evaka.core.shared.dev.insert
 import evaka.core.shared.dev.insertServiceNeedOption
-import evaka.core.shared.dev.insertServiceNeedOptions
 import evaka.core.shared.domain.BadRequest
 import evaka.core.shared.domain.FiniteDateRange
 import evaka.core.shared.domain.HelsinkiDateTime
@@ -41,6 +39,7 @@ import evaka.core.shared.security.AccessControl
 import evaka.core.shared.security.AccessControlTest.TestActionRuleMapping
 import evaka.core.shared.security.Action
 import evaka.core.shared.security.actionrule.IsCitizen
+import evaka.core.snDefaultDaycare
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalTime
@@ -89,19 +88,19 @@ class HolidayPeriodControllerCitizenIntegrationTest :
         )
     private val mockToday: LocalDate = freePeriodQuestionnaire.active.end.minusWeeks(1)
 
-    final val area = DevCareArea()
-    val daycare = DevDaycare(areaId = area.id)
-    val voucherDaycare =
+    private val area = DevCareArea()
+    private val daycare = DevDaycare(areaId = area.id)
+    private val voucherDaycare =
         DevDaycare(areaId = area.id, providerType = ProviderType.PRIVATE_SERVICE_VOUCHER)
-    val child1 = DevPerson(id = ChildId(UUID.randomUUID()))
-    val child2 = DevPerson(id = ChildId(UUID.randomUUID()))
-    val child3 = DevPerson(id = ChildId(UUID.randomUUID()))
-    val child4 = DevPerson(id = ChildId(UUID.randomUUID()))
+    private val child1 = DevPerson()
+    private val child2 = DevPerson()
+    private val child3 = DevPerson()
+    private val child4 = DevPerson()
     private val parent = DevPerson()
-    private val authenticatedParent = AuthenticatedUser.Citizen(parent.id, CitizenAuthLevel.STRONG)
+    private val authenticatedParent = parent.user(CitizenAuthLevel.STRONG)
 
     @BeforeEach
-    fun setUp() {
+    fun beforeEach() {
         db.transaction { tx ->
             tx.insert(area)
             tx.insert(daycare)
@@ -118,18 +117,13 @@ class HolidayPeriodControllerCitizenIntegrationTest :
                     endDate = mockToday.plusYears(1),
                 )
             tx.insert(placement)
-            tx.insertServiceNeedOptions()
+            tx.insertServiceNeedOption(snDefaultDaycare)
             tx.insert(
                 DevServiceNeed(
                     placementId = placement.id,
                     startDate = placement.startDate,
                     endDate = placement.endDate,
-                    optionId =
-                        ServiceNeedOptionId(
-                            UUID.fromString(
-                                "7406df92-e715-11ec-9ec2-9b7ff580dcb4"
-                            ) // full time daycare
-                        ),
+                    optionId = snDefaultDaycare.id,
                     confirmedBy = authenticatedParent.evakaUserId,
                 )
             )
@@ -357,14 +351,12 @@ class HolidayPeriodControllerCitizenIntegrationTest :
                     endDate = mockToday.plusYears(1),
                 )
             tx.insert(placement)
-            val fullTimeDaycareOption =
-                ServiceNeedOptionId(UUID.fromString("7406df92-e715-11ec-9ec2-9b7ff580dcb4"))
             tx.insert(
                 DevServiceNeed(
                     placementId = placement.id,
                     startDate = placement.startDate,
                     endDate = firstOption.start.minusDays(1),
-                    optionId = fullTimeDaycareOption,
+                    optionId = snDefaultDaycare.id,
                     shiftCare = ShiftCareType.NONE,
                     confirmedBy = authenticatedParent.evakaUserId,
                 )
@@ -374,7 +366,7 @@ class HolidayPeriodControllerCitizenIntegrationTest :
                     placementId = placement.id,
                     startDate = firstOption.start,
                     endDate = placement.endDate,
-                    optionId = fullTimeDaycareOption,
+                    optionId = snDefaultDaycare.id,
                     shiftCare = ShiftCareType.FULL,
                     confirmedBy = authenticatedParent.evakaUserId,
                 )
@@ -696,12 +688,7 @@ class HolidayPeriodControllerCitizenIntegrationTest :
                     placementId = placement.id,
                     startDate = placement.startDate,
                     endDate = placement.endDate,
-                    optionId =
-                        ServiceNeedOptionId(
-                            UUID.fromString(
-                                "7406df92-e715-11ec-9ec2-9b7ff580dcb4"
-                            ) // full time daycare
-                        ),
+                    optionId = snDefaultDaycare.id,
                     shiftCare = ShiftCareType.FULL,
                     confirmedBy = authenticatedParent.evakaUserId,
                 )

--- a/service/src/main/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -468,7 +468,10 @@ class HolidayPeriodControllerCitizen(
 
         val daycare = daycares[placement.unitId] ?: return false
         val serviceNeed =
-            serviceNeeds.find { serviceNeed -> serviceNeed.placementId == placement.id }
+            serviceNeeds.find { serviceNeed ->
+                serviceNeed.placementId == placement.id &&
+                    FiniteDateRange(serviceNeed.startDate, serviceNeed.endDate).includes(date)
+            }
 
         return isUnitOperationDay(
             daycare.operationDays,


### PR DESCRIPTION
Jos lapsella on samalle sijoitukselle useampi palveluntarve, joista osa on vuorohoitoa ja osa ei, luodaan poissaoloja oikean vuorohoitotiedon perusteella.