### PR TITLE
Kuntalaisen Lapsen asiakirjat -osion näkyvyys sijoituksen perusteella

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/pis/SystemControllerCitizenTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/SystemControllerCitizenTest.kt
@@ -6,10 +6,12 @@ package evaka.core.pis
 
 import evaka.core.FullApplicationTest
 import evaka.core.placement.PlacementType
+import evaka.core.shared.DaycareId
 import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.dev.*
 import evaka.core.shared.domain.MockEvakaClock
 import evaka.core.shared.security.PilotFeature
+import java.time.LocalDate
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -24,6 +26,18 @@ class SystemControllerCitizenTest : FullApplicationTest(resetDbBeforeEach = true
     private val clock = MockEvakaClock(2024, 10, 15, 10, 0)
     private val area = DevCareArea()
     private val daycare =
+        DevDaycare(
+            areaId = area.id,
+            enabledPilotFeatures = setOf(PilotFeature.MESSAGING, PilotFeature.VASU_AND_PEDADOC),
+        )
+    private val citizenBasicDaycare =
+        DevDaycare(
+            areaId = area.id,
+            enabledPilotFeatures = setOf(PilotFeature.CITIZEN_BASIC_DOCUMENT),
+        )
+    private val otherDecisionDaycare =
+        DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.OTHER_DECISION))
+    private val noDocumentDaycare =
         DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.MESSAGING))
     private val child = DevPerson()
     private val adult = DevPerson()
@@ -33,10 +47,35 @@ class SystemControllerCitizenTest : FullApplicationTest(resetDbBeforeEach = true
         db.transaction {
             it.insert(area)
             it.insert(daycare)
+            it.insert(citizenBasicDaycare)
+            it.insert(otherDecisionDaycare)
+            it.insert(noDocumentDaycare)
             it.insert(child, DevPersonType.CHILD)
             it.insert(adult, DevPersonType.ADULT)
             it.insert(DevGuardian(adult.id, child.id))
         }
+    }
+
+    private fun childDocumentationAccess(
+        unitId: DaycareId,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): Boolean {
+        db.transaction { tx ->
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = unitId,
+                    type = PlacementType.DAYCARE,
+                    startDate = startDate,
+                    endDate = endDate,
+                )
+            )
+        }
+        return systemController
+            .citizenUser(dbInstance(), user, clock, adult.id)
+            .accessibleFeatures
+            .childDocumentation
     }
 
     @Test
@@ -109,5 +148,115 @@ class SystemControllerCitizenTest : FullApplicationTest(resetDbBeforeEach = true
         val result = systemController.citizenUser(dbInstance(), user, clock, adult.id)
         assertTrue(result.accessibleFeatures.messages)
         assertTrue(result.accessibleFeatures.composeNewMessage)
+    }
+
+    @Test
+    fun `pedagogical documentation access requires an active placement in a VASU_AND_PEDADOC unit`() {
+        assertTrue(
+            childDocumentationAccess(
+                daycare.id,
+                clock.today().minusDays(1),
+                clock.today().plusDays(1),
+            )
+        )
+    }
+
+    @Test
+    fun `no pedagogical documentation access when VASU_AND_PEDADOC placement is in the past`() {
+        assertFalse(
+            childDocumentationAccess(
+                daycare.id,
+                clock.today().minusMonths(2),
+                clock.today().minusDays(1),
+            )
+        )
+    }
+
+    @Test
+    fun `no pedagogical documentation access when VASU_AND_PEDADOC placement starts in the future`() {
+        assertFalse(
+            childDocumentationAccess(
+                daycare.id,
+                clock.today().plusDays(30),
+                clock.today().plusMonths(4),
+            )
+        )
+    }
+
+    @Test
+    fun `citizen basic documentation access starts the configured days before placement start`() {
+        assertTrue(
+            childDocumentationAccess(
+                citizenBasicDaycare.id,
+                clock.today().plusDays(60),
+                clock.today().plusMonths(4),
+            )
+        )
+    }
+
+    @Test
+    fun `no citizen basic documentation access when placement starts over 60 days in the future`() {
+        assertFalse(
+            childDocumentationAccess(
+                citizenBasicDaycare.id,
+                clock.today().plusDays(61),
+                clock.today().plusMonths(4),
+            )
+        )
+    }
+
+    @Test
+    fun `citizen basic documentation access when placement is active`() {
+        assertTrue(
+            childDocumentationAccess(
+                citizenBasicDaycare.id,
+                clock.today().minusDays(1),
+                clock.today().plusDays(1),
+            )
+        )
+    }
+
+    @Test
+    fun `no citizen basic documentation access when placement has ended`() {
+        assertFalse(
+            childDocumentationAccess(
+                citizenBasicDaycare.id,
+                clock.today().minusMonths(2),
+                clock.today().minusDays(1),
+            )
+        )
+    }
+
+    @Test
+    fun `other decision documentation access requires an active placement in an OTHER_DECISION unit`() {
+        assertTrue(
+            childDocumentationAccess(
+                otherDecisionDaycare.id,
+                clock.today().minusDays(1),
+                clock.today().plusDays(1),
+            )
+        )
+    }
+
+    @Test
+    fun `no other decision documentation access when placement starts in the future`() {
+        assertFalse(
+            childDocumentationAccess(
+                otherDecisionDaycare.id,
+                clock.today().plusDays(30),
+                clock.today().plusMonths(4),
+            )
+        )
+    }
+
+    @Test
+    fun `no documentation access when unit has none of the document pilot features`() {
+        assertFalse(
+            childDocumentationAccess(
+                noDocumentDaycare.id,
+                clock.today().minusDays(1),
+                clock.today().plusDays(1),
+            )
+        )
     }
 }

--- a/service/src/main/kotlin/evaka/core/shared/security/AccessControlCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/AccessControlCitizen.kt
@@ -5,13 +5,17 @@
 package evaka.core.shared.security
 
 import evaka.core.CitizenCalendarEnv
+import evaka.core.shared.FeatureConfig
 import evaka.core.shared.PersonId
 import evaka.core.shared.db.Database
 import evaka.core.shared.domain.EvakaClock
 import org.springframework.stereotype.Service
 
 @Service
-class AccessControlCitizen(val citizenCalendarEnv: CitizenCalendarEnv) {
+class AccessControlCitizen(
+    val citizenCalendarEnv: CitizenCalendarEnv,
+    val featureConfig: FeatureConfig,
+) {
     fun getPermittedFeatures(
         tx: Database.Read,
         clock: EvakaClock,
@@ -28,7 +32,12 @@ class AccessControlCitizen(val citizenCalendarEnv: CitizenCalendarEnv) {
                     citizen,
                     citizenCalendarEnv.calendarOpenBeforePlacementDays,
                 ),
-            childDocumentation = tx.citizenHasAccessToChildDocumentation(clock, citizen),
+            childDocumentation =
+                tx.citizenHasAccessToChildDocumentation(
+                    clock,
+                    citizen,
+                    featureConfig.citizenDocumentCreationDaysBeforePlacement,
+                ),
         )
     }
 
@@ -122,6 +131,7 @@ SELECT EXISTS (
     private fun Database.Read.citizenHasAccessToChildDocumentation(
         clock: EvakaClock,
         userId: PersonId,
+        citizenDocumentCreationDaysBeforePlacement: Int,
     ): Boolean {
         val today = clock.today()
         return createQuery {
@@ -135,9 +145,18 @@ WITH children AS (
 SELECT EXISTS (
     SELECT 1
     FROM children c
-    JOIN placement pl ON c.child_id = pl.child_id AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(today)}
+    JOIN placement pl ON c.child_id = pl.child_id
     JOIN daycare ON pl.unit_id = daycare.id
-    WHERE 'VASU_AND_PEDADOC' = ANY(enabled_pilot_features)
+    WHERE (
+        daterange(pl.start_date, pl.end_date, '[]') @> ${bind(today)}
+        AND (
+            'VASU_AND_PEDADOC' = ANY(enabled_pilot_features)
+            OR 'OTHER_DECISION' = ANY(enabled_pilot_features)
+        )
+    ) OR (
+        'CITIZEN_BASIC_DOCUMENT' = ANY(enabled_pilot_features)
+        AND daterange((pl.start_date - ${bind(citizenDocumentCreationDaysBeforePlacement)}), pl.end_date, '[]') @> ${bind(today)}
+    )
 )
 """
                 )


### PR DESCRIPTION
Ennen korjausta Lapsen asiakirjat -osio oli näkyvissä silloin, kun lapsella on voimassaoleva sijoitus yksikköön, jossa on *Pedagogiset asiakirjat ja pedagoginen dokumentointi* -toiminto päällä.

Korjauksen jälkeen Lapsen asiakirjat -osio on näkyvissä, jos:
- Lapsella on voimassaoleva sijoitus yksikköön, jossa on *Pedagogiset asiakirjat ja pedagoginen dokumentointi* tai *Muut päätökset* -toiminto päällä, **tai**
- Lapsella on voimassaoleva tai 60 päivän sisällä alkava sijoitus yksikköön, jossa on *Huoltajien täytettävät dokumentit* -toiminto päällä.