### PR TITLE
Poistetaan Pirkkalasta esiopetustuki

### DIFF
--- a/frontend/src/lib-customizations/pirkkala/featureFlags.tsx
+++ b/frontend/src/lib-customizations/pirkkala/featureFlags.tsx
@@ -24,7 +24,7 @@ const prod: FeatureFlags = {
   },
   decisionDraftMultipleUnits: true,
   urgencyAttachments: true,
-  preschool: true,
+  preschool: false,
   preparatory: false,
   assistanceActionOther: false,
   financeDecisionHandlerSelect: true,


### PR DESCRIPTION
Esiopetusta ei järjestetä eVakan alla Pirkkalassa, joten Esiopetukseen viittaavat tekstit voisi kaikki poistaa kirjautumissivulta