### PR TITLE
Yksiköt kartalla -sivun saavutettavuusparannuksia

### DIFF
--- a/frontend/src/citizen-frontend/map/MapBox.tsx
+++ b/frontend/src/citizen-frontend/map/MapBox.tsx
@@ -213,8 +213,25 @@ const UnitMarker = React.memo(function UnitMarker({
     [location]
   )
   const eventHandlers = useMemo<LeafletEventHandlerFnMap>(
-    () => ({ click: () => onClick(unit) }),
-    [onClick, unit]
+    () => ({
+      click: () => onClick(unit),
+      // on popup open, move focus to the popup so that screen
+      // readers can read the content without having to navigate
+      // through all the markers first
+      popupopen: (e) => {
+        const element = e.popup.getElement()
+        if (element) {
+          element.setAttribute('role', 'dialog')
+          element.setAttribute('aria-label', name)
+          element.setAttribute('tabindex', '-1')
+          element.focus({ preventScroll: true })
+        }
+      },
+      popupclose: () => {
+        markerRef.current?.getElement()?.focus({ preventScroll: true })
+      }
+    }),
+    [onClick, unit, name]
   )
 
   if (!location) return null

--- a/frontend/src/citizen-frontend/map/MapBox.tsx
+++ b/frontend/src/citizen-frontend/map/MapBox.tsx
@@ -140,6 +140,7 @@ function AddressMarker({ address }: { address: MapAddress }) {
   return (
     <Marker
       title={address.streetAddress}
+      alt={address.streetAddress}
       position={[lat, lon]}
       icon={addressIcon}
       zIndexOffset={20}
@@ -205,6 +206,7 @@ const UnitMarker = React.memo(function UnitMarker({
   return (
     <Marker
       title={name}
+      alt={name}
       position={position}
       icon={isSelected ? unitHighlightIcon : unitIcon}
       zIndexOffset={isSelected ? 10 : 0}

--- a/frontend/src/citizen-frontend/map/MapBox.tsx
+++ b/frontend/src/citizen-frontend/map/MapBox.tsx
@@ -223,6 +223,9 @@ const UnitMarker = React.memo(function UnitMarker({
         if (element) {
           element.setAttribute('role', 'dialog')
           element.setAttribute('aria-label', name)
+          element
+            .querySelector('.leaflet-popup-close-button')
+            ?.setAttribute('aria-label', t.map.closePopup)
           element.setAttribute('tabindex', '-1')
           element.focus({ preventScroll: true })
         }
@@ -231,7 +234,7 @@ const UnitMarker = React.memo(function UnitMarker({
         markerRef.current?.getElement()?.focus({ preventScroll: true })
       }
     }),
-    [onClick, unit, name]
+    [onClick, unit, name, t]
   )
 
   if (!location) return null

--- a/frontend/src/citizen-frontend/map/MapBox.tsx
+++ b/frontend/src/citizen-frontend/map/MapBox.tsx
@@ -25,7 +25,7 @@ import { mapConfig } from 'lib-customizations/citizen'
 import colors from 'lib-customizations/common'
 
 import { FooterContent } from '../Footer'
-import { useTranslation } from '../localization'
+import { useLang, useTranslation } from '../localization'
 
 import type { MapAddress } from './MapView'
 import { mapViewBreakpoint } from './const'
@@ -44,6 +44,8 @@ export interface Props {
 }
 
 export default React.memo(function MapBox(props: Props) {
+  const t = useTranslation()
+  const [lang] = useLang()
   return (
     <Wrapper className="map-box">
       <Map
@@ -52,7 +54,12 @@ export default React.memo(function MapBox(props: Props) {
         zoomControl={false}
       >
         <MapContents {...props} />
-        <ZoomControl position="bottomright" />
+        <ZoomControl
+          key={lang}
+          position="bottomright"
+          zoomInTitle={t.map.zoomIn}
+          zoomOutTitle={t.map.zoomOut}
+        />
       </Map>
       <FooterWrapper>
         <FooterContent />
@@ -86,7 +93,14 @@ function MapContents({
   selectedAddress,
   setSelectedUnit
 }: Props) {
+  const t = useTranslation()
   const map = useMap()
+
+  useEffect(() => {
+    const container = map.getContainer()
+    container.setAttribute('role', 'region')
+    container.setAttribute('aria-label', t.map.title)
+  }, [map, t])
 
   useEffect(() => {
     if (selectedAddress) {
@@ -189,8 +203,10 @@ const UnitMarker = React.memo(function UnitMarker({
     const element = markerRef.current?.getElement()
     if (element) {
       element.setAttribute('data-qa', `map-marker-${id}`)
+      element.setAttribute('title', name)
+      element.setAttribute('alt', name)
     }
-  }, [markerRef, id])
+  }, [markerRef, id, name])
 
   const position = useMemo<LatLngTuple>(
     () => [location?.lat ?? 0, location?.lon ?? 0],

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -389,7 +389,9 @@ const en: Translations = {
     serviceVoucherLink:
       'https://www.espoo.fi/en/childcare-and-education/early-childhood-education/applying-private-early-childhood-education#section-55369',
     noApplying: 'No applying via eVaka, contact the unit',
-    backToSearch: 'Back to search'
+    backToSearch: 'Back to search',
+    zoomIn: 'Zoom in',
+    zoomOut: 'Zoom out'
   },
   calendar: {
     title: 'Calendar',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -391,7 +391,8 @@ const en: Translations = {
     noApplying: 'No applying via eVaka, contact the unit',
     backToSearch: 'Back to search',
     zoomIn: 'Zoom in',
-    zoomOut: 'Zoom out'
+    zoomOut: 'Zoom out',
+    closePopup: 'Close unit information'
   },
   calendar: {
     title: 'Calendar',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -389,7 +389,9 @@ export default {
     serviceVoucherLink:
       'https://www.espoo.fi/fi/kasvatus-ja-opetus/varhaiskasvatus/yksityiseen-varhaiskasvatukseen-hakeminen#section-55369',
     noApplying: 'Ei hakua eVakan kautta, ota yhteys yksikköön',
-    backToSearch: 'Takaisin hakuun'
+    backToSearch: 'Takaisin hakuun',
+    zoomIn: 'Lähennä',
+    zoomOut: 'Loitonna'
   },
   calendar: {
     title: 'Kalenteri',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -391,7 +391,8 @@ export default {
     noApplying: 'Ei hakua eVakan kautta, ota yhteys yksikköön',
     backToSearch: 'Takaisin hakuun',
     zoomIn: 'Lähennä',
-    zoomOut: 'Loitonna'
+    zoomOut: 'Loitonna',
+    closePopup: 'Sulje yksikön tiedot'
   },
   calendar: {
     title: 'Kalenteri',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -381,7 +381,8 @@ const sv: Translations = {
     noApplying: 'Ingen sökning via eVaka, kontakta tjänsten',
     backToSearch: 'Tillbaka till sökning',
     zoomIn: 'Zooma in',
-    zoomOut: 'Zooma ut'
+    zoomOut: 'Zooma ut',
+    closePopup: 'Stäng enhetens information'
   },
   calendar: {
     title: 'Kalender',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -379,7 +379,9 @@ const sv: Translations = {
     serviceVoucherLink:
       'https://www.espoo.fi/sv/fostran-och-utbildning/smabarnspedagogik/ansokan-till-privat-smabarnspedagogik#section-55369',
     noApplying: 'Ingen sökning via eVaka, kontakta tjänsten',
-    backToSearch: 'Tillbaka till sökning'
+    backToSearch: 'Tillbaka till sökning',
+    zoomIn: 'Zooma in',
+    zoomOut: 'Zooma ut'
   },
   calendar: {
     title: 'Kalender',


### PR DESCRIPTION
Yksiköt kartalla -sivulla:
- lisätty alt-tekstejä muutamiin paikkoihin
- lisätty käännöksiä kartan toimintoihin (aiemmin aina englanniksi)
- siirretään kohdistus yksikön tietoihin, kun yksikön merkki valitaan kartalta -> ruudunlukijan ei tarvitse käydä kaikkia merkkejä läpi ennen tietojen lukemista