### PR TITLE
Ei lähetetä Nekku-tilauksia jotka epäonnistuvat varmasti

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/nekku/NekkuOrderIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/nekku/NekkuOrderIntegrationTest.kt
@@ -417,6 +417,61 @@ class NekkuOrderIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) 
     }
 
     @Test
+    fun `daily meal order jobs are not re-planned for days without nekku customer weekday mapping`() {
+
+        val client = TestNekkuClient(customers = weekdayOnlyTestClientCustomers)
+        fetchAndUpdateNekkuCustomers(client, db, asyncJobRunner, now)
+
+        val area = DevCareArea()
+
+        val daycare =
+            DevDaycare(
+                areaId = area.id,
+                mealtimeBreakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                mealtimeLunch = TimeRange(LocalTime.of(11, 15), LocalTime.of(11, 45)),
+                mealtimeSnack = TimeRange(LocalTime.of(13, 30), LocalTime.of(13, 50)),
+                shiftCareOperationTimes =
+                    listOf(
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                    ),
+            )
+        val group = DevDaycareGroup(daycareId = daycare.id, nekkuCustomerNumber = "2501K6089")
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(group)
+        }
+
+        // Saturday — customer has no Saturday weekday, so the original order fails
+        val originalDate = HelsinkiDateTime.of(LocalDate.of(2025, 3, 29), LocalTime.of(2, 25))
+        assertThrows<RuntimeException> {
+            createAndSendNekkuOrder(
+                client,
+                db,
+                group.id,
+                originalDate.toLocalDate(),
+                asyncJobRunner,
+                now,
+                remainingAttempts = 0,
+            )
+        }
+
+        // Friday → daycareOpenNextTime is Saturday
+        val now = HelsinkiDateTime.of(LocalDate.of(2025, 3, 28), LocalTime.of(2, 25))
+
+        planNekkuDailyOrderJobs(db, asyncJobRunner, now)
+
+        assertEquals(0, getNekkuJobs(db).count())
+    }
+
+    @Test
     fun `meal order jobs for daycare groups are re-planned four days before actual date even if there is a faulty order`() {
 
         val client = TestNekkuClient(customers = basicTestClientCustomers)
@@ -563,6 +618,61 @@ class NekkuOrderIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) 
         planNekkuSpecifyOrderJobs(db, asyncJobRunner, now)
 
         assertEquals(toFourDays.toLocalDate().toString(), getNekkuJobs(db).single().date.toString())
+    }
+
+    @Test
+    fun `specify meal order jobs are not re-planned for days without nekku customer weekday mapping`() {
+
+        val client = TestNekkuClient(customers = weekdayOnlyTestClientCustomers)
+        fetchAndUpdateNekkuCustomers(client, db, asyncJobRunner, now)
+
+        val area = DevCareArea()
+
+        val daycare =
+            DevDaycare(
+                areaId = area.id,
+                mealtimeBreakfast = TimeRange(LocalTime.of(8, 0), LocalTime.of(8, 20)),
+                mealtimeLunch = TimeRange(LocalTime.of(11, 15), LocalTime.of(11, 45)),
+                mealtimeSnack = TimeRange(LocalTime.of(13, 30), LocalTime.of(13, 50)),
+                operationTimes =
+                    listOf(
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                        TimeRange(LocalTime.parse("00:00"), LocalTime.parse("23:59")),
+                    ),
+            )
+        val group = DevDaycareGroup(daycareId = daycare.id, nekkuCustomerNumber = "2501K6089")
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(group)
+        }
+
+        // Sunday — customer has no Sunday weekday, so the original order fails
+        val originalDate = HelsinkiDateTime.of(LocalDate.of(2025, 3, 30), LocalTime.of(2, 25))
+        assertThrows<RuntimeException> {
+            createAndSendNekkuOrder(
+                client,
+                db,
+                group.id,
+                originalDate.toLocalDate(),
+                asyncJobRunner,
+                now,
+                remainingAttempts = 0,
+            )
+        }
+
+        // Wednesday → today+4 is Sunday
+        val now = HelsinkiDateTime.of(LocalDate.of(2025, 3, 26), LocalTime.of(2, 25))
+
+        planNekkuSpecifyOrderJobs(db, asyncJobRunner, now)
+
+        assertEquals(0, getNekkuJobs(db).count())
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/evaka/core/nekku/NekkuOrderIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/nekku/NekkuOrderIntegrationTest.kt
@@ -449,18 +449,10 @@ class NekkuOrderIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) 
             tx.insert(group)
         }
 
