### PR TITLE
Näytetään lapsen asiakirjat henkilökuntaroolille 60 päivää ennen sijoitusta

### DIFF
--- a/frontend/src/e2e-test/specs/5_employee/child-document.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-document.spec.ts
@@ -10,7 +10,6 @@ import { Fixture } from '../../dev-api/fixtures'
 import { resetServiceState } from '../../generated/api-clients'
 import type { DevEmployee, DevPerson } from '../../generated/api-types'
 import ChildInformationPage from '../../pages/employee/child-information'
-import { ChildDocumentPage } from '../../pages/employee/documents/child-document'
 import { test, expect } from '../../playwright'
 import { employeeLogin } from '../../utils/user'
 
@@ -21,7 +20,6 @@ test.describe('child document with person duplicate', () => {
   test.use({ evakaOptions: { mockedTime } })
 
   let admin: DevEmployee
-  let daycareSupervisor: DevEmployee
   let child: DevPerson
   let duplicate: DevPerson
 
@@ -34,9 +32,6 @@ test.describe('child document with person duplicate', () => {
       type: ['CENTRE'],
       enabledPilotFeatures: ['VASU_AND_PEDADOC', 'OTHER_DECISION']
     }).save()
-    daycareSupervisor = await Fixture.employee()
-      .unitSupervisor(daycare.id)
-      .save()
     const preschool = await Fixture.daycare({
       areaId: area.id,
       type: ['PRESCHOOL'],
@@ -63,62 +58,6 @@ test.describe('child document with person duplicate', () => {
       startDate: mockedDate,
       endDate: mockedDate
     }).save()
-  })
-
-  test('unit supervisor sees hojks document from duplicate', async ({
-    evaka
-  }) => {
-    const template = await Fixture.documentTemplate({
-      type: 'HOJKS',
-      validity: new DateRange(mockedDate, mockedDate)
-    }).save()
-    const document = await Fixture.childDocument({
-      childId: duplicate.id,
-      templateId: template.id
-    }).save()
-
-    await employeeLogin(evaka, daycareSupervisor)
-    await evaka.goto(`${config.employeeUrl}/child-documents/${document.id}`)
-    const childDocumentPage = new ChildDocumentPage(evaka)
-    await expect(childDocumentPage.status).toBeVisible()
-  })
-
-  test('unit supervisor sees hojks documents from duplicate', async ({
-    evaka
-  }) => {
-    const pedagogicalAssessmentTemplate = await Fixture.documentTemplate({
-      type: 'PEDAGOGICAL_ASSESSMENT',
-      validity: new DateRange(mockedDate, mockedDate)
-    }).save()
-    await Fixture.childDocument({
-      childId: duplicate.id,
-      templateId: pedagogicalAssessmentTemplate.id
-    }).save()
-    const pedagogicalReportTemplate = await Fixture.documentTemplate({
-      type: 'PEDAGOGICAL_REPORT',
-      validity: new DateRange(mockedDate, mockedDate)
-    }).save()
-    await Fixture.childDocument({
-      childId: duplicate.id,
-      templateId: pedagogicalReportTemplate.id
-    }).save()
-    const hojksTemplate = await Fixture.documentTemplate({
-      type: 'HOJKS',
-      validity: new DateRange(mockedDate, mockedDate)
-    }).save()
-    const hojksDocument = await Fixture.childDocument({
-      childId: duplicate.id,
-      templateId: hojksTemplate.id
-    }).save()
-
-    await employeeLogin(evaka, daycareSupervisor)
-    await evaka.goto(`${config.employeeUrl}/child-information/${child.id}`)
-    const childInformationPage = new ChildInformationPage(evaka)
-    const childDocumentsSection =
-      await childInformationPage.openCollapsible('childDocuments')
-    await childDocumentsSection.assertInternalChildDocuments([
-      { id: hojksDocument.id }
-    ])
   })
 
   test('admin can see all documents from duplicate and edit', async ({

--- a/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-documents.spec.ts
@@ -375,7 +375,7 @@ test.describe('Employee - Child documents', () => {
     ).toBeHidden()
   })
 
-  test('Staff can create CITIZEN_BASIC document for child with placement starting in less than 30 days', async ({
+  test('Staff can create CITIZEN_BASIC document for child with placement starting in less than 60 days', async ({
     newEvakaPage
   }) => {
     const group1: DevDaycareGroup = await Fixture.daycareGroup({
@@ -397,11 +397,11 @@ test.describe('Employee - Child documents', () => {
 
     await Fixture.guardian(childFuture, testAdult).save()
 
-    // Create a placement that starts in 20 days (within the 30-day window)
+    // placement starts inside the citizen-document creation window
     const futurePlacement = await Fixture.placement({
       childId: childFuture.id,
       unitId: testDaycare.id,
-      startDate: now.toLocalDate().addDays(20),
+      startDate: now.toLocalDate().addDays(45),
       endDate: now.toLocalDate().addYears(1),
       type: 'DAYCARE'
     }).save()

--- a/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
@@ -245,14 +245,27 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     @Test
     fun `published template without documents can be deleted, with documents cannot`() {
         val otherChild = DevPerson()
-        db.transaction { tx -> tx.insert(otherChild, DevPersonType.CHILD) }
+        db.transaction { tx ->
+            tx.insert(otherChild, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = otherChild.id,
+                    unitId = daycare.id,
+                    startDate = now.today(),
+                    endDate = now.today().plusDays(5),
+                )
+            )
+        }
 
         val withDocs =
             controller.createTemplate(
                 dbInstance(),
                 employee.user,
                 now,
-                testCreationRequest.copy(validity = DateRange(now.today(), null)),
+                testCreationRequest.copy(
+                    language = UiLanguage.SV,
+                    validity = DateRange(now.today(), null),
+                ),
             )
         controller.publishTemplate(dbInstance(), employee.user, now, withDocs.id)
         childDocumentController.createDocument(
@@ -282,14 +295,27 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     @Test
     fun `document count`() {
         val otherChild = DevPerson()
-        db.transaction { tx -> tx.insert(otherChild, DevPersonType.CHILD) }
+        db.transaction { tx ->
+            tx.insert(otherChild, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = otherChild.id,
+                    unitId = daycare.id,
+                    startDate = now.today(),
+                    endDate = now.today().plusDays(5),
+                )
+            )
+        }
 
         val created =
             controller.createTemplate(
                 dbInstance(),
                 employee.user,
                 now,
-                testCreationRequest.copy(validity = DateRange(now.today(), null)),
+                testCreationRequest.copy(
+                    language = UiLanguage.SV,
+                    validity = DateRange(now.today(), null),
+                ),
             )
         controller.publishTemplate(dbInstance(), employee.user, now, created.id)
 

--- a/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/DocumentTemplateIntegrationTest.kt
@@ -48,13 +48,6 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
             testFeatureConfig.copy(allowEnglishChildDocumentsForAllTypes = enabled),
         )
 
-    private fun controllerWithCitizenDocumentDays(days: Int) =
-        DocumentTemplateController(
-            accessControl,
-            evakaEnv,
-            testFeatureConfig.copy(citizenDocumentCreationDaysBeforePlacement = days),
-        )
-
     private val now = MockEvakaClock(2022, 1, 1, 15, 0)
     private val area = DevCareArea()
     private val daycare =
@@ -405,37 +398,52 @@ class DocumentTemplateIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
     }
 
     @Test
-    fun `citizen basic templates become creatable the configured number of days before placement start`() {
-        val futureChild = DevPerson()
-        val placementStart = now.today().plusDays(40)
+    fun `citizen basic templates become creatable a fixed number of days before placement start`() {
+        val childWithinWindow = DevPerson()
+        val childBeyondWindow = DevPerson()
+        val withinWindowStart =
+            now.today().plusDays((CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT - 5).toLong())
+        val beyondWindowStart =
+            now.today().plusDays((CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT + 5).toLong())
         db.transaction { tx ->
-            tx.insert(futureChild, DevPersonType.CHILD)
+            tx.insert(childWithinWindow, DevPersonType.CHILD)
             tx.insert(
                 DevPlacement(
-                    childId = futureChild.id,
+                    childId = childWithinWindow.id,
                     unitId = daycare.id,
-                    startDate = placementStart,
-                    endDate = placementStart.plusDays(5),
+                    startDate = withinWindowStart,
+                    endDate = withinWindowStart.plusDays(5),
+                )
+            )
+            tx.insert(childBeyondWindow, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = childBeyondWindow.id,
+                    unitId = daycare.id,
+                    startDate = beyondWindowStart,
+                    endDate = beyondWindowStart.plusDays(5),
                 )
             )
         }
         publishCitizenBasicTemplate(UiLanguage.SV)
         publishPedagogicalAssessmentTemplate(UiLanguage.SV)
 
-        // placement starts 40 days out, beyond a 30-day window
+        // within the window only the citizen basic template is creatable; other types still require
+        // an active placement
         assertEquals(
-            0,
-            controllerWithCitizenDocumentDays(30)
-                .getActiveTemplates(dbInstance(), employee.user, now, futureChild.id)
-                .size,
+            listOf(ChildDocumentType.CITIZEN_BASIC),
+            controller
+                .getActiveTemplates(dbInstance(), employee.user, now, childWithinWindow.id)
+                .map { it.type },
         )
 
-        // a wider window exposes only the citizen basic template; other types still require an
-        // active placement
-        val active =
-            controllerWithCitizenDocumentDays(60)
-                .getActiveTemplates(dbInstance(), employee.user, now, futureChild.id)
-        assertEquals(listOf(ChildDocumentType.CITIZEN_BASIC), active.map { it.type })
+        // beyond the window no templates are creatable yet
+        assertEquals(
+            0,
+            controller
+                .getActiveTemplates(dbInstance(), employee.user, now, childBeyondWindow.id)
+                .size,
+        )
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentControllerIntegrationTest.kt
@@ -21,6 +21,7 @@ import evaka.core.document.Question
 import evaka.core.document.RadioButtonGroupQuestionOption
 import evaka.core.document.Section
 import evaka.core.pis.service.insertGuardian
+import evaka.core.placement.PlacementType
 import evaka.core.sficlient.MockSfiMessagesClient
 import evaka.core.sficlient.rest.EventType
 import evaka.core.shared.ChildDocumentDecisionId
@@ -37,6 +38,7 @@ import evaka.core.shared.auth.CitizenAuthLevel
 import evaka.core.shared.auth.UserRole
 import evaka.core.shared.auth.insertDaycareAclRow
 import evaka.core.shared.dev.DevCareArea
+import evaka.core.shared.dev.DevChildDocument
 import evaka.core.shared.dev.DevDaycare
 import evaka.core.shared.dev.DevDaycareGroup
 import evaka.core.shared.dev.DevDaycareGroupPlacement
@@ -55,6 +57,7 @@ import evaka.core.shared.domain.Forbidden
 import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.domain.MockEvakaClock
 import evaka.core.shared.domain.NotFound
+import evaka.core.shared.domain.UiLanguage
 import evaka.core.shared.security.Action
 import evaka.core.shared.security.PilotFeature
 import java.time.LocalDate
@@ -83,8 +86,13 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
     private val daycare =
         DevDaycare(
             areaId = area.id,
-            language = Language.sv,
-            enabledPilotFeatures = setOf(PilotFeature.VASU_AND_PEDADOC),
+            language = Language.fi,
+            enabledPilotFeatures =
+                setOf(
+                    PilotFeature.VASU_AND_PEDADOC,
+                    PilotFeature.OTHER_DECISION,
+                    PilotFeature.CITIZEN_BASIC_DOCUMENT,
+                ),
         )
     private val child = DevPerson(dateOfBirth = LocalDate.of(2017, 6, 1), ssn = "010617A123U")
     private val adult = DevPerson(ssn = "010180-1232")
@@ -1281,7 +1289,13 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
     @Test
     fun `unit supervisor doesn't see pedagogical assessment document from duplicate`() {
         val duplicateId = db.transaction { tx ->
-            val unitId = tx.insert(DevDaycare(areaId = area.id))
+            val unitId =
+                tx.insert(
+                    DevDaycare(
+                        areaId = area.id,
+                        enabledPilotFeatures = setOf(PilotFeature.VASU_AND_PEDADOC),
+                    )
+                )
             val childId = tx.insert(DevPerson().copy(duplicateOf = child.id), DevPersonType.CHILD)
             tx.insert(
                 DevPlacement(
@@ -1578,14 +1592,9 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
             AuthenticatedUser.Employee(staffId, setOf(UserRole.STAFF))
         }
 
-        // Create a document as admin
-        val documentId =
-            controller.createDocument(
-                dbInstance(),
-                employeeUser.user,
-                clock,
-                ChildDocumentCreateRequest(child.id, templateIdCitizenBasic),
-            )
+        // placement is beyond the creation window, so the document cannot be created via the
+        // controller
+        val documentId = insertDocument(child.id, templateIdCitizenBasic)
 
         // STAFF should NOT be able to read the document (too far in future)
         assertThrows<Forbidden> {
@@ -1613,13 +1622,8 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
             AuthenticatedUser.Employee(staffId, setOf(UserRole.STAFF))
         }
 
-        val documentId =
-            controller.createDocument(
-                dbInstance(),
-                employeeUser.user,
-                clock,
-                ChildDocumentCreateRequest(child.id, templateIdCitizenBasic),
-            )
+        // placement has ended, so the document cannot be created via the controller
+        val documentId = insertDocument(child.id, templateIdCitizenBasic)
 
         // STAFF should NOT be able to access expired placement documents
         assertThrows<Forbidden> {
@@ -1677,14 +1681,8 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
             AuthenticatedUser.Employee(staffId, setOf(UserRole.STAFF))
         }
 
-        // Create a decision document as admin
-        val decisionDocumentId =
-            controller.createDecisionDocument(
-                dbInstance(),
-                employeeUser.user,
-                clock,
-                ChildDocumentCreateRequest(child.id, templateIdAssistanceDecision),
-            )
+        // a decision document cannot be created via the controller before the placement starts
+        val decisionDocumentId = insertDocument(child.id, templateIdAssistanceDecision)
 
         // STAFF should be able to READ the decision document
         val document = controller.getDocument(dbInstance(), staffUser, clock, decisionDocumentId)
@@ -1822,18 +1820,106 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
         }
     }
 
+    @Test
+    fun `creating a document fails when the child has no current or upcoming placement`() {
+        val childWithoutPlacement = db.transaction { tx ->
+            tx.insert(DevPerson(), DevPersonType.CHILD)
+        }
+        assertThrows<BadRequest> {
+            controller.createDocument(
+                dbInstance(),
+                employeeUser.user,
+                clock,
+                ChildDocumentCreateRequest(childWithoutPlacement, templateIdPed),
+            )
+        }
+    }
+
+    @Test
+    fun `creating a document fails when the placement type is not in the template`() {
+        val templateId = DocumentTemplateId(UUID.randomUUID())
+        db.transaction { tx ->
+            tx.insert(
+                devTemplatePed.copy(id = templateId, placementTypes = setOf(PlacementType.CLUB))
+            )
+        }
+        // the helper creates a DAYCARE placement, which the template does not allow
+        assertThrows<BadRequest> { createDocument(templateId = templateId) }
+    }
+
+    @Test
+    fun `creating a document fails when the template language does not match the unit language`() {
+        val templateId = DocumentTemplateId(UUID.randomUUID())
+        db.transaction { tx ->
+            // unit is Finnish but the template is Swedish
+            tx.insert(devTemplatePed.copy(id = templateId, language = UiLanguage.SV))
+        }
+        assertThrows<BadRequest> { createDocument(templateId = templateId) }
+    }
+
+    @Test
+    fun `creating a document fails when the unit lacks the required pilot feature`() {
+        val childInUnitWithoutPilot = db.transaction { tx ->
+            val unitId = tx.insert(DevDaycare(areaId = area.id, language = Language.fi))
+            val childId = tx.insert(DevPerson(), DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = childId,
+                    unitId = unitId,
+                    startDate = clock.today(),
+                    endDate = clock.today().plusDays(5),
+                )
+            )
+            childId
+        }
+        // PEDAGOGICAL_ASSESSMENT requires the VASU_AND_PEDADOC pilot feature
+        assertThrows<BadRequest> {
+            createDocument(childId = childInUnitWithoutPilot, templateId = templateIdPed)
+        }
+    }
+
+    @Test
+    fun `creating a non-citizen document fails before the placement has started`() {
+        val futureChild = createChildWithUpcomingPlacement()
+        assertThrows<BadRequest> {
+            createDocument(childId = futureChild, templateId = templateIdPed)
+        }
+    }
+
+    @Test
+    fun `creating a citizen document is allowed before the placement has started`() {
+        val futureChild = createChildWithUpcomingPlacement()
+        val documentId = createDocument(childId = futureChild, templateId = templateIdCitizenBasic)
+        assertNotNull(documentId)
+    }
+
+    private fun createChildWithUpcomingPlacement(): PersonId = db.transaction { tx ->
+        val childId = tx.insert(DevPerson(), DevPersonType.CHILD)
+        tx.insert(
+            DevPlacement(
+                childId = childId,
+                unitId = daycare.id,
+                startDate = clock.today().plusDays(30),
+                endDate = clock.today().plusDays(90),
+            )
+        )
+        childId
+    }
+
     private fun createDocument(
         childId: PersonId = child.id,
         templateId: DocumentTemplateId = templateIdPed,
         user: AuthenticatedUser.Employee = employeeUser.user,
         clockOverride: MockEvakaClock = clock,
-    ) =
-        controller.createDocument(
+    ): ChildDocumentId {
+        ensurePlacement(childId, clockOverride)
+        return controller.createDocument(
             dbInstance(),
             user,
             clockOverride,
             ChildDocumentCreateRequest(childId, templateId),
         )
+    }
 
     private fun publishDocument(
         id: ChildDocumentId,
@@ -1858,13 +1944,50 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
         templateId: DocumentTemplateId = templateIdAssistanceDecision,
         user: AuthenticatedUser.Employee = employeeUser.user,
         clockOverride: MockEvakaClock = clock,
-    ) =
-        controller.createDecisionDocument(
+    ): ChildDocumentId {
+        ensurePlacement(childId, clockOverride)
+        return controller.createDecisionDocument(
             dbInstance(),
             user,
             clockOverride,
             ChildDocumentCreateRequest(childId, templateId),
         )
+    }
+
+    private fun ensurePlacement(childId: PersonId, clockOverride: MockEvakaClock) {
+        val hasPlacement = db.read { tx ->
+            tx.createQuery {
+                    sql("SELECT EXISTS(SELECT 1 FROM placement WHERE child_id = ${bind(childId)})")
+                }
+                .exactlyOne<Boolean>()
+        }
+        if (!hasPlacement) {
+            createPlacement(
+                childId = childId,
+                startDate = clockOverride.today(),
+                endDate = clockOverride.today().plusYears(1),
+            )
+        }
+    }
+
+    private fun insertDocument(
+        childId: PersonId,
+        templateId: DocumentTemplateId,
+        status: DocumentStatus = DocumentStatus.DRAFT,
+    ): ChildDocumentId = db.transaction { tx ->
+        tx.insert(
+            DevChildDocument(
+                childId = childId,
+                templateId = templateId,
+                status = status,
+                content = DocumentContent(answers = emptyList()),
+                modifiedAt = clock.now(),
+                modifiedBy = employeeUser.evakaUserId,
+                contentLockedAt = clock.now(),
+                contentLockedBy = null,
+            )
+        )
+    }
 
     private fun takeDocumentWriteLock(
         id: ChildDocumentId,

--- a/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentControllerIntegrationTest.kt
@@ -1528,10 +1528,10 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
         metadataController.getChildDocumentMetadata(dbInstance(), employeeUser.user, clock, id)
 
     @Test
-    fun `STAFF can access child documents when placement starts within 30 days`() {
-        // Create a placement starting 15 days from now
-        val futureStartDate = clock.today().plusDays(15)
-        val futureEndDate = clock.today().plusDays(90)
+    fun `STAFF can access child documents when placement starts within 60 days`() {
+        // placement starts inside the citizen-document creation window
+        val futureStartDate = clock.today().plusDays(45)
+        val futureEndDate = clock.today().plusDays(120)
 
         val groupId = createPlacementWithGroup(startDate = futureStartDate, endDate = futureEndDate)
 
@@ -1564,10 +1564,10 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
     }
 
     @Test
-    fun `STAFF cannot access child documents when placement starts beyond 30 days`() {
-        // Create a placement starting 35 days from now (beyond 30-day window)
-        val futureStartDate = clock.today().plusDays(35)
-        val futureEndDate = clock.today().plusDays(120)
+    fun `STAFF cannot access child documents when placement starts beyond 60 days`() {
+        // placement starts beyond the citizen-document creation window
+        val futureStartDate = clock.today().plusDays(65)
+        val futureEndDate = clock.today().plusDays(150)
 
         val groupId = createPlacementWithGroup(startDate = futureStartDate, endDate = futureEndDate)
 
@@ -1633,9 +1633,9 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
     }
 
     @Test
-    fun `STAFF can create documents for placement starting within 30 days`() {
-        val futureStartDate = clock.today().plusDays(20)
-        val futureEndDate = clock.today().plusDays(100)
+    fun `STAFF can create documents for placement starting within 60 days`() {
+        val futureStartDate = clock.today().plusDays(45)
+        val futureEndDate = clock.today().plusDays(120)
 
         val groupId = createPlacementWithGroup(startDate = futureStartDate, endDate = futureEndDate)
 

--- a/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentControllerIntegrationTest.kt
@@ -1338,32 +1338,6 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
     }
 
     @Test
-    fun `unit supervisor sees hojks document from duplicate`() {
-        createPlacement()
-        val duplicateId = db.transaction { tx ->
-            val unitId =
-                tx.insert(
-                    DevDaycare(
-                        areaId = area.id,
-                        enabledPilotFeatures = setOf(PilotFeature.VASU_AND_PEDADOC),
-                    )
-                )
-            val childId = tx.insert(DevPerson().copy(duplicateOf = child.id), DevPersonType.CHILD)
-            tx.insert(
-                DevPlacement(
-                    childId = childId,
-                    unitId = unitId,
-                    startDate = clock.today(),
-                    endDate = clock.today().plusDays(5),
-                )
-            )
-            childId
-        }
-        val documentId = createDocument(childId = duplicateId, templateId = templateIdHojks)
-        assertNotNull(controller.getDocument(dbInstance(), unitSupervisorUser, clock, documentId))
-    }
-
-    @Test
     fun `archiving document with template not marked for external archiving fails`() {
         // Create document with a template not marked for external archiving (Ped template)
         val documentId = createDocument()
@@ -1889,44 +1863,6 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
         assertThrows<Forbidden> {
             controller.getDocument(dbInstance(), staffUser, clock, documentId)
         }
-        assertThrows<Forbidden> {
-            controller.getDocument(dbInstance(), unitSupervisorUser, clock, documentId)
-        }
-    }
-
-    @Test
-    fun `unit supervisor sees hojks from duplicate during the primary's backup care, but not after`() {
-        // the HOJKS belongs to the duplicate; access comes via the primary child's backup care
-        val duplicateId = db.transaction { tx ->
-            tx.insert(DevPerson().copy(duplicateOf = child.id), DevPersonType.CHILD)
-        }
-        val documentId = insertDocument(duplicateId, templateIdHojks)
-
-        val activeBackupCareId = db.transaction { tx ->
-            tx.insert(
-                DevBackupCare(
-                    childId = child.id,
-                    unitId = daycare.id,
-                    period = FiniteDateRange(clock.today().minusDays(1), clock.today().plusDays(1)),
-                )
-            )
-        }
-
-        assertTrue(
-            controller
-                .getDocument(dbInstance(), unitSupervisorUser, clock, documentId)
-                .permittedActions
-                .contains(Action.ChildDocument.READ)
-        )
-
-        db.transaction { tx ->
-            tx.execute {
-                sql(
-                    "UPDATE backup_care SET end_date = ${bind(clock.today().minusDays(1))} WHERE id = ${bind(activeBackupCareId)}"
-                )
-            }
-        }
-
         assertThrows<Forbidden> {
             controller.getDocument(dbInstance(), unitSupervisorUser, clock, documentId)
         }

--- a/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentControllerIntegrationTest.kt
@@ -37,6 +37,7 @@ import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.auth.CitizenAuthLevel
 import evaka.core.shared.auth.UserRole
 import evaka.core.shared.auth.insertDaycareAclRow
+import evaka.core.shared.dev.DevBackupCare
 import evaka.core.shared.dev.DevCareArea
 import evaka.core.shared.dev.DevChildDocument
 import evaka.core.shared.dev.DevDaycare
@@ -53,6 +54,7 @@ import evaka.core.shared.dev.insertEmployeeToDaycareGroupAcl
 import evaka.core.shared.domain.BadRequest
 import evaka.core.shared.domain.Conflict
 import evaka.core.shared.domain.DateRange
+import evaka.core.shared.domain.FiniteDateRange
 import evaka.core.shared.domain.Forbidden
 import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.domain.MockEvakaClock
@@ -1542,7 +1544,7 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
         metadataController.getChildDocumentMetadata(dbInstance(), employeeUser.user, clock, id)
 
     @Test
-    fun `STAFF can access child documents when placement starts within 60 days`() {
+    fun `STAFF can access citizen documents when placement starts within 60 days`() {
         // placement starts inside the citizen-document creation window
         val futureStartDate = clock.today().plusDays(45)
         val futureEndDate = clock.today().plusDays(120)
@@ -1578,7 +1580,7 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
     }
 
     @Test
-    fun `STAFF cannot access child documents when placement starts beyond 60 days`() {
+    fun `STAFF cannot access citizen documents when placement starts beyond 60 days`() {
         // placement starts beyond the citizen-document creation window
         val futureStartDate = clock.today().plusDays(65)
         val futureEndDate = clock.today().plusDays(150)
@@ -1667,8 +1669,8 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
     }
 
     @Test
-    fun `STAFF with future access still cannot manage decision documents`() {
-        // Create a placement starting 15 days from now
+    fun `STAFF cannot access non-citizen documents before the placement starts`() {
+        // placement starts in the future, within the citizen-document creation window
         val futureStartDate = clock.today().plusDays(15)
         val futureEndDate = clock.today().plusDays(90)
 
@@ -1681,24 +1683,23 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
             AuthenticatedUser.Employee(staffId, setOf(UserRole.STAFF))
         }
 
-        // a decision document cannot be created via the controller before the placement starts
+        // non-citizen documents are not accessible before the placement starts, so they cannot be
+        // created via the controller
+        val pedagogicalDocumentId = insertDocument(child.id, templateIdPed)
         val decisionDocumentId = insertDocument(child.id, templateIdAssistanceDecision)
 
-        // STAFF should be able to READ the decision document
-        val document = controller.getDocument(dbInstance(), staffUser, clock, decisionDocumentId)
-        assertTrue(document.permittedActions.contains(Action.ChildDocument.READ))
-
-        // But STAFF should NOT be able to UPDATE the decision document
-        assertFalse(document.permittedActions.contains(Action.ChildDocument.UPDATE))
-
-        // Verify by attempting to update - should throw Forbidden
-        val decisionContent =
-            DocumentContent(
-                answers = listOf(AnsweredQuestion.TextAnswer("q1", "staff edit decision"))
-            )
         assertThrows<Forbidden> {
-            updateDocumentContent(decisionDocumentId, decisionContent, user = staffUser)
+            controller.getDocument(dbInstance(), staffUser, clock, pedagogicalDocumentId)
         }
+        assertThrows<Forbidden> {
+            controller.getDocument(dbInstance(), staffUser, clock, decisionDocumentId)
+        }
+
+        // citizen documents remain accessible within the creation window
+        val citizenDocumentId = insertDocument(child.id, templateIdCitizenBasic)
+        val citizenDocument =
+            controller.getDocument(dbInstance(), staffUser, clock, citizenDocumentId)
+        assertTrue(citizenDocument.permittedActions.contains(Action.ChildDocument.READ))
     }
 
     @Test
@@ -1818,6 +1819,130 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
         assertThrows<Forbidden> {
             updateDocumentContent(decisionDocumentId, content, user = staffUser)
         }
+    }
+
+    @Test
+    fun `staff and unit supervisor can read documents during an active backup care, but only read`() {
+        val backupGroupId =
+            insertBackupCare(
+                period = FiniteDateRange(clock.today().minusDays(2), clock.today().plusDays(2))
+            )
+
+        val staffUser = db.transaction { tx ->
+            val staffId = tx.insert(DevEmployee())
+            tx.insertDaycareAclRow(daycare.id, staffId, UserRole.STAFF)
+            tx.insertEmployeeToDaycareGroupAcl(backupGroupId, staffId)
+            AuthenticatedUser.Employee(staffId, setOf(UserRole.STAFF))
+        }
+
+        val documentId = insertDocument(child.id, templateIdPed)
+
+        listOf(staffUser, unitSupervisorUser).forEach { user ->
+            val document = controller.getDocument(dbInstance(), user, clock, documentId)
+            assertTrue(document.permittedActions.contains(Action.ChildDocument.READ))
+            assertFalse(document.permittedActions.contains(Action.ChildDocument.UPDATE))
+            assertFalse(document.permittedActions.contains(Action.ChildDocument.DELETE))
+        }
+    }
+
+    @Test
+    fun `backup care access does not allow updating or publishing documents`() {
+        val backupGroupId =
+            insertBackupCare(
+                period = FiniteDateRange(clock.today().minusDays(2), clock.today().plusDays(2))
+            )
+
+        val staffUser = db.transaction { tx ->
+            val staffId = tx.insert(DevEmployee())
+            tx.insertDaycareAclRow(daycare.id, staffId, UserRole.STAFF)
+            tx.insertEmployeeToDaycareGroupAcl(backupGroupId, staffId)
+            AuthenticatedUser.Employee(staffId, setOf(UserRole.STAFF))
+        }
+
+        val documentId = insertDocument(child.id, templateIdPed)
+        val content =
+            DocumentContent(answers = listOf(AnsweredQuestion.TextAnswer("q1", "attempt to edit")))
+
+        listOf(staffUser, unitSupervisorUser).forEach { user ->
+            controller.getDocument(dbInstance(), user, clock, documentId)
+            assertThrows<Forbidden> { updateDocumentContent(documentId, content, user = user) }
+            assertThrows<Forbidden> { publishDocument(documentId, user = user) }
+        }
+    }
+
+    @Test
+    fun `staff and unit supervisor cannot access documents outside the backup care period`() {
+        val backupGroupId =
+            insertBackupCare(
+                period = FiniteDateRange(clock.today().plusDays(5), clock.today().plusDays(10))
+            )
+
+        val staffUser = db.transaction { tx ->
+            val staffId = tx.insert(DevEmployee())
+            tx.insertDaycareAclRow(daycare.id, staffId, UserRole.STAFF)
+            tx.insertEmployeeToDaycareGroupAcl(backupGroupId, staffId)
+            AuthenticatedUser.Employee(staffId, setOf(UserRole.STAFF))
+        }
+
+        val documentId = insertDocument(child.id, templateIdPed)
+
+        assertThrows<Forbidden> {
+            controller.getDocument(dbInstance(), staffUser, clock, documentId)
+        }
+        assertThrows<Forbidden> {
+            controller.getDocument(dbInstance(), unitSupervisorUser, clock, documentId)
+        }
+    }
+
+    @Test
+    fun `unit supervisor sees hojks from duplicate during the primary's backup care, but not after`() {
+        // the HOJKS belongs to the duplicate; access comes via the primary child's backup care
+        val duplicateId = db.transaction { tx ->
+            tx.insert(DevPerson().copy(duplicateOf = child.id), DevPersonType.CHILD)
+        }
+        val documentId = insertDocument(duplicateId, templateIdHojks)
+
+        val activeBackupCareId = db.transaction { tx ->
+            tx.insert(
+                DevBackupCare(
+                    childId = child.id,
+                    unitId = daycare.id,
+                    period = FiniteDateRange(clock.today().minusDays(1), clock.today().plusDays(1)),
+                )
+            )
+        }
+
+        assertTrue(
+            controller
+                .getDocument(dbInstance(), unitSupervisorUser, clock, documentId)
+                .permittedActions
+                .contains(Action.ChildDocument.READ)
+        )
+
+        db.transaction { tx ->
+            tx.execute {
+                sql(
+                    "UPDATE backup_care SET end_date = ${bind(clock.today().minusDays(1))} WHERE id = ${bind(activeBackupCareId)}"
+                )
+            }
+        }
+
+        assertThrows<Forbidden> {
+            controller.getDocument(dbInstance(), unitSupervisorUser, clock, documentId)
+        }
+    }
+
+    private fun insertBackupCare(period: FiniteDateRange): GroupId = db.transaction { tx ->
+        val groupId = tx.insert(DevDaycareGroup(daycareId = daycare.id))
+        tx.insert(
+            DevBackupCare(
+                childId = child.id,
+                unitId = daycare.id,
+                groupId = groupId,
+                period = period,
+            )
+        )
+        groupId
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentServiceIntegrationTest.kt
@@ -33,6 +33,7 @@ import evaka.core.shared.dev.insert
 import evaka.core.shared.domain.DateRange
 import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.domain.MockEvakaClock
+import evaka.core.shared.security.PilotFeature
 import java.time.LocalTime
 import java.util.*
 import kotlin.test.assertEquals
@@ -50,7 +51,13 @@ class ChildDocumentServiceIntegrationTest : FullApplicationTest(resetDbBeforeEac
     final val clock = MockEvakaClock(2022, 1, 1, 15, 0)
 
     private val area = DevCareArea()
-    private val daycare = DevDaycare(areaId = area.id, language = Language.sv)
+    private val daycare =
+        DevDaycare(
+            areaId = area.id,
+            language = Language.fi,
+            enabledPilotFeatures =
+                setOf(PilotFeature.VASU_AND_PEDADOC, PilotFeature.CITIZEN_BASIC_DOCUMENT),
+        )
     private val adult = DevPerson(email = "joan.doe@example.com")
     private val child = DevPerson()
 

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplate.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplate.kt
@@ -21,6 +21,8 @@ import java.time.format.DateTimeFormatter
 import org.jdbi.v3.core.mapper.Nested
 import org.jdbi.v3.json.Json
 
+const val CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT = 60
+
 private data class Translations(val yes: String, val no: String)
 
 private val translationsFi = Translations(yes = "Kyllä", no = "Ei")

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
@@ -134,7 +134,7 @@ class DocumentTemplateController(
                         tx.getCurrentOrNextPlacement(
                             childId,
                             clock.today(),
-                            featureConfig.citizenDocumentCreationDaysBeforePlacement,
+                            CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT,
                         ) ?: return@read emptyList()
                     val placementHasStarted = !placement.startDate.isAfter(clock.today())
 

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplateController.kt
@@ -9,9 +9,7 @@ import evaka.core.AuditId
 import evaka.core.EvakaEnv
 import evaka.core.ForcePlainGet
 import evaka.core.absence.getDaycareIdByGroup
-import evaka.core.daycare.domain.Language
 import evaka.core.daycare.getDaycare
-import evaka.core.placement.PlacementType
 import evaka.core.shared.ChildId
 import evaka.core.shared.DocumentTemplateId
 import evaka.core.shared.FeatureConfig
@@ -26,8 +24,6 @@ import evaka.core.shared.domain.NotFound
 import evaka.core.shared.domain.UiLanguage
 import evaka.core.shared.security.AccessControl
 import evaka.core.shared.security.Action
-import evaka.core.shared.security.PilotFeature
-import java.time.LocalDate
 import org.springframework.http.ContentDisposition
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
@@ -136,25 +132,17 @@ class DocumentTemplateController(
                             clock.today(),
                             CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT,
                         ) ?: return@read emptyList()
-                    val placementHasStarted = !placement.startDate.isAfter(clock.today())
 
                     tx.getTemplateSummaries().filter {
                         it.published &&
                             it.validity.includes(clock.today()) &&
-                            it.placementTypes.contains(placement.type) &&
-                            // Allowed templates: same-language, EN CITIZEN_BASIC for any unit,
-                            // FI templates for EN units.
-                            (it.language.name.equals(
-                                placement.unitLanguage.name,
-                                ignoreCase = true,
-                            ) ||
-                                (it.language == UiLanguage.EN &&
-                                    it.type == ChildDocumentType.CITIZEN_BASIC) ||
-                                (placement.unitLanguage == Language.en &&
-                                    it.language == UiLanguage.FI)) &&
-                            isAllowedByPilotFeatures(it.type, placement.enabledPilotFeatures) &&
-                            // Not-yet-started placements qualify only for CITIZEN_BASIC documents
-                            (it.type == ChildDocumentType.CITIZEN_BASIC || placementHasStarted)
+                            isTemplateApplicableToPlacement(
+                                it.type,
+                                it.language,
+                                it.placementTypes,
+                                placement,
+                                clock.today(),
+                            )
                     }
                 }
             }
@@ -184,12 +172,7 @@ class DocumentTemplateController(
                         it.published &&
                             it.validity.includes(clock.today()) &&
                             (types.isEmpty() || types.contains(it.type)) &&
-                            // Allowed templates: same-language, EN CITIZEN_BASIC for any unit,
-                            // FI templates for EN units.
-                            (it.language.name.equals(unit.language.name, ignoreCase = true) ||
-                                (it.language == UiLanguage.EN &&
-                                    it.type == ChildDocumentType.CITIZEN_BASIC) ||
-                                (unit.language == Language.en && it.language == UiLanguage.FI)) &&
+                            languageMatches(it.language, it.type, unit.language) &&
                             isAllowedByPilotFeatures(it.type, unit.enabledPilotFeatures)
                     }
                 }
@@ -476,54 +459,3 @@ private fun assertUniqueIds(content: DocumentTemplateContent) {
     if (questionIds.size > questionIds.distinct().size)
         throw BadRequest("Found non unique question ids")
 }
-
-private data class PlacementInfo(
-    val startDate: LocalDate,
-    val type: PlacementType,
-    val unitLanguage: Language,
-    val enabledPilotFeatures: Set<PilotFeature>,
-)
-
-private fun Database.Read.getCurrentOrNextPlacement(
-    childId: ChildId,
-    date: LocalDate,
-    daysAllowedBeforePlacementStart: Int,
-): PlacementInfo? =
-    createQuery {
-            sql(
-                """
-SELECT pl.start_date, pl.type, d.language AS unit_language, d.enabled_pilot_features AS enabled_pilot_features
-FROM placement pl
-JOIN daycare d on d.id = pl.unit_id
-WHERE pl.child_id = ${bind(childId)}
-    AND pl.start_date <= ${bind(date.plusDays(daysAllowedBeforePlacementStart.toLong()))}
-    AND pl.end_date >= ${bind(date)}
-ORDER BY pl.start_date
-"""
-            )
-        }
-        .toList<PlacementInfo>()
-        .firstOrNull()
-
-private val PEDAGOGICAL_DOCUMENT_TYPES =
-    setOf(
-        ChildDocumentType.HOJKS,
-        ChildDocumentType.LEOPS,
-        ChildDocumentType.MIGRATED_LEOPS,
-        ChildDocumentType.MIGRATED_VASU,
-        ChildDocumentType.PEDAGOGICAL_ASSESSMENT,
-        ChildDocumentType.VASU,
-        ChildDocumentType.OTHER,
-    )
-
-private fun isPedagogicalDocument(type: ChildDocumentType) = type in PEDAGOGICAL_DOCUMENT_TYPES
-
-private fun isAllowedByPilotFeatures(
-    type: ChildDocumentType,
-    enabledPilotFeatures: Collection<PilotFeature>,
-): Boolean =
-    (PilotFeature.VASU_AND_PEDADOC in enabledPilotFeatures || !isPedagogicalDocument(type)) &&
-        (PilotFeature.OTHER_DECISION in enabledPilotFeatures ||
-            type != ChildDocumentType.OTHER_DECISION) &&
-        (PilotFeature.CITIZEN_BASIC_DOCUMENT in enabledPilotFeatures ||
-            type != ChildDocumentType.CITIZEN_BASIC)

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplatePlacement.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplatePlacement.kt
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2017-2023 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package evaka.core.document
+
+import evaka.core.daycare.domain.Language
+import evaka.core.placement.PlacementType
+import evaka.core.shared.ChildId
+import evaka.core.shared.db.Database
+import evaka.core.shared.domain.UiLanguage
+import evaka.core.shared.security.PilotFeature
+import java.time.LocalDate
+
+data class DocumentPlacementInfo(
+    val startDate: LocalDate,
+    val type: PlacementType,
+    val unitLanguage: Language,
+    val enabledPilotFeatures: Set<PilotFeature>,
+)
+
+fun Database.Read.getCurrentOrNextPlacement(
+    childId: ChildId,
+    date: LocalDate,
+    daysAllowedBeforePlacementStart: Int,
+): DocumentPlacementInfo? =
+    createQuery {
+            sql(
+                """
+SELECT pl.start_date, pl.type, d.language AS unit_language, d.enabled_pilot_features AS enabled_pilot_features
+FROM placement pl
+JOIN daycare d on d.id = pl.unit_id
+WHERE pl.child_id = ${bind(childId)}
+    AND pl.start_date <= ${bind(date.plusDays(daysAllowedBeforePlacementStart.toLong()))}
+    AND pl.end_date >= ${bind(date)}
+ORDER BY pl.start_date
+"""
+            )
+        }
+        .toList<DocumentPlacementInfo>()
+        .firstOrNull()
+
+private val PEDAGOGICAL_DOCUMENT_TYPES =
+    setOf(
+        ChildDocumentType.HOJKS,
+        ChildDocumentType.LEOPS,
+        ChildDocumentType.MIGRATED_LEOPS,
+        ChildDocumentType.MIGRATED_VASU,
+        ChildDocumentType.PEDAGOGICAL_ASSESSMENT,
+        ChildDocumentType.VASU,
+        ChildDocumentType.OTHER,
+    )
+
+private fun isPedagogicalDocument(type: ChildDocumentType) = type in PEDAGOGICAL_DOCUMENT_TYPES
+
+fun isAllowedByPilotFeatures(
+    type: ChildDocumentType,
+    enabledPilotFeatures: Collection<PilotFeature>,
+): Boolean =
+    (PilotFeature.VASU_AND_PEDADOC in enabledPilotFeatures || !isPedagogicalDocument(type)) &&
+        (PilotFeature.OTHER_DECISION in enabledPilotFeatures ||
+            type != ChildDocumentType.OTHER_DECISION) &&
+        (PilotFeature.CITIZEN_BASIC_DOCUMENT in enabledPilotFeatures ||
+            type != ChildDocumentType.CITIZEN_BASIC)
+
+// Allowed templates: same-language, EN CITIZEN_BASIC for any unit, FI templates for EN units.
+fun languageMatches(
+    templateLanguage: UiLanguage,
+    type: ChildDocumentType,
+    unitLanguage: Language,
+): Boolean =
+    templateLanguage.name.equals(unitLanguage.name, ignoreCase = true) ||
+        (templateLanguage == UiLanguage.EN && type == ChildDocumentType.CITIZEN_BASIC) ||
+        (unitLanguage == Language.en && templateLanguage == UiLanguage.FI)
+
+fun isTemplateApplicableToPlacement(
+    type: ChildDocumentType,
+    language: UiLanguage,
+    placementTypes: Set<PlacementType>,
+    placement: DocumentPlacementInfo,
+    today: LocalDate,
+): Boolean {
+    val placementHasStarted = !placement.startDate.isAfter(today)
+    return placementTypes.contains(placement.type) &&
+        languageMatches(language, type, placement.unitLanguage) &&
+        isAllowedByPilotFeatures(type, placement.enabledPilotFeatures) &&
+        // Not-yet-started placements qualify only for CITIZEN_BASIC documents
+        (type == ChildDocumentType.CITIZEN_BASIC || placementHasStarted)
+}

--- a/service/src/main/kotlin/evaka/core/document/DocumentTemplatePlacement.kt
+++ b/service/src/main/kotlin/evaka/core/document/DocumentTemplatePlacement.kt
@@ -34,11 +34,11 @@ WHERE pl.child_id = ${bind(childId)}
     AND pl.start_date <= ${bind(date.plusDays(daysAllowedBeforePlacementStart.toLong()))}
     AND pl.end_date >= ${bind(date)}
 ORDER BY pl.start_date
+LIMIT 1
 """
             )
         }
-        .toList<DocumentPlacementInfo>()
-        .firstOrNull()
+        .exactlyOneOrNull<DocumentPlacementInfo>()
 
 private val PEDAGOGICAL_DOCUMENT_TYPES =
     setOf(

--- a/service/src/main/kotlin/evaka/core/document/childdocument/ChildDocumentController.kt
+++ b/service/src/main/kotlin/evaka/core/document/childdocument/ChildDocumentController.kt
@@ -12,10 +12,13 @@ import evaka.core.caseprocess.deleteProcessByDocumentId
 import evaka.core.caseprocess.insertCaseProcess
 import evaka.core.caseprocess.insertCaseProcessHistoryRow
 import evaka.core.caseprocess.updateDocumentCaseProcessHistory
+import evaka.core.document.CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT
 import evaka.core.document.ChildDocumentType
 import evaka.core.document.DocumentTemplate
 import evaka.core.document.DocumentTemplateContent
+import evaka.core.document.getCurrentOrNextPlacement
 import evaka.core.document.getTemplate
+import evaka.core.document.isTemplateApplicableToPlacement
 import evaka.core.pis.Employee
 import evaka.core.pis.listPersonByDuplicateOf
 import evaka.core.placement.getPlacementsForChildDuring
@@ -1030,6 +1033,24 @@ private fun getTemplate(
                 throw BadRequest("Invalid template")
             }
         } ?: throw NotFound()
+
+    val placement =
+        tx.getCurrentOrNextPlacement(
+            body.childId,
+            clock.today(),
+            CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT,
+        ) ?: throw BadRequest("Child has no current or upcoming placement for the template")
+    if (
+        !isTemplateApplicableToPlacement(
+            template.type,
+            template.language,
+            template.placementTypes,
+            placement,
+            clock.today(),
+        )
+    ) {
+        throw BadRequest("Template ${body.templateId} is not applicable to the child's placement")
+    }
 
     val sameTemplateAlreadyStarted =
         tx.getNonCompletedChildDocumentChildIds(template.id, setOf(body.childId))

--- a/service/src/main/kotlin/evaka/core/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/evaka/core/shared/FeatureConfig.kt
@@ -156,12 +156,6 @@ data class FeatureConfig(
 
     /** Whether placement decisions can be made in Swedish. */
     val placementDecisionSwedishLanguageEnabled: Boolean,
-
-    /**
-     * How many days before a placement starts a guardian-fillable (`CITIZEN_BASIC`) child document
-     * can be created for the child.
-     */
-    val citizenDocumentCreationDaysBeforePlacement: Int = 60,
 )
 
 enum class ArchiveProcessType {

--- a/service/src/main/kotlin/evaka/core/shared/security/AccessControlCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/AccessControlCitizen.kt
@@ -5,17 +5,14 @@
 package evaka.core.shared.security
 
 import evaka.core.CitizenCalendarEnv
-import evaka.core.shared.FeatureConfig
+import evaka.core.document.CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT
 import evaka.core.shared.PersonId
 import evaka.core.shared.db.Database
 import evaka.core.shared.domain.EvakaClock
 import org.springframework.stereotype.Service
 
 @Service
-class AccessControlCitizen(
-    val citizenCalendarEnv: CitizenCalendarEnv,
-    val featureConfig: FeatureConfig,
-) {
+class AccessControlCitizen(val citizenCalendarEnv: CitizenCalendarEnv) {
     fun getPermittedFeatures(
         tx: Database.Read,
         clock: EvakaClock,
@@ -36,7 +33,7 @@ class AccessControlCitizen(
                 tx.citizenHasAccessToChildDocumentation(
                     clock,
                     citizen,
-                    featureConfig.citizenDocumentCreationDaysBeforePlacement,
+                    CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT,
                 ),
         )
     }

--- a/service/src/main/kotlin/evaka/core/shared/security/Action.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/Action.kt
@@ -2235,9 +2235,14 @@ sealed interface Action {
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
                 .inPlacementUnitOfChildOfChildDocument(),
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
+                .inActiveBackupCareUnitOfChildOfChildDocument(),
+            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
                 .inPlacementUnitOfDuplicateChildOfHojksChildDocument(),
+            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
+                .inActiveBackupCareUnitOfDuplicateChildOfHojksChildDocument(),
             HasGroupRole(STAFF).inPlacementGroupOfDuplicateChildOfHojksChildDocument(),
             HasGroupRole(STAFF).inPlacementGroupOfChildOfChildDocumentWithFutureAccess(),
+            HasGroupRole(STAFF).inActiveBackupCareGroupOfChildOfChildDocument(),
             IsEmployee.andIsDecisionMakerForChildDocumentDecision(),
         ),
         READ_METADATA(HasGlobalRole(ADMIN)),
@@ -2247,9 +2252,14 @@ sealed interface Action {
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
                 .inPlacementUnitOfChildOfChildDocument(),
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
+                .inActiveBackupCareUnitOfChildOfChildDocument(),
+            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
                 .inPlacementUnitOfDuplicateChildOfHojksChildDocument(),
+            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
+                .inActiveBackupCareUnitOfDuplicateChildOfHojksChildDocument(),
             HasGroupRole(STAFF).inPlacementGroupOfDuplicateChildOfHojksChildDocument(),
             HasGroupRole(STAFF).inPlacementGroupOfChildOfChildDocumentWithFutureAccess(),
+            HasGroupRole(STAFF).inActiveBackupCareGroupOfChildOfChildDocument(),
             IsEmployee.andIsDecisionMakerForChildDocumentDecision(),
         ),
         DOWNLOAD_VERSION(HasGlobalRole(ADMIN)),

--- a/service/src/main/kotlin/evaka/core/shared/security/Action.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/Action.kt
@@ -2236,10 +2236,6 @@ sealed interface Action {
                 .inPlacementUnitOfChildOfChildDocument(),
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
                 .inActiveBackupCareUnitOfChildOfChildDocument(),
-            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
-                .inPlacementUnitOfDuplicateChildOfHojksChildDocument(),
-            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
-                .inActiveBackupCareUnitOfDuplicateChildOfHojksChildDocument(),
             HasGroupRole(STAFF).inPlacementGroupOfDuplicateChildOfHojksChildDocument(),
             HasGroupRole(STAFF).inPlacementGroupOfChildOfChildDocumentWithFutureAccess(),
             HasGroupRole(STAFF).inActiveBackupCareGroupOfChildOfChildDocument(),
@@ -2253,10 +2249,6 @@ sealed interface Action {
                 .inPlacementUnitOfChildOfChildDocument(),
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
                 .inActiveBackupCareUnitOfChildOfChildDocument(),
-            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
-                .inPlacementUnitOfDuplicateChildOfHojksChildDocument(),
-            HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER)
-                .inActiveBackupCareUnitOfDuplicateChildOfHojksChildDocument(),
             HasGroupRole(STAFF).inPlacementGroupOfDuplicateChildOfHojksChildDocument(),
             HasGroupRole(STAFF).inPlacementGroupOfChildOfChildDocumentWithFutureAccess(),
             HasGroupRole(STAFF).inActiveBackupCareGroupOfChildOfChildDocument(),

--- a/service/src/main/kotlin/evaka/core/shared/security/Action.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/Action.kt
@@ -6,6 +6,7 @@ package evaka.core.shared.security
 
 import evaka.core.daycare.CareType
 import evaka.core.daycare.domain.ProviderType
+import evaka.core.document.CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT
 import evaka.core.shared.AbsenceApplicationId
 import evaka.core.shared.ApplicationId
 import evaka.core.shared.ApplicationNoteId
@@ -1157,7 +1158,10 @@ sealed interface Action {
         CREATE_CHILD_DOCUMENT(
             HasGlobalRole(ADMIN),
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER).inPlacementUnitOfChild(),
-            HasGroupRole(STAFF).inPlacementGroupOfChildWithFutureAccess(),
+            HasGroupRole(STAFF)
+                .inPlacementGroupOfChildWithFutureAccess(
+                    CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT
+                ),
         ),
         CREATE_CHILD_DECISION_DOCUMENT(
             HasGlobalRole(ADMIN),
@@ -1166,7 +1170,10 @@ sealed interface Action {
         READ_CHILD_DOCUMENT(
             HasGlobalRole(ADMIN),
             HasUnitRole(UNIT_SUPERVISOR, SPECIAL_EDUCATION_TEACHER).inPlacementUnitOfChild(),
-            HasGroupRole(STAFF).inPlacementGroupOfChildWithFutureAccess(),
+            HasGroupRole(STAFF)
+                .inPlacementGroupOfChildWithFutureAccess(
+                    CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT
+                ),
         ),
         CREATE_PEDAGOGICAL_DOCUMENT(
             HasGlobalRole(ADMIN),

--- a/service/src/main/kotlin/evaka/core/shared/security/actionrule/HasGroupRole.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/actionrule/HasGroupRole.kt
@@ -244,8 +244,8 @@ WHERE employee_id = ${bind(user.id)}
             )
 
         return rule { user, now ->
-            val futureAccessDate = now.toLocalDate().plusDays(daysBeforePlacement.toLong())
-            val pastAccessDate = now.toLocalDate().minusDays(daysBeforePlacement.toLong())
+            val today = now.toLocalDate()
+            val futureAccessDate = today.plusDays(daysBeforePlacement.toLong())
             sql(
                 """
 SELECT child_document.id AS id, daycare_acl.role, enabled_pilot_features AS unit_features, provider_type AS unit_provider_type
@@ -257,12 +257,19 @@ JOIN daycare_group ON dgp.daycare_group_id = daycare_group.id
 JOIN daycare_acl ON group_acl.employee_id = daycare_acl.employee_id AND daycare_group.daycare_id = daycare_acl.daycare_id
 JOIN daycare ON daycare_acl.daycare_id = daycare.id
 WHERE daycare_acl.employee_id = ${bind(user.id)}
-  AND dgp.start_date <= ${bind(futureAccessDate)}
-  AND dgp.end_date >= ${bind(now.toLocalDate())}
+  AND dgp.start_date <= CASE WHEN child_document.type = 'CITIZEN_BASIC' THEN ${bind(futureAccessDate)} ELSE ${bind(today)} END
+  AND dgp.end_date >= ${bind(today)}
   AND ${predicate(childDocumentFilters)}
+            """
+                    .trimIndent()
+            )
+        }
+    }
 
-UNION ALL
-
+    fun inActiveBackupCareGroupOfChildOfChildDocument() =
+        rule<ChildDocumentId> { user, now ->
+            sql(
+                """
 SELECT child_document.id AS id, daycare_acl.role, enabled_pilot_features AS unit_features, provider_type AS unit_provider_type
 FROM child_document
 JOIN backup_care bc ON child_document.child_id = bc.child_id
@@ -271,25 +278,48 @@ JOIN daycare_group ON bc.group_id = daycare_group.id
 JOIN daycare_acl ON group_acl.employee_id = daycare_acl.employee_id AND daycare_group.daycare_id = daycare_acl.daycare_id
 JOIN daycare ON daycare_acl.daycare_id = daycare.id
 WHERE daycare_acl.employee_id = ${bind(user.id)}
-  AND bc.end_date > ${bind(pastAccessDate)}
-  AND ${predicate(childDocumentFilters)}
+  AND bc.start_date <= ${bind(now.toLocalDate())}
+  AND bc.end_date >= ${bind(now.toLocalDate())}
             """
                     .trimIndent()
             )
         }
-    }
 
     fun inPlacementGroupOfDuplicateChildOfHojksChildDocument() =
         rule<ChildDocumentId> { user, now ->
+            val today = now.toLocalDate()
             sql(
                 """
-SELECT child_document.id AS id, role, enabled_pilot_features AS unit_features, provider_type AS unit_provider_type
+SELECT child_document.id AS id, daycare_acl.role, enabled_pilot_features AS unit_features, provider_type AS unit_provider_type
 FROM child_document
 JOIN document_template ON document_template.id = child_document.template_id
 JOIN person ON person.id = child_document.child_id
-JOIN employee_child_group_acl(${bind(now.toLocalDate())}) acl ON acl.child_id = person.duplicate_of
-JOIN daycare ON acl.daycare_id = daycare.id
-WHERE employee_id = ${bind(user.id)} AND document_template.type = 'HOJKS'
+JOIN placement dp ON dp.child_id = person.duplicate_of
+JOIN daycare_group_placement dgp ON dp.id = dgp.daycare_placement_id
+JOIN daycare_group_acl AS group_acl USING (daycare_group_id)
+JOIN daycare_group ON dgp.daycare_group_id = daycare_group.id
+JOIN daycare_acl ON group_acl.employee_id = daycare_acl.employee_id AND daycare_group.daycare_id = daycare_acl.daycare_id
+JOIN daycare ON daycare_acl.daycare_id = daycare.id
+WHERE daycare_acl.employee_id = ${bind(user.id)}
+  AND document_template.type = 'HOJKS'
+  AND dgp.start_date <= ${bind(today)}
+  AND dgp.end_date >= ${bind(today)}
+
+UNION ALL
+
+SELECT child_document.id AS id, daycare_acl.role, enabled_pilot_features AS unit_features, provider_type AS unit_provider_type
+FROM child_document
+JOIN document_template ON document_template.id = child_document.template_id
+JOIN person ON person.id = child_document.child_id
+JOIN backup_care bc ON bc.child_id = person.duplicate_of
+JOIN daycare_group_acl AS group_acl ON bc.group_id = group_acl.daycare_group_id
+JOIN daycare_group ON bc.group_id = daycare_group.id
+JOIN daycare_acl ON group_acl.employee_id = daycare_acl.employee_id AND daycare_group.daycare_id = daycare_acl.daycare_id
+JOIN daycare ON daycare_acl.daycare_id = daycare.id
+WHERE daycare_acl.employee_id = ${bind(user.id)}
+  AND document_template.type = 'HOJKS'
+  AND bc.start_date <= ${bind(today)}
+  AND bc.end_date >= ${bind(today)}
             """
                     .trimIndent()
             )

--- a/service/src/main/kotlin/evaka/core/shared/security/actionrule/HasGroupRole.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/actionrule/HasGroupRole.kt
@@ -5,6 +5,7 @@
 package evaka.core.shared.security.actionrule
 
 import evaka.core.daycare.domain.ProviderType
+import evaka.core.document.CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT
 import evaka.core.document.childdocument.DocumentStatus
 import evaka.core.shared.AbsenceApplicationId
 import evaka.core.shared.ChildDocumentId
@@ -24,10 +25,6 @@ import java.util.EnumSet
 
 private typealias GetGroupRoles =
     QuerySql.Builder.(user: AuthenticatedUser.Employee, now: HelsinkiDateTime) -> QuerySql
-
-// Default number of days before a placement starts that staff can access CITIZEN_BASIC
-// type of child documents.
-private const val DEFAULT_FUTURE_ACCESS_DAYS = 30
 
 data class HasGroupRole(
     val oneOf: EnumSet<UserRole>,
@@ -165,9 +162,7 @@ WHERE employee_id = ${bind(user.id)}
             )
         }
 
-    fun inPlacementGroupOfChildWithFutureAccess(
-        daysBeforePlacement: Int = DEFAULT_FUTURE_ACCESS_DAYS
-    ) =
+    fun inPlacementGroupOfChildWithFutureAccess(daysBeforePlacement: Int) =
         rule<ChildId> { user, now ->
             val futureAccessDate = now.toLocalDate().plusDays(daysBeforePlacement.toLong())
             val pastAccessDate = now.toLocalDate().minusDays(daysBeforePlacement.toLong())
@@ -216,7 +211,7 @@ WHERE employee_id = ${bind(user.id)}
         }
 
     fun inPlacementGroupOfChildOfChildDocumentWithFutureAccess(
-        daysBeforePlacement: Int = DEFAULT_FUTURE_ACCESS_DAYS,
+        daysBeforePlacement: Int = CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT,
         editable: Boolean = false,
         deletable: Boolean = false,
         publishable: Boolean = false,

--- a/service/src/main/kotlin/evaka/core/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/actionrule/HasUnitRole.kt
@@ -632,7 +632,7 @@ WHERE employee_id = ${bind(user.id)}
         deletable: Boolean = false,
         publishable: Boolean = false,
         canGoToPrevStatus: Boolean = false,
-        cfg: ChildAclConfig = ChildAclConfig(),
+        cfg: ChildAclConfig = ChildAclConfig(backupCare = false),
     ) =
         ruleViaChildAcl<ChildDocumentId>(cfg) { _, _ ->
             sql(
@@ -648,8 +648,23 @@ ${if (canGoToPrevStatus) "AND ((type = 'OTHER_DECISION') OR (type = 'CITIZEN_BAS
             )
         }
 
+    fun inActiveBackupCareUnitOfChildOfChildDocument() =
+        rule<ChildDocumentId> { user, now ->
+            sql(
+                """
+SELECT child_document.id AS id, daycare_acl.role, daycare_acl.daycare_id AS unit_id
+FROM child_document
+JOIN backup_care bc ON child_document.child_id = bc.child_id
+JOIN daycare_acl ON bc.unit_id = daycare_acl.daycare_id
+WHERE daycare_acl.employee_id = ${bind(user.id)}
+  AND bc.start_date <= ${bind(now.toLocalDate())}
+  AND bc.end_date >= ${bind(now.toLocalDate())}
+            """
+            )
+        }
+
     fun inPlacementUnitOfDuplicateChildOfHojksChildDocument(
-        cfg: ChildAclConfig = ChildAclConfig()
+        cfg: ChildAclConfig = ChildAclConfig(backupCare = false)
     ) =
         ruleViaChildAcl<ChildDocumentId>(cfg) { _, _ ->
             sql(
@@ -659,6 +674,24 @@ FROM child_document
 JOIN document_template ON document_template.id = child_document.template_id
 JOIN person ON person.id = child_document.child_id
 WHERE document_template.type = 'HOJKS'
+            """
+            )
+        }
+
+    fun inActiveBackupCareUnitOfDuplicateChildOfHojksChildDocument() =
+        rule<ChildDocumentId> { user, now ->
+            sql(
+                """
+SELECT child_document.id AS id, daycare_acl.role, daycare_acl.daycare_id AS unit_id
+FROM child_document
+JOIN document_template ON document_template.id = child_document.template_id
+JOIN person ON person.id = child_document.child_id
+JOIN backup_care bc ON bc.child_id = person.duplicate_of
+JOIN daycare_acl ON bc.unit_id = daycare_acl.daycare_id
+WHERE daycare_acl.employee_id = ${bind(user.id)}
+  AND document_template.type = 'HOJKS'
+  AND bc.start_date <= ${bind(now.toLocalDate())}
+  AND bc.end_date >= ${bind(now.toLocalDate())}
             """
             )
         }

--- a/service/src/main/kotlin/evaka/core/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/actionrule/HasUnitRole.kt
@@ -663,39 +663,6 @@ WHERE daycare_acl.employee_id = ${bind(user.id)}
             )
         }
 
-    fun inPlacementUnitOfDuplicateChildOfHojksChildDocument(
-        cfg: ChildAclConfig = ChildAclConfig(backupCare = false)
-    ) =
-        ruleViaChildAcl<ChildDocumentId>(cfg) { _, _ ->
-            sql(
-                """
-SELECT child_document.id AS id, person.duplicate_of AS child_id
-FROM child_document
-JOIN document_template ON document_template.id = child_document.template_id
-JOIN person ON person.id = child_document.child_id
-WHERE document_template.type = 'HOJKS'
-            """
-            )
-        }
-
-    fun inActiveBackupCareUnitOfDuplicateChildOfHojksChildDocument() =
-        rule<ChildDocumentId> { user, now ->
-            sql(
-                """
-SELECT child_document.id AS id, daycare_acl.role, daycare_acl.daycare_id AS unit_id
-FROM child_document
-JOIN document_template ON document_template.id = child_document.template_id
-JOIN person ON person.id = child_document.child_id
-JOIN backup_care bc ON bc.child_id = person.duplicate_of
-JOIN daycare_acl ON bc.unit_id = daycare_acl.daycare_id
-WHERE daycare_acl.employee_id = ${bind(user.id)}
-  AND document_template.type = 'HOJKS'
-  AND bc.start_date <= ${bind(now.toLocalDate())}
-  AND bc.end_date >= ${bind(now.toLocalDate())}
-            """
-            )
-        }
-
     fun inPlacementUnitOfChildOfDailyServiceTime(cfg: ChildAclConfig = ChildAclConfig()) =
         ruleViaChildAcl<DailyServiceTimesId>(cfg) { _, _ ->
             sql(

--- a/service/src/main/kotlin/evaka/instance/turku/security/TurkuActionRuleMapping.kt
+++ b/service/src/main/kotlin/evaka/instance/turku/security/TurkuActionRuleMapping.kt
@@ -464,10 +464,38 @@ class TurkuActionRuleMapping : ActionRuleMapping {
                     sequenceOf(
                         HasUnitRole(UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY)
                             .inPlacementUnitOfChildOfChildDocument() as ScopedActionRule<in T>
+                    ) +
+                    sequenceOf(
+                        HasUnitRole(UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY)
+                            .inActiveBackupCareUnitOfChildOfChildDocument()
+                            as ScopedActionRule<in T>
                     )
             }
 
-            Action.ChildDocument.DOWNLOAD,
+            Action.ChildDocument.DOWNLOAD -> {
+                @Suppress("UNCHECKED_CAST")
+                action.defaultRules.asSequence() +
+                    // These status flags AND together, so the rule permits action only
+                    // on DRAFT, unpublished documents that are decision documents (or
+                    // empty citizen-basic drafts). This intentionally scopes the
+                    // secretary to handling decision documents, not pedagogical/VASU
+                    // documents.
+                    sequenceOf(
+                        HasUnitRole(UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY)
+                            .inPlacementUnitOfChildOfChildDocument(
+                                editable = true,
+                                deletable = true,
+                                publishable = true,
+                                canGoToPrevStatus = true,
+                            ) as ScopedActionRule<in T>
+                    ) +
+                    sequenceOf(
+                        HasUnitRole(UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY)
+                            .inActiveBackupCareUnitOfChildOfChildDocument()
+                            as ScopedActionRule<in T>
+                    )
+            }
+
             Action.ChildDocument.UPDATE,
             Action.ChildDocument.PUBLISH,
             Action.ChildDocument.NEXT_STATUS,
@@ -476,6 +504,11 @@ class TurkuActionRuleMapping : ActionRuleMapping {
             Action.ChildDocument.PROPOSE_DECISION -> {
                 @Suppress("UNCHECKED_CAST")
                 action.defaultRules.asSequence() +
+                    // These status flags AND together, so the rule permits action only
+                    // on DRAFT, unpublished documents that are decision documents (or
+                    // empty citizen-basic drafts). This intentionally scopes the
+                    // secretary to handling decision documents, not pedagogical/VASU
+                    // documents.
                     sequenceOf(
                         HasUnitRole(UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY)
                             .inPlacementUnitOfChildOfChildDocument(


### PR DESCRIPTION
Päivitetty lisäksi asiakirjojen luku- ja muokkausoikeuksia. Uudet oikeudet on kuvattu [wikissä](https://github.com/espoon-voltti/evaka/wiki/Lomakepohjat-ja-lapsen-asiakirjat#henkil%C3%B6st%C3%B6n-k%C3%A4ytt%C3%B6oikeudet-lapsen-asiakirjoihin).