### PR TITLE
"Ei avoimia tuloselvityksiä"-suodatus ottaa huomioon myös maksupäätöksen ajanjakson

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/invoicing/FeeDecisionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/invoicing/FeeDecisionIntegrationTest.kt
@@ -72,6 +72,7 @@ import evaka.core.snDaycarePartDay25
 import evaka.core.snDefaultDaycare
 import evaka.core.toFeeDecisionServiceNeed
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -907,6 +908,304 @@ class FeeDecisionIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
             )
 
         assertEqualEnough(listOf(toSummary(decisionWithHandledStatements)), result.data)
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS excludes decisions with open statements during decision period`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decisionWithMidPeriodOpenStatement =
+            createFeeDecisionsForFamily(
+                headOfFamily = adult1,
+                partner = null,
+                familyChildren = listOf(child1),
+                period = FiniteDateRange(clock.today().plusMonths(1), clock.today().plusMonths(6)),
+            )
+        val decisionWithNoOpenStatements =
+            createFeeDecisionsForFamily(
+                headOfFamily = adult3,
+                partner = null,
+                familyChildren = listOf(child2),
+                period = FiniteDateRange(clock.today().plusMonths(1), clock.today().plusMonths(6)),
+            )
+
+        db.transaction { tx ->
+            tx.upsertFeeDecisions(
+                listOf(decisionWithMidPeriodOpenStatement, decisionWithNoOpenStatements)
+            )
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult1.id,
+                    data =
+                        IncomeStatementBody.HighestFee(
+                            clock.today().plusMonths(3),
+                            clock.today().plusMonths(5),
+                        ),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            searchDecisions(
+                SearchFeeDecisionRequest(
+                    page = 0,
+                    distinctions = listOf(DistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            )
+
+        assertEqualEnough(listOf(toSummary(decisionWithNoOpenStatements)), result.data)
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS excludes decisions when statement starts exactly on decision end`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decisionStart = clock.today().plusMonths(1)
+        val decisionEnd = clock.today().plusMonths(6)
+
+        val decision =
+            createFeeDecisionsForFamily(
+                headOfFamily = adult1,
+                partner = null,
+                familyChildren = listOf(child1),
+                period = FiniteDateRange(decisionStart, decisionEnd),
+            )
+
+        db.transaction { tx ->
+            tx.upsertFeeDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult1.id,
+                    data = IncomeStatementBody.HighestFee(decisionEnd, decisionEnd.plusMonths(2)),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            searchDecisions(
+                SearchFeeDecisionRequest(
+                    page = 0,
+                    distinctions = listOf(DistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            )
+
+        assertEqualEnough(listOf(), result.data)
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS excludes decisions when statement ends exactly on decision start`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decisionStart = clock.today().plusMonths(1)
+        val decisionEnd = clock.today().plusMonths(6)
+
+        val decision =
+            createFeeDecisionsForFamily(
+                headOfFamily = adult1,
+                partner = null,
+                familyChildren = listOf(child1),
+                period = FiniteDateRange(decisionStart, decisionEnd),
+            )
+
+        db.transaction { tx ->
+            tx.upsertFeeDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult1.id,
+                    data =
+                        IncomeStatementBody.HighestFee(decisionStart.minusMonths(2), decisionStart),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            searchDecisions(
+                SearchFeeDecisionRequest(
+                    page = 0,
+                    distinctions = listOf(DistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            )
+
+        assertEqualEnough(listOf(), result.data)
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS excludes decisions when open statement belongs to partner`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decision =
+            createFeeDecisionsForFamily(
+                headOfFamily = adult1,
+                partner = adult2,
+                familyChildren = listOf(child1),
+                period = FiniteDateRange(clock.today().plusMonths(1), clock.today().plusMonths(6)),
+            )
+
+        db.transaction { tx ->
+            tx.upsertFeeDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult2.id,
+                    data =
+                        IncomeStatementBody.HighestFee(
+                            clock.today().plusMonths(3),
+                            clock.today().plusMonths(5),
+                        ),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            searchDecisions(
+                SearchFeeDecisionRequest(
+                    page = 0,
+                    distinctions = listOf(DistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            )
+
+        assertEqualEnough(listOf(), result.data)
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS excludes decisions when open statement belongs to child`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decision =
+            createFeeDecisionsForFamily(
+                headOfFamily = adult1,
+                partner = null,
+                familyChildren = listOf(child1),
+                period = FiniteDateRange(clock.today().plusMonths(1), clock.today().plusMonths(6)),
+            )
+
+        db.transaction { tx ->
+            tx.upsertFeeDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = child1.id,
+                    data =
+                        IncomeStatementBody.HighestFee(
+                            clock.today().plusMonths(3),
+                            clock.today().plusMonths(5),
+                        ),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            searchDecisions(
+                SearchFeeDecisionRequest(
+                    page = 0,
+                    distinctions = listOf(DistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            )
+
+        assertEqualEnough(listOf(), result.data)
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS includes decisions when in-period statement is HANDLED`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decision =
+            createFeeDecisionsForFamily(
+                headOfFamily = adult1,
+                partner = null,
+                familyChildren = listOf(child1),
+                period = FiniteDateRange(clock.today().plusMonths(1), clock.today().plusMonths(6)),
+            )
+
+        db.transaction { tx ->
+            tx.upsertFeeDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult1.id,
+                    data =
+                        IncomeStatementBody.HighestFee(
+                            clock.today().plusMonths(3),
+                            clock.today().plusMonths(5),
+                        ),
+                    status = IncomeStatementStatus.HANDLED,
+                    handledAt = clock.now(),
+                    handlerId = decisionMaker1.id,
+                )
+            )
+        }
+
+        val result =
+            searchDecisions(
+                SearchFeeDecisionRequest(
+                    page = 0,
+                    distinctions = listOf(DistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            )
+
+        assertEqualEnough(listOf(toSummary(decision)), result.data)
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS includes decisions when open statement starts the day after decision end`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decisionStart = clock.today().plusMonths(1)
+        val decisionEnd = clock.today().plusMonths(6)
+
+        val decision =
+            createFeeDecisionsForFamily(
+                headOfFamily = adult1,
+                partner = null,
+                familyChildren = listOf(child1),
+                period = FiniteDateRange(decisionStart, decisionEnd),
+            )
+
+        db.transaction { tx ->
+            tx.upsertFeeDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult1.id,
+                    data =
+                        IncomeStatementBody.HighestFee(
+                            decisionEnd.plusDays(1),
+                            decisionEnd.plusMonths(2),
+                        ),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            searchDecisions(
+                SearchFeeDecisionRequest(
+                    page = 0,
+                    distinctions = listOf(DistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            )
+
+        assertEqualEnough(listOf(toSummary(decision)), result.data)
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/evaka/core/invoicing/data/VoucherValueDecisionQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/invoicing/data/VoucherValueDecisionQueriesTest.kt
@@ -1258,6 +1258,445 @@ internal class VoucherValueDecisionQueriesTest : PureJdbiTest(resetDbBeforeEach 
     }
 
     @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS excludes decisions with open statements during decision period`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+
+        val decisionWithMidPeriodOpenStatement =
+            createVoucherValueDecisionFixture(
+                status = VoucherValueDecisionStatus.DRAFT,
+                validFrom = clock.today().plusMonths(1),
+                validTo = clock.today().plusMonths(6),
+                headOfFamilyId = adult1.id,
+                partnerId = null,
+                childId = child1.id,
+                dateOfBirth = child1.dateOfBirth,
+                unitId = daycare.id,
+                placementType = PlacementType.DAYCARE,
+                serviceNeed = snDefaultDaycare.toValueDecisionServiceNeed(),
+            )
+        val decisionWithNoOpenStatements =
+            createVoucherValueDecisionFixture(
+                status = VoucherValueDecisionStatus.DRAFT,
+                validFrom = clock.today().plusMonths(1),
+                validTo = clock.today().plusMonths(6),
+                headOfFamilyId = adult3.id,
+                partnerId = null,
+                childId = child2.id,
+                dateOfBirth = child2.dateOfBirth,
+                unitId = daycare.id,
+                placementType = PlacementType.DAYCARE,
+                serviceNeed = snDefaultDaycare.toValueDecisionServiceNeed(),
+            )
+
+        db.transaction { tx ->
+            tx.upsertValueDecisions(
+                listOf(decisionWithMidPeriodOpenStatement, decisionWithNoOpenStatements)
+            )
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult1.id,
+                    data =
+                        IncomeStatementBody.HighestFee(
+                            clock.today().plusMonths(3),
+                            clock.today().plusMonths(5),
+                        ),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            db.read { tx ->
+                tx.searchValueDecisions(
+                    evakaClock = clock,
+                    postOffice = "ESPOO",
+                    page = 0,
+                    pageSize = 100,
+                    sortBy = VoucherValueDecisionSortParam.HEAD_OF_FAMILY,
+                    sortDirection = SortDirection.ASC,
+                    statuses = listOf(VoucherValueDecisionStatus.DRAFT),
+                    areas = emptyList(),
+                    unit = null,
+                    startDate = null,
+                    endDate = null,
+                    difference = emptySet(),
+                    financeDecisionHandlerId = null,
+                    distinctiveParams =
+                        listOf(VoucherValueDecisionDistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            }
+
+        assertThat(result.data.map { it.child.id }).containsExactly(child2.id)
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS excludes decisions when statement starts exactly on decision end`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decisionStart = clock.today().plusMonths(1)
+        val decisionEnd = clock.today().plusMonths(6)
+
+        val decision =
+            createVoucherValueDecisionFixture(
+                status = VoucherValueDecisionStatus.DRAFT,
+                validFrom = decisionStart,
+                validTo = decisionEnd,
+                headOfFamilyId = adult1.id,
+                partnerId = null,
+                childId = child1.id,
+                dateOfBirth = child1.dateOfBirth,
+                unitId = daycare.id,
+                placementType = PlacementType.DAYCARE,
+                serviceNeed = snDefaultDaycare.toValueDecisionServiceNeed(),
+            )
+
+        db.transaction { tx ->
+            tx.upsertValueDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult1.id,
+                    data = IncomeStatementBody.HighestFee(decisionEnd, decisionEnd.plusMonths(2)),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            db.read { tx ->
+                tx.searchValueDecisions(
+                    evakaClock = clock,
+                    postOffice = "ESPOO",
+                    page = 0,
+                    pageSize = 100,
+                    sortBy = VoucherValueDecisionSortParam.HEAD_OF_FAMILY,
+                    sortDirection = SortDirection.ASC,
+                    statuses = listOf(VoucherValueDecisionStatus.DRAFT),
+                    areas = emptyList(),
+                    unit = null,
+                    startDate = null,
+                    endDate = null,
+                    difference = emptySet(),
+                    financeDecisionHandlerId = null,
+                    distinctiveParams =
+                        listOf(VoucherValueDecisionDistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            }
+
+        assertThat(result.data).isEmpty()
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS excludes decisions when statement ends exactly on decision start`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decisionStart = clock.today().plusMonths(1)
+        val decisionEnd = clock.today().plusMonths(6)
+
+        val decision =
+            createVoucherValueDecisionFixture(
+                status = VoucherValueDecisionStatus.DRAFT,
+                validFrom = decisionStart,
+                validTo = decisionEnd,
+                headOfFamilyId = adult1.id,
+                partnerId = null,
+                childId = child1.id,
+                dateOfBirth = child1.dateOfBirth,
+                unitId = daycare.id,
+                placementType = PlacementType.DAYCARE,
+                serviceNeed = snDefaultDaycare.toValueDecisionServiceNeed(),
+            )
+
+        db.transaction { tx ->
+            tx.upsertValueDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult1.id,
+                    data =
+                        IncomeStatementBody.HighestFee(decisionStart.minusMonths(2), decisionStart),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            db.read { tx ->
+                tx.searchValueDecisions(
+                    evakaClock = clock,
+                    postOffice = "ESPOO",
+                    page = 0,
+                    pageSize = 100,
+                    sortBy = VoucherValueDecisionSortParam.HEAD_OF_FAMILY,
+                    sortDirection = SortDirection.ASC,
+                    statuses = listOf(VoucherValueDecisionStatus.DRAFT),
+                    areas = emptyList(),
+                    unit = null,
+                    startDate = null,
+                    endDate = null,
+                    difference = emptySet(),
+                    financeDecisionHandlerId = null,
+                    distinctiveParams =
+                        listOf(VoucherValueDecisionDistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            }
+
+        assertThat(result.data).isEmpty()
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS excludes decisions when open statement belongs to partner`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decision =
+            createVoucherValueDecisionFixture(
+                status = VoucherValueDecisionStatus.DRAFT,
+                validFrom = clock.today().plusMonths(1),
+                validTo = clock.today().plusMonths(6),
+                headOfFamilyId = adult1.id,
+                partnerId = adult2.id,
+                childId = child1.id,
+                dateOfBirth = child1.dateOfBirth,
+                unitId = daycare.id,
+                placementType = PlacementType.DAYCARE,
+                serviceNeed = snDefaultDaycare.toValueDecisionServiceNeed(),
+            )
+
+        db.transaction { tx ->
+            tx.upsertValueDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult2.id,
+                    data =
+                        IncomeStatementBody.HighestFee(
+                            clock.today().plusMonths(3),
+                            clock.today().plusMonths(5),
+                        ),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            db.read { tx ->
+                tx.searchValueDecisions(
+                    evakaClock = clock,
+                    postOffice = "ESPOO",
+                    page = 0,
+                    pageSize = 100,
+                    sortBy = VoucherValueDecisionSortParam.HEAD_OF_FAMILY,
+                    sortDirection = SortDirection.ASC,
+                    statuses = listOf(VoucherValueDecisionStatus.DRAFT),
+                    areas = emptyList(),
+                    unit = null,
+                    startDate = null,
+                    endDate = null,
+                    difference = emptySet(),
+                    financeDecisionHandlerId = null,
+                    distinctiveParams =
+                        listOf(VoucherValueDecisionDistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            }
+
+        assertThat(result.data).isEmpty()
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS excludes decisions when open statement belongs to child`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decision =
+            createVoucherValueDecisionFixture(
+                status = VoucherValueDecisionStatus.DRAFT,
+                validFrom = clock.today().plusMonths(1),
+                validTo = clock.today().plusMonths(6),
+                headOfFamilyId = adult1.id,
+                partnerId = null,
+                childId = child1.id,
+                dateOfBirth = child1.dateOfBirth,
+                unitId = daycare.id,
+                placementType = PlacementType.DAYCARE,
+                serviceNeed = snDefaultDaycare.toValueDecisionServiceNeed(),
+            )
+
+        db.transaction { tx ->
+            tx.upsertValueDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = child1.id,
+                    data =
+                        IncomeStatementBody.HighestFee(
+                            clock.today().plusMonths(3),
+                            clock.today().plusMonths(5),
+                        ),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            db.read { tx ->
+                tx.searchValueDecisions(
+                    evakaClock = clock,
+                    postOffice = "ESPOO",
+                    page = 0,
+                    pageSize = 100,
+                    sortBy = VoucherValueDecisionSortParam.HEAD_OF_FAMILY,
+                    sortDirection = SortDirection.ASC,
+                    statuses = listOf(VoucherValueDecisionStatus.DRAFT),
+                    areas = emptyList(),
+                    unit = null,
+                    startDate = null,
+                    endDate = null,
+                    difference = emptySet(),
+                    financeDecisionHandlerId = null,
+                    distinctiveParams =
+                        listOf(VoucherValueDecisionDistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            }
+
+        assertThat(result.data).isEmpty()
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS includes decisions when in-period statement is HANDLED`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decision =
+            createVoucherValueDecisionFixture(
+                status = VoucherValueDecisionStatus.DRAFT,
+                validFrom = clock.today().plusMonths(1),
+                validTo = clock.today().plusMonths(6),
+                headOfFamilyId = adult1.id,
+                partnerId = null,
+                childId = child1.id,
+                dateOfBirth = child1.dateOfBirth,
+                unitId = daycare.id,
+                placementType = PlacementType.DAYCARE,
+                serviceNeed = snDefaultDaycare.toValueDecisionServiceNeed(),
+            )
+
+        db.transaction { tx ->
+            tx.insert(decisionMaker)
+            tx.upsertValueDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult1.id,
+                    data =
+                        IncomeStatementBody.HighestFee(
+                            clock.today().plusMonths(3),
+                            clock.today().plusMonths(5),
+                        ),
+                    status = IncomeStatementStatus.HANDLED,
+                    handledAt = clock.now(),
+                    handlerId = decisionMaker.id,
+                )
+            )
+        }
+
+        val result =
+            db.read { tx ->
+                tx.searchValueDecisions(
+                    evakaClock = clock,
+                    postOffice = "ESPOO",
+                    page = 0,
+                    pageSize = 100,
+                    sortBy = VoucherValueDecisionSortParam.HEAD_OF_FAMILY,
+                    sortDirection = SortDirection.ASC,
+                    statuses = listOf(VoucherValueDecisionStatus.DRAFT),
+                    areas = emptyList(),
+                    unit = null,
+                    startDate = null,
+                    endDate = null,
+                    difference = emptySet(),
+                    financeDecisionHandlerId = null,
+                    distinctiveParams =
+                        listOf(VoucherValueDecisionDistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            }
+
+        assertThat(result.data.map { it.child.id }).containsExactly(child1.id)
+    }
+
+    @Test
+    fun `search with NO_OPEN_INCOME_STATEMENTS includes decisions when open statement starts the day after decision end`() {
+        val clock =
+            MockEvakaClock(HelsinkiDateTime.of(LocalDate.of(2024, 6, 15), LocalTime.of(12, 0)))
+        val decisionStart = clock.today().plusMonths(1)
+        val decisionEnd = clock.today().plusMonths(6)
+
+        val decision =
+            createVoucherValueDecisionFixture(
+                status = VoucherValueDecisionStatus.DRAFT,
+                validFrom = decisionStart,
+                validTo = decisionEnd,
+                headOfFamilyId = adult1.id,
+                partnerId = null,
+                childId = child1.id,
+                dateOfBirth = child1.dateOfBirth,
+                unitId = daycare.id,
+                placementType = PlacementType.DAYCARE,
+                serviceNeed = snDefaultDaycare.toValueDecisionServiceNeed(),
+            )
+
+        db.transaction { tx ->
+            tx.upsertValueDecisions(listOf(decision))
+
+            tx.insert(
+                DevIncomeStatement(
+                    personId = adult1.id,
+                    data =
+                        IncomeStatementBody.HighestFee(
+                            decisionEnd.plusDays(1),
+                            decisionEnd.plusMonths(2),
+                        ),
+                    status = IncomeStatementStatus.SENT,
+                    handledAt = null,
+                    handlerId = null,
+                )
+            )
+        }
+
+        val result =
+            db.read { tx ->
+                tx.searchValueDecisions(
+                    evakaClock = clock,
+                    postOffice = "ESPOO",
+                    page = 0,
+                    pageSize = 100,
+                    sortBy = VoucherValueDecisionSortParam.HEAD_OF_FAMILY,
+                    sortDirection = SortDirection.ASC,
+                    statuses = listOf(VoucherValueDecisionStatus.DRAFT),
+                    areas = emptyList(),
+                    unit = null,
+                    startDate = null,
+                    endDate = null,
+                    difference = emptySet(),
+                    financeDecisionHandlerId = null,
+                    distinctiveParams =
+                        listOf(VoucherValueDecisionDistinctiveParams.NO_OPEN_INCOME_STATEMENTS),
+                )
+            }
+
+        assertThat(result.data.map { it.child.id }).containsExactly(child1.id)
+    }
+
+    @Test
     fun `search with status`() {
         db.transaction { tx ->
             val baseDecision = { child: DevPerson ->

--- a/service/src/main/kotlin/evaka/core/invoicing/data/FeeDecisionQueries.kt
+++ b/service/src/main/kotlin/evaka/core/invoicing/data/FeeDecisionQueries.kt
@@ -500,7 +500,7 @@ fun Database.Read.searchFeeDecisions(
                 NOT EXISTS (
                     SELECT FROM income_statement
                     WHERE person_id IN (decision.head_of_family_id, decision.partner_id, part.child_id) AND
-                        daterange(income_statement.start_date, income_statement.end_date, '[]') && daterange((lower(decision.valid_during) - interval '14 months')::date, lower(decision.valid_during), '[]') AND
+                        daterange(income_statement.start_date, income_statement.end_date, '[]') && daterange((lower(decision.valid_during) - interval '14 months')::date, upper(decision.valid_during), '[)') AND
                         income_statement.status = ANY('{SENT,HANDLING}'::income_statement_status[])
                     )
                             """

--- a/service/src/main/kotlin/evaka/core/invoicing/data/VoucherValueDecisionQueries.kt
+++ b/service/src/main/kotlin/evaka/core/invoicing/data/VoucherValueDecisionQueries.kt
@@ -403,7 +403,7 @@ NOT EXISTS (
                 NOT EXISTS (
                     SELECT FROM income_statement
                     WHERE person_id IN (decision.head_of_family_id, decision.partner_id, decision.child_id) AND
-                        daterange(income_statement.start_date, income_statement.end_date, '[]') && daterange((decision.valid_from - interval '14 months')::date, decision.valid_from, '[]') AND
+                        daterange(income_statement.start_date, income_statement.end_date, '[]') && daterange((decision.valid_from - interval '14 months')::date, decision.valid_to, '[]') AND
                         income_statement.status = ANY('{SENT,HANDLING}'::income_statement_status[])
                     )
                 """


### PR DESCRIPTION
ennen muutosta:

Suodatettaessa maksupäätöksiä "Ei avoimia tuloselvityksiä"-täpällä tarkasteltiin avoimia tulotietoja ainoastaan 14kk ennen maksupäätöksen voimassaolon alkupäivää.

muutoksen jälkeen:

Aikaisemman tarkasteluajanjakson lisäksi samalla suodattimella huomioidaan myös avoimet tulotietoselvitykset, jotka osuvat maksupäätöksen ajanjaksolle. Tällä vältetään päätösten lähettämistä tapauksissa joissa tuloselvityksiä/tulotietoja ei ole vielä käsitelty.

Suodatin työntekijän käyttöliittymässä:
<img width="1159" height="676" alt="Ei avoimia tuloselvityksiä" src="https://github.com/user-attachments/assets/defa6335-5ced-420f-a78f-e11d4ed67b76" />

