### PR TITLE
Korjataan Suomi.fi-uloskirjautuminen hylätyn sfi-kirjautumisen jälkeen

### DIFF
--- a/apigw/src/shared/__tests__/saml-relaystate.ts
+++ b/apigw/src/shared/__tests__/saml-relaystate.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import type express from 'express'
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildRelayStateWithCorrelationToken,
+  extractCorrelationToken,
+  validateRelayStateUrl
+} from '../saml/index.ts'
+
+const reqWith = (relayState: string) =>
+  ({
+    body: { RelayState: relayState },
+    query: {}
+  }) as express.Request
+
+describe('RelayState correlation token', () => {
+  test('appends and extracts the token', () => {
+    const built = buildRelayStateWithCorrelationToken('/citizen/foo', 'tok-abc')
+    expect(built).toBe('/citizen/foo&sfiCorr=tok-abc')
+    expect(extractCorrelationToken(reqWith(built))).toBe('tok-abc')
+  })
+
+  test('no token appended when undefined; extraction yields undefined', () => {
+    const built = buildRelayStateWithCorrelationToken('/x', undefined)
+    expect(built).toBe('/x')
+    expect(extractCorrelationToken(reqWith(built))).toBeUndefined()
+  })
+
+  test('strips and reads only the appended token when the base URL already carries a query string with the token param', () => {
+    const built = buildRelayStateWithCorrelationToken(
+      '/c/foo?a=1&sfiCorr=decoy',
+      'tok-1'
+    )
+    expect(extractCorrelationToken(reqWith(built))).toBe('tok-1')
+    const url = validateRelayStateUrl(reqWith(built))
+    expect(url?.pathname).toBe('/c/foo')
+    expect(url?.search).toBe('?a=1&sfiCorr=decoy')
+  })
+
+  test('malformed token percent-encoding yields undefined instead of throwing', () => {
+    expect(extractCorrelationToken(reqWith('/x&sfiCorr=%'))).toBeUndefined()
+  })
+})

--- a/apigw/src/shared/__tests__/saml-slo.ts
+++ b/apigw/src/shared/__tests__/saml-slo.ts
@@ -541,6 +541,36 @@ describe('SLO session tracking on rejected sfi login', () => {
     expect(await isEmployeeLoggedIn(tester)).toBe(false)
   })
 