-        // Saturday — customer has no Saturday weekday, so the original order fails
-        val originalDate = HelsinkiDateTime.of(LocalDate.of(2025, 3, 29), LocalTime.of(2, 25))
-        assertThrows<RuntimeException> {
-            createAndSendNekkuOrder(
-                client,
-                db,
-                group.id,
-                originalDate.toLocalDate(),
-                asyncJobRunner,
-                now,
-                remainingAttempts = 0,
-            )
+        // Saturday: seed a failed-order row so the planner would otherwise re-plan it
+        val originalDate = LocalDate.of(2025, 3, 29)
+        db.transaction { tx ->
+            tx.setNekkuReportOrderErrorReport(group.id, originalDate, "seeded failure", now)
         }
 
         // Friday → daycareOpenNextTime is Saturday
@@ -494,18 +486,10 @@ class NekkuOrderIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) 
             tx.insert(group)
         }
 
-        // Original order
-        val originalDate = HelsinkiDateTime.of(LocalDate.of(2025, 3, 28), LocalTime.of(2, 25))
-        assertThrows<RuntimeException> {
-            createAndSendNekkuOrder(
-                client,
-                db,
-                group.id,
-                originalDate.toLocalDate(),
-                asyncJobRunner,
-                now,
-                remainingAttempts = 0,
-            )
+        // Seed a previously failed order
+        val originalDate = LocalDate.of(2025, 3, 28)
+        db.transaction { tx ->
+            tx.setNekkuReportOrderErrorReport(group.id, originalDate, "seeded failure", now)
         }
 
         // Monday
@@ -595,18 +579,10 @@ class NekkuOrderIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) 
             tx.insert(group)
         }
 
-        // Original order
-        val originalDate = HelsinkiDateTime.of(LocalDate.of(2025, 3, 30), LocalTime.of(2, 25))
-        assertThrows<RuntimeException> {
-            createAndSendNekkuOrder(
-                client,
-                db,
-                group.id,
-                originalDate.toLocalDate(),
-                asyncJobRunner,
-                now,
-                remainingAttempts = 0,
-            )
+        // Seed a previously failed order
+        val originalDate = LocalDate.of(2025, 3, 30)
+        db.transaction { tx ->
+            tx.setNekkuReportOrderErrorReport(group.id, originalDate, "seeded failure", now)
         }
 
         // Wednesday
@@ -653,18 +629,10 @@ class NekkuOrderIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) 
             tx.insert(group)
         }
 
