### PR TITLE
Tehdään poistetun viestin ruotsinkielisten tekstien näkyvyys kuntakohtaisesti konfiguroitavaksi

### DIFF
--- a/frontend/src/employee-frontend/components/messages/ConfirmDeleteMessage.tsx
+++ b/frontend/src/employee-frontend/components/messages/ConfirmDeleteMessage.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { useQueryClient } from '@tanstack/react-query'
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 
 import type {
@@ -22,6 +22,7 @@ import { defaultMargins, Gap } from 'lib-components/white-space'
 import { faTrash } from 'lib-icons'
 
 import { useTranslation } from '../../state/i18n'
+import { UserContext } from '../../state/user'
 
 import { deleteMessageContentMutation } from './queries'
 
@@ -48,8 +49,17 @@ export const ConfirmDeleteMessage = React.memo(function ConfirmDeleteMessage({
 }: Props) {
   const { i18n } = useTranslation()
   const t = i18n.messages.deletion.modal
+  const { featureConfig } = useContext(UserContext)
   const queryClient = useQueryClient()
   const [alreadyDeleted, setAlreadyDeleted] = useState(false)
+
+  // Deleted message placeholder text in multiple languages.
+  // Swedish is excluded if the feature flag is set to false.
+  const svEnabled =
+    featureConfig?.messageDeletedSwedishLanguageEnabled !== false
+  const deletedMessagePlaceholderLines = Object.entries(t.placeholderQuote)
+    .filter(([language]) => svEnabled || language !== 'sv')
+    .map(([, line]) => line)
 
   if (alreadyDeleted) {
     // Shown when a concurrent delete was detected on confirm (see onFailure below).
@@ -76,7 +86,7 @@ export const ConfirmDeleteMessage = React.memo(function ConfirmDeleteMessage({
     >
       <P>{t.intro}</P>
       <Blockquote data-qa="placeholder-quote">
-        {t.placeholderQuote.join('\n\n')}
+        {deletedMessagePlaceholderLines.join('\n\n')}
       </Blockquote>
       <H3>{t.stepsHeader}</H3>
       <P>{t.stepsBody1}</P>

--- a/frontend/src/employee-frontend/components/messages/ConfirmDeleteMessage.tsx
+++ b/frontend/src/employee-frontend/components/messages/ConfirmDeleteMessage.tsx
@@ -53,14 +53,6 @@ export const ConfirmDeleteMessage = React.memo(function ConfirmDeleteMessage({
   const queryClient = useQueryClient()
   const [alreadyDeleted, setAlreadyDeleted] = useState(false)
 
-  // Deleted message placeholder text in multiple languages.
-  // Swedish is excluded if the feature flag is set to false.
-  const svEnabled =
-    featureConfig?.messageDeletedSwedishLanguageEnabled !== false
-  const deletedMessagePlaceholderLines = Object.entries(t.placeholderQuote)
-    .filter(([language]) => svEnabled || language !== 'sv')
-    .map(([, line]) => line)
-
   if (alreadyDeleted) {
     // Shown when a concurrent delete was detected on confirm (see onFailure below).
     return (
@@ -86,7 +78,7 @@ export const ConfirmDeleteMessage = React.memo(function ConfirmDeleteMessage({
     >
       <P>{t.intro}</P>
       <Blockquote data-qa="placeholder-quote">
-        {deletedMessagePlaceholderLines.join('\n\n')}
+        {featureConfig?.deletedMessagePlaceholderBody}
       </Blockquote>
       <H3>{t.stepsHeader}</H3>
       <P>{t.stepsBody1}</P>

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -123,7 +123,7 @@ export interface EmployeeFeatureConfig {
   allowEnglishChildDocumentsForAllTypes: boolean
   decisionReasoningGenericRemoval: boolean
   decisionReasoningsEnabled: boolean
-  messageDeletedSwedishLanguageEnabled: boolean
+  deletedMessagePlaceholderBody: string
   messageSupportEmail: string | null
   openRangesHolidayQuestionnaire: boolean
   replacementInvoices: boolean

--- a/frontend/src/lib-common/generated/api-types/shared.ts
+++ b/frontend/src/lib-common/generated/api-types/shared.ts
@@ -123,6 +123,7 @@ export interface EmployeeFeatureConfig {
   allowEnglishChildDocumentsForAllTypes: boolean
   decisionReasoningGenericRemoval: boolean
   decisionReasoningsEnabled: boolean
+  messageDeletedSwedishLanguageEnabled: boolean
   messageSupportEmail: string | null
   openRangesHolidayQuestionnaire: boolean
   replacementInvoices: boolean

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4625,11 +4625,11 @@ export const fi = {
         title: 'Viestin poistaminen',
         intro:
           'Toiminto on tarkoitettu vain tilanteeseen, jossa viesti on lähetetty vahingossa väärälle vastaanottajalle. Poistetun viestin sisältö korvataan jokaisen vastaanottajan eVakassa seuraavalla tekstillä:',
-        placeholderQuote: [
-          'Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.',
-          'Avsändaren har tagit bort meddelandet. Du behöver inte göra något.',
-          'The sender has deleted this message. No action is needed on your part.'
-        ],
+        placeholderQuote: {
+          fi: 'Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.',
+          sv: 'Avsändaren har tagit bort meddelandet. Du behöver inte göra något.',
+          en: 'The sender has deleted this message. No action is needed on your part.'
+        },
         stepsHeader: 'Toimenpiteet välittömästi poiston jälkeen',
         stepsBody1:
           'Väärälle vastaanottajalle lähetetystä viestistä tulee aina tehdä tietosuojailmoitus. Ota poiston jälkeen yhteyttä kunnan eVaka-tukeen jatkotoimenpiteitä varten.',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4625,11 +4625,6 @@ export const fi = {
         title: 'Viestin poistaminen',
         intro:
           'Toiminto on tarkoitettu vain tilanteeseen, jossa viesti on lähetetty vahingossa väärälle vastaanottajalle. Poistetun viestin sisältö korvataan jokaisen vastaanottajan eVakassa seuraavalla tekstillä:',
-        placeholderQuote: {
-          fi: 'Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.',
-          sv: 'Avsändaren har tagit bort meddelandet. Du behöver inte göra något.',
-          en: 'The sender has deleted this message. No action is needed on your part.'
-        },
         stepsHeader: 'Toimenpiteet välittömästi poiston jälkeen',
         stepsBody1:
           'Väärälle vastaanottajalle lähetetystä viestistä tulee aina tehdä tietosuojailmoitus. Ota poiston jälkeen yhteyttä kunnan eVaka-tukeen jatkotoimenpiteitä varten.',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
@@ -4660,11 +4660,11 @@ export const sv: typeof fi = {
         title: 'Radera meddelandet',
         intro:
           'Funktionen är endast avsedd för situationer där ett meddelande av misstag har skickats till fel mottagare. Det raderade meddelandets innehåll ersätts hos varje mottagare i eVaka med följande text:',
-        placeholderQuote: [
-          'Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.',
-          'Avsändaren har tagit bort meddelandet. Du behöver inte göra något.',
-          'The sender has deleted this message. No action is needed on your part.'
-        ],
+        placeholderQuote: {
+          fi: 'Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.',
+          sv: 'Avsändaren har tagit bort meddelandet. Du behöver inte göra något.',
+          en: 'The sender has deleted this message. No action is needed on your part.'
+        },
         stepsHeader: 'Åtgärder omedelbart efter raderingen',
         stepsBody1:
           'För ett meddelande som skickats till fel mottagare ska alltid en dataskyddsanmälan göras. Kontakta kommunens eVaka-stöd efter raderingen för fortsatta åtgärder.',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
@@ -4660,11 +4660,6 @@ export const sv: typeof fi = {
         title: 'Radera meddelandet',
         intro:
           'Funktionen är endast avsedd för situationer där ett meddelande av misstag har skickats till fel mottagare. Det raderade meddelandets innehåll ersätts hos varje mottagare i eVaka med följande text:',
-        placeholderQuote: {
-          fi: 'Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.',
-          sv: 'Avsändaren har tagit bort meddelandet. Du behöver inte göra något.',
-          en: 'The sender has deleted this message. No action is needed on your part.'
-        },
         stepsHeader: 'Åtgärder omedelbart efter raderingen',
         stepsBody1:
           'För ett meddelande som skickats till fel mottagare ska alltid en dataskyddsanmälan göras. Kontakta kommunens eVaka-stöd efter raderingen för fortsatta åtgärder.',

--- a/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
@@ -1579,7 +1579,11 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_CONFIRMATION, application.status)
 
-            val notes = tx.getApplicationNotes(applicationId)
+            val notes =
+                tx.getApplicationNotes(
+                    applicationId,
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                )
             assertEquals(emptyList(), notes)
 
             val decisionsByApplication =
@@ -1668,7 +1672,11 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             val application = tx.fetchApplicationDetails(applicationId)!!
             assertEquals(ApplicationStatus.WAITING_UNIT_CONFIRMATION, application.status)
 
-            val notes = tx.getApplicationNotes(applicationId)
+            val notes =
+                tx.getApplicationNotes(
+                    applicationId,
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                )
             assertEquals(emptyList(), notes)
 
             val decisionDrafts = tx.fetchDecisionDrafts(applicationId)

--- a/service/src/integrationTest/kotlin/evaka/core/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/messaging/MessageIntegrationTest.kt
@@ -42,6 +42,7 @@ import evaka.core.shared.auth.CitizenAuthLevel
 import evaka.core.shared.auth.UserRole
 import evaka.core.shared.auth.insertDaycareAclRow
 import evaka.core.shared.auth.syncDaycareGroupAcl
+import evaka.core.shared.config.testFeatureConfig
 import evaka.core.shared.db.Database
 import evaka.core.shared.dev.*
 import evaka.core.shared.domain.*
@@ -1278,7 +1279,11 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
 
             db.transaction { tx ->
                 // then a note is created on the application
-                val applicationNotes = tx.getApplicationNotes(applicationId)
+                val applicationNotes =
+                    tx.getApplicationNotes(
+                        applicationId,
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                    )
                 assertEquals(1, applicationNotes.size)
                 val note = applicationNotes.first()
                 assertEquals(messageContent, note.content)
@@ -1813,7 +1818,15 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             }
 
             // then sent message is shown as one
-            val sentMessages = db.read { it.getMessagesSentByAccount(employee1Account, 10, 1) }
+            val sentMessages = db.read {
+                it.getMessagesSentByAccount(
+                    employee1Account,
+                    10,
+                    1,
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                    deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+                )
+            }
             assertEquals(1, sentMessages.total)
             assertEquals(1, sentMessages.data.size)
             assertEquals(recipientNames, sentMessages.data.flatMap { it.recipientNames })
@@ -3312,6 +3325,8 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
                         municipalAccountName = "Municipal Account",
                         serviceWorkerAccountName = "Service Worker",
                         financeAccountName = "Finance",
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     )
                 }
                 assertEquals(1, threads.data.size)
@@ -3326,7 +3341,13 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             }
 
             val sentMessages = db.read {
-                it.getMessagesSentByAccount(accountId = municipalAccount, pageSize = 20, page = 1)
+                it.getMessagesSentByAccount(
+                    accountId = municipalAccount,
+                    pageSize = 20,
+                    page = 1,
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                    deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+                )
             }
             assertEquals(1, sentMessages.data.size)
             assertEquals("Municipal Bulletin", sentMessages.data.first().threadTitle)
@@ -3726,7 +3747,17 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
         private fun getThreadAs(
             accountId: MessageAccountId,
             threadId: MessageThreadId,
-        ): MessageThread = db.read { tx -> tx.getMessageThread(accountId, threadId, "", "", "") }
+        ): MessageThread = db.read { tx ->
+            tx.getMessageThread(
+                accountId,
+                threadId,
+                "",
+                "",
+                "",
+                deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+            )
+        }
 
         private fun deletionInfoOf(messageId: MessageId): DeletionInfo = db.read { tx ->
             tx.createQuery {
@@ -3864,7 +3895,7 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             val person1ThreadId = threadIdOfContentFor(contentId, person1Account)
 
             val recipientView = getThreadAs(person1Account, person1ThreadId).messages.single()
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, recipientView.content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderBody, recipientView.content)
         }
 
         @Test
@@ -3940,7 +3971,7 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             deleteContent(employee1, employee1Account, messageId)
 
             val message = getThreadAs(person1Account, threadId).messages.single()
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, message.content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderBody, message.content)
             assertEquals(emptyList(), message.attachments)
             assertNotNull(message.contentDeletedAt)
         }
@@ -3953,7 +3984,7 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             deleteContent(employee1, employee1Account, messageId)
 
             val message = getThreadAs(employee1Account, threadId).messages.single()
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, message.content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderBody, message.content)
             assertEquals(emptyList(), message.attachments)
             assertNotNull(message.contentDeletedAt)
         }
@@ -3966,11 +3997,11 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             deleteContent(employee1, employee1Account, messageId)
 
             assertEquals(
-                DELETED_MESSAGE_PLACEHOLDER_TITLE,
+                testFeatureConfig.deletedMessagePlaceholderTitle,
                 getThreadAs(person1Account, threadId).title,
             )
             assertEquals(
-                DELETED_MESSAGE_PLACEHOLDER_TITLE,
+                testFeatureConfig.deletedMessagePlaceholderTitle,
                 getThreadAs(employee1Account, threadId).title,
             )
         }
@@ -4006,12 +4037,12 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
 
             assertEquals("Guardian reply", messages[1].content)
 
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, messages[2].content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderBody, messages[2].content)
             assertNotNull(messages[2].contentDeletedAt)
 
             val senderReply =
                 getThreadAs(employee1Account, threadId).messages.maxByOrNull { it.sentAt }!!
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, senderReply.content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderBody, senderReply.content)
             assertNotNull(senderReply.contentDeletedAt)
         }
 
@@ -4026,7 +4057,10 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
 
             val recipientMessages =
                 getThreadAs(person1Account, threadId).messages.sortedBy { it.sentAt }
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, recipientMessages[0].content)
+            assertEquals(
+                testFeatureConfig.deletedMessagePlaceholderBody,
+                recipientMessages[0].content,
+            )
             assertNotNull(recipientMessages[0].contentDeletedAt)
             assertEquals("Guardian reply", recipientMessages[1].content)
             assertNull(recipientMessages[1].contentDeletedAt)
@@ -4035,7 +4069,7 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
 
             val senderMessages =
                 getThreadAs(employee1Account, threadId).messages.sortedBy { it.sentAt }
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, senderMessages[0].content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderBody, senderMessages[0].content)
             assertEquals("Guardian reply", senderMessages[1].content)
             assertEquals("Employee reply", senderMessages[2].content)
         }
@@ -4047,18 +4081,42 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             deleteContent(employee1, employee1Account, messageId)
 
             val received = db.read { tx ->
-                tx.getReceivedThreads(person1Account, pageSize = 10, page = 1, "", "", "")
+                tx.getReceivedThreads(
+                    person1Account,
+                    pageSize = 10,
+                    page = 1,
+                    "",
+                    "",
+                    "",
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                    deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+                )
             }
             val thread = received.data.single()
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_TITLE, thread.title)
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, thread.messages.single().content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderTitle, thread.title)
+            assertEquals(
+                testFeatureConfig.deletedMessagePlaceholderBody,
+                thread.messages.single().content,
+            )
 
             val sent = db.read { tx ->
-                tx.getThreads(employee1Account, pageSize = 10, page = 1, "", "", "")
+                tx.getThreads(
+                    employee1Account,
+                    pageSize = 10,
+                    page = 1,
+                    "",
+                    "",
+                    "",
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                    deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+                )
             }
             val sentThread = sent.data.single()
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_TITLE, sentThread.title)
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, sentThread.messages.single().content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderTitle, sentThread.title)
+            assertEquals(
+                testFeatureConfig.deletedMessagePlaceholderBody,
+                sentThread.messages.single().content,
+            )
         }
 
         @Test
