### PR TITLE
Korjataan henkilökunnan läsnäoloeditorin datan päivittyminen

### DIFF
--- a/frontend/src/employee-mobile-frontend/staff-attendance/StaffAttendanceEditPage.tsx
+++ b/frontend/src/employee-mobile-frontend/staff-attendance/StaffAttendanceEditPage.tsx
@@ -251,25 +251,34 @@ export default React.memo(function StaffAttendanceEditPage({
     [employeeId, unitInfoResponse, staffAttendanceResponse]
   )
 
-  return renderResult(combinedResult, ({ groups, staff, staffMember }) => (
-    <StaffMemberPageContainer>
-      {staffMember === undefined || staff === undefined ? (
-        <ErrorSegment title={i18n.attendances.staff.errors.employeeNotFound} />
-      ) : !staff.pinSet ? (
-        <ErrorSegment title={i18n.attendances.staff.pinNotSet} />
-      ) : staff.pinLocked ? (
-        <ErrorSegment title={i18n.attendances.staff.pinLocked} />
-      ) : (
-        <StaffAttendancesEditor
-          date={date}
-          unitOrGroup={unitOrGroup}
-          employeeId={employeeId}
-          groups={groups}
-          staffMember={staffMember}
-        />
-      )}
-    </StaffMemberPageContainer>
-  ))
+  return renderResult(
+    combinedResult,
+    ({ groups, staff, staffMember }, isReloading) => {
+      if (isReloading) return null
+
+      return (
+        <StaffMemberPageContainer>
+          {staffMember === undefined || staff === undefined ? (
+            <ErrorSegment
+              title={i18n.attendances.staff.errors.employeeNotFound}
+            />
+          ) : !staff.pinSet ? (
+            <ErrorSegment title={i18n.attendances.staff.pinNotSet} />
+          ) : staff.pinLocked ? (
+            <ErrorSegment title={i18n.attendances.staff.pinLocked} />
+          ) : (
+            <StaffAttendancesEditor
+              date={date}
+              unitOrGroup={unitOrGroup}
+              employeeId={employeeId}
+              groups={groups}
+              staffMember={staffMember}
+            />
+          )}
+        </StaffMemberPageContainer>
+      )
+    }
+  )
 })
 
 const StaffAttendancesEditor = ({


### PR DESCRIPTION
Henkilökunnan mobiilissa läsnäoloeditori saattoi alustua välimuistissa olleella vanhalla datalla, kun muokkaussivun avasi nopeasti. Tämä aiheuttaa epävakautta [e2e-testissä](https://github.com/espoon-voltti/evaka/blob/8e5d0a13c5bd72487e8d80de41cee384feb1a65d/frontend/src/e2e-test/specs/6_mobile/realtime-staff-attendances.spec.ts#L202-L235). Muutoksen jälkeen näkymä odottaa datan päivittymistä.