### PR TITLE
Korjataan ylivuotavat monivalintakenttien tekstit

### DIFF
--- a/frontend/src/lib-components/atoms/form/Checkbox.tsx
+++ b/frontend/src/lib-components/atoms/form/Checkbox.tsx
@@ -34,13 +34,15 @@ const Wrapper = styled.div`
 
   @media (hover: hover) {
     &:hover:not(.disabled) {
-      input:checked {
-        border-color: ${(p) => p.theme.colors.main.m2Hover};
-        background-color: ${(p) => p.theme.colors.main.m2Hover};
-      }
+      input[type='checkbox'] {
+        &:checked {
+          border-color: ${(p) => p.theme.colors.main.m2Hover};
+          background-color: ${(p) => p.theme.colors.main.m2Hover};
+        }
 
-      input:not(:checked) {
-        border-color: ${(p) => p.theme.colors.grayscale.g100};
+        &:not(:checked) {
+          border-color: ${(p) => p.theme.colors.grayscale.g100};
+        }
       }
     }
   }

--- a/frontend/src/lib-components/document-templates/question-descriptors/CheckboxGroupQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/CheckboxGroupQuestionDescriptor.tsx
@@ -90,8 +90,8 @@ const GroupIndentation = styled.div`
   margin-left: ${defaultMargins.s};
 `
 
-const NoShrink = styled.div`
-  flex-shrink: 0;
+const CheckboxLabelGap = styled.span`
+  margin-right: ${defaultMargins.xs};
 `
 
 const View = React.memo(function View({
@@ -137,38 +137,41 @@ const View = React.memo(function View({
             )
 
             return (
-              <FixedSpaceRow key={option.state.id} $alignItems="center">
-                <NoShrink>
-                  <Checkbox
-                    label={option.state.label}
-                    checked={answerOption !== undefined}
-                    onChange={(checked) =>
-                      answer.update((old) => [
-                        ...old.filter(
-                          (opt) => opt.optionId !== option.state.id
-                        ),
-                        ...(checked
-                          ? [{ optionId: option.state.id, extra: '' }]
-                          : [])
-                      ])
-                    }
-                  />
-                </NoShrink>
-                {option.state.withText && (
-                  <InputField
-                    value={answerOption?.extra ?? ''}
-                    readonly={!answerOption}
-                    onChange={(value) =>
-                      answer.update((old) => [
-                        ...old.filter(
-                          (opt) => opt.optionId !== option.state.id
-                        ),
-                        { optionId: option.state.id, extra: value }
-                      ])
-                    }
-                    width="L"
-                  />
-                )}
+              <FixedSpaceRow key={option.state.id} $spacing="xxs">
+                <Checkbox
+                  label={<>
+                    <CheckboxLabelGap>
+                      {option.state.label}
+                    </CheckboxLabelGap>
+
+                    {option.state.withText && (
+                      <InputField
+                        value={answerOption?.extra ?? ''}
+                        readonly={!answerOption}
+                        onChange={(value) =>
+                          answer.update((old) => [
+                            ...old.filter(
+                              (opt) => opt.optionId !== option.state.id
+                            ),
+                            { optionId: option.state.id, extra: value }
+                          ])
+                        }
+                        width="L"
+                      />
+                    )}
+                  </>}
+                  checked={answerOption !== undefined}
+                  onChange={(checked) =>
+                    answer.update((old) => [
+                      ...old.filter(
+                        (opt) => opt.optionId !== option.state.id
+                      ),
+                      ...(checked
+                        ? [{ optionId: option.state.id, extra: '' }]
+                        : [])
+                    ])
+                  }
+                />
               </FixedSpaceRow>
             )
           })}

--- a/frontend/src/lib-components/document-templates/question-descriptors/CheckboxGroupQuestionDescriptor.tsx
+++ b/frontend/src/lib-components/document-templates/question-descriptors/CheckboxGroupQuestionDescriptor.tsx
@@ -139,33 +139,31 @@ const View = React.memo(function View({
             return (
               <FixedSpaceRow key={option.state.id} $spacing="xxs">
                 <Checkbox
-                  label={<>
-                    <CheckboxLabelGap>
-                      {option.state.label}
-                    </CheckboxLabelGap>
+                  label={
+                    <>
+                      <CheckboxLabelGap>{option.state.label}</CheckboxLabelGap>
 
-                    {option.state.withText && (
-                      <InputField
-                        value={answerOption?.extra ?? ''}
-                        readonly={!answerOption}
-                        onChange={(value) =>
-                          answer.update((old) => [
-                            ...old.filter(
-                              (opt) => opt.optionId !== option.state.id
-                            ),
-                            { optionId: option.state.id, extra: value }
-                          ])
-                        }
-                        width="L"
-                      />
-                    )}
-                  </>}
+                      {option.state.withText && (
+                        <InputField
+                          value={answerOption?.extra ?? ''}
+                          readonly={!answerOption}
+                          onChange={(value) =>
+                            answer.update((old) => [
+                              ...old.filter(
+                                (opt) => opt.optionId !== option.state.id
+                              ),
+                              { optionId: option.state.id, extra: value }
+                            ])
+                          }
+                          width="L"
+                        />
+                      )}
+                    </>
+                  }
                   checked={answerOption !== undefined}
                   onChange={(checked) =>
                     answer.update((old) => [
-                      ...old.filter(
-                        (opt) => opt.optionId !== option.state.id
-                      ),
+                      ...old.filter((opt) => opt.optionId !== option.state.id),
                       ...(checked
                         ? [{ optionId: option.state.id, extra: '' }]
                         : [])


### PR DESCRIPTION
Sallitaan monivalintakentän tekstien rivittyminen. Mahdolliset lisätietokentät asemoituvat tekstin loppuun samalle riville jos mahtuu, muutoin putoaa omalle riville.