@@ -4068,9 +4126,15 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             deleteContent(employee1, employee1Account, messageId)
 
             val sentMessage = db.read { tx ->
-                tx.getSentMessage(employee1Account, messageId, "", "")
+                tx.getSentMessage(
+                    employee1Account,
+                    messageId,
+                    "",
+                    "",
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                )
             }
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, sentMessage.content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderBody, sentMessage.content)
             assertNotNull(sentMessage.contentDeletedAt)
             assertTrue(sentMessage.attachments.isEmpty())
         }
@@ -4082,13 +4146,19 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             deleteContent(employee1, employee1Account, messageId)
 
             val sent = db.read { tx ->
-                tx.getMessagesSentByAccount(employee1Account, pageSize = 10, page = 1)
+                tx.getMessagesSentByAccount(
+                    employee1Account,
+                    pageSize = 10,
+                    page = 1,
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                    deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+                )
             }
             val sentMessage = sent.data.single()
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, sentMessage.content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderBody, sentMessage.content)
             assertTrue(sentMessage.attachments.isEmpty())
 
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_TITLE, sentMessage.threadTitle)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderTitle, sentMessage.threadTitle)
         }
 
         @Test
@@ -4102,12 +4172,18 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             deleteContent(employee1, employee1Account, replyMessageId)
 
             val sent = db.read { tx ->
-                tx.getMessagesSentByAccount(employee1Account, pageSize = 10, page = 1)
+                tx.getMessagesSentByAccount(
+                    employee1Account,
+                    pageSize = 10,
+                    page = 1,
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                    deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+                )
             }
             val deletedReply = sent.data.single { it.contentDeletedAt != null }
             assertEquals("Test message", deletedReply.threadTitle)
             assertNull(deletedReply.firstMessageContentDeletedAt)
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, deletedReply.content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderBody, deletedReply.content)
         }
 
         @Test
@@ -4121,12 +4197,18 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             deleteContent(employee1, employee1Account, messageId)
 
             val sent = db.read { tx ->
-                tx.getMessagesSentByAccount(employee1Account, pageSize = 10, page = 1)
+                tx.getMessagesSentByAccount(
+                    employee1Account,
+                    pageSize = 10,
+                    page = 1,
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                    deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+                )
             }
             // employee1 sent two contents in this thread: the first message and the reply
             assertEquals(2, sent.data.size)
             sent.data.forEach { row ->
-                assertEquals(DELETED_MESSAGE_PLACEHOLDER_TITLE, row.threadTitle)
+                assertEquals(testFeatureConfig.deletedMessagePlaceholderTitle, row.threadTitle)
                 assertNotNull(row.firstMessageContentDeletedAt)
             }
         }
@@ -4162,7 +4244,14 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
             // the message body is mirrored into an application note on send
             assertEquals(
                 "Hello!",
-                db.read { it.getApplicationNotes(applicationId) }.single().content,
+                db.read {
+                        it.getApplicationNotes(
+                            applicationId,
+                            deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        )
+                    }
+                    .single()
+                    .content,
             )
 
             // a plain note unrelated to any message must not be affected by redaction
