### PR TITLE
Näytetään "läsnä, ei aikoja"-tekstin sijaan päivittäinen vaka-aika

### DIFF
--- a/frontend/src/e2e-test/specs/6_mobile/child-attendances.spec.ts
+++ b/frontend/src/e2e-test/specs/6_mobile/child-attendances.spec.ts
@@ -1096,6 +1096,42 @@ test.describe('Child attendances', () => {
       )
     })
 
+    test("NO_TIMES reservation child's daily service time is shown when available", async ({
+      newEvakaPage
+    }) => {
+      await openPage(newEvakaPage)
+      const child = testChild2.id
+      await createPlacements(child)
+
+      const today = now.toLocalDate()
+      await Fixture.dailyServiceTime({
+        childId: child,
+        validityPeriod: new DateRange(today, today),
+        type: 'REGULAR',
+        regularTimes: new TimeRange(
+          now.subHours(3).toLocalTime(),
+          now.addHours(3).toLocalTime()
+        )
+      }).save()
+      await Fixture.holidayPeriod({
+        period: new FiniteDateRange(today, today)
+      }).save()
+      await Fixture.attendanceReservationRaw({
+        childId: child,
+        date: today,
+        range: null
+      }).save()
+
+      const mobileSignupUrl = await pairMobileDevice(testDaycare.id)
+      await page.goto(mobileSignupUrl)
+
+      await assertAttendanceCounts(1, 0, 0, 0, 1)
+      await listPage.selectChild(child)
+      await expect(childPage.reservation).toHaveText(
+        'Varhaiskasvatusaika tänään 10:00-16:00'
+      )
+    })
+
     test('Term break child is shown in absent list', async ({
       newEvakaPage
     }) => {

--- a/frontend/src/employee-mobile-frontend/child-attendance/ChildListItem.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/ChildListItem.tsx
@@ -334,18 +334,18 @@ function ChildReservationInfo(props: { child: AttendanceChild }) {
 
   return (
     <em>
-      {reservations.length > 0
-        ? i18n.attendances.serviceTime.reservationNoTimes
-        : todaysServiceTime === 'not_set'
-          ? i18n.attendances.serviceTime.notSetShort
-          : todaysServiceTime === 'not_today'
-            ? i18n.attendances.serviceTime.noServiceTodayShort
-            : todaysServiceTime === 'variable_times'
-              ? i18n.attendances.serviceTime.variableTimesShort
-              : i18n.attendances.serviceTime.serviceTodayShort(
-                  todaysServiceTime.formatStart(),
-                  todaysServiceTime.formatEnd()
-                )}
+      {typeof todaysServiceTime !== 'string'
+        ? i18n.attendances.serviceTime.serviceTodayShort(
+            todaysServiceTime.formatStart(),
+            todaysServiceTime.formatEnd()
+          )
+        : reservations.length > 0
+          ? i18n.attendances.serviceTime.reservationNoTimes
+          : todaysServiceTime === 'not_set'
+            ? i18n.attendances.serviceTime.notSetShort
+            : todaysServiceTime === 'not_today'
+              ? i18n.attendances.serviceTime.noServiceTodayShort
+              : i18n.attendances.serviceTime.variableTimesShort}
     </em>
   )
 }

--- a/frontend/src/employee-mobile-frontend/child-info/AttendanceDailyServiceTimes.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/AttendanceDailyServiceTimes.tsx
@@ -47,8 +47,9 @@ export default React.memo(function AttendanceDailyServiceTimes({
     )
   }
 
-  if (reservationsNoTimes.length > 0) {
-    // NO_TIMES reservation
+  const todaysTimes = getTodaysServiceTimes(dailyServiceTimes)
+
+  if (reservationsNoTimes.length > 0 && typeof todaysTimes === 'string') {
     return (
       <ServiceTime data-qa="reservation">
         <ReservationNoTimes hideLabel={hideLabel} />
@@ -56,7 +57,6 @@ export default React.memo(function AttendanceDailyServiceTimes({
     )
   }
 
-  const todaysTimes = getTodaysServiceTimes(dailyServiceTimes)
   return (
     <ServiceTime data-qa="reservation">
       {scheduleType === 'FIXED_SCHEDULE' ? (


### PR DESCRIPTION
PR #9234 muutti loma-ajan "Läsnä, kellonaika ei vielä tiedossa"-varaukset näkymään kasvattajan mobiilissa. Se ei kuitenkaan ottanut huomioon päivittäisiä varhaiskasvatusaikoja oikein. Tämä korjaa ne taas näkyviin.