### PR TITLE
Espoo: hallinnoidaan palvelualueet ja tukitoimet afterMigrate-skripteillä

### DIFF
--- a/service/src/main/resources/espoo/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/espoo/db/migration/afterMigrate__assistance_action_options.sql
@@ -1,0 +1,36 @@
+-- SPDX-FileCopyrightText: 2017-2026 City of Espoo
+--
+-- SPDX-License-Identifier: LGPL-2.1-or-later
+
+INSERT INTO assistance_action_option
+    (value, name_fi, description_fi, display_order, category, valid_from, valid_to)
+VALUES
+    ('ASSISTANCE_SERVICE_CHILD', 'Avustamispalvelut yhdelle lapselle', NULL, 10, 'DAYCARE', NULL, NULL),
+    ('ASSISTANCE_SERVICE_UNIT', 'Avustamispalvelut yksikköön', NULL, 20, 'DAYCARE', NULL, NULL),
+    ('SMALLER_GROUP', 'Pedagogisesti vahvistettu ryhmä', NULL, 30, 'DAYCARE', NULL, NULL),
+    ('SPECIAL_GROUP', 'Erityisryhmä', NULL, 40, 'DAYCARE', NULL, NULL),
+    ('PERVASIVE_VEO_SUPPORT', 'Laaja-alaisen veon tuki', NULL, 50, 'DAYCARE', NULL, NULL),
+    ('RESOURCE_PERSON', 'Resurssihenkilö', NULL, 60, 'DAYCARE', NULL, NULL),
+    ('RATIO_DECREASE', 'Suhdeluvun väljennys', NULL, 70, 'DAYCARE', NULL, NULL),
+    ('PERIODICAL_VEO_SUPPORT', 'Lisäresurssi hankerahoituksella', NULL, 80, 'DAYCARE', NULL, NULL),
+    ('FULL_VEO_SUPPORT_IN_SMALLER_GROUP', 'Kokoaikainen erityisopettajan antama opetus pienryhmässä', NULL, 10, 'PRESCHOOL', '2025-08-01', NULL),
+    ('REGULAR_VEO_SUPPORT_PARTIALLY_IN_SMALLER_GROUP', 'Säännöllinen erityisopettajan antama opetus osittain pienryhmässä ja muun opetuksen yhteydessä', NULL, 20, 'PRESCHOOL', '2025-08-01', NULL),
+    ('PERSONAL_ASSISTANT', 'Lapsikohtainen avustaja', NULL, 30, 'PRESCHOOL', '2025-08-01', NULL),
+    ('ASSISTIVE_DEVICES', 'Apuvälineet', NULL, 40, 'PRESCHOOL', '2025-08-01', NULL),
+    ('INTERPRETATION_SERVICES', 'Tulkitsemispalvelut', NULL, 50, 'PRESCHOOL', '2025-08-01', NULL),
+    ('PART_TIME_SPECIAL_EDUCATION', 'Osa-aikainen erityisopetus esiopetuksessa', NULL, 55, 'PRESCHOOL', NULL, '2025-07-31')
+ON CONFLICT (value) DO
+UPDATE SET
+    name_fi = EXCLUDED.name_fi,
+    description_fi = EXCLUDED.description_fi,
+    display_order = EXCLUDED.display_order,
+    category = EXCLUDED.category,
+    valid_from = EXCLUDED.valid_from,
+    valid_to = EXCLUDED.valid_to
+WHERE
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category OR
+    assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
+    assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;

--- a/service/src/main/resources/espoo/db/migration/afterMigrate__care_areas.sql
+++ b/service/src/main/resources/espoo/db/migration/afterMigrate__care_areas.sql
@@ -1,0 +1,27 @@
+-- SPDX-FileCopyrightText: 2017-2026 City of Espoo
+--
+-- SPDX-License-Identifier: LGPL-2.1-or-later
+
+INSERT INTO care_area
+    (id, name, area_code, sub_cost_center, short_name)
+VALUES
+    ('a01b0e03-b86e-4cbc-a744-6a35473b9628', 'Leppävaara (itä)', 249, '01', 'leppavaara-ita'),
+    ('801a6cc7-e8a5-4279-b192-4e8192d82c18', 'Leppävaara (länsi)', 249, '01', 'leppavaara-lansi'),
+    ('aede1c92-39a0-47b3-9f7a-45b4355f6c87', 'Tapiola', 250, '02', 'tapiola'),
+    ('7f08ec20-3843-466e-807e-a8cddf5d5605', 'Matinkylä-Olari', 251, '03', 'matinkyla-olari'),
+    ('d60f3dae-e164-4ad0-b5ec-af9c8c35a586', 'Espoonlahti', 252, '04', 'espoonlahti'),
+    ('7119009f-ec26-45d2-be61-d3f802c1d1e5', 'Espoon keskus (eteläinen)', 253, '05', 'espoon-keskus-etela'),
+    ('10842fdc-5750-447d-9b6b-50a1ca66864c', 'Espoon keskus (pohjoinen)', 253, '05', 'espoon-keskus-pohjoinen'),
+    ('2daff112-788e-11e9-bd0e-07d5525c2890', 'Svenska bildningstjänster', 254, NULL, 'svenska-bildningstjanster'),
+    ('b4c4e4ce-123c-11f1-8104-af3da164f107', 'Palveluseteli muut kunnat', NULL, NULL, 'palveluseteli-muut-kunnat')
+ON CONFLICT (id) DO
+UPDATE SET
+    name = EXCLUDED.name,
+    area_code = EXCLUDED.area_code,
+    sub_cost_center = EXCLUDED.sub_cost_center,
+    short_name = EXCLUDED.short_name
+WHERE
+    care_area.name IS DISTINCT FROM EXCLUDED.name OR
+    care_area.area_code IS DISTINCT FROM EXCLUDED.area_code OR
+    care_area.sub_cost_center IS DISTINCT FROM EXCLUDED.sub_cost_center OR
+    care_area.short_name IS DISTINCT FROM EXCLUDED.short_name;


### PR DESCRIPTION
Stagingin data on jo korjattu niin että migraatiot menevät läpi myös siellä (ainoastaan yhden palvelualueen ID piti muuttaa)