### PR TITLE
Vaaditaan kohde- ja näkyvyys-labelit PR:ille

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,16 @@ Ohjeet PR:n tekijälle:
   - tech: Tekninen muutos, esim. refaktorointi
   - dependencies: Riippuvuuspäivitys
   - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan
+
+- PR:t listataan eri kanavissa sen mukaan, mihin kuntaan ne vaikuttavat.
+  - Lisää PR:lle yksi tai useampi label seuraavista: espoo, oulu, seutu, turku,
+    core (ytimen muutokset)
+  - Labelia ei tarvita jos muutos on dependencies tai no-changelog
+
+- Lisää PR:lle yksi tai useampi label sen mukaan, missä muutos näkyy:
+  - citizen: kuntalaisten käyttöliittymä
+  - employee: henkilökunnan käyttöliittymä
+  - employee-mobile: henkilökunnan mobiili
+  - not-visible: muutos ei näy käyttöliittymässä (ei voi yhdistää muihin näkyvyys-labeleihin)
+  - Labelia ei tarvita jos muutos on dependencies, tech tai no-changelog
 -->

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -70,7 +70,7 @@ const scopeSections = [
 const changelogSections = {
   breaking: 'Toimia vaativat muutokset',
   enhancement:  'Uudet ominaisuudet ja parannukset',
-  bug: 'Bugikorjaukset',
+  bugfix: 'Bugikorjaukset',
   tech: 'Tekniset',
   dependencies: 'Riippuvuuksien päivitykset',
   unknown: 'Muut',

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -34,8 +34,8 @@ function main() {
       } catch (error) {
           console.error("An error occurred while parsing JSON:", error.message);
       }
-      const grouped = processPrs(json, startDate, endDate)
-      const markdown = toMarkdown(grouped, startDate, endDate)
+      const prs = processPrs(json, startDate, endDate)
+      const markdown = toMarkdown(prs, startDate, endDate)
       console.log(markdown)
   });
 }
@@ -59,62 +59,78 @@ function parseArgs() {
   return {startDate, endDate}
 }
 
-const ignoreLabels = ['no-changelog']
+const scopeSections = [
+  { label: 'core', title: 'Ytimen muutokset' },
+  { label: 'espoo', title: 'Espoo' },
+  { label: 'oulu', title: 'Oulu' },
+  { label: 'turku', title: 'Turku' },
+  { label: 'seutu', title: 'Seutu' },
+]
 
