### PR TITLE
Aseta sarma use_mock_client oletukseksi false

### DIFF
--- a/service/src/main/kotlin/evaka/core/EvakaEnv.kt
+++ b/service/src/main/kotlin/evaka/core/EvakaEnv.kt
@@ -733,7 +733,7 @@ data class ArchiveEnv(
         fun fromEnvironment(env: Environment) =
             ArchiveEnv(
                 url = URI.create(env.lookup("evaka.integration.sarma.url")),
-                useMockClient = env.lookup("evaka.integration.sarma.use_mock_client"),
+                useMockClient = env.lookup("evaka.integration.sarma.use_mock_client") ?: false,
                 userId = env.lookup("evaka.integration.sarma.user_id"),
                 userRole = env.lookup("evaka.integration.sarma.user_role"),
                 metadataMainNamespace =


### PR DESCRIPTION
## Yhteenveto
- Espoo stagingin käynnistys kaatuu virheeseen `Missing required configuration: evaka.integration.sarma.use_mock_client` sen jälkeen kun #8804 poisti oletusarvon. "Käytä oikeaa clientia" (`false`) on järkevä tuotanto-oletus, joten palautetaan `?: false` -fallback tälle kentälle.
- Muut placeholder-tyyppiset arvot (`master_id`, `virtual_archive_id`, namespacet) eivät edelleenkään defaulttaa, vaan ne pitää konfiguroida eksplisiittisesti.

## Testaussuunnitelma
- [ ] Service käynnistyy Espoo stagingissa ilman `EVAKA_INTEGRATION_SARMA_USE_MOCK_CLIENT`-muuttujaa
- [ ] CI vihreä

🤖 Generated with [Claude Code](https://claude.com/claude-code)