@@ -4188,17 +4277,24 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
                             "",
                             "",
                             "",
+                            deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                            deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                         )
                     }
                 )
             val message = thread.messages.single()
-            assertEquals(DELETED_MESSAGE_PLACEHOLDER_BODY, message.content)
+            assertEquals(testFeatureConfig.deletedMessagePlaceholderBody, message.content)
             assertTrue(message.attachments.isEmpty())
 
-            val notes = db.read { it.getApplicationNotes(applicationId) }
+            val notes = db.read {
+                it.getApplicationNotes(
+                    applicationId,
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                )
+            }
             // the application note that mirrored the body is redacted too
             assertEquals(
-                DELETED_MESSAGE_PLACEHOLDER_BODY,
+                testFeatureConfig.deletedMessagePlaceholderBody,
                 notes.single { it.id != plainNoteId }.content,
             )
             // the plain note keeps its real content

--- a/service/src/integrationTest/kotlin/evaka/core/messaging/MessagePushNotificationsTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/messaging/MessagePushNotificationsTest.kt
@@ -11,6 +11,7 @@ import evaka.core.shared.MobileDeviceId
 import evaka.core.shared.async.AsyncJob
 import evaka.core.shared.async.AsyncJobRunner
 import evaka.core.shared.auth.AuthenticatedUser
+import evaka.core.shared.config.testFeatureConfig
 import evaka.core.shared.dev.DevCareArea
 import evaka.core.shared.dev.DevDaycare
 import evaka.core.shared.dev.DevDaycareGroup
@@ -165,7 +166,14 @@ class MessagePushNotificationsTest : FullApplicationTest(resetDbBeforeEach = tru
 
         val copy =
             db.read { tx ->
-                    tx.getMessageCopiesByAccount(groupAccount, pageSize = 20, page = 1).data
+                    tx.getMessageCopiesByAccount(
+                            groupAccount,
+                            pageSize = 20,
+                            page = 1,
+                            deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                            deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+                        )
+                        .data
                 }
                 .single()
         assertEquals(municipalAccount, copy.senderId)

--- a/service/src/integrationTest/kotlin/evaka/core/messaging/MessageQueriesTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/messaging/MessageQueriesTest.kt
@@ -154,6 +154,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         "Espoo",
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     )
                 }
                 .data
@@ -167,6 +169,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 "Espoo",
                 "Espoon palveluohjaus",
                 "Espoon asiakasmaksut",
+                deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
             )
         }
         assertEquals(2, personResult.data.size)
@@ -187,6 +191,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 "Espoo",
                 "Espoon palveluohjaus",
                 "Espoon asiakasmaksut",
+                deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
             )
         }
         assertEquals(2, person1Threads.data.size)
@@ -205,6 +211,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         "Espoo",
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     )
                 }
                 .data
@@ -230,6 +238,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 "Espoo",
                 "Espoon palveluohjaus",
                 "Espoon asiakasmaksut",
+                deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
             )
         }
         assertEquals(1, employeeResult.data.size)
@@ -245,6 +255,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 "Espoo",
                 "Espoon palveluohjaus",
                 "Espoon asiakasmaksut",
+                deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
             )
         }
         assertEquals(2, person1Result.data.size)
@@ -275,6 +287,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 "Espoo",
                 "Espoon palveluohjaus",
                 "Espoon asiakasmaksut",
+                deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
             )
         }
         assertEquals(1, person2Result.data.size)
@@ -290,6 +304,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 "Espoo",
                 "Espoon palveluohjaus",
                 "Espoon asiakasmaksut",
+                deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
             )
         }
         assertEquals(1, employee2Result.data.size)
@@ -311,6 +327,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                 "Espoo",
                 "Espoon palveluohjaus",
                 "Espoon asiakasmaksut",
+                deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
             )
         }
         assertEquals(2, messages.total)
@@ -327,6 +345,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         "Espoo",
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     ),
                     it.getThreads(
                         accounts.person1.id,
@@ -335,6 +355,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         "Espoo",
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     ),
                 )
             }
@@ -368,7 +390,15 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         // then sent messages are returned for sender id
-        val firstPage = db.read { it.getMessagesSentByAccount(accounts.employee1.id, 1, 1) }
+        val firstPage = db.read {
+            it.getMessagesSentByAccount(
+                accounts.employee1.id,
+                1,
+                1,
+                deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+            )
+        }
         assertEquals(2, firstPage.total)
         assertEquals(2, firstPage.pages)
         assertEquals(1, firstPage.data.size)
@@ -378,7 +408,15 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertEquals("thread 2", newestMessage.threadTitle)
         assertEquals(listOf(accounts.person1.name), newestMessage.recipientNames)
 
-        val secondPage = db.read { it.getMessagesSentByAccount(accounts.employee1.id, 1, 2) }
+        val secondPage = db.read {
+            it.getMessagesSentByAccount(
+                accounts.employee1.id,
+                1,
+                2,
+                deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+            )
+        }
         assertEquals(2, secondPage.total)
         assertEquals(2, secondPage.pages)
         assertEquals(1, secondPage.data.size)
@@ -392,7 +430,19 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
         )
 
         // then fetching sent messages by recipient ids does not return the messages
-        assertEquals(0, db.read { it.getMessagesSentByAccount(accounts.person1.id, 1, 1) }.total)
+        assertEquals(
+            0,
+            db.read {
+                    it.getMessagesSentByAccount(
+                        accounts.person1.id,
+                        1,
+                        1,
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+                    )
+                }
+                .total,
+        )
     }
 
     @Test
@@ -932,6 +982,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
                         archiveFolderId,
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     )
                     .total
             },
@@ -956,6 +1008,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
                         archiveFolderId,
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     )
                     .total
             },
@@ -974,6 +1028,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
                         null,
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     )
                     .total
             },
@@ -990,6 +1046,8 @@ class MessageQueriesTest : PureJdbiTest(resetDbBeforeEach = true) {
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
                         archiveFolderId,
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     )
                     .total
             },

--- a/service/src/integrationTest/kotlin/evaka/core/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/service/MergeServiceIntegrationTest.kt
@@ -23,6 +23,7 @@ import evaka.core.shared.PersonId
 import evaka.core.shared.async.AsyncJob
 import evaka.core.shared.async.AsyncJobRunner
 import evaka.core.shared.auth.AuthenticatedUser
+import evaka.core.shared.config.testFeatureConfig
 import evaka.core.shared.dev.DevCareArea
 import evaka.core.shared.dev.DevDaycare
 import evaka.core.shared.dev.DevEmployee
@@ -250,7 +251,16 @@ class MergeServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
     }
 
     private fun sentMessageCounts(vararg accountIds: MessageAccountId): List<Int> = db.read { tx ->
-        accountIds.map { tx.getMessagesSentByAccount(it, 10, 1).total }
+        accountIds.map {
+            tx.getMessagesSentByAccount(
+                    it,
+                    10,
+                    1,
+                    deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                    deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
+                )
+                .total
+        }
     }
 
     @Test
@@ -312,6 +322,8 @@ class MergeServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
                         "Espoo",
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     )
                     .total
             }
@@ -329,6 +341,8 @@ class MergeServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
                         archiveFolderId,
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     )
                     .total
             }
@@ -372,6 +386,8 @@ class MergeServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
                         "Espoo",
                         "Espoon palveluohjaus",
                         "Espoon asiakasmaksut",
+                        deletedMessageBody = testFeatureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = testFeatureConfig.deletedMessagePlaceholderTitle,
                     )
                     .data
                     .first()

--- a/service/src/main/kotlin/evaka/core/application/notes/ApplicationNoteQueries.kt
+++ b/service/src/main/kotlin/evaka/core/application/notes/ApplicationNoteQueries.kt
@@ -5,7 +5,6 @@
 package evaka.core.application.notes
 
 import evaka.core.application.ApplicationNote
-import evaka.core.messaging.deletedMessagePlaceholderBody
 import evaka.core.shared.ApplicationId
 import evaka.core.shared.ApplicationNoteId
 import evaka.core.shared.EvakaUserId
@@ -17,14 +16,14 @@ import evaka.core.shared.domain.HelsinkiDateTime
 // Read-time redaction: the body of a message-linked note is replaced with the
 // placeholder once the linked message's content has been deleted. The original
 // is retained in application_note (soft delete).
