### PR TITLE
Lisätään yksikön kalenterin viikkonäkymään poissaolo-tooltip

### DIFF
--- a/frontend/src/employee-frontend/components/absences/UnitCalendarDayCellTooltip.tsx
+++ b/frontend/src/employee-frontend/components/absences/UnitCalendarDayCellTooltip.tsx
@@ -5,14 +5,52 @@
 import React, { useMemo } from 'react'
 
 import type {
+  AbsenceCategory,
+  AbsenceType,
   AbsenceWithModifierInfo,
   ChildReservation
 } from 'lib-common/generated/api-types/absence'
 import type { ServiceTimesPresenceStatus } from 'lib-common/generated/api-types/dailyservicetimes'
+import type HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import type LocalDate from 'lib-common/local-date'
 import { featureFlags } from 'lib-customizations/employee'
 
 import { useTranslation } from '../../state/i18n'
+
+export interface AbsenceTooltipItem {
+  category: AbsenceCategory
+  absenceType: AbsenceType
+  modifiedAt: HelsinkiDateTime
+  modifiedByStaff: boolean
+}
+
+export const AbsencesTooltipContent = React.memo(
+  function AbsencesTooltipContent({
+    absences
+  }: {
+    absences: AbsenceTooltipItem[]
+  }) {
+    const { i18n } = useTranslation()
+    return (
+      <>
+        {absences.map(
+          ({ category, absenceType, modifiedAt, modifiedByStaff }, index) => (
+            <div key={index}>
+              {index !== 0 && <br />}
+              {`${i18n.absences.absenceCategories[category]}: ${i18n.absences.absenceTypes[absenceType]}`}
+              <br />
+              {`${modifiedAt.format()} ${
+                modifiedByStaff
+                  ? i18n.absences.modifiedByStaff
+                  : i18n.absences.modifiedByCitizen
+              }`}
+            </div>
+          )
+        )}
+      </>
+    )
+  }
+)
 
 interface UnitCalendarMonthlyDayCellTooltipProps {
   date: LocalDate
@@ -104,22 +142,8 @@ export default React.memo(function UnitCalendarMonthlyDayCellTooltip({
   )
 
   const absencesTooltip = useMemo(
-    () =>
-      absences.map(
-        ({ category, absenceType, modifiedAt, modifiedByStaff }, index) => (
-          <div key={index}>
-            {index !== 0 && <br />}
-            {`${i18n.absences.absenceCategories[category]}: ${i18n.absences.absenceTypes[absenceType]}`}
-            <br />
-            {`${modifiedAt.toLocalDate().format()} ${
-              modifiedByStaff
-                ? i18n.absences.modifiedByStaff
-                : i18n.absences.modifiedByCitizen
-            }`}
-          </div>
-        )
-      ),
-    [i18n, absences]
+    () => <AbsencesTooltipContent absences={absences} />,
+    [absences]
   )
 
   const requiresBackupCareTooltip = useMemo(

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/AbsenceDay.tsx
@@ -2,38 +2,60 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import React from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
 
-import type { AbsenceType } from 'lib-common/generated/api-types/absence'
+import type { AbsenceCategory } from 'lib-common/generated/api-types/absence'
+import type { AbsenceTypeResponse } from 'lib-common/generated/api-types/reservations'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
 import Tooltip from 'lib-components/atoms/Tooltip'
 import { FixedSpaceRow } from 'lib-components/layout/flex-helpers'
 import { absenceColors, absenceIcons } from 'lib-customizations/common'
 
 import { useTranslation } from '../../../state/i18n'
+import { AbsencesTooltipContent } from '../../absences/UnitCalendarDayCellTooltip'
 
-interface Props {
-  type: AbsenceType
-  staffCreated: boolean
+export interface AbsenceWithCategory {
+  category: AbsenceCategory
+  absence: AbsenceTypeResponse
 }
 
-export default React.memo(function AbsenceDay({ type, staffCreated }: Props) {
+interface Props {
+  absences: AbsenceWithCategory[]
+}
+
+export default React.memo(function AbsenceDay({ absences }: Props) {
   const { i18n } = useTranslation()
+
+  const tooltipItems = useMemo(
+    () =>
+      absences.map(({ category, absence }) => ({
+        category,
+        absenceType: absence.absenceType,
+        modifiedAt: absence.modifiedAt,
+        modifiedByStaff: absence.staffCreated
+      })),
+    [absences]
+  )
+
+  const first = absences[0]
+  if (first === undefined) return null
+
+  const { absenceType, staffCreated } = first.absence
   return (
     <FixedSpaceRow $spacing="xs" $alignItems="center" data-qa="absence">
       <AbsenceTooltip
-        tooltip={
-          staffCreated && i18n.unit.attendanceReservations.createdByEmployee
-        }
+        tooltip={<AbsencesTooltipContent absences={tooltipItems} />}
+        width="large"
+        data-qa="absence-tooltip"
       >
         <RoundIcon
-          content={absenceIcons[type]}
-          color={absenceColors[type]}
+          content={absenceIcons[absenceType]}
+          color={absenceColors[absenceType]}
           size="m"
         />
         <span>
-          {i18n.absences.absenceTypesShort[type]}
+          {i18n.absences.absenceTypesShort[absenceType]}
           {staffCreated && '*'}
         </span>
       </AbsenceTooltip>

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayAttendance.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayAttendance.tsx
@@ -115,7 +115,7 @@ export default React.memo(function ChildDayAttendance({
       <Tooltip
         tooltip={
           attendance &&
-          i18n.unit.attendanceReservations.lastModifiedStaff(
+          i18n.unit.attendanceReservations.lastModified(
             attendance.modifiedAt.format(),
             attendance.modifiedBy.name
           )

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayReservation.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayReservation.tsx
@@ -116,15 +116,10 @@ export default React.memo(function ChildDayReservation({
           <ReservationTooltip
             tooltip={
               reservation &&
-              (reservation.staffCreated
-                ? i18n.unit.attendanceReservations.lastModifiedStaff(
-                    reservation.modifiedAt?.format() || '',
-                    reservation.modifiedBy?.name || ''
-                  )
-                : i18n.unit.attendanceReservations.lastModifiedOther(
-                    reservation.modifiedAt?.format() || '',
-                    reservation.modifiedBy?.name || ''
-                  ))
+              i18n.unit.attendanceReservations.lastModified(
+                reservation.modifiedAt?.format() || '',
+                reservation.modifiedBy?.name || ''
+              )
             }
           >
             <TimeCell

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayReservation.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildDayReservation.tsx
@@ -12,10 +12,7 @@ import {
   isRegular,
   isVariableTime
 } from 'lib-common/api-types/daily-service-times'
-import type {
-  AbsenceType,
-  ChildServiceNeedInfo
-} from 'lib-common/generated/api-types/absence'
+import type { ChildServiceNeedInfo } from 'lib-common/generated/api-types/absence'
 import type { DailyServiceTimesValue } from 'lib-common/generated/api-types/dailyservicetimes'
 import type { ScheduleType } from 'lib-common/generated/api-types/placement'
 import type {
@@ -32,6 +29,7 @@ import { faExclamationTriangle } from 'lib-icons'
 
 import { useTranslation } from '../../../state/i18n'
 
+import type { AbsenceWithCategory } from './AbsenceDay'
 import AbsenceDay from './AbsenceDay'
 import { DateCell, DetailsToggle, TimeCell, TimesRow } from './ChildDayCommons'
 
@@ -40,8 +38,7 @@ interface Props {
   reservationIndex: number
   dateInfo: UnitDateInfo
   reservation: ReservationResponse | undefined
-  absence: AbsenceType | null
-  absenceStaffCreated: boolean | undefined
+  absences: AbsenceWithCategory[]
   dailyServiceTimes: DailyServiceTimesValue | null
   inOtherUnit: boolean
   isInBackupGroup: boolean
@@ -55,8 +52,7 @@ export default React.memo(function ChildDayReservation({
   reservationIndex,
   dateInfo,
   reservation,
-  absence,
-  absenceStaffCreated,
+  absences,
   dailyServiceTimes,
   inOtherUnit,
   isInBackupGroup,
@@ -112,9 +108,9 @@ export default React.memo(function ChildDayReservation({
           <TimeCell data-qa="in-other-group">
             <Light>{i18n.unit.attendanceReservations.inOtherGroup}</Light>
           </TimeCell>
-        ) : absence ? (
+        ) : absences.length > 0 ? (
           reservationIndex === 0 ? (
-            <AbsenceDay type={absence} staffCreated={!!absenceStaffCreated} />
+            <AbsenceDay absences={absences} />
           ) : null
         ) : reservation && reservation.type === 'TIMES' ? (
           <ReservationTooltip

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/ChildReservationsTable.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/ChildReservationsTable.tsx
@@ -30,6 +30,7 @@ import { ContractDaysIndicatorChip } from '../../common/ContractDaysIndicatorChi
 import EllipsisMenu from '../../common/EllipsisMenu'
 import type { AttendanceGroupFilter } from '../TabCalendar'
 
+import type { AbsenceWithCategory } from './AbsenceDay'
 import ChildDayAttendance from './ChildDayAttendance'
 import ChildDayReservation from './ChildDayReservation'
 import {
@@ -107,6 +108,22 @@ const isFullyAbsent = (child: ChildRecordOfDay) =>
         return child.absenceNonbillable !== null
     }
   })
+
+const absencesWithCategories = (
+  child: ChildRecordOfDay
+): AbsenceWithCategory[] => {
+  const absences: AbsenceWithCategory[] = []
+  if (child.absenceBillable !== null) {
+    absences.push({ category: 'BILLABLE', absence: child.absenceBillable })
+  }
+  if (child.absenceNonbillable !== null) {
+    absences.push({
+      category: 'NONBILLABLE',
+      absence: child.absenceNonbillable
+    })
+  }
+  return absences
+}
 
 const occupancyFormatter = new Intl.NumberFormat('fi-FI', {
   minimumFractionDigits: 2,
@@ -281,8 +298,8 @@ const ChildRowGroup = React.memo(function ChildRowGroup({
             const fullyAbsent = !!child && isFullyAbsent(child)
             const hasReservations = !!child && child.reservations.length > 0
             const displayAbsence = fullyAbsent || !hasReservations
-            const absence =
-              child?.absenceBillable ?? child?.absenceNonbillable ?? null
+            const absences =
+              child && displayAbsence ? absencesWithCategories(child) : []
 
             return (
               <DayTd
@@ -299,10 +316,7 @@ const ChildRowGroup = React.memo(function ChildRowGroup({
                     reservationIndex={index}
                     dateInfo={dateInfo}
                     reservation={child.reservations[index]}
-                    absence={
-                      displayAbsence && absence ? absence.absenceType : null
-                    }
-                    absenceStaffCreated={absence?.staffCreated}
+                    absences={absences}
                     dailyServiceTimes={child.dailyServiceTimes}
                     inOtherUnit={child.inOtherUnit}
                     isInBackupGroup={

--- a/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
+++ b/frontend/src/employee-frontend/components/unit/unit-reservations/UnitAttendanceReservationsView.tsx
@@ -20,7 +20,6 @@ import {
 } from 'lib-components/layout/flex-helpers'
 import LabelValueList from 'lib-components/molecules/LabelValueList'
 import { fontWeights, Label } from 'lib-components/typography'
-import { Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 import { featureFlags } from 'lib-customizations/employee'
 import { faChevronDown, faChevronUp } from 'lib-icons'
@@ -51,6 +50,12 @@ const Time = styled.span`
 const AttendanceTime = styled(Time)`
   font-weight: ${fontWeights.semibold};
   background: ${colors.grayscale.g4};
+`
+
+const Footnote = styled.div`
+  color: ${colors.grayscale.g70};
+  font-size: 14px;
+  margin-top: -24px;
 `
 
 interface Props {
@@ -183,8 +188,10 @@ export default React.memo(function UnitAttendanceReservationsView({
               selectedDate={selectedDate}
               selectedGroup={selectedGroup}
             />
+            <Footnote data-qa="created-by-employee-footnote">
+              {i18n.unit.attendanceReservations.createdByEmployee}
+            </Footnote>
             <div>
-              <Gap $size="s" />
               <FixedSpaceRow $alignItems="center">
                 <Label id="legend-title-label">
                   {i18n.absences.legendTitle}

--- a/frontend/src/lib-common/generated/api-types/reservations.ts
+++ b/frontend/src/lib-common/generated/api-types/reservations.ts
@@ -51,6 +51,7 @@ export interface AbsenceRequest {
 */
 export interface AbsenceTypeResponse {
   absenceType: AbsenceType
+  modifiedAt: HelsinkiDateTime
   staffCreated: boolean
 }
 
@@ -467,6 +468,14 @@ export function deserializeJsonAbsenceRequest(json: JsonOf<AbsenceRequest>): Abs
 }
 
 
+export function deserializeJsonAbsenceTypeResponse(json: JsonOf<AbsenceTypeResponse>): AbsenceTypeResponse {
+  return {
+    ...json,
+    modifiedAt: HelsinkiDateTime.parseIso(json.modifiedAt)
+  }
+}
+
+
 export function deserializeJsonAttendanceTimesForDate(json: JsonOf<AttendanceTimesForDate>): AttendanceTimesForDate {
   return {
     ...json,
@@ -499,6 +508,8 @@ export function deserializeJsonChildDatePresence(json: JsonOf<ChildDatePresence>
 export function deserializeJsonChildRecordOfDay(json: JsonOf<ChildRecordOfDay>): ChildRecordOfDay {
   return {
     ...json,
+    absenceBillable: (json.absenceBillable != null) ? deserializeJsonAbsenceTypeResponse(json.absenceBillable) : null,
+    absenceNonbillable: (json.absenceNonbillable != null) ? deserializeJsonAbsenceTypeResponse(json.absenceNonbillable) : null,
     attendances: json.attendances.map(e => deserializeJsonAttendanceTimesForDate(e)),
     dailyServiceTimes: (json.dailyServiceTimes != null) ? deserializeJsonDailyServiceTimesValue(json.dailyServiceTimes) : null,
     reservations: json.reservations.map(e => deserializeJsonReservationResponse(e))

--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -2494,15 +2494,7 @@ export const fi = {
       requiresBackupCare: 'Tee varasijoitus',
       openReservationModal: 'Tee toistuva varaus',
       childCount: 'Lapsia läsnä',
-      lastModifiedStaff: (date: string, name: string) => (
-        <div>
-          <p>*Henkilökunnan tekemä merkintä</p>
-          <p>
-            Viimeksi muokattu {date}; muokkaaja: {name}
-          </p>
-        </div>
-      ),
-      lastModifiedOther: (date: string, name: string) =>
+      lastModified: (date: string, name: string) =>
         `Viimeksi muokattu ${date}; muokkaaja: ${name}`,
       reservationModal: {
         title: 'Tee varaus',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
@@ -2509,15 +2509,7 @@ export const sv: typeof fi = {
       requiresBackupCare: 'Gör reservplacering',
       openReservationModal: 'Gör återkommande reservation',
       childCount: 'Barn närvarande',
-      lastModifiedStaff: (date: string, name: string) => (
-        <div>
-          <p>*Anteckning gjord av personal</p>
-          <p>
-            Senast redigerad {date}; redigerare: {name}
-          </p>
-        </div>
-      ),
-      lastModifiedOther: (date: string, name: string) =>
+      lastModified: (date: string, name: string) =>
         `Senast redigerad ${date}; redigerare: ${name}`,
       reservationModal: {
         title: 'Gör reservation',

--- a/service/src/integrationTest/kotlin/evaka/core/reservations/AttendanceReservationsControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/reservations/AttendanceReservationsControllerIntegrationTest.kt
@@ -486,7 +486,8 @@ class AttendanceReservationsControllerIntegrationTest :
                             childId = child1.id,
                             reservations = emptyList(),
                             attendances = emptyList(),
-                            absenceBillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true),
+                            absenceBillable =
+                                AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true, now),
                             absenceNonbillable = null,
                             possibleAbsenceCategories = setOf(AbsenceCategory.BILLABLE),
                             shiftCare = ShiftCareType.NONE,
@@ -1594,8 +1595,8 @@ class AttendanceReservationsControllerIntegrationTest :
                             employee.evakaUser,
                         )
                     ),
-                absenceBillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true),
-                absenceNonbillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true),
+                absenceBillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true, testNow),
+                absenceNonbillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true, testNow),
                 possibleAbsenceCategories =
                     setOf(AbsenceCategory.NONBILLABLE, AbsenceCategory.BILLABLE),
                 shiftCare = null,
@@ -1658,8 +1659,8 @@ class AttendanceReservationsControllerIntegrationTest :
                             employee2.evakaUser,
                         )
                     ),
-                absenceBillable = AbsenceTypeResponse(AbsenceType.FORCE_MAJEURE, true),
-                absenceNonbillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true),
+                absenceBillable = AbsenceTypeResponse(AbsenceType.FORCE_MAJEURE, true, testNow),
+                absenceNonbillable = AbsenceTypeResponse(AbsenceType.OTHER_ABSENCE, true, testNow),
                 possibleAbsenceCategories =
                     setOf(AbsenceCategory.NONBILLABLE, AbsenceCategory.BILLABLE),
                 shiftCare = null,

--- a/service/src/main/kotlin/evaka/core/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/evaka/core/reservations/AttendanceReservationController.kt
@@ -1179,7 +1179,8 @@ SELECT
             'category', a.category,
             'absenceTypeResponse', jsonb_build_object(
                 'absenceType', a.absence_type,
-                'staffCreated', eu.type <> 'CITIZEN'
+                'staffCreated', eu.type <> 'CITIZEN',
+                'modifiedAt', a.modified_at
             )
         ) ORDER BY a.date)
         FROM absence a

--- a/service/src/main/kotlin/evaka/core/reservations/Reservations.kt
+++ b/service/src/main/kotlin/evaka/core/reservations/Reservations.kt
@@ -112,7 +112,11 @@ sealed class Reservation : Comparable<Reservation> {
     }
 }
 
-data class AbsenceTypeResponse(val absenceType: AbsenceType, val staffCreated: Boolean)
+data class AbsenceTypeResponse(
+    val absenceType: AbsenceType,
+    val staffCreated: Boolean,
+    val modifiedAt: HelsinkiDateTime,
+)
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 sealed class ReservationResponse : Comparable<ReservationResponse> {


### PR DESCRIPTION
Näytetään myös viikkonäkymässä poissaolojen kohdalla tooltip, joka kertoo poissaolotyypin, tekijän, päivämäärän ja ajan.
Lisäksi laitetaan kellonaika näkyviin myös kuukausinäkymään.