### PR TITLE
Lisää dataa automaattipoiston piiriin (ei vielä käytössä)

### DIFF
--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -3647,7 +3647,10 @@ CREATE TABLE public.nekku_special_diet_choices (
     child_id uuid NOT NULL,
     diet_id text NOT NULL,
     field_id text NOT NULL,
-    value text NOT NULL
+    value text NOT NULL,
+    id uuid DEFAULT ext.uuid_generate_v1mc() NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 -- Name: nekku_special_diet_field; Type: TABLE; Schema: public
@@ -4805,6 +4808,11 @@ ALTER TABLE ONLY public.nekku_customer
 
 ALTER TABLE ONLY public.nekku_product
     ADD CONSTRAINT nekku_product_pkey PRIMARY KEY (sku);
+
+-- Name: nekku_special_diet_choices nekku_special_diet_choices_pkey; Type: CONSTRAINT; Schema: public
+
+ALTER TABLE ONLY public.nekku_special_diet_choices
+    ADD CONSTRAINT nekku_special_diet_choices_pkey PRIMARY KEY (id);
 
 -- Name: nekku_special_diet_field nekku_special_diet_field_pkey; Type: CONSTRAINT; Schema: public
 
@@ -6871,6 +6879,10 @@ CREATE TRIGGER set_timestamp BEFORE UPDATE ON public.mobile_device FOR EACH ROW 
 -- Name: mobile_device_push_subscription set_timestamp; Type: TRIGGER; Schema: public
 
 CREATE TRIGGER set_timestamp BEFORE UPDATE ON public.mobile_device_push_subscription FOR EACH ROW EXECUTE FUNCTION public.trigger_refresh_updated_at();
+
+-- Name: nekku_special_diet_choices set_timestamp; Type: TRIGGER; Schema: public
+
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON public.nekku_special_diet_choices FOR EACH ROW EXECUTE FUNCTION public.trigger_refresh_updated_at();
 
 -- Name: other_assistance_measure set_timestamp; Type: TRIGGER; Schema: public
 

--- a/frontend/src/e2e-test/generated/api-clients.ts
+++ b/frontend/src/e2e-test/generated/api-clients.ts
@@ -1623,12 +1623,14 @@ export async function deletePlacement(
 export async function forceFullVtjRefresh(
   request: {
     person: PersonId
-  }
+  },
+  options?: { mockedTime?: HelsinkiDateTime }
 ): Promise<void> {
   try {
     const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/persons/${request.person}/force-full-vtj-refresh`.toString(),
-      method: 'POST'
+      method: 'POST',
+      headers: { EvakaMockedTime: options?.mockedTime?.formatIso() }
     })
     return json
   } catch (e) {

--- a/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
@@ -26,7 +26,6 @@ import evaka.core.shared.dev.DevPersonType
 import evaka.core.shared.dev.insert
 import evaka.core.shared.domain.DateRange
 import evaka.core.shared.domain.HelsinkiDateTime
-import evaka.core.shared.domain.MockEvakaClock
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlin.test.assertEquals
@@ -40,7 +39,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     @Autowired private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
 
     private val today = LocalDate.of(2026, 5, 7)
-    private val clock = MockEvakaClock(HelsinkiDateTime.of(today, LocalTime.of(2, 0)))
+    private val now = HelsinkiDateTime.of(today, LocalTime.of(2, 0))
 
     private val admin = DevEmployee(roles = setOf(UserRole.ADMIN))
     private val careArea = DevCareArea()
@@ -65,11 +64,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         // A pending PDF (null key) must not leak as a null payload.
         insertExpiredDocument(template, keys = listOf("s3-key-c-v1", null))
 
-        dataRemovalService.deleteExpiredChildDocuments(
-            db,
-            clock,
-            AsyncJob.DeleteExpiredChildDocuments(),
-        )
+        dataRemovalService.deleteExpiredChildDocuments(db, now, limit = 100)
 
         assertEquals(
             setOf("s3-key-a-v1", "s3-key-a-v2", "s3-key-b-v1", "s3-key-c-v1"),
@@ -81,13 +76,9 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     fun `handler enqueues nothing when no documents are eligible for deletion`() {
         val template = insertTemplate()
         // Recently modified document is not yet expired.
-        insertDocument(template, statusModifiedAt = clock.now(), keys = listOf("fresh-key"))
+        insertDocument(template, statusModifiedAt = now, keys = listOf("fresh-key"))
 
-        dataRemovalService.deleteExpiredChildDocuments(
-            db,
-            clock,
-            AsyncJob.DeleteExpiredChildDocuments(),
-        )
+        dataRemovalService.deleteExpiredChildDocuments(db, now, limit = 1000)
 
         assertTrue(scheduledPdfDeletionKeys().isEmpty())
     }
@@ -97,11 +88,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         val template = insertTemplate()
         insertExpiredDocument(template, keys = emptyList())
 
-        dataRemovalService.deleteExpiredChildDocuments(
-            db,
-            clock,
-            AsyncJob.DeleteExpiredChildDocuments(),
-        )
+        dataRemovalService.deleteExpiredChildDocuments(db, now, limit = 1000)
 
         assertTrue(scheduledPdfDeletionKeys().isEmpty())
     }
@@ -134,8 +121,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     private fun insertExpiredDocument(
         template: DevDocumentTemplate,
         keys: List<String?>,
-    ): ChildDocumentId =
-        insertDocument(template, statusModifiedAt = clock.now().minusYears(1), keys = keys)
+    ): ChildDocumentId = insertDocument(template, statusModifiedAt = now.minusYears(1), keys = keys)
 
     private fun insertDocument(
         template: DevDocumentTemplate,

--- a/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
@@ -4,46 +4,75 @@
 
 package evaka.core.dataremoval
 
+import evaka.core.DataRemovalEnv
 import evaka.core.FullApplicationTest
+import evaka.core.calendarevent.CalendarEventType
+import evaka.core.childimages.insertChildImage
 import evaka.core.document.ChildDocumentType
 import evaka.core.document.DocumentDeletionBasis
 import evaka.core.document.DocumentTemplateContent
 import evaka.core.document.childdocument.DocumentContent
 import evaka.core.document.childdocument.DocumentStatus
+import evaka.core.nekku.NekkuProductMealType
+import evaka.core.note.child.sticky.ChildStickyNoteBody
+import evaka.core.note.child.sticky.createChildStickyNote
 import evaka.core.placement.PlacementType
+import evaka.core.s3.DocumentService
 import evaka.core.shared.ChildDocumentId
+import evaka.core.shared.ChildId
 import evaka.core.shared.async.AsyncJob
 import evaka.core.shared.async.AsyncJobRunner
 import evaka.core.shared.auth.UserRole
+import evaka.core.shared.dev.DevCalendarEvent
+import evaka.core.shared.dev.DevCalendarEventAttendee
+import evaka.core.shared.dev.DevCalendarEventTime
 import evaka.core.shared.dev.DevCareArea
+import evaka.core.shared.dev.DevChild
 import evaka.core.shared.dev.DevChildDocument
 import evaka.core.shared.dev.DevChildDocumentPublishedVersion
 import evaka.core.shared.dev.DevDaycare
+import evaka.core.shared.dev.DevDaycareGroup
 import evaka.core.shared.dev.DevDocumentTemplate
 import evaka.core.shared.dev.DevEmployee
+import evaka.core.shared.dev.DevFamilyContact
 import evaka.core.shared.dev.DevPerson
 import evaka.core.shared.dev.DevPersonType
+import evaka.core.shared.dev.DevPlacement
 import evaka.core.shared.dev.insert
 import evaka.core.shared.domain.DateRange
+import evaka.core.shared.domain.FiniteDateRange
 import evaka.core.shared.domain.HelsinkiDateTime
+import evaka.core.shared.domain.MockEvakaClock
+import evaka.core.specialdiet.MealTexture
+import evaka.core.specialdiet.SpecialDiet
+import evaka.core.specialdiet.setMealTextures
+import evaka.core.specialdiet.setSpecialDiets
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.util.ReflectionTestUtils
 
 class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     @Autowired private lateinit var dataRemovalService: DataRemovalService
     @Autowired private lateinit var asyncJobRunner: AsyncJobRunner<AsyncJob>
+    @Autowired private lateinit var documentClient: DocumentService
 
     private val today = LocalDate.of(2026, 5, 7)
     private val now = HelsinkiDateTime.of(today, LocalTime.of(2, 0))
+    private val clock = MockEvakaClock(now)
+
+    private val leafExpireDate = today.minusYears(1)
+    private val imageExpireDate = today.minusMonths(1)
 
     private val admin = DevEmployee(roles = setOf(UserRole.ADMIN))
     private val careArea = DevCareArea()
     private val daycare = DevDaycare(areaId = careArea.id)
+    private val daycareGroup = DevDaycareGroup(daycareId = daycare.id)
     private val child = DevPerson()
 
     @BeforeEach
@@ -52,6 +81,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
             tx.insert(admin)
             tx.insert(careArea)
             tx.insert(daycare)
+            tx.insert(daycareGroup)
             tx.insert(child, DevPersonType.CHILD)
         }
     }
@@ -152,4 +182,493 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
             )
         return db.transaction { tx -> tx.insert(doc) }
     }
+
+    @Test
+    fun `deleteExpiredChildLeafRows deletes rows in every listed table for an expired child`() {
+        insertExpiredPlacement(child.id)
+        insertCalendarEventAttendee(child.id)
+        insertCalendarEventTime(child.id)
+        insertChildStickyNote(child.id)
+        insertFamilyContact(child.id)
+        insertNekkuSpecialDietChoice(child.id)
+
+        deleteExpiredChildLeafRows(
+            db,
+            expireDate = leafExpireDate,
+            limit = 100,
+            leafTables = allLeafTables,
+        )
+
+        allLeafTables.forEach { assertEquals(0, rowCount(it), "table $it should be empty") }
+    }
+
+    @Test
+    fun `deleteExpiredChildLeafRows preserves rows for active children`() {
+        insertActivePlacement(child.id)
+        insertChildStickyNote(child.id)
+        insertCalendarEventAttendee(child.id)
+
+        deleteExpiredChildLeafRows(
+            db,
+            expireDate = leafExpireDate,
+            limit = 100,
+            leafTables = allLeafTables,
+        )
+
+        assertEquals(1, rowCount("child_sticky_note"))
+        assertEquals(1, rowCount("calendar_event_attendee"))
+    }
+
+    @Test
+    fun `deleteExpiredChildLeafRows respects limit`() {
+        insertExpiredPlacement(child.id)
+        repeat(5) { insertChildStickyNote(child.id) }
+
+        deleteExpiredChildLeafRows(
+            db,
+            expireDate = leafExpireDate,
+            limit = 2,
+            leafTables = listOf("child_sticky_note"),
+        )
+
+        assertEquals(3, rowCount("child_sticky_note"))
+    }
+
+    @Test
+    fun `deleteExpiredChildLeafRows with empty leaf table list is a no-op`() {
+        insertExpiredPlacement(child.id)
+        insertChildStickyNote(child.id)
+
+        deleteExpiredChildLeafRows(
+            db,
+            expireDate = leafExpireDate,
+            limit = 100,
+            leafTables = emptyList(),
+        )
+
+        assertEquals(1, rowCount("child_sticky_note"))
+    }
+
+    @Test
+    fun `unsetExpiredChildReferences nulls diet_id, meal_texture_id, and nekku_diet for expired children`() {
+        insertExpiredPlacement(child.id)
+        setUpChildDietReferences(child.id)
+
+        unsetExpiredChildReferences(
+            db,
+            expireDate = leafExpireDate,
+            limit = 100,
+            columns = listOf("diet_id", "meal_texture_id", "nekku_diet"),
+        )
+
+        assertEquals(
+            ChildDietColumns(dietId = null, mealTextureId = null, nekkuDiet = null),
+            readChildDietColumns(child.id),
+        )
+    }
+
+    @Test
+    fun `unsetExpiredChildReferences preserves values for active children`() {
+        insertActivePlacement(child.id)
+        setUpChildDietReferences(child.id)
+
+        unsetExpiredChildReferences(
+            db,
+            expireDate = leafExpireDate,
+            limit = 100,
+            columns = listOf("diet_id", "meal_texture_id", "nekku_diet"),
+        )
+
+        assertEquals(
+            ChildDietColumns(
+                dietId = 1,
+                mealTextureId = 2,
+                nekkuDiet = NekkuProductMealType.VEGAN.name,
+            ),
+            readChildDietColumns(child.id),
+        )
+    }
+
+    @Test
+    fun `unsetExpiredChildReferences respects limit across columns`() {
+        val children = (1..5).map { DevPerson() }
+        db.transaction { tx ->
+            children.forEach { tx.insert(it, DevPersonType.CHILD) }
+            tx.setSpecialDiets(listOf(SpecialDiet(1, "diet")))
+            tx.setMealTextures(listOf(MealTexture(2, "texture")))
+        }
+        children.forEach {
+            insertExpiredPlacement(it.id)
+            db.transaction { tx ->
+                tx.insert(
+                    DevChild(
+                        id = it.id,
+                        dietId = 1,
+                        mealTextureId = 2,
+                        nekkuDiet = NekkuProductMealType.VEGAN,
+                    )
+                )
+            }
+        }
+
+        unsetExpiredChildReferences(
+            db,
+            expireDate = leafExpireDate,
+            limit = 2,
+            columns = listOf("diet_id"),
+        )
+
+        assertEquals(3, countChildrenWithNull("diet_id"))
+    }
+
+    @Test
+    fun `deleteExpiredChildImages deletes child_images row and enqueues DeleteChildImage job for expired child`() {
+        insertPlacementEnding(child.id, today.minusMonths(2))
+        val imageId = db.transaction { it.insertChildImage(child.id) }
+
+        dataRemovalService.deleteExpiredChildImages(
+            db,
+            now,
+            expireDate = imageExpireDate,
+            limit = 100,
+        )
+
+        assertEquals(0, rowCount("child_images"))
+        assertEquals(setOf(imageId.toString()), scheduledChildImageDeletionIds())
+    }
+
+    @Test
+    fun `deleteExpiredChildImages preserves images for children at the 1-month boundary`() {
+        insertPlacementEnding(child.id, today.minusDays(15))
+        db.transaction { it.insertChildImage(child.id) }
+
+        dataRemovalService.deleteExpiredChildImages(
+            db,
+            now,
+            expireDate = imageExpireDate,
+            limit = 100,
+        )
+
+        assertEquals(1, rowCount("child_images"))
+        assertTrue(scheduledChildImageDeletionIds().isEmpty())
+    }
+
+    @Test
+    fun `deleteExpiredChildImages respects limit`() {
+        val children = (1..5).map { DevPerson() }
+        db.transaction { tx -> children.forEach { tx.insert(it, DevPersonType.CHILD) } }
+        children.forEach {
+            insertPlacementEnding(it.id, today.minusMonths(2))
+            db.transaction { tx -> tx.insertChildImage(it.id) }
+        }
+
+        dataRemovalService.deleteExpiredChildImages(
+            db,
+            now,
+            expireDate = imageExpireDate,
+            limit = 2,
+        )
+
+        assertEquals(3, rowCount("child_images"))
+        assertEquals(2, scheduledChildImageDeletionIds().size)
+    }
+
+    @Test
+    fun `deleteExpiredData with limit zero performs no deletions`() {
+        insertExpiredPlacement(child.id)
+        setUpChildDietReferences(child.id)
+        insertChildStickyNote(child.id)
+        insertFamilyContact(child.id)
+        db.transaction { it.insertChildImage(child.id) }
+
+        withLimit(0) { dataRemovalService.deleteExpiredData(db, clock, AsyncJob.DeleteExpiredData) }
+
+        assertEquals(1, rowCount("child_sticky_note"))
+        assertEquals(1, rowCount("family_contact"))
+        assertEquals(1, rowCount("child_images"))
+        assertEquals(
+            ChildDietColumns(
+                dietId = 1,
+                mealTextureId = 2,
+                nekkuDiet = NekkuProductMealType.VEGAN.name,
+            ),
+            readChildDietColumns(child.id),
+        )
+        assertTrue(scheduledChildImageDeletionIds().isEmpty())
+    }
+
+    @Test
+    fun `deleteExpiredData cleans up leaf rows, child references, and images in one pass`() {
+        insertExpiredPlacement(child.id)
+        setUpChildDietReferences(child.id)
+        insertCalendarEventAttendee(child.id)
+        insertCalendarEventTime(child.id)
+        insertChildStickyNote(child.id)
+        insertFamilyContact(child.id)
+        insertNekkuSpecialDietChoice(child.id)
+        val imageId = db.transaction { it.insertChildImage(child.id) }
+
+        withLimit(100) {
+            dataRemovalService.deleteExpiredData(db, clock, AsyncJob.DeleteExpiredData)
+        }
+
+        allLeafTables.forEach { assertEquals(0, rowCount(it), "table $it should be empty") }
+        assertEquals(0, rowCount("child_images"))
+        assertEquals(
+            ChildDietColumns(dietId = null, mealTextureId = null, nekkuDiet = null),
+            readChildDietColumns(child.id),
+        )
+        assertEquals(setOf(imageId.toString()), scheduledChildImageDeletionIds())
+    }
+
+    @Test
+    fun `child with no placements is not considered expired`() {
+        // child has no placements at all
+        setUpChildDietReferences(child.id)
+
+        unsetExpiredChildReferences(
+            db,
+            expireDate = leafExpireDate,
+            limit = 100,
+            columns = listOf("diet_id"),
+        )
+
+        assertEquals(0, countChildrenWithNull("diet_id"))
+    }
+
+    @Test
+    fun `child whose only placement ends after expireDate is not considered expired`() {
+        insertPlacementEnding(child.id, leafExpireDate.plusDays(1))
+        setUpChildDietReferences(child.id)
+
+        unsetExpiredChildReferences(
+            db,
+            expireDate = leafExpireDate,
+            limit = 100,
+            columns = listOf("diet_id"),
+        )
+
+        assertEquals(0, countChildrenWithNull("diet_id"))
+    }
+
+    @Test
+    fun `child whose only placement ends before expireDate is considered expired`() {
+        insertPlacementEnding(child.id, leafExpireDate.minusDays(1))
+        setUpChildDietReferences(child.id)
+
+        unsetExpiredChildReferences(
+            db,
+            expireDate = leafExpireDate,
+            limit = 100,
+            columns = listOf("diet_id"),
+        )
+
+        assertEquals(1, countChildrenWithNull("diet_id"))
+    }
+
+    @Test
+    fun `child with an old placement but a recent active one is not considered expired`() {
+        // Old placement that ended years ago
+        insertPlacement(child.id, startDate = today.minusYears(5), endDate = today.minusYears(4))
+        // Later placement still ongoing
+        insertPlacement(child.id, startDate = today.minusMonths(2), endDate = today.plusYears(1))
+        setUpChildDietReferences(child.id)
+
+        unsetExpiredChildReferences(
+            db,
+            expireDate = leafExpireDate,
+            limit = 100,
+            columns = listOf("diet_id"),
+        )
+
+        assertEquals(0, countChildrenWithNull("diet_id"))
+    }
+
+    private val allLeafTables =
+        listOf(
+            "calendar_event_attendee",
+            "calendar_event_time",
+            "child_sticky_note",
+            "family_contact",
+            "nekku_special_diet_choices",
+        )
+
+    private fun withLimit(limit: Int, block: () -> Unit) {
+        ReflectionTestUtils.setField(
+            dataRemovalService,
+            "dataRemovalEnv",
+            DataRemovalEnv(limit = limit),
+        )
+        block()
+    }
+
+    private fun insertExpiredPlacement(childId: ChildId) =
+        insertPlacementEnding(childId, leafExpireDate.minusDays(1))
+
+    private fun insertActivePlacement(childId: ChildId) =
+        insertPlacementEnding(childId, today.plusYears(1))
+
+    private fun insertPlacementEnding(childId: ChildId, endDate: LocalDate) =
+        insertPlacement(childId, startDate = endDate.minusYears(1), endDate = endDate)
+
+    private fun insertPlacement(childId: ChildId, startDate: LocalDate, endDate: LocalDate) {
+        db.transaction { tx ->
+            tx.insert(
+                DevPlacement(
+                    childId = childId,
+                    unitId = daycare.id,
+                    startDate = startDate,
+                    endDate = endDate,
+                )
+            )
+        }
+    }
+
+    private fun insertCalendarEvent(): DevCalendarEvent {
+        val event =
+            DevCalendarEvent(
+                title = "title",
+                description = "desc",
+                period = FiniteDateRange(today, today),
+                modifiedAt = now,
+                modifiedBy = admin.evakaUserId,
+                eventType = CalendarEventType.DAYCARE_EVENT,
+            )
+        db.transaction { tx -> tx.insert(event) }
+        return event
+    }
+
+    private fun insertCalendarEventAttendee(childId: ChildId) {
+        val event = insertCalendarEvent()
+        db.transaction { tx ->
+            tx.insert(
+                DevCalendarEventAttendee(
+                    calendarEventId = event.id,
+                    unitId = daycare.id,
+                    groupId = daycareGroup.id,
+                    childId = childId,
+                )
+            )
+        }
+    }
+
+    private fun insertCalendarEventTime(childId: ChildId) {
+        val event = insertCalendarEvent()
+        db.transaction { tx ->
+            tx.insert(
+                DevCalendarEventTime(
+                    calendarEventId = event.id,
+                    date = today,
+                    start = LocalTime.of(9, 0),
+                    end = LocalTime.of(10, 0),
+                    childId = childId,
+                    modifiedAt = now,
+                    modifiedBy = admin.evakaUserId,
+                )
+            )
+        }
+    }
+
+    private fun insertChildStickyNote(childId: ChildId) {
+        db.transaction { tx ->
+            tx.createChildStickyNote(
+                childId = childId,
+                note = ChildStickyNoteBody(note = "note", expires = today.plusDays(1)),
+            )
+        }
+    }
+
+    private fun insertFamilyContact(childId: ChildId) {
+        val contactPerson = DevPerson()
+        db.transaction { tx ->
+            tx.insert(contactPerson, DevPersonType.ADULT)
+            tx.insert(
+                DevFamilyContact(
+                    id = UUID.randomUUID(),
+                    childId = childId,
+                    contactPersonId = contactPerson.id,
+                    priority = 1,
+                )
+            )
+        }
+    }
+
+    private fun insertNekkuSpecialDietChoice(childId: ChildId) {
+        db.transaction { tx ->
+            tx.execute {
+                sql(
+                    """
+                    INSERT INTO nekku_special_diet (id, name) VALUES ('test-diet', 'Test Diet')
+                    ON CONFLICT DO NOTHING
+                    """
+                )
+            }
+            tx.execute {
+                sql(
+                    """
+                    INSERT INTO nekku_special_diet_field (id, name, type, diet_id)
+                    VALUES ('test-field', 'Test Field', 'TEXT'::nekku_special_diet_type, 'test-diet')
+                    ON CONFLICT DO NOTHING
+                    """
+                )
+            }
+            tx.execute {
+                sql(
+                    """
+                    INSERT INTO nekku_special_diet_choices (child_id, diet_id, field_id, value, created_at)
+                    VALUES (${bind(childId)}, 'test-diet', 'test-field', 'val', ${bind(now)})
+                    """
+                )
+            }
+        }
+    }
+
+    private fun setUpChildDietReferences(childId: ChildId) {
+        db.transaction { tx ->
+            tx.setSpecialDiets(listOf(SpecialDiet(1, "diet")))
+            tx.setMealTextures(listOf(MealTexture(2, "texture")))
+            tx.insert(
+                DevChild(
+                    id = childId,
+                    dietId = 1,
+                    mealTextureId = 2,
+                    nekkuDiet = NekkuProductMealType.VEGAN,
+                )
+            )
+        }
+    }
+
+    private fun rowCount(table: String): Int = db.read { tx ->
+        tx.createQuery { sql("SELECT count(*) FROM $table") }.exactlyOne<Int>()
+    }
+
+    private fun countChildrenWithNull(column: String): Int = db.read { tx ->
+        tx.createQuery { sql("SELECT count(*) FROM child WHERE $column IS NULL") }.exactlyOne<Int>()
+    }
+
+    private data class ChildDietColumns(
+        val dietId: Int?,
+        val mealTextureId: Int?,
+        val nekkuDiet: String?,
+    )
+
+    private fun readChildDietColumns(childId: ChildId): ChildDietColumns = db.read { tx ->
+        tx.createQuery {
+                sql(
+                    "SELECT diet_id, meal_texture_id, nekku_diet::text AS nekku_diet FROM child WHERE id = ${bind(childId)}"
+                )
+            }
+            .exactlyOne<ChildDietColumns>()
+    }
+
+    private fun scheduledChildImageDeletionIds(): Set<String> =
+        db.read { tx ->
+                tx.createQuery {
+                        sql(
+                            "SELECT payload::json->>'imageId' FROM async_job WHERE type = 'DeleteChildImage'"
+                        )
+                    }
+                    .toList<String>()
+            }
+            .toSet()
 }

--- a/service/src/integrationTest/kotlin/evaka/core/daycare/controllers/ChildrenControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/daycare/controllers/ChildrenControllerIntegrationTest.kt
@@ -21,6 +21,7 @@ import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.auth.UserRole
 import evaka.core.shared.config.testFeatureConfig
 import evaka.core.shared.domain.BadRequest
+import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.domain.RealEvakaClock
 import evaka.core.shared.noopTracer
 import evaka.core.shared.security.AccessControl
@@ -59,7 +60,8 @@ class ChildrenControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach 
                             diet = "bcvxnvgmn",
                             additionalInfo = "fjmhj",
                         ),
-                )
+                ),
+                HelsinkiDateTime.now(),
             )
             child = tx.getChild(childId)!!
         }

--- a/service/src/integrationTest/kotlin/evaka/core/daycare/dao/ChildDAOIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/daycare/dao/ChildDAOIntegrationTest.kt
@@ -11,6 +11,7 @@ import evaka.core.daycare.createChild
 import evaka.core.daycare.getChild
 import evaka.core.daycare.updateChild
 import evaka.core.shared.ChildId
+import evaka.core.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
 import java.util.UUID.randomUUID
 import kotlin.test.assertEquals
@@ -38,7 +39,8 @@ class ChildDAOIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                             diet = "Kasvisruokavalio",
                             additionalInfo = "Ei osaa solmia kengännauhoja",
                         ),
-                )
+                ),
+                HelsinkiDateTime.now(),
             )
             child = tx.getChild(childId)!!
         }
@@ -63,7 +65,7 @@ class ChildDAOIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                     )
             )
 
-        db.transaction { it.updateChild(updated) }
+        db.transaction { it.updateChild(updated, HelsinkiDateTime.now()) }
 
         val actual = db.transaction { it.getChild(childId) }
         assertEquals(actual, updated)

--- a/service/src/integrationTest/kotlin/evaka/core/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/decision/DecisionCreationIntegrationTest.kt
@@ -1299,7 +1299,7 @@ class DecisionCreationIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
         hideFromGuardian: Boolean = false,
     ): ApplicationId = db.transaction { tx ->
         // make sure guardians are up-to-date
-        personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, child.id)
+        personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, clock.now(), child.id)
 
         val preschoolDaycare = type == PlacementType.PRESCHOOL_DAYCARE
         val applicationId =

--- a/service/src/integrationTest/kotlin/evaka/core/nekku/NekkuIntegrationTestUtils.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/nekku/NekkuIntegrationTestUtils.kt
@@ -107,12 +107,15 @@ fun insertNekkuSpecialDietChoice(
     db.transaction { tx ->
         tx.createUpdate {
                 sql(
-                    "INSERT INTO nekku_special_diet_choices VALUES (" +
-                        "${bind(childId)}," +
-                        "${bind(dietId)}," +
-                        "${bind(dietField)}," +
-                        "${bind(dietValue)}" +
-                        ")"
+                    """
+                    INSERT INTO nekku_special_diet_choices (child_id, created_at, diet_id, field_id, value) VALUES (
+                        ${bind(childId)},
+                        ${bind(HelsinkiDateTime.now())},
+                        ${bind(dietId)},
+                        ${bind(dietField)},
+                        ${bind(dietValue)}
+                    )
+                    """
                 )
             }
             .execute()

--- a/service/src/integrationTest/kotlin/evaka/core/pis/service/DVVBatchRefreshServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/service/DVVBatchRefreshServiceIntegrationTest.kt
@@ -93,7 +93,7 @@ class DVVBatchRefreshServiceIntegrationTest : FullApplicationTest(resetDbBeforeE
     @Test
     fun `children in same address are added`() {
         val dto = getDto(adult1).copy(children = listOf(getDto(child)))
-        whenever(personService.getPersonWithChildren(any(), eq(user), eq(adult1.id), any()))
+        whenever(personService.getPersonWithChildren(any(), eq(user), any(), eq(adult1.id), any()))
             .thenReturn(dto)
         whenever(personService.personsLiveInTheSameAddress(any(), any())).thenReturn(true)
 
@@ -125,7 +125,7 @@ class DVVBatchRefreshServiceIntegrationTest : FullApplicationTest(resetDbBeforeE
                             residenceCode = "2",
                         ),
                 )
-        whenever(personService.getPersonWithChildren(any(), eq(user), eq(adult1.id), any()))
+        whenever(personService.getPersonWithChildren(any(), eq(user), any(), eq(adult1.id), any()))
             .thenReturn(dto)
         service.doVTJRefresh(db, RealEvakaClock(), AsyncJob.VTJRefresh(adult1.id))
         verifyNoInteractions(parentshipService)
@@ -161,9 +161,9 @@ class DVVBatchRefreshServiceIntegrationTest : FullApplicationTest(resetDbBeforeE
 
         val dto1 = getDto(adult1)
         val dto2 = getDto(adult2).copy(children = listOf(getDto(child)))
-        whenever(personService.getPersonWithChildren(any(), eq(user), eq(adult1.id), any()))
+        whenever(personService.getPersonWithChildren(any(), eq(user), any(), eq(adult1.id), any()))
             .thenReturn(dto1)
-        whenever(personService.getPersonWithChildren(any(), eq(user), eq(adult2.id), any()))
+        whenever(personService.getPersonWithChildren(any(), eq(user), any(), eq(adult2.id), any()))
             .thenReturn(dto2)
         whenever(personService.personsLiveInTheSameAddress(any(), any())).thenReturn(true)
 
@@ -213,9 +213,9 @@ class DVVBatchRefreshServiceIntegrationTest : FullApplicationTest(resetDbBeforeE
 
         val dto1 = getDto(adult1)
         val dto2 = getDto(adult2).copy(children = listOf(getDto(child)))
-        whenever(personService.getPersonWithChildren(any(), eq(user), eq(adult1.id), any()))
+        whenever(personService.getPersonWithChildren(any(), eq(user), any(), eq(adult1.id), any()))
             .thenReturn(dto1)
-        whenever(personService.getPersonWithChildren(any(), eq(user), eq(adult2.id), any()))
+        whenever(personService.getPersonWithChildren(any(), eq(user), any(), eq(adult2.id), any()))
             .thenReturn(dto2)
 
         service.doVTJRefresh(db, RealEvakaClock(), AsyncJob.VTJRefresh(adult1.id))

--- a/service/src/integrationTest/kotlin/evaka/core/pis/service/PersonServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/service/PersonServiceIntegrationTest.kt
@@ -10,6 +10,7 @@ import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.dev.DevPerson
 import evaka.core.shared.dev.DevPersonType
 import evaka.core.shared.dev.insert
+import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.vtjclient.mapper.VtjHenkiloMapper
 import evaka.core.vtjclient.service.persondetails.VTJPersonDetailsService
 import evaka.core.vtjclient.service.vtjclient.IVtjClientService
@@ -101,7 +102,12 @@ class PersonServiceIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         MockVtjClientService.addPERUSSANOMA3RequestExpectation(testPersonWithVtjChildren)
         MockVtjClientService.addPERUSSANOMA3RequestExpectation(testPersonDependantChild)
         db.transaction {
-            personService.getPersonWithChildren(it, user, testPersonWithVtjChildren.id)
+            personService.getPersonWithChildren(
+                it,
+                user,
+                HelsinkiDateTime.now(),
+                testPersonWithVtjChildren.id,
+            )
         }
         assertEquals(0, MockVtjClientService.getPERUSSANOMA3RequestCount(testPersonWithVtjChildren))
         assertEquals(1, MockVtjClientService.getPERUSSANOMA3RequestCount(testPersonDependantChild))

--- a/service/src/main/kotlin/evaka/core/EvakaEnv.kt
+++ b/service/src/main/kotlin/evaka/core/EvakaEnv.kt
@@ -724,16 +724,13 @@ data class ChildDocumentArchivalEnv(val delayDays: Int, val limit: Int) {
     }
 }
 
-/**
- * Per-task batch limits for [evaka.core.dataremoval] scheduled jobs. `null` means unlimited; any
- * backlog beyond the limit is processed on subsequent runs.
- */
-data class DataRemovalEnv(val childDocumentLimit: Int?) {
+data class DataRemovalEnv(
+    /** Maximum number of entries to delete *per data type*. */
+    val limit: Int
+) {
     companion object {
         fun fromEnvironment(env: Environment) =
-            DataRemovalEnv(
-                childDocumentLimit = env.lookup("evaka.data_removal.child_document_limit") ?: 5000
-            )
+            DataRemovalEnv(limit = env.lookup("evaka.data_removal.limit") ?: 0)
     }
 }
 

--- a/service/src/main/kotlin/evaka/core/application/ApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/application/ApplicationControllerCitizen.kt
@@ -188,6 +188,7 @@ class ApplicationControllerCitizen(
                         personService.getOtherGuardian(
                             tx,
                             user,
+                            clock.now(),
                             application.guardianId,
                             application.childId,
                         )

--- a/service/src/main/kotlin/evaka/core/application/ApplicationControllerV2.kt
+++ b/service/src/main/kotlin/evaka/core/application/ApplicationControllerV2.kt
@@ -305,9 +305,9 @@ class ApplicationControllerV2(
 
                     val decisions = tx.getDecisionsByApplication(applicationId, decisionFilter)
                     val guardians =
-                        personService.getGuardians(tx, user, application.childId).map { personDTO ->
-                            PersonJSON.from(personDTO)
-                        }
+                        personService
+                            .getGuardians(tx, user, clock.now(), application.childId)
+                            .map { personDTO -> PersonJSON.from(personDTO) }
 
                     val attachments =
                         tx.getApplicationAttachments(applicationId).let { allAttachments ->
@@ -513,7 +513,7 @@ class ApplicationControllerV2(
                     val child =
                         tx.getPersonById(application.childId)
                             ?: throw NotFound("Child ${application.childId} not found")
-                    val vtjGuardians = personService.getGuardians(tx, user, child.id)
+                    val vtjGuardians = personService.getGuardians(tx, user, clock.now(), child.id)
 
                     val applicationGuardianIsVtjGuardian: Boolean = vtjGuardians.any {
                         it.id == application.guardianId

--- a/service/src/main/kotlin/evaka/core/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/evaka/core/application/ApplicationStateService.kt
@@ -187,7 +187,7 @@ class ApplicationStateService(
         val form =
             ApplicationForm.initForm(type, guardian, child)
                 .let { form -> withDefaultStartDate(tx, now.toLocalDate(), type, form) }
-                .let { form -> withDefaultOtherChildren(tx, user, guardian, child, form) }
+                .let { form -> withDefaultOtherChildren(tx, user, now, guardian, child, form) }
 
         return tx.insertApplication(
             now = now,
@@ -252,12 +252,13 @@ class ApplicationStateService(
     private fun withDefaultOtherChildren(
         tx: Database.Transaction,
         user: AuthenticatedUser,
+        now: HelsinkiDateTime,
         guardian: PersonDTO,
         child: PersonDTO,
         form: ApplicationForm,
     ): ApplicationForm {
         val vtjChildren =
-            personService.getPersonWithChildren(tx, user, guardian.id)?.children ?: listOf()
+            personService.getPersonWithChildren(tx, user, now, guardian.id)?.children ?: listOf()
         // if the applicant is not the child's guardian (ie. they are a foster parent) do not
         // include other children
         val vtjOtherChildren =
@@ -304,7 +305,7 @@ class ApplicationStateService(
             validateApplicationPeriod = true,
         )
 
-        personService.getGuardians(tx, user, application.childId)
+        personService.getGuardians(tx, user, now, application.childId)
 
         val applicationFlags = tx.applicationFlags(application, currentDate)
         tx.updateApplicationFlags(application.id, applicationFlags, now, user.evakaUserId)
@@ -671,6 +672,9 @@ class ApplicationStateService(
         applicationId: ApplicationId,
         placementPlan: DaycarePlacementPlan,
     ): PlacementPlanId {
+        val now = clock.now()
+        val today = now.toLocalDate()
+
         val application = getApplication(tx, applicationId)
         verifyStatus(application, WAITING_PLACEMENT)
 
@@ -681,8 +685,8 @@ class ApplicationStateService(
             placementPlanService.createPlacementPlan(tx, application, placementPlan)
         createDecisionDrafts(tx, user, application)
 
-        personService.getGuardians(tx, user, application.childId)
-        tx.syncApplicationOtherGuardians(applicationId, clock.today())
+        personService.getGuardians(tx, user, now, application.childId)
+        tx.syncApplicationOtherGuardians(applicationId, today)
         tx.updateApplicationStatus(application.id, WAITING_DECISION, user.evakaUserId, clock.now())
         tx.deleteApplicationPlacementDraftIfExists(applicationId)
         return placementPlanId
@@ -1621,10 +1625,13 @@ class ApplicationStateService(
         application: ApplicationDetails,
         config: FeatureConfig = featureConfig,
     ): List<DecisionId> {
+        val now = clock.now()
+        val today = now.toLocalDate()
+
         val skipGuardian =
             config.skipGuardianPreschoolDecisionApproval &&
                 application.type == ApplicationType.PRESCHOOL
-        val sendBySfi = canSendDecisionsBySfi(tx, user, application)
+        val sendBySfi = canSendDecisionsBySfi(tx, user, now, application)
         val decisionDrafts = tx.fetchDecisionDrafts(application.id)
         return if (decisionDrafts.any { it.planned }) {
             val decisionIds =
@@ -1636,9 +1643,9 @@ class ApplicationStateService(
                     sendBySfi,
                     skipGuardian,
                 )
-            tx.syncApplicationOtherGuardians(application.id, clock.today())
+            tx.syncApplicationOtherGuardians(application.id, today)
             val newStatus = if (sendBySfi) WAITING_CONFIRMATION else WAITING_MAILING
-            tx.updateApplicationStatus(application.id, newStatus, user.evakaUserId, clock.now())
+            tx.updateApplicationStatus(application.id, newStatus, user.evakaUserId, now)
 
             if (skipGuardian) {
                 decisionIds.forEach { decisionId ->
@@ -1664,7 +1671,7 @@ class ApplicationStateService(
                 asyncJobRunner.plan(
                     tx,
                     listOf(AsyncJob.SendNewDecisionEmail(application.id)),
-                    runAt = clock.now(),
+                    runAt = now,
                 )
             }
 
@@ -1673,7 +1680,7 @@ class ApplicationStateService(
                     tx.insertCaseProcessHistoryRow(
                         processId = process.id,
                         state = CaseProcessState.DECIDING,
-                        now = clock.now(),
+                        now = now,
                         userId = user.evakaUserId,
                     )
                 }
@@ -1688,6 +1695,7 @@ class ApplicationStateService(
     private fun canSendDecisionsBySfi(
         tx: Database.Transaction,
         user: AuthenticatedUser,
+        now: HelsinkiDateTime,
         application: ApplicationDetails,
     ): Boolean {
         val hasSsn =
@@ -1695,7 +1703,7 @@ class ApplicationStateService(
                 tx.getPersonById(application.childId)!!.identity is ExternalIdentifier.SSN)
         val guardianIsVtjGuardian =
             personService
-                .getGuardians(tx, user, application.childId)
+                .getGuardians(tx, user, now, application.childId)
                 .filter { it.dateOfDeath == null }
                 .any { it.id == application.guardianId }
 

--- a/service/src/main/kotlin/evaka/core/childimages/ChildImage.kt
+++ b/service/src/main/kotlin/evaka/core/childimages/ChildImage.kt
@@ -36,11 +36,13 @@ fun replaceImage(
     return imageId
 }
 
-fun removeImage(
+fun deleteImage(
     tx: Database.Transaction,
     documentClient: DocumentService,
     childId: ChildId,
 ): ChildImageId? =
-    tx.deleteChildImage(childId)?.also { imageId ->
-        documentClient.delete(DocumentKey.ChildImage(imageId))
-    }
+    tx.deleteChildImage(childId)?.also { imageId -> deleteImageFile(documentClient, imageId) }
+
+fun deleteImageFile(documentClient: DocumentService, childImageId: ChildImageId) {
+    documentClient.delete(DocumentKey.ChildImage(childImageId))
+}

--- a/service/src/main/kotlin/evaka/core/childimages/ChildImageController.kt
+++ b/service/src/main/kotlin/evaka/core/childimages/ChildImageController.kt
@@ -92,7 +92,7 @@ class ChildImageController(
                     childId,
                 )
             }
-            dbc.transaction { tx -> removeImage(tx, documentClient, childId) }
+            dbc.transaction { tx -> deleteImage(tx, documentClient, childId) }
         }
         Audit.ChildImageDelete.log(
             targetId = AuditId(childId),

--- a/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
+++ b/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
@@ -5,14 +5,22 @@
 package evaka.core.dataremoval
 
 import evaka.core.DataRemovalEnv
+import evaka.core.childimages.deleteImageFile
 import evaka.core.document.childdocument.deleteExpiredChildDocuments
+import evaka.core.s3.DocumentService
+import evaka.core.shared.ChildId
+import evaka.core.shared.ChildImageId
+import evaka.core.shared.Id
 import evaka.core.shared.async.AsyncJob
 import evaka.core.shared.async.AsyncJobRunner
 import evaka.core.shared.async.AsyncJobType
 import evaka.core.shared.async.removeUnclaimedJobs
 import evaka.core.shared.db.Database
+import evaka.core.shared.db.QuerySql
 import evaka.core.shared.domain.EvakaClock
+import evaka.core.shared.domain.HelsinkiDateTime
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.LocalDate
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {}
@@ -21,34 +29,76 @@ private val logger = KotlinLogging.logger {}
 class DataRemovalService(
     private val asyncJobRunner: AsyncJobRunner<AsyncJob>,
     private val dataRemovalEnv: DataRemovalEnv,
+    private val documentClient: DocumentService,
 ) {
     init {
-        asyncJobRunner.registerHandler(::deleteExpiredChildDocuments)
+        asyncJobRunner.registerHandler(::deleteExpiredData)
+        asyncJobRunner.registerHandler(::deleteChildImage)
     }
 
     fun planDataRemoval(db: Database.Connection, clock: EvakaClock) {
-        val payloads: List<AsyncJob> = listOf(AsyncJob.DeleteExpiredChildDocuments())
         db.transaction { tx ->
-            tx.removeUnclaimedJobs(payloads.map { AsyncJobType.ofPayload(it) }.toSet())
-            asyncJobRunner.plan(tx, payloads, retryCount = 1, runAt = clock.now())
+            tx.removeUnclaimedJobs(setOf(AsyncJobType.ofPayload(AsyncJob.DeleteExpiredData)))
+            asyncJobRunner.plan(
+                tx,
+                listOf(AsyncJob.DeleteExpiredData),
+                retryCount = 1,
+                runAt = clock.now(),
+            )
         }
-        logger.info { "Planned ${payloads.size} data removal job(s)" }
+        logger.info { "Planned data removal job" }
     }
 
-    fun deleteExpiredChildDocuments(
-        db: Database.Connection,
+    fun deleteExpiredData(
+        dbc: Database.Connection,
         clock: EvakaClock,
-        msg: AsyncJob.DeleteExpiredChildDocuments,
+        msg: AsyncJob.DeleteExpiredData,
     ) {
-        val limit = dataRemovalEnv.childDocumentLimit
+        val now = clock.now()
+        val today = now.toLocalDate()
+        val limit = dataRemovalEnv.limit
+
+        if (limit == 0) {
+            logger.warn { "Data removal limit is set to 0, not deleting anything" }
+            return
+        }
+
+        deleteExpiredChildDocuments(dbc, now, limit)
+
+        deleteExpiredChildLeafRows(
+            dbc,
+            expireDate = today.minusYears(1),
+            limit,
+            leafTables =
+                listOf(
+                    "calendar_event_attendee",
+                    "calendar_event_time",
+                    "child_sticky_note",
+                    "family_contact",
+                    "nekku_special_diet_choices",
+                ),
+        )
+
+        unsetExpiredChildReferences(
+            dbc,
+            expireDate = today.minusYears(1),
+            limit,
+            columns = listOf("diet_id", "meal_texture_id", "nekku_diet"),
+        )
+
+        deleteExpiredChildImages(dbc, now, expireDate = today.minusMonths(1), limit)
+    }
+
+    fun deleteExpiredChildDocuments(db: Database.Connection, now: HelsinkiDateTime, limit: Int) {
+        logger.info { "Deleting at most $limit expired child documents" }
         val deleted = db.transaction { tx ->
-            val results = tx.deleteExpiredChildDocuments(clock.now(), limit = limit)
+            val results = tx.deleteExpiredChildDocuments(now, limit = limit)
             val pdfKeys = results.flatMap { it.documentKeys }
             if (pdfKeys.isNotEmpty()) {
                 asyncJobRunner.plan(
                     tx = tx,
                     payloads = pdfKeys.map { AsyncJob.DeleteChildDocumentPdf(it) },
-                    runAt = clock.now(),
+                    runAt = now,
                 )
             }
             results
@@ -65,14 +115,159 @@ class DataRemovalService(
                     "deletedSfiMessageIds" to chunk.flatMap { it.sfiMessageIds },
                 )
             },
-            message = { index, total ->
-                "Expired child document deletion audit (chunk $index/$total)"
-            },
+            message = { index, total -> "Deleted expired child documents (chunk $index/$total)" },
         )
-        if (limit != null && deleted.size >= limit) {
+        if (deleted.size >= limit) {
             logger.info {
                 "Child document deletion hit batch limit of $limit; remaining backlog will be processed on the next run"
             }
         }
     }
+
+    fun deleteExpiredChildImages(
+        dbc: Database.Connection,
+        now: HelsinkiDateTime,
+        expireDate: LocalDate,
+        limit: Int,
+    ) {
+        val ids = dbc.transaction { tx ->
+            val childImageIds: List<ChildImageId> =
+                tx.deleteExpiredChildLeafRowsFromTable(expireDate, limit, table = "child_images")
+            asyncJobRunner.plan(
+                tx,
+                childImageIds.map { AsyncJob.DeleteChildImage(it) },
+                runAt = now,
+            )
+            childImageIds
+        }
+
+        logger.infoChunked(
+            items = ids,
+            meta = { chunk -> mapOf("deletedIds" to chunk) },
+            message = { index, total -> "Deleted expired child images (chunk $index/$total)" },
+        )
+    }
+
+    fun deleteChildImage(
+        db: Database.Connection,
+        clock: EvakaClock,
+        msg: AsyncJob.DeleteChildImage,
+    ) {
+        deleteImageFile(documentClient, msg.imageId)
+    }
+}
+
+fun deleteExpiredChildLeafRows(
+    dbc: Database.Connection,
+    expireDate: LocalDate,
+    limit: Int,
+    leafTables: List<String>,
+) {
+    leafTables.forEach { table ->
+        logger.info { "Deleting at most $limit expired rows in table $table" }
+        val deleted = dbc.transaction { tx ->
+            tx.deleteExpiredChildLeafRowsFromTable<Id<*>>(expireDate, limit, table)
+        }
+        logger.infoChunked(
+            items = deleted,
+            meta = { chunk -> mapOf("table" to table, "deletedIds" to chunk) },
+            message = { index, total ->
+                "Deleted expired rows from table $table (chunk $index/$total)"
+            },
+        )
+    }
+}
+
+private inline fun <reified T : Id<*>> Database.Transaction.deleteExpiredChildLeafRowsFromTable(
+    expireDate: LocalDate,
+    limit: Int,
+    table: String,
+): List<T> =
+    createUpdate {
+            sql(
+                """
+WITH del_batch AS (
+    SELECT id
+    FROM $table
+    WHERE child_id = ANY(${subquery(childIdsWithPlacementsEndingBefore(expireDate))})
+    FOR UPDATE
+    LIMIT ${bind(limit)}
+)
+DELETE FROM $table
+USING del_batch
+WHERE $table.id = del_batch.id
+RETURNING $table.id
+        """
+            )
+        }
+        .executeAndReturnGeneratedKeys()
+        .toList()
+
+fun unsetExpiredChildReferences(
+    dbc: Database.Connection,
+    expireDate: LocalDate,
+    limit: Int,
+    columns: List<String>,
+) {
+    columns.forEach { column ->
+        if (limit > 0) {
+            logger.info { "Unsetting at most $limit expired references in child.$column" }
+            val childIds = dbc.transaction { tx ->
+                tx.unsetExpiredChildReference(expireDate, limit, column)
+            }
+            logger.infoChunked(
+                items = childIds,
+                meta = { chunk -> mapOf("column" to column, "childIds" to chunk) },
+                message = { index, total ->
+                    "Unset expired child.$column values (chunk $index/$total)"
+                },
+            )
+        }
+    }
+}
+
+fun Database.Transaction.unsetExpiredChildReference(
+    expireDate: LocalDate,
+    limit: Int,
+    column: String,
+): List<ChildId> =
+    createUpdate {
+            sql(
+                """
+WITH update_batch AS (
+    SELECT id
+    FROM child
+    WHERE
+        id = ANY(${subquery(childIdsWithPlacementsEndingBefore(expireDate))}) AND
+        $column IS NOT NULL
+    FOR UPDATE
+    LIMIT ${bind(limit)}
+)
+UPDATE child
+SET $column = NULL
+FROM update_batch
+WHERE child.id = update_batch.id
+RETURNING child.id
+"""
+            )
+        }
+        .executeAndReturnGeneratedKeys()
+        .toList()
+
+private fun childIdsWithPlacementsEndingBefore(date: LocalDate) = QuerySql {
+    sql(
+        """
+SELECT child_id
+FROM placement p_last
+WHERE
+    p_last.end_date < ${bind(date)} AND
+    NOT EXISTS (
+        SELECT
+        FROM placement p_later
+        WHERE
+            p_later.child_id = p_last.child_id AND
+            p_later.start_date > p_last.start_date
+    )
+"""
+    )
 }

--- a/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
+++ b/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
@@ -258,16 +258,9 @@ private fun childIdsWithPlacementsEndingBefore(date: LocalDate) = QuerySql {
     sql(
         """
 SELECT child_id
-FROM placement p_last
-WHERE
-    p_last.end_date < ${bind(date)} AND
-    NOT EXISTS (
-        SELECT
-        FROM placement p_later
-        WHERE
-            p_later.child_id = p_last.child_id AND
-            p_later.start_date > p_last.start_date
-    )
+FROM placement
+GROUP BY child_id
+HAVING max(end_date) < ${bind(date)}
 """
     )
 }

--- a/service/src/main/kotlin/evaka/core/daycare/ChildQueries.kt
+++ b/service/src/main/kotlin/evaka/core/daycare/ChildQueries.kt
@@ -7,6 +7,7 @@ package evaka.core.daycare
 import evaka.core.daycare.controllers.Child
 import evaka.core.shared.ChildId
 import evaka.core.shared.db.Database
+import evaka.core.shared.domain.HelsinkiDateTime
 
 fun Database.Read.getChild(id: ChildId): Child? {
     val child =
@@ -27,7 +28,7 @@ WHERE child.id = ${bind(id)}
     return child
 }
 
-fun Database.Transaction.createChild(child: Child) {
+fun Database.Transaction.createChild(child: Child, now: HelsinkiDateTime) {
     execute {
         sql(
             """
@@ -47,7 +48,7 @@ INSERT INTO child (id, allergies, diet, additionalinfo, medication, language_at_
 """
         )
     }
-    resetNekkuSpecialDietChoices(child)
+    resetNekkuSpecialDietChoices(child, now)
 }
 
 fun Database.Transaction.upsertChild(child: Child) {
@@ -61,7 +62,7 @@ ON CONFLICT (id) DO UPDATE SET allergies = ${bind(child.additionalInformation.al
     }
 }
 
-fun Database.Transaction.updateChild(child: Child) {
+fun Database.Transaction.updateChild(child: Child, now: HelsinkiDateTime) {
     execute {
         sql(
             """
@@ -80,10 +81,10 @@ WHERE id = ${bind(child.id)}
 """
         )
     }
-    resetNekkuSpecialDietChoices(child)
+    resetNekkuSpecialDietChoices(child, now)
 }
 
-fun Database.Transaction.resetNekkuSpecialDietChoices(child: Child) {
+fun Database.Transaction.resetNekkuSpecialDietChoices(child: Child, now: HelsinkiDateTime) {
     execute {
         sql(
             """
@@ -94,12 +95,13 @@ fun Database.Transaction.resetNekkuSpecialDietChoices(child: Child) {
     executeBatch(child.additionalInformation.nekkuSpecialDietChoices) {
         sql(
             """
-                INSERT INTO nekku_special_diet_choices (child_id, diet_id, field_id, value)
+                INSERT INTO nekku_special_diet_choices (child_id, diet_id, field_id, value, created_at)
                 VALUES (
                     ${bind(child.id)},
-                    ${bind{it.dietId}},
-                    ${bind{it.fieldId}},
-                    ${bind{it.value}}
+                    ${bind { it.dietId }},
+                    ${bind { it.fieldId }},
+                    ${bind { it.value }},
+                    ${bind(now)}
                 )
             """
         )

--- a/service/src/main/kotlin/evaka/core/daycare/controllers/ChildController.kt
+++ b/service/src/main/kotlin/evaka/core/daycare/controllers/ChildController.kt
@@ -22,6 +22,7 @@ import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.db.Database
 import evaka.core.shared.domain.BadRequest
 import evaka.core.shared.domain.EvakaClock
+import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.domain.NotFound
 import evaka.core.shared.security.AccessControl
 import evaka.core.shared.security.Action
@@ -128,7 +129,7 @@ class ChildController(
                     Action.Child.UPDATE_ADDITIONAL_INFO,
                     childId,
                 )
-                it.upsertAdditionalInformation(childId, data)
+                it.upsertAdditionalInformation(childId, data, clock.now())
             }
         }
         Audit.ChildAdditionalInformationUpdate.log(targetId = AuditId(childId))
@@ -151,13 +152,14 @@ fun Database.Read.getAdditionalInformation(childId: ChildId): AdditionalInformat
 fun Database.Transaction.upsertAdditionalInformation(
     childId: ChildId,
     data: AdditionalInformation,
+    now: HelsinkiDateTime,
 ) {
     updatePreferredName(childId, data.preferredName)
     val child = getChild(childId)
     if (child != null) {
-        updateChild(child.copy(additionalInformation = data))
+        updateChild(child.copy(additionalInformation = data), now)
     } else {
-        createChild(Child(id = childId, additionalInformation = data))
+        createChild(Child(id = childId, additionalInformation = data), now)
     }
 }
 

--- a/service/src/main/kotlin/evaka/core/decision/DecisionService.kt
+++ b/service/src/main/kotlin/evaka/core/decision/DecisionService.kt
@@ -195,7 +195,7 @@ class DecisionService(
             tx.getDecision(decisionId) ?: throw NotFound("No decision with id: $decisionId")
 
         // make sure VTJ guardians are up-to-date
-        personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, decision.childId)
+        personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, now, decision.childId)
 
         val applicationId = decision.applicationId
         val application =
@@ -309,6 +309,9 @@ class DecisionService(
         clock: EvakaClock,
         applicationId: ApplicationId,
     ) {
+        val now = clock.now()
+        val today = now.toLocalDate()
+
         val guardianId = db.transaction { tx ->
             val application =
                 tx.fetchApplicationDetails(applicationId)
@@ -316,9 +319,9 @@ class DecisionService(
             val childId = application.childId
 
             // make sure VTJ guardians are up-to-date
-            personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, childId)
+            personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, now, childId)
 
-            val currentGuardians = tx.getChildGuardiansAndFosterParents(childId, clock.today())
+            val currentGuardians = tx.getChildGuardiansAndFosterParents(childId, today)
 
             application.guardianId.takeIf { currentGuardians.contains(it) }
         }

--- a/service/src/main/kotlin/evaka/core/pis/SystemController.kt
+++ b/service/src/main/kotlin/evaka/core/pis/SystemController.kt
@@ -76,7 +76,7 @@ class SystemController(
                     tx.updateLastStrongLogin(now, citizen.id)
                     tx.updateCitizenOnLogin(now, citizen.id)
                     tx.upsertCitizenUser(citizen.id)
-                    personService.getPersonWithChildren(tx, user, citizen.id)
+                    personService.getPersonWithChildren(tx, user, now, citizen.id)
                     citizen
                 }
             }
@@ -144,7 +144,7 @@ class SystemController(
                     val now = clock.now()
                     tx.updateLastWeakLogin(now, citizen.id)
                     tx.updateCitizenOnLogin(now, citizen.id)
-                    personService.getPersonWithChildren(tx, user, citizen.id)
+                    personService.getPersonWithChildren(tx, user, now, citizen.id)
                     CitizenUserIdentity(citizen.id)
                 }
                 .also {

--- a/service/src/main/kotlin/evaka/core/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/evaka/core/pis/controllers/PersonController.kt
@@ -189,7 +189,7 @@ class PersonController(
                             Action.Person.READ_DEPENDANTS,
                             personId,
                         )
-                        personService.getPersonWithChildren(it, user, personId)
+                        personService.getPersonWithChildren(it, user, clock.now(), personId)
                     }
                     ?.children ?: throw NotFound()
             }
@@ -227,7 +227,9 @@ class PersonController(
                         )
                     GuardiansResponse(
                         guardians =
-                            personService.getGuardians(tx, user, personId).map(PersonJSON::from),
+                            personService
+                                .getGuardians(tx, user, clock.now(), personId)
+                                .map(PersonJSON::from),
                         blockedGuardians =
                             if (fetchBlockedGuardians)
                                 tx.getBlockedGuardians(personId)
@@ -593,7 +595,7 @@ class PersonController(
                     tx.blockGuardian(childId, body.guardianId)
                 } else {
                     tx.unblockGuardian(childId, body.guardianId)
-                    personService.getGuardians(tx, user, childId, forceRefresh = true)
+                    personService.getGuardians(tx, user, clock.now(), childId, forceRefresh = true)
                 }
             }
         }

--- a/service/src/main/kotlin/evaka/core/pis/service/FamilyInitializerService.kt
+++ b/service/src/main/kotlin/evaka/core/pis/service/FamilyInitializerService.kt
@@ -139,6 +139,9 @@ class FamilyInitializerService(
         user: AuthenticatedUser,
         application: ApplicationDetails,
     ): FridgeFamilyMembers {
+        val now = clock.now()
+        val today = now.toLocalDate()
+
         val headOfFamily =
             tx.getPersonById(application.guardianId)
                 ?: error("Application guardian not found with id ${application.guardianId}")
@@ -148,7 +151,7 @@ class FamilyInitializerService(
 
         val otherGuardian =
             personService
-                .getGuardians(tx, user, application.childId)
+                .getGuardians(tx, user, now, application.childId)
                 .firstOrNull { it.id != application.guardianId }
                 ?.takeIf { otherGuardian ->
                     personService.personsLiveInTheSameAddress(headOfFamily, otherGuardian)
@@ -164,7 +167,7 @@ class FamilyInitializerService(
             } else {
                 tx.getPartnershipsForPerson(application.guardianId, false)
                     .filter {
-                        DateRange(it.startDate, it.endDate).includes(clock.today()) &&
+                        DateRange(it.startDate, it.endDate).includes(today) &&
                             it.partners.any { partner ->
                                 partner.id != application.guardianId &&
                                     personService.personsLiveInTheSameAddress(

--- a/service/src/main/kotlin/evaka/core/pis/service/FridgeFamilyService.kt
+++ b/service/src/main/kotlin/evaka/core/pis/service/FridgeFamilyService.kt
@@ -61,7 +61,7 @@ class FridgeFamilyService(
             db.read { tx -> tx.getDependantGuardians(personId) }.map { it.id }.toSet()
         val updatedGuardians =
             db.transaction { tx ->
-                    personService.getGuardians(tx, user, personId, forceRefresh = true)
+                    personService.getGuardians(tx, user, clock.now(), personId, forceRefresh = true)
                 }
                 .map { it.id }
                 .toSet()
@@ -76,9 +76,18 @@ class FridgeFamilyService(
         clock: EvakaClock,
         personId: PersonId,
     ) {
+        val now = clock.now()
+        val today = now.toLocalDate()
+
         logger.info { "Refreshing $personId from VTJ" }
         val targetPerson = db.transaction {
-            personService.getPersonWithChildren(it, user = user, id = personId, forceRefresh = true)
+            personService.getPersonWithChildren(
+                it,
+                user = user,
+                now = now,
+                id = personId,
+                forceRefresh = true,
+            )
         }
         if (targetPerson != null) {
             logger.info { "Person to refresh has ${targetPerson.children.size} children" }
@@ -91,6 +100,7 @@ class FridgeFamilyService(
                             personService.getPersonWithChildren(
                                 it,
                                 user = user,
+                                now = now,
                                 id = partnerId,
                                 forceRefresh = true,
                             )
@@ -104,10 +114,7 @@ class FridgeFamilyService(
                     }
 
             val head =
-                if (
-                    partner != null &&
-                        db.read { it.personIsHeadOfFamily(partner.id, clock.today()) }
-                )
+                if (partner != null && db.read { it.personIsHeadOfFamily(partner.id, today) })
                     partner
                 else targetPerson
 
@@ -130,7 +137,7 @@ class FridgeFamilyService(
                     .asSequence()
                     .distinct()
                     .filter { child -> !child.socialSecurityNumber.isNullOrBlank() }
-                    .filter { child -> child.dateOfBirth.isAfter(clock.today().minusYears(18)) }
+                    .filter { child -> child.dateOfBirth.isAfter(today.minusYears(18)) }
                     .filter {
                         personService.personsLiveInTheSameAddress(
                             it.toPersonDTO(),
@@ -139,9 +146,7 @@ class FridgeFamilyService(
                     }
                     .filter { !currentFridgeChildren.contains(it.id) }
                     .filter { child ->
-                        tx.getFosterParents(child.id).none {
-                            it.validDuring.includes(clock.today())
-                        }
+                        tx.getFosterParents(child.id).none { it.validDuring.includes(today) }
                     }
                     .toList()
             }
@@ -150,14 +155,11 @@ class FridgeFamilyService(
                 try {
                     val startDate =
                         if (
-                            childShouldBeAddedToFamilyStartingFromBirthday(
-                                clock.today(),
-                                child.dateOfBirth,
-                            )
+                            childShouldBeAddedToFamilyStartingFromBirthday(today, child.dateOfBirth)
                         ) {
                             child.dateOfBirth
                         } else {
-                            clock.today()
+                            today
                         }
                     db.transaction { tx ->
                         parentshipService.createParentship(

--- a/service/src/main/kotlin/evaka/core/pis/service/MergeService.kt
+++ b/service/src/main/kotlin/evaka/core/pis/service/MergeService.kt
@@ -4,7 +4,7 @@
 
 package evaka.core.pis.service
 
-import evaka.core.childimages.removeImage
+import evaka.core.childimages.deleteImage
 import evaka.core.pis.getTransferablePersonReferences
 import evaka.core.s3.DocumentService
 import evaka.core.shared.ChildId
@@ -160,7 +160,7 @@ SELECT
 
         // Does nothing if there is no image (also if the image was assigned from duplicate to
         // master in merge)
-        removeImage(tx, documentClient, ChildId(id.raw))
+        deleteImage(tx, documentClient, ChildId(id.raw))
 
         tx.createUpdate {
                 sql(

--- a/service/src/main/kotlin/evaka/core/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/evaka/core/pis/service/PersonService.kt
@@ -115,6 +115,7 @@ class PersonService(private val personDetailsService: IPersonDetailsService) {
     fun getPersonWithChildren(
         tx: Database.Transaction,
         user: AuthenticatedUser,
+        now: HelsinkiDateTime,
         id: PersonId,
         forceRefresh: Boolean = false,
     ): PersonWithChildrenDTO? {
@@ -128,7 +129,7 @@ class PersonService(private val personDetailsService: IPersonDetailsService) {
             is ExternalIdentifier.SSN -> {
                 if (forceRefresh || guardian.vtjDependantsQueried == null) {
                     getPersonWithDependants(user, guardian.identity)
-                        .let { upsertVtjChildren(tx, it) }
+                        .let { upsertVtjChildren(tx, now, it) }
                         .let {
                             toPersonWithChildrenDTO(
                                 it,
@@ -150,6 +151,7 @@ class PersonService(private val personDetailsService: IPersonDetailsService) {
     fun getGuardians(
         tx: Database.Transaction,
         user: AuthenticatedUser,
+        now: HelsinkiDateTime,
         id: ChildId,
         forceRefresh: Boolean = false,
     ): List<PersonDTO> {
@@ -163,7 +165,7 @@ class PersonService(private val personDetailsService: IPersonDetailsService) {
             is ExternalIdentifier.SSN -> {
                 if (forceRefresh || child.vtjGuardiansQueried == null) {
                     getPersonWithGuardians(user, child.identity)
-                        .let { upsertVtjGuardians(tx, it) }
+                        .let { upsertVtjGuardians(tx, now, it) }
                         .guardians
                         .map(::toPersonDTO)
                 } else {
@@ -179,10 +181,13 @@ class PersonService(private val personDetailsService: IPersonDetailsService) {
     fun getOtherGuardian(
         tx: Database.Transaction,
         user: AuthenticatedUser,
+        now: HelsinkiDateTime,
         otherGuardianId: PersonId,
         childId: ChildId,
     ): PersonDTO? =
-        getGuardians(tx, user, childId).firstOrNull { guardian -> guardian.id != otherGuardianId }
+        getGuardians(tx, user, now, childId).firstOrNull { guardian ->
+            guardian.id != otherGuardianId
+        }
 
     // Does a request to VTJ if person is not found in database or person data has not been
     // initialized from VTJ
@@ -684,9 +689,13 @@ data class PersonAddressDTO(
 
 data class RestrictedDetails(val enabled: Boolean, val endDate: LocalDate? = null)
 
-private fun upsertVtjGuardians(tx: Database.Transaction, vtjPersonDTO: VtjPersonDTO): VtjPersonDTO {
+private fun upsertVtjGuardians(
+    tx: Database.Transaction,
+    now: HelsinkiDateTime,
+    vtjPersonDTO: VtjPersonDTO,
+): VtjPersonDTO {
     val child = upsertVtjPerson(tx, vtjPersonDTO)
-    initChildIfNotExists(tx, child.id)
+    initChildIfNotExists(tx, now, child.id)
     val guardians =
         vtjPersonDTO.guardians
             .map { upsertVtjPerson(tx, it) }
@@ -696,11 +705,17 @@ private fun upsertVtjGuardians(tx: Database.Transaction, vtjPersonDTO: VtjPerson
     return child.toVtjPersonDTO().copy(guardians = guardians.map { it.toVtjPersonDTO() })
 }
 
-private fun upsertVtjChildren(tx: Database.Transaction, vtjPersonDTO: VtjPersonDTO): VtjPersonDTO {
+private fun upsertVtjChildren(
+    tx: Database.Transaction,
+    now: HelsinkiDateTime,
+    vtjPersonDTO: VtjPersonDTO,
+): VtjPersonDTO {
     val guardian = upsertVtjPerson(tx, vtjPersonDTO)
     val children =
         vtjPersonDTO.children
-            .map { upsertVtjPerson(tx, it).also { child -> initChildIfNotExists(tx, child.id) } }
+            .map {
+                upsertVtjPerson(tx, it).also { child -> initChildIfNotExists(tx, now, child.id) }
+            }
             .filterNot { tx.isGuardianBlocked(guardian.id, it.id) }
     createOrReplaceGuardianRelationships(
         tx,
@@ -726,9 +741,13 @@ private fun upsertVtjPerson(tx: Database.Transaction, inputPerson: VtjPersonDTO)
     }
 }
 
-private fun initChildIfNotExists(tx: Database.Transaction, childId: ChildId) {
+private fun initChildIfNotExists(
+    tx: Database.Transaction,
+    now: HelsinkiDateTime,
+    childId: ChildId,
+) {
     if (tx.getChild(childId) == null) {
-        tx.createChild(Child(id = childId, additionalInformation = AdditionalInformation()))
+        tx.createChild(Child(id = childId, additionalInformation = AdditionalInformation()), now)
     }
 }
 

--- a/service/src/main/kotlin/evaka/core/placement/PlacementController.kt
+++ b/service/src/main/kotlin/evaka/core/placement/PlacementController.kt
@@ -143,7 +143,8 @@ class PlacementController(
                 )
                 if (tx.getChild(body.childId) == null) {
                     tx.createChild(
-                        Child(id = body.childId, additionalInformation = AdditionalInformation())
+                        Child(id = body.childId, additionalInformation = AdditionalInformation()),
+                        clock.now(),
                     )
                 }
 

--- a/service/src/main/kotlin/evaka/core/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/evaka/core/shared/async/AsyncJob.kt
@@ -229,7 +229,13 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
-    data class DeleteExpiredChildDocuments(override val user: AuthenticatedUser? = null) : AsyncJob
+    data class DeleteChildImage(val imageId: ChildImageId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
+    data object DeleteExpiredData : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
 
     data class SendCalendarEventDigestEmail(
         val parentId: PersonId,
@@ -494,7 +500,8 @@ sealed interface AsyncJob : AsyncJobPayload {
                     CreateExpiredIncome::class,
                     DeleteAttachment::class,
                     DeleteChildDocumentPdf::class,
-                    DeleteExpiredChildDocuments::class,
+                    DeleteChildImage::class,
+                    DeleteExpiredData::class,
                     DeletePersonalDevicesIfNeeded::class,
                     DvvModificationsRefresh::class,
                     GarbageCollectPairing::class,

--- a/service/src/main/kotlin/evaka/core/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/evaka/core/shared/dev/DevApi.kt
@@ -846,13 +846,14 @@ UPDATE placement SET end_date = ${bind(req.endDate)}, termination_requested_date
     }
 
     @PostMapping("/persons/{person}/force-full-vtj-refresh")
-    fun forceFullVtjRefresh(db: Database, @PathVariable person: PersonId) {
+    fun forceFullVtjRefresh(db: Database, clock: EvakaClock, @PathVariable person: PersonId) {
+        val now = clock.now()
         db.connect { dbc ->
             dbc.transaction { tx ->
                 val user = AuthenticatedUser.SystemInternalUser
                 personService.getUpToDatePersonFromVtj(tx, user, person)
-                personService.getGuardians(tx, user, person)
-                personService.getPersonWithChildren(tx, user, person)
+                personService.getGuardians(tx, user, now, person)
+                personService.getPersonWithChildren(tx, user, now, person)
             }
         }
     }

--- a/service/src/main/resources/db/migration/V593__nekku_special_diet_choices_pk.sql
+++ b/service/src/main/resources/db/migration/V593__nekku_special_diet_choices_pk.sql
@@ -1,0 +1,9 @@
+ALTER TABLE nekku_special_diet_choices
+    ADD COLUMN id UUID PRIMARY KEY DEFAULT ext.uuid_generate_v1mc(),
+    ADD COLUMN created_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN updated_at timestamptz NOT NULL DEFAULT now();
+
+ALTER TABLE nekku_special_diet_choices
+    ALTER COLUMN created_at DROP DEFAULT;
+
+CREATE TRIGGER set_timestamp BEFORE UPDATE ON nekku_special_diet_choices FOR EACH ROW EXECUTE PROCEDURE trigger_refresh_updated_at();

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -588,3 +588,4 @@ V589__unit_language_en.sql
 V590__decision_reasoning_generic_removed_at.sql
 V591__child_document_deletion_rules.sql
 V592__decision_reasoning_links.sql
+V593__nekku_special_diet_choices_pk.sql


### PR DESCRIPTION
Poistetaan automaattisesti dataa, jota on yksinkertainen poistaa. Diffi on aika iso, koska `nekku_special_diet_choices` lisätään samalla `id`, `created_at` ja `updated_at` kuten tapana on. `id` tarvitaan batchattyyn automaatipoistoon.