### PR TITLE
Lisätään englanninkielinen tuki yksiköille

### DIFF
--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -716,7 +716,8 @@ CREATE TYPE public.ui_language AS ENUM (
 
 CREATE TYPE public.unit_language AS ENUM (
     'fi',
-    'sv'
+    'sv',
+    'en'
 );
 
 -- Name: unit_provider_type; Type: TYPE; Schema: public

--- a/frontend/src/citizen-frontend/applications/editor/unit-preference/PreferredUnitBox.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/unit-preference/PreferredUnitBox.tsx
@@ -5,7 +5,10 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import type { PublicUnit } from 'lib-common/generated/api-types/daycare'
+import type {
+  Language,
+  PublicUnit
+} from 'lib-common/generated/api-types/daycare'
 import { StaticChip } from 'lib-components/atoms/Chip'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
 import { Button } from 'lib-components/atoms/buttons/Button'
@@ -87,15 +90,13 @@ export default React.memo(function PreferredUnitBox({
             )}
           </FixedSpaceColumn>
           <FixedSpaceFlexWrap $horizontalSpacing="xs" $verticalSpacing="xs">
-            {unit.language === 'sv' ? (
-              <StaticChip $color={colors.accents.a5orangeLight}>
-                {t.applications.editor.unitPreference.units.preferences.sv}
-              </StaticChip>
-            ) : (
-              <StaticChip $color={colors.main.m3}>
-                {t.applications.editor.unitPreference.units.preferences.fi}
-              </StaticChip>
-            )}
+            <StaticChip $color={unitLanguageChipColor[unit.language]}>
+              {
+                t.applications.editor.unitPreference.units.preferences[
+                  unit.language
+                ]
+              }
+            </StaticChip>
             <StaticChip {...getProviderTypeColors()}>
               {providerTypeText.toLowerCase()}
             </StaticChip>
@@ -148,6 +149,12 @@ export default React.memo(function PreferredUnitBox({
     </Wrapper>
   )
 })
+
+const unitLanguageChipColor: Record<Language, string> = {
+  fi: colors.main.m3,
+  sv: colors.accents.a5orangeLight,
+  en: colors.accents.a10powder
+}
 
 const noOp = () => undefined
 

--- a/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
+++ b/frontend/src/citizen-frontend/applications/editor/unit-preference/UnitsSubSection.tsx
@@ -2,20 +2,22 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useState, useRef, useCallback } from 'react'
+import React, { useState, useMemo, useRef, useCallback } from 'react'
 import styled from 'styled-components'
 
 import type { PreferredUnit } from 'lib-common/generated/api-types/application'
-import type { PublicUnit } from 'lib-common/generated/api-types/daycare'
-import { SelectionChip } from 'lib-components/atoms/Chip'
+import type {
+  Language,
+  PublicUnit
+} from 'lib-common/generated/api-types/daycare'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
 import { ScreenReaderOnly } from 'lib-components/atoms/ScreenReaderOnly'
 import MultiSelect from 'lib-components/atoms/form/MultiSelect'
 import {
   FixedSpaceColumn,
-  FixedSpaceFlexWrap,
-  FixedSpaceRow
+  FixedSpaceFlexWrap
 } from 'lib-components/layout/flex-helpers'
+import LanguageFilterChips from 'lib-components/molecules/LanguageFilterChips'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 import { H3, Label, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
@@ -43,8 +45,30 @@ export default React.memo(function UnitsSubSection({
 }: Props) {
   const t = useTranslation()
   const emptyPreferredUnitsLabel = useRef<HTMLLabelElement>(null)
-  const [displayFinnish, setDisplayFinnish] = useState(true)
-  const [displaySwedish, setDisplaySwedish] = useState(false)
+  const availableLanguages = useMemo(
+    () => new Set((units ?? []).map((u) => u.language)),
+    [units]
+  )
+  const [displayedLanguages, setDisplayedLanguages] = useState<Language[]>([
+    'fi'
+  ])
+  const effectiveLanguages = useMemo(
+    () => displayedLanguages.filter((l) => availableLanguages.has(l)),
+    [displayedLanguages, availableLanguages]
+  )
+  // Stale selection (e.g. default ['fi'] but no Finnish units exist) shows
+  // all units to avoid locking the user out of the dropdown. Explicitly
+  // empty selection (user deselected every chip) is intentional and still
+  // hides everything.
+  const showAllAsFallback =
+    displayedLanguages.length > 0 && effectiveLanguages.length === 0
+  const visibleUnits = useMemo(
+    () =>
+      (units ?? []).filter(
+        (u) => showAllAsFallback || effectiveLanguages.includes(u.language)
+      ),
+    [units, showAllAsFallback, effectiveLanguages]
+  )
   const [isUnitSelectionInvalid, setIsUnitSelectionInvalid] = useState(false)
   const [screenReaderMessage, showTimedScreenReaderMessage] =
     useScreenReaderMessage()
@@ -133,28 +157,19 @@ export default React.memo(function UnitsSubSection({
         </div>
       ) : (
         <>
-          <div role="group" aria-labelledby="language-selection-label">
-            <Label id="language-selection-label">
-              {t.applications.editor.unitPreference.units.languageFilter.label}
-            </Label>
-            <Gap $size="xs" />
-            <FixedSpaceRow>
-              <SelectionChip
-                text={
-                  t.applications.editor.unitPreference.units.languageFilter.fi
-                }
-                selected={displayFinnish}
-                onChange={setDisplayFinnish}
-              />
-              <SelectionChip
-                text={
-                  t.applications.editor.unitPreference.units.languageFilter.sv
-                }
-                selected={displaySwedish}
-                onChange={setDisplaySwedish}
-              />
-            </FixedSpaceRow>
-          </div>
+          <LanguageFilterChips
+            availableLanguages={availableLanguages}
+            selected={displayedLanguages}
+            onChange={setDisplayedLanguages}
+            getLabel={(lang) =>
+              t.applications.editor.unitPreference.units.languageFilter[lang]
+            }
+            label={
+              t.applications.editor.unitPreference.units.languageFilter.label
+            }
+            labelId="language-selection-label"
+            dataQa="unit-language-filter"
+          />
 
           <Gap $size="m" />
 
@@ -178,15 +193,7 @@ export default React.memo(function UnitsSubSection({
                       )
                     : []
                 }
-                options={
-                  units
-                    ? units.filter(
-                        (u) =>
-                          (displayFinnish && u.language === 'fi') ||
-                          (displaySwedish && u.language === 'sv')
-                      )
-                    : []
-                }
+                options={visibleUnits}
                 getOptionId={(unit) => unit.id}
                 getOptionLabel={(unit) => unit.name}
                 getOptionSecondaryText={(unit) => unit.streetAddress}

--- a/frontend/src/citizen-frontend/map/MapView.tsx
+++ b/frontend/src/citizen-frontend/map/MapView.tsx
@@ -82,12 +82,33 @@ export default React.memo(function MapView() {
 
   const allUnits = useQueryResult(unitsQuery({ applicationType: careType }))
 
-  const filteredUnits = useMemo(
+  const careTypeFilteredUnits = useMemo(
     () =>
       allUnits.map((units) =>
-        filterAndSortUnits(units, careType, languages, providerTypes, shiftCare)
+        units.filter((u) => matchesCareType(u, careType))
       ),
-    [allUnits, careType, languages, providerTypes, shiftCare]
+    [allUnits, careType]
+  )
+
+  const availableLanguages = useMemo(
+    () => new Set(careTypeFilteredUnits.getOrElse([]).map((u) => u.language)),
+    [careTypeFilteredUnits]
+  )
+
+  // Any selected language chip that's no longer available (e.g., after a
+  // careType switch) is ignored so the user never ends up filtering against
+  // a hidden chip with no way to clear it.
+  const effectiveLanguages = useMemo(
+    () => languages.filter((l) => availableLanguages.has(l)),
+    [languages, availableLanguages]
+  )
+
+  const filteredUnits = useMemo(
+    () =>
+      careTypeFilteredUnits.map((units) =>
+        filterAndSortUnits(units, effectiveLanguages, providerTypes, shiftCare)
+      ),
+    [careTypeFilteredUnits, effectiveLanguages, providerTypes, shiftCare]
   )
 
   const unitsWithDistances = useChainedQuery(
@@ -128,6 +149,7 @@ export default React.memo(function MapView() {
           <PanelWrapper>
             <SearchSection
               allUnits={allUnits}
+              availableLanguages={availableLanguages}
               careType={careType}
               setCareType={setCareType}
               languages={languages}
@@ -166,32 +188,35 @@ export default React.memo(function MapView() {
   )
 })
 
+const matchesCareType = (
+  unit: PublicUnit,
+  careType: CareTypeOption
+): boolean => {
+  switch (careType) {
+    case 'DAYCARE':
+      return (
+        unit.type.includes('CENTRE') ||
+        unit.type.includes('FAMILY') ||
+        unit.type.includes('GROUP_FAMILY')
+      )
+    case 'CLUB':
+      return unit.type.includes('CLUB')
+    case 'PRESCHOOL':
+      return (
+        unit.type.includes('PRESCHOOL') ||
+        unit.type.includes('PREPARATORY_EDUCATION')
+      )
+  }
+}
+
 const filterAndSortUnits = (
   units: PublicUnit[],
-  careType: CareTypeOption,
   languages: Language[],
   providerTypes: ProviderType[],
   shiftCare: boolean
 ): PublicUnit[] => {
   const filteredUnits = units
-    .filter((u) =>
-      careType === 'DAYCARE'
-        ? u.type.includes('CENTRE') ||
-          u.type.includes('FAMILY') ||
-          u.type.includes('GROUP_FAMILY')
-        : careType === 'CLUB'
-          ? u.type.includes('CLUB')
-          : careType === 'PRESCHOOL'
-            ? u.type.includes('PRESCHOOL') ||
-              u.type.includes('PREPARATORY_EDUCATION')
-            : false
-    )
-    .filter(
-      (u) =>
-        languages.length === 0 ||
-        (!(u.language === 'fi' && !languages.includes('fi')) &&
-          !(u.language === 'sv' && !languages.includes('sv')))
-    )
+    .filter((u) => languages.length === 0 || languages.includes(u.language))
     .filter(
       (u) =>
         providerTypes.length === 0 ||

--- a/frontend/src/citizen-frontend/map/SearchSection.tsx
+++ b/frontend/src/citizen-frontend/map/SearchSection.tsx
@@ -22,6 +22,7 @@ import {
   FixedSpaceFlexWrap,
   FixedSpaceRow
 } from 'lib-components/layout/flex-helpers'
+import LanguageFilterChips from 'lib-components/molecules/LanguageFilterChips'
 import { fontWeights, H1, Label, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
 import { mapConfig } from 'lib-customizations/citizen'
@@ -35,6 +36,7 @@ import SearchInput from './SearchInput'
 
 interface Props {
   allUnits: Result<PublicUnit[]>
+  availableLanguages: Set<Language>
   careType: CareTypeOption
   setCareType: (c: CareTypeOption) => void
   languages: Language[]
@@ -51,6 +53,7 @@ interface Props {
 
 export default React.memo(function SearchSection({
   allUnits,
+  availableLanguages,
   careType,
   setCareType,
   languages,
@@ -122,35 +125,15 @@ export default React.memo(function SearchSection({
 
       <Gap $size="xs" />
 
-      <FixedSpaceColumn
-        $spacing="xs"
-        role="group"
-        aria-labelledby="map-language-label"
-      >
-        <Label id="map-language-label">{t.map.language}</Label>
-        <FixedSpaceRow>
-          <SelectionChip
-            data-qa="map-filter-fi"
-            text={t.common.unit.languagesShort.fi}
-            selected={languages.includes('fi')}
-            onChange={(selected) => {
-              const nextValue: Language[] = languages.filter((l) => l !== 'fi')
-              if (selected) nextValue.push('fi')
-              setLanguages(nextValue)
-            }}
-          />
-          <SelectionChip
-            data-qa="map-filter-sv"
-            text={t.common.unit.languagesShort.sv}
-            selected={languages.includes('sv')}
-            onChange={(selected) => {
-              const nextValue: Language[] = languages.filter((l) => l !== 'sv')
-              if (selected) nextValue.push('sv')
-              setLanguages(nextValue)
-            }}
-          />
-        </FixedSpaceRow>
-      </FixedSpaceColumn>
+      <LanguageFilterChips
+        availableLanguages={availableLanguages}
+        selected={languages}
+        onChange={setLanguages}
+        getLabel={(lang) => t.common.unit.languagesShort[lang]}
+        label={t.map.language}
+        labelId="map-language-label"
+        dataQa="map-language-filter"
+      />
 
       {showMoreFilters && (
         <>

--- a/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-applications.ts
@@ -4,6 +4,7 @@
 
 import type { ApplicationFormData } from 'lib-common/api-types/application/ApplicationFormData'
 import type { ServiceNeedOption } from 'lib-common/generated/api-types/application'
+import type { Language } from 'lib-common/generated/api-types/daycare'
 import type { PlacementType } from 'lib-common/generated/api-types/placement'
 import type { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { fromUuid } from 'lib-common/id-type'
@@ -14,7 +15,14 @@ import { expect } from '../../playwright'
 import type { FormInput, Section } from '../../utils/application-forms'
 import { sections } from '../../utils/application-forms'
 import type { Page, Element } from '../../utils/page'
-import { Checkbox, Radio, TextInput, FileUpload } from '../../utils/page'
+import {
+  Checkbox,
+  MultiSelect,
+  Radio,
+  SelectionChip,
+  TextInput,
+  FileUpload
+} from '../../utils/page'
 
 export default class CitizenApplicationsPage {
   #createNewApplicationButton: Element
@@ -178,6 +186,7 @@ class CitizenApplicationEditor {
   #preferredStartDateWarning: Element
   #preferredStartDateInfo: Element
   #preferredUnitsInput: TextInput
+  #preferredUnitsSelect: MultiSelect
   #partTimeLimitError: Element
   saveAsDraftButton: Element
   modalOkBtn: Element
@@ -205,6 +214,9 @@ class CitizenApplicationEditor {
     )
     this.#preferredUnitsInput = new TextInput(
       page.find('[data-qa="preferredUnits-input"] input')
+    )
+    this.#preferredUnitsSelect = new MultiSelect(
+      page.findByDataQa('preferredUnits-input')
     )
     this.#partTimeLimitError = page.findByDataQa('part-time-limit-error')
     this.saveAsDraftButton = page.findByDataQa('save-as-draft-btn')
@@ -407,6 +419,52 @@ class CitizenApplicationEditor {
         `[data-qa*="${this.serviceNeedOptionDataQaPrefix(placementType)}"]`
       )
     ).toHaveText(options.map((option) => option.nameFi))
+  }
+
+  unitLanguageFilterChip(language: Language) {
+    return new SelectionChip(
+      this.page.findByDataQa(`unit-language-filter-${language}`)
+    )
+  }
+
+  #languageFilterGroup = () => this.page.findByDataQa('unit-language-filter')
+
+  async assertLanguageFilterVisible(visible: boolean) {
+    if (visible) {
+      await expect(this.#languageFilterGroup()).toBeVisible()
+    } else {
+      await expect(this.#languageFilterGroup()).toBeHidden()
+    }
+  }
+
+  async setUnitLanguageFilter(language: Language, selected: boolean) {
+    const chip = this.unitLanguageFilterChip(language)
+    if (selected) {
+      await chip.check()
+    } else {
+      await chip.uncheck()
+    }
+  }
+
+  async assertPreferredUnitOptions(unitNames: string[]) {
+    await this.#preferredUnitsSelect.click()
+    await this.#preferredUnitsSelect.assertOptionsContain(unitNames)
+    await this.#preferredUnitsSelect.close()
+  }
+
+  async assertHiddenFromPreferredUnits(unitNames: string[]) {
+    await this.#preferredUnitsSelect.click()
+    const options = this.#preferredUnitsSelect.findAllByDataQa('option')
+    for (const name of unitNames) {
+      await expect(options.locator.filter({ hasText: name })).toHaveCount(0)
+    }
+    await this.#preferredUnitsSelect.close()
+  }
+
+  async assertNoPreferredUnitOptions() {
+    await this.#preferredUnitsSelect.click()
+    await this.#preferredUnitsSelect.assertNoOptions()
+    await this.#preferredUnitsSelect.close()
   }
 
   async assertSelectedPreferredUnits(unitIds: UUID[]) {

--- a/frontend/src/e2e-test/pages/citizen/citizen-map.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-map.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import type { Language } from 'lib-common/generated/api-types/daycare'
+
 import type { DevDaycare } from '../../generated/api-types'
 import { expect } from '../../playwright'
 import type { Page } from '../../utils/page'
@@ -14,7 +16,8 @@ export default class CitizenMapPage {
   unitDetailsPanel: UnitDetailsPanel
   map: Map
   searchInput: MapSearchInput
-  languageChips: { fi: SelectionChip; sv: SelectionChip }
+  languageChips: Record<Language, SelectionChip>
+  languageFilterGroup: Element
   constructor(private readonly page: Page) {
     this.daycareFilter = new Radio(page.findByDataQa('map-filter-DAYCARE'))
     this.preschoolFilter = new Radio(page.findByDataQa('map-filter-PRESCHOOL'))
@@ -25,15 +28,25 @@ export default class CitizenMapPage {
     this.map = new Map(page.findByDataQa('map-view'))
     this.searchInput = new MapSearchInput(page.findByDataQa('map-search-input'))
     this.languageChips = {
-      fi: new SelectionChip(page.findByDataQa('map-filter-fi')),
-      sv: new SelectionChip(page.findByDataQa('map-filter-sv'))
+      fi: new SelectionChip(page.findByDataQa('map-language-filter-fi')),
+      sv: new SelectionChip(page.findByDataQa('map-language-filter-sv')),
+      en: new SelectionChip(page.findByDataQa('map-language-filter-en'))
     }
+    this.languageFilterGroup = page.findByDataQa('map-language-filter')
   }
 
-  async setLanguageFilter(language: 'fi' | 'sv', selected: boolean) {
+  async setLanguageFilter(language: Language, selected: boolean) {
     const chip = this.languageChips[language]
     if ((await chip.checked) !== selected) {
       await chip.click()
+    }
+  }
+
+  async assertLanguageFilterVisible(visible: boolean) {
+    if (visible) {
+      await expect(this.languageFilterGroup).toBeVisible()
+    } else {
+      await expect(this.languageFilterGroup).toBeHidden()
     }
   }
 

--- a/frontend/src/e2e-test/pages/employee/documents/document-templates.ts
+++ b/frontend/src/e2e-test/pages/employee/documents/document-templates.ts
@@ -79,6 +79,7 @@ export class TemplateModal extends Element {
   readonly nameInput
   readonly typeSelect
   readonly placementTypesSelect
+  readonly languageSelect
   readonly validityStartInput
   readonly processDefinitionNumberInput
   readonly archiveDurationMonthsInput
@@ -94,6 +95,7 @@ export class TemplateModal extends Element {
     this.placementTypesSelect = new MultiSelect(
       this.findByDataQa('placement-types-select')
     )
+    this.languageSelect = new Select(this.findByDataQa('language-select'))
     this.validityStartInput = new TextInput(this.findByDataQa('start-date'))
     this.processDefinitionNumberInput = new TextInput(
       this.findByDataQa('process-definition-number')

--- a/frontend/src/e2e-test/pages/employee/units/unit.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit.ts
@@ -6,7 +6,7 @@ import type {
   ApplicationType,
   TransferApplicationUnitSummary
 } from 'lib-common/generated/api-types/application'
-import type { CareType } from 'lib-common/generated/api-types/daycare'
+import type { CareType, Language } from 'lib-common/generated/api-types/daycare'
 import type LocalDate from 'lib-common/local-date'
 import type { UUID } from 'lib-common/types'
 
@@ -408,6 +408,10 @@ export class UnitEditor {
 
   async selectProviderType(providerType: UnitProviderType) {
     await this.#providerTypeRadio(providerType).click()
+  }
+
+  async selectLanguage(language: Language) {
+    await this.page.findByDataQa(`language-${language}`).click()
   }
 
   async setUnitHandlerAddress(text: string) {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-daycare-application.spec.ts
@@ -2,12 +2,17 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import type { DaycareId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
+import { randomId } from 'lib-common/id-type'
 
 import { execSimpleApplicationActions } from '../../dev-api'
 import {
   applicationFixture,
+  clubTerm2021,
+  testClub,
   testDaycare,
+  testDaycare2,
   testAdult,
   Fixture,
   testAdult2,
@@ -26,6 +31,7 @@ import {
 import CitizenApplicationsPage from '../../pages/citizen/citizen-applications'
 import CitizenHeader from '../../pages/citizen/citizen-header'
 import CitizenPersonalDetailsPage from '../../pages/citizen/citizen-personal-details'
+import { UnitEditor } from '../../pages/employee/units/unit'
 import { test, expect } from '../../playwright'
 import {
   fullDaycareForm,
@@ -33,7 +39,7 @@ import {
 } from '../../utils/application-forms'
 import { getVerificationCodeFromEmail } from '../../utils/email'
 import type { Page } from '../../utils/page'
-import { enduserLogin } from '../../utils/user'
+import { employeeLogin, enduserLogin } from '../../utils/user'
 
 const testFileName = 'test_file.png'
 const testFilePath = `src/e2e-test/assets/${testFileName}`
@@ -392,5 +398,227 @@ test.describe('Citizen daycare applications', () => {
     // then the email in the application updates and cannot be edited
     await editorPage.openSection('contactInfo')
     await editorPage.assertVerifiedReadOnlyEmail('new-email@example.com')
+  })
+
+  test('Language filter limits selectable units to chosen languages', async () => {
+    const swedishDaycare = {
+      ...testDaycare2,
+      id: randomId<DaycareId>(),
+      areaId: testCareArea.id,
+      name: 'Svensk daghem',
+      language: 'sv' as const,
+      daycareApplyPeriod: testDaycare.daycareApplyPeriod
+    }
+    const englishDaycare = {
+      ...testDaycare2,
+      id: randomId<DaycareId>(),
+      areaId: testCareArea.id,
+      name: 'English Daycare',
+      language: 'en' as const,
+      daycareApplyPeriod: testDaycare.daycareApplyPeriod
+    }
+    await Fixture.daycare(swedishDaycare).save()
+    await Fixture.daycare(englishDaycare).save()
+
+    const editorPage = await applicationsPage.createApplication(
+      testChild.id,
+      'DAYCARE'
+    )
+    await editorPage.fillData({
+      serviceNeed: {
+        preferredStartDate: '16.08.2021',
+        startTime: '09:00',
+        endTime: '17:00'
+      },
+      contactInfo: {
+        guardianPhone: '040123456',
+        noGuardianEmail: true
+      }
+    })
+    await editorPage.openSection('unitPreference')
+
+    // All three language chips should be visible
+    await expect(editorPage.unitLanguageFilterChip('fi')).toBeVisible()
+    await expect(editorPage.unitLanguageFilterChip('sv')).toBeVisible()
+    await expect(editorPage.unitLanguageFilterChip('en')).toBeVisible()
+
+    // Default: fi pre-selected → only Finnish unit is selectable
+    await editorPage.assertPreferredUnitOptions([testDaycare.name])
+
+    // Deselecting all chips empties the dropdown
+    await editorPage.setUnitLanguageFilter('fi', false)
+    await editorPage.assertNoPreferredUnitOptions()
+    await editorPage.setUnitLanguageFilter('fi', true)
+
+    // Add sv → fi + sv units selectable
+    await editorPage.setUnitLanguageFilter('sv', true)
+    await editorPage.assertPreferredUnitOptions([
+      testDaycare.name,
+      swedishDaycare.name
+    ])
+
+    // Remove fi → only sv units selectable
+    await editorPage.setUnitLanguageFilter('fi', false)
+    await editorPage.assertPreferredUnitOptions([swedishDaycare.name])
+
+    // Switch to en only → only English units selectable
+    await editorPage.setUnitLanguageFilter('sv', false)
+    await editorPage.setUnitLanguageFilter('en', true)
+    await editorPage.assertPreferredUnitOptions([englishDaycare.name])
+    await editorPage.assertHiddenFromPreferredUnits([
+      testDaycare.name,
+      swedishDaycare.name
+    ])
+
+    // The filtered unit is still selectable
+    await editorPage.selectUnit('English Daycare')
+    await editorPage.assertSelectedPreferredUnits([englishDaycare.id])
+  })
+
+  test('Language filter is hidden when only one language exists', async () => {
+    const editorPage = await applicationsPage.createApplication(
+      testChild.id,
+      'DAYCARE'
+    )
+    await editorPage.fillData({
+      serviceNeed: {
+        preferredStartDate: '16.08.2021',
+        startTime: '09:00',
+        endTime: '17:00'
+      },
+      contactInfo: {
+        guardianPhone: '040123456',
+        noGuardianEmail: true
+      }
+    })
+    await editorPage.openSection('unitPreference')
+
+    // Only Finnish units exist, so the language filter should be hidden
+    await editorPage.assertLanguageFilterVisible(false)
+
+    // The Finnish unit must still be selectable when the filter is hidden
+    await editorPage.selectUnit(testDaycare.name)
+    await editorPage.assertSelectedPreferredUnits([testDaycare.id])
+  })
+
+  test('Default chip selection includes all available languages when no Finnish units exist', async () => {
+    // testDaycare (Finnish) does not match a CLUB application, so this scenario
+    // exercises the no-fi-units fallback path of the language filter default.
+    const swedishClub = {
+      ...testClub,
+      id: randomId<DaycareId>(),
+      areaId: testCareArea.id,
+      name: 'Svensk klubb',
+      language: 'sv' as const
+    }
+    const englishClub = {
+      ...testClub,
+      id: randomId<DaycareId>(),
+      areaId: testCareArea.id,
+      name: 'English Club',
+      language: 'en' as const
+    }
+    await Fixture.daycare(swedishClub).save()
+    await Fixture.daycare(englishClub).save()
+    await clubTerm2021.save()
+
+    const editorPage = await applicationsPage.createApplication(
+      testChild.id,
+      'CLUB'
+    )
+    await editorPage.fillData({
+      serviceNeed: { preferredStartDate: '16.08.2021' },
+      contactInfo: { guardianPhone: '040123456', noGuardianEmail: true }
+    })
+    await editorPage.openSection('unitPreference')
+
+    // No Finnish units → fi chip hidden, sv + en chips visible
+    await expect(editorPage.unitLanguageFilterChip('fi')).toBeHidden()
+    await expect(editorPage.unitLanguageFilterChip('sv')).toBeVisible()
+    await expect(editorPage.unitLanguageFilterChip('en')).toBeVisible()
+
+    // Default selection is ['fi'], but no Finnish units exist in the CLUB
+    // care type → the stale-selection fallback shows all units rather than
+    // locking the user out of an empty dropdown.
+    await editorPage.assertPreferredUnitOptions([
+      englishClub.name,
+      swedishClub.name
+    ])
+
+    // The fallback default lets the user actually apply
+    await editorPage.selectUnit(englishClub.name)
+    await editorPage.assertSelectedPreferredUnits([englishClub.id])
+  })
+
+  test('Language filter chip is shown only if there is at least one unit with that language', async ({
+    newEvakaPage
+  }) => {
+    const swedishDaycare = {
+      ...testDaycare2,
+      id: randomId<DaycareId>(),
+      areaId: testCareArea.id,
+      name: 'Svensk daghem',
+      language: 'sv' as const,
+      daycareApplyPeriod: testDaycare.daycareApplyPeriod
+    }
+    await Fixture.daycare(swedishDaycare).save()
+
+    const editorPage = await applicationsPage.createApplication(
+      testChild.id,
+      'DAYCARE'
+    )
+    const applicationId = editorPage.getNewApplicationId()
+    await editorPage.fillData({
+      serviceNeed: {
+        preferredStartDate: '16.08.2021',
+        startTime: '09:00',
+        endTime: '17:00'
+      },
+      contactInfo: {
+        guardianPhone: '040123456',
+        noGuardianEmail: true
+      }
+    })
+    await editorPage.openSection('unitPreference')
+
+    // Initially: fi + sv chips visible, en chip hidden
+    await expect(editorPage.unitLanguageFilterChip('fi')).toBeVisible()
+    await expect(editorPage.unitLanguageFilterChip('sv')).toBeVisible()
+    await expect(editorPage.unitLanguageFilterChip('en')).toBeHidden()
+
+    // Persist the draft so the form state survives the reload below
+    await editorPage.saveAsDraftButton.click()
+    await editorPage.modalOkBtn.click()
+
+    // Admin updates the Finnish unit's language to English
+    const admin = await Fixture.employee().admin().save()
+    const adminPage = await newEvakaPage({ mockedTime: mockedNow })
+    await employeeLogin(adminPage, admin)
+    const unitEditor = await UnitEditor.openById(adminPage, testDaycare.id)
+    await unitEditor.selectLanguage('en')
+    await unitEditor.fillManagerData(
+      'Päiväkodin Johtaja',
+      '01234567',
+      'manager@example.com'
+    )
+    await unitEditor.setInvoiceByMunicipality(false)
+    await unitEditor.submit()
+
+    // Citizen re-enters the draft and revisits the unit preference section
+    await applicationsPage.editApplication(applicationId)
+    await editorPage.openSection('unitPreference')
+
+    // Now: sv + en chips visible, fi chip hidden
+    await expect(editorPage.unitLanguageFilterChip('fi')).toBeHidden()
+    await expect(editorPage.unitLanguageFilterChip('sv')).toBeVisible()
+    await expect(editorPage.unitLanguageFilterChip('en')).toBeVisible()
+
+    // The persisted ['fi'] chip selection no longer overlaps with available
+    // languages → the stale-selection fallback fires and the dropdown still
+    // shows the (now-English) unit and the Swedish unit, instead of being empty.
+    await editorPage.assertPreferredUnitOptions([
+      testDaycare.name,
+      swedishDaycare.name
+    ])
   })
 })

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-map.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-map.spec.ts
@@ -35,6 +35,24 @@ const swedishDaycare: DevDaycare = {
   }
 }
 
+const englishDaycare: DevDaycare = {
+  ...testDaycare2,
+  name: 'Black hole english daycare',
+  id: fromUuid('1d4ca4f9-e3d2-4c0c-9b56-9e72b41f8c2a'),
+  language: 'en',
+  location: {
+    lat: 60.200745762705296,
+    lon: 24.785286409387005
+  }
+}
+
+const swedishPreschool: DevDaycare = {
+  ...testPreschool,
+  name: 'Svart hål svenska förskola',
+  id: fromUuid('6c8e1f4b-3a52-4d7a-a8d6-5b1c0e2f9a73'),
+  language: 'sv'
+}
+
 const testStreet: DigitransitFeature = {
   geometry: {
     coordinates: [24.700883345430185, 60.18686533339131]
@@ -69,6 +87,8 @@ test.describe('Citizen map page', () => {
     await Fixture.daycare({ ...testDaycare2, areaId: careArea.id }).save()
     await Fixture.daycare({ ...testPreschool, areaId: careArea.id }).save()
     await Fixture.daycare({ ...swedishDaycare, areaId: careArea.id }).save()
+    await Fixture.daycare({ ...englishDaycare, areaId: careArea.id }).save()
+    await Fixture.daycare({ ...swedishPreschool, areaId: careArea.id }).save()
     await Fixture.daycare({
       ...privateDaycareWithoutPeriods,
       areaId: careArea.id
@@ -104,13 +124,81 @@ test.describe('Citizen map page', () => {
     expect(await mapPage.daycareFilter.checked).toBe(true)
     await expect(mapPage.listItemFor(testDaycare2)).toBeVisible()
     await expect(mapPage.listItemFor(swedishDaycare)).toBeVisible()
+    await expect(mapPage.listItemFor(englishDaycare)).toBeVisible()
 
     await mapPage.setLanguageFilter('fi', true)
     await expect(mapPage.listItemFor(swedishDaycare)).toBeHidden()
+    await expect(mapPage.listItemFor(englishDaycare)).toBeHidden()
+    await expect(mapPage.listItemFor(testDaycare2)).toBeVisible()
+
+    await mapPage.setLanguageFilter('en', true)
+    await expect(mapPage.listItemFor(swedishDaycare)).toBeHidden()
+    await expect(mapPage.listItemFor(englishDaycare)).toBeVisible()
     await expect(mapPage.listItemFor(testDaycare2)).toBeVisible()
 
     await mapPage.setLanguageFilter('sv', true)
     await mapPage.setLanguageFilter('fi', false)
+    await mapPage.setLanguageFilter('en', false)
+    await expect(mapPage.listItemFor(swedishDaycare)).toBeVisible()
+    await expect(mapPage.listItemFor(englishDaycare)).toBeHidden()
+    await expect(mapPage.listItemFor(testDaycare2)).toBeHidden()
+
+    await mapPage.setLanguageFilter('sv', false)
+    await expect(mapPage.listItemFor(testDaycare2)).toBeVisible()
+    await expect(mapPage.listItemFor(swedishDaycare)).toBeVisible()
+    await expect(mapPage.listItemFor(englishDaycare)).toBeVisible()
+  })
+
+  test('Language filter is hidden when only one language exists in the current care type', async () => {
+    // The shared seed has only the Finnish testClub for CLUB care type
+    await mapPage.clubFilter.check()
+    await mapPage.assertLanguageFilterVisible(false)
+
+    // Switching back to DAYCARE (which has fi + sv + en units) shows the filter again
+    await mapPage.daycareFilter.check()
+    await mapPage.assertLanguageFilterVisible(true)
+  })
+
+  test('Language filter chips reflect available languages in the current care type', async () => {
+    // DAYCARE has fi (testDaycare2) + sv (swedishDaycare) + en (englishDaycare)
+    await expect(mapPage.languageChips.fi).toBeVisible()
+    await expect(mapPage.languageChips.sv).toBeVisible()
+    await expect(mapPage.languageChips.en).toBeVisible()
+
+    // PRESCHOOL has fi (testPreschool) + sv (swedishPreschool) but no English unit
+    await mapPage.preschoolFilter.check()
+    await expect(mapPage.languageChips.fi).toBeVisible()
+    await expect(mapPage.languageChips.sv).toBeVisible()
+    await expect(mapPage.languageChips.en).toBeHidden()
+
+    // Switching back to DAYCARE re-introduces the en chip
+    await mapPage.daycareFilter.check()
+    await expect(mapPage.languageChips.en).toBeVisible()
+  })
+
+  test('Language selections for unavailable languages are ignored on care type switch', async () => {
+    // Select en in DAYCARE — only the English unit should remain
+    await mapPage.setLanguageFilter('en', true)
+    await expect(mapPage.listItemFor(englishDaycare)).toBeVisible()
+    await expect(mapPage.listItemFor(testDaycare2)).toBeHidden()
+    await expect(mapPage.listItemFor(swedishDaycare)).toBeHidden()
+
+    // Switch to PRESCHOOL — no English preschools exist, so the stale en
+    // selection is ignored and all preschool units are shown.
+    await mapPage.preschoolFilter.check()
+    await expect(mapPage.listItemFor(testPreschool)).toBeVisible()
+    await expect(mapPage.listItemFor(swedishPreschool)).toBeVisible()
+
+    // Adding an applicable chip (sv) filters normally; the stale en is still
+    // ignored, so only the Swedish preschool matches
+    await mapPage.setLanguageFilter('sv', true)
+    await expect(mapPage.listItemFor(swedishPreschool)).toBeVisible()
+    await expect(mapPage.listItemFor(testPreschool)).toBeHidden()
+
+    // Switching back to DAYCARE reactivates both selections — en and sv
+    // are both applicable there, so English and Swedish daycares show
+    await mapPage.daycareFilter.check()
+    await expect(mapPage.listItemFor(englishDaycare)).toBeVisible()
     await expect(mapPage.listItemFor(swedishDaycare)).toBeVisible()
     await expect(mapPage.listItemFor(testDaycare2)).toBeHidden()
   })

--- a/frontend/src/e2e-test/utils/page.ts
+++ b/frontend/src/e2e-test/utils/page.ts
@@ -624,6 +624,11 @@ export class MultiSelect extends Element {
     const actualOptions = this.findAllByDataQa('option')
     await expect(actualOptions.locator).toHaveText(options)
   }
+
+  async assertOptionsContain(options: string[]) {
+    const actualOptions = this.findAllByDataQa('option')
+    await expect(actualOptions.locator).toContainText(options)
+  }
 }
 
 export class Collapsible extends Element {

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateContentEditor.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateContentEditor.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useContext, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { useLocation } from 'wouter'
 
@@ -52,6 +52,7 @@ import {
 import { faPen } from 'lib-icons'
 
 import { useTranslation } from '../../../state/i18n'
+import { UserContext } from '../../../state/user'
 import {
   documentTemplateForm,
   getTemplateFormInitialState,
@@ -323,6 +324,9 @@ const BasicsEditor = React.memo(function BasicsEditor({
   onClose: () => void
 }) {
   const { i18n, lang } = useTranslation()
+  const { user } = useContext(UserContext)
+  const allowEnglishForAllTypes =
+    user?.accessibleFeatures.allowEnglishChildDocumentsForAllTypes
 
   const typeOptions = useMemo(
     () =>
@@ -335,15 +339,17 @@ const BasicsEditor = React.memo(function BasicsEditor({
   )
 
   const getLanguageOptions = useCallback(
-    (type: ChildDocumentType) =>
-      uiLanguages
-        .filter((option) => type === 'CITIZEN_BASIC' || option !== 'EN')
+    (type: ChildDocumentType) => {
+      const englishAllowed = type === 'CITIZEN_BASIC' || allowEnglishForAllTypes
+      return uiLanguages
+        .filter((option) => option !== 'EN' || englishAllowed)
         .map((option) => ({
           domValue: option,
           value: option,
           label: i18n.documentTemplates.languages[option]
-        })),
-    [i18n.documentTemplates]
+        }))
+    },
+    [i18n.documentTemplates, allowEnglishForAllTypes]
   )
 
   const form = useForm(

--- a/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/TemplateModal.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useContext, useMemo } from 'react'
 
 import DateRange from 'lib-common/date-range'
 import { openEndedLocalDateRange } from 'lib-common/form/fields'
@@ -38,6 +38,7 @@ import {
 } from 'lib-customizations/employee'
 
 import { useTranslation } from '../../../state/i18n'
+import { UserContext } from '../../../state/user'
 import { renderResult } from '../../async-rendering'
 import { documentTemplateForm } from '../forms'
 import {
@@ -93,6 +94,9 @@ const TemplateModalInner = React.memo(function TemplateModalInner({
   mode
 }: InternalProps) {
   const { i18n, lang } = useTranslation()
+  const { user } = useContext(UserContext)
+  const allowEnglishForAllTypes =
+    user?.accessibleFeatures.allowEnglishChildDocumentsForAllTypes
 
   const { mutateAsync: createDocumentTemplate } = useMutationResult(
     createDocumentTemplateMutation
@@ -126,15 +130,17 @@ const TemplateModalInner = React.memo(function TemplateModalInner({
   )
 
   const getLanguageOptions = useCallback(
-    (type: ChildDocumentType) =>
-      uiLanguages
-        .filter((option) => type === 'CITIZEN_BASIC' || option !== 'EN')
+    (type: ChildDocumentType) => {
+      const englishAllowed = type === 'CITIZEN_BASIC' || allowEnglishForAllTypes
+      return uiLanguages
+        .filter((option) => option !== 'EN' || englishAllowed)
         .map((option) => ({
           domValue: option,
           value: option,
           label: i18n.documentTemplates.languages[option]
-        })),
-    [i18n.documentTemplates]
+        }))
+    },
+    [i18n.documentTemplates, allowEnglishForAllTypes]
   )
 
   const form = useForm(
@@ -328,7 +334,7 @@ const TemplateModalInner = React.memo(function TemplateModalInner({
       />
       <Gap />
       <Label>{i18n.documentTemplates.templateModal.language}</Label>
-      <SelectF bind={language} />
+      <SelectF bind={language} data-qa="language-select" />
       <Gap />
       <Label>{i18n.documentTemplates.templateModal.legalBasis}</Label>
       <InputFieldF bind={legalBasis} hideErrorsBeforeTouched />

--- a/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
@@ -1655,7 +1655,7 @@ export default function UnitEditor(props: Props) {
         </div>
         {props.editable ? (
           <FixedSpaceColumn>
-            {(['fi', 'sv'] as const).map((value) => (
+            {(['fi', 'sv', 'en'] as const).map((value) => (
               <Radio
                 key={value}
                 label={i18n.language[value]}

--- a/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-details/UnitEditor.tsx
@@ -1661,6 +1661,7 @@ export default function UnitEditor(props: Props) {
                 label={i18n.language[value]}
                 checked={form.language === value}
                 onChange={() => updateForm({ language: value })}
+                data-qa={`language-${value}`}
               />
             ))}
           </FixedSpaceColumn>

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -120,6 +120,7 @@ export type DocumentTemplateId = Id<'DocumentTemplate'>
 * Generated from evaka.core.shared.security.EmployeeFeatures
 */
 export interface EmployeeFeatures {
+  allowEnglishChildDocumentsForAllTypes: boolean
   applications: boolean
   createDraftInvoices: boolean
   createPlacements: boolean

--- a/frontend/src/lib-components/molecules/LanguageFilterChips.tsx
+++ b/frontend/src/lib-components/molecules/LanguageFilterChips.tsx
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import React from 'react'
+
+import type { Language } from 'lib-common/generated/api-types/daycare'
+
+import { SelectionChip } from '../atoms/Chip'
+import { FixedSpaceColumn, FixedSpaceRow } from '../layout/flex-helpers'
+import { Label } from '../typography'
+
+interface Props {
+  availableLanguages: Set<Language>
+  selected: Language[]
+  onChange: (next: Language[]) => void
+  getLabel: (lang: Language) => string
+  label: string
+  labelId: string
+  /** Used as the group's data-qa and as the prefix for each chip's data-qa (`${dataQa}-${lang}`). */
+  dataQa: string
+}
+
+export default React.memo(function LanguageFilterChips({
+  availableLanguages,
+  selected,
+  onChange,
+  getLabel,
+  label,
+  labelId,
+  dataQa
+}: Props) {
+  if (availableLanguages.size < 2) return null
+
+  return (
+    <FixedSpaceColumn
+      $spacing="xs"
+      role="group"
+      aria-labelledby={labelId}
+      data-qa={dataQa}
+    >
+      <Label id={labelId}>{label}</Label>
+      <FixedSpaceRow>
+        {(['fi', 'sv', 'en'] as const)
+          .filter((lang) => availableLanguages.has(lang))
+          .map((lang) => (
+            <SelectionChip
+              key={lang}
+              data-qa={`${dataQa}-${lang}`}
+              text={getLabel(lang)}
+              selected={selected.includes(lang)}
+              onChange={(s) =>
+                onChange(
+                  s ? [...selected, lang] : selected.filter((l) => l !== lang)
+                )
+              }
+            />
+          ))}
+      </FixedSpaceRow>
+    </FixedSpaceColumn>
+  )
+})

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1447,7 +1447,8 @@ const en: Translations = {
           languageFilter: {
             label: 'Language of the location:',
             fi: 'Finnish',
-            sv: 'Swedish'
+            sv: 'Swedish',
+            en: 'English'
           },
           select: {
             label: (maxUnits: number) =>

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -1419,7 +1419,8 @@ export default {
           languageFilter: {
             label: 'Yksikön kieli',
             fi: 'suomi',
-            sv: 'ruotsi'
+            sv: 'ruotsi',
+            en: 'englanti'
           },
           select: {
             label: (maxUnits: number): string =>

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -1406,7 +1406,8 @@ const sv: Translations = {
           languageFilter: {
             label: 'Enhetens språk:',
             fi: 'finska',
-            sv: 'svenska'
+            sv: 'svenska',
+            en: 'engelska'
           },
           select: {
             label: (maxUnits: number) =>

--- a/frontend/src/lib-customizations/turku/enCustomizations.tsx
+++ b/frontend/src/lib-customizations/turku/enCustomizations.tsx
@@ -474,7 +474,8 @@ const en: DeepPartial<Translations> = {
           languageFilter: {
             label: 'Unit language',
             fi: 'Finnish',
-            sv: 'Swedish'
+            sv: 'Swedish',
+            en: 'English'
           },
           select: {
             label: (maxUnits: number): string =>

--- a/frontend/src/lib-customizations/turku/fiCustomizations.tsx
+++ b/frontend/src/lib-customizations/turku/fiCustomizations.tsx
@@ -468,7 +468,8 @@ const fi: DeepPartial<Translations> = {
           languageFilter: {
             label: 'Yksikön kieli',
             fi: 'suomi',
-            sv: 'ruotsi'
+            sv: 'ruotsi',
+            en: 'englanti'
           },
           select: {
             label: (maxUnits: number): string =>

--- a/frontend/src/lib-customizations/turku/svCustomizations.tsx
+++ b/frontend/src/lib-customizations/turku/svCustomizations.tsx
@@ -470,7 +470,8 @@ const sv: DeepPartial<Translations> = {
           languageFilter: {
             label: 'Enhetens språk',
             fi: 'finska',
-            sv: 'svenska'
+            sv: 'svenska',
+            en: 'engelska'
           },
           select: {
             label: (maxUnits: number): string =>

--- a/service/src/integrationTest/kotlin/evaka/core/daycare/DaycareEditIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/daycare/DaycareEditIntegrationTest.kt
@@ -164,6 +164,27 @@ class DaycareEditIntegrationTest : FullApplicationTest(resetDbBeforeEach = true)
     }
 
     @Test
+    fun testCreateEnglish() {
+        val englishFields = fields.copy(language = Language.en)
+        val result =
+            daycareController.createDaycare(dbInstance(), admin, RealEvakaClock(), englishFields)
+        getAndAssertDaycareFields(result.id, englishFields)
+    }
+
+    @Test
+    fun testUpdateEnglish() {
+        val englishFields = fields.copy(language = Language.en)
+        daycareController.updateDaycare(
+            dbInstance(),
+            admin,
+            RealEvakaClock(),
+            daycare.id,
+            englishFields,
+        )
+        getAndAssertDaycareFields(daycare.id, englishFields)
+    }
+
+    @Test
     fun testUpdatePreschool() {
         val preschoolFields =
             fields.copy(

--- a/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
@@ -4,6 +4,7 @@
 
 package evaka.core.document
 
+import evaka.core.CitizenCalendarEnv
 import evaka.core.FullApplicationTest
 import evaka.core.caseprocess.DocumentConfidentiality
 import evaka.core.daycare.domain.Language
@@ -11,6 +12,7 @@ import evaka.core.document.childdocument.ChildDocumentController
 import evaka.core.document.childdocument.ChildDocumentCreateRequest
 import evaka.core.placement.PlacementType
 import evaka.core.shared.auth.UserRole
+import evaka.core.shared.config.testFeatureConfig
 import evaka.core.shared.dev.DevCareArea
 import evaka.core.shared.dev.DevDaycare
 import evaka.core.shared.dev.DevEmployee
@@ -23,6 +25,7 @@ import evaka.core.shared.domain.DateRange
 import evaka.core.shared.domain.MockEvakaClock
 import evaka.core.shared.domain.NotFound
 import evaka.core.shared.domain.UiLanguage
+import evaka.core.shared.security.AccessControl
 import evaka.core.shared.security.PilotFeature
 import java.time.LocalDate
 import kotlin.test.assertEquals
@@ -36,6 +39,16 @@ import org.springframework.beans.factory.annotation.Autowired
 class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     @Autowired lateinit var controller: DocumentTemplateController
     @Autowired lateinit var childDocumentController: ChildDocumentController
+    @Autowired lateinit var accessControl: AccessControl
+    @Autowired lateinit var citizenCalendarEnv: CitizenCalendarEnv
+
+    private fun controllerWithEnglishFlag(enabled: Boolean) =
+        DocumentTemplateController(
+            accessControl,
+            evakaEnv,
+            citizenCalendarEnv,
+            testFeatureConfig.copy(allowEnglishChildDocumentsForAllTypes = enabled),
+        )
 
     private val now = MockEvakaClock(2022, 1, 1, 15, 0)
     private val area = DevCareArea()
@@ -672,6 +685,165 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                 ),
             )
         }
+    }
+
+    @Test
+    fun `English is rejected for non-CITIZEN_BASIC types when flag is off - create`() {
+        val request =
+            testCreationRequest.copy(
+                type = ChildDocumentType.PEDAGOGICAL_REPORT,
+                language = UiLanguage.EN,
+            )
+        val ex =
+            assertThrows<BadRequest> {
+                controllerWithEnglishFlag(enabled = false)
+                    .createTemplate(dbInstance(), employee.user, now, request)
+            }
+        assertEquals("English is not supported for this document type", ex.message)
+    }
+
+    @Test
+    fun `English is rejected for non-CITIZEN_BASIC types when flag is off - import`() {
+        val exported =
+            testCreationRequest
+                .copy(type = ChildDocumentType.PEDAGOGICAL_REPORT, language = UiLanguage.EN)
+                .toExported(testContent)
+        val ex =
+            assertThrows<BadRequest> {
+                controllerWithEnglishFlag(enabled = false)
+                    .importTemplate(dbInstance(), employee.user, now, exported)
+            }
+        assertEquals("English is not supported for this document type", ex.message)
+    }
+
+    @Test
+    fun `English is rejected for non-CITIZEN_BASIC types when flag is off - duplicate`() {
+        val disabledController = controllerWithEnglishFlag(enabled = false)
+        val created =
+            disabledController.createTemplate(dbInstance(), employee.user, now, testCreationRequest)
+        val ex =
+            assertThrows<BadRequest> {
+                disabledController.duplicateTemplate(
+                    dbInstance(),
+                    employee.user,
+                    now,
+                    created.id,
+                    testCreationRequest.copy(
+                        name = "dup",
+                        type = ChildDocumentType.PEDAGOGICAL_REPORT,
+                        language = UiLanguage.EN,
+                    ),
+                )
+            }
+        assertEquals("English is not supported for this document type", ex.message)
+    }
+
+    @Test
+    fun `English is rejected for non-CITIZEN_BASIC types when flag is off - update`() {
+        val disabledController = controllerWithEnglishFlag(enabled = false)
+        val created =
+            disabledController.createTemplate(dbInstance(), employee.user, now, testCreationRequest)
+        val ex =
+            assertThrows<BadRequest> {
+                disabledController.updateDraftTemplateBasics(
+                    dbInstance(),
+                    employee.user,
+                    now,
+                    created.id,
+                    testCreationRequest.copy(
+                        type = ChildDocumentType.PEDAGOGICAL_REPORT,
+                        language = UiLanguage.EN,
+                    ),
+                )
+            }
+        assertEquals("English is not supported for this document type", ex.message)
+    }
+
+    @Test
+    fun `English is accepted for non-CITIZEN_BASIC types when flag is on - create`() {
+        val englishController = controllerWithEnglishFlag(enabled = true)
+        val request =
+            testCreationRequest.copy(
+                type = ChildDocumentType.PEDAGOGICAL_REPORT,
+                language = UiLanguage.EN,
+            )
+        val created = englishController.createTemplate(dbInstance(), employee.user, now, request)
+        assertEquals(UiLanguage.EN, created.language)
+        assertEquals(ChildDocumentType.PEDAGOGICAL_REPORT, created.type)
+    }
+
+    @Test
+    fun `English is accepted for non-CITIZEN_BASIC types when flag is on - update`() {
+        val englishController = controllerWithEnglishFlag(enabled = true)
+        val created =
+            englishController.createTemplate(dbInstance(), employee.user, now, testCreationRequest)
+        englishController.updateDraftTemplateBasics(
+            dbInstance(),
+            employee.user,
+            now,
+            created.id,
+            testCreationRequest.copy(
+                type = ChildDocumentType.PEDAGOGICAL_REPORT,
+                language = UiLanguage.EN,
+            ),
+        )
+        val updated = englishController.getTemplate(dbInstance(), employee.user, now, created.id)
+        assertEquals(UiLanguage.EN, updated.language)
+        assertEquals(ChildDocumentType.PEDAGOGICAL_REPORT, updated.type)
+    }
+
+    @Test
+    fun `English is accepted for non-CITIZEN_BASIC types when flag is on - import`() {
+        val englishController = controllerWithEnglishFlag(enabled = true)
+        val exported =
+            testCreationRequest
+                .copy(type = ChildDocumentType.PEDAGOGICAL_REPORT, language = UiLanguage.EN)
+                .toExported(testContent)
+        val imported = englishController.importTemplate(dbInstance(), employee.user, now, exported)
+        assertEquals(UiLanguage.EN, imported.language)
+        assertEquals(ChildDocumentType.PEDAGOGICAL_REPORT, imported.type)
+    }
+
+    @Test
+    fun `English is accepted for non-CITIZEN_BASIC types when flag is on - duplicate`() {
+        val englishController = controllerWithEnglishFlag(enabled = true)
+        val created =
+            englishController.createTemplate(dbInstance(), employee.user, now, testCreationRequest)
+        val duplicated =
+            englishController.duplicateTemplate(
+                dbInstance(),
+                employee.user,
+                now,
+                created.id,
+                testCreationRequest.copy(
+                    name = "dup",
+                    type = ChildDocumentType.PEDAGOGICAL_REPORT,
+                    language = UiLanguage.EN,
+                ),
+            )
+        assertEquals(UiLanguage.EN, duplicated.language)
+        assertEquals(ChildDocumentType.PEDAGOGICAL_REPORT, duplicated.type)
+    }
+
+    @Test
+    fun `English is accepted for CITIZEN_BASIC regardless of flag`() {
+        val request =
+            testCreationRequest.copy(
+                type = ChildDocumentType.CITIZEN_BASIC,
+                language = UiLanguage.EN,
+                confidentiality = null,
+            )
+        val createdFlagOff =
+            controllerWithEnglishFlag(enabled = false)
+                .createTemplate(dbInstance(), employee.user, now, request)
+        assertEquals(UiLanguage.EN, createdFlagOff.language)
+        assertEquals(ChildDocumentType.CITIZEN_BASIC, createdFlagOff.type)
+
+        val createdFlagOn =
+            controllerWithEnglishFlag(enabled = true)
+                .createTemplate(dbInstance(), employee.user, now, request.copy(name = "cb2"))
+        assertEquals(UiLanguage.EN, createdFlagOn.language)
+        assertEquals(ChildDocumentType.CITIZEN_BASIC, createdFlagOn.type)
     }
 }
 

--- a/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
@@ -15,6 +15,7 @@ import evaka.core.shared.auth.UserRole
 import evaka.core.shared.config.testFeatureConfig
 import evaka.core.shared.dev.DevCareArea
 import evaka.core.shared.dev.DevDaycare
+import evaka.core.shared.dev.DevDaycareGroup
 import evaka.core.shared.dev.DevEmployee
 import evaka.core.shared.dev.DevPerson
 import evaka.core.shared.dev.DevPersonType
@@ -562,6 +563,152 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
 
         val active = controller.getActiveTemplates(dbInstance(), employee.user, now, childId)
         assertTrue(active.isEmpty())
+    }
+
+    @Test
+    fun `active templates endpoint returns templates in all languages when placement unit is english`() {
+        val childId = insertChildInUnitWithLanguage(Language.en, name = "English Daycare")
+        listOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN).forEach { lang ->
+            publishPedagogicalAssessmentTemplate(lang)
+        }
+
+        val active = controller.getActiveTemplates(dbInstance(), employee.user, now, childId)
+        assertEquals(
+            setOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN),
+            active.map { it.language }.toSet(),
+        )
+    }
+
+    @Test
+    fun `active templates endpoint returns finnish and english templates only when placement unit is finnish`() {
+        val childId = insertChildInUnitWithLanguage(Language.fi, name = "Finnish Daycare")
+        listOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN).forEach { lang ->
+            publishPedagogicalAssessmentTemplate(lang)
+        }
+
+        val active = controller.getActiveTemplates(dbInstance(), employee.user, now, childId)
+        assertEquals(setOf(UiLanguage.FI, UiLanguage.EN), active.map { it.language }.toSet())
+    }
+
+    @Test
+    fun `active templates by group id endpoint returns templates in all languages when group unit is english`() {
+        val groupId = insertGroupInUnitWithLanguage(Language.en, name = "English Daycare")
+        listOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN).forEach { lang ->
+            publishCitizenBasicTemplate(lang)
+        }
+
+        val active =
+            controller.getActiveTemplatesByGroupId(
+                dbInstance(),
+                employee.user,
+                now,
+                groupId,
+                emptySet(),
+            )
+        assertEquals(
+            setOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN),
+            active.map { it.language }.toSet(),
+        )
+    }
+
+    @Test
+    fun `active templates by group id endpoint returns only matching language templates when group unit is finnish`() {
+        val groupId = insertGroupInUnitWithLanguage(Language.fi, name = "Finnish Daycare")
+        listOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN).forEach { lang ->
+            publishCitizenBasicTemplate(lang)
+        }
+
+        val active =
+            controller.getActiveTemplatesByGroupId(
+                dbInstance(),
+                employee.user,
+                now,
+                groupId,
+                emptySet(),
+            )
+        assertEquals(setOf(UiLanguage.FI), active.map { it.language }.toSet())
+    }
+
+    private fun insertChildInUnitWithLanguage(language: Language, name: String) =
+        db.transaction { tx ->
+            val areaId =
+                tx.insert(DevCareArea(name = "Area for $name", shortName = "area_${language.name}"))
+            val daycareId =
+                tx.insert(
+                    DevDaycare(
+                        areaId = areaId,
+                        name = name,
+                        language = language,
+                        enabledPilotFeatures =
+                            setOf(
+                                PilotFeature.VASU_AND_PEDADOC,
+                                PilotFeature.OTHER_DECISION,
+                                PilotFeature.CITIZEN_BASIC_DOCUMENT,
+                            ),
+                    )
+                )
+            val childId = tx.insert(DevPerson(), DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = childId,
+                    unitId = daycareId,
+                    startDate = now.today(),
+                    endDate = now.today().plusDays(5),
+                )
+            )
+            childId
+        }
+
+    private fun insertGroupInUnitWithLanguage(language: Language, name: String) =
+        db.transaction { tx ->
+            val areaId =
+                tx.insert(
+                    DevCareArea(name = "Area for $name", shortName = "area_group_${language.name}")
+                )
+            val daycareId =
+                tx.insert(
+                    DevDaycare(
+                        areaId = areaId,
+                        name = name,
+                        language = language,
+                        enabledPilotFeatures = setOf(PilotFeature.CITIZEN_BASIC_DOCUMENT),
+                    )
+                )
+            tx.insert(DevDaycareGroup(daycareId = daycareId))
+        }
+
+    private fun publishPedagogicalAssessmentTemplate(language: UiLanguage) {
+        val template =
+            controllerWithEnglishFlag(enabled = true)
+                .createTemplate(
+                    dbInstance(),
+                    employee.user,
+                    now,
+                    testCreationRequest.copy(
+                        name = "PA-${language.name}",
+                        type = ChildDocumentType.PEDAGOGICAL_ASSESSMENT,
+                        language = language,
+                        validity = DateRange(now.today(), null),
+                    ),
+                )
+        controller.publishTemplate(dbInstance(), employee.user, now, template.id)
+    }
+
+    private fun publishCitizenBasicTemplate(language: UiLanguage) {
+        val template =
+            controller.createTemplate(
+                dbInstance(),
+                employee.user,
+                now,
+                testCreationRequest.copy(
+                    name = "CB-${language.name}",
+                    type = ChildDocumentType.CITIZEN_BASIC,
+                    language = language,
+                    confidentiality = null,
+                    validity = DateRange(now.today(), null),
+                ),
+            )
+        controller.publishTemplate(dbInstance(), employee.user, now, template.id)
     }
 
     @Test

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
@@ -153,9 +153,11 @@ class DocumentTemplateController(
                         it.published &&
                             it.validity.includes(clock.today()) &&
                             it.placementTypes.contains(placement.type) &&
+                            // English-language units can issue documents in any language
                             (it.language.name.uppercase() ==
                                 placement.unitLanguage.name.uppercase() ||
-                                it.language == UiLanguage.EN) &&
+                                it.language == UiLanguage.EN ||
+                                placement.unitLanguage == Language.en) &&
                             (placement.enabledPilotFeatures.contains(
                                 PilotFeature.VASU_AND_PEDADOC
                             ) || !isPedagogicalDocument((it.type))) &&
@@ -196,7 +198,9 @@ class DocumentTemplateController(
                         it.published &&
                             it.validity.includes(clock.today()) &&
                             (types.isEmpty() || types.contains(it.type)) &&
-                            (it.language.name.uppercase() == unit.language.name.uppercase())
+                            // English-language units can issue documents in any language
+                            (it.language.name.uppercase() == unit.language.name.uppercase() ||
+                                unit.language == Language.en)
                     }
                 }
             }

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
@@ -15,6 +15,7 @@ import evaka.core.daycare.getDaycare
 import evaka.core.placement.PlacementType
 import evaka.core.shared.ChildId
 import evaka.core.shared.DocumentTemplateId
+import evaka.core.shared.FeatureConfig
 import evaka.core.shared.GroupId
 import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.db.Database
@@ -47,6 +48,7 @@ class DocumentTemplateController(
     private val accessControl: AccessControl,
     private val evakaEnv: EvakaEnv,
     private val citizenCalendarEnv: CitizenCalendarEnv,
+    private val featureConfig: FeatureConfig,
 ) {
     @PostMapping
     fun createTemplate(
@@ -449,11 +451,15 @@ class DocumentTemplateController(
             }
             .also { Audit.DocumentTemplateDelete.log(targetId = AuditId(templateId)) }
     }
-}
 
-private fun validateLanguage(lang: UiLanguage, type: ChildDocumentType) {
-    if (type != ChildDocumentType.CITIZEN_BASIC && lang == UiLanguage.EN) {
-        throw BadRequest("English is not supported for this document type")
+    private fun validateLanguage(lang: UiLanguage, type: ChildDocumentType) {
+        if (
+            lang == UiLanguage.EN &&
+                type != ChildDocumentType.CITIZEN_BASIC &&
+                !featureConfig.allowEnglishChildDocumentsForAllTypes
+        ) {
+            throw BadRequest("English is not supported for this document type")
+        }
     }
 }
 

--- a/service/src/main/kotlin/evaka/core/pis/SystemController.kt
+++ b/service/src/main/kotlin/evaka/core/pis/SystemController.kt
@@ -338,6 +338,8 @@ class SystemController(
                                 permittedGlobalActions.contains(
                                     Action.Global.WRITE_DECISION_REASONINGS
                                 ),
+                            allowEnglishChildDocumentsForAllTypes =
+                                featureConfig.allowEnglishChildDocumentsForAllTypes,
                         )
 
                     EmployeeUserResponse(

--- a/service/src/main/kotlin/evaka/core/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/evaka/core/shared/FeatureConfig.kt
@@ -126,6 +126,9 @@ data class FeatureConfig(
 
     /** Accept preschool decision without asking guardian confirmation */
     val skipGuardianPreschoolDecisionApproval: Boolean = false,
+
+    /** Allow English as a language for every child document type, not only `CITIZEN_BASIC` */
+    val allowEnglishChildDocumentsForAllTypes: Boolean = false,
 )
 
 enum class ArchiveProcessType {

--- a/service/src/main/kotlin/evaka/core/shared/security/EmployeeFeatures.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/EmployeeFeatures.kt
@@ -29,4 +29,5 @@ data class EmployeeFeatures(
     val openRangesHolidayQuestionnaire: Boolean,
     val outOfOffice: Boolean,
     val decisionReasonings: Boolean,
+    val allowEnglishChildDocumentsForAllTypes: Boolean,
 )

--- a/service/src/main/kotlin/evaka/instance/turku/TurkuConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/turku/TurkuConfig.kt
@@ -130,6 +130,7 @@ class TurkuConfig {
                 }
             },
             placementToolApplicationStatus = ApplicationStatus.WAITING_DECISION,
+            allowEnglishChildDocumentsForAllTypes = true,
         )
 
     @Bean

--- a/service/src/main/resources/db/migration/V589__unit_language_en.sql
+++ b/service/src/main/resources/db/migration/V589__unit_language_en.sql
@@ -1,0 +1,1 @@
+ALTER TYPE unit_language ADD VALUE 'en';

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -584,3 +584,4 @@ V585__varda_errored_since.sql
 V586__income_statement_citizen_modified_at.sql
 V587__income_statement_citizen_modified_at_constraint.sql
 V588__decision_reasoning.sql
+V589__unit_language_en.sql


### PR DESCRIPTION
Tämän muutoksen jälkeen:
- Pääkäyttäjä voi luoda ja muokata jo olemassaolevasta yksiköstä englanninkielisen.
- Kuntalaisen hakemuksen ja kartan näkymissä kielirajaukseen lisätään "englanti" vaihtoehdoksi. Kielirajausta muutetaan myös siten, että rajausvaihtoehto näkyy vain jos löytyy edes yksi yksikkö kyseisellä kielellä.
- Lisätään uusi feature flag "allowEnglishChildDocumentsForAllTypes", joka pitää laittaa päälle backendissä. Tämä sallii englanninkielisten dokumenttipohjien luomisen myös muille kuin CITIZEN_BASIC dokumenteille.
- Englanninkielisissä yksiköissä oleville lapsille voidaan lähettää dokumentteja minkä tahansa kielisestä pohjasta.
- Englanninkielisistä yksiköistä lähetetään kielitieto Varda- ja Koski-palveluihin.