### PR TITLE
Muutetaan testit käyttämään sijoitus-fikstuureja 

### DIFF
--- a/frontend/src/e2e-test/dev-api/fixtures.ts
+++ b/frontend/src/e2e-test/dev-api/fixtures.ts
@@ -27,7 +27,6 @@ import type {
   FeeThresholds,
   IncomeNotification
 } from 'lib-common/generated/api-types/invoicing'
-import type { PlacementType } from 'lib-common/generated/api-types/placement'
 import type { DailyReservationRequest } from 'lib-common/generated/api-types/reservations'
 import type { ServiceNeedOption } from 'lib-common/generated/api-types/serviceneed'
 import type {
@@ -37,11 +36,9 @@ import type {
   DecisionGenericReasoningId,
   DecisionIndividualReasoningId,
   EmployeeId,
-  EvakaUserId,
   FeeDecisionId,
   GroupId,
   PersonId,
-  PlacementId,
   VoucherValueDecisionId
 } from 'lib-common/generated/api-types/shared'
 import type { EvakaUser } from 'lib-common/generated/api-types/user'
@@ -156,7 +153,6 @@ import type {
   NekkuCustomer,
   NekkuSpecialDiet,
   PlacementPlan,
-  PlacementSource,
   ReservationInsert,
   VoucherValueDecision
 } from '../generated/api-types'
@@ -3047,41 +3043,6 @@ export const testDaycareGroup = Fixture.daycareGroup({
   aromiCustomerId: null,
   nekkuCustomerNumber: null
 })
-
-/**
- *  @deprecated Use `Fixture.placement()` instead
- **/
-export function createDaycarePlacementFixture(
-  id: PlacementId,
-  childId: PersonId,
-  unitId: DaycareId,
-  startDate = LocalDate.of(2022, 5, 1),
-  endDate = LocalDate.of(2023, 8, 31),
-  type: PlacementType = 'DAYCARE',
-  placeGuarantee = false,
-  createdAt = HelsinkiDateTime.now(),
-  createdBy = systemInternalUser.id,
-  source: PlacementSource = 'MANUAL',
-  modifiedAt: HelsinkiDateTime | null = HelsinkiDateTime.now(),
-  modifiedBy: EvakaUserId | null = systemInternalUser.id
-): DevPlacement {
-  return Fixture.placement({
-    id,
-    type,
-    childId,
-    unitId,
-    startDate,
-    endDate,
-    placeGuarantee,
-    createdAt,
-    createdBy,
-    source,
-    modifiedAt,
-    modifiedBy,
-    terminationRequestedDate: null,
-    terminatedBy: null
-  })
-}
 
 export const DecisionIncomeFixture = (total: number): DecisionIncome => ({
   id: null,

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-calendar.spec.ts
@@ -3,10 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import FiniteDateRange from 'lib-common/finite-date-range'
-import type {
-  CalendarEventId,
-  PlacementId
-} from 'lib-common/generated/api-types/shared'
+import type { CalendarEventId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
@@ -14,7 +11,6 @@ import LocalTime from 'lib-common/local-time'
 import type { UUID } from 'lib-common/types'
 
 import {
-  createDaycarePlacementFixture,
   Fixture,
   testAdult,
   testCareArea,
@@ -23,10 +19,7 @@ import {
   testChildRestricted,
   testDaycare
 } from '../../dev-api/fixtures'
-import {
-  createDaycarePlacements,
-  resetServiceState
-} from '../../generated/api-clients'
+import { resetServiceState } from '../../generated/api-clients'
 import type { DevPerson } from '../../generated/api-types'
 import CitizenCalendarPage from '../../pages/citizen/citizen-calendar'
 import { test } from '../../playwright'
@@ -49,32 +42,23 @@ test.beforeEach(async () => {
   children = [testChild, testChild2, testChildRestricted]
   jariId = testChild.id
   await Fixture.family({ guardian: testAdult, children }).save()
-  const placementIds = new Map(
-    children.map((child) => [child.id, randomId<PlacementId>()])
-  )
-  await createDaycarePlacements({
-    body: children.map((child) =>
-      createDaycarePlacementFixture(
-        placementIds.get(child.id)!,
-        child.id,
-        testDaycare.id,
-        today,
-        today.addYears(1)
-      )
-    )
-  })
-
   const daycareGroup = await Fixture.daycareGroup({
     daycareId: testDaycare.id,
     name: 'Group 1'
   }).save()
 
   for (const child of children) {
+    const placement = await Fixture.placement({
+      childId: child.id,
+      unitId: testDaycare.id,
+      startDate: today,
+      endDate: today.addYears(1)
+    }).save()
     await Fixture.groupPlacement({
       startDate: today,
       endDate: today.addYears(1),
       daycareGroupId: daycareGroup.id,
-      daycarePlacementId: placementIds.get(child.id)!
+      daycarePlacementId: placement.id
     }).save()
   }
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-documents.spec.ts
@@ -10,10 +10,10 @@ import type {
 import type { DocumentTemplateId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { evakaUserId, randomId } from 'lib-common/id-type'
+import LocalDate from 'lib-common/local-date'
 import type { UUID } from 'lib-common/types'
 
 import {
-  createDaycarePlacementFixture,
   testDaycareGroup,
   Fixture,
   testAdult,
@@ -25,7 +25,6 @@ import {
 } from '../../dev-api/fixtures'
 import {
   createDaycareGroups,
-  createDaycarePlacements,
   insertGuardians,
   resetServiceState,
   upsertWeakCredentials
@@ -77,9 +76,12 @@ test.beforeEach(async () => {
     ]
   })
 
-  await createDaycarePlacements({
-    body: [createDaycarePlacementFixture(randomId(), child.id, unitId)]
-  })
+  await Fixture.placement({
+    childId: child.id,
+    unitId,
+    startDate: LocalDate.of(2022, 5, 1),
+    endDate: LocalDate.of(2023, 8, 31)
+  }).save()
 
   templateIdVasu = (
     await Fixture.documentTemplate({
@@ -258,11 +260,12 @@ test.describe('Citizen child documents listing page', () => {
     await insertGuardians({
       body: [{ guardianId: testAdult2.id, childId: testChild2.id }]
     })
-    await createDaycarePlacements({
-      body: [
-        createDaycarePlacementFixture(randomId(), testChild2.id, testDaycare.id)
-      ]
-    })
+    await Fixture.placement({
+      childId: testChild2.id,
+      unitId: testDaycare.id,
+      startDate: LocalDate.of(2022, 5, 1),
+      endDate: LocalDate.of(2023, 8, 31)
+    }).save()
 
     const page = await newEvakaPage({ mockedTime: mockedNow })
     await enduserLogin(page, testAdult2, '/')

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-child-income-statement.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-child-income-statement.spec.ts
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import {
-  createDaycarePlacementFixture,
   Fixture,
   testAdult,
   testCareArea,
@@ -15,7 +13,6 @@ import {
   testDaycare
 } from '../../dev-api/fixtures'
 import {
-  createDaycarePlacements,
   resetServiceState,
   updateIncomeStatementHandled
 } from '../../generated/api-clients'
@@ -52,24 +49,18 @@ for (const env of ['desktop', 'mobile'] as const) {
         children: [testChild]
       }).save()
 
-      await createDaycarePlacements({
-        body: [
-          createDaycarePlacementFixture(
-            randomId(),
-            testChild.id,
-            testDaycare.id,
-            LocalDate.todayInSystemTz(),
-            LocalDate.todayInSystemTz()
-          ),
-          createDaycarePlacementFixture(
-            randomId(),
-            testChild.id,
-            testDaycare.id,
-            LocalDate.todayInSystemTz().addDays(1),
-            LocalDate.todayInSystemTz().addDays(1)
-          )
-        ]
-      })
+      await Fixture.placement({
+        childId: testChild.id,
+        unitId: testDaycare.id,
+        startDate: LocalDate.todayInSystemTz(),
+        endDate: LocalDate.todayInSystemTz()
+      }).save()
+      await Fixture.placement({
+        childId: testChild.id,
+        unitId: testDaycare.id,
+        startDate: LocalDate.todayInSystemTz().addDays(1),
+        endDate: LocalDate.todayInSystemTz().addDays(1)
+      }).save()
     })
 
     test('Shows a warning of missing income statement', async ({ evaka }) => {

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-discussion-surveys.spec.ts
@@ -6,8 +6,7 @@ import FiniteDateRange from 'lib-common/finite-date-range'
 import type {
   CalendarEventId,
   CalendarEventTimeId,
-  GroupId,
-  PlacementId
+  GroupId
 } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { randomId } from 'lib-common/id-type'
@@ -15,7 +14,6 @@ import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 
 import {
-  createDaycarePlacementFixture,
   Fixture,
   testAdult,
   testAdult2,
@@ -24,10 +22,7 @@ import {
   testChild2,
   testDaycare
 } from '../../dev-api/fixtures'
-import {
-  createDaycarePlacements,
-  resetServiceState
-} from '../../generated/api-clients'
+import { resetServiceState } from '../../generated/api-clients'
 import type { DevCalendarEventTime, DevPerson } from '../../generated/api-types'
 import CitizenCalendarPage from '../../pages/citizen/citizen-calendar'
 import { DiscussionSurveyModal } from '../../pages/citizen/citizen-discussion-surveys'
@@ -79,22 +74,6 @@ for (const env of ['desktop', 'mobile'] as const) {
         children: children
       }).save()
 
-      const placementIds = new Map(
-        children.map((child) => [child.id, randomId<PlacementId>()])
-      )
-
-      await createDaycarePlacements({
-        body: children.map((child) =>
-          createDaycarePlacementFixture(
-            placementIds.get(child.id)!,
-            child.id,
-            testDaycare.id,
-            today,
-            today.addYears(1)
-          )
-        )
-      })
-
       const daycareGroup = await Fixture.daycareGroup({
         id: groupId,
         daycareId: testDaycare.id,
@@ -102,11 +81,17 @@ for (const env of ['desktop', 'mobile'] as const) {
       }).save()
 
       for (const child of children) {
+        const placement = await Fixture.placement({
+          childId: child.id,
+          unitId: testDaycare.id,
+          startDate: today,
+          endDate: today.addYears(1)
+        }).save()
         await Fixture.groupPlacement({
           startDate: today,
           endDate: today.addYears(1),
           daycareGroupId: daycareGroup.id,
-          daycarePlacementId: placementIds.get(child.id)!
+          daycarePlacementId: placement.id
         }).save()
       }
 
@@ -434,22 +419,6 @@ for (const env of ['desktop', 'mobile'] as const) {
         children: children
       }).save()
 
-      const placementIds = new Map(
-        children.map((child) => [child.id, randomId<PlacementId>()])
-      )
-
-      await createDaycarePlacements({
-        body: children.map((child) =>
-          createDaycarePlacementFixture(
-            placementIds.get(child.id)!,
-            child.id,
-            testDaycare.id,
-            today,
-            today.addYears(1)
-          )
-        )
-      })
-
       const daycareGroup = await Fixture.daycareGroup({
         id: groupId,
         daycareId: testDaycare.id,
@@ -457,11 +426,17 @@ for (const env of ['desktop', 'mobile'] as const) {
       }).save()
 
       for (const child of children) {
+        const placement = await Fixture.placement({
+          childId: child.id,
+          unitId: testDaycare.id,
+          startDate: today,
+          endDate: today.addYears(1)
+        }).save()
         await Fixture.groupPlacement({
           startDate: today,
           endDate: today.addYears(1),
           daycareGroupId: daycareGroup.id,
-          daycarePlacementId: placementIds.get(child.id)!
+          daycarePlacementId: placement.id
         }).save()
       }
 
@@ -525,25 +500,19 @@ for (const env of ['desktop', 'mobile'] as const) {
     test('Citizen receives only one correct set of event times despite 2 placements', async ({
       newEvakaPage
     }) => {
-      const placement1 = createDaycarePlacementFixture(
-        randomId(),
-        testChild2.id,
-        testDaycare.id,
-        today,
-        today.addDays(2)
-      )
+      const placement1 = await Fixture.placement({
+        childId: testChild2.id,
+        unitId: testDaycare.id,
+        startDate: today,
+        endDate: today.addDays(2)
+      }).save()
 
-      const placement2 = createDaycarePlacementFixture(
-        randomId(),
-        testChild2.id,
-        testDaycare.id,
-        today.addDays(4),
-        today.addDays(4)
-      )
-
-      await createDaycarePlacements({
-        body: [placement1, placement2]
-      })
+      const placement2 = await Fixture.placement({
+        childId: testChild2.id,
+        unitId: testDaycare.id,
+        startDate: today.addDays(4),
+        endDate: today.addDays(4)
+      }).save()
 
       await Fixture.groupPlacement({
         startDate: today,
@@ -576,17 +545,12 @@ for (const env of ['desktop', 'mobile'] as const) {
     test('Citizen receives only one correct set of event times despite 2 group placements', async ({
       newEvakaPage
     }) => {
-      const placement1 = createDaycarePlacementFixture(
-        randomId(),
-        testChild2.id,
-        testDaycare.id,
-        today,
-        today.addDays(4)
-      )
-
-      await createDaycarePlacements({
-        body: [placement1]
-      })
+      const placement1 = await Fixture.placement({
+        childId: testChild2.id,
+        unitId: testDaycare.id,
+        startDate: today,
+        endDate: today.addDays(4)
+      }).save()
 
       await Fixture.groupPlacement({
         startDate: today,

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-pedagogical-documents.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-pedagogical-documents.spec.ts
@@ -3,21 +3,17 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { randomId } from 'lib-common/id-type'
+import LocalDate from 'lib-common/local-date'
 
 import { insertPedagogicalDocumentAttachment } from '../../dev-api'
 import {
-  createDaycarePlacementFixture,
   Fixture,
   testAdult,
   testCareArea,
   testChild,
   testDaycare
 } from '../../dev-api/fixtures'
-import {
-  createDaycarePlacements,
-  resetServiceState
-} from '../../generated/api-clients'
+import { resetServiceState } from '../../generated/api-clients'
 import { CitizenChildPage } from '../../pages/citizen/citizen-children'
 import CitizenHeader from '../../pages/citizen/citizen-header'
 import CitizenPedagogicalDocumentsPage from '../../pages/citizen/citizen-pedagogical-documents'
@@ -43,11 +39,12 @@ test.describe('Citizen pedagogical documents', () => {
     await testDaycare.save()
     await Fixture.family({ guardian: testAdult, children: [testChild] }).save()
 
-    await createDaycarePlacements({
-      body: [
-        createDaycarePlacementFixture(randomId(), testChild.id, testDaycare.id)
-      ]
-    })
+    await Fixture.placement({
+      childId: testChild.id,
+      unitId: testDaycare.id,
+      startDate: LocalDate.of(2022, 5, 1),
+      endDate: LocalDate.of(2023, 8, 31)
+    }).save()
 
     page = evaka
     await enduserLogin(page, testAdult, '/')

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-reservations.spec.ts
@@ -8,7 +8,7 @@ import FiniteDateRange from 'lib-common/finite-date-range'
 import type { PlacementType } from 'lib-common/generated/api-types/placement'
 import type { DaycareId } from 'lib-common/generated/api-types/shared'
 import type HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { evakaUserId, randomId } from 'lib-common/id-type'
+import { evakaUserId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
 import TimeRange from 'lib-common/time-range'
@@ -17,7 +17,6 @@ import type { DeepPartial, FeatureFlags } from 'lib-customizations/types'
 import {
   testCareArea2,
   testCareArea,
-  createDaycarePlacementFixture,
   testDaycare2,
   testDaycare,
   testChild2,
@@ -29,7 +28,6 @@ import {
   preschoolTerm2021
 } from '../../dev-api/fixtures'
 import {
-  createDaycarePlacements,
   createDefaultServiceNeedOptions,
   getAbsences,
   resetServiceState
@@ -88,34 +86,27 @@ for (const env of ['desktop', 'mobile'] as const) {
         'DAYCARE'
       ] as const
 
-      const placementFixtures = zip(children, placementTypes).map(
-        ([child, placementType]) =>
-          createDaycarePlacementFixture(
-            randomId(),
-            child!.id,
-            testDaycare.id,
-            today,
-            today.addYears(1),
-            placementType
-          )
-      )
-      await createDaycarePlacements({ body: placementFixtures })
       await createDefaultServiceNeedOptions()
 
       const group = await Fixture.daycareGroup({
         daycareId: testDaycare.id
       }).save()
 
-      await Promise.all(
-        placementFixtures.map((placement) =>
-          Fixture.groupPlacement({
-            daycareGroupId: group.id,
-            daycarePlacementId: placement.id,
-            startDate: placement.startDate,
-            endDate: placement.endDate
-          }).save()
-        )
-      )
+      for (const [child, placementType] of zip(children, placementTypes)) {
+        const placement = await Fixture.placement({
+          childId: child!.id,
+          unitId: testDaycare.id,
+          startDate: today,
+          endDate: today.addYears(1),
+          type: placementType
+        }).save()
+        await Fixture.groupPlacement({
+          daycareGroupId: group.id,
+          daycarePlacementId: placement.id,
+          startDate: placement.startDate,
+          endDate: placement.endDate
+        }).save()
+      }
     })
 
     test('Citizen creates a repeating reservation for all children', async ({
@@ -1566,31 +1557,24 @@ test.describe('Citizen calendar child visibility', () => {
     child = testChild
     child2 = testChild2
 
-    await createDaycarePlacements({
-      body: [
-        createDaycarePlacementFixture(
-          randomId(),
-          child.id,
-          testDaycare.id,
-          placement1start,
-          placement1end
-        ),
-        createDaycarePlacementFixture(
-          randomId(),
-          child.id,
-          testDaycare.id,
-          placement2start,
-          placement2end
-        ),
-        createDaycarePlacementFixture(
-          randomId(),
-          child2.id,
-          testDaycare.id,
-          placement1start.subYears(1),
-          placement1start.subDays(2)
-        )
-      ]
-    })
+    await Fixture.placement({
+      childId: child.id,
+      unitId: testDaycare.id,
+      startDate: placement1start,
+      endDate: placement1end
+    }).save()
+    await Fixture.placement({
+      childId: child.id,
+      unitId: testDaycare.id,
+      startDate: placement2start,
+      endDate: placement2end
+    }).save()
+    await Fixture.placement({
+      childId: child2.id,
+      unitId: testDaycare.id,
+      startDate: placement1start.subYears(1),
+      endDate: placement1start.subDays(2)
+    }).save()
   })
 
   test('Child visible only while placement is active', async ({
@@ -1658,16 +1642,12 @@ test.describe('Citizen calendar child visibility', () => {
     }).save()
 
     // Sibling is in 24/7 daycare with shift care
-    const placement = createDaycarePlacementFixture(
-      randomId(),
-      testChild2.id,
-      testDaycare2.id,
-      placement1start,
-      placement1end
-    )
-    await createDaycarePlacements({
-      body: [placement]
-    })
+    const placement = await Fixture.placement({
+      childId: testChild2.id,
+      unitId: testDaycare2.id,
+      startDate: placement1start,
+      endDate: placement1end
+    }).save()
     const serviceNeedOption = await Fixture.serviceNeedOption().save()
     const unitSupervisor = await Fixture.employee()
       .unitSupervisor(daycare.id)
@@ -1710,16 +1690,12 @@ test.describe('Citizen calendar child visibility', () => {
     const child = testChild2
 
     // Child is in 24/7 daycare with shift care
-    const placement = createDaycarePlacementFixture(
-      randomId(),
-      testChild2.id,
-      testDaycare2.id,
-      placement1start,
-      placement1end
-    )
-    await createDaycarePlacements({
-      body: [placement]
-    })
+    const placement = await Fixture.placement({
+      childId: testChild2.id,
+      unitId: testDaycare2.id,
+      startDate: placement1start,
+      endDate: placement1end
+    }).save()
     const serviceNeedOption = await Fixture.serviceNeedOption().save()
     const unitSupervisor = await Fixture.employee()
       .unitSupervisor(daycare.id)
@@ -1830,17 +1806,12 @@ test.describe('Citizen calendar visibility', () => {
     newEvakaPage
   }) => {
     const visibilityToday = LocalDate.todayInSystemTz()
-    await createDaycarePlacements({
-      body: [
-        createDaycarePlacementFixture(
-          randomId(),
-          child.id,
-          daycareId,
-          visibilityToday.subYears(1),
-          visibilityToday.subDays(1)
-        )
-      ]
-    })
+    await Fixture.placement({
+      childId: child.id,
+      unitId: daycareId,
+      startDate: visibilityToday.subYears(1),
+      endDate: visibilityToday.subDays(1)
+    }).save()
 
     const page = await newEvakaPage({
       mockedTime: visibilityToday.toHelsinkiDateTime(LocalTime.of(12, 0))
@@ -2146,17 +2117,12 @@ for (const env of ['desktop', 'mobile'] as const) {
       const careArea = await testCareArea2.save()
       await Fixture.daycare({ ...testDaycare2, areaId: careArea.id }).save()
 
-      await createDaycarePlacements({
-        body: [
-          createDaycarePlacementFixture(
-            randomId(),
-            testChild2.id,
-            testDaycare2.id,
-            placement1start,
-            placement1end
-          )
-        ]
-      })
+      await Fixture.placement({
+        childId: testChild2.id,
+        unitId: testDaycare2.id,
+        startDate: placement1start,
+        endDate: placement1end
+      }).save()
       const page = await newEvakaPage({
         mockedTime: today.toHelsinkiDateTime(LocalTime.of(12, 0))
       })

--- a/frontend/src/e2e-test/specs/4_finance/income-staments.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/income-staments.spec.ts
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { randomId } from 'lib-common/id-type'
 
 import config from '../../config'
 import {
-  createDaycarePlacementFixture,
   testDaycare,
   testDaycare2,
   testChild,
@@ -18,10 +16,7 @@ import {
   testCareArea,
   testCareArea2
 } from '../../dev-api/fixtures'
-import {
-  createDaycarePlacements,
-  resetServiceState
-} from '../../generated/api-clients'
+import { resetServiceState } from '../../generated/api-clients'
 import EmployeeNav from '../../pages/employee/employee-nav'
 import {
   FinancePage,
@@ -85,24 +80,18 @@ test.describe('Income statements', () => {
     const startDate = today.addYears(-1)
     const endDate = today
 
-    await createDaycarePlacements({
-      body: [
-        createDaycarePlacementFixture(
-          randomId(),
-          testChild.id,
-          testDaycare.id,
-          startDate,
-          endDate
-        ),
-        createDaycarePlacementFixture(
-          randomId(),
-          testChild2.id,
-          testDaycare2.id,
-          startDate,
-          endDate
-        )
-      ]
-    })
+    await Fixture.placement({
+      childId: testChild.id,
+      unitId: testDaycare.id,
+      startDate,
+      endDate
+    }).save()
+    await Fixture.placement({
+      childId: testChild2.id,
+      unitId: testDaycare2.id,
+      startDate,
+      endDate
+    }).save()
 
     await Fixture.incomeStatement({
       personId: testAdult.id,
@@ -197,17 +186,12 @@ test.describe('Income statements', () => {
     const startDate = today.addYears(-1)
     const endDate = today
 
-    await createDaycarePlacements({
-      body: [
-        createDaycarePlacementFixture(
-          randomId(),
-          testChild.id,
-          testDaycare.id,
-          startDate,
-          endDate
-        )
-      ]
-    })
+    await Fixture.placement({
+      childId: testChild.id,
+      unitId: testDaycare.id,
+      startDate,
+      endDate
+    }).save()
 
     await Fixture.incomeStatement({
       personId: testAdult.id,

--- a/frontend/src/e2e-test/specs/4_finance/person-finance-decisions.spec.ts
+++ b/frontend/src/e2e-test/specs/4_finance/person-finance-decisions.spec.ts
@@ -10,7 +10,6 @@ import LocalTime from 'lib-common/local-time'
 
 import config from '../../config'
 import {
-  createDaycarePlacementFixture,
   testDaycare,
   testDaycarePrivateVoucher,
   testChild2,
@@ -21,7 +20,6 @@ import {
   testCareArea
 } from '../../dev-api/fixtures'
 import {
-  createDaycarePlacements,
   createDefaultServiceNeedOptions,
   createFeeDecisions,
   createVoucherValueDecisions,
@@ -152,17 +150,12 @@ test.describe('Person finance decisions', () => {
       endDate: LocalDate.of(2099, 1, 1)
     }).save()
 
-    await createDaycarePlacements({
-      body: [
-        createDaycarePlacementFixture(
-          randomId(),
-          testChild2.id,
-          testDaycarePrivateVoucher.id,
-          from,
-          LocalDate.todayInSystemTz()
-        )
-      ]
-    })
+    await Fixture.placement({
+      childId: testChild2.id,
+      unitId: testDaycarePrivateVoucher.id,
+      startDate: from,
+      endDate: LocalDate.todayInSystemTz()
+    }).save()
 
     const adminUser = await Fixture.employee().admin().save()
     page = await newEvakaPage()

--- a/frontend/src/e2e-test/specs/5_employee/child-income-statements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/child-income-statements.spec.ts
@@ -2,22 +2,17 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import type { UUID } from 'lib-common/types'
 
 import config from '../../config'
 import {
-  createDaycarePlacementFixture,
   testDaycare,
   testChild,
   Fixture,
   testCareArea
 } from '../../dev-api/fixtures'
-import {
-  createDaycarePlacements,
-  resetServiceState
-} from '../../generated/api-clients'
+import { resetServiceState } from '../../generated/api-clients'
 import ChildInformationPage from '../../pages/employee/child-information'
 import { test } from '../../playwright'
 import type { Page } from '../../utils/page'
@@ -43,12 +38,10 @@ test.describe('Child profile income statements', () => {
   })
 
   test('Shows income statements', async () => {
-    const daycarePlacementFixture = createDaycarePlacementFixture(
-      randomId(),
-      testChild.id,
-      testDaycare.id
-    )
-    await createDaycarePlacements({ body: [daycarePlacementFixture] })
+    await Fixture.placement({
+      childId: testChild.id,
+      unitId: testDaycare.id
+    }).save()
 
     await Fixture.incomeStatement({
       personId: testChild.id,

--- a/frontend/src/e2e-test/specs/5_employee/guardian-income-statements.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/guardian-income-statements.spec.ts
@@ -3,23 +3,18 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { randomId } from 'lib-common/id-type'
+import LocalDate from 'lib-common/local-date'
 import type { UUID } from 'lib-common/types'
 
 import config from '../../config'
 import {
-  createDaycarePlacementFixture,
   testDaycare,
   testAdult,
   Fixture,
   testChildRestricted,
   testCareArea
 } from '../../dev-api/fixtures'
-import {
-  createDaycarePlacements,
-  insertGuardians,
-  resetServiceState
-} from '../../generated/api-clients'
+import { insertGuardians, resetServiceState } from '../../generated/api-clients'
 import type { DevPerson } from '../../generated/api-types'
 import GuardianInformationPage from '../../pages/employee/guardian-information'
 import { test } from '../../playwright'
@@ -54,12 +49,12 @@ test.describe('Guardian income statements', () => {
   })
 
   test("Shows placed child's income statements", async () => {
-    const daycarePlacementFixture = createDaycarePlacementFixture(
-      randomId(),
-      child.id,
-      testDaycare.id
-    )
-    await createDaycarePlacements({ body: [daycarePlacementFixture] })
+    await Fixture.placement({
+      childId: child.id,
+      unitId: testDaycare.id,
+      startDate: LocalDate.of(2022, 5, 1),
+      endDate: LocalDate.of(2023, 8, 31)
+    }).save()
 
     await insertGuardians({
       body: [

--- a/frontend/src/e2e-test/specs/5_employee/guardian-information-page.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/guardian-information-page.spec.ts
@@ -4,15 +4,13 @@
 
 import type {
   ApplicationId,
-  DecisionId,
-  PlacementId
+  DecisionId
 } from 'lib-common/generated/api-types/shared'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 
 import {
   applicationFixture,
-  createDaycarePlacementFixture,
   testDaycare,
   testDaycareGroup,
   decisionFixture,
@@ -26,7 +24,6 @@ import {
 import {
   createApplications,
   createDaycareGroups,
-  createDaycarePlacements,
   createDecisions,
   deleteDaycareCostCenter,
   resetServiceState
@@ -52,11 +49,10 @@ test.describe('Employee - Guardian Information', () => {
 
     const admin = await Fixture.employee().admin().save()
 
-    const daycarePlacementFixture = createDaycarePlacementFixture(
-      randomId<PlacementId>(),
-      testChild.id,
-      testDaycare.id
-    )
+    await Fixture.placement({
+      childId: testChild.id,
+      unitId: testDaycare.id
+    }).save()
     const application = applicationFixture(testChild, testAdult)
 
     const application2 = {
@@ -69,7 +65,6 @@ test.describe('Employee - Guardian Information', () => {
     }
 
     const startDate = LocalDate.of(2021, 8, 16)
-    await createDaycarePlacements({ body: [daycarePlacementFixture] })
     await createApplications({ body: [application, application2] })
     await createDecisions({
       body: [

--- a/frontend/src/e2e-test/specs/5_employee/pedagogical-document.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/pedagogical-document.spec.ts
@@ -4,11 +4,10 @@
 
 import type { PersonId } from 'lib-common/generated/api-types/shared'
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { randomId } from 'lib-common/id-type'
+import LocalDate from 'lib-common/local-date'
 
 import config from '../../config'
 import {
-  createDaycarePlacementFixture,
   testDaycareGroup,
   Fixture,
   familyWithTwoGuardians,
@@ -17,7 +16,6 @@ import {
 } from '../../dev-api/fixtures'
 import {
   createDaycareGroups,
-  createDaycarePlacements,
   resetServiceState
 } from '../../generated/api-clients'
 import type { PedagogicalDocumentsSection } from '../../pages/employee/child-information'
@@ -53,12 +51,12 @@ test.describe('Child Information - Pedagogical documents', () => {
     const unitId = testDaycare.id
     childId = familyWithTwoGuardians.children[0].id
 
-    const daycarePlacementFixture = createDaycarePlacementFixture(
-      randomId(),
+    await Fixture.placement({
       childId,
-      unitId
-    )
-    await createDaycarePlacements({ body: [daycarePlacementFixture] })
+      unitId,
+      startDate: LocalDate.of(2022, 5, 1),
+      endDate: LocalDate.of(2023, 8, 31)
+    }).save()
 
     const admin = await Fixture.employee().admin().save()
 

--- a/frontend/src/e2e-test/specs/5_employee/placement-sketching-report.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/placement-sketching-report.spec.ts
@@ -2,10 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import type {
-  ApplicationId,
-  PlacementId
-} from 'lib-common/generated/api-types/shared'
+import type { ApplicationId } from 'lib-common/generated/api-types/shared'
 import { randomId } from 'lib-common/id-type'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
@@ -13,7 +10,6 @@ import LocalTime from 'lib-common/local-time'
 import config from '../../config'
 import {
   applicationFixture,
-  createDaycarePlacementFixture,
   testDaycare,
   Fixture,
   testAdult,
@@ -24,7 +20,6 @@ import {
 } from '../../dev-api/fixtures'
 import {
   createApplications,
-  createDaycarePlacements,
   resetServiceState
 } from '../../generated/api-clients'
 import type { DevApplicationWithForm } from '../../generated/api-types'
@@ -136,13 +131,12 @@ test.describe('Placement sketching report', () => {
     const preferredUnit = testDaycare
     const currentUnit = preferredUnit
 
-    const daycarePlacementFixture = createDaycarePlacementFixture(
-      randomId<PlacementId>(),
-      createdApplication.childId,
-      preferredUnit.id,
-      placementStartDate
-    )
-    await createDaycarePlacements({ body: [daycarePlacementFixture] })
+    await Fixture.placement({
+      childId: createdApplication.childId,
+      unitId: preferredUnit.id,
+      startDate: placementStartDate,
+      endDate: LocalDate.of(2023, 8, 31)
+    }).save()
 
     const report = await openPlacementSketchingReport()
     await report.assertRow(


### PR DESCRIPTION
Osa päästä päähän -testeistä käyttää edelleen deprekoitua `createDaycarePlacementFixture`-funktiota sijoitusten luomiseen. Muutoksen jälkeen kaikki testit käyttävät `Fixture.placement`-metodia, ja deprekoitu funktio poistuu.