### PR TITLE
Poistetaan riippuvuus through2

### DIFF
--- a/apigw/package.json
+++ b/apigw/package.json
@@ -39,7 +39,6 @@
     "query-string": "9.3.1",
     "redis": "5.12.1",
     "split2": "4.2.0",
-    "through2": "4.0.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
@@ -54,7 +53,6 @@
     "@types/node-forge": "1.3.14",
     "@types/pump": "1.1.3",
     "@types/split2": "4.2.3",
-    "@types/through2": "2.0.41",
     "@types/tough-cookie": "4.0.5",
     "@types/xml2js": "0.4.14",
     "concurrently": "9.2.1",

--- a/apigw/src/pino-cli/cli/index.ts
+++ b/apigw/src/pino-cli/cli/index.ts
@@ -2,12 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { Transform, type TransformCallback } from 'node:stream'
+
 import type {
   SerializedRequest,
   SerializedResponse
 } from 'pino-std-serializers'
 import split from 'split2'
-import * as through from 'through2'
 
 import { ipv6ToIpv4 } from './utils.ts'
 
@@ -242,7 +243,7 @@ const parser = (input: string) => {
 export const parserStream = split(parser)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const transport = (obj: any, _: string, cb: through.TransformCallback) => {
+const transport = (obj: any, _: BufferEncoding, cb: TransformCallback) => {
   try {
     if (
       !isPinoAccessLog(obj) &&
@@ -279,4 +280,7 @@ const transport = (obj: any, _: string, cb: through.TransformCallback) => {
   }
 }
 
-export const transportStream = through.obj(transport)
+export const transportStream = new Transform({
+  objectMode: true,
+  transform: transport
+})

--- a/apigw/yarn.lock
+++ b/apigw/yarn.lock
@@ -969,15 +969,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/through2@npm:2.0.41":
-  version: 2.0.41
-  resolution: "@types/through2@npm:2.0.41"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/d5a475db410065169bdd40fcf118d888b3d7976cebbcd44d44d1c744fa7d475f37c59cdf9f28b1a0d9388892691029d1fccef955ba0e521bb58508aad0f86518
-  languageName: node
-  linkType: hard
-
 "@types/tough-cookie@npm:4.0.5":
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
@@ -2511,7 +2502,6 @@ __metadata:
     "@types/node-forge": "npm:1.3.14"
     "@types/pump": "npm:1.1.3"
     "@types/split2": "npm:4.2.3"
-    "@types/through2": "npm:2.0.41"
     "@types/tough-cookie": "npm:4.0.5"
     "@types/xml2js": "npm:0.4.14"
     axios: "npm:1.16.0"
@@ -2545,7 +2535,6 @@ __metadata:
     query-string: "npm:9.3.1"
     redis: "npm:5.12.1"
     split2: "npm:4.2.0"
-    through2: "npm:4.0.2"
     tough-cookie: "npm:6.0.1"
     typescript: "npm:6.0.3"
     typescript-eslint: "npm:8.59.3"
@@ -4788,7 +4777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:3, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.6.0":
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
   dependencies:
@@ -5522,15 +5511,6 @@ __metadata:
   dependencies:
     real-require: "npm:^0.2.0"
   checksum: 10/698ac8bd104c6cf91dda8421c30790979b867d7b6c878f914ddef18f1b1bc846f8776976d9f0113ed0ee90043f2e9e6554b96f4c1154ff84cd199da657f214fa
-  languageName: node
-  linkType: hard
-
-"through2@npm:4.0.2":
-  version: 4.0.2
-  resolution: "through2@npm:4.0.2"
-  dependencies:
-    readable-stream: "npm:3"
-  checksum: 10/72c246233d9a989bbebeb6b698ef0b7b9064cb1c47930f79b25d87b6c867e075432811f69b7b2ac8da00ca308191c507bdab913944be8019ac43b036ce88f6ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Renovate [päivitysPR](https://github.com/espoon-voltti/evaka/pull/9089) aiheutti virheitä, joten samalla vaivalla poistettu koko riippuvuus ja käytetään noden streameja suoraan.