### PR TITLE
Estetään hakemukseen liittyvät tiedote-viestit

### DIFF
--- a/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
+++ b/frontend/src/e2e-test/pages/employee/messages/messages-page.ts
@@ -404,6 +404,10 @@ export class MessageEditor extends Element {
     await expect(this).toBeHidden()
   }
 
+  async assertMessageType(type: MessageType) {
+    await expect(this).toHaveAttribute('data-type', type)
+  }
+
   async assertSimpleViewVisible() {
     await expect(this.inputTitle).toBeVisible()
     await expect(this.messageTypeMessage).toBeHidden()

--- a/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
+++ b/frontend/src/e2e-test/specs/7_messaging/service-worker-messaging.spec.ts
@@ -123,6 +123,45 @@ test.describe('Service Worker Messaging', () => {
       await citizenMessagesPage.assertThreadContent({ title, content })
     })
 
+    test('should not send a bulletin when the sender is switched to the municipal account and back', async () => {
+      await openStaffPage(mockedTime, messagingAndServiceWorker)
+      const applReadView = new ApplicationReadView(staffPage)
+      await applReadView.navigateToApplication(applicationFixtureId)
+      const messageEditor = (
+        await applReadView.openMessagesPage()
+      ).getMessageEditor()
+
+      // Switching the sender to the municipal account selects the bulletin type...
+      await messageEditor.senderSelection.fillAndSelectFirst('Espoon kaupunki')
+      await messageEditor.messageTypeBulletin.waitUntilChecked()
+
+      // ...and switching back hides the type selection and reverts the type to
+      // a regular message
+      await messageEditor.senderSelection.fillAndSelectFirst(
+        'Varhaiskasvatuksen palveluohjaus'
+      )
+      await messageEditor.assertSimpleViewVisible()
+      await messageEditor.assertMessageType('MESSAGE')
+
+      const title = 'Message to citizen'
+      const content = 'Hello citizen!'
+      await messageEditor.inputTitle.fill(title)
+      await messageEditor.inputContent.fill(content)
+      await messageEditor.sendButton.click()
+      await expect(messageEditor).toBeHidden()
+      await runPendingAsyncJobs(mockedTime.addMinutes(1))
+
+      // The citizen can reply, so the message was not sent as a bulletin
+      await openCitizenPage(mockedTime.addHours(1), '/messages')
+      const citizenMessagesPage = new CitizenMessagesPage(
+        citizenPage,
+        'desktop'
+      )
+      await citizenMessagesPage.openFirstThread()
+      await citizenMessagesPage.assertThreadContent({ title, content })
+      await citizenMessagesPage.replyToFirstThread('Reply from citizen')
+    })
+
     test('should NOT be possible for a citizen without placed children to send new messages', async () => {
       await openStaffPage(mockedTime, serviceWorker)
       const applReadView = new ApplicationReadView(staffPage)

--- a/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
+++ b/frontend/src/employee-frontend/components/messages/MessageEditor.tsx
@@ -11,9 +11,11 @@ import type { UpdateStateFn } from 'lib-common/form-state'
 import { useBoolean } from 'lib-common/form/hooks'
 import type { Attachment } from 'lib-common/generated/api-types/attachment'
 import type {
+  AccountType,
   AuthorizedMessageAccount,
   DraftContent,
   MessageThreadFolder,
+  MessageType,
   PostMessageBody,
   PostMessageFilters,
   SelectableRecipientsResponse,
@@ -125,11 +127,30 @@ const getEmptyMessage = (
   type: 'MESSAGE' as const
 })
 
+// Municipal accounts can only send bulletins, and service worker messages are
+// always related to an application, which bulletins cannot be
+const messageTypeForSender = (
+  senderAccountType: AccountType | undefined,
+  type: MessageType
+): MessageType =>
+  senderAccountType === 'MUNICIPAL'
+    ? 'BULLETIN'
+    : senderAccountType === 'SERVICE_WORKER'
+      ? 'MESSAGE'
+      : type
+
 const getInitialMessage = (
   draft: DraftContent | undefined,
   sender: SelectOption<MessageAccountId>,
-  title: string
-): Message => (draft ? { ...draft, sender } : getEmptyMessage(sender, title))
+  title: string,
+  senderAccountType: AccountType | undefined
+): Message => {
+  const message = draft ? { ...draft, sender } : getEmptyMessage(sender, title)
+  return {
+    ...message,
+    type: messageTypeForSender(senderAccountType, message.type)
+  }
+}
 
 const areRequiredFieldsFilled = (
   msg: Message,
@@ -255,8 +276,18 @@ export default React.memo(function MessageEditor({
     }))
   )
 
+  const getSenderAccount = useCallback(
+    (senderId: string) =>
+      accounts.find(({ account }) => account.id === senderId),
+    [accounts]
+  )
   const [message, setMessage] = useState<Message>(() =>
-    getInitialMessage(draftContent, defaultSender, defaultTitle)
+    getInitialMessage(
+      draftContent,
+      defaultSender,
+      defaultTitle,
+      getSenderAccount(defaultSender.value)?.account.type
+    )
   )
   const [initialFolder, setInitialFolder] =
     useState<MessageThreadFolder | null>(null)
@@ -285,11 +316,6 @@ export default React.memo(function MessageEditor({
       )
     },
     [message, recipientTree, setDraft]
-  )
-  const getSenderAccount = useCallback(
-    (senderId: string) =>
-      accounts.find(({ account }) => account.id === senderId),
-    [accounts]
   )
   const senderAccountType = useMemo(
     () => getSenderAccount(message.sender.value)?.account.type,
@@ -335,10 +361,14 @@ export default React.memo(function MessageEditor({
         }
         return
       }
+      const type = messageTypeForSender(
+        getSenderAccount(sender.value)?.account.type,
+        message.type
+      )
       if (shouldResetSensitivity) {
-        updateMessage({ sender, sensitive: false })
+        updateMessage({ sender, type, sensitive: false })
       } else {
-        updateMessage({ sender })
+        updateMessage({ sender, type })
       }
 
       const accountRecipients = selectableRecipientsToNode(
@@ -355,7 +385,8 @@ export default React.memo(function MessageEditor({
       i18n.messages.recipientSelection.starters,
       message.type,
       selectedRecipients,
-      updateMessage
+      updateMessage,
+      getSenderAccount
     ]
   )
   const handleRecipientChange = useCallback(
@@ -478,12 +509,6 @@ export default React.memo(function MessageEditor({
       })),
     [accounts]
   )
-
-  useEffect(() => {
-    if (senderAccountType === 'MUNICIPAL' && message.type !== 'BULLETIN') {
-      updateMessage({ type: 'BULLETIN' })
-    }
-  }, [senderAccountType, message.type, updateMessage])
 
   const sendEnabled =
     !sending &&
@@ -608,6 +633,7 @@ export default React.memo(function MessageEditor({
         <Container
           data-qa="message-editor"
           data-status={draftState}
+          data-type={message.type}
           className={classNames({ fullscreen: expandedView })}
         >
           <TopBar>

--- a/service/src/integrationTest/kotlin/evaka/core/messaging/MessageIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/messaging/MessageIntegrationTest.kt
@@ -3097,6 +3097,23 @@ class MessageIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     inner class Bulletins {
 
         @Test
+        fun `bulletins cannot be related to an application`() {
+            val exception =
+                assertThrows<BadRequest> {
+                    postNewThread(
+                        title = "title",
+                        message = "content",
+                        messageType = MessageType.BULLETIN,
+                        sender = serviceWorkerAccount,
+                        recipients = listOf(MessageRecipient.Citizen(adult1.id)),
+                        user = serviceWorker.user,
+                        relatedApplicationId = ApplicationId(UUID.randomUUID()),
+                    )
+                }
+            assertEquals("Bulletins cannot be related to an application", exception.message)
+        }
+
+        @Test
         fun `a bulletin cannot be replied to by the recipients`() {
             // when a bulletin thread is created
             postNewThread(

--- a/service/src/main/kotlin/evaka/core/messaging/MessageController.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageController.kt
@@ -706,6 +706,9 @@ class MessageController(
                             "Municipal message accounts are only allowed to send bulletins"
                         )
                     }
+                    if (body.type == MessageType.BULLETIN && body.relatedApplicationId != null) {
+                        throw BadRequest("Bulletins cannot be related to an application")
+                    }
                     if (senderAccountType == AccountType.SERVICE_WORKER) {
                         if (body.relatedApplicationId == null) {
                             throw BadRequest(


### PR DESCRIPTION
Tiedote saattoi sisältää yhteyden hakemukseen, kun viestin lähetys aloitettiin hakemussivun Lähetä viesti -painikkeen kautta. Lähettäjää vaihtamalla viestin tyyppi saattoi vaihtua `BULLETIN`-tyypiksi, ja `SERVICE_WORKER`-lähettäjäksi palattaessa tyyppi ei vaihtunut takaisin `MESSAGE`-tyypiksi. Tällöin lähetetty viesti oli tyypiltään `BULLETIN` ja sisälsi yhteyden hakemukseen.

Muutoksen jälkeen viestin tyyppi määräytyy käyttäjän tyypin mukaan, mikäli tyyppiä ei voi itse valita. `SERVICE_WORKER` voi lähettää vain `MESSAGE`-tyyppisiä viestejä ja `MUNICIPAL` voi lähettää vain `BULLETIN`-viestejä. Muut voivat valita viestin tyypin. Service-puolella estetään myös viestin lähetys, kun tyyppi on `BULLETIN` ja sisältää yhteyden hakemukseen.