### PR TITLE
Pidetään kalenterin kuukausinavigoinnin napit paikallaan kuukausia vaihdettaessa

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarMonthView.tsx
@@ -735,7 +735,10 @@ const MonthTitle = styled(H1).attrs({ $noMargin: true })`
   color: ${(p) => p.theme.colors.main.m1};
   align-items: center;
   display: flex;
-  min-width: 240px;
+  /* Reserve enough width for the longest localized month name plus the
+     inline info button and warning icon, so the navigation buttons that
+     follow don't shift horizontally when the month (or alert state) changes. */
+  min-width: 320px;
 `
 
 const DayCell = styled.button<{


### PR DESCRIPTION
## Ennen tätä muutosta

Huoltajan kalenterissa (`CalendarMonthView` → `MonthPicker`) kuukausiotsikko skaalautui sisältönsä mukaan. Edellinen/seuraava/"Tänään"-napit ovat samassa flex-rivissä heti otsikon perässä, joten ne liukuivat vaakasuunnassa aina kun kuukauden nimen leveys muuttui (esim. "Kesäkuu" → "Heinäkuu" → "Elokuu", tai pisin "Maaliskuu"/"September").

Tämän seurauksena seuraava-nappia (›) ei voinut klikkailla montaa kuukautta peräkkäin: nappi siirtyi kursorin alta pois joka vaihdoksella, ja käyttäjä osui vahingossa kalenteri-/"Tänään"-ikoniin. Vika havaittiin näytön tallenteesta.

Otsikon vanha `min-width: 240px` oli liian pieni: pisimmät lokalisoidut kuukausien nimet (~237px fontilla Montserrat 500 / 32px) sekä rivin sisäinen info-nappi ja varoitusikoni ylittävät sen, joten otsikko kasvoi sisällön mukaan ja napit liikkuivat.

![Ennen muutosta](https://raw.githubusercontent.com/espoon-voltti/evaka/pr-assets-calendar-month-nav/docs/screenshots/calendar-month-nav/comparison-before.png)

Huomaa kuinka `‹ › Tänään` -napit ovat eri kohdassa "Maaliskuu"- ja "Elokuu"-kuukausilla (alin rivi on kuukausien päällekkäisasettelu, jossa napit eivät osu kohdakkain).

## Tämän muutoksen jälkeen

Kuukausiotsikolle varataan riittävästi leveyttä, johon mahtuvat pisin lokalisoitu kuukauden nimi **sekä** rivin sisäinen info-nappi ja varoitusikoni. Näin navigointinapit pysyvät kiinteässä kohdassa valitusta kuukaudesta tai varoitustilasta riippumatta.

Pahimman tapauksen leveys (mitattu oikealla fontilla `Montserrat 500 / 32px`):
- Pisin otsikkoteksti: "September 2026" ≈ 237px (sv/en), "Marraskuu 2026" ≈ 231px (fi)
- + info-nappi (8px marginaali + 20px) ≈ 28px
- + varoitusikoni (8px marginaali + ~36px) ≈ 44px
- ≈ **309px** → `min-width: 320px` antaa pienen turvamarginaalin.

![Tämän muutoksen jälkeen](https://raw.githubusercontent.com/espoon-voltti/evaka/pr-assets-calendar-month-nav/docs/screenshots/calendar-month-nav/comparison-after.png)

Napit pysyvät samassa kohdassa kuukaudesta riippumatta (alin rivi: napit osuvat täsmälleen kohdakkain).

## Testaus
- [x] `eslint --max-warnings 0` läpäisee muutetun tiedoston osalta
- [x] Manuaalinen: paikallinen ympäristö ajettuna (citizen-kalenteri), kuvakaappaukset otettu e2e-testillä klikkaamalla `›` usean kuukauden yli — napit eivät enää liiku (ks. yllä)