### PR TITLE
Lisätään Oulun BI-datan sftp-vienti

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/shared/sftp/SftpClientTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/shared/sftp/SftpClientTest.kt
@@ -4,10 +4,13 @@
 
 package evaka.core.shared.sftp
 
+import com.jcraft.jsch.JSchException
 import evaka.core.Sensitive
 import evaka.core.SftpEnv
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 private val sftpPort = System.getenv("EVAKA_SFTP_PORT")?.toIntOrNull() ?: 2222
 
@@ -46,5 +49,23 @@ class SftpClientTest {
         val client = SftpClient(env.copy(password = null, privateKey = Sensitive(privateKey)))
         "hello world".byteInputStream(Charsets.UTF_8).use { client.put(it, "upload/test.txt") }
         assertEquals("hello world", client.getAsString("upload/test.txt", Charsets.UTF_8))
+    }
+
+    @Test
+    fun `refuses to connect when the server host key is not pinned`() {
+        val wrongKey = "AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        val client =
+            SftpClient(
+                env.copy(
+                    hostKeys = listOf(wrongKey),
+                    password = Sensitive(password),
+                    privateKey = null,
+                )
+            )
+        val exception =
+            assertThrows<JSchException> {
+                "hello".byteInputStream(Charsets.UTF_8).use { client.put(it, "upload/test.txt") }
+            }
+        assertContains(exception.message ?: "", "UnknownHostKey")
     }
 }

--- a/service/src/integrationTest/kotlin/evaka/instance/oulu/bi/OuluBiSftpExportClientTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/instance/oulu/bi/OuluBiSftpExportClientTest.kt
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 City of Oulu
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package evaka.instance.oulu.bi
+
+import evaka.core.Sensitive
+import evaka.core.SftpEnv
+import evaka.core.bi.CsvInputStream
+import evaka.core.shared.domain.MockEvakaClock
+import evaka.core.shared.sftp.SftpClient
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import java.util.zip.ZipInputStream
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import org.junit.jupiter.api.Test
+
+private val sftpPort = System.getenv("EVAKA_SFTP_PORT")?.toIntOrNull() ?: 2222
+
+private val env =
+    SftpEnv(
+        host = "localhost",
+        port = sftpPort,
+        hostKeys = listOf("AAAAC3NzaC1lZDI1NTE5AAAAICADdlntyAKbOUGQDkdzdhQBu12jZjb0KmxLyrklMXTq"),
+        username = "foo",
+        password = Sensitive("pass"),
+        privateKey = null,
+    )
+
+class OuluBiSftpExportClientTest {
+
+    @Test
+    fun `zips and uploads a CSV to the remote path`() {
+        val client = OuluBiSftpExportClient(SftpClient(env), "upload/")
+        val clock = MockEvakaClock(2026, 4, 24, 12, 0)
+        val csv = sequenceOf("col\r\n", "value\r\n")
+
+        val (returnedPath, returnedName) =
+            client.sendBiCsvFile("foo", clock, CsvInputStream(StandardCharsets.UTF_8, csv))
+
+        assertEquals("upload/", returnedPath)
+        assertEquals("foo_2026-04-24.zip", returnedName)
+
+        val bytes =
+            SftpClient(env)
+                .getAsString("upload/foo_2026-04-24.zip", StandardCharsets.ISO_8859_1)
+                .toByteArray(StandardCharsets.ISO_8859_1)
+
+        ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+            val entry = zip.nextEntry
+            assertNotNull(entry)
+            assertEquals("foo.csv", entry.name)
+            val content = zip.readBytes().toString(StandardCharsets.UTF_8)
+            assertEquals("col\r\nvalue\r\n", content)
+        }
+    }
+}

--- a/service/src/integrationTest/kotlin/evaka/instance/oulu/dw/DwExportJobTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/instance/oulu/dw/DwExportJobTest.kt
@@ -8,6 +8,7 @@ import com.jcraft.jsch.JSch
 import evaka.core.BucketEnv
 import evaka.core.FullApplicationTest
 import evaka.core.Sensitive
+import evaka.core.SftpEnv
 import evaka.core.absence.AbsenceCategory
 import evaka.core.shared.dev.DevAbsence
 import evaka.core.shared.dev.DevCareArea
@@ -24,6 +25,7 @@ import evaka.core.shared.dev.insert
 import evaka.core.shared.domain.FiniteDateRange
 import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.domain.MockEvakaClock
+import evaka.instance.oulu.BiProperties
 import evaka.instance.oulu.BucketProperties
 import evaka.instance.oulu.DwExportProperties
 import evaka.instance.oulu.OuluEnv
@@ -86,6 +88,19 @@ class DwExportJobTest : FullApplicationTest(resetDbBeforeEach = true) {
                                 username = Sensitive("foo"),
                                 password = Sensitive("pass"),
                             ),
+                    ),
+                bi =
+                    BiProperties(
+                        sftp =
+                            SftpEnv(
+                                host = "localhost",
+                                port = sftpPort,
+                                hostKeys = emptyList(),
+                                username = "foo",
+                                password = Sensitive("pass"),
+                                privateKey = null,
+                            ),
+                        remotePath = "upload/",
                     ),
             )
 

