### PR TITLE
Näytetään kasvatusvastuullisuus mobiilissa kirjauksen perusteella

### DIFF
--- a/frontend/src/employee-mobile-frontend/staff-attendance/StaffAttendancesPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/StaffAttendancesPage.tsx
@@ -222,14 +222,7 @@ const StaffAttendancesToday = React.memo(function StaffAttendancesToday({
         <FixedSpaceColumn $spacing="zero">
           {staff.map((staffMember) => {
             const s = toStaff(staffMember)
-            return (
-              <StaffListItem
-                {...s}
-                key={s.id}
-                unitOrGroup={unitOrGroup}
-                occupancyEffect={staffMember.occupancyEffect}
-              />
-            )
+            return <StaffListItem {...s} key={s.id} unitOrGroup={unitOrGroup} />
           })}
         </FixedSpaceColumn>
       ))}

--- a/frontend/src/employee-mobile-frontend/staff-attendance/StaffListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/StaffListItem.tsx
@@ -73,7 +73,7 @@ export default React.memo(function StaffListItem({
   present,
   type,
   occupancyEffect
-}: Staff & { unitOrGroup: UnitOrGroup; occupancyEffect: boolean }) {
+}: Staff & { unitOrGroup: UnitOrGroup }) {
   const theme = useTheme()
 
   const link = (

--- a/frontend/src/employee-mobile-frontend/staff-attendance/utils.ts
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/utils.ts
@@ -17,6 +17,7 @@ export interface Staff {
   name: string
   id: string
   present: boolean
+  occupancyEffect: boolean
 }
 
 function isStaffMember(
@@ -31,14 +32,18 @@ export function toStaff(staff: StaffMember | ExternalStaffMember): Staff {
       type: 'employee',
       name: [staff.lastName, staff.firstName].join(' '),
       id: staff.employeeId,
-      present: !!staff.present
+      present: !!staff.present,
+      occupancyEffect: staff.latestCurrentDayAttendance
+        ? staff.latestCurrentDayAttendance.occupancyCoefficient > 0
+        : staff.occupancyEffect
     }
   }
   return {
     type: 'external',
     name: staff.name,
     id: staff.id,
-    present: true
+    present: true,
+    occupancyEffect: staff.occupancyEffect
   }
 }
 


### PR DESCRIPTION
Aiemmin tieto näytettiin käyttäjän luvituksessa asetetun tiedon perusteella, nyt kirjauksen perusteella.

<img width="442" height="460" alt="Screenshot 2026-05-05 at 11 14 21" src="https://github.com/user-attachments/assets/c5d95173-3314-45d9-ba8c-5bfd854bc1db" />