+  test('IdP-initiated SLO with cookies reports success for the session it names', async () => {
+    await tester.login(mockUser, {
+      SAMLResponse: buildLoginResponse('citizen@local', '_c-idx', 'authnC')
+    })
+    await employeeSfiLogin(tester, 'employee@local', '_e-idx', {
+      rejected: false
+    })
+
+    const status = await idpInitiatedSlo(tester, 'employee@local', '_e-idx', {
+      withCookies: true
+    })
+
+    expect(status).toBe(SAML_SUCCESS)
+    expect(await isCitizenLoggedIn(tester)).toBe(false)
+    expect(await isEmployeeLoggedIn(tester)).toBe(false)
+  })
+
+  test('IdP-initiated SLO for a principal we never logged in reports failure', async () => {
+    await tester.login(mockUser, {
+      SAMLResponse: buildLoginResponse('citizen@local', '_c-idx', 'authnC')
+    })
+
+    const status = await idpInitiatedSlo(tester, 'stranger@local', '_s-idx', {
+      withCookies: true
+    })
+
+    expect(status).not.toBe(SAML_SUCCESS)
+    expect(await isCitizenLoggedIn(tester)).toBe(false)
+  })
+
   test('no pre-existing session: rejected login writes nothing', async () => {
     // Employee sfi login with no citizen or employee session present.
     const startRes = await tester.client.get('/api/employee/auth/sfi/login', {

--- a/apigw/src/shared/__tests__/saml-slo.ts
+++ b/apigw/src/shared/__tests__/saml-slo.ts
@@ -239,3 +239,370 @@ function getSamlMessageFromRedirectResponse(res: AxiosResponse) {
   const inflated = zlib.inflateRawSync(decoded)
   return new xmldom.DOMParser({}).parseFromString(inflated.toString())
 }
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Reads the SAML LogoutRequest that our /logout endpoint redirects the browser
+// to, and returns its SessionIndex.
+async function logoutRequestSessionIndex(
+  tester: GatewayTester,
+  logoutPath: string
+): Promise<string> {
+  const res = await tester.client.get(logoutPath, {
+    maxRedirects: 0,
+    validateStatus: () => true
+  })
+  expect(res.status).toBe(302)
+  const dom = getSamlMessageFromRedirectResponse(res)
+  // oxlint-disable-next-line typescript/no-unsafe-assignment
+  const json = await xml2js.parseStringPromise(dom)
+  // node-saml emits the SessionIndex element with a different (but
+  // equivalent) namespace prefix than the rest of the LogoutRequest, and
+  // since it declares that namespace inline, xml2js parses it as a node
+  // with attributes (`$`) rather than a plain string.
+  // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-assignment
+  const sessionIndexNode = json['samlp:LogoutRequest']['saml2p:SessionIndex'][0]
+  return typeof sessionIndexNode === 'string'
+    ? sessionIndexNode
+    : // oxlint-disable-next-line typescript/no-unsafe-member-access
+      (sessionIndexNode._ as string)
+}
+
+// The SP registers a single SLO callback for both audiences; an IdP-initiated
+// logout carries no eVaka RelayState, so it always dispatches to the citizen
+// integration regardless of which session it names.
+const SHARED_SLO_ENDPOINT = '/api/application/auth/saml/logout/callback'
+
+async function idpInitiatedSlo(
+  tester: GatewayTester,
+  nameId: string,
+  sessionIndex: string,
+  { withCookies }: { withCookies: boolean }
+): Promise<string> {
+  const cookies = withCookies
+    ? []
+    : [
+        await tester.getCookie(sessionCookie('citizen')),
+        await tester.getCookie(sessionCookie('employee'))
+      ]
+  // The IdP's logout request is cross-site, so SameSite=lax withholds our
+  // session cookies from it.
+  if (!withCookies) await tester.cookies.removeAllCookies()
+
+  const res = await tester.client.post(
+    SHARED_SLO_ENDPOINT,
+    new URLSearchParams({
+      SAMLRequest: buildIdPInitiatedLogoutRequest(nameId, sessionIndex)
+    }),
+    { maxRedirects: 0, validateStatus: () => true }
+  )
+  expect(res.status).toBe(302)
+
+  for (const cookie of cookies) if (cookie) await tester.setCookie(cookie)
+
+  const logoutResponse = getSamlMessageFromRedirectResponse(res)
+  // oxlint-disable-next-line typescript/no-unsafe-assignment
+  const json = await xml2js.parseStringPromise(logoutResponse)
+  // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-return
+  return json['samlp:LogoutResponse']['samlp:Status'][0]['samlp:StatusCode'][0]
+    .$.Value
+}
+
+const SAML_SUCCESS = 'urn:oasis:names:tc:SAML:2.0:status:Success'
+
+async function isCitizenLoggedIn(tester: GatewayTester): Promise<boolean> {
+  tester.nockScope
+    .get(`/system/citizen/${mockUser.id}`)
+    .reply(200, { id: mockUser.id })
+  const res = await tester.client.get(SECURED_ENDPOINT, {
+    validateStatus: () => true
+  })
+  // oxlint-disable-next-line typescript/no-unsafe-member-access
+  return res.data?.loggedIn === true
+}
+
+async function isEmployeeLoggedIn(tester: GatewayTester): Promise<boolean> {
+  tester.nockScope.get(`/system/employee/${mockUser.id}`).reply(200, {
+    user: {
+      id: mockUser.id,
+      firstName: '',
+      lastName: '',
+      globalRoles: [],
+      allScopedRoles: [],
+      accessibleFeatures: {},
+      permittedGlobalActions: [],
+      startPage: '/'
+    },
+    featureConfig: {}
+  })
+  const res = await tester.client.get('/api/employee/auth/status', {
+    validateStatus: () => true
+  })
+  // oxlint-disable-next-line typescript/no-unsafe-member-access
+  return res.data?.loggedIn === true
+}
+
+// Starts a sfi login through /login so the co-resident session is captured in
+// the sfiCorr correlation record, then completes it at the shared callback.
+async function employeeSfiLogin(
+  tester: GatewayTester,
+  nameId: string,
+  sessionIndex: string,
+  { rejected }: { rejected: boolean }
+): Promise<void> {
+  const startRes = await tester.client.get(
+    '/api/employee/auth/sfi/login?RelayState=%2Femployee',
+    { maxRedirects: 0, validateStatus: () => true }
+  )
+  const relayState =
+    // oxlint-disable-next-line typescript/no-unsafe-argument
+    new URL(startRes.headers.location).searchParams.get('RelayState') ?? ''
+
+  const scope = tester.nockScope.post('/system/employee-sfi-login')
+  if (rejected) scope.reply(403)
+  else
+    scope.reply(200, { id: mockUser.id, globalRoles: [], allScopedRoles: [] })
+
+  await tester.client.post(
+    '/api/application/auth/saml/login/callback',
+    new URLSearchParams({
+      SAMLResponse: buildLoginResponse(nameId, sessionIndex, 'authnEmployee'),
+      RelayState: relayState
+    }),
+    { maxRedirects: 0, validateStatus: () => true }
+  )
+  tester.nockScope.done()
+}
+
+describe('SLO session tracking on rejected sfi login', () => {
+  let tester: GatewayTester
+
+  beforeEach(async () => {
+    const config: Config = {
+      ...configFromEnv(),
+      sfi: {
+        type: 'saml',
+        saml: {
+          callbackUrl: SP_CALLBACK_URL,
+          entryPoint: IDP_ENTRY_POINT_URL,
+          logoutUrl: IDP_ENTRY_POINT_URL,
+          issuer: SP_ISSUER,
+          publicCert: 'config/test-cert/slo-test-idp-cert.pem',
+          privateCert: 'config/test-cert/saml-private.pem',
+          validateInResponseTo: ValidateInResponseTo.never,
+          decryptAssertions: false,
+          acceptedClockSkewMs: 0
+        }
+      }
+    }
+    tester = await GatewayTester.start(config, 'citizen')
+  })
+  afterEach(async () => {
+    await tester?.afterEach()
+    await tester?.stop()
+  })
+
+  test('citizen logout uses the rejected employee login sessionIndex', async () => {
+    // 1. Citizen logs in via sfi.
+    const citizenSessionIndex = '_citizen-session-index'
+    await tester.login(mockUser, {
+      SAMLResponse: buildLoginResponse(
+        'citizen@local',
+        citizenSessionIndex,
+        'authnCitizen'
+      )
+    })
+
+    await delay(5) // guarantee the rejected login's createdAt is strictly newer
+
+    // 2. Employee sfi login: SAML validates, but eVaka rejects it.
+    //    Go through /login so the citizen session is captured in the sfiCorr
+    //    correlation record referenced by RelayState.
+    const startRes = await tester.client.get('/api/employee/auth/sfi/login', {
+      maxRedirects: 0,
+      validateStatus: () => true
+    })
+    const relayState =
+      // oxlint-disable-next-line typescript/no-unsafe-argument
+      new URL(startRes.headers.location).searchParams.get('RelayState') ?? ''
+    expect(relayState).toContain('sfiCorr=')
+
+    const employeeSessionIndex = '_employee-session-index'
+    tester.nockScope.post('/system/employee-sfi-login').reply(403)
+    await tester.client.post(
+      '/api/employee/auth/sfi/login/callback',
+      new URLSearchParams({
+        SAMLResponse: buildLoginResponse(
+          'employee@local',
+          employeeSessionIndex,
+          'authnEmployee'
+        ),
+        RelayState: relayState
+      }),
+      { maxRedirects: 0, validateStatus: () => true }
+    )
+    tester.nockScope.done()
+
+    // 3. Citizen logout must SLO with the employee (IdP-valid) sessionIndex.
+    expect(
+      await logoutRequestSessionIndex(tester, '/api/citizen/auth/logout')
+    ).toBe(employeeSessionIndex)
+  })
+
+  test('same-side: employee logout uses the rejected re-login sessionIndex', async () => {
+    // 1. Employee logs in via sfi (backend accepts).
+    const firstIndex = '_employee-first-index'
+    const startRes1 = await tester.client.get('/api/employee/auth/sfi/login', {
+      maxRedirects: 0,
+      validateStatus: () => true
+    })
+    const relayState1 =
+      // oxlint-disable-next-line typescript/no-unsafe-argument
+      new URL(startRes1.headers.location).searchParams.get('RelayState') ?? ''
+    tester.nockScope
+      .post('/system/employee-sfi-login')
+      .reply(200, { id: mockUser.id, globalRoles: [], allScopedRoles: [] })
+    await tester.client.post(
+      '/api/employee/auth/sfi/login/callback',
+      new URLSearchParams({
+        SAMLResponse: buildLoginResponse('emp@local', firstIndex, 'authn1'),
+        RelayState: relayState1
+      }),
+      { maxRedirects: 0, validateStatus: () => true }
+    )
+    tester.nockScope.done()
+
+    await delay(5)
+
+    // 2. Employee re-login on the same side: SAML validates, eVaka rejects.
+    //    The existing employee session is captured as the own-side session
+    //    via the correlation record.
+    const secondIndex = '_employee-second-index'
+    const startRes2 = await tester.client.get('/api/employee/auth/sfi/login', {
+      maxRedirects: 0,
+      validateStatus: () => true
+    })
+    const relayState2 =
+      // oxlint-disable-next-line typescript/no-unsafe-argument
+      new URL(startRes2.headers.location).searchParams.get('RelayState') ?? ''
+    expect(relayState2).toContain('sfiCorr=')
+    tester.nockScope.post('/system/employee-sfi-login').reply(403)
+    await tester.client.post(
+      '/api/employee/auth/sfi/login/callback',
+      new URLSearchParams({
+        SAMLResponse: buildLoginResponse('emp@local', secondIndex, 'authn2'),
+        RelayState: relayState2
+      }),
+      { maxRedirects: 0, validateStatus: () => true }
+    )
+    tester.nockScope.done()
+
+    // 3. Employee logout must SLO with the newer (rejected re-login) index.
+    expect(
+      await logoutRequestSessionIndex(tester, '/api/employee/auth/logout')
+    ).toBe(secondIndex)
+  })
+
+  test('IdP-initiated SLO without cookies logs out the session linked to a rejected login', async () => {
+    await tester.login(mockUser, {
+      SAMLResponse: buildLoginResponse('citizen@local', '_c-idx', 'authnC')
+    })
+    await delay(5) // guarantee the rejected login's createdAt is strictly newer
+    await employeeSfiLogin(tester, 'employee@local', '_e-idx', {
+      rejected: true
+    })
+    expect(await isCitizenLoggedIn(tester)).toBe(true)
+
+    const status = await idpInitiatedSlo(tester, 'employee@local', '_e-idx', {
+      withCookies: false
+    })
+
+    expect(status).toBe(SAML_SUCCESS)
+    expect(await isCitizenLoggedIn(tester)).toBe(false)
+  })
+
+  test('IdP-initiated SLO without cookies logs out both co-resident sessions', async () => {
+    await tester.login(mockUser, {
+      SAMLResponse: buildLoginResponse('citizen@local', '_c-idx', 'authnC')
+    })
+    await employeeSfiLogin(tester, 'employee@local', '_e-idx', {
+      rejected: false
+    })
+    expect(await isCitizenLoggedIn(tester)).toBe(true)
+    expect(await isEmployeeLoggedIn(tester)).toBe(true)
+
+    // Suomi.fi only knows the newest login, and expects it to log out both.
+    const status = await idpInitiatedSlo(tester, 'employee@local', '_e-idx', {
+      withCookies: false
+    })
+
+    expect(status).toBe(SAML_SUCCESS)
+    expect(await isCitizenLoggedIn(tester)).toBe(false)
+    expect(await isEmployeeLoggedIn(tester)).toBe(false)
+  })
+
+  test('no pre-existing session: rejected login writes nothing', async () => {
+    // Employee sfi login with no citizen or employee session present.
+    const startRes = await tester.client.get('/api/employee/auth/sfi/login', {
+      maxRedirects: 0,
+      validateStatus: () => true
+    })
+    const relayState =
+      // oxlint-disable-next-line typescript/no-unsafe-argument
+      new URL(startRes.headers.location).searchParams.get('RelayState') ?? ''
+    expect(relayState).not.toContain('sfiCorr=')
+
+    tester.nockScope.post('/system/employee-sfi-login').reply(403)
+    const res = await tester.client.post(
+      '/api/employee/auth/sfi/login/callback',
+      new URLSearchParams({
+        SAMLResponse: buildLoginResponse('nobody@local', '_x', 'authnX'),
+        RelayState: relayState
+      }),
+      { maxRedirects: 0, validateStatus: () => true }
+    )
+    // Login still fails (redirect to the employee error page); nothing persisted.
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toContain('loginError')
+    tester.nockScope.done()
+  })
+
+  test('the latest rejected attempt replaces the previous one', async () => {
+    const citizenIndex = '_citizen-idx'
+    await tester.login(mockUser, {
+      SAMLResponse: buildLoginResponse('citizen@local', citizenIndex, 'authnC')
+    })
+
+    const attempt = async (employeeIndex: string) => {
+      await delay(5)
+      const startRes = await tester.client.get('/api/employee/auth/sfi/login', {
+        maxRedirects: 0,
+        validateStatus: () => true
+      })
+      const relayState =
+        // oxlint-disable-next-line typescript/no-unsafe-argument
+        new URL(startRes.headers.location).searchParams.get('RelayState') ?? ''
+      tester.nockScope.post('/system/employee-sfi-login').reply(403)
+      await tester.client.post(
+        '/api/employee/auth/sfi/login/callback',
+        new URLSearchParams({
+          SAMLResponse: buildLoginResponse(
+            'employee@local',
+            employeeIndex,
+            'authnE'
+          ),
+          RelayState: relayState
+        }),
+        { maxRedirects: 0, validateStatus: () => true }
+      )
+      tester.nockScope.done()
+    }
+
+    await attempt('_employee-idx-1')
+    await attempt('_employee-idx-2')
+
+    expect(
+      await logoutRequestSessionIndex(tester, '/api/citizen/auth/logout')
+    ).toBe('_employee-idx-2')
+  })
+})

--- a/apigw/src/shared/__tests__/session-sfi-logout.ts
+++ b/apigw/src/shared/__tests__/session-sfi-logout.ts
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { sign } from 'cookie-signature'
+import type express from 'express'
+import { describe, expect, test } from 'vitest'
+
+import { createLogoutToken } from '../auth/index.ts'
+import type { SamlSession } from '../saml/index.ts'
+import { sessionSupport } from '../session.ts'
+import { MockRedisClient } from '../test/mock-redis-client.ts'
+
+const sessionConfig = {
+  useSecureCookies: false,
+  cookieSecret: 'test-secret',
+  sessionTimeoutMinutes: 32
+}
+
+const samlSession: SamlSession = {
+  issuer: 'idp',
+  nameID: 'name-id',
+  nameIDFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+  sessionIndex: '_new-session-index'
+}
+
+const primaryReq = (id: string, createdAt: number) =>
+  ({
+    session: { id, evaka: { user: { authType: 'sfi', createdAt } } }
+  }) as express.Request
+
+const storeSfiSession = (redis: MockRedisClient, id: string) =>
+  redis.set(
+    `sess:${id}`,
+    JSON.stringify({ passport: { user: { authType: 'sfi' } } })
+  )
+
+describe('saveRejectedSfiLogin', () => {
+  test('links a session to a newer rejected login, returning only the samlSession', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    const req = primaryReq('p-ovr-1', 1000) // primary createdAt far in the past
+    await storeSfiSession(redis, 'p-ovr-1')
+
+    await sessions.saveRejectedSfiLogin(['p-ovr-1'], samlSession)
+
+    const secondary = await sessions.getSecondaryUserIfNewer(req)
+    expect(secondary).toBeDefined()
+    // non-privileged: a bare samlSession, no user identity/roles
+    expect((secondary as { id?: string }).id).toBeUndefined()
+    expect((secondary as { userType?: string }).userType).toBeUndefined()
+    expect((secondary as { sessionIndex?: string }).sessionIndex).toBe(
+      '_new-session-index'
+    )
+  })
+
+  test('a rejected login older-or-equal than the primary session is ignored (strict >)', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    // Write the rejected login record directly so createdAt is deterministic.
+    await redis.set(
+      'sfilogin:p-ovr-2',
+      JSON.stringify({ samlSession, createdAt: 5000 })
+    )
+    // equal
+    expect(
+      await sessions.getSecondaryUserIfNewer(primaryReq('p-ovr-2', 5000))
+    ).toBeUndefined()
+    // older
+    expect(
+      await sessions.getSecondaryUserIfNewer(primaryReq('p-ovr-2', 6000))
+    ).toBeUndefined()
+  })
+
+  test('no-op for empty ids and for unset maxSessionTimeoutMinutes', async () => {
+    const redis = new MockRedisClient()
+    const withTimeout = sessionSupport('citizen', redis, sessionConfig, 32)
+    await withTimeout.saveRejectedSfiLogin([], samlSession)
+    expect(
+      await withTimeout.getSecondaryUserIfNewer(primaryReq('p-ovr-3', 1000))
+    ).toBeUndefined()
+
+    const noTimeout = sessionSupport('citizen', redis, sessionConfig)
+    await noTimeout.saveRejectedSfiLogin(['p-ovr-4'], samlSession)
+    expect(
+      await noTimeout.getSecondaryUserIfNewer(primaryReq('p-ovr-4', 1000))
+    ).toBeUndefined()
+  })
+
+  test('a rejected login expires after its TTL', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await storeSfiSession(redis, 'p-ovr-5')
+    await sessions.saveRejectedSfiLogin(['p-ovr-5'], samlSession)
+    expect(await redis.get('sfilogin:p-ovr-5')).not.toBeNull()
+
+    redis.advanceTime(32 * 60 + 1)
+
+    expect(
+      await sessions.getSecondaryUserIfNewer(primaryReq('p-ovr-5', 1000))
+    ).toBeUndefined()
+  })
+
+  test('prefers the rejected login when it is newer than the real secondary session', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await redis.set('sfisess:dual-1', 'secondary-1')
+    await redis.set(
+      'sess:secondary-1',
+      JSON.stringify({
+        evaka: {
+          user: {
+            authType: 'sfi',
+            createdAt: 2000,
+            sessionIndex: '_real-secondary'
+          }
+        }
+      })
+    )
+    await redis.set(
+      'sfilogin:dual-1',
+      JSON.stringify({ samlSession, createdAt: 3000 })
+    )
+
+    const secondary = await sessions.getSecondaryUserIfNewer(
+      primaryReq('dual-1', 1000)
+    )
+    expect((secondary as { sessionIndex?: string }).sessionIndex).toBe(
+      '_new-session-index'
+    )
+  })
+
+  test('prefers the real secondary session when it is newer than the rejected login', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await redis.set('sfisess:dual-2', 'secondary-2')
+    await redis.set(
+      'sess:secondary-2',
+      JSON.stringify({
+        evaka: {
+          user: {
+            authType: 'sfi',
+            createdAt: 3000,
+            sessionIndex: '_real-secondary'
+          }
+        }
+      })
+    )
+    await redis.set(
+      'sfilogin:dual-2',
+      JSON.stringify({ samlSession, createdAt: 2000 })
+    )
+
+    const secondary = await sessions.getSecondaryUserIfNewer(
+      primaryReq('dual-2', 1000)
+    )
+    expect((secondary as { sessionIndex?: string }).sessionIndex).toBe(
+      '_real-secondary'
+    )
+  })
+
+  test('ignores both candidates when the primary session is newer than both', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await redis.set('sfisess:tri-1', 'secondary-3')
+    await redis.set(
+      'sess:secondary-3',
+      JSON.stringify({
+        evaka: {
+          user: { authType: 'sfi', createdAt: 2000, sessionIndex: '_sec' }
+        }
+      })
+    )
+    await redis.set(
+      'sfilogin:tri-1',
+      JSON.stringify({ samlSession, createdAt: 1500 })
+    )
+    // The newest candidate is the real secondary (2000), but the primary (3000)
+    // is newer than both it and the rejected login (1500) -> nothing supersedes it.
+    expect(
+      await sessions.getSecondaryUserIfNewer(primaryReq('tri-1', 3000))
+    ).toBeUndefined()
+  })
+})
+
+describe('destroy clears the rejected sfi login', () => {
+  test('deletes the rejected login key for the session being destroyed', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await storeSfiSession(redis, 'destroy-1')
+    await sessions.saveRejectedSfiLogin(['destroy-1'], samlSession)
+    expect(await redis.get('sfilogin:destroy-1')).not.toBeNull()
+
+    const req = {
+      session: { id: 'destroy-1', destroy: (cb: () => void) => cb() },
+      user: { authType: 'sfi' }
+    } as express.Request
+    const res = {
+      clearCookie: () => undefined
+    } as unknown as express.Response
+
+    await sessions.destroy(req, res)
+
+    expect(await redis.get('sfilogin:destroy-1')).toBeNull()
+  })
+})
+
+describe('logoutWithToken via a rejected sfi login', () => {
+  const rejectedLoginToken = createLogoutToken(samlSession)
+
+  const storeSession = async (
+    redis: MockRedisClient,
+    id: string,
+    authType: string,
+    logoutToken: string
+  ) => {
+    await redis.set(
+      `sess:${id}`,
+      JSON.stringify({
+        passport: { user: { authType } },
+        logoutToken: { value: logoutToken }
+      })
+    )
+    await redis.set(`slo:${logoutToken}`, id)
+  }
+
+  test('tears down a linked sfi session and reports the logged out samlSession', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await storeSession(redis, 'ovr-c', 'sfi', 'stale-token')
+    await sessions.saveRejectedSfiLogin(['ovr-c'], samlSession)
+
+    const user = await sessions.logoutWithToken(rejectedLoginToken)
+
+    expect(user).toEqual(samlSession)
+    expect(await redis.get('sess:ovr-c')).toBeNull()
+    // the session's own stale logout token must not outlive it
+    expect(await redis.get('slo:stale-token')).toBeNull()
+    expect(await redis.get('sfilogin:ovr-c')).toBeNull()
+    expect(await redis.get(`sfislo:${rejectedLoginToken}`)).toBeNull()
+  })
+
+  test('also tears down the co-resident session cross-linked to it', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await storeSession(redis, 'ovr-c', 'sfi', 'citizen-token')
+    await storeSession(redis, 'ovr-e', 'sfi', 'employee-token')
+    await redis.set('sfisess:ovr-c', 'ovr-e')
+    await redis.set('sfisess:ovr-e', 'ovr-c')
+    await sessions.saveRejectedSfiLogin(['ovr-c'], samlSession)
+
+    await sessions.logoutWithToken(rejectedLoginToken)
+
+    expect(await redis.get('sess:ovr-e')).toBeNull()
+    expect(await redis.get('slo:employee-token')).toBeNull()
+    expect(await redis.get('sfisess:ovr-c')).toBeNull()
+    expect(await redis.get('sfisess:ovr-e')).toBeNull()
+  })
+
+  test('reports nothing logged out when the linked session is already gone', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await storeSession(redis, 'ovr-gone', 'sfi', 'gone-token')
+    await sessions.saveRejectedSfiLogin(['ovr-gone'], samlSession)
+    // the session logs out normally before the IdP's logout request arrives
+    await redis.del('sess:ovr-gone')
+
+    expect(await sessions.logoutWithToken(rejectedLoginToken)).toBeUndefined()
+    expect(await redis.get('sfilogin:ovr-gone')).toBeNull()
+  })
+
+  test('the sfislo index expires with the rejected login', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await storeSession(redis, 'ovr-ttl', 'sfi', 'ttl-token')
+    await sessions.saveRejectedSfiLogin(['ovr-ttl'], samlSession)
+
+    redis.advanceTime(32 * 60 + 1)
+
+    expect(await sessions.logoutWithToken(rejectedLoginToken)).toBeUndefined()
+    expect(await redis.get('sess:ovr-ttl')).not.toBeNull()
+  })
+})
+
+describe('login correlation', () => {
+  test('round-trips and is consumed exactly once', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+
+    await sessions.saveLoginCorrelation('tok-1', {
+      ownSid: 'own-1',
+      secondarySid: 'sec-1'
+    })
+
+    expect(await sessions.consumeLoginCorrelation('tok-1')).toEqual({
+      ownSid: 'own-1',
+      secondarySid: 'sec-1'
+    })
+    // second read is empty (deleted on consume)
+    expect(await sessions.consumeLoginCorrelation('tok-1')).toEqual({})
+  })
+
+  test('missing token yields an empty record', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    expect(await sessions.consumeLoginCorrelation('nope')).toEqual({})
+  })
+
+  test('expires after the correlation TTL', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await sessions.saveLoginCorrelation('tok-2', { ownSid: 'own-2' })
+
+    redis.advanceTime(15 * 60 + 1)
+
+    expect(await sessions.consumeLoginCorrelation('tok-2')).toEqual({})
+  })
+})
+
+describe('sessionIdFromCookie', () => {
+  test('returns the id for a validly-signed own cookie', () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    const cookie = 's:' + sign('sid-123', sessionConfig.cookieSecret)
+    expect(sessions.sessionIdFromCookie(cookie)).toBe('sid-123')
+  })
+
+  test('returns undefined for a tampered or missing cookie', () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    const tampered = 's:sid-123.deadbeefsignature'
+    expect(sessions.sessionIdFromCookie(tampered)).toBeUndefined()
+    expect(sessions.sessionIdFromCookie(undefined)).toBeUndefined()
+  })
+})

