### PR TITLE
Korjataan kesäajan poissaolokysely

### DIFF
--- a/frontend/src/citizen-frontend/calendar/holiday-modal/OpenRangesSelectionModal.tsx
+++ b/frontend/src/citizen-frontend/calendar/holiday-modal/OpenRangesSelectionModal.tsx
@@ -29,14 +29,14 @@ import { RangeSelector } from './RangesSelector'
 type FormState = OpenRangesBody['openRanges']
 
 const initializeForm = (
-  children: ReservationChild[],
+  eligibleChildIds: ChildId[],
   previousAnswers: HolidayQuestionnaireAnswer[]
 ): FormState =>
-  children.reduce(
-    (acc, child) => ({
+  eligibleChildIds.reduce(
+    (acc, childId) => ({
       ...acc,
-      [child.id]:
-        previousAnswers.find((a) => a.childId === child.id)?.openRanges ?? []
+      [childId]:
+        previousAnswers.find((a) => a.childId === childId)?.openRanges ?? []
     }),
     {}
   )
@@ -60,7 +60,7 @@ export default React.memo(function OpenRangesSelectionModal({
   const [lang] = useLang()
 
   const [openRanges, setOpenRanges] = useState<FormState>(() =>
-    initializeForm(availableChildren, previousAnswers)
+    initializeForm(Object.keys(eligibleChildren) as ChildId[], previousAnswers)
   )
 
   const selectRanges = useCallback(

--- a/service/src/integrationTest/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
@@ -596,6 +596,47 @@ class HolidayPeriodControllerCitizenIntegrationTest :
     }
 
     @Test
+    fun `open ranges submission ignores ineligible children with empty range list`() {
+        db.transaction { tx ->
+            tx.insertGuardian(parent.id, child2.id)
+            tx.insert(
+                DevPlacement(
+                    childId = child2.id,
+                    unitId = daycare.id,
+                    type = PlacementType.CLUB,
+                    startDate = mockToday.minusYears(1),
+                    endDate = mockToday.plusYears(1),
+                )
+            )
+        }
+
+        val id = createOpenRangesQuestionnaire(freeRangesQuestionnaire)
+        val range =
+            FiniteDateRange(
+                freeRangesQuestionnaire.period.start,
+                freeRangesQuestionnaire.period.start.plusDays(40),
+            )
+
+        reportFreeRanges(
+            id,
+            OpenRangesBody(mapOf(child1.id to listOf(range), child2.id to emptyList())),
+        )
+
+        val absences = db.read { it.getAllAbsences() }
+        assertThat(absences.map { it.childId }.toSet()).containsExactly(child1.id)
+    }
+
+    @Test
+    fun `open ranges submission with empty list for eligible child is a no-op`() {
+        val id = createOpenRangesQuestionnaire(freeRangesQuestionnaire)
+
+        reportFreeRanges(id, OpenRangesBody(mapOf(child1.id to emptyList())))
+
+        val absences = db.read { it.getAllAbsences() }
+        assertThat(absences).isEmpty()
+    }
+
+    @Test
     fun `free absences are saved only when length of absence exceeds threshold`() {
         val id = createOpenRangesQuestionnaire(freeRangesQuestionnaire)
         reportFreeRanges(

--- a/service/src/main/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -226,6 +226,8 @@ class HolidayPeriodControllerCitizen(
         val now = clock.now()
         val today = now.toLocalDate()
         val childIds = body.openRanges.keys
+        val nonEmptyOpenRanges = body.openRanges.filterValues { it.isNotEmpty() }
+        val answeredChildIds = nonEmptyOpenRanges.keys
 
         db.connect { dbc ->
             dbc.transaction { tx ->
@@ -241,13 +243,13 @@ class HolidayPeriodControllerCitizen(
                         if (!it.active.includes(today))
                             throw BadRequest("Questionnaire is not open")
                     } ?: throw BadRequest("Questionnaire not found")
-                validate(questionnaire, tx, today, user, body.openRanges)
+                validate(questionnaire, tx, today, user, nonEmptyOpenRanges)
 
-                val allRanges = body.openRanges.values.flatten()
+                val allRanges = nonEmptyOpenRanges.values.flatten()
                 val plannedAbsenceEnabledRanges =
                     if (allRanges.isNotEmpty()) {
                         tx.getPlannedAbsenceEnabledRanges(
-                            childIds,
+                            answeredChildIds,
                             FiniteDateRange(
                                 allRanges.minOf { it.start },
                                 allRanges.maxOf { it.end },
@@ -257,7 +259,7 @@ class HolidayPeriodControllerCitizen(
                     } else emptyMap()
 
                 val absences =
-                    body.openRanges.entries.flatMap { (childId, ranges) ->
+                    nonEmptyOpenRanges.entries.flatMap { (childId, ranges) ->
                         val placements =
                             tx.getPlacementsForChildDuring(
                                 childId,
@@ -317,10 +319,10 @@ class HolidayPeriodControllerCitizen(
                         }
                     }
 
-                upsertAbsences(tx, now, user, absences, questionnaire, childIds)
+                upsertAbsences(tx, now, user, absences, questionnaire, answeredChildIds)
                 tx.insertQuestionnaireAnswers(
                     user.id,
-                    body.openRanges.entries.map { (childId, ranges) ->
+                    nonEmptyOpenRanges.entries.map { (childId, ranges) ->
                         HolidayQuestionnaireAnswer(questionnaire.id, childId, null, ranges)
                     },
                 )
@@ -347,7 +349,7 @@ class HolidayPeriodControllerCitizen(
         val invalid =
             data
                 .mapNotNull { (childId, periods) ->
-                    if (periods == null) {
+                    if (periods.isNullOrEmpty()) {
                         return@mapNotNull null
                     }
                     val validPeriods =


### PR DESCRIPTION
Mikäli perheessä on lapsi joka ei näy poissaolokyselyssä (esim. kerhopaikkalainen), lomake lähetti silti ko. lapsen tiedot mukana "tyhjänä" - validoinnissa tämä polku hylkäsi pyynnön väärästä syystä (käsitteli ko. lapsen tyhjän tiedon validointivirheenä kun sitä ei olisi pitänyt päätyä edes käsittelemään).

Korjauksena frontista ei lähetetä lomakkeen "ulkopuolisten lasten" tietoja, ja backend tuottaa poissaolomerkintöjä vain jos niitä on syötetty.