### PR TITLE
Kevätsiivous: Poistettujen Gradle-alimoduulien viittaukset pois .dockerignoresta ja .gitignoresta

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,12 +28,6 @@
 !service/service-lib/*.kts
 !service/service-lib/src
 
-!service/sficlient/*.kts
-!service/sficlient/src
-
-!service/sarmamodel/*.kts
-!service/sarmamodel/src
-
 !service/vtjclient/*.kts
 !service/vtjclient/src
 

--- a/service/.gitignore
+++ b/service/.gitignore
@@ -23,8 +23,6 @@
 /evaka-bom/target/
 /service-lib/build/
 /service-lib/target/
-/sficlient/build/
-/sficlient/target/
 /vtjclient/build/
 /vtjclient/target/
 


### PR DESCRIPTION
## Ennen tätä muutosta

`.dockerignore` ja `service/.gitignore` sisälsivät sääntöjä `service/sficlient`- ja `service/sarmamodel`-Gradle-alimoduuleille, jotka on jo aikaa sitten poistettu.

## Tämän muutoksen jälkeen

Vanhentuneet rulet on poistettu `sficlient`-nimiavaruus elää edelleen pakettina pääpalvelumoduulin sisällä (`service/src/main/kotlin/evaka/core/sficlient/...`), ja sen kattaa jo olemassa oleva `!service/src`-sääntö – Docker-buildi ei siis muutu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)