--- a/service/src/main/kotlin/evaka/core/shared/sftp/SftpClient.kt
+++ b/service/src/main/kotlin/evaka/core/shared/sftp/SftpClient.kt
@@ -13,6 +13,7 @@ import evaka.core.SftpEnv
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.BufferedReader
 import java.io.InputStream
+import java.io.OutputStream
 import java.nio.charset.Charset
 import java.util.*
 
@@ -22,6 +23,11 @@ class SftpClient(private val sftpEnv: SftpEnv) {
     fun put(inputStream: InputStream, filename: String) = execute { channel ->
         logger.info { "Uploading $filename to ${sftpEnv.host}:${sftpEnv.port}" }
         channel.put(inputStream, filename)
+    }
+
+    fun put(filename: String, write: (OutputStream) -> Unit) = execute { channel ->
+        logger.info { "Uploading $filename to ${sftpEnv.host}:${sftpEnv.port}" }
+        channel.put(filename).use(write)
     }
 
     fun getAsString(filename: String, encoding: Charset): String = execute { channel ->

--- a/service/src/main/kotlin/evaka/instance/oulu/OuluProperties.kt
+++ b/service/src/main/kotlin/evaka/instance/oulu/OuluProperties.kt
@@ -5,6 +5,7 @@
 package evaka.instance.oulu
 
 import evaka.core.Sensitive
+import evaka.core.SftpEnv
 import evaka.core.lookup
 import org.springframework.core.env.Environment
 
@@ -13,6 +14,7 @@ data class OuluEnv(
     val intimePayments: SftpProperties,
     val bucket: BucketProperties,
     val dwExport: DwExportProperties,
+    val bi: BiProperties,
 ) {
     companion object {
         fun fromEnvironment(env: Environment) =
@@ -25,6 +27,7 @@ data class OuluEnv(
                         prefix = env.lookup("evakaoulu.dw_export.prefix"),
                         sftp = SftpProperties.fromEnvironment(env, "evakaoulu.dw_export.sftp"),
                     ),
+                bi = BiProperties.fromEnvironment(env),
             )
     }
 }
@@ -53,3 +56,37 @@ data class BucketProperties(val export: String) {
 }
 
 data class DwExportProperties(val prefix: String, val sftp: SftpProperties)
+
+private fun String.ensureTrailingSlash(): String = if (this.endsWith("/")) this else "$this/"
+
+data class BiProperties(
+    val sftp: SftpEnv,
+    val remotePath: String,
+    val windowMonths: Int = 3,
+    val excludedTables: Set<String> = emptySet(),
+) {
+    companion object {
+        fun fromEnvironment(env: Environment) =
+            BiProperties(
+                sftp =
+                    SftpEnv(
+                        host = env.lookup("evakaoulu.bi.sftp.host"),
+                        port = env.lookup<Int?>("evakaoulu.bi.sftp.port") ?: 22,
+                        hostKeys = env.lookup("evakaoulu.bi.sftp.host_keys"),
+                        username = env.lookup("evakaoulu.bi.sftp.username"),
+                        password =
+                            env.lookup<String?>("evakaoulu.bi.sftp.password")?.let {
+                                Sensitive(it)
+                            },
+                        privateKey =
+                            env.lookup<String?>("evakaoulu.bi.sftp.private_key")?.let {
+                                Sensitive(it)
+                            },
+                    ),
+                remotePath = env.lookup<String>("evakaoulu.bi.remote_path").ensureTrailingSlash(),
+                windowMonths = env.lookup<Int?>("evakaoulu.bi.window_months") ?: 3,
+                excludedTables =
+                    env.lookup<List<String>?>("evakaoulu.bi.excluded_tables")?.toSet() ?: emptySet(),
+            )
+    }
+}

--- a/service/src/main/kotlin/evaka/instance/oulu/bi/OuluBiSftpExportClient.kt
+++ b/service/src/main/kotlin/evaka/instance/oulu/bi/OuluBiSftpExportClient.kt
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 City of Oulu
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package evaka.instance.oulu.bi
+
+import evaka.core.bi.BiExportClient
+import evaka.core.bi.CsvInputStream
+import evaka.core.shared.domain.EvakaClock
+import evaka.core.shared.sftp.SftpClient
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.BufferedOutputStream
+import java.time.format.DateTimeFormatter
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class OuluBiSftpExportClient(private val sftpClient: SftpClient, private val remotePath: String) :
+    BiExportClient {
+    private val logger = KotlinLogging.logger {}
+
+    override fun sendBiCsvFile(
+        tableName: String,
+        clock: EvakaClock,
+        stream: CsvInputStream,
+    ): Pair<String, String> {
+        val date = clock.now().toLocalDate()
+        val entryName = "$tableName.csv"
+        val fileName = "${tableName}_${date.format(DateTimeFormatter.ISO_DATE)}.zip"
+        val target = "$remotePath$fileName"
+
+        logger.info { "Sending BI content for '$tableName' via SFTP" }
+
+        sftpClient.put(target) { os ->
+            BufferedOutputStream(os).use { bos ->
+                ZipOutputStream(bos).use { zip ->
+                    zip.putNextEntry(ZipEntry(entryName))
+                    stream.transferTo(zip)
+                    zip.closeEntry()
+                }
+            }
+        }
+
+        logger.info { "BI file '$target' successfully sent via SFTP" }
+        return remotePath to fileName
+    }
+}

--- a/service/src/main/resources/application-oulu_evaka.yaml
+++ b/service/src/main/resources/application-oulu_evaka.yaml
@@ -62,3 +62,20 @@ evakaoulu:
       password: pass
       address: address
       path: path
+  bi:
+    window_months: 3
+    remote_path: upload/
+    sftp:
+      host: localhost
+      port: 2222
+      host_keys:
+        - AAAAC3NzaC1lZDI1NTE5AAAAICADdlntyAKbOUGQDkdzdhQBu12jZjb0KmxLyrklMXTq
+      username: foo
+      private_key: |
+        -----BEGIN OPENSSH PRIVATE KEY-----
+        b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+        QyNTUxOQAAACBKQkRdkXMfuHv/1PWMJ6Thchv2PeE+uEkUbbpf+ce/mQAAAJjUgHxz1IB8
+        cwAAAAtzc2gtZWQyNTUxOQAAACBKQkRdkXMfuHv/1PWMJ6Thchv2PeE+uEkUbbpf+ce/mQ
+        AAAEBOKiwR898c7d20IF4F4O6++awDPFfhoeDlH+t09hwEw0pCRF2Rcx+4e//U9YwnpOFy
+        G/Y94T64SRRtul/5x7+ZAAAADmV2YWthX2xvY2FsL2l0AQIDBAUGBw==
+        -----END OPENSSH PRIVATE KEY-----

--- a/service/src/test/kotlin/evaka/instance/oulu/BiPropertiesTest.kt
+++ b/service/src/test/kotlin/evaka/instance/oulu/BiPropertiesTest.kt
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 City of Oulu
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package evaka.instance.oulu
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.springframework.mock.env.MockEnvironment
+
+class BiPropertiesTest {
+    private fun env(vararg overrides: Pair<String, String>): MockEnvironment {
+        val base =
+            mapOf(
+                "evakaoulu.bi.sftp.host" to "localhost",
+                "evakaoulu.bi.sftp.host_keys[0]" to "AAAA",
+                "evakaoulu.bi.sftp.username" to "user",
+                "evakaoulu.bi.remote_path" to "upload/",
+            )
+        return MockEnvironment().apply {
+            (base + overrides).forEach { (k, v) -> setProperty(k, v) }
+        }
+    }
+
+    @Test
+    fun `remote_path without trailing slash is normalized`() {
+        val props =
+            BiProperties.fromEnvironment(
+                env("evakaoulu.bi.sftp.password" to "pw", "evakaoulu.bi.remote_path" to "upload")
+            )
+        assertEquals("upload/", props.remotePath)
+    }
+
+    @Test
+    fun `remote_path with trailing slash is unchanged`() {
+        val props = BiProperties.fromEnvironment(env("evakaoulu.bi.sftp.password" to "pw"))
+        assertEquals("upload/", props.remotePath)
+    }
+
+    @Test
+    fun `empty remote_path is normalized to root`() {
+        val props =
+            BiProperties.fromEnvironment(
+                env("evakaoulu.bi.sftp.password" to "pw", "evakaoulu.bi.remote_path" to "")
+            )
+        assertEquals("/", props.remotePath)
+    }
+
+    @Test
+    fun `both password and private_key fail the SftpEnv credentials invariant`() {
+        assertFailsWith<IllegalStateException> {
+            BiProperties.fromEnvironment(
+                env("evakaoulu.bi.sftp.password" to "pw", "evakaoulu.bi.sftp.private_key" to "key")
+            )
+        }
+    }
+
+    @Test
+    fun `neither password nor private_key fail the SftpEnv credentials invariant`() {
+        assertFailsWith<IllegalStateException> { BiProperties.fromEnvironment(env()) }
+    }
+
+    @Test
+    fun `windowMonths defaults to 3 when omitted`() {
+        val props = BiProperties.fromEnvironment(env("evakaoulu.bi.sftp.password" to "pw"))
+        assertEquals(3, props.windowMonths)
+    }
+
+    @Test
+    fun `excludedTables defaults to empty set when omitted`() {
+        val props = BiProperties.fromEnvironment(env("evakaoulu.bi.sftp.password" to "pw"))
+        assertEquals(emptySet(), props.excludedTables)
+    }
+}


### PR DESCRIPTION
Lisää Oulun fabric-integraation BI-datan sftp-vienticlientin.

`OuluBiSftpExportClient` pakkaa csv-tietoaineiston zip-tiedostoksi ja siirtää sen sftp:n yli Oulun osoittamaan hakemistoon.

Ajastettu ajo ja `OuluConfig`-kytkentä tulevat erillisessä jatko-PR:ssä.

