### PR TITLE
TypeScript 6 -konffipäivityksiä

### DIFF
--- a/apigw/tsconfig.json
+++ b/apigw/tsconfig.json
@@ -2,12 +2,9 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
-    "esModuleInterop": true,
-    "module": "node16",
-    "moduleResolution": "node16",
-    "noEmit": true,
-    "strict": true,
-    "target": "es2023"
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true
   },
   "include": ["**/*.ts"]
 }

--- a/dummy-idp/src/tsconfig.json
+++ b/dummy-idp/src/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "outDir": "../dist",
-    "rootDir": "./"
+    "outDir": "../dist"
   }
 }

--- a/dummy-idp/tsconfig.json
+++ b/dummy-idp/tsconfig.json
@@ -1,17 +1,14 @@
 {
   "compilerOptions": {
-    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
-    "module": "node16",
-    "moduleResolution": "node16",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmitOnError": true,
     "noEmit": true,
     "outDir": "dist",
     "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es2023"
+    "sourceMap": true
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/frontend/src/citizen-frontend/tsconfig.json
+++ b/frontend/src/citizen-frontend/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "composite": true,
     "jsx": "react-jsx",
     "outDir": "../../dist/citizen-frontend"

--- a/frontend/src/e2e-test/tsconfig.json
+++ b/frontend/src/e2e-test/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "composite": true,
     "jsx": "react-jsx",
     "outDir": "../../dist/e2e-test",

--- a/frontend/src/employee-frontend/state/user.tsx
+++ b/frontend/src/employee-frontend/state/user.tsx
@@ -65,9 +65,12 @@ export const UserContextProvider = React.memo(function UserContextProvider({
       loginStatusEvent.preventDefault()
       setUnauthorizedApiCallDetected(!loginStatusEvent.detail)
     }
-    window.addEventListener(LoginStatusChangeEvent.name, eventListener)
+    window.addEventListener(LoginStatusChangeEvent.eventName, eventListener)
     return () => {
-      window.removeEventListener(LoginStatusChangeEvent.name, eventListener)
+      window.removeEventListener(
+        LoginStatusChangeEvent.eventName,
+        eventListener
+      )
     }
   }, [setUnauthorizedApiCallDetected])
 

--- a/frontend/src/employee-frontend/tsconfig.json
+++ b/frontend/src/employee-frontend/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "composite": true,
     "jsx": "react-jsx",
     "outDir": "../../dist/employee-frontend",

--- a/frontend/src/employee-mobile-frontend/tsconfig.json
+++ b/frontend/src/employee-mobile-frontend/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "composite": true,
     "jsx": "react-jsx",
     "outDir": "../../dist/employee-mobile-frontend"

--- a/frontend/src/lib-common/tsconfig.json
+++ b/frontend/src/lib-common/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "composite": true,
     "outDir": "../../dist/lib-common",
     "types": ["node"]

--- a/frontend/src/lib-common/utils/login-status.ts
+++ b/frontend/src/lib-common/utils/login-status.ts
@@ -3,19 +3,19 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 export class LoginStatusChangeEvent extends CustomEvent<boolean> {
-  static name = 'loginstatuschange' as const
+  static eventName = 'loginstatuschange' as const
 
   constructor(loginStatus: boolean) {
-    super(LoginStatusChangeEvent.name, {
+    super(LoginStatusChangeEvent.eventName, {
       cancelable: true,
       detail: loginStatus
     })
   }
 }
 // TS typings to allow type safe listening for the custom event, e.g.:
-// window.addEventListener(LoginStatusChangeEvent.name, (e) => {e.detail /* <- TS knows this is a boolean */})
+// window.addEventListener(LoginStatusChangeEvent.eventName, (e) => {e.detail /* <- TS knows this is a boolean */})
 declare global {
   interface WindowEventMap {
-    [LoginStatusChangeEvent.name]: CustomEvent<boolean>
+    [LoginStatusChangeEvent.eventName]: CustomEvent<boolean>
   }
 }

--- a/frontend/src/lib-components/tsconfig.json
+++ b/frontend/src/lib-components/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "composite": true,
     "jsx": "react-jsx",
     "outDir": "../../dist/lib-components",

--- a/frontend/src/lib-customizations/tsconfig.json
+++ b/frontend/src/lib-customizations/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "composite": true,
     "jsx": "react-jsx",
     "outDir": "../../dist/lib-customizations",

--- a/frontend/src/lib-icons/tsconfig.json
+++ b/frontend/src/lib-icons/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "composite": true,
     "outDir": "../../dist/lib-icons"
   }

--- a/frontend/tsconfig.base.json
+++ b/frontend/tsconfig.base.json
@@ -1,11 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2022",
-    "module": "esnext",
     "lib": ["dom", "es2022"],
     "types": ["node"],
     "declaration": true,
-    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "isolatedModules": true,
@@ -14,7 +11,6 @@
     "noUnusedLocals": true,
     "resolveJsonModule": true,
     "sourceMap": true,
-    "strict": true,
     "paths": {
       "lib-common": ["./src/lib-common"],
       "lib-components": ["./src/lib-components"],

--- a/frontend/tsconfig.eslint.json
+++ b/frontend/tsconfig.eslint.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "jsx": "react-jsx",
     "noEmit": true,
     "types": ["node"]


### PR DESCRIPTION
TypeScript 6 toi muutoksia oletuskonfiguraatioon:
- `strict` on oletuksena päällä
- `esModuleInterop` on aina päällä
- `rootDir` on oletuksena `.`
- `target` on oletuksena kuluvan vuoden ES-versio, se on ihan hyvä oletus meille

Lisäksi moderneissa NodeJS-projekteissa suositellaan käytettävän `module`- ja `moduleResolution`-arvoa `nodenext`.