### PR TITLE
Näytetään vain suomen- ja englanninkieliset asiakirjapohjat englanninkieliselle yksikölle

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
@@ -629,6 +629,27 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
         assertEquals(setOf(UiLanguage.FI), active.map { it.language }.toSet())
     }
 
+    @Test
+    fun `active templates by group id endpoint does not show citizen basic templates when pilot feature is disabled`() {
+        val groupId =
+            insertGroupInUnitWithLanguage(
+                Language.fi,
+                name = "Finnish Daycare",
+                enabledPilotFeatures = emptySet(),
+            )
+        publishCitizenBasicTemplate(UiLanguage.FI)
+
+        val active =
+            controller.getActiveTemplatesByGroupId(
+                dbInstance(),
+                employee.user,
+                now,
+                groupId,
+                emptySet(),
+            )
+        assertEquals(emptyList(), active)
+    }
+
     private fun insertChildInUnitWithLanguage(language: Language, name: String) =
         db.transaction { tx ->
             val areaId =
@@ -659,23 +680,26 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             childId
         }
 
-    private fun insertGroupInUnitWithLanguage(language: Language, name: String) =
-        db.transaction { tx ->
-            val areaId =
-                tx.insert(
-                    DevCareArea(name = "Area for $name", shortName = "area_group_${language.name}")
+    private fun insertGroupInUnitWithLanguage(
+        language: Language,
+        name: String,
+        enabledPilotFeatures: Set<PilotFeature> = setOf(PilotFeature.CITIZEN_BASIC_DOCUMENT),
+    ) = db.transaction { tx ->
+        val areaId =
+            tx.insert(
+                DevCareArea(name = "Area for $name", shortName = "area_group_${language.name}")
+            )
+        val daycareId =
+            tx.insert(
+                DevDaycare(
+                    areaId = areaId,
+                    name = name,
+                    language = language,
+                    enabledPilotFeatures = enabledPilotFeatures,
                 )
-            val daycareId =
-                tx.insert(
-                    DevDaycare(
-                        areaId = areaId,
-                        name = name,
-                        language = language,
-                        enabledPilotFeatures = setOf(PilotFeature.CITIZEN_BASIC_DOCUMENT),
-                    )
-                )
-            tx.insert(DevDaycareGroup(daycareId = daycareId))
-        }
+            )
+        tx.insert(DevDaycareGroup(daycareId = daycareId))
+    }
 
     private fun publishPedagogicalAssessmentTemplate(language: UiLanguage) {
         val template =

--- a/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
@@ -513,85 +513,65 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     }
 
     @Test
-    fun `active templates endpoint does not return templates in finnish when placement unit is swedish`() {
-        val template =
-            controller.createTemplate(
-                dbInstance(),
-                employee.user,
-                now,
-                testCreationRequest.copy(
-                    language = UiLanguage.FI,
-                    validity = DateRange(now.today(), null),
-                ),
-            )
-        controller.publishTemplate(dbInstance(), employee.user, now, template.id)
-
-        val active = controller.getActiveTemplates(dbInstance(), employee.user, now, child.id)
-        assertTrue(active.isEmpty())
-    }
-
-    @Test
-    fun `active templates endpoint does not return templates in swedish when placement unit is finnish`() {
-        val childId = db.transaction { tx ->
-            val areaId = tx.insert(DevCareArea(name = "Other Area", shortName = "other_area"))
-            val daycareId =
-                tx.insert(
-                    DevDaycare(areaId = areaId, name = "Finnish Daycare", language = Language.fi)
-                )
-            val childId = tx.insert(DevPerson(), DevPersonType.CHILD)
-            tx.insert(
-                DevPlacement(
-                    childId = childId,
-                    unitId = daycareId,
-                    startDate = now.today(),
-                    endDate = now.today().plusDays(5),
-                )
-            )
-            childId
-        }
-        val template =
-            controller.createTemplate(
-                dbInstance(),
-                employee.user,
-                now,
-                testCreationRequest.copy(
-                    language = UiLanguage.SV,
-                    validity = DateRange(now.today(), null),
-                ),
-            )
-        controller.publishTemplate(dbInstance(), employee.user, now, template.id)
-
-        val active = controller.getActiveTemplates(dbInstance(), employee.user, now, childId)
-        assertTrue(active.isEmpty())
-    }
-
-    @Test
-    fun `active templates endpoint returns templates in all languages when placement unit is english`() {
-        val childId = insertChildInUnitWithLanguage(Language.en, name = "English Daycare")
+    fun `active templates endpoint returns same-language templates and english citizen basic when placement unit is finnish`() {
+        val childId = insertChildInUnitWithLanguage(Language.fi, name = "Finnish Daycare")
         listOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN).forEach { lang ->
             publishPedagogicalAssessmentTemplate(lang)
+            publishCitizenBasicTemplate(lang)
         }
 
         val active = controller.getActiveTemplates(dbInstance(), employee.user, now, childId)
         assertEquals(
-            setOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN),
-            active.map { it.language }.toSet(),
+            setOf(
+                UiLanguage.FI to ChildDocumentType.PEDAGOGICAL_ASSESSMENT,
+                UiLanguage.FI to ChildDocumentType.CITIZEN_BASIC,
+                UiLanguage.EN to ChildDocumentType.CITIZEN_BASIC,
+            ),
+            active.map { it.language to it.type }.toSet(),
         )
     }
 
     @Test
