### PR TITLE
Nekku: Ei sallita vegaani + erityisruokavalio -kombinaatiota

### DIFF
--- a/frontend/src/employee-frontend/components/child-information/person-details/AdditionalInformation.tsx
+++ b/frontend/src/employee-frontend/components/child-information/person-details/AdditionalInformation.tsx
@@ -468,7 +468,11 @@ export default React.memo(function AdditionalInformation({ childId }: Props) {
                         <>
                           <Combobox
                             data-qa="nekku-diet-input"
-                            items={nekkuDiets}
+                            items={nekkuDiets.filter(
+                              (diet) =>
+                                diet.type !== 'VEGAN' ||
+                                form.nekkuSpecialDietChoices.length === 0
+                            )}
                             selectedItem={nekkuDiets.find(
                               (value) => value.type === form.nekkuDiet
                             )}
@@ -501,6 +505,7 @@ export default React.memo(function AdditionalInformation({ childId }: Props) {
                           setField={setChoiceField}
                           toggleField={toggleChoiceField}
                           editing={editing}
+                          disabled={form.nekkuDiet === 'VEGAN'}
                         />
                       )
                     }

--- a/frontend/src/employee-frontend/components/child-information/person-details/NekkuSpecialDiet.tsx
+++ b/frontend/src/employee-frontend/components/child-information/person-details/NekkuSpecialDiet.tsx
@@ -24,6 +24,7 @@ interface Props {
   dietChoices: NekkuSpecialDietChoices[]
   formData: AdditionalInformation
   editing: boolean
+  disabled?: boolean
   setField(dietId: string, fieldId: string, value: string): void
   toggleField(dietId: string, fieldId: string, value: string): void
 }
@@ -65,6 +66,7 @@ export default React.memo(function NekkuSpecialDiet(props: Props) {
                           }
                           key={field.id + '-' + option.key}
                           label={option.key}
+                          disabled={props.disabled}
                           checked={
                             props.formData.nekkuSpecialDietChoices.find(
                               (value) =>
@@ -109,6 +111,7 @@ export default React.memo(function NekkuSpecialDiet(props: Props) {
                       {field.name}
                       <TextArea
                         data-qa={field.diet_id + '-' + field.id + '-textarea'}
+                        readonly={props.disabled}
                         value={
                           props.formData.nekkuSpecialDietChoices.find(
                             (value) =>

--- a/service/src/integrationTest/kotlin/evaka/core/daycare/controllers/ChildrenControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/daycare/controllers/ChildrenControllerIntegrationTest.kt
@@ -7,12 +7,20 @@ package evaka.core.daycare.controllers
 import evaka.core.FullApplicationTest
 import evaka.core.daycare.createChild
 import evaka.core.daycare.getChild
+import evaka.core.nekku.NekkuProductMealType
+import evaka.core.nekku.NekkuSpecialDiet
+import evaka.core.nekku.NekkuSpecialDietChoices
+import evaka.core.nekku.NekkuSpecialDietType
+import evaka.core.nekku.NekkuSpecialDietsField
+import evaka.core.nekku.setSpecialDietFields
+import evaka.core.nekku.setSpecialDiets
 import evaka.core.shared.ChildId
 import evaka.core.shared.EmployeeId
 import evaka.core.shared.FeatureConfig
 import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.auth.UserRole
 import evaka.core.shared.config.testFeatureConfig
+import evaka.core.shared.domain.BadRequest
 import evaka.core.shared.domain.RealEvakaClock
 import evaka.core.shared.noopTracer
 import evaka.core.shared.security.AccessControl
@@ -24,6 +32,7 @@ import kotlin.test.assertEquals
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 
 class ChildrenControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
@@ -85,6 +94,71 @@ class ChildrenControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         Assertions.assertThat(result.permittedActions)
             .doesNotContain(Action.Child.READ_DAILY_SERVICE_TIMES)
+    }
+
+    @Test
+    fun `updateAdditionalInfo rejects VEGAN nekku diet combined with special diet choices`() {
+        val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
+        val data =
+            child.additionalInformation.copy(
+                nekkuDiet = NekkuProductMealType.VEGAN,
+                nekkuSpecialDietChoices =
+                    listOf(NekkuSpecialDietChoices(dietId = "2", fieldId = "f1", value = "v1")),
+            )
+        val exception =
+            assertThrows<BadRequest> {
+                childController.updateAdditionalInfo(
+                    dbInstance(),
+                    user,
+                    RealEvakaClock(),
+                    childId,
+                    data,
+                )
+            }
+        assertEquals("NEKKU_VEGAN_AND_SPECIAL_DIET_BOTH_SET", exception.errorCode)
+    }
+
+    @Test
+    fun `updateAdditionalInfo allows VEGETABLE nekku diet combined with special diet choices`() {
+        val diets =
+            listOf(
+                NekkuSpecialDiet(
+                    id = "2",
+                    name = "Test diet",
+                    fields =
+                        listOf(
+                            NekkuSpecialDietsField(
+                                id = "f1",
+                                name = "Field 1",
+                                type = NekkuSpecialDietType.TEXT,
+                            )
+                        ),
+                )
+            )
+        db.transaction { tx ->
+            tx.setSpecialDiets(diets)
+            tx.setSpecialDietFields(diets.map { it.id to it.fields })
+        }
+
+        val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
+        val data =
+            child.additionalInformation.copy(
+                nekkuDiet = NekkuProductMealType.VEGETABLE,
+                nekkuSpecialDietChoices =
+                    listOf(NekkuSpecialDietChoices(dietId = "2", fieldId = "f1", value = "v1")),
+            )
+        childController.updateAdditionalInfo(dbInstance(), user, RealEvakaClock(), childId, data)
+    }
+
+    @Test
+    fun `updateAdditionalInfo allows VEGAN nekku diet without special diet choices`() {
+        val user = AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
+        val data =
+            child.additionalInformation.copy(
+                nekkuDiet = NekkuProductMealType.VEGAN,
+                nekkuSpecialDietChoices = emptyList(),
+            )
+        childController.updateAdditionalInfo(dbInstance(), user, RealEvakaClock(), childId, data)
     }
 
     @Test

--- a/service/src/main/kotlin/evaka/core/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/evaka/core/daycare/controllers/ChildController.kt
@@ -20,6 +20,7 @@ import evaka.core.shared.ChildId
 import evaka.core.shared.FeatureConfig
 import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.db.Database
+import evaka.core.shared.domain.BadRequest
 import evaka.core.shared.domain.EvakaClock
 import evaka.core.shared.domain.NotFound
 import evaka.core.shared.security.AccessControl
@@ -109,6 +110,15 @@ class ChildController(
         @PathVariable childId: ChildId,
         @RequestBody data: AdditionalInformation,
     ) {
+        if (
+            data.nekkuDiet == NekkuProductMealType.VEGAN &&
+                data.nekkuSpecialDietChoices.isNotEmpty()
+        ) {
+            throw BadRequest(
+                "Vegan Nekku diet and special diet choices cannot both be set",
+                errorCode = "NEKKU_VEGAN_AND_SPECIAL_DIET_BOTH_SET",
+            )
+        }
         db.connect { dbc ->
             dbc.transaction {
                 accessControl.requirePermissionFor(

--- a/service/src/main/kotlin/evaka/core/nekku/NekkuService.kt
+++ b/service/src/main/kotlin/evaka/core/nekku/NekkuService.kt
@@ -652,7 +652,7 @@ fun nekkuMealReportData(
                         val sku =
                             getNekkuProductNumber(nekkuProducts, mealTime, childInfo, customerType)
                         if (sku == null) {
-                            logger.error {
+                            logger.warn {
                                 "No Nekku product found for child ${childInfo.childId} with customertype=$customerType optionsId=${childInfo.optionsId} mealtype=${childInfo.mealType} mealtime=${mealTime.name}"
                             }
                             null


### PR DESCRIPTION
1. Lasketaan logituksen tasoa virheestä varoitukseksi kun Nekku-tuotetta ei löydy

2. Ei sallita vegaani + erityisruokavalio -kombinaatiota, koska Nekun bäkkäri ei sitä hyväksy. Ks. screenshot alla tilanteesta, jossa vegaani on valittu ja siksi erityisruokavalio disabloitu.

<img width="742" height="316" alt="Screenshot 2026-05-12 at 8 53 25" src="https://github.com/user-attachments/assets/7ec9e321-d872-4571-ae0a-2356baf134f7" />
