### PR TITLE
CVE-hälyn korjaus (Spring Boot)

### DIFF
--- a/service/gradle/libs.versions.toml
+++ b/service/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ ktlint = "1.8.0"
 ktlint-gradle = "14.2.0"
 mockito = "5.23.0"
 owasp = "12.2.1"
-spring-boot = "4.0.5"
+spring-boot = "4.0.6"
 versions = "0.53.0"
 
 [libraries]

--- a/service/src/integrationTest/kotlin/evaka/core/s3/S3DocumentServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/s3/S3DocumentServiceIntegrationTest.kt
@@ -101,7 +101,7 @@ class S3DocumentServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach =
         assertContentEquals(byteArrayOf(0x33, 0x11, 0x22), s3response.body.bytes())
         assertEquals(
             listOf(
-                "attachment; filename=\"=?UTF-8?Q?overridden-filename.pdf?=\"; filename*=UTF-8''overridden-filename.pdf"
+                "attachment; filename=\"overridden-filename.pdf\"; filename*=UTF-8''overridden-filename.pdf"
             ),
             response.headers["Content-Disposition"],
         )
@@ -120,7 +120,7 @@ class S3DocumentServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach =
         assertContentEquals(byteArrayOf(0x12, 0x34, 0x56), s3response.body.bytes())
         assertEquals(
             listOf(
-                "inline; filename=\"=?UTF-8?Q?overridden-filename.txt?=\"; filename*=UTF-8''overridden-filename.txt"
+                "inline; filename=\"overridden-filename.txt\"; filename*=UTF-8''overridden-filename.txt"
             ),
             response.headers["Content-Disposition"],
         )


### PR DESCRIPTION
Content-Disposition tiedostonimien muotoiluun on tullut [korjaus](https://github.com/spring-projects/spring-framework/pull/36328), joka rikkoi testin. 