-private fun redactedNoteContent(swedishEnabled: Boolean) = QuerySql {
+private fun redactedNoteContent(deletedMessageBody: String) = QuerySql {
     sql(
         """
 CASE
     WHEN EXISTS (
         SELECT 1 FROM message msg
         WHERE msg.content_id = n.message_content_id AND msg.content_deleted_at IS NOT NULL
-    ) THEN ${bind(deletedMessagePlaceholderBody(swedishEnabled))}
+    ) THEN ${bind(deletedMessageBody)}
     ELSE n.content
 END AS content
 """
@@ -33,14 +32,14 @@ END AS content
 
 fun Database.Read.getApplicationNotes(
     applicationId: ApplicationId,
-    swedishEnabled: Boolean = true,
+    deletedMessageBody: String,
 ): List<ApplicationNote> =
     createQuery {
             sql(
                 """
 SELECT
     n.id, n.application_id,
-    ${subquery(redactedNoteContent(swedishEnabled))},
+    ${subquery(redactedNoteContent(deletedMessageBody))},
     n.created_at, n.created_by, (SELECT name FROM evaka_user WHERE id = n.created_by) AS created_by_name,
     n.modified_at, n.modified_by, (SELECT name FROM evaka_user WHERE id = n.modified_by) AS modified_by_name,
     n.message_content_id, m.thread_id as message_thread_id
@@ -55,14 +54,14 @@ ORDER BY n.created_at
 
 fun Database.Read.getApplicationSpecialEducationTeacherNotes(
     applicationId: ApplicationId,
-    swedishEnabled: Boolean = true,
+    deletedMessageBody: String,
 ): List<ApplicationNote> =
     createQuery {
             sql(
                 """
 SELECT
     n.id, n.application_id,
-    ${subquery(redactedNoteContent(swedishEnabled))},
+    ${subquery(redactedNoteContent(deletedMessageBody))},
     n.created_at, n.created_by, (SELECT name FROM evaka_user WHERE id = n.created_by) AS created_by_name,
     n.modified_at, n.modified_by, (SELECT name FROM evaka_user WHERE id = n.modified_by) AS modified_by_name
 FROM application_note n

--- a/service/src/main/kotlin/evaka/core/application/notes/ApplicationNoteQueries.kt
+++ b/service/src/main/kotlin/evaka/core/application/notes/ApplicationNoteQueries.kt
@@ -5,7 +5,7 @@
 package evaka.core.application.notes
 
 import evaka.core.application.ApplicationNote
-import evaka.core.messaging.DELETED_MESSAGE_PLACEHOLDER_BODY
+import evaka.core.messaging.deletedMessagePlaceholderBody
 import evaka.core.shared.ApplicationId
 import evaka.core.shared.ApplicationNoteId
 import evaka.core.shared.EvakaUserId
@@ -17,27 +17,30 @@ import evaka.core.shared.domain.HelsinkiDateTime
 // Read-time redaction: the body of a message-linked note is replaced with the
 // placeholder once the linked message's content has been deleted. The original
 // is retained in application_note (soft delete).
-private val redactedNoteContent = QuerySql {
+private fun redactedNoteContent(swedishEnabled: Boolean) = QuerySql {
     sql(
         """
 CASE
     WHEN EXISTS (
         SELECT 1 FROM message msg
         WHERE msg.content_id = n.message_content_id AND msg.content_deleted_at IS NOT NULL
-    ) THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_BODY)}
+    ) THEN ${bind(deletedMessagePlaceholderBody(swedishEnabled))}
     ELSE n.content
 END AS content
 """
     )
 }
 
-fun Database.Read.getApplicationNotes(applicationId: ApplicationId): List<ApplicationNote> =
+fun Database.Read.getApplicationNotes(
+    applicationId: ApplicationId,
+    swedishEnabled: Boolean = true,
+): List<ApplicationNote> =
     createQuery {
             sql(
                 """
 SELECT
     n.id, n.application_id,
-    ${subquery(redactedNoteContent)},
+    ${subquery(redactedNoteContent(swedishEnabled))},
     n.created_at, n.created_by, (SELECT name FROM evaka_user WHERE id = n.created_by) AS created_by_name,
     n.modified_at, n.modified_by, (SELECT name FROM evaka_user WHERE id = n.modified_by) AS modified_by_name,
     n.message_content_id, m.thread_id as message_thread_id
@@ -51,14 +54,15 @@ ORDER BY n.created_at
         .toList()
 
 fun Database.Read.getApplicationSpecialEducationTeacherNotes(
-    applicationId: ApplicationId
+    applicationId: ApplicationId,
+    swedishEnabled: Boolean = true,
 ): List<ApplicationNote> =
     createQuery {
             sql(
                 """
 SELECT
     n.id, n.application_id,
-    ${subquery(redactedNoteContent)},
+    ${subquery(redactedNoteContent(swedishEnabled))},
     n.created_at, n.created_by, (SELECT name FROM evaka_user WHERE id = n.created_by) AS created_by_name,
     n.modified_at, n.modified_by, (SELECT name FROM evaka_user WHERE id = n.modified_by) AS modified_by_name
 FROM application_note n

--- a/service/src/main/kotlin/evaka/core/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/evaka/core/application/notes/NoteController.kt
@@ -9,6 +9,7 @@ import evaka.core.AuditId
 import evaka.core.application.ApplicationNote
 import evaka.core.shared.ApplicationId
 import evaka.core.shared.ApplicationNoteId
+import evaka.core.shared.FeatureConfig
 import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.db.Database
 import evaka.core.shared.domain.EvakaClock
@@ -25,7 +26,10 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/employee/note")
-class NoteController(private val accessControl: AccessControl) {
+class NoteController(
+    private val accessControl: AccessControl,
+    private val featureConfig: FeatureConfig,
+) {
     @GetMapping("/application/{applicationId}")
     fun getNotes(
         db: Database,
@@ -43,7 +47,10 @@ class NoteController(private val accessControl: AccessControl) {
                     applicationId,
                 )
             ) {
-                tx.getApplicationNotes(applicationId)
+                tx.getApplicationNotes(
+                    applicationId,
+                    swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                )
             } else {
                 accessControl.requirePermissionFor(
                     tx,
@@ -52,7 +59,10 @@ class NoteController(private val accessControl: AccessControl) {
                     Action.Application.READ_SPECIAL_EDUCATION_TEACHER_NOTES,
                     applicationId,
                 )
-                tx.getApplicationSpecialEducationTeacherNotes(applicationId)
+                tx.getApplicationSpecialEducationTeacherNotes(
+                    applicationId,
+                    swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                )
             }
         }
 

--- a/service/src/main/kotlin/evaka/core/application/notes/NoteController.kt
+++ b/service/src/main/kotlin/evaka/core/application/notes/NoteController.kt
@@ -49,7 +49,7 @@ class NoteController(
             ) {
                 tx.getApplicationNotes(
                     applicationId,
-                    swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                    deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
                 )
             } else {
                 accessControl.requirePermissionFor(
@@ -61,7 +61,7 @@ class NoteController(
                 )
                 tx.getApplicationSpecialEducationTeacherNotes(
                     applicationId,
-                    swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                    deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
                 )
             }
         }

--- a/service/src/main/kotlin/evaka/core/messaging/Message.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/Message.kt
@@ -29,15 +29,35 @@ import org.jdbi.v3.core.mapper.PropagateNull
 import org.jdbi.v3.json.Json
 import tools.jackson.databind.annotation.JsonTypeIdResolver
 
-const val DELETED_MESSAGE_PLACEHOLDER_BODY =
-    """Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.
+private const val DELETED_MESSAGE_PLACEHOLDER_BODY_FI =
+    "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään."
+private const val DELETED_MESSAGE_PLACEHOLDER_BODY_SV =
+    "Avsändaren har tagit bort meddelandet. Du behöver inte göra något."
+private const val DELETED_MESSAGE_PLACEHOLDER_BODY_EN =
+    "The sender has deleted this message. No action is needed on your part."
 
-Avsändaren har tagit bort meddelandet. Du behöver inte göra något.
+private const val DELETED_MESSAGE_PLACEHOLDER_TITLE_FI = "Viesti on poistettu"
+private const val DELETED_MESSAGE_PLACEHOLDER_TITLE_SV = "Meddelandet har raderats"
+private const val DELETED_MESSAGE_PLACEHOLDER_TITLE_EN = "Message was deleted"
 
-The sender has deleted this message. No action is needed on your part."""
+fun deletedMessagePlaceholderBody(swedishEnabled: Boolean): String =
+    listOfNotNull(
+            DELETED_MESSAGE_PLACEHOLDER_BODY_FI,
+            DELETED_MESSAGE_PLACEHOLDER_BODY_SV.takeIf { swedishEnabled },
+            DELETED_MESSAGE_PLACEHOLDER_BODY_EN,
+        )
+        .joinToString("\n\n")
 
-const val DELETED_MESSAGE_PLACEHOLDER_TITLE =
-    "Viesti on poistettu / Meddelandet har raderats / Message was deleted"
+fun deletedMessagePlaceholderTitle(swedishEnabled: Boolean): String =
+    listOfNotNull(
+            DELETED_MESSAGE_PLACEHOLDER_TITLE_FI,
+            DELETED_MESSAGE_PLACEHOLDER_TITLE_SV.takeIf { swedishEnabled },
+            DELETED_MESSAGE_PLACEHOLDER_TITLE_EN,
+        )
+        .joinToString(" / ")
+
+val DELETED_MESSAGE_PLACEHOLDER_BODY = deletedMessagePlaceholderBody(swedishEnabled = true)
+val DELETED_MESSAGE_PLACEHOLDER_TITLE = deletedMessagePlaceholderTitle(swedishEnabled = true)
 
 data class Message(
     val id: MessageId,

--- a/service/src/main/kotlin/evaka/core/messaging/Message.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/Message.kt
@@ -29,36 +29,6 @@ import org.jdbi.v3.core.mapper.PropagateNull
 import org.jdbi.v3.json.Json
 import tools.jackson.databind.annotation.JsonTypeIdResolver
 
-private const val DELETED_MESSAGE_PLACEHOLDER_BODY_FI =
-    "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään."
-private const val DELETED_MESSAGE_PLACEHOLDER_BODY_SV =
-    "Avsändaren har tagit bort meddelandet. Du behöver inte göra något."
-private const val DELETED_MESSAGE_PLACEHOLDER_BODY_EN =
-    "The sender has deleted this message. No action is needed on your part."
-
-private const val DELETED_MESSAGE_PLACEHOLDER_TITLE_FI = "Viesti on poistettu"
-private const val DELETED_MESSAGE_PLACEHOLDER_TITLE_SV = "Meddelandet har raderats"
-private const val DELETED_MESSAGE_PLACEHOLDER_TITLE_EN = "Message was deleted"
-
-fun deletedMessagePlaceholderBody(swedishEnabled: Boolean): String =
-    listOfNotNull(
-            DELETED_MESSAGE_PLACEHOLDER_BODY_FI,
-            DELETED_MESSAGE_PLACEHOLDER_BODY_SV.takeIf { swedishEnabled },
-            DELETED_MESSAGE_PLACEHOLDER_BODY_EN,
-        )
-        .joinToString("\n\n")
-
-fun deletedMessagePlaceholderTitle(swedishEnabled: Boolean): String =
-    listOfNotNull(
-            DELETED_MESSAGE_PLACEHOLDER_TITLE_FI,
-            DELETED_MESSAGE_PLACEHOLDER_TITLE_SV.takeIf { swedishEnabled },
-            DELETED_MESSAGE_PLACEHOLDER_TITLE_EN,
-        )
-        .joinToString(" / ")
-
-val DELETED_MESSAGE_PLACEHOLDER_BODY = deletedMessagePlaceholderBody(swedishEnabled = true)
-val DELETED_MESSAGE_PLACEHOLDER_TITLE = deletedMessagePlaceholderTitle(swedishEnabled = true)
-
 data class Message(
     val id: MessageId,
     val threadId: MessageThreadId,

--- a/service/src/main/kotlin/evaka/core/messaging/MessageController.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageController.kt
@@ -184,7 +184,8 @@ class MessageController(
                     featureConfig.financeMessageAccountName,
                     accountAccessLimit = accountAccessLimit,
                     childId = childId,
-                    swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                    deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
+                    deletedMessageTitle = featureConfig.deletedMessagePlaceholderTitle,
                 )
             }
             .also {
@@ -221,7 +222,8 @@ class MessageController(
                             featureConfig.financeMessageAccountName,
                             archiveFolderId,
                             accountAccessLimit,
-                            swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                            deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
+                            deletedMessageTitle = featureConfig.deletedMessagePlaceholderTitle,
                         )
                     }
                 }
@@ -281,7 +283,8 @@ class MessageController(
                         featureConfig.serviceWorkerMessageAccountName,
                         featureConfig.financeMessageAccountName,
                         folderId,
-                        swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                        deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = featureConfig.deletedMessagePlaceholderTitle,
                     )
                 }
             }
@@ -310,7 +313,8 @@ class MessageController(
                         pageSize = 20,
                         page,
                         accountAccessLimit,
-                        swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                        deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = featureConfig.deletedMessagePlaceholderTitle,
                     )
                 }
             }
@@ -363,7 +367,8 @@ class MessageController(
                     pageSize = 20,
                     page,
                     accountAccessLimit,
-                    swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                    deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
+                    deletedMessageTitle = featureConfig.deletedMessagePlaceholderTitle,
                 )
             }
             .also {
@@ -408,7 +413,8 @@ class MessageController(
                         featureConfig.municipalMessageAccountName,
                         featureConfig.serviceWorkerMessageAccountName,
                         featureConfig.financeMessageAccountName,
-                        swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                        deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = featureConfig.deletedMessagePlaceholderTitle,
                     )
                 }
             }
@@ -440,7 +446,8 @@ class MessageController(
                         featureConfig.municipalMessageAccountName,
                         featureConfig.serviceWorkerMessageAccountName,
                         featureConfig.financeMessageAccountName,
-                        swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                        deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
+                        deletedMessageTitle = featureConfig.deletedMessagePlaceholderTitle,
                     )
                 }
                 accountId to thread
@@ -485,7 +492,8 @@ class MessageController(
                                 personAccountId = personAccountId,
                                 messagesSortDirection = SortDirection.DESC,
                                 folderId = folderId,
-                                swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                                deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
+                                deletedMessageTitle = featureConfig.deletedMessagePlaceholderTitle,
                             )
                             .data
                     }
@@ -1074,7 +1082,7 @@ class MessageController(
                     municipalAccountName = featureConfig.municipalMessageAccountName,
                     serviceWorkerAccountName = featureConfig.serviceWorkerMessageAccountName,
                     financeAccountName = featureConfig.financeMessageAccountName,
-                    swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                    deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
                 )
             }
             .also {

--- a/service/src/main/kotlin/evaka/core/messaging/MessageController.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageController.kt
@@ -184,6 +184,7 @@ class MessageController(
                     featureConfig.financeMessageAccountName,
                     accountAccessLimit = accountAccessLimit,
                     childId = childId,
+                    swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
                 )
             }
             .also {
@@ -220,6 +221,7 @@ class MessageController(
                             featureConfig.financeMessageAccountName,
                             archiveFolderId,
                             accountAccessLimit,
+                            swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
                         )
                     }
                 }