-const labels = {
+const changelogSections = {
   breaking: 'Toimia vaativat muutokset',
-  enhancement: 'Uudet ominaisuudet ja parannukset',
+  enhancement:  'Uudet ominaisuudet ja parannukset',
   bug: 'Bugikorjaukset',
-  unknown: 'Muut',
   tech: 'Tekniset',
   dependencies: 'Riippuvuuksien päivitykset',
+  unknown: 'Muut',
+}
+
+const visibilityLabels = {
+  citizen: 'kuntalainen',
+  employee: 'henkilökunta',
+  'employee-mobile': 'henkilökunnan mobiili',
 }
 
 function processPrs(prs, startDate, endDate) {
-  const min = startDate
-  const maxExclusive = new Date(endDate + 24 * 60 * 60 * 1000)
+  const min = startDate.getTime()
+  const maxExclusive = endDate.getTime() + 24 * 60 * 60 * 1000
 
-  const prsToInclude = prs
-    .filter((pr) => min <= new Date(pr.closedAt) && new Date(pr.closedAt) < maxExclusive)
-    .filter((pr) => !ignoreLabels.some((ignore) => hasLabel(pr, ignore)))
-
-  // Sort by closedAt descending
-  prsToInclude.sort((a, b) => a.closedAt < b.closedAt ? 1 : -1);
-
-  const grouped = groupBy(prsToInclude, (pr) => {
-    for (const label of Object.keys(labels)) {
-      if (hasLabel(pr, label)) return label
-    }
-    return 'unknown'
-  })
-
-  return grouped
-}
-
-function toMarkdown(groups, startDate, endDate) {
-  let markdown = [`# eVakan muutosloki ${formatDate(startDate)}-${formatDate(endDate)}`]
-  for (const [label, title] of Object.entries(labels)) {
-    const prs = groups[label]
-    if (!prs || !prs.length) continue
-
-    const lines = prs.map((pr) => {
-      return `- ${pr.title} [#${pr.number}](${pr.url})`
+  return prs
+    .filter((pr) => {
+      const t = new Date(pr.closedAt).getTime()
+      return min <= t && t < maxExclusive
     })
-    markdown.push('', `## ${title}`, '', ...lines)
-  }
-  return markdown.join('\n')
+    .filter((pr) => !hasLabel(pr, 'no-changelog'))
+    .sort((a, b) => a.closedAt < b.closedAt ? 1 : -1)
 }
 
-function groupBy(arr, fn) {
-  const result = {}
-  arr.forEach((item) => {
-    const key = fn(item)
-    if (result[key] === undefined) {
-      result[key] = []
+function toMarkdown(prs, startDate, endDate) {
+  const parts = [`# eVakan muutosloki ${formatDate(startDate)}-${formatDate(endDate)}`]
+
+  for (const { label: scopeLabel, title: scopeTitle } of scopeSections) {
+    const hasNoScopeLabel = (pr) => !scopeSections.some(({ label }) => hasLabel(pr, label))
+    const scopePrs = prs.filter((pr) => hasLabel(pr, scopeLabel) || (scopeLabel === 'core' && hasNoScopeLabel(pr)))
+    if (scopePrs.length === 0) continue
+
+    parts.push('', `## ${scopeTitle}`)
+
+    for (const [changelogLabel, changelogTitle] of Object.entries(changelogSections)) {
+      const sectionPrs = scopePrs.filter((pr) => changelogLabel === 'unknown'
+        ? !Object.keys(changelogSections).filter((l) => l !== 'unknown').some((l) => hasLabel(pr, l))
+        : hasLabel(pr, changelogLabel)
+      )
+      if (sectionPrs.length === 0) continue
+
+      const lines = sectionPrs.map(formatPrLine)
+      if (changelogLabel === 'dependencies') {
+        parts.push('', `<details><summary>${changelogTitle}</summary>`, '', ...lines, '', '</details>')
+      } else {
+        parts.push('', `### ${changelogTitle}`, '', ...lines)
+      }
     }
-    result[key].push(item)
-  })
-  return result
+  }
+
+  return parts.join('\n')
+}
+
+function formatPrLine(pr) {
+  const visibility = Object.entries(visibilityLabels)
+    .filter(([label]) => hasLabel(pr, label))
+    .map(([, name]) => name)
+
+  const suffix = visibility.length > 0 ? ` _(${visibility.join(', ')})_` : ''
+  return `- ${pr.title} [#${pr.number}](${pr.url})${suffix}`
 }
 
 function hasLabel(pr, labelName) {

--- a/bin/validate-labels.js
+++ b/bin/validate-labels.js
@@ -26,8 +26,11 @@ function main() {
         console.error('An error occurred while parsing JSON:', error.message);
         process.exit(1);
     }
-    if (!validateLabels(json)) {
-      console.error('Each pull request must have exactly one of the following labels:', knownLabels.join(', '));
+    const errors = validateLabels(json)
+    if (errors.length > 0) {
+      for (const error of errors) {
+        console.error(error);
+      }
       console.error('Other labels are ignored by the validation.')
       console.error('This pull request has the following labels:', json.join(', '));
       process.exit(1);
@@ -35,7 +38,7 @@ function main() {
   });
 }
 
-const knownLabels = [
+const changelogLabels = [
   'no-changelog',
   'breaking',
   'enhancement',
@@ -44,12 +47,44 @@ const knownLabels = [
   'dependencies'
 ];
 
-function validateLabels(labels) {
-  const numKnownLabels = labels.reduce(
-    (acc, label) => (knownLabels.includes(label)) ? acc + 1 : acc,
+const scopeLabels = ['core', 'espoo', 'oulu', 'turku', 'seutu'];
+
+const visibilityLabels = ['citizen', 'employee', 'employee-mobile', 'not-visible'];
+
+const scopeExemptChangelogLabels = ['no-changelog', 'dependencies'];
+const visibilityExemptChangelogLabels = ['no-changelog', 'dependencies', 'tech'];
+
+function countMatches(labels, group) {
+  return labels.reduce(
+    (acc, label) => (group.includes(label) ? acc + 1 : acc),
     0
   );
-  return numKnownLabels === 1;
+}
+
+function validateLabels(labels) {
+  const errors = [];
+
+  const numChangelogLabels = countMatches(labels, changelogLabels);
+  if (numChangelogLabels !== 1) {
+    errors.push(`Each pull request must have exactly one of the following labels: ${changelogLabels.join(', ')}`);
+  }
+
+  const numScopeLabels = countMatches(labels, scopeLabels);
+  const scopeExempt = labels.some((label) => scopeExemptChangelogLabels.includes(label));
+  if (!scopeExempt && numScopeLabels < 1) {
+    errors.push(`Each pull request must have at least one of the following labels: ${scopeLabels.join(', ')}`);
+  }
+
+  const numVisibilityLabels = countMatches(labels, visibilityLabels);
+  const visibilityExempt = labels.some((label) => visibilityExemptChangelogLabels.includes(label));
+  if (!visibilityExempt && numVisibilityLabels < 1) {
+    errors.push(`Each pull request must have at least one of the following labels: ${visibilityLabels.join(', ')}`);
+  }
+  if (labels.includes('not-visible') && numVisibilityLabels > 1) {
+    errors.push(`Label 'not-visible' cannot be combined with other visibility labels: ${visibilityLabels.filter(l => l !== 'not-visible').join(', ')}`);
+  }
+
+  return errors;
 }
 
 main();

--- a/bin/validate-labels.js
+++ b/bin/validate-labels.js
@@ -42,7 +42,7 @@ const changelogLabels = [
   'no-changelog',
   'breaking',
   'enhancement',
-  'bug',
+  'bugfix',
   'tech',
   'dependencies'
 ];


### PR DESCRIPTION
Muutentaan PR:ien labelointivaatimuksia. Tästä lähtien PR:t tarvitsevat:

- Kohteen: `espoo`, `oulu`, `seutu`, `turku`, `core` (ytimen muutokset)
- Näkyvyyden:`citizen`, `employee`, `employee-mobile` (yksi tai useampi) TAI `not-visible` jos muutos ei näy käyttäjälle
- Kohdetta ei vaadita jos kyseessä on `no-changelog` tai `dependencies`.
- Näkyvyyttä ei vaadita jos kyseessä on `no-changelog`, `dependencies` tai `tech`.

Muutoslokin generointi ottaa nämä myös huomioon jatkossa.

Uudelleennimetään samalla label `bug` -> `bugfix`.