-    fun `active templates endpoint returns finnish and english templates only when placement unit is finnish`() {
-        val childId = insertChildInUnitWithLanguage(Language.fi, name = "Finnish Daycare")
+    fun `active templates endpoint returns same-language templates and english citizen basic when placement unit is swedish`() {
+        val childId = insertChildInUnitWithLanguage(Language.sv, name = "Swedish Daycare")
         listOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN).forEach { lang ->
             publishPedagogicalAssessmentTemplate(lang)
+            publishCitizenBasicTemplate(lang)
         }
 
         val active = controller.getActiveTemplates(dbInstance(), employee.user, now, childId)
-        assertEquals(setOf(UiLanguage.FI, UiLanguage.EN), active.map { it.language }.toSet())
+        assertEquals(
+            setOf(
+                UiLanguage.SV to ChildDocumentType.PEDAGOGICAL_ASSESSMENT,
+                UiLanguage.SV to ChildDocumentType.CITIZEN_BASIC,
+                UiLanguage.EN to ChildDocumentType.CITIZEN_BASIC,
+            ),
+            active.map { it.language to it.type }.toSet(),
+        )
     }
 
     @Test
-    fun `active templates by group id endpoint returns templates in all languages when group unit is english`() {
+    fun `active templates endpoint returns finnish and english templates when placement unit is english`() {
+        val childId = insertChildInUnitWithLanguage(Language.en, name = "English Daycare")
+        listOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN).forEach { lang ->
+            publishPedagogicalAssessmentTemplate(lang)
+            publishCitizenBasicTemplate(lang)
+        }
+
+        val active = controller.getActiveTemplates(dbInstance(), employee.user, now, childId)
+        assertEquals(
+            setOf(
+                UiLanguage.FI to ChildDocumentType.PEDAGOGICAL_ASSESSMENT,
+                UiLanguage.EN to ChildDocumentType.PEDAGOGICAL_ASSESSMENT,
+                UiLanguage.FI to ChildDocumentType.CITIZEN_BASIC,
+                UiLanguage.EN to ChildDocumentType.CITIZEN_BASIC,
+            ),
+            active.map { it.language to it.type }.toSet(),
+        )
+    }
+
+    @Test
+    fun `active templates by group id endpoint returns finnish and english but not swedish citizen basic templates when group unit is english`() {
         val groupId = insertGroupInUnitWithLanguage(Language.en, name = "English Daycare")
         listOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN).forEach { lang ->
             publishCitizenBasicTemplate(lang)
@@ -603,16 +583,13 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                 employee.user,
                 now,
                 groupId,
-                emptySet(),
+                setOf(ChildDocumentType.CITIZEN_BASIC),
             )
-        assertEquals(
-            setOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN),
-            active.map { it.language }.toSet(),
-        )
+        assertEquals(setOf(UiLanguage.FI, UiLanguage.EN), active.map { it.language }.toSet())
     }
 
     @Test
-    fun `active templates by group id endpoint returns only matching language templates when group unit is finnish`() {
+    fun `active templates by group id endpoint returns finnish and english but not swedish citizen basic templates when group unit is finnish`() {
         val groupId = insertGroupInUnitWithLanguage(Language.fi, name = "Finnish Daycare")
         listOf(UiLanguage.FI, UiLanguage.SV, UiLanguage.EN).forEach { lang ->
             publishCitizenBasicTemplate(lang)
@@ -626,7 +603,7 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                 groupId,
                 emptySet(),
             )
-        assertEquals(setOf(UiLanguage.FI), active.map { it.language }.toSet())
+        assertEquals(setOf(UiLanguage.FI, UiLanguage.EN), active.map { it.language }.toSet())
     }
 
     @Test
@@ -638,6 +615,49 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                 enabledPilotFeatures = emptySet(),
             )
         publishCitizenBasicTemplate(UiLanguage.FI)
