### PR TITLE
Ei lisätä lapsia `varda_state` -tauluun jos ei ole hetua eikä oidia

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/varda/VardaUpdateServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/varda/VardaUpdateServiceIntegrationTest.kt
@@ -72,6 +72,37 @@ class VardaUpdateServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     }
 
     @Test
+    fun `children without ssn and oph_person_oid are not added to varda_state`() {
+        val area = DevCareArea()
+        val unit = DevDaycare(areaId = area.id)
+        val childWithSsn = DevPerson(ssn = "030320A904N", ophPersonOid = null)
+        val childWithOid = DevPerson(ssn = null, ophPersonOid = "1.2.3.4")
+        val childWithEmptyOid = DevPerson(ssn = null, ophPersonOid = "")
+        val childWithNeither = DevPerson(ssn = null, ophPersonOid = null)
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(unit)
+            listOf(childWithSsn, childWithOid, childWithEmptyOid, childWithNeither).forEach { child
+                ->
+                tx.insert(child, DevPersonType.CHILD)
+                tx.insert(
+                    DevPlacement(
+                        childId = child.id,
+                        unitId = unit.id,
+                        startDate = LocalDate.of(2021, 1, 1),
+                        endDate = LocalDate.of(2021, 2, 28),
+                    )
+                )
+            }
+
+            tx.addNewChildrenForVardaUpdate()
+        }
+
+        assertEquals(setOf(childWithSsn.id, childWithOid.id), getVardaStateChildIds())
+    }
+
+    @Test
     fun `update is not planned if state is up-to-date`() {
         val area = DevCareArea()
         val unit = DevDaycare(areaId = area.id, ophOrganizerOid = ophEnv.organizerOid)

--- a/service/src/main/kotlin/evaka/core/varda/VardaQueries.kt
+++ b/service/src/main/kotlin/evaka/core/varda/VardaQueries.kt
@@ -227,10 +227,12 @@ fun Database.Transaction.addNewChildrenForVardaUpdate(): Int {
         sql(
             """
                     INSERT INTO varda_state (child_id, state)
-                    SELECT child_id, null
+                    SELECT pl.child_id, null
                     FROM placement pl
+                    JOIN person p ON p.id = pl.child_id
                     WHERE
                         pl.type = ANY(${bind(vardaPlacementTypes)}) AND
+                        (p.social_security_number IS NOT NULL OR (p.oph_person_oid IS NOT NULL AND p.oph_person_oid != '')) AND
                         NOT EXISTS (SELECT FROM varda_state vs WHERE vs.child_id = pl.child_id)
                     ON CONFLICT (child_id) DO NOTHING
                     """


### PR DESCRIPTION
Tämä helpottaa duplikaattien yhdistämistä, koska `varda_state` estää sen. Jos lapsella ei ole hetua eikä oidia, tietoja ei vardaan vietäisi kuitenkaan.