### PR TITLE
Lisätään työntekijöiden oman tiedotteen poisto

### DIFF
--- a/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/messaging.spec.ts
@@ -1362,7 +1362,7 @@ test.describe('Sending and receiving messages', () => {
       await expect(sentMessage.deleteMessageButton).toBeHidden()
     })
 
-    test('Bulletins cannot be deleted', async () => {
+    test('Own bulletins can be deleted', async () => {
       await openSupervisorPage(mockedDateAt10)
       await unitSupervisorPage.goto(`${config.employeeUrl}/messages`)
       const messagesPage = new MessagesPage(unitSupervisorPage)
@@ -1370,6 +1370,28 @@ test.describe('Sending and receiving messages', () => {
       await messageEditor.sendNewMessage({
         ...defaultMessage,
         type: 'BULLETIN'
+      })
+      await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
+
+      const sentMessage = await (
+        await messagesPage.openSentMessages()
+      ).openMessage(0)
+      await sentMessage.deleteMessage()
+
+      await expect(sentMessage.messageDeletedBanner).toBeVisible()
+      await expect(sentMessage.viewDeletedMessageButton).toBeVisible()
+    })
+
+    test('Municipal bulletins cannot be deleted', async () => {
+      const messenger = await Fixture.employee().messenger().save()
+      const messengerPage = await newPage({ mockedTime: mockedDateAt10 })
+      await employeeLogin(messengerPage, messenger)
+      await messengerPage.goto(`${config.employeeUrl}/messages`)
+      const messagesPage = new MessagesPage(messengerPage)
+      const messageEditor = await messagesPage.openMessageEditor()
+      await messageEditor.sendNewMessage({
+        ...defaultMessage,
+        recipientKeys: [`${careArea.id}+false`]
       })
       await runPendingAsyncJobs(mockedDateAt10.addMinutes(1))
 

--- a/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
+++ b/frontend/src/employee-frontend/components/messages/SingleThreadView.tsx
@@ -19,7 +19,6 @@ import type {
   Message,
   MessageChild,
   MessageThread,
-  MessageType,
   ThreadReply
 } from 'lib-common/generated/api-types/messaging'
 import type { MessageContentId } from 'lib-common/generated/api-types/shared'
@@ -110,7 +109,6 @@ const deletionWindowDays = 8
 
 function SingleMessage({
   account,
-  threadType,
   view,
   message,
   messageChildren,
@@ -122,7 +120,6 @@ function SingleMessage({
   onDelete
 }: {
   account: TypedMessageAccount
-  threadType: MessageType
   view: View
   message: Message
   messageChildren: MessageChild[]
@@ -159,7 +156,7 @@ function SingleMessage({
   const isOwnMessage = message.sender.id === account.id
   const isDeleted = message.contentDeletedAt !== null
   const canDelete =
-    threadType === 'MESSAGE' &&
+    account.type !== 'MUNICIPAL' &&
     isOwnMessage &&
     !isDeleted &&
     HelsinkiDateTime.now().isBefore(
@@ -499,7 +496,6 @@ export function SingleThreadView({
               <SingleMessage
                 key={message.id}
                 account={account}
-                threadType={type}
                 view={view}
                 message={message}
                 messageChildren={children}

--- a/service/src/integrationTest/kotlin/evaka/core/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/messaging/MessageIntegrationTest.kt
@@ -3580,15 +3580,19 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             return messageIdOfContent(contentId) to attachmentId
         }
 
-        private fun sendBulletin(): MessageId {
+        private fun sendBulletinFrom(
+            sender: MessageAccountId,
+            recipients: List<MessageRecipient>,
+            user: AuthenticatedUser.Employee = employee1,
+        ): MessageId {
             val contentId =
                 postNewThread(
                     title = "Bulletin test",
                     message = "Important announcement",
                     messageType = MessageType.BULLETIN,
-                    sender = group1Account,
-                    recipients = listOf(MessageRecipient.Group(groupId1)),
-                    user = employee1,
+                    sender = sender,
+                    recipients = recipients,
+                    user = user,
                 )!!
             return messageIdOfContent(contentId)
         }
@@ -3706,10 +3710,81 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         }
 
         @Test
-        fun `bulletin cannot be deleted`() {
-            val messageId = sendBulletin()
+        fun `sender can delete own bulletin sent from a personal account`() {
+            val messageId =
+                sendBulletinFrom(
+                    sender = employee1Account,
+                    recipients = listOf(MessageRecipient.Child(child1.id)),
+                )
 
-            assertThrows<Forbidden> { deleteContent(employee1, group1Account, messageId) }
+            deleteContent(employee1, employee1Account, messageId)
+
+            val info = deletionInfoOf(messageId)
+            assertNotNull(info.contentDeletedAt)
+            assertEquals(employee1.id, info.contentDeletedByEmployeeId)
+        }
+
+        @Test
+        fun `sender can delete own bulletin sent from a group account`() {
+            val messageId =
+                sendBulletinFrom(
+                    sender = group1Account,
+                    recipients = listOf(MessageRecipient.Group(groupId1)),
+                )
+
+            deleteContent(employee1, group1Account, messageId)
+
+            val info = deletionInfoOf(messageId)
+            assertNotNull(info.contentDeletedAt)
+            assertEquals(employee1.id, info.contentDeletedByEmployeeId)
+        }
+
+        @Test
+        fun `municipal bulletin cannot be deleted`() {
+            val messageId =
+                sendBulletinFrom(
+                    sender = municipalAccount,
+                    recipients = listOf(MessageRecipient.Child(child1.id)),
+                    user = messager.user,
+                )
+
+            val exception =
+                assertThrows<Forbidden> {
+                    deleteContent(messager.user, municipalAccount, messageId)
+                }
+            assertEquals(
+                "Messages sent by the municipal account cannot be deleted",
+                exception.message,
+            )
+            assertNull(deletionInfoOf(messageId).contentDeletedAt)
+        }
+
+        @Test
+        fun `deleting a bulletin redacts every recipient copy`() {
+            val contentId =
+                postNewThread(
+                    title = "Bulletin test",
+                    message = "Important announcement",
+                    messageType = MessageType.BULLETIN,
+                    sender = group1Account,
+                    recipients = listOf(MessageRecipient.Group(groupId1)),
+                    user = employee1,
+                )!!
+            val copies = db.read { tx ->
+                tx.createQuery {
+                        sql("SELECT id FROM message WHERE content_id = ${bind(contentId)}")
+                    }
+                    .toList<MessageId>()
+            }
+            assertTrue(copies.size > 1)
+
+            deleteContent(employee1, group1Account, messageIdOfContent(contentId))
+
+            copies.forEach { assertNotNull(deletionInfoOf(it).contentDeletedAt) }
+
+            val recipientView =
+                getThreadAs(person1Account, threadIdOf(copies.first())).messages.single()
+            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, recipientView.content)
         }
 
         @Test

--- a/service/src/main/kotlin/evaka/core/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageQueries.kt
@@ -2252,17 +2252,21 @@ fun Database.Read.messageAttachmentsAllowedForCitizen(
 data class MessageDeletionTarget(
     val contentId: MessageContentId,
     val senderId: MessageAccountId,
+    val senderAccountType: AccountType,
     val sentAt: HelsinkiDateTime,
-    val messageType: MessageType,
 )
 
 fun Database.Read.getMessageDeletionTarget(contentId: MessageContentId): MessageDeletionTarget? =
     createQuery {
             sql(
                 """
-                SELECT m.content_id, m.sender_id, coalesce(m.sent_at, m.created) AS sent_at, t.message_type
+                SELECT
+                    m.content_id,
+                    m.sender_id,
+                    sender.type AS sender_account_type,
+                    coalesce(m.sent_at, m.created) AS sent_at
                 FROM message m
-                JOIN message_thread t ON t.id = m.thread_id
+                JOIN message_account sender ON sender.id = m.sender_id
                 WHERE m.content_id = ${bind(contentId)}
                 LIMIT 1
             """

--- a/service/src/main/kotlin/evaka/core/messaging/MessageService.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageService.kt
@@ -382,8 +382,8 @@ class MessageService(
         val target =
             tx.getMessageDeletionTarget(contentId) ?: throw NotFound("Message $contentId not found")
         if (target.senderId != accountId) throw Forbidden("Message was not sent from this account")
-        if (target.messageType != MessageType.MESSAGE)
-            throw Forbidden("Only personal and group messages can be deleted")
+        if (target.senderAccountType == AccountType.MUNICIPAL)
+            throw Forbidden("Messages sent by the municipal account cannot be deleted")
         val now = clock.now()
         val windowEnd =
             HelsinkiDateTime.atStartOfDay(


### PR DESCRIPTION
Tämän muutoksen jälkeen tiedotteita voidaan poistaa samalla tavalla kuin viestejä (PR #9137) kaikista muista viestintätileistä paitsi kunnan viestintätililtä.