### PR TITLE
Vanhojen mockNow- ja mockToday-funktioiden poisto

### DIFF
--- a/frontend/src/citizen-frontend/map/UnitDetailsPanel.tsx
+++ b/frontend/src/citizen-frontend/map/UnitDetailsPanel.tsx
@@ -10,9 +10,9 @@ import type {
   CareType,
   PublicUnit
 } from 'lib-common/generated/api-types/daycare'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import { constantQuery, useQueryResult } from 'lib-common/query'
 import { capitalizeFirstLetter } from 'lib-common/string'
-import { mockNow } from 'lib-common/utils/helpers'
 import ExternalLink from 'lib-components/atoms/ExternalLink'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { ContentArea } from 'lib-components/layout/Container'
@@ -82,7 +82,7 @@ export default React.memo(function UnitDetailsPanel({
     const end = encodeURIComponent(
       `${unit.streetAddress}, ${unit.postOffice}::${unit.location.lat},${unit.location.lon}`
     )
-    let arrival = addDays(mockNow() ?? new Date(), 1)
+    let arrival = addDays(HelsinkiDateTime.now().toSystemTzDate(), 1)
     if (isSaturday(arrival)) {
       arrival = addDays(arrival, 2)
     } else if (isSunday(arrival)) {

--- a/frontend/src/employee-frontend/components/holiday-term-periods/HolidayPeriodForm.tsx
+++ b/frontend/src/employee-frontend/components/holiday-term-periods/HolidayPeriodForm.tsx
@@ -12,7 +12,6 @@ import { ValidationError, ValidationSuccess } from 'lib-common/form/types'
 import type { HolidayPeriod } from 'lib-common/generated/api-types/holidayperiod'
 import LocalDate from 'lib-common/local-date'
 import { useMutationResult } from 'lib-common/query'
-import { mockToday } from 'lib-common/utils/helpers'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
 import { Button } from 'lib-components/atoms/buttons/Button'
 import { CheckboxF } from 'lib-components/atoms/form/Checkbox'
@@ -31,7 +30,7 @@ import {
   updateHolidayPeriodMutation
 } from './queries'
 
-const minStartDate = (mockToday() ?? LocalDate.todayInSystemTz()).addWeeks(4)
+const minStartDate = LocalDate.todayInSystemTz().addWeeks(4)
 const maxPeriod = 15 * 7 * 24 * 60 * 60 * 1000 // 15 weeks
 
 function makeHolidayPeriodForm(mode: 'create' | 'update') {

--- a/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraphRealized.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-unit-information/occupancy/OccupancyDayGraphRealized.tsx
@@ -17,7 +17,6 @@ import type { RealtimeOccupancy } from 'lib-common/generated/api-types/occupancy
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import LocalTime from 'lib-common/local-time'
-import { mockNow } from 'lib-common/utils/helpers'
 import {
   FixedSpaceColumn,
   FixedSpaceRow
@@ -432,7 +431,7 @@ function graphData(
 
 function getCurrentMinute(): HelsinkiDateTime {
   return HelsinkiDateTime.fromSystemTzDate(
-    roundToNearestMinutes(mockNow() ?? new Date())
+    roundToNearestMinutes(HelsinkiDateTime.now().toSystemTzDate())
   )
 }
 

--- a/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkAbsentBeforehand.tsx
+++ b/frontend/src/employee-mobile-frontend/child-attendance/actions/MarkAbsentBeforehand.tsx
@@ -9,10 +9,10 @@ import styled from 'styled-components'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import type { AbsenceType } from 'lib-common/generated/api-types/absence'
 import type { ChildId, DaycareId } from 'lib-common/generated/api-types/shared'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import LocalDate from 'lib-common/local-date'
 import { useMutationResult, useQueryResult } from 'lib-common/query'
 import { groupAbsencesByDateRange } from 'lib-common/utils/absences'
-import { mockNow } from 'lib-common/utils/helpers'
 import HorizontalLine from 'lib-components/atoms/HorizontalLine'
 import Title from 'lib-components/atoms/Title'
 import { AsyncButton } from 'lib-components/atoms/buttons/AsyncButton'
@@ -96,8 +96,10 @@ export default React.memo(function MarkAbsentBeforehand({
 
   const canSave = useMemo(
     () =>
-      isAfter(new Date(startDate), subDays(mockNow() ?? new Date(), 1)) &&
-      isBefore(new Date(startDate), addDays(new Date(endDate), 1)),
+      isAfter(
+        new Date(startDate),
+        subDays(HelsinkiDateTime.now().toSystemTzDate(), 1)
+      ) && isBefore(new Date(startDate), addDays(new Date(endDate), 1)),
     [endDate, startDate]
   )
 
@@ -175,7 +177,10 @@ export default React.memo(function MarkAbsentBeforehand({
                       onChange={setStartDate}
                       width="s"
                       info={
-                        isBefore(new Date(startDate), mockNow() ?? new Date())
+                        isBefore(
+                          new Date(startDate),
+                          HelsinkiDateTime.now().toSystemTzDate()
+                        )
                           ? {
                               text: i18n.absences.chooseStartDate,
                               status: 'warning'

--- a/frontend/src/employee-mobile-frontend/common/dailyServiceTimes.ts
+++ b/frontend/src/employee-mobile-frontend/common/dailyServiceTimes.ts
@@ -8,8 +8,7 @@ import {
   isVariableTime
 } from 'lib-common/api-types/daily-service-times'
 import type { DailyServiceTimesValue } from 'lib-common/generated/api-types/dailyservicetimes'
-import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import type LocalDate from 'lib-common/local-date'
+import LocalDate from 'lib-common/local-date'
 import type TimeRange from 'lib-common/time-range'
 
 const dayNames = [
@@ -23,8 +22,7 @@ const dayNames = [
 type DayName = (typeof dayNames)[number]
 
 function getToday(): DayName | undefined {
-  // Sunday is 0
-  const dayIndex = (HelsinkiDateTime.now().toSystemTzDate().getDay() + 6) % 7
+  const dayIndex = LocalDate.todayInSystemTz().getIsoDayOfWeek() - 1
   return dayNames[dayIndex]
 }
 

--- a/frontend/src/employee-mobile-frontend/common/dailyServiceTimes.ts
+++ b/frontend/src/employee-mobile-frontend/common/dailyServiceTimes.ts
@@ -8,9 +8,9 @@ import {
   isVariableTime
 } from 'lib-common/api-types/daily-service-times'
 import type { DailyServiceTimesValue } from 'lib-common/generated/api-types/dailyservicetimes'
+import HelsinkiDateTime from 'lib-common/helsinki-date-time'
 import type LocalDate from 'lib-common/local-date'
 import type TimeRange from 'lib-common/time-range'
-import { mockNow } from 'lib-common/utils/helpers'
 
 const dayNames = [
   'monday',
@@ -24,7 +24,7 @@ type DayName = (typeof dayNames)[number]
 
 function getToday(): DayName | undefined {
   // Sunday is 0
-  const dayIndex = ((mockNow() ?? new Date()).getDay() + 6) % 7
+  const dayIndex = (HelsinkiDateTime.now().toSystemTzDate().getDay() + 6) % 7
   return dayNames[dayIndex]
 }
 

--- a/frontend/src/employee-mobile-frontend/common/service-worker.tsx
+++ b/frontend/src/employee-mobile-frontend/common/service-worker.tsx
@@ -13,7 +13,6 @@ import React, {
 } from 'react'
 
 import HelsinkiDateTime from 'lib-common/helsinki-date-time'
-import { mockNow } from 'lib-common/utils/helpers'
 
 import { UserContext } from '../auth/state'
 import { upsertPushSubscription } from '../generated/api-clients/webpush'
@@ -171,7 +170,7 @@ export class PushNotifications {
     }
     const sub = await this.pushManager.getSubscription()
     if (sub) {
-      const now = mockNow() ?? new Date()
+      const now = HelsinkiDateTime.now().toSystemTzDate()
       const expiringSoon = sub.expirationTime
         ? differenceInDays(now, sub.expirationTime) < 7
         : false

--- a/frontend/src/lib-common/utils/helpers.ts
+++ b/frontend/src/lib-common/utils/helpers.ts
@@ -48,9 +48,3 @@ declare global {
     keepSessionAliveThrottleTime?: number
   }
 }
-
-/**
- * @deprecated use HelsinkiDateTime.now() instead
- */
-export const mockNow = (): Date | undefined =>
-  typeof window !== 'undefined' ? window.evaka?.mockedTime : undefined

--- a/frontend/src/lib-common/utils/helpers.ts
+++ b/frontend/src/lib-common/utils/helpers.ts
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import LocalDate from '../local-date'
-
 export const getEnvironment = (): string => {
   if (
     window.location.host.startsWith('localhost') ||
@@ -56,11 +54,3 @@ declare global {
  */
 export const mockNow = (): Date | undefined =>
   typeof window !== 'undefined' ? window.evaka?.mockedTime : undefined
-
-/**
- * @deprecated use LocalDate.todayInHelsinkiTz() or LocalDate.todayInSystemTz() instead
- */
-export function mockToday(): LocalDate | undefined {
-  const mockedTime = mockNow()
-  return mockedTime ? LocalDate.fromSystemTzDate(mockedTime) : undefined
-}


### PR DESCRIPTION
Poistetaan deprekoidut `mockNow`- ja `mockToday`-apufunktiot ja refaktoroidaan edellisten kutsupaikat käyttämään `LocalDate`- ja `HelsinkiDateTime`-apureita.