@@ -279,6 +281,7 @@ class MessageController(
                         featureConfig.serviceWorkerMessageAccountName,
                         featureConfig.financeMessageAccountName,
                         folderId,
+                        swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
                     )
                 }
             }
@@ -302,7 +305,13 @@ class MessageController(
                 requireMessageAccountAccess(dbc, user, clock, accountId)
                 dbc.read {
                     val accountAccessLimit = it.getAccountAccessLimit(accountId, user.id)
-                    it.getMessageCopiesByAccount(accountId, pageSize = 20, page, accountAccessLimit)
+                    it.getMessageCopiesByAccount(
+                        accountId,
+                        pageSize = 20,
+                        page,
+                        accountAccessLimit,
+                        swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                    )
                 }
             }
             .also {
@@ -349,7 +358,13 @@ class MessageController(
     ): PagedSentMessages {
         return dbc.read {
                 val accountAccessLimit = it.getAccountAccessLimit(accountId, employeeId)
-                it.getMessagesSentByAccount(accountId, pageSize = 20, page, accountAccessLimit)
+                it.getMessagesSentByAccount(
+                    accountId,
+                    pageSize = 20,
+                    page,
+                    accountAccessLimit,
+                    swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                )
             }
             .also {
                 Audit.MessagingSentMessagesRead.log(
@@ -393,6 +408,7 @@ class MessageController(
                         featureConfig.municipalMessageAccountName,
                         featureConfig.serviceWorkerMessageAccountName,
                         featureConfig.financeMessageAccountName,
+                        swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
                     )
                 }
             }
@@ -424,6 +440,7 @@ class MessageController(
                         featureConfig.municipalMessageAccountName,
                         featureConfig.serviceWorkerMessageAccountName,
                         featureConfig.financeMessageAccountName,
+                        swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
                     )
                 }
                 accountId to thread
@@ -468,6 +485,7 @@ class MessageController(
                                 personAccountId = personAccountId,
                                 messagesSortDirection = SortDirection.DESC,
                                 folderId = folderId,
+                                swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
                             )
                             .data
                     }
@@ -1056,6 +1074,7 @@ class MessageController(
                     municipalAccountName = featureConfig.municipalMessageAccountName,
                     serviceWorkerAccountName = featureConfig.serviceWorkerMessageAccountName,
                     financeAccountName = featureConfig.financeMessageAccountName,
+                    swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
                 )
             }
             .also {

--- a/service/src/main/kotlin/evaka/core/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageControllerCitizen.kt
@@ -172,7 +172,8 @@ class MessageControllerCitizen(
                                 featureConfig.municipalMessageAccountName,
                                 featureConfig.serviceWorkerMessageAccountName,
                                 featureConfig.financeMessageAccountName,
-                                swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                                deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
+                                deletedMessageTitle = featureConfig.deletedMessagePlaceholderTitle,
                             )
                         }
                         .mapTo(::PagedCitizenMessageThreads) {
@@ -294,7 +295,7 @@ class MessageControllerCitizen(
                         municipalAccountName = featureConfig.municipalMessageAccountName,
                         serviceWorkerAccountName = featureConfig.serviceWorkerMessageAccountName,
                         financeAccountName = featureConfig.financeMessageAccountName,
-                        swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
+                        deletedMessageBody = featureConfig.deletedMessagePlaceholderBody,
                     )
                 accountId to response
             }

--- a/service/src/main/kotlin/evaka/core/messaging/MessageControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageControllerCitizen.kt
@@ -172,6 +172,7 @@ class MessageControllerCitizen(
                                 featureConfig.municipalMessageAccountName,
                                 featureConfig.serviceWorkerMessageAccountName,
                                 featureConfig.financeMessageAccountName,
+                                swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
                             )
                         }
                         .mapTo(::PagedCitizenMessageThreads) {
@@ -293,6 +294,7 @@ class MessageControllerCitizen(
                         municipalAccountName = featureConfig.municipalMessageAccountName,
                         serviceWorkerAccountName = featureConfig.serviceWorkerMessageAccountName,
                         financeAccountName = featureConfig.financeMessageAccountName,
+                        swedishEnabled = featureConfig.messageDeletedSwedishLanguageEnabled,
                     )
                 accountId to response
             }

--- a/service/src/main/kotlin/evaka/core/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageQueries.kt
@@ -601,7 +601,8 @@ fun Database.Read.getThreads(
     folderId: MessageThreadFolderId? = null,
     personAccountId: MessageAccountId? = null,
     messagesSortDirection: SortDirection = SortDirection.ASC,
-    swedishEnabled: Boolean = true,
+    deletedMessageBody: String,
+    deletedMessageTitle: String,
 ): PagedMessageThreads {
     val personAccountPredicate =
         if (personAccountId != null) {
@@ -630,7 +631,7 @@ SELECT
     t.id,
     CASE
         WHEN first_msg.content_deleted_at IS NOT NULL
-        THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
+        THEN ${bind(deletedMessageTitle)}
         ELSE t.title
     END AS title,
     t.message_type AS type,
@@ -678,7 +679,7 @@ LIMIT ${bind(pageSize)} OFFSET ${bind((page - 1) * pageSize)}
             serviceWorkerAccountName,
             financeAccountName,
             messagesSortDirection,
-            swedishEnabled,
+            deletedMessageBody,
         )
     return combineThreadsAndMessages(accountId, threads, messagesByThread)
 }