-        // Sunday — customer has no Sunday weekday, so the original order fails
-        val originalDate = HelsinkiDateTime.of(LocalDate.of(2025, 3, 30), LocalTime.of(2, 25))
-        assertThrows<RuntimeException> {
-            createAndSendNekkuOrder(
-                client,
-                db,
-                group.id,
-                originalDate.toLocalDate(),
-                asyncJobRunner,
-                now,
-                remainingAttempts = 0,
-            )
+        // Sunday: seed a failed-order row so the planner would otherwise re-plan it
+        val originalDate = LocalDate.of(2025, 3, 30)
+        db.transaction { tx ->
+            tx.setNekkuReportOrderErrorReport(group.id, originalDate, "seeded failure", now)
         }
 
         // Wednesday → today+4 is Sunday

--- a/service/src/main/kotlin/evaka/core/nekku/NekkuService.kt
+++ b/service/src/main/kotlin/evaka/core/nekku/NekkuService.kt
@@ -351,6 +351,7 @@ fun planNekkuDailyOrderJobs(
                     else daycareOpenNextTime(today, operationDays) >= it.validFrom
                 }
         val orderedGroupIds = openGroups + openingGroupsToOrder
+        val customerWeekdays = tx.getNekkuCustomerWeekdaysByGroups(orderedGroupIds.map { it.id })
         asyncJobRunner.plan(
             tx,
             orderedGroupIds.mapNotNull { nekkuGroup ->
@@ -368,7 +369,11 @@ fun planNekkuDailyOrderJobs(
                             daycareOpenNextTime,
                         )
 
-                    if (nekkuOrders.isNotEmpty()) {
+                    val nekkuWeekday = getNekkuWeekday(daycareOpenNextTime)
+                    if (
+                        nekkuOrders.isNotEmpty() &&
+                            nekkuWeekday in (customerWeekdays[nekkuGroup.id] ?: emptySet())
+                    ) {
                         AsyncJob.SendNekkuOrder(groupId = nekkuGroup.id, date = daycareOpenNextTime)
                     } else null
                 } else null
@@ -389,6 +394,8 @@ fun planNekkuSpecifyOrderJobs(
 
     dbc.transaction { tx ->
         val openGroups = tx.getNekkuOpenDaycareGroupDates(fourDaysFromNow)
+        val customerWeekdays = tx.getNekkuCustomerWeekdaysByGroups(openGroups.map { it.id })
+        val nekkuWeekday = getNekkuWeekday(fourDaysFromNow)
 
         asyncJobRunner.plan(
             tx,
@@ -404,7 +411,8 @@ fun planNekkuSpecifyOrderJobs(
                 if (
                     nekkuOrders.isNotEmpty() &&
                         groupOperationDays != null &&
-                        isGroupOpenOnDate(fourDaysFromNow, groupOperationDays)
+                        isGroupOpenOnDate(fourDaysFromNow, groupOperationDays) &&
+                        nekkuWeekday in (customerWeekdays[nekkuGroup.id] ?: emptySet())
                 ) {
                     AsyncJob.SendNekkuOrder(groupId = nekkuGroup.id, date = fourDaysFromNow)
                 } else null

--- a/service/src/main/kotlin/evaka/core/nekku/NekkuService.kt
+++ b/service/src/main/kotlin/evaka/core/nekku/NekkuService.kt
@@ -79,61 +79,45 @@ class NekkuService(
         clock: EvakaClock,
         job: AsyncJob.SyncNekkuCustomers,
     ) {
-        if (client == null) error("Cannot sync Nekku customers: NekkuEnv is not configured")
-        fetchAndUpdateNekkuCustomers(client, db, asyncJobRunner, clock.now())
+        runSync("customers") { fetchAndUpdateNekkuCustomers(it, db, asyncJobRunner, clock.now()) }
     }
 
-    fun planNekkuCustomersSync(db: Database.Connection, clock: EvakaClock) {
-        db.transaction { tx ->
-            tx.removeUnclaimedJobs(setOf(AsyncJobType(AsyncJob.SyncNekkuCustomers::class)))
-            asyncJobRunner.plan(
-                tx,
-                listOf(AsyncJob.SyncNekkuCustomers()),
-                runAt = clock.now(),
-                retryCount = 1,
-            )
-        }
-    }
+    fun planNekkuCustomersSync(db: Database.Connection, clock: EvakaClock) =
+        planSync(db, clock, AsyncJob.SyncNekkuCustomers())
 
     fun syncNekkuSpecialDiets(
         db: Database.Connection,
         clock: EvakaClock,
         job: AsyncJob.SyncNekkuSpecialDiets,
     ) {
-        if (client == null) error("Cannot sync Nekku special diets: NekkuEnv is not configured")
-        fetchAndUpdateNekkuSpecialDiets(client, db, asyncJobRunner, clock.now())
-    }
-
-    fun planNekkuSpecialDietsSync(db: Database.Connection, clock: EvakaClock) {
-        db.transaction { tx ->
-            tx.removeUnclaimedJobs(setOf(AsyncJobType(AsyncJob.SyncNekkuSpecialDiets::class)))
-            asyncJobRunner.plan(
-                tx,
-                listOf(AsyncJob.SyncNekkuSpecialDiets()),
-                runAt = clock.now(),
-                retryCount = 1,
-            )
+        runSync("special diets") {
+            fetchAndUpdateNekkuSpecialDiets(it, db, asyncJobRunner, clock.now())
         }
     }
+
+    fun planNekkuSpecialDietsSync(db: Database.Connection, clock: EvakaClock) =
+        planSync(db, clock, AsyncJob.SyncNekkuSpecialDiets())
 
     fun syncNekkuProducts(
         db: Database.Connection,
         clock: EvakaClock,
         job: AsyncJob.SyncNekkuProducts,
     ) {
-        if (client == null) error("Cannot sync Nekku products: NekkuEnv is not configured")
-        fetchAndUpdateNekkuProducts(client, db)
+        runSync("products") { fetchAndUpdateNekkuProducts(it, db) }
     }
 
-    fun planNekkuProductsSync(db: Database.Connection, clock: EvakaClock) {
+    fun planNekkuProductsSync(db: Database.Connection, clock: EvakaClock) =
+        planSync(db, clock, AsyncJob.SyncNekkuProducts())
+
+    private fun runSync(typeName: String, fetch: (NekkuClient) -> Unit) {
+        if (client == null) error("Cannot sync Nekku $typeName: NekkuEnv is not configured")
+        fetch(client)
+    }
+
+    private fun planSync(db: Database.Connection, clock: EvakaClock, job: AsyncJob) {
         db.transaction { tx ->
-            tx.removeUnclaimedJobs(setOf(AsyncJobType(AsyncJob.SyncNekkuProducts::class)))
-            asyncJobRunner.plan(
-                tx,
-                listOf(AsyncJob.SyncNekkuProducts()),
-                runAt = clock.now(),
-                retryCount = 1,
-            )
+            tx.removeUnclaimedJobs(setOf(AsyncJobType(job::class)))
+            asyncJobRunner.plan(tx, listOf(job), runAt = clock.now(), retryCount = 1)
         }
     }
 


### PR DESCRIPTION
Sama epäonnistuvien filtteröinti oli tehty aiemmin jo yhteen tilaustenlähetysmetodiin, nyt lisätään se muihinkin.

Samalla siivotaan vähän testejä ja vähennetään duplikaatiota.