--- a/apigw/src/shared/__tests__/session-sfi-logout.ts
+++ b/apigw/src/shared/__tests__/session-sfi-logout.ts
@@ -205,6 +205,59 @@ describe('destroy clears the rejected sfi login', () => {
   })
 })
 
+describe('sfi session cross-link', () => {
+  const citizenSfiUser = {
+    id: '942b9cab-210d-4d49-b4c9-65f26390eed3',
+    authType: 'sfi',
+    userType: 'CITIZEN_STRONG',
+    createdAt: 1000,
+    samlSession
+  } as Parameters<ReturnType<typeof sessionSupport<'citizen'>>['login']>[1]
+
+  const loginReq = (id: string) =>
+    ({
+      session: {
+        id,
+        regenerate: (cb: () => void) => cb(),
+        save: (cb: () => void) => cb()
+      }
+    }) as express.Request
+
+  const storeSecondary = (
+    redis: MockRedisClient,
+    id: string,
+    authType: string
+  ) =>
+    redis.set(
+      `sess:${id}`,
+      JSON.stringify({ passport: { user: { authType } } })
+    )
+
+  test('links a co-resident sfi session in both directions', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    await storeSecondary(redis, 'emp-sfi', 'sfi')
+
+    await sessions.login(loginReq('cit-1'), citizenSfiUser, 'emp-sfi')
+
+    expect(await redis.get('sfisess:cit-1')).toBe('emp-sfi')
+    expect(await redis.get('sfisess:emp-sfi')).toBe('cit-1')
+  })
+
+  test('does not link a secondary session that is not an sfi session', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    // Only Suomi.fi couples sessions; an AD login on the employee side is not
+    // part of the SSO session and must survive a Suomi.fi logout.
+    await storeSecondary(redis, 'emp-ad', 'ad')
+
+    await sessions.login(loginReq('cit-2'), citizenSfiUser, 'emp-ad')
+
+    expect(await redis.get('sfisess:cit-2')).toBeNull()
+    expect(await redis.get('sfisess:emp-ad')).toBeNull()
+  })
+})
+
 describe('logoutWithToken via a rejected sfi login', () => {
   const rejectedLoginToken = createLogoutToken(samlSession)
 
@@ -255,6 +308,28 @@ describe('logoutWithToken via a rejected sfi login', () => {
     expect(await redis.get('slo:employee-token')).toBeNull()
     expect(await redis.get('sfisess:ovr-c')).toBeNull()
     expect(await redis.get('sfisess:ovr-e')).toBeNull()
+  })
+
+  test('is not recorded for a linked non-sfi session', async () => {
+    const redis = new MockRedisClient()
+    const sessions = sessionSupport('citizen', redis, sessionConfig, 32)
+    // A rejected employee sfi login links the record to the employee's own
+    // pre-existing AD session, which is not part of the Suomi.fi SSO session.
+    await storeSession(redis, 'ovr-ad', 'ad', 'ad-token')
+    await storeSession(redis, 'ovr-sfi', 'sfi', 'sfi-token')
+
+    await sessions.saveRejectedSfiLogin(['ovr-ad', 'ovr-sfi'], samlSession)
+
+    expect(await redis.get('sfilogin:ovr-ad')).toBeNull()
+    expect(await redis.get('sfilogin:ovr-sfi')).not.toBeNull()
+
+    // ...so a Suomi.fi logout tears down only the sfi session
+    expect(await sessions.logoutWithToken(rejectedLoginToken)).toEqual(
+      samlSession
+    )
+    expect(await redis.get('sess:ovr-sfi')).toBeNull()
+    expect(await redis.get('sess:ovr-ad')).not.toBeNull()
+    expect(await redis.get('slo:ad-token')).not.toBeNull()
   })
 
   test('reports nothing logged out when the linked session is already gone', async () => {

--- a/apigw/src/shared/auth/index.ts
+++ b/apigw/src/shared/auth/index.ts
@@ -87,6 +87,8 @@ export const systemUserHeader = JSON.stringify({ type: 'system' })
 
 export const integrationUserHeader = JSON.stringify({ type: 'integration' })
 
-export function createLogoutToken(profile: Profile) {
+export function createLogoutToken(
+  profile: Pick<Profile, 'nameID' | 'sessionIndex'>
+) {
   return `${profile.nameID}:::${profile.sessionIndex}`
 }

--- a/apigw/src/shared/routes/saml.ts
+++ b/apigw/src/shared/routes/saml.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+import { randomUUID } from 'node:crypto'
 import * as url from 'node:url'
 
 import type { AuthOptions, Profile, SAML } from '@node-saml/node-saml'
@@ -14,21 +15,21 @@ import { createLogoutToken } from '../auth/index.ts'
 import { setDeviceAuthHistoryCookie } from '../device-cookies.ts'
 import type { AsyncRequestHandler } from '../express.ts'
 import { toRequestHandler } from '../express.ts'
-import { logAuditEvent, logDebug } from '../logging.ts'
+import { logAuditEvent, logDebug, logError } from '../logging.ts'
 import {
   parseDescriptionFromSamlError,
   samlErrorSchema
 } from '../saml/error-utils.ts'
 import type { AuthenticateProfile } from '../saml/index.ts'
 import {
-  buildRelayStateWithSecondarySessionCookie,
-  extractSecondarySessionCookie,
+  buildRelayStateWithCorrelationToken,
+  extractCorrelationToken,
   getRawUnvalidatedRelayState,
   SamlProfileIdSchema,
   SamlSessionSchema,
   validateRelayStateUrl
 } from '../saml/index.ts'
-import type { Sessions, SessionType } from '../session.ts'
+import type { LoginCorrelation, Sessions, SessionType } from '../session.ts'
 
 const urlencodedParser = express.urlencoded({ extended: false })
 
@@ -159,21 +160,33 @@ export function createSamlIntegration<T extends SessionType>(
     // Run cookieParser to get req.cookies, but do not pass cookie secret to get access to raw cookies
     await runMiddleware(cookieParser(), req, res)
     try {
-      let secondarySessionCookie: string | undefined
+      const relayState = getRawUnvalidatedRelayState(req) ?? ''
+      // Only sfi integrations have a co-resident session to correlate with, and
+      // only they can leave a rejected login behind that needs one.
+      let correlationToken: string | undefined
       if (secondaryCookieConfig) {
-        secondarySessionCookie = req.cookies[
+        const ownSid = sessions.sessionIdFromCookie(
+          req.cookies[sessions.cookieName] as string | undefined
+        )
+        const secondaryCookie = req.cookies[
           secondaryCookieConfig.cookieName
         ] as string | undefined
+        const secondarySid = secondaryCookie
+          ? signedCookie(secondaryCookie, secondaryCookieConfig.cookieSecret) ||
+            undefined
+          : undefined
+        if (ownSid || secondarySid) {
+          correlationToken = randomUUID()
+          await sessions.saveLoginCorrelation(correlationToken, {
+            ownSid,
+            secondarySid
+          })
+        }
       }
-      const relayState = getRawUnvalidatedRelayState(req) ?? ''
+      // The RelayState (redirect URL + correlation token) is sent unvalidated to
+      // the IdP here; it only matters in the login callback, where it is validated.
       const idpLoginUrl = await saml.getAuthorizeUrlAsync(
-        // no need for validation here, because the value only matters in the login callback request and is validated there
-        secondarySessionCookie
-          ? buildRelayStateWithSecondarySessionCookie(
-              relayState,
-              secondarySessionCookie
-            )
-          : relayState,
+        buildRelayStateWithCorrelationToken(relayState, correlationToken),
         undefined,
         samlRequestOptions(req)
       )
@@ -190,6 +203,19 @@ export function createSamlIntegration<T extends SessionType>(
       })
     }
   }
+  const persistRejectedSfiLogin = async (
+    profile: Profile,
+    correlation: LoginCorrelation
+  ): Promise<void> => {
+    const samlSession = SamlSessionSchema.safeParse(profile)
+    if (!samlSession.success) return
+    const ids = [correlation.ownSid, correlation.secondarySid].filter(
+      (id): id is string => !!id
+    )
+    if (ids.length === 0) return
+    await sessions.saveRejectedSfiLogin(ids, samlSession.data)
+  }
+
   const loginCallback: AsyncRequestHandler = async (req, res) => {
     logAuditEvent(eventCode('sign_in'), req, 'Login callback endpoint called')
     let profile: Profile
@@ -241,18 +267,13 @@ export function createSamlIntegration<T extends SessionType>(
         })
       }
     }
+    const correlationToken = extractCorrelationToken(req)
+    const correlation = correlationToken
+      ? await sessions.consumeLoginCorrelation(correlationToken)
+      : {}
     try {
       const user = await authenticate(req, profile)
-      const secondarySessionCookie = extractSecondarySessionCookie(req)
-      const secondarySessionId =
-        secondarySessionCookie && secondaryCookieConfig
-          ? signedCookie(
-              secondarySessionCookie,
-              secondaryCookieConfig.cookieSecret
-            ) || undefined
-          : undefined
-
-      await sessions.login(req, user, secondarySessionId)
+      await sessions.login(req, user, correlation.secondarySid)
       logAuditEvent(eventCode('sign_in'), req, 'User logged in successfully')
 
       // Set device cookie for citizen authentication
@@ -269,6 +290,16 @@ export function createSamlIntegration<T extends SessionType>(
       logDebug(`Redirecting to ${redirectUrl}`, req, { redirectUrl })
       return res.redirect(redirectUrl)
     } catch (err) {
+      try {
+        await persistRejectedSfiLogin(profile, correlation)
+      } catch (persistErr) {
+        logError(
+          'Failed to persist rejected sfi login',
+          req,
+          undefined,
+          persistErr instanceof Error ? persistErr : undefined
+        )
+      }
       logAuditEvent(
         eventCode('sign_in_failed'),
         req,

--- a/apigw/src/shared/routes/saml.ts
+++ b/apigw/src/shared/routes/saml.ts
@@ -382,23 +382,36 @@ export function createSamlIntegration<T extends SessionType>(
       // 2. SP-initiated logout, and we've just received a logout response -> profile is null, the SAML transaction
       // is complete, and we should redirect the user to some meaningful page
       if (profile) {
-        let user: unknown
+        // Suomi.fi issues a fresh nameID per login, so the session holding the
+        // cookie is not necessarily the one the logout request names. Collect
+        // every identity we log out, and report success if it covers that one.
+        const loggedOutIdentities: unknown[] = []
         const sessionUser = sessions.getUser(req)
         if (sessionUser) {
-          const userId = SamlProfileIdSchema.safeParse(sessionUser)
-          user = userId.success ? userId.data : undefined
-
+          loggedOutIdentities.push(sessionUser)
+          if (secondaryCookieConfig) {
+            // destroy() tears the co-resident session down too, but also deletes
+            // the keys this reads, so its identity must be resolved first.
+            const secondaryUser = await sessions.getSecondaryUserIfNewer(req)
+            if (secondaryUser) loggedOutIdentities.push(secondaryUser)
+          }
           await sessions.destroy(req, res)
         } else {
           // We're possibly doing SLO without a real session (e.g. browser has
           // 3rd party cookies disabled)
           const logoutToken = createLogoutToken(profile)
-          const sessionUser = await sessions.logoutWithToken(logoutToken)
-          const userId = SamlProfileIdSchema.safeParse(sessionUser)
-          user = userId.success ? userId.data : undefined
+          const tokenUser = await sessions.logoutWithToken(logoutToken)
+          if (tokenUser) loggedOutIdentities.push(tokenUser)
         }
         const profileId = SamlProfileIdSchema.safeParse(profile)
-        const success = profileId.success && _.isEqual(user, profileId.data)
+        const success =
+          profileId.success &&
+          loggedOutIdentities.some((identity) => {
+            const identityId = SamlProfileIdSchema.safeParse(identity)
+            return (
+              identityId.success && _.isEqual(identityId.data, profileId.data)
+            )
+          })
 
         url = await saml.getLogoutResponseUrlAsync(
           profile,

--- a/apigw/src/shared/saml/index.ts
+++ b/apigw/src/shared/saml/index.ts
@@ -99,7 +99,7 @@ export const SamlSessionSchema = z.object({
   spNameQualifier: z.string().optional()
 })
 
-const SECONDARY_COOKIE_PARAM = '&secondarySessionCookie='
+const CORRELATION_TOKEN_PARAM = '&sfiCorr='
 
 export function getRawUnvalidatedRelayState(
   req: express.Request
@@ -110,20 +110,29 @@ export function getRawUnvalidatedRelayState(
   return relayState
 }
 
-export function buildRelayStateWithSecondarySessionCookie(
+export function buildRelayStateWithCorrelationToken(
   relayState: string,
-  secondarySessionCookie: string
+  token: string | undefined
 ): string {
-  return `${relayState}${SECONDARY_COOKIE_PARAM}${encodeURIComponent(secondarySessionCookie)}`
+  return token
+    ? `${relayState}${CORRELATION_TOKEN_PARAM}${encodeURIComponent(token)}`
+    : relayState
 }
 
-export function extractSecondarySessionCookie(
+export function extractCorrelationToken(
   req: express.Request
 ): string | undefined {
   const relayState = getRawUnvalidatedRelayState(req)
   if (!relayState) return undefined
-  const encoded = relayState.split(SECONDARY_COOKIE_PARAM)[1]
-  return encoded ? decodeURIComponent(encoded) : undefined
+  const start = relayState.lastIndexOf(CORRELATION_TOKEN_PARAM)
+  if (start < 0) return undefined
+  const encoded = relayState.slice(start + CORRELATION_TOKEN_PARAM.length)
+  if (!encoded) return undefined
+  try {
+    return decodeURIComponent(encoded)
+  } catch (err) {
+    return undefined
+  }
 }
 
 // SAML RelayState is an arbitrary string that gets passed in a SAML transaction.
@@ -132,10 +141,10 @@ export function extractSecondarySessionCookie(
 // is not signed or encrypted, we must make sure the URL points to our application
 // and not to some 3rd party domain
 export function validateRelayStateUrl(req: express.Request): URL | undefined {
-  const relayState = getRawUnvalidatedRelayState(req)?.split(
-    SECONDARY_COOKIE_PARAM
-  )[0]
-  if (relayState) {
+  const raw = getRawUnvalidatedRelayState(req)
+  if (raw) {
+    const i = raw.lastIndexOf(CORRELATION_TOKEN_PARAM)
+    const relayState = i >= 0 ? raw.slice(0, i) : raw
     const url = parseUrlWithOrigin(evakaBaseUrl, relayState)
     if (url) return url
     logError('Invalid RelayState in request', req)

--- a/apigw/src/shared/session.ts
+++ b/apigw/src/shared/session.ts
@@ -227,7 +227,10 @@ export function sessionSupport<T extends SessionType>(
     samlSession: SamlSession
   ): Promise<void> {
     if (!maxSessionTimeoutMinutes) return
-    const ids = linkedSessionIds.filter((id) => !!id)
+    const ids: string[] = []
+    for (const id of linkedSessionIds) {
+      if (id && (await isSfiSession(id))) ids.push(id)
+    }
     if (ids.length === 0) return
 
     const ttlSeconds = maxSessionTimeoutMinutes * 60
@@ -292,6 +295,11 @@ export function sessionSupport<T extends SessionType>(
     if (typeof user !== 'object' || user === null) return undefined
     const authType = (user as Record<string, unknown>).authType
     return typeof authType === 'string' ? authType : undefined
+  }
+
+  async function isSfiSession(sessionId: string): Promise<boolean> {
+    const session = await redisClient.get(sessionKey(sessionId))
+    return !!session && authTypeOf(storedUser(session)) === 'sfi'
   }
 
   async function deleteSessionById(sessionId: string): Promise<void> {
@@ -447,7 +455,8 @@ export function sessionSupport<T extends SessionType>(
       req.session.id &&
       user.authType === 'sfi' &&
       maxSessionTimeoutMinutes &&
-      secondarySessionId
+      secondarySessionId &&
+      (await isSfiSession(secondarySessionId))
     ) {
       await redisClient.set(
         secondarySfiSessionKey(req.session.id),

--- a/apigw/src/shared/session.ts
+++ b/apigw/src/shared/session.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import { RedisStore } from 'connect-redis'
+import { signedCookie } from 'cookie-parser'
 import { addMinutes } from 'date-fns/addMinutes'
 import { differenceInMinutes } from 'date-fns/differenceInMinutes'
 import { differenceInSeconds } from 'date-fns/differenceInSeconds'
@@ -11,7 +12,7 @@ import type express from 'express'
 import session from 'express-session'
 
 import type { EvakaSessionUser } from './auth/index.ts'
-import { createUserHeader } from './auth/index.ts'
+import { createLogoutToken, createUserHeader } from './auth/index.ts'
 import type { SessionConfig } from './config.ts'
 import { createSha256Hash } from './crypto.ts'
 import type { LogoutToken } from './express.ts'
@@ -19,8 +20,11 @@ import { toMiddleware } from './express.ts'
 import { logAuditEvent, logDebug } from './logging.ts'
 import { fromCallback } from './promise-utils.ts'
 import type { RedisClient } from './redis-client.ts'
+import type { SamlSession } from './saml/index.ts'
 
 export type SessionType = 'citizen' | 'employee' | 'employee-mobile'
+
+export type LoginCorrelation = { ownSid?: string; secondarySid?: string }
 
 function cookiePrefix(sessionType: SessionType) {
   switch (sessionType) {
@@ -45,8 +49,20 @@ function userSessionsKey(userIdHash: string) {
   return `usess:${userIdHash}`
 }
 
-function secondarySfiSessionsKey(sfiNameId: string) {
-  return `sfisess:${sfiNameId}`
+function secondarySfiSessionKey(sfiSessionId: string) {
+  return `sfisess:${sfiSessionId}`
+}
+
+function sfiLoginKey(sfiSessionId: string) {
+  return `sfilogin:${sfiSessionId}`
+}
+
+function sfiSloKey(logoutToken: LogoutToken['value']) {
+  return `sfislo:${logoutToken}`
+}
+
+function loginCorrelationKey(token: string) {
+  return `sficorr:${token}`
 }
 
 export function sessionCookie(sessionType: SessionType) {
@@ -65,6 +81,15 @@ export interface Sessions<T extends SessionType> {
     req: express.Request,
     logoutToken?: LogoutToken['value']
   ): Promise<void>
+  saveRejectedSfiLogin(
+    linkedSessionIds: string[],
+    samlSession: SamlSession
+  ): Promise<void>
+  saveLoginCorrelation(
+    token: string,
+    correlation: LoginCorrelation
+  ): Promise<void>
+  consumeLoginCorrelation(token: string): Promise<LoginCorrelation>
   logoutWithToken(token: LogoutToken['value']): Promise<unknown>
 
   login(
@@ -78,10 +103,15 @@ export interface Sessions<T extends SessionType> {
   getUser(req: express.Request): EvakaSessionUser | undefined
   getSecondaryUserIfNewer(
     req: express.Request
-  ): Promise<EvakaSessionUser | undefined>
+  ): Promise<EvakaSessionUser | SamlSession | undefined>
   getUserHeader(req: express.Request): string | undefined
   isAuthenticated(req: express.Request): boolean
+  sessionIdFromCookie(rawCookie: string | undefined): string | undefined
 }
+
+// Only needs to bridge login-start -> login-callback while a human completes the
+// IdP login; independent of the 32-min rejected-login TTL.
+const LOGIN_CORRELATION_TTL_SECONDS = 15 * 60
 
 export function sessionSupport<T extends SessionType>(
   sessionType: T,
@@ -192,32 +222,144 @@ export function sessionSupport<T extends SessionType>(
     }
   }
 
+  async function saveRejectedSfiLogin(
+    linkedSessionIds: string[],
+    samlSession: SamlSession
+  ): Promise<void> {
+    if (!maxSessionTimeoutMinutes) return
+    const ids = linkedSessionIds.filter((id) => !!id)
+    if (ids.length === 0) return
+
+    const ttlSeconds = maxSessionTimeoutMinutes * 60
+    await redisClient.set(
+      sfiSloKey(createLogoutToken(samlSession)),
+      JSON.stringify({ samlSession, sessionIds: ids }),
+      { EX: ttlSeconds }
+    )
+    const record = JSON.stringify({ samlSession, createdAt: Date.now() })
+    for (const id of ids) {
+      await redisClient.set(sfiLoginKey(id), record, {
+        EX: ttlSeconds
+      })
+    }
+  }
+
+  async function saveLoginCorrelation(
+    token: string,
+    correlation: LoginCorrelation
+  ): Promise<void> {
+    await redisClient.set(
+      loginCorrelationKey(token),
+      JSON.stringify(correlation),
+      { EX: LOGIN_CORRELATION_TTL_SECONDS }
+    )
+  }
+
+  async function consumeLoginCorrelation(
+    token: string
+  ): Promise<LoginCorrelation> {
+    const key = loginCorrelationKey(token)
+    const raw = await redisClient.get(key)
+    await redisClient.del(key)
+    if (!raw) return {}
+    // oxlint-disable-next-line typescript/no-unsafe-assignment
+    const parsed = JSON.parse(raw)
+    return {
+      // oxlint-disable-next-line typescript/no-unsafe-assignment,typescript/no-unsafe-member-access
+      ownSid: typeof parsed?.ownSid === 'string' ? parsed.ownSid : undefined,
+      // oxlint-disable-next-line typescript/no-unsafe-assignment
+      secondarySid:
+        // oxlint-disable-next-line typescript/no-unsafe-member-access
+        typeof parsed?.secondarySid === 'string'
+          ? // oxlint-disable-next-line typescript/no-unsafe-member-access
+            parsed.secondarySid
+          : undefined
+    }
+  }
+
+  function storedLogoutToken(rawSession: string): string | undefined {
+    // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-assignment
+    const value = JSON.parse(rawSession)?.logoutToken?.value
+    return typeof value === 'string' ? value : undefined
+  }
+
+  function storedUser(rawSession: string): unknown {
+    // oxlint-disable-next-line typescript/no-unsafe-member-access
+    return JSON.parse(rawSession)?.passport?.user ?? undefined
+  }
+
+  function authTypeOf(user: unknown): string | undefined {
+    if (typeof user !== 'object' || user === null) return undefined
+    const authType = (user as Record<string, unknown>).authType
+    return typeof authType === 'string' ? authType : undefined
+  }
+
+  async function deleteSessionById(sessionId: string): Promise<void> {
+    const session = await redisClient.get(sessionKey(sessionId))
+    const keys = [sessionKey(sessionId), sfiLoginKey(sessionId)]
+    const token = session ? storedLogoutToken(session) : undefined
+    if (token) keys.push(logoutKey(token))
+    await redisClient.del(keys)
+  }
+
+  async function destroyLinkedSfiSession(sessionId: string): Promise<void> {
+    const secondarySessionId = await redisClient.get(
+      secondarySfiSessionKey(sessionId)
+    )
+    if (!secondarySessionId) return
+    await deleteSessionById(secondarySessionId)
+    await redisClient.del([
+      secondarySfiSessionKey(sessionId),
+      secondarySfiSessionKey(secondarySessionId)
+    ])
+  }
+
+  async function logoutWithRejectedSfiLogin(
+    logoutToken: LogoutToken['value']
+  ): Promise<unknown> {
+    const key = sfiSloKey(logoutToken)
+    const raw = await redisClient.get(key)
+    if (!raw) return
+    // oxlint-disable-next-line typescript/no-unsafe-assignment
+    const rejectedLogin = JSON.parse(raw)
+    // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-assignment
+    const samlSession = rejectedLogin?.samlSession
+    // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-assignment
+    const sessionIds = rejectedLogin?.sessionIds
+    if (!samlSession || !Array.isArray(sessionIds)) {
+      await redisClient.del(key)
+      return
+    }
+
+    let loggedOut = false
+    for (const sessionId of sessionIds) {
+      if (typeof sessionId !== 'string') continue
+      const alive = !!(await redisClient.get(sessionKey(sessionId)))
+      await deleteSessionById(sessionId)
+      if (!alive) continue
+      await destroyLinkedSfiSession(sessionId)
+      loggedOut = true
+    }
+    await redisClient.del(key)
+    return loggedOut ? samlSession : undefined
+  }
+
   async function logoutWithToken(
     logoutToken: LogoutToken['value']
   ): Promise<unknown> {
     if (!logoutToken) return
     const sid = await redisClient.get(logoutKey(logoutToken))
-    if (!sid) return
+    if (!sid) return await logoutWithRejectedSfiLogin(logoutToken)
     const session = await redisClient.get(sessionKey(sid))
-    await redisClient.del([sessionKey(sid), logoutKey(logoutToken)])
-    if (!session) return
-    // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-assignment
-    const user = JSON.parse(session)?.passport?.user
+    if (!session) {
+      await redisClient.del(logoutKey(logoutToken))
+      return
+    }
+    const user = storedUser(session)
+    await deleteSessionById(sid)
     if (!user) return
 
-    // oxlint-disable-next-line typescript/no-unsafe-member-access
-    if (user?.authType === 'sfi') {
-      const secondarySession = await redisClient.get(
-        secondarySfiSessionsKey(sid)
-      )
-      if (secondarySession) {
-        await redisClient.del(sessionKey(secondarySession))
-        await redisClient.del([
-          secondarySfiSessionsKey(sid),
-          secondarySfiSessionsKey(secondarySession)
-        ])
-      }
-    }
+    if (authTypeOf(user) === 'sfi') await destroyLinkedSfiSession(sid)
 
     return user
   }
@@ -263,16 +405,8 @@ export function sessionSupport<T extends SessionType>(
     }
 
     if (req.user?.authType === 'sfi' && sessionId) {
-      const secondarySession = await redisClient.get(
-        secondarySfiSessionsKey(sessionId)
-      )
-      if (secondarySession) {
-        await redisClient.del(sessionKey(secondarySession))
-        await redisClient.del([
-          secondarySfiSessionsKey(sessionId),
-          secondarySfiSessionsKey(secondarySession)
-        ])
-      }
+      await redisClient.del(sfiLoginKey(sessionId))
+      await destroyLinkedSfiSession(sessionId)
     }
   }
 
@@ -316,14 +450,14 @@ export function sessionSupport<T extends SessionType>(
       secondarySessionId
     ) {
       await redisClient.set(
-        secondarySfiSessionsKey(req.session.id),
+        secondarySfiSessionKey(req.session.id),
         secondarySessionId,
         {
           EX: maxSessionTimeoutMinutes * 60
         }
       )
       await redisClient.set(
-        secondarySfiSessionsKey(secondarySessionId),
+        secondarySfiSessionKey(secondarySessionId),
         req.session.id,
         {
           EX: maxSessionTimeoutMinutes * 60
@@ -338,32 +472,58 @@ export function sessionSupport<T extends SessionType>(
 
   async function getSecondaryUserIfNewer(
     req: express.Request
-  ): Promise<EvakaSessionUser | undefined> {
+  ): Promise<EvakaSessionUser | SamlSession | undefined> {
     const primaryUser = req.session?.evaka?.user
     if (!primaryUser || primaryUser.authType !== 'sfi') return undefined
 
     const primarySessionId = req.session.id
     const primaryUserCreatedAt = primaryUser.createdAt
 
+    let newest:
+      | { value: EvakaSessionUser | SamlSession; createdAt: number }
+      | undefined
+
+    // Candidate 1: the real other-side session via the bidirectional sfisess: link
+    // written by a successful co-resident login.
     const secondarySessionId = await redisClient.get(
-      secondarySfiSessionsKey(primarySessionId)
+      secondarySfiSessionKey(primarySessionId)
     )
-    if (!secondarySessionId) return undefined
+    if (secondarySessionId) {
+      const secondarySession = await redisClient.get(
+        sessionKey(secondarySessionId)
+      )
+      if (secondarySession) {
+        // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-assignment
+        const user = JSON.parse(secondarySession)?.evaka?.user
+        // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-assignment
+        const createdAt = user?.createdAt
+        if (typeof createdAt === 'number')
+          // oxlint-disable-next-line typescript/no-unsafe-assignment
+          newest = { value: user, createdAt }
+      }
+    }
 
-    const secondarySession = await redisClient.get(
-      sessionKey(secondarySessionId)
-    )
-    if (!secondarySession) return undefined
+    // Candidate 2: a validated-but-rejected co-resident login, which has no
+    // eVaka session of its own.
+    const raw = await redisClient.get(sfiLoginKey(primarySessionId))
+    if (raw) {
+      // oxlint-disable-next-line typescript/no-unsafe-assignment
+      const rejectedLogin = JSON.parse(raw)
+      // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-assignment
+      const createdAt = rejectedLogin?.createdAt
+      // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-assignment
+      const samlSession = rejectedLogin?.samlSession
+      if (
+        typeof createdAt === 'number' &&
+        samlSession &&
+        (!newest || createdAt > newest.createdAt)
+      )
+        // oxlint-disable-next-line typescript/no-unsafe-assignment
+        newest = { value: samlSession, createdAt }
+    }
 
-    // oxlint-disable-next-line typescript/no-unsafe-member-access,typescript/no-unsafe-assignment
-    const user = JSON.parse(secondarySession)?.evaka?.user
-    // oxlint-disable-next-line typescript/no-unsafe-assignment,typescript/no-unsafe-member-access
-    const secondaryUserCreatedAt = user?.createdAt
-    if (!secondaryUserCreatedAt) return undefined
-
-    return secondaryUserCreatedAt > primaryUserCreatedAt
-      ? (user as EvakaSessionUser)
-      : undefined
+    if (!newest) return undefined
+    return newest.createdAt > primaryUserCreatedAt ? newest.value : undefined
   }
 
   function getUserHeader(req: express.Request): string | undefined {
@@ -375,6 +535,13 @@ export function sessionSupport<T extends SessionType>(
     return !!req.session?.passport?.user
   }
 
+  function sessionIdFromCookie(
+    rawCookie: string | undefined
+  ): string | undefined {
+    if (!rawCookie) return undefined
+    return signedCookie(rawCookie, config.cookieSecret) || undefined
+  }
+
   return {
     sessionType,
     cookieName,
@@ -382,6 +549,9 @@ export function sessionSupport<T extends SessionType>(
     requireAuthentication,
     save,
     saveLogoutToken,
+    saveRejectedSfiLogin,
+    saveLoginCorrelation,
+    consumeLoginCorrelation,
     logoutWithToken,
     login,
     destroy,
@@ -389,6 +559,7 @@ export function sessionSupport<T extends SessionType>(
     getUser,
     getSecondaryUserIfNewer,
     getUserHeader,
-    isAuthenticated
+    isAuthenticated,
+    sessionIdFromCookie
   }
 }


### PR DESCRIPTION
Kuntalaisen ja työntekijän Suomi.fi-kirjautumiset ovat liitoksissa toisiinsa ja vain uusin kirjautuminen omistaa aktiivisen Suomi.fi-session. Tämä muutos korjaa tilanteen, jossa Suomi.fi-kirjautuminen onnistuu, mutta evaka hylkää kirjautumisen jostain syystä. Jatkossa aktiivinen Suomi.fi-sessio tallennetaan käyttäjälle vaikka kirjautuminen hylätään, jotta evaka tietää mikä on uusin aktiivinen sessio.