### PR TITLE
Tietojen poisto: Kevytkirjautumistiedot (ei vielä kytketty päälle)

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
@@ -20,6 +20,7 @@ import evaka.core.placement.PlacementType
 import evaka.core.s3.DocumentService
 import evaka.core.shared.ChildDocumentId
 import evaka.core.shared.ChildId
+import evaka.core.shared.PersonId
 import evaka.core.shared.async.AsyncJob
 import evaka.core.shared.async.AsyncJobRunner
 import evaka.core.shared.auth.UserRole
@@ -35,6 +36,8 @@ import evaka.core.shared.dev.DevDaycareGroup
 import evaka.core.shared.dev.DevDocumentTemplate
 import evaka.core.shared.dev.DevEmployee
 import evaka.core.shared.dev.DevFamilyContact
+import evaka.core.shared.dev.DevFosterParent
+import evaka.core.shared.dev.DevGuardian
 import evaka.core.shared.dev.DevPerson
 import evaka.core.shared.dev.DevPersonType
 import evaka.core.shared.dev.DevPlacement
@@ -47,10 +50,12 @@ import evaka.core.specialdiet.MealTexture
 import evaka.core.specialdiet.SpecialDiet
 import evaka.core.specialdiet.setMealTextures
 import evaka.core.specialdiet.setSpecialDiets
+import evaka.core.user.updateLastStrongLogin
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -482,6 +487,113 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         )
 
         assertEquals(0, countChildrenWithNull("diet_id"))
+    }
+
+    @Test
+    fun `deleteExpiredCitizenUsers deletes citizen user whose child's last placement ended before expireDate`() {
+        val guardian = insertAdultWithCitizenUser()
+        insertGuardianship(guardian, child.id)
+        insertPlacementEnding(child.id, leafExpireDate.minusDays(1))
+
+        deleteExpiredCitizenUsers(db, expireDate = leafExpireDate, limit = 100)
+
+        assertFalse(citizenUserExists(guardian))
+    }
+
+    @Test
+    fun `deleteExpiredCitizenUsers keeps citizen user whose child has a recent placement`() {
+        val guardian = insertAdultWithCitizenUser()
+        insertGuardianship(guardian, child.id)
+        insertPlacementEnding(child.id, leafExpireDate.plusDays(1))
+
+        deleteExpiredCitizenUsers(db, expireDate = leafExpireDate, limit = 100)
+
+        assertTrue(citizenUserExists(guardian))
+    }
+
+    @Test
+    fun `deleteExpiredCitizenUsers keeps citizen user whose child placement ends exactly on expireDate`() {
+        val guardian = insertAdultWithCitizenUser()
+        insertGuardianship(guardian, child.id)
+        insertPlacementEnding(child.id, leafExpireDate)
+
+        deleteExpiredCitizenUsers(db, expireDate = leafExpireDate, limit = 100)
+
+        assertTrue(citizenUserExists(guardian))
+    }
+
+    @Test
+    fun `deleteExpiredCitizenUsers keeps citizen user with one expired and one recent child placement`() {
+        val guardian = insertAdultWithCitizenUser()
+        val recentChild = DevPerson()
+        db.transaction { it.insert(recentChild, DevPersonType.CHILD) }
+        insertGuardianship(guardian, child.id)
+        insertGuardianship(guardian, recentChild.id)
+        insertPlacementEnding(child.id, leafExpireDate.minusDays(1))
+        insertPlacementEnding(recentChild.id, leafExpireDate.plusDays(1))
+
+        deleteExpiredCitizenUsers(db, expireDate = leafExpireDate, limit = 100)
+
+        assertTrue(citizenUserExists(guardian))
+    }
+
+    @Test
+    fun `deleteExpiredCitizenUsers keeps citizen user whose child has no placements`() {
+        val guardian = insertAdultWithCitizenUser()
+        insertGuardianship(guardian, child.id)
+
+        deleteExpiredCitizenUsers(db, expireDate = leafExpireDate, limit = 100)
+
+        assertTrue(citizenUserExists(guardian))
+    }
+
+    @Test
+    fun `deleteExpiredCitizenUsers keeps citizen user with no guardian or foster relationship`() {
+        val person = insertAdultWithCitizenUser()
+
+        deleteExpiredCitizenUsers(db, expireDate = leafExpireDate, limit = 100)
+
+        assertTrue(citizenUserExists(person))
+    }
+
+    @Test
+    fun `deleteExpiredCitizenUsers deletes citizen user linked to an expired child via foster parent`() {
+        val fosterParent = insertAdultWithCitizenUser()
+        insertFosterParenthood(fosterParent, child.id)
+        insertPlacementEnding(child.id, leafExpireDate.minusDays(1))
+
+        deleteExpiredCitizenUsers(db, expireDate = leafExpireDate, limit = 100)
+
+        assertFalse(citizenUserExists(fosterParent))
+    }
+
+    private fun insertAdultWithCitizenUser(): PersonId = db.transaction { tx ->
+        val id = tx.insert(DevPerson(), DevPersonType.RAW_ROW)
+        tx.updateLastStrongLogin(now, id)
+        id
+    }
+
+    private fun insertGuardianship(guardian: PersonId, childId: ChildId) {
+        db.transaction { it.insert(DevGuardian(guardianId = guardian, childId = childId)) }
+    }
+
+    private fun insertFosterParenthood(parent: PersonId, childId: ChildId) {
+        db.transaction {
+            it.insert(
+                DevFosterParent(
+                    childId = childId,
+                    parentId = parent,
+                    validDuring = DateRange(today.minusYears(2), today.minusYears(1)),
+                    modifiedAt = now,
+                    modifiedBy = admin.evakaUserId,
+                )
+            )
+        }
+    }
+
+    private fun citizenUserExists(id: PersonId): Boolean = db.read { tx ->
+        tx.createQuery { sql("SELECT EXISTS(SELECT FROM citizen_user WHERE id = ${bind(id)})") }
+            .exactlyOne<Boolean>()
     }
 
     private val allLeafTables =

