### PR TITLE
Viedään docker kuvat ECR repositoryyn ilman indeksiä

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -686,7 +686,7 @@ jobs:
             src="ghcr.io/espoon-voltti/evaka/${image}:${SHA}"
             dst="${ECR}/${PREFIX}/${image}:${SHA}"
             echo "Copying ${src} -> ${dst}"
-            docker buildx imagetools create --tag "${dst}" "${src}"
+            docker buildx imagetools create --prefer-index=false --tag "${dst}" "${src}"
           done
 
   frontend-s3:


### PR DESCRIPTION
ECR skannaus ei toimi hyvin image index -tyypin kanssa joten vaihdetaan tämä ECR:än vietävään kuvaan.