### PR TITLE
Sandbox-korjauksia

### DIFF
--- a/.sandbox/sandbox.mjs
+++ b/.sandbox/sandbox.mjs
@@ -307,19 +307,17 @@ function ensurePortForwarding(ports) {
     } catch {}
   }
 
-  const sshArgs = ["-N"];
+  const sshConfig = resolve(homedir(), ".colima", "ssh_config");
+  const sshArgs = ["-F", sshConfig, "-N"];
   for (const port of ports) {
     const [host, container] = port.includes(":")
       ? port.split(":")
       : [port, port];
     sshArgs.push("-L", `${host}:localhost:${container}`);
   }
+  sshArgs.push(`colima-${profile}`);
 
-  const child = spawn(
-    "colima",
-    ["ssh", "--profile", profile, "--", ...sshArgs],
-    { detached: true, stdio: "ignore" }
-  );
+  const child = spawn("ssh", sshArgs, { detached: true, stdio: "ignore" });
   child.unref();
   writeFileSync(portFwdPidFile, String(child.pid));
 }
@@ -375,6 +373,7 @@ function buildStartArgs(config) {
     "--mount-inotify",
     "--vz-rosetta",
     "--ssh-agent",
+    "--port-forwarder", "none",
     ...mountArgs,
   ];
 }

--- a/mise.toml
+++ b/mise.toml
@@ -266,8 +266,7 @@ echo "Restart your shell or run: source $RC_FILE"
 [tasks.sandbox]
 description = "Manage the Colima VM sandbox"
 dir = ".sandbox"
-usage = 'arg "[args]" var=#true'
-run = "node sandbox.mjs {{arg(name='args')}}"
+run = 'node sandbox.mjs'
 
 [tasks.reset-local-db]
 description = "Drop and recreate the evaka_local development database"


### PR DESCRIPTION
Forwardoidaan vain portit jotka on määritetty sandbox.json:issa.

Sandbox-virtuaalikone pitää joko luoda uudelleen:

```sh
mise sandbox rm
mise sandbox exec
```

tai editoida tiedostoa `~/.colima/sandbox-evaka/colima.yaml`:

```diff
# Port forwarder for the virtual machine (ssh, grpc, none).
# ssh is more stable but supports only TCP.
# grpc supports both TCP and UDP, but is experimental.
# none disables port forwarding.
#
# Default: ssh
-portForwarder: ssh
+portForwarder: none
```

Tämän jälkeen riittää `mise sandbox stop` ja `mise sandbox exec`.

Korjataan samalla mise-varoitus.