### PR TITLE
Poistetaan tiedostojen zippaus Oulu Fabric-siirrossa

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/bi/BiTableExportTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/bi/BiTableExportTest.kt
@@ -277,12 +277,7 @@ class BiTableExportTest : PureJdbiTest(resetDbBeforeEach = false) {
 private class CapturingBiExportClient : BiExportClient {
     val captured = linkedMapOf<String, ByteArray>()
 
-    override fun sendBiCsvFile(
-        tableName: String,
-        clock: EvakaClock,
-        stream: CsvInputStream,
-    ): Pair<String, String> {
+    override fun sendBiCsvFile(tableName: String, clock: EvakaClock, stream: CsvInputStream) {
         captured[tableName] = stream.readAllBytes()
-        return "fake-bucket" to tableName
     }
 }

--- a/service/src/integrationTest/kotlin/evaka/instance/oulu/bi/OuluBiSftpExportClientTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/instance/oulu/bi/OuluBiSftpExportClientTest.kt
@@ -9,11 +9,8 @@ import evaka.core.SftpEnv
 import evaka.core.bi.CsvInputStream
 import evaka.core.shared.domain.MockEvakaClock
 import evaka.core.shared.sftp.SftpClient
-import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
-import java.util.zip.ZipInputStream
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Test
 
 private val sftpPort = System.getenv("EVAKA_SFTP_PORT")?.toIntOrNull() ?: 2222
@@ -31,28 +28,15 @@ private val env =
 class OuluBiSftpExportClientTest {
 
     @Test
-    fun `zips and uploads a CSV to the remote path`() {
+    fun `uploads a CSV to the remote path`() {
         val client = OuluBiSftpExportClient(SftpClient(env), "upload/")
         val clock = MockEvakaClock(2026, 4, 24, 12, 0)
-        val csv = sequenceOf("col\r\n", "value\r\n")
+        val csv = sequenceOf("col\r\n", "Hämäläinen\r\n")
 
-        val (returnedPath, returnedName) =
-            client.sendBiCsvFile("foo", clock, CsvInputStream(StandardCharsets.UTF_8, csv))
+        client.sendBiCsvFile("foo", clock, CsvInputStream(StandardCharsets.UTF_8, csv))
 
-        assertEquals("upload/", returnedPath)
-        assertEquals("foo_2026-04-24.zip", returnedName)
-
-        val bytes =
-            SftpClient(env)
-                .getAsString("upload/foo_2026-04-24.zip", StandardCharsets.ISO_8859_1)
-                .toByteArray(StandardCharsets.ISO_8859_1)
-
-        ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
-            val entry = zip.nextEntry
-            assertNotNull(entry)
-            assertEquals("foo.csv", entry.name)
-            val content = zip.readBytes().toString(StandardCharsets.UTF_8)
-            assertEquals("col\r\nvalue\r\n", content)
-        }
+        val content =
+            SftpClient(env).getAsString("upload/foo_2026-04-24.csv", StandardCharsets.UTF_8)
+        assertEquals("col\r\nHämäläinen\r\n", content)
     }
 }

--- a/service/src/main/kotlin/evaka/core/bi/BiExportClient.kt
+++ b/service/src/main/kotlin/evaka/core/bi/BiExportClient.kt
@@ -7,9 +7,5 @@ package evaka.core.bi
 import evaka.core.shared.domain.EvakaClock
 
 interface BiExportClient {
-    fun sendBiCsvFile(
-        tableName: String,
-        clock: EvakaClock,
-        stream: CsvInputStream,
-    ): Pair<String, String>
+    fun sendBiCsvFile(tableName: String, clock: EvakaClock, stream: CsvInputStream)
 }

--- a/service/src/main/kotlin/evaka/instance/oulu/bi/OuluBiSftpExportClient.kt
+++ b/service/src/main/kotlin/evaka/instance/oulu/bi/OuluBiSftpExportClient.kt
@@ -9,38 +9,21 @@ import evaka.core.bi.CsvInputStream
 import evaka.core.shared.domain.EvakaClock
 import evaka.core.shared.sftp.SftpClient
 import io.github.oshai.kotlinlogging.KotlinLogging
-import java.io.BufferedOutputStream
 import java.time.format.DateTimeFormatter
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
 
 class OuluBiSftpExportClient(private val sftpClient: SftpClient, private val remotePath: String) :
     BiExportClient {
     private val logger = KotlinLogging.logger {}
 
-    override fun sendBiCsvFile(
-        tableName: String,
-        clock: EvakaClock,
-        stream: CsvInputStream,
-    ): Pair<String, String> {
+    override fun sendBiCsvFile(tableName: String, clock: EvakaClock, stream: CsvInputStream) {
         val date = clock.now().toLocalDate()
-        val entryName = "$tableName.csv"
-        val fileName = "${tableName}_${date.format(DateTimeFormatter.ISO_DATE)}.zip"
+        val fileName = "${tableName}_${date.format(DateTimeFormatter.ISO_DATE)}.csv"
         val target = "$remotePath$fileName"
 
         logger.info { "Sending BI content for '$tableName' via SFTP" }
 
-        sftpClient.put(target) { os ->
-            BufferedOutputStream(os).use { bos ->
-                ZipOutputStream(bos).use { zip ->
-                    zip.putNextEntry(ZipEntry(entryName))
-                    stream.transferTo(zip)
-                    zip.closeEntry()
-                }
-            }
-        }
+        sftpClient.put(stream, target)
 
         logger.info { "BI file '$target' successfully sent via SFTP" }
-        return remotePath to fileName
     }
 }

--- a/service/src/main/kotlin/evaka/instance/tampere/bi/FileBiExportS3Client.kt
+++ b/service/src/main/kotlin/evaka/instance/tampere/bi/FileBiExportS3Client.kt
@@ -23,11 +23,7 @@ class FileBiExportS3Client(
 ) : BiExportClient {
     private val logger = KotlinLogging.logger {}
 
-    override fun sendBiCsvFile(
-        tableName: String,
-        clock: EvakaClock,
-        stream: CsvInputStream,
-    ): Pair<String, String> {
+    override fun sendBiCsvFile(tableName: String, clock: EvakaClock, stream: CsvInputStream) {
         val date = clock.now().toLocalDate()
         val entryName = "$tableName.csv"
         logger.info { "Sending BI content for '$tableName'" }
@@ -71,7 +67,5 @@ class FileBiExportS3Client(
                 }
             }
         }
-
-        return bucket to key
     }
 }


### PR DESCRIPTION
Lisäksi poistettu `sendBiCsvFile` paluuarvo jota ei käytetty mihinkään