### PR TITLE
Espoo - lisätään palveluohjaajalle oikeus nähdä enemmän tukitoimia

### DIFF
--- a/service/src/main/kotlin/evaka/instance/espoo/EspooActionRuleMapping.kt
+++ b/service/src/main/kotlin/evaka/instance/espoo/EspooActionRuleMapping.kt
@@ -205,6 +205,16 @@ class EspooActionRuleMapping : ActionRuleMapping {
                 )
             }
 
+            Action.AssistanceAction.READ,
+            Action.AssistanceFactor.READ,
+            Action.DaycareAssistance.READ,
+            Action.PreschoolAssistance.READ,
+            Action.OtherAssistanceMeasure.READ -> {
+                @Suppress("UNCHECKED_CAST")
+                action.defaultRules.asSequence() +
+                    sequenceOf(HasGlobalRole(UserRole.SERVICE_WORKER) as ScopedActionRule<in T>)
+            }
+
             else -> {
                 action.defaultRules.asSequence()
             }


### PR DESCRIPTION
Ytimen default-luvituksissa ei ole palveluohjaajalle lukuoikeutta varhaiskasvatuksen tuen tasoon lapsen tiedot -sivulla. 

Espoossa tuli vastaan tapauksessa, jossa lapsella on tukitoimia ja tuen taso varhaiskasvatuksessa, mutta palveluohjaajalle nämä eivät olleet näkyvissä.

Asetetaan kuntakohtaisiin sääntöihin vastaava lisäys kuin esim. Oulussa on voimassa.