+
+        val active =
+            controller.getActiveTemplatesByGroupId(
+                dbInstance(),
+                employee.user,
+                now,
+                groupId,
+                emptySet(),
+            )
+        assertEquals(emptyList(), active)
+    }
+
+    @Test
+    fun `active templates by group id endpoint does not show english pedagogical templates to finnish unit`() {
+        val groupId =
+            insertGroupInUnitWithLanguage(
+                Language.fi,
+                name = "Finnish Daycare",
+                enabledPilotFeatures = setOf(PilotFeature.VASU_AND_PEDADOC),
+            )
+        publishPedagogicalAssessmentTemplate(UiLanguage.FI)
+        publishPedagogicalAssessmentTemplate(UiLanguage.EN)
+
+        val active =
+            controller.getActiveTemplatesByGroupId(
+                dbInstance(),
+                employee.user,
+                now,
+                groupId,
+                emptySet(),
+            )
+        assertEquals(setOf(UiLanguage.FI), active.map { it.language }.toSet())
+    }
+
+    @Test
+    fun `active templates by group id endpoint does not show swedish pedagogical template to english unit`() {
+        val groupId =
+            insertGroupInUnitWithLanguage(
+                Language.en,
+                name = "English Daycare",
+                enabledPilotFeatures = setOf(PilotFeature.VASU_AND_PEDADOC),
+            )
+        publishPedagogicalAssessmentTemplate(UiLanguage.SV)
 
         val active =
             controller.getActiveTemplatesByGroupId(

--- a/service/src/integrationTest/kotlin/evaka/core/reports/ChildDocumentsReportTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/reports/ChildDocumentsReportTest.kt
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package evaka.core.reports
+
+import evaka.core.FullApplicationTest
+import evaka.core.daycare.domain.Language
+import evaka.core.document.ChildDocumentType
+import evaka.core.document.DocumentTemplateContent
+import evaka.core.document.childdocument.DocumentContent
+import evaka.core.document.childdocument.DocumentStatus
+import evaka.core.shared.ChildId
+import evaka.core.shared.DaycareId
+import evaka.core.shared.DocumentTemplateId
+import evaka.core.shared.auth.UserRole
+import evaka.core.shared.dev.DevCareArea
+import evaka.core.shared.dev.DevChildDocument
+import evaka.core.shared.dev.DevDaycare
+import evaka.core.shared.dev.DevDaycareGroup
+import evaka.core.shared.dev.DevDaycareGroupPlacement
+import evaka.core.shared.dev.DevDocumentTemplate
+import evaka.core.shared.dev.DevEmployee
+import evaka.core.shared.dev.DevPerson
+import evaka.core.shared.dev.DevPersonType
+import evaka.core.shared.dev.DevPlacement
+import evaka.core.shared.dev.insert
+import evaka.core.shared.domain.DateRange
+import evaka.core.shared.domain.MockEvakaClock
+import evaka.core.shared.domain.UiLanguage
+import evaka.core.shared.security.PilotFeature
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+
+class ChildDocumentsReportTest : FullApplicationTest(resetDbBeforeEach = true) {
+    @Autowired lateinit var controller: ChildDocumentsReport
+
+    private val clock = MockEvakaClock(2024, 3, 1, 15, 0)
+    private val area = DevCareArea()
+    private val supervisor = DevEmployee()
+
+    private data class TestSetup(
+        val unitId: DaycareId,
+        val templateId: DocumentTemplateId,
+        val childId: ChildId,
+    )
+
+    private fun setupUnitWithChildAndTemplate(
+        unitLanguage: Language,
+        templateLanguage: UiLanguage,
+    ): TestSetup {
+        val daycare =
+            DevDaycare(
+                areaId = area.id,
+                language = unitLanguage,
+                enabledPilotFeatures = setOf(PilotFeature.VASU_AND_PEDADOC),
+            )
+        val group = DevDaycareGroup(daycareId = daycare.id)
+        val child = DevPerson()
+        val template =
+            DevDocumentTemplate(
+                type = ChildDocumentType.VASU,
+                name = "VASU ${templateLanguage.name}",
+                language = templateLanguage,
+                validity = DateRange(clock.today().minusYears(1), null),
+                content = DocumentTemplateContent(sections = emptyList()),
+            )
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(supervisor, unitRoles = mapOf(daycare.id to UserRole.UNIT_SUPERVISOR))
+            tx.insert(group)
+            tx.insert(child, type = DevPersonType.CHILD)
+            val placementId =
+                tx.insert(
+                    DevPlacement(
+                        childId = child.id,
+                        unitId = daycare.id,
+                        startDate = clock.today().minusMonths(1),
+                        endDate = clock.today().plusMonths(1),
+                    )
+                )
+            tx.insert(
+                DevDaycareGroupPlacement(
+                    daycarePlacementId = placementId,
+                    daycareGroupId = group.id,
+                    startDate = clock.today().minusMonths(1),
+                    endDate = clock.today().plusMonths(1),
+                )
+            )
+            tx.insert(template)
+        }
+        return TestSetup(unitId = daycare.id, templateId = template.id, childId = child.id)
+    }
+
+    @Suppress("unused")
+    fun languageMatrix(): Stream<Arguments> =
+        listOf(
+                Arguments.of(Language.fi, UiLanguage.FI, 1),
+                Arguments.of(Language.fi, UiLanguage.SV, 0),
+                Arguments.of(Language.fi, UiLanguage.EN, 0),
+                Arguments.of(Language.sv, UiLanguage.FI, 0),
+                Arguments.of(Language.sv, UiLanguage.SV, 1),
+                Arguments.of(Language.sv, UiLanguage.EN, 0),
+                Arguments.of(Language.en, UiLanguage.FI, 1),
+                Arguments.of(Language.en, UiLanguage.SV, 0),
+                Arguments.of(Language.en, UiLanguage.EN, 1),
+            )
+            .stream()
+
+    @ParameterizedTest(name = "{0} unit, {1} template -> {2} documents counted")
+    @MethodSource("languageMatrix")
+    fun `report counts VASU documents according to language matrix`(
+        unitLanguage: Language,
+        templateLanguage: UiLanguage,
+        expectedCount: Int,
+    ) {
+        val setup = setupUnitWithChildAndTemplate(unitLanguage, templateLanguage)
+        db.transaction { tx ->
+            tx.insert(
+                DevChildDocument(
+                    status = DocumentStatus.COMPLETED,
+                    childId = setup.childId,
+                    templateId = setup.templateId,
+                    content = DocumentContent(answers = emptyList()),
+                    modifiedAt = clock.now(),
+                    modifiedBy = supervisor.evakaUserId,
+                    contentLockedAt = clock.now(),
+                    contentLockedBy = supervisor.id,
+                )
+            )
+        }
+        val rows =
+            controller.getChildDocumentsReport(
+                db = dbInstance(),
+                clock = clock,
+                user = supervisor.user,
+                templateIds = setOf(setup.templateId),
+                unitIds = setOf(setup.unitId),
+            )
+        val row = rows.single()
+        assertEquals(expectedCount, row.total)
+        assertEquals(expectedCount, row.completed)
+    }
+}

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
@@ -158,14 +158,7 @@ class DocumentTemplateController(
                                 placement.unitLanguage.name.uppercase() ||
                                 it.language == UiLanguage.EN ||
                                 placement.unitLanguage == Language.en) &&
-                            (placement.enabledPilotFeatures.contains(
-                                PilotFeature.VASU_AND_PEDADOC
-                            ) || !isPedagogicalDocument((it.type))) &&
-                            (placement.enabledPilotFeatures.contains(PilotFeature.OTHER_DECISION) ||
-                                it.type != ChildDocumentType.OTHER_DECISION) &&
-                            (placement.enabledPilotFeatures.contains(
-                                PilotFeature.CITIZEN_BASIC_DOCUMENT
-                            ) || it.type != ChildDocumentType.CITIZEN_BASIC) &&
+                            isAllowedByPilotFeatures(it.type, placement.enabledPilotFeatures) &&
                             // Allow not-yet-started placements only for CITIZEN_BASIC documents,
                             // require an active placement for others
                             (it.type == ChildDocumentType.CITIZEN_BASIC || activePlacement != null)
@@ -200,7 +193,8 @@ class DocumentTemplateController(
                             (types.isEmpty() || types.contains(it.type)) &&
                             // English-language units can issue documents in any language
                             (it.language.name.uppercase() == unit.language.name.uppercase() ||
-                                unit.language == Language.en)
+                                unit.language == Language.en) &&
+                            isAllowedByPilotFeatures(it.type, unit.enabledPilotFeatures)
                     }
                 }
             }
@@ -525,3 +519,13 @@ private val PEDAGOGICAL_DOCUMENT_TYPES =
     )
 
 private fun isPedagogicalDocument(type: ChildDocumentType) = type in PEDAGOGICAL_DOCUMENT_TYPES
+
+private fun isAllowedByPilotFeatures(
+    type: ChildDocumentType,
+    enabledPilotFeatures: Collection<PilotFeature>,
+): Boolean =
+    (PilotFeature.VASU_AND_PEDADOC in enabledPilotFeatures || !isPedagogicalDocument(type)) &&
+        (PilotFeature.OTHER_DECISION in enabledPilotFeatures ||
+            type != ChildDocumentType.OTHER_DECISION) &&
+        (PilotFeature.CITIZEN_BASIC_DOCUMENT in enabledPilotFeatures ||
+            type != ChildDocumentType.CITIZEN_BASIC)

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
@@ -153,11 +153,14 @@ class DocumentTemplateController(
                         it.published &&
                             it.validity.includes(clock.today()) &&
                             it.placementTypes.contains(placement.type) &&
-                            // English-language units can issue documents in any language
+                            // Allowed templates: same-language, EN CITIZEN_BASIC for any unit,
+                            // FI templates for EN units.
                             (it.language.name.uppercase() ==
                                 placement.unitLanguage.name.uppercase() ||
-                                it.language == UiLanguage.EN ||
-                                placement.unitLanguage == Language.en) &&
+                                (it.language == UiLanguage.EN &&
+                                    it.type == ChildDocumentType.CITIZEN_BASIC) ||
+                                (placement.unitLanguage == Language.en &&
+                                    it.language == UiLanguage.FI)) &&
                             isAllowedByPilotFeatures(it.type, placement.enabledPilotFeatures) &&
                             // Allow not-yet-started placements only for CITIZEN_BASIC documents,
                             // require an active placement for others
@@ -191,9 +194,12 @@ class DocumentTemplateController(
                         it.published &&
                             it.validity.includes(clock.today()) &&
                             (types.isEmpty() || types.contains(it.type)) &&
-                            // English-language units can issue documents in any language
+                            // Allowed templates: same-language, EN CITIZEN_BASIC for any unit,
+                            // FI templates for EN units.
                             (it.language.name.uppercase() == unit.language.name.uppercase() ||
-                                unit.language == Language.en) &&
+                                (it.language == UiLanguage.EN &&
+                                    it.type == ChildDocumentType.CITIZEN_BASIC) ||
+                                (unit.language == Language.en && it.language == UiLanguage.FI)) &&
                             isAllowedByPilotFeatures(it.type, unit.enabledPilotFeatures)
                     }
                 }

--- a/service/src/main/kotlin/evaka/core/reports/ChildDocumentsReport.kt
+++ b/service/src/main/kotlin/evaka/core/reports/ChildDocumentsReport.kt
@@ -152,7 +152,11 @@ WITH valid_children AS (
     WHERE dt.id = ANY(${bind(templateIds)})
       AND pl.unit_id = ANY(${bind(unitIds)})
       AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(today)}
-      AND lower(dt.language::text) = lower(d.language::text)
+      -- CITIZEN_BASIC templates are filtered out upstream by getChildDocumentsReportTemplateOptions
+      AND (
+          lower(dt.language::text) = lower(d.language::text)
+          OR (lower(d.language::text) = 'en' AND lower(dt.language::text) = 'fi')
+      )
       AND daterange(dg.start_date, dg.end_date, '[]') @> ${bind(today)}
 )
 SELECT


### PR DESCRIPTION
Tämä muutos rajaa pois ruotsinkieliset asiakirjapohjat englanninkielisiltä yksiköiltä.

Tämän muutoksen jälkeen asiakirjapohjia näytetään seuraavien sääntöjen perusteella:
- Yksikkö näkee yksikön kieltä vastaavat asiakirjapohjat
- Englanninkieliset "Huoltajan kanssa täytettävä asiakirja" pohjat näkyvät kaikille yksiköille
- Englanninkieliset yksiköt näkevät myös suomenkieliset asiakirjapohjat

Samalla korjataan myös pari asiakirjoihin liittyvää bugia:
- Yksikön sivun kautta lähetettävä asiakirja ei tarkistanut yksikön pilottiominaisuuksia, joka mahdollisti huoltajan kanssa täytettävä asiakirjan lähettämisen vaikka pilottiominaisuus olisi pois päältä yksiköllä.
- Pedagogiset asiakirjat -raportti huomioi vain englanninkieliset asiakirjat englanninkieliselle yksikölle. Raportti on muutettu ottamaan huomioon suomen- ja englanninkieliset asiakirjat

