### PR TITLE
Salli käyttämättömien asiakirjapohjien poistaminen

### DIFF
--- a/frontend/src/employee-frontend/components/document-templates/template-editor/DocumentTemplatesPage.tsx
+++ b/frontend/src/employee-frontend/components/document-templates/template-editor/DocumentTemplatesPage.tsx
@@ -173,7 +173,7 @@ const TemplateRow = React.memo(function TemplateRow({
           <IconOnlyButton
             icon={faTrash}
             aria-label={i18n.common.remove}
-            disabled={template.published}
+            disabled={template.documentCount > 0}
             onClick={() => deleteDocumentTemplate({ templateId: template.id })}
           />
           <a data-qa="export" href={exportUrl} target="_blank" rel="noreferrer">

--- a/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
@@ -185,7 +185,7 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     }
 
     @Test
-    fun `test publishing, after which basics and content cannot be updated or template deleted`() {
+    fun `test publishing, after which basics and content cannot be updated`() {
         val created =
             controller.createTemplate(dbInstance(), employee.user, now, testCreationRequest)
         controller.updateDraftTemplateContent(
@@ -219,10 +219,6 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             )
         }
 
-        assertThrows<BadRequest> {
-            controller.deleteDraftTemplate(dbInstance(), employee.user, now, created.id)
-        }
-
         // validity period can still be updated
         controller.updateTemplateValidity(
             dbInstance(),
@@ -231,6 +227,43 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             created.id,
             DateRange(LocalDate.of(2000, 1, 1), null),
         )
+    }
+
+    @Test
+    fun `published template without documents can be deleted, with documents cannot`() {
+        val otherChild = DevPerson()
+        db.transaction { tx -> tx.insert(otherChild, DevPersonType.CHILD) }
+
+        val withDocs =
+            controller.createTemplate(
+                dbInstance(),
+                employee.user,
+                now,
+                testCreationRequest.copy(validity = DateRange(now.today(), null)),
+            )
+        controller.publishTemplate(dbInstance(), employee.user, now, withDocs.id)
+        childDocumentController.createDocument(
+            dbInstance(),
+            employee.user,
+            now,
+            ChildDocumentCreateRequest(otherChild.id, withDocs.id),
+        )
+        assertThrows<BadRequest> {
+            controller.deleteDraftTemplate(dbInstance(), employee.user, now, withDocs.id)
+        }
+
+        val withoutDocs =
+            controller.createTemplate(
+                dbInstance(),
+                employee.user,
+                now,
+                testCreationRequest.copy(validity = DateRange(now.today(), null)),
+            )
+        controller.publishTemplate(dbInstance(), employee.user, now, withoutDocs.id)
+        controller.deleteDraftTemplate(dbInstance(), employee.user, now, withoutDocs.id)
+        assertThrows<NotFound> {
+            controller.getTemplate(dbInstance(), employee.user, now, withoutDocs.id)
+        }
     }
 
     @Test

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
@@ -440,11 +440,12 @@ class DocumentTemplateController(
                         Action.DocumentTemplate.DELETE,
                         templateId,
                     )
-                    tx.getTemplate(templateId)?.also {
-                        if (it.published) throw BadRequest("Cannot delete published template")
-                    } ?: throw NotFound("Template $templateId not found")
+                    if (tx.getTemplate(templateId) == null)
+                        throw NotFound("Template $templateId not found")
+                    if (tx.templateHasDocuments(templateId))
+                        throw BadRequest("Cannot delete template that has documents")
 
-                    tx.deleteDraftTemplate(templateId)
+                    tx.deleteUnusedTemplate(templateId)
                 }
             }
             .also { Audit.DocumentTemplateDelete.log(targetId = AuditId(templateId)) }

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplateQueries.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplateQueries.kt
@@ -228,12 +228,19 @@ fun Database.Transaction.forceUnpublishTemplate(id: DocumentTemplateId) {
     }
 }
 
-fun Database.Transaction.deleteDraftTemplate(id: DocumentTemplateId) {
+fun Database.Read.templateHasDocuments(id: DocumentTemplateId): Boolean =
+    createQuery {
+            sql("SELECT EXISTS (SELECT 1 FROM child_document WHERE template_id = ${bind(id)})")
+        }
+        .exactlyOne<Boolean>()
+
+fun Database.Transaction.deleteUnusedTemplate(id: DocumentTemplateId) {
     createUpdate {
             sql(
                 """
-                DELETE FROM document_template 
-                WHERE id = ${bind(id)} AND published = false
+                DELETE FROM document_template
+                WHERE id = ${bind(id)}
+                  AND NOT EXISTS (SELECT 1 FROM child_document WHERE template_id = ${bind(id)})
                 """
             )
         }


### PR DESCRIPTION
## Ennen tätä muutosta

Julkaistua asiakirjapohjaa ei voinut poistaa missään tilanteessa, vaikka sen pohjalta ei olisi luotu yhtäkään dokumenttia. Käytännössä julkaisu oli peruuttamaton lukitustoimi, joten pieneenkin virheeseen (esim. tuotantoon vahingossa julkaistu pohja) oli mahdotonta korjata käyttöliittymästä.

## Tämän muutoksen jälkeen

Asiakirjapohjan voi poistaa aina kun siitä ei ole vielä luotu yhtäkään dokumenttia — riippumatta siitä, onko pohja luonnostilassa vai julkaistu, ja riippumatta voimassaoloajasta. Heti kun pohjasta on syntynyt yksikin ilmentymä, poistaminen estyy. Esto on varmistettu sekä käyttöliittymässä, rajapinnassa että tietokantatasolla, joten käytössä olevia pohjia ei pääse poistamaan kilpailutilanteessakaan.