--- a/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
+++ b/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
@@ -11,6 +11,7 @@ import evaka.core.s3.DocumentService
 import evaka.core.shared.ChildId
 import evaka.core.shared.ChildImageId
 import evaka.core.shared.Id
+import evaka.core.shared.PersonId
 import evaka.core.shared.async.AsyncJob
 import evaka.core.shared.async.AsyncJobRunner
 import evaka.core.shared.async.AsyncJobType
@@ -87,6 +88,8 @@ class DataRemovalService(
         )
 
         deleteExpiredChildImages(dbc, now, expireDate = today.minusMonths(1), limit)
+
+        deleteExpiredCitizenUsers(dbc, expireDate = today.minusYears(1), limit)
     }
 
     fun deleteExpiredChildDocuments(db: Database.Connection, now: HelsinkiDateTime, limit: Int) {
@@ -261,6 +264,58 @@ SELECT child_id
 FROM placement
 GROUP BY child_id
 HAVING max(end_date) < ${bind(date)}
+"""
+    )
+}
+
+fun deleteExpiredCitizenUsers(dbc: Database.Connection, expireDate: LocalDate, limit: Int) {
+    logger.info { "Deleting at most $limit expired citizen users" }
+    val deleted = dbc.transaction { tx -> tx.deleteExpiredCitizenUsersBatch(expireDate, limit) }
+    logger.infoChunked(
+        items = deleted,
+        meta = { chunk -> mapOf("deletedIds" to chunk) },
+        message = { index, total -> "Deleted expired citizen users (chunk $index/$total)" },
+    )
+}
+
+private fun Database.Transaction.deleteExpiredCitizenUsersBatch(
+    expireDate: LocalDate,
+    limit: Int,
+): List<PersonId> =
+    createUpdate {
+            sql(
+                """
+WITH del_batch AS (
+    SELECT id
+    FROM citizen_user
+    WHERE id = ANY(${subquery(citizenUserIdsWithPlacementsEndingBefore(expireDate))})
+    FOR UPDATE
+    LIMIT ${bind(limit)}
+)
+DELETE FROM citizen_user
+USING del_batch
+WHERE citizen_user.id = del_batch.id
+RETURNING citizen_user.id
+"""
+            )
+        }
+        .executeAndReturnGeneratedKeys()
+        .toList()
+
+private fun citizenUserIdsWithPlacementsEndingBefore(date: LocalDate) = QuerySql {
+    sql(
+        """
+WITH guardian_child AS (
+    SELECT guardian_id AS person_id, child_id FROM guardian
+    UNION ALL
+    SELECT parent_id AS person_id, child_id FROM foster_parent
+)
+SELECT gc.person_id
+FROM guardian_child gc
+JOIN citizen_user cu ON cu.id = gc.person_id
+JOIN placement p ON p.child_id = gc.child_id
+GROUP BY gc.person_id
+HAVING max(p.end_date) < ${bind(date)}
 """
     )
 }


### PR DESCRIPTION
Poistetaan, kun viimeisimmästä lapsen sijoituksen päättymisestä on 1 vuosi.