@@ -718,7 +719,8 @@ fun Database.Read.getReceivedThreads(
     folderId: MessageThreadFolderId? = null,
     accountAccessLimit: AccountAccessLimit = AccountAccessLimit.NoFurtherLimit,
     childId: ChildId? = null,
-    swedishEnabled: Boolean = true,
+    deletedMessageBody: String,
+    deletedMessageTitle: String,
 ): PagedMessageThreads {
     val accountAccessPredicate =
         if (accountAccessLimit is AccountAccessLimit.AvailableFrom)
@@ -748,7 +750,7 @@ SELECT
     t.id,
     CASE
         WHEN first_msg.content_deleted_at IS NOT NULL
-        THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
+        THEN ${bind(deletedMessageTitle)}
         ELSE t.title
     END AS title,
     t.message_type AS type,
@@ -799,7 +801,7 @@ LIMIT ${bind(pageSize)} OFFSET ${bind((page - 1) * pageSize)}
             municipalAccountName,
             serviceWorkerAccountName,
             financeAccountName,
-            swedishEnabled = swedishEnabled,
+            deletedMessageBody = deletedMessageBody,
         )
     return combineThreadsAndMessages(accountId, threads, messagesByThread)
 }
@@ -811,7 +813,7 @@ private fun Database.Read.getThreadMessages(
     serviceWorkerAccountName: String,
     financeAccountName: String,
     sortDirection: SortDirection = SortDirection.ASC,
-    swedishEnabled: Boolean = true,
+    deletedMessageBody: String,
 ): Map<MessageThreadId, List<Message>> {
     if (threadIds.isEmpty()) return mapOf()
     val sortDir = sortDirection.name
@@ -824,7 +826,7 @@ SELECT
     m.content_id,
     COALESCE(m.sent_at, m.created) AS sent_at,
     CASE
-        WHEN m.content_deleted_at IS NOT NULL THEN ${bind(deletedMessagePlaceholderBody(swedishEnabled))}
+        WHEN m.content_deleted_at IS NOT NULL THEN ${bind(deletedMessageBody)}
         ELSE mc.content
     END AS content,
     m.content_deleted_at,
@@ -950,7 +952,8 @@ fun Database.Read.getMessageCopiesByAccount(
     pageSize: Int,
     page: Int,
     accountAccessLimit: AccountAccessLimit = AccountAccessLimit.NoFurtherLimit,
-    swedishEnabled: Boolean = true,
+    deletedMessageBody: String,
+    deletedMessageTitle: String,
 ): PagedMessageCopies {
     val accountAccessPredicate =
         if (accountAccessLimit is AccountAccessLimit.AvailableFrom)
@@ -968,7 +971,7 @@ fun Database.Read.getMessageCopiesByAccount(
         m.id AS message_id,
         CASE
             WHEN m.content_deleted_at IS NOT NULL
-            THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
+            THEN ${bind(deletedMessageTitle)}
             ELSE t.title
         END AS title,
         t.message_type AS type,
@@ -981,7 +984,7 @@ fun Database.Read.getMessageCopiesByAccount(
         m.content_id,
         CASE
             WHEN m.content_deleted_at IS NOT NULL
-            THEN ${bind(deletedMessagePlaceholderBody(swedishEnabled))}
+            THEN ${bind(deletedMessageBody)}
             ELSE c.content
         END AS content,
         m.content_deleted_at,
@@ -1093,7 +1096,7 @@ fun Database.Read.getSentMessage(
     messageId: MessageId,
     serviceWorkerAccountName: String,
     financeAccountName: String,
-    swedishEnabled: Boolean = true,
+    deletedMessageBody: String,
 ): Message {
     return createQuery {
             sql(
@@ -1104,7 +1107,7 @@ SELECT
     m.content_id,
     COALESCE(m.sent_at, m.created) AS sent_at,  -- use the created timestamp until the asyncjob marks the message as sent
     CASE
-        WHEN m.content_deleted_at IS NOT NULL THEN ${bind(deletedMessagePlaceholderBody(swedishEnabled))}
+        WHEN m.content_deleted_at IS NOT NULL THEN ${bind(deletedMessageBody)}
         ELSE mc.content
     END AS content,
     m.content_deleted_at,
@@ -1311,7 +1314,8 @@ fun Database.Read.getMessagesSentByAccount(
     pageSize: Int,
     page: Int,
     accountAccessLimit: AccountAccessLimit = AccountAccessLimit.NoFurtherLimit,
-    swedishEnabled: Boolean = true,
+    deletedMessageBody: String,
+    deletedMessageTitle: String,
 ): PagedSentMessages {
     val accountAccessPredicate =
         if (accountAccessLimit is AccountAccessLimit.AvailableFrom)
@@ -1356,7 +1360,7 @@ SELECT
     msg.recipient_names,
     CASE
         WHEN msg.first_message_content_deleted_at IS NOT NULL
-        THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
+        THEN ${bind(deletedMessageTitle)}
         ELSE msg.title
     END AS thread_title,
     msg.first_message_content_deleted_at,
@@ -1365,7 +1369,7 @@ SELECT
     msg.sensitive,
     msg.content_deleted_at,
     CASE
-        WHEN msg.is_content_deleted THEN ${bind(deletedMessagePlaceholderBody(swedishEnabled))}
+        WHEN msg.is_content_deleted THEN ${bind(deletedMessageBody)}
         ELSE mc.content
     END AS content,
     CASE
@@ -1433,7 +1437,8 @@ fun Database.Read.getMessageThread(
     municipalAccountName: String,
     serviceWorkerAccountName: String,
     financeAccountName: String,
-    swedishEnabled: Boolean = true,
+    deletedMessageBody: String,
+    deletedMessageTitle: String,
 ): MessageThread {
     val thread =
         createQuery {
@@ -1443,7 +1448,7 @@ SELECT
     t.id,
     CASE
         WHEN first_msg.content_deleted_at IS NOT NULL
-        THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
+        THEN ${bind(deletedMessageTitle)}
         ELSE t.title
     END AS title,
     t.message_type AS type,
@@ -1484,7 +1489,7 @@ WHERE t.id = ${bind(threadId)} AND tp.participant_id = ${bind(accountId)}
             municipalAccountName,
             serviceWorkerAccountName,
             financeAccountName,
-            swedishEnabled = swedishEnabled,
+            deletedMessageBody = deletedMessageBody,
         )
     return combineThreadsAndMessages(
             accountId,
@@ -1501,7 +1506,8 @@ fun Database.Read.getMessageThreadByApplicationId(
     municipalAccountName: String,
     serviceWorkerAccountName: String,
     financeAccountName: String,
-    swedishEnabled: Boolean = true,
+    deletedMessageBody: String,
+    deletedMessageTitle: String,
 ): MessageThread? {
     val thread =
         createQuery {
@@ -1511,7 +1517,7 @@ SELECT
     t.id,
     CASE
         WHEN first_msg.content_deleted_at IS NOT NULL
-        THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
+        THEN ${bind(deletedMessageTitle)}
         ELSE t.title
     END AS title,
     t.message_type AS type,
@@ -1554,7 +1560,7 @@ LIMIT 1
                 municipalAccountName,
                 serviceWorkerAccountName,
                 financeAccountName,
-                swedishEnabled = swedishEnabled,
+                deletedMessageBody = deletedMessageBody,
             )
         return combineThreadsAndMessages(
                 accountId,

--- a/service/src/main/kotlin/evaka/core/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageQueries.kt
@@ -601,6 +601,7 @@ fun Database.Read.getThreads(
     folderId: MessageThreadFolderId? = null,
     personAccountId: MessageAccountId? = null,
     messagesSortDirection: SortDirection = SortDirection.ASC,
+    swedishEnabled: Boolean = true,
 ): PagedMessageThreads {
     val personAccountPredicate =
         if (personAccountId != null) {
@@ -629,7 +630,7 @@ SELECT
     t.id,
     CASE
         WHEN first_msg.content_deleted_at IS NOT NULL
-        THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_TITLE)}
+        THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
         ELSE t.title
     END AS title,
     t.message_type AS type,
@@ -677,6 +678,7 @@ LIMIT ${bind(pageSize)} OFFSET ${bind((page - 1) * pageSize)}
             serviceWorkerAccountName,
             financeAccountName,
             messagesSortDirection,
+            swedishEnabled,
         )
     return combineThreadsAndMessages(accountId, threads, messagesByThread)
 }
@@ -716,6 +718,7 @@ fun Database.Read.getReceivedThreads(
     folderId: MessageThreadFolderId? = null,
     accountAccessLimit: AccountAccessLimit = AccountAccessLimit.NoFurtherLimit,
     childId: ChildId? = null,
+    swedishEnabled: Boolean = true,
 ): PagedMessageThreads {
     val accountAccessPredicate =
         if (accountAccessLimit is AccountAccessLimit.AvailableFrom)
@@ -745,7 +748,7 @@ SELECT
     t.id,
     CASE
         WHEN first_msg.content_deleted_at IS NOT NULL
-        THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_TITLE)}
+        THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
         ELSE t.title
     END AS title,
     t.message_type AS type,
@@ -796,6 +799,7 @@ LIMIT ${bind(pageSize)} OFFSET ${bind((page - 1) * pageSize)}
             municipalAccountName,
             serviceWorkerAccountName,
             financeAccountName,
+            swedishEnabled = swedishEnabled,
         )
     return combineThreadsAndMessages(accountId, threads, messagesByThread)
 }
@@ -807,6 +811,7 @@ private fun Database.Read.getThreadMessages(
     serviceWorkerAccountName: String,
     financeAccountName: String,
     sortDirection: SortDirection = SortDirection.ASC,
+    swedishEnabled: Boolean = true,
 ): Map<MessageThreadId, List<Message>> {
     if (threadIds.isEmpty()) return mapOf()
     val sortDir = sortDirection.name
@@ -819,7 +824,7 @@ SELECT
     m.content_id,
     COALESCE(m.sent_at, m.created) AS sent_at,
     CASE
-        WHEN m.content_deleted_at IS NOT NULL THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_BODY)}
+        WHEN m.content_deleted_at IS NOT NULL THEN ${bind(deletedMessagePlaceholderBody(swedishEnabled))}
         ELSE mc.content
     END AS content,
     m.content_deleted_at,
@@ -945,6 +950,7 @@ fun Database.Read.getMessageCopiesByAccount(
     pageSize: Int,
     page: Int,
     accountAccessLimit: AccountAccessLimit = AccountAccessLimit.NoFurtherLimit,
+    swedishEnabled: Boolean = true,
 ): PagedMessageCopies {
     val accountAccessPredicate =
         if (accountAccessLimit is AccountAccessLimit.AvailableFrom)
@@ -962,7 +968,7 @@ fun Database.Read.getMessageCopiesByAccount(
         m.id AS message_id,
         CASE
             WHEN m.content_deleted_at IS NOT NULL
-            THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_TITLE)}
+            THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
             ELSE t.title
         END AS title,
         t.message_type AS type,
@@ -975,7 +981,7 @@ fun Database.Read.getMessageCopiesByAccount(
         m.content_id,
         CASE
             WHEN m.content_deleted_at IS NOT NULL
-            THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_BODY)}
+            THEN ${bind(deletedMessagePlaceholderBody(swedishEnabled))}
             ELSE c.content
         END AS content,
         m.content_deleted_at,
@@ -1087,6 +1093,7 @@ fun Database.Read.getSentMessage(
     messageId: MessageId,
     serviceWorkerAccountName: String,
     financeAccountName: String,
+    swedishEnabled: Boolean = true,
 ): Message {
     return createQuery {
             sql(
@@ -1097,7 +1104,7 @@ SELECT
     m.content_id,
     COALESCE(m.sent_at, m.created) AS sent_at,  -- use the created timestamp until the asyncjob marks the message as sent
     CASE
-        WHEN m.content_deleted_at IS NOT NULL THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_BODY)}
+        WHEN m.content_deleted_at IS NOT NULL THEN ${bind(deletedMessagePlaceholderBody(swedishEnabled))}
         ELSE mc.content
     END AS content,
     m.content_deleted_at,
@@ -1304,6 +1311,7 @@ fun Database.Read.getMessagesSentByAccount(
     pageSize: Int,
     page: Int,
     accountAccessLimit: AccountAccessLimit = AccountAccessLimit.NoFurtherLimit,
+    swedishEnabled: Boolean = true,
 ): PagedSentMessages {
     val accountAccessPredicate =
         if (accountAccessLimit is AccountAccessLimit.AvailableFrom)
@@ -1348,7 +1356,7 @@ SELECT
     msg.recipient_names,
     CASE
         WHEN msg.first_message_content_deleted_at IS NOT NULL
-        THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_TITLE)}
+        THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
         ELSE msg.title
     END AS thread_title,
     msg.first_message_content_deleted_at,
@@ -1357,7 +1365,7 @@ SELECT
     msg.sensitive,
     msg.content_deleted_at,
     CASE
-        WHEN msg.is_content_deleted THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_BODY)}
+        WHEN msg.is_content_deleted THEN ${bind(deletedMessagePlaceholderBody(swedishEnabled))}
         ELSE mc.content
     END AS content,
     CASE
@@ -1425,6 +1433,7 @@ fun Database.Read.getMessageThread(
     municipalAccountName: String,
     serviceWorkerAccountName: String,
     financeAccountName: String,
+    swedishEnabled: Boolean = true,
 ): MessageThread {
     val thread =
         createQuery {
@@ -1434,7 +1443,7 @@ SELECT
     t.id,
     CASE
         WHEN first_msg.content_deleted_at IS NOT NULL
-        THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_TITLE)}
+        THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
         ELSE t.title
     END AS title,
     t.message_type AS type,
@@ -1475,6 +1484,7 @@ WHERE t.id = ${bind(threadId)} AND tp.participant_id = ${bind(accountId)}
             municipalAccountName,
             serviceWorkerAccountName,
             financeAccountName,
+            swedishEnabled = swedishEnabled,
         )
     return combineThreadsAndMessages(
             accountId,
@@ -1491,6 +1501,7 @@ fun Database.Read.getMessageThreadByApplicationId(
     municipalAccountName: String,
     serviceWorkerAccountName: String,
     financeAccountName: String,
+    swedishEnabled: Boolean = true,
 ): MessageThread? {
     val thread =
         createQuery {
@@ -1500,7 +1511,7 @@ SELECT
     t.id,
     CASE
         WHEN first_msg.content_deleted_at IS NOT NULL
-        THEN ${bind(DELETED_MESSAGE_PLACEHOLDER_TITLE)}
+        THEN ${bind(deletedMessagePlaceholderTitle(swedishEnabled))}
         ELSE t.title
     END AS title,
     t.message_type AS type,
@@ -1543,6 +1554,7 @@ LIMIT 1
                 municipalAccountName,
                 serviceWorkerAccountName,
                 financeAccountName,
+                swedishEnabled = swedishEnabled,
             )
         return combineThreadsAndMessages(
                 accountId,

--- a/service/src/main/kotlin/evaka/core/messaging/MessageService.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageService.kt
@@ -273,7 +273,7 @@ class MessageService(
         serviceWorkerAccountName: String,
         financeAccountName: String,
         user: AuthenticatedUser,
-        swedishEnabled: Boolean = true,
+        deletedMessageBody: String,
     ): ThreadReply {
         val today = now.toLocalDate()
         val thread =
@@ -368,7 +368,7 @@ class MessageService(
                 messageId,
                 serviceWorkerAccountName,
                 financeAccountName,
-                swedishEnabled = swedishEnabled,
+                deletedMessageBody = deletedMessageBody,
             )
         }
         return ThreadReply(threadId, message)

--- a/service/src/main/kotlin/evaka/core/messaging/MessageService.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageService.kt
@@ -273,6 +273,7 @@ class MessageService(
         serviceWorkerAccountName: String,
         financeAccountName: String,
         user: AuthenticatedUser,
+        swedishEnabled: Boolean = true,
     ): ThreadReply {
         val today = now.toLocalDate()
         val thread =
@@ -367,6 +368,7 @@ class MessageService(
                 messageId,
                 serviceWorkerAccountName,
                 financeAccountName,
+                swedishEnabled = swedishEnabled,
             )
         }
         return ThreadReply(threadId, message)

--- a/service/src/main/kotlin/evaka/core/pis/SystemController.kt
+++ b/service/src/main/kotlin/evaka/core/pis/SystemController.kt
@@ -359,8 +359,8 @@ class SystemController(
                             allowEnglishChildDocumentsForAllTypes =
                                 featureConfig.allowEnglishChildDocumentsForAllTypes,
                             messageSupportEmail = featureConfig.messageSupportEmail,
-                            messageDeletedSwedishLanguageEnabled =
-                                featureConfig.messageDeletedSwedishLanguageEnabled,
+                            deletedMessagePlaceholderBody =
+                                featureConfig.deletedMessagePlaceholderBody,
                         )
 
                     EmployeeAuthResponse(

--- a/service/src/main/kotlin/evaka/core/pis/SystemController.kt
+++ b/service/src/main/kotlin/evaka/core/pis/SystemController.kt
@@ -359,6 +359,8 @@ class SystemController(
                             allowEnglishChildDocumentsForAllTypes =
                                 featureConfig.allowEnglishChildDocumentsForAllTypes,
                             messageSupportEmail = featureConfig.messageSupportEmail,
+                            messageDeletedSwedishLanguageEnabled =
+                                featureConfig.messageDeletedSwedishLanguageEnabled,
                         )
 
                     EmployeeAuthResponse(

--- a/service/src/main/kotlin/evaka/core/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/evaka/core/shared/FeatureConfig.kt
@@ -88,8 +88,13 @@ data class FeatureConfig(
      */
     val messageSupportEmail: String? = null,
 
-    /** Whether the Swedish text is included in the deleted message note. */
-    val messageDeletedSwedishLanguageEnabled: Boolean = true,
+    /** Title and body shown in place of a deleted message. */
+    val deletedMessagePlaceholderBody: String =
+        "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+            "Avsändaren har tagit bort meddelandet. Du behöver inte göra något.\n\n" +
+            "The sender has deleted this message. No action is needed on your part.",
+    val deletedMessagePlaceholderTitle: String =
+        "Viesti on poistettu / Meddelandet har raderats / Message was deleted",
 
     /**
      * true = placement unit is resolved from decision when it's accepted, false = placement unit is

--- a/service/src/main/kotlin/evaka/core/shared/FeatureConfig.kt
+++ b/service/src/main/kotlin/evaka/core/shared/FeatureConfig.kt
@@ -88,6 +88,9 @@ data class FeatureConfig(
      */
     val messageSupportEmail: String? = null,
 
+    /** Whether the Swedish text is included in the deleted message note. */
+    val messageDeletedSwedishLanguageEnabled: Boolean = true,
+
     /**
      * true = placement unit is resolved from decision when it's accepted, false = placement unit is
      * resolved from placement plan

--- a/service/src/main/kotlin/evaka/core/shared/security/EmployeeFeatureConfig.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/EmployeeFeatureConfig.kt
@@ -15,5 +15,5 @@ data class EmployeeFeatureConfig(
     val openRangesHolidayQuestionnaire: Boolean,
     val allowEnglishChildDocumentsForAllTypes: Boolean,
     val messageSupportEmail: String?,
-    val messageDeletedSwedishLanguageEnabled: Boolean,
+    val deletedMessagePlaceholderBody: String,
 )

--- a/service/src/main/kotlin/evaka/core/shared/security/EmployeeFeatureConfig.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/EmployeeFeatureConfig.kt
@@ -15,4 +15,5 @@ data class EmployeeFeatureConfig(
     val openRangesHolidayQuestionnaire: Boolean,
     val allowEnglishChildDocumentsForAllTypes: Boolean,
     val messageSupportEmail: String?,
+    val messageDeletedSwedishLanguageEnabled: Boolean,
 )

--- a/service/src/main/kotlin/evaka/instance/hameenkyro/HameenkyroConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/hameenkyro/HameenkyroConfig.kt
@@ -89,6 +89,7 @@ class HameenkyroConfig {
                 }
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
+            messageDeletedSwedishLanguageEnabled = false,
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/hameenkyro/HameenkyroConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/hameenkyro/HameenkyroConfig.kt
@@ -89,7 +89,10 @@ class HameenkyroConfig {
                 }
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
-            messageDeletedSwedishLanguageEnabled = false,
+            deletedMessagePlaceholderBody =
+                "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+                    "The sender has deleted this message. No action is needed on your part.",
+            deletedMessagePlaceholderTitle = "Viesti on poistettu / Message was deleted",
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/kangasala/KangasalaConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/kangasala/KangasalaConfig.kt
@@ -92,6 +92,7 @@ class KangasalaConfig {
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
             placementToolApplicationStatus = ApplicationStatus.WAITING_DECISION,
+            messageDeletedSwedishLanguageEnabled = false,
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/kangasala/KangasalaConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/kangasala/KangasalaConfig.kt
@@ -92,7 +92,10 @@ class KangasalaConfig {
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
             placementToolApplicationStatus = ApplicationStatus.WAITING_DECISION,
-            messageDeletedSwedishLanguageEnabled = false,
+            deletedMessagePlaceholderBody =
+                "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+                    "The sender has deleted this message. No action is needed on your part.",
+            deletedMessagePlaceholderTitle = "Viesti on poistettu / Message was deleted",
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/lempaala/LempaalaConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/lempaala/LempaalaConfig.kt
@@ -82,6 +82,7 @@ class LempaalaConfig {
                 }
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
+            messageDeletedSwedishLanguageEnabled = false,
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/lempaala/LempaalaConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/lempaala/LempaalaConfig.kt
@@ -82,7 +82,10 @@ class LempaalaConfig {
                 }
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
-            messageDeletedSwedishLanguageEnabled = false,
+            deletedMessagePlaceholderBody =
+                "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+                    "The sender has deleted this message. No action is needed on your part.",
+            deletedMessagePlaceholderTitle = "Viesti on poistettu / Message was deleted",
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/nokia/NokiaConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/nokia/NokiaConfig.kt
@@ -92,6 +92,7 @@ class NokiaConfig {
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
             placementToolApplicationStatus = ApplicationStatus.WAITING_DECISION,
+            messageDeletedSwedishLanguageEnabled = false,
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/nokia/NokiaConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/nokia/NokiaConfig.kt
@@ -92,7 +92,10 @@ class NokiaConfig {
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
             placementToolApplicationStatus = ApplicationStatus.WAITING_DECISION,
-            messageDeletedSwedishLanguageEnabled = false,
+            deletedMessagePlaceholderBody =
+                "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+                    "The sender has deleted this message. No action is needed on your part.",
+            deletedMessagePlaceholderTitle = "Viesti on poistettu / Message was deleted",
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/orivesi/OrivesiConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/orivesi/OrivesiConfig.kt
@@ -89,6 +89,7 @@ class OrivesiConfig {
                 }
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
+            messageDeletedSwedishLanguageEnabled = false,
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/orivesi/OrivesiConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/orivesi/OrivesiConfig.kt
@@ -89,7 +89,10 @@ class OrivesiConfig {
                 }
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
-            messageDeletedSwedishLanguageEnabled = false,
+            deletedMessagePlaceholderBody =
+                "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+                    "The sender has deleted this message. No action is needed on your part.",
+            deletedMessagePlaceholderTitle = "Viesti on poistettu / Message was deleted",
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/oulu/OuluConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/oulu/OuluConfig.kt
@@ -145,7 +145,10 @@ class OuluConfig {
             holidayQuestionnaireType = QuestionnaireType.OPEN_RANGES,
             minimumInvoiceAmount = 800,
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 20),
-            messageDeletedSwedishLanguageEnabled = false,
+            deletedMessagePlaceholderBody =
+                "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+                    "The sender has deleted this message. No action is needed on your part.",
+            deletedMessagePlaceholderTitle = "Viesti on poistettu / Message was deleted",
         )
 
     @Bean fun actionRuleMapping(): ActionRuleMapping = OuluActionRuleMapping()

--- a/service/src/main/kotlin/evaka/instance/oulu/OuluConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/oulu/OuluConfig.kt
@@ -145,6 +145,7 @@ class OuluConfig {
             holidayQuestionnaireType = QuestionnaireType.OPEN_RANGES,
             minimumInvoiceAmount = 800,
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 20),
+            messageDeletedSwedishLanguageEnabled = false,
         )
 
     @Bean fun actionRuleMapping(): ActionRuleMapping = OuluActionRuleMapping()

--- a/service/src/main/kotlin/evaka/instance/pirkkala/PirkkalaConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/pirkkala/PirkkalaConfig.kt
@@ -90,6 +90,7 @@ class PirkkalaConfig {
                 }
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
+            messageDeletedSwedishLanguageEnabled = false,
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/pirkkala/PirkkalaConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/pirkkala/PirkkalaConfig.kt
@@ -90,7 +90,10 @@ class PirkkalaConfig {
                 }
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
-            messageDeletedSwedishLanguageEnabled = false,
+            deletedMessagePlaceholderBody =
+                "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+                    "The sender has deleted this message. No action is needed on your part.",
+            deletedMessagePlaceholderTitle = "Viesti on poistettu / Message was deleted",
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/tampere/TampereConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/tampere/TampereConfig.kt
@@ -128,6 +128,7 @@ class TampereConfig {
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
             placementToolApplicationStatus = ApplicationStatus.WAITING_DECISION,
+            messageDeletedSwedishLanguageEnabled = false,
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/tampere/TampereConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/tampere/TampereConfig.kt
@@ -128,7 +128,10 @@ class TampereConfig {
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
             placementToolApplicationStatus = ApplicationStatus.WAITING_DECISION,
-            messageDeletedSwedishLanguageEnabled = false,
+            deletedMessagePlaceholderBody =
+                "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+                    "The sender has deleted this message. No action is needed on your part.",
+            deletedMessagePlaceholderTitle = "Viesti on poistettu / Message was deleted",
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/vesilahti/VesilahtiConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/vesilahti/VesilahtiConfig.kt
@@ -89,6 +89,7 @@ class VesilahtiConfig {
                 }
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
+            messageDeletedSwedishLanguageEnabled = false,
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/vesilahti/VesilahtiConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/vesilahti/VesilahtiConfig.kt
@@ -89,7 +89,10 @@ class VesilahtiConfig {
                 }
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
-            messageDeletedSwedishLanguageEnabled = false,
+            deletedMessagePlaceholderBody =
+                "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+                    "The sender has deleted this message. No action is needed on your part.",
+            deletedMessagePlaceholderTitle = "Viesti on poistettu / Message was deleted",
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/ylojarvi/YlojarviConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/ylojarvi/YlojarviConfig.kt
@@ -91,7 +91,10 @@ class YlojarviConfig {
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
             placementToolApplicationStatus = ApplicationStatus.WAITING_DECISION,
-            messageDeletedSwedishLanguageEnabled = false,
+            deletedMessagePlaceholderBody =
+                "Lähettäjä on poistanut viestin. Sinun ei tarvitse tehdä mitään.\n\n" +
+                    "The sender has deleted this message. No action is needed on your part.",
+            deletedMessagePlaceholderTitle = "Viesti on poistettu / Message was deleted",
         )
 
     @Bean

--- a/service/src/main/kotlin/evaka/instance/ylojarvi/YlojarviConfig.kt
+++ b/service/src/main/kotlin/evaka/instance/ylojarvi/YlojarviConfig.kt
@@ -91,6 +91,7 @@ class YlojarviConfig {
             },
             daycarePlacementPlanEndMonthDay = MonthDay.of(8, 15),
             placementToolApplicationStatus = ApplicationStatus.WAITING_DECISION,
+            messageDeletedSwedishLanguageEnabled = false,
         )
 
     @Bean


### PR DESCRIPTION
Piilotetaan ruotsinkieliset tekstit Tampereen seutukunnilta ja Oululta.