### PR TITLE
Lähetetään uuden asiakkaan tulotietomuistutukset päivittäin ja huomioidaan takautuvat sijoitukset

### DIFF
--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -7756,6 +7756,11 @@ ALTER TABLE ONLY public.absence
 ALTER TABLE ONLY public.attachment
     ADD CONSTRAINT "fk$income" FOREIGN KEY (income_id) REFERENCES public.income(id) ON DELETE SET NULL;
 
+-- Name: income_notification fk$income_notification_receiver; Type: FK CONSTRAINT; Schema: public
+
+ALTER TABLE ONLY public.income_notification
+    ADD CONSTRAINT "fk$income_notification_receiver" FOREIGN KEY (receiver_id) REFERENCES public.person(id) ON DELETE CASCADE;
+
 -- Name: attachment fk$income_statement; Type: FK CONSTRAINT; Schema: public
 
 ALTER TABLE ONLY public.attachment

--- a/service/src/integrationTest/kotlin/evaka/core/invoicing/service/NewCustomerIncomeNotificationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/invoicing/service/NewCustomerIncomeNotificationIntegrationTest.kt
@@ -111,6 +111,7 @@ class NewCustomerIncomeNotificationIntegrationTest : FullApplicationTest(resetDb
         start: LocalDate,
         end: LocalDate,
         type: PlacementType = PlacementType.DAYCARE,
+        createdAt: HelsinkiDateTime = HelsinkiDateTime.now(),
     ): PlacementId {
         return db.transaction { tx ->
             tx.insert(
@@ -120,6 +121,7 @@ class NewCustomerIncomeNotificationIntegrationTest : FullApplicationTest(resetDb
                     type = type,
                     startDate = start,
                     endDate = end,
+                    createdAt = createdAt,
                 )
             )
         }
@@ -192,6 +194,112 @@ class NewCustomerIncomeNotificationIntegrationTest : FullApplicationTest(resetDb
     }
 
     @Test
+    fun `notification is sent for a retroactive placement that started in the previous month`() {
+        val start = clock.today().minusWeeks(3) // 2024-01-11, previous month
+        val placementId = insertPlacement(child, start, placementEnd)
+        insertServiceNeed(placementId, start, placementEnd)
+
+        assertEquals(1, getEmails().size)
+        assertEquals(1, getIncomeNotifications(fridgeHeadOfChild.id).size)
+    }
+
+    @Test
+    fun `notification is sent for a placement created on the last day of the previous month`() {
+        // The daily job runs at 06:45, so a placement created later on the last day of
+        // the month is first evaluated on the first day of the next month. Its created_at
+        // is then "before the current month", and its start is not in the current month
+        // either, so it must still be picked up.
+        val createdAt = HelsinkiDateTime.of(LocalDate.of(2024, 1, 31), LocalTime.of(20, 0))
+        val start = LocalDate.of(2024, 1, 31) // last day of the previous month
+        val placementId = insertPlacement(child, start, placementEnd, createdAt = createdAt)
+        insertServiceNeed(placementId, start, placementEnd)
+
+        assertEquals(1, getEmails().size)
+        assertEquals(1, getIncomeNotifications(fridgeHeadOfChild.id).size)
+    }
+
+    @Test
+    fun `notification is not sent for a retroactive placement that already ended`() {
+        val start = clock.today().minusWeeks(3) // 2024-01-11
+        val end = clock.today().minusDays(1) // 2024-01-31, ended before today
+        val placementId = insertPlacement(child, start, end)
+        insertServiceNeed(placementId, start, end)
+
+        assertEquals(0, getEmails().size)
+    }
+
+    @Test
+    fun `notification is not sent for an old placement created before this month`() {
+        val start = clock.today().minusMonths(2) // 2023-12-01
+        val placementId =
+            insertPlacement(
+                child,
+                start,
+                placementEnd,
+                createdAt = HelsinkiDateTime.of(start, LocalTime.of(12, 0)),
+            )
+        insertServiceNeed(placementId, start, placementEnd)
+
+        assertEquals(0, getEmails().size)
+    }
+
+    @Test
+    fun `family with two retroactive siblings entered this month is notified once`() {
+        val otherChild = DevPerson()
+        db.transaction { tx ->
+            tx.insert(otherChild, DevPersonType.CHILD)
+            tx.insert(
+                DevFridgeChild(
+                    childId = otherChild.id,
+                    headOfChild = fridgeHeadOfChild.id,
+                    startDate = clock.today().minusYears(1),
+                    endDate = clock.today().plusYears(1),
+                )
+            )
+        }
+        val start = clock.today().minusWeeks(3) // 2024-01-11, previous month
+        val p1 = insertPlacement(child, start, placementEnd)
+        insertServiceNeed(p1, start, placementEnd)
+        val p2 = insertPlacement(otherChild, start, placementEnd)
+        insertServiceNeed(p2, start, placementEnd)
+
+        assertEquals(1, getEmails().size)
+        assertEquals(1, getIncomeNotifications(fridgeHeadOfChild.id).size)
+    }
+
+    @Test
+    fun `sibling placement entered on the last day of the previous month does not suppress the notification`() {
+        // A sibling's placement was entered on the last day of the previous month (and has
+        // already ended). Because it was entered within the last month, it must not count
+        // as a previous placement that marks the family as an existing customer, so the
+        // notification for the child starting this month is still sent.
+        val sibling = DevPerson()
+        db.transaction { tx ->
+            tx.insert(sibling, DevPersonType.CHILD)
+            tx.insert(
+                DevFridgeChild(
+                    childId = sibling.id,
+                    headOfChild = fridgeHeadOfChild.id,
+                    startDate = clock.today().minusYears(1),
+                    endDate = clock.today().plusYears(1),
+                )
+            )
+        }
+        val siblingCreatedAt = HelsinkiDateTime.of(LocalDate.of(2024, 1, 31), LocalTime.of(20, 0))
+        val siblingStart = LocalDate.of(2024, 1, 11)
+        val siblingEnd = LocalDate.of(2024, 1, 20) // already ended
+        val siblingPlacement =
+            insertPlacement(sibling, siblingStart, siblingEnd, createdAt = siblingCreatedAt)
+        insertServiceNeed(siblingPlacement, siblingStart, siblingEnd)
+
+        val placementId = insertPlacement(child, placementStart, placementEnd)
+        insertServiceNeed(placementId, placementStart, placementEnd)
+
+        assertEquals(1, getEmails().size)
+        assertEquals(1, getIncomeNotifications(fridgeHeadOfChild.id).size)
+    }
+
+    @Test
     fun `notifications are not sent when placement does not start in current month`() {
         val placementId = insertPlacement(child, placementStart, placementEnd)
         insertServiceNeed(placementId, placementStart, placementEnd)
@@ -225,7 +333,13 @@ class NewCustomerIncomeNotificationIntegrationTest : FullApplicationTest(resetDb
 
         val otherPlacementStart = clock.today().minusYears(1)
         val otherPlacementEnd = clock.today().plusYears(1)
-        val otherPlacementId = insertPlacement(otherChild, otherPlacementStart, otherPlacementEnd)
+        val otherPlacementId =
+            insertPlacement(
+                otherChild,
+                otherPlacementStart,
+                otherPlacementEnd,
+                createdAt = HelsinkiDateTime.of(otherPlacementStart, LocalTime.of(12, 0)),
+            )
         insertServiceNeed(otherPlacementId, otherPlacementStart, otherPlacementEnd)
 
         assertEquals(0, getEmails().size)
@@ -374,7 +488,12 @@ class NewCustomerIncomeNotificationIntegrationTest : FullApplicationTest(resetDb
         val otherPlacementStart = clock.today().minusYears(2)
         val otherPlacementEnd = clock.today().plusMonths(6)
         val otherPlacementId =
-            insertPlacement(partnersChild, otherPlacementStart, otherPlacementEnd)
+            insertPlacement(
+                partnersChild,
+                otherPlacementStart,
+                otherPlacementEnd,
+                createdAt = HelsinkiDateTime.of(otherPlacementStart, LocalTime.of(12, 0)),
+            )
         insertServiceNeed(otherPlacementId, otherPlacementStart, otherPlacementEnd)
 
         assertEquals(0, getEmails().size)

--- a/service/src/integrationTest/kotlin/evaka/core/invoicing/service/NewCustomerIncomeNotificationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/invoicing/service/NewCustomerIncomeNotificationIntegrationTest.kt
@@ -586,6 +586,24 @@ class NewCustomerIncomeNotificationIntegrationTest : FullApplicationTest(resetDb
     }
 
     @Test
+    fun `notifications are not sent if there is an indefinite income`() {
+        db.transaction {
+            it.insert(
+                DevIncome(
+                    personId = fridgeHeadOfChild.id,
+                    modifiedBy = AuthenticatedUser.SystemInternalUser.evakaUserId,
+                    validFrom = clock.today().minusYears(1),
+                    validTo = null,
+                )
+            )
+        }
+        val placementId = insertPlacement(child, placementStart, placementEnd)
+        insertServiceNeed(placementId, placementStart, placementEnd)
+
+        assertEquals(0, getEmails().size)
+    }
+
+    @Test
     fun `expiring income is not notified if there is a new unhandled income statement`() {
         val incomeExpirationDate = clock.today().plusWeeks(4)
 

--- a/service/src/integrationTest/kotlin/evaka/core/invoicing/service/NewCustomerIncomeNotificationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/invoicing/service/NewCustomerIncomeNotificationIntegrationTest.kt
@@ -154,6 +154,44 @@ class NewCustomerIncomeNotificationIntegrationTest : FullApplicationTest(resetDb
     }
 
     @Test
+    fun `does not send a second new customer notification on a later day`() {
+        val placementId = insertPlacement(child, placementStart, placementEnd)
+        insertServiceNeed(placementId, placementStart, placementEnd)
+
+        assertEquals(1, getEmails().size)
+        assertEquals(1, getIncomeNotifications(fridgeHeadOfChild.id).size)
+
+        clock.tick(Duration.ofDays(1))
+
+        assertEquals(1, getEmails().size)
+        assertEquals(1, getIncomeNotifications(fridgeHeadOfChild.id).size)
+    }
+
+    @Test
+    fun `notification is sent when the job runs later in the month for a placement starting later this month`() {
+        clock.tick(Duration.ofDays(9)) // 2024-02-10
+        val laterStart = clock.today().plusDays(10) // 2024-02-20, still the current month
+        val placementId = insertPlacement(child, laterStart, placementEnd)
+        insertServiceNeed(placementId, laterStart, placementEnd)
+
+        assertEquals(1, getEmails().size)
+        assertEquals(1, getIncomeNotifications(fridgeHeadOfChild.id).size)
+    }
+
+    @Test
+    fun `placement starting this month is not notified again the following month`() {
+        val placementId = insertPlacement(child, placementStart, placementEnd)
+        insertServiceNeed(placementId, placementStart, placementEnd)
+
+        assertEquals(1, getEmails().size)
+
+        clock.tick(Duration.ofDays(35)) // 2024-03-07, next calendar month
+
+        assertEquals(1, getEmails().size)
+        assertEquals(1, getIncomeNotifications(fridgeHeadOfChild.id).size)
+    }
+
+    @Test
     fun `notifications are not sent when placement does not start in current month`() {
         val placementId = insertPlacement(child, placementStart, placementEnd)
         insertServiceNeed(placementId, placementStart, placementEnd)

--- a/service/src/integrationTest/kotlin/evaka/core/pis/PersonIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/PersonIntegrationTest.kt
@@ -121,6 +121,7 @@ class PersonIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
                 PersonReference("fridge_partner", "person_id"),
                 PersonReference("holiday_questionnaire_answer", "child_id"),
                 PersonReference("income", "person_id"),
+                PersonReference("income_notification", "receiver_id"),
                 PersonReference("income_statement", "person_id"),
                 PersonReference("invoice", "codebtor"),
                 PersonReference("invoice", "head_of_family"),

--- a/service/src/main/kotlin/evaka/core/invoicing/service/IncomeQueries.kt
+++ b/service/src/main/kotlin/evaka/core/invoicing/service/IncomeQueries.kt
@@ -181,6 +181,12 @@ WHERE NOT EXISTS (
       AND (status = 'SENT'::income_statement_status OR status = 'HANDLING'::income_statement_status)
       AND sent_at > ${bind(today)} - INTERVAL '12 months'
 )
+AND NOT EXISTS (
+    SELECT 1 FROM income_notification
+    WHERE receiver_id = parent.person_id
+      AND notification_type = 'NEW_CUSTOMER'::income_notification_type
+      AND created > ${bind(today)} - INTERVAL '1 month'
+)
 """
             )
         }

--- a/service/src/main/kotlin/evaka/core/invoicing/service/IncomeQueries.kt
+++ b/service/src/main/kotlin/evaka/core/invoicing/service/IncomeQueries.kt
@@ -171,7 +171,7 @@ WITH previously_placed_children AS (
             SELECT 1
             FROM income i
             WHERE (i.person_id = fc_head.head_of_child OR i.person_id = fp_spouse.person_id)
-            AND (i.valid_to >= pl.end_date OR (i.valid_to < pl.end_date AND i.valid_to > (${bind(today)} + INTERVAL '4 weeks')))
+            AND (coalesce(i.valid_to, 'infinity') >= pl.end_date OR (i.valid_to < pl.end_date AND i.valid_to > (${bind(today)} + INTERVAL '4 weeks')))
         ) AND
         ${predicate(guardianPredicate)}
 )

--- a/service/src/main/kotlin/evaka/core/invoicing/service/IncomeQueries.kt
+++ b/service/src/main/kotlin/evaka/core/invoicing/service/IncomeQueries.kt
@@ -128,6 +128,7 @@ WITH previously_placed_children AS (
     JOIN fridge_child fc ON pl.child_id = fc.child_id AND ${bind(today)} BETWEEN fc.start_date AND fc.end_date
     WHERE
         pl.start_date < ${bind(currentMonth.start)} AND
+        pl.created_at < ${bind(today)} - INTERVAL '1 month' AND
         pl.type = ANY(${bind(PlacementType.invoiced)})
 ), fridge_parents AS (
     SELECT fc_head.head_of_child AS parent_id, fp_spouse.person_id AS spouse_id
@@ -151,7 +152,14 @@ WITH previously_placed_children AS (
         daterange(fp_spouse.start_date, fp_spouse.end_date, '[]') @> ${bind(today)} AND fp_spouse.conflict = false
     )
     WHERE
-        pl.start_date BETWEEN ${bind(currentMonth.start)} AND ${bind(currentMonth.end)} AND
+        (
+            (pl.start_date BETWEEN ${bind(currentMonth.start)} AND ${bind(currentMonth.end)}) OR
+            (
+                pl.created_at >= ${bind(today)} - INTERVAL '1 month' AND
+                pl.start_date < ${bind(currentMonth.start)} AND
+                pl.end_date >= ${bind(today)}
+            )
+        ) AND
         pl.type = ANY(${bind(PlacementType.invoiced)}) AND
         NOT EXISTS(
             SELECT 1

--- a/service/src/main/kotlin/evaka/core/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/evaka/core/shared/job/ScheduledJobs.kt
@@ -231,10 +231,7 @@ enum class ScheduledJob(
     ),
     SendNewCustomerIncomeNotification(
         ScheduledJobs::sendNewCustomerIncomeNotifications,
-        ScheduledJobSettings(
-            enabled = false,
-            schedule = JobSchedule.cron("0 45 6 1 * *"), // first day of month, 6:45
-        ),
+        ScheduledJobSettings(enabled = false, schedule = JobSchedule.daily(LocalTime.of(6, 45))),
     ),
     SendCalendarEventDigests(
         ScheduledJobs::sendCalendarEventDigests,

--- a/service/src/main/resources/db/migration/V595__income_notification_receiver_fk.sql
+++ b/service/src/main/resources/db/migration/V595__income_notification_receiver_fk.sql
@@ -1,0 +1,3 @@
+DELETE FROM income_notification WHERE NOT EXISTS (SELECT 1 FROM person WHERE person.id = income_notification.receiver_id);
+
+ALTER TABLE income_notification ADD CONSTRAINT fk$income_notification_receiver FOREIGN KEY (receiver_id) REFERENCES person (id) ON DELETE CASCADE;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -590,3 +590,4 @@ V591__child_document_deletion_rules.sql
 V592__decision_reasoning_links.sql
 V593__nekku_special_diet_choices_pk.sql
 V594__message_content_deletion.sql
+V595__income_notification_receiver_fk.sql


### PR DESCRIPTION
Uuden asiakkaan tulotietomuistutuksia lähetettiin aiemmin vain kerran kuukaudessa kuukauden ensimmäisenä päivänä, joten kuukauden 1. päivän jälkeen lisätyt tai takautuvasti edelliselle kuukaudelle ajoittuvat maksulliset sijoitukset jäivät kokonaan ilman tulotietomuistutusta. Nyt ajo tehdään päivittäin, ja päivittäisten ajojen aiheuttamat toistot estetään huoltajakohtaisella kuukauden mittaisella karenssilla. Nyös takautuvat sijoitukset huomioidaan nyt, kunhan ne on luotu kuluvan kuun aikana ja ovat yhä voimassa.

Lisäksi korjataan tilanne, jossa huoltajalle, jolla on toistaiseksi voimassa oleva (ilman päättymispäivää) tulotieto, lähetettiin virheellisesti uuden asiakkaan tulotietomuistutus.