### PR TITLE
Käytetään `IS DISTINCT FROM` -operaattoria `<>`:n sijaan afterMigrate-skripteissä

### DIFF
--- a/service/src/main/resources/hameenkyro/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/hameenkyro/db/migration/afterMigrate__assistance_action_options.sql
@@ -29,9 +29,9 @@ UPDATE SET
     valid_from = EXCLUDED.valid_from,
     valid_to = EXCLUDED.valid_to
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
     assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category OR
     assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;

--- a/service/src/main/resources/hameenkyro/db/migration/afterMigrate__care_areas.sql
+++ b/service/src/main/resources/hameenkyro/db/migration/afterMigrate__care_areas.sql
@@ -13,7 +13,7 @@ UPDATE SET
     sub_cost_center = EXCLUDED.sub_cost_center,
     short_name = EXCLUDED.short_name
 WHERE
-    care_area.name <> EXCLUDED.name OR
+    care_area.name IS DISTINCT FROM EXCLUDED.name OR
     care_area.area_code IS DISTINCT FROM EXCLUDED.area_code OR
     care_area.sub_cost_center IS DISTINCT FROM EXCLUDED.sub_cost_center OR
-    care_area.short_name <> EXCLUDED.short_name;
+    care_area.short_name IS DISTINCT FROM EXCLUDED.short_name;

--- a/service/src/main/resources/hameenkyro/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/hameenkyro/db/migration/afterMigrate__service_need_options.sql
@@ -76,26 +76,26 @@ ON CONFLICT (id) DO
                show_for_citizen = EXCLUDED.show_for_citizen,
                display_order = EXCLUDED.display_order
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.realized_occupancy_coefficient <> EXCLUDED.realized_occupancy_coefficient OR
-    service_need_option.realized_occupancy_coefficient_under_3y <> EXCLUDED.realized_occupancy_coefficient_under_3y OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.realized_occupancy_coefficient IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient OR
+    service_need_option.realized_occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient_under_3y OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
     service_need_option.contract_days_per_month IS DISTINCT FROM EXCLUDED.contract_days_per_month OR
     service_need_option.daycare_hours_per_month IS DISTINCT FROM EXCLUDED.daycare_hours_per_month OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     service_need_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.display_order <> EXCLUDED.display_order;
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order;

--- a/service/src/main/resources/hameenkyro/db/migration/afterMigrate__special_diet.sql
+++ b/service/src/main/resources/hameenkyro/db/migration/afterMigrate__special_diet.sql
@@ -5,4 +5,4 @@
 INSERT INTO special_diet (id, abbreviation)
 VALUES (0, 'erityisruokavalio')
 ON CONFLICT (id) DO UPDATE SET abbreviation = EXCLUDED.abbreviation
-WHERE special_diet.abbreviation <> EXCLUDED.abbreviation;
+WHERE special_diet.abbreviation IS DISTINCT FROM EXCLUDED.abbreviation;

--- a/service/src/main/resources/kangasala/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/kangasala/db/migration/afterMigrate__assistance_action_options.sql
@@ -35,9 +35,9 @@ UPDATE SET
     valid_from = EXCLUDED.valid_from,
     valid_to = EXCLUDED.valid_to
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
     assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category OR
     assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;

--- a/service/src/main/resources/kangasala/db/migration/afterMigrate__care_areas.sql
+++ b/service/src/main/resources/kangasala/db/migration/afterMigrate__care_areas.sql
@@ -13,7 +13,7 @@ UPDATE SET
     sub_cost_center = EXCLUDED.sub_cost_center,
     short_name = EXCLUDED.short_name
 WHERE
-    care_area.name <> EXCLUDED.name OR
+    care_area.name IS DISTINCT FROM EXCLUDED.name OR
     care_area.area_code IS DISTINCT FROM EXCLUDED.area_code OR
     care_area.sub_cost_center IS DISTINCT FROM EXCLUDED.sub_cost_center OR
-    care_area.short_name <> EXCLUDED.short_name;
+    care_area.short_name IS DISTINCT FROM EXCLUDED.short_name;

--- a/service/src/main/resources/kangasala/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/kangasala/db/migration/afterMigrate__service_need_options.sql
@@ -77,26 +77,26 @@ ON CONFLICT (id) DO
                show_for_citizen = EXCLUDED.show_for_citizen,
                display_order = EXCLUDED.display_order
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.realized_occupancy_coefficient <> EXCLUDED.realized_occupancy_coefficient OR
-    service_need_option.realized_occupancy_coefficient_under_3y <> EXCLUDED.realized_occupancy_coefficient_under_3y OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.realized_occupancy_coefficient IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient OR
+    service_need_option.realized_occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient_under_3y OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
     service_need_option.contract_days_per_month IS DISTINCT FROM EXCLUDED.contract_days_per_month OR
     service_need_option.daycare_hours_per_month IS DISTINCT FROM EXCLUDED.daycare_hours_per_month OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     service_need_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.display_order <> EXCLUDED.display_order;
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order;

--- a/service/src/main/resources/lempaala/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/lempaala/db/migration/afterMigrate__assistance_action_options.sql
@@ -20,7 +20,7 @@ UPDATE SET
     display_order = EXCLUDED.display_order,
     category = EXCLUDED.category
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category;

--- a/service/src/main/resources/lempaala/db/migration/afterMigrate__care_areas.sql
+++ b/service/src/main/resources/lempaala/db/migration/afterMigrate__care_areas.sql
@@ -13,7 +13,7 @@ UPDATE SET
     sub_cost_center = EXCLUDED.sub_cost_center,
     short_name = EXCLUDED.short_name
 WHERE
-    care_area.name <> EXCLUDED.name OR
+    care_area.name IS DISTINCT FROM EXCLUDED.name OR
     care_area.area_code IS DISTINCT FROM EXCLUDED.area_code OR
     care_area.sub_cost_center IS DISTINCT FROM EXCLUDED.sub_cost_center OR
-    care_area.short_name <> EXCLUDED.short_name;
+    care_area.short_name IS DISTINCT FROM EXCLUDED.short_name;

--- a/service/src/main/resources/lempaala/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/lempaala/db/migration/afterMigrate__service_need_options.sql
@@ -42,26 +42,26 @@ UPDATE SET
     show_for_citizen = EXCLUDED.show_for_citizen,
     display_order = EXCLUDED.display_order
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.realized_occupancy_coefficient <> EXCLUDED.realized_occupancy_coefficient OR
-    service_need_option.realized_occupancy_coefficient_under_3y <> EXCLUDED.realized_occupancy_coefficient_under_3y OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.realized_occupancy_coefficient IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient OR
+    service_need_option.realized_occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient_under_3y OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
     service_need_option.contract_days_per_month IS DISTINCT FROM EXCLUDED.contract_days_per_month OR
     service_need_option.daycare_hours_per_month IS DISTINCT FROM EXCLUDED.daycare_hours_per_month OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     service_need_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.display_order <> EXCLUDED.display_order;
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order;

--- a/service/src/main/resources/nokia/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/nokia/db/migration/afterMigrate__assistance_action_options.sql
@@ -31,9 +31,9 @@ UPDATE SET
     valid_from = EXCLUDED.valid_from,
     valid_to = EXCLUDED.valid_to
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
     assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category OR
     assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;

--- a/service/src/main/resources/nokia/db/migration/afterMigrate__care_areas.sql
+++ b/service/src/main/resources/nokia/db/migration/afterMigrate__care_areas.sql
@@ -13,7 +13,7 @@ UPDATE SET
     sub_cost_center = EXCLUDED.sub_cost_center,
     short_name = EXCLUDED.short_name
 WHERE
-    care_area.name <> EXCLUDED.name OR
+    care_area.name IS DISTINCT FROM EXCLUDED.name OR
     care_area.area_code IS DISTINCT FROM EXCLUDED.area_code OR
     care_area.sub_cost_center IS DISTINCT FROM EXCLUDED.sub_cost_center OR
-    care_area.short_name <> EXCLUDED.short_name;
+    care_area.short_name IS DISTINCT FROM EXCLUDED.short_name;

--- a/service/src/main/resources/nokia/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/nokia/db/migration/afterMigrate__service_need_options.sql
@@ -73,26 +73,26 @@ ON CONFLICT (id) DO
                show_for_citizen = EXCLUDED.show_for_citizen,
                display_order = EXCLUDED.display_order
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.realized_occupancy_coefficient <> EXCLUDED.realized_occupancy_coefficient OR
-    service_need_option.realized_occupancy_coefficient_under_3y <> EXCLUDED.realized_occupancy_coefficient_under_3y OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.realized_occupancy_coefficient IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient OR
+    service_need_option.realized_occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient_under_3y OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
     service_need_option.contract_days_per_month IS DISTINCT FROM EXCLUDED.contract_days_per_month OR
     service_need_option.daycare_hours_per_month IS DISTINCT FROM EXCLUDED.daycare_hours_per_month OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     service_need_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.display_order <> EXCLUDED.display_order;
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order;

--- a/service/src/main/resources/orivesi/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/orivesi/db/migration/afterMigrate__assistance_action_options.sql
@@ -20,7 +20,7 @@ UPDATE SET
     display_order = EXCLUDED.display_order,
     category = EXCLUDED.category
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category;

--- a/service/src/main/resources/orivesi/db/migration/afterMigrate__care_areas.sql
+++ b/service/src/main/resources/orivesi/db/migration/afterMigrate__care_areas.sql
@@ -13,7 +13,7 @@ UPDATE SET
     sub_cost_center = EXCLUDED.sub_cost_center,
     short_name = EXCLUDED.short_name
 WHERE
-    care_area.name <> EXCLUDED.name OR
+    care_area.name IS DISTINCT FROM EXCLUDED.name OR
     care_area.area_code IS DISTINCT FROM EXCLUDED.area_code OR
     care_area.sub_cost_center IS DISTINCT FROM EXCLUDED.sub_cost_center OR
-    care_area.short_name <> EXCLUDED.short_name;
+    care_area.short_name IS DISTINCT FROM EXCLUDED.short_name;

--- a/service/src/main/resources/orivesi/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/orivesi/db/migration/afterMigrate__service_need_options.sql
@@ -53,26 +53,26 @@ ON CONFLICT (id) DO
                show_for_citizen = EXCLUDED.show_for_citizen,
                display_order = EXCLUDED.display_order
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.realized_occupancy_coefficient <> EXCLUDED.realized_occupancy_coefficient OR
-    service_need_option.realized_occupancy_coefficient_under_3y <> EXCLUDED.realized_occupancy_coefficient_under_3y OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.realized_occupancy_coefficient IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient OR
+    service_need_option.realized_occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient_under_3y OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
     service_need_option.contract_days_per_month IS DISTINCT FROM EXCLUDED.contract_days_per_month OR
     service_need_option.daycare_hours_per_month IS DISTINCT FROM EXCLUDED.daycare_hours_per_month OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     service_need_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.display_order <> EXCLUDED.display_order;
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order;

--- a/service/src/main/resources/oulu/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/oulu/db/migration/afterMigrate__assistance_action_options.sql
@@ -23,7 +23,7 @@ UPDATE SET
     display_order = EXCLUDED.display_order,
     category = EXCLUDED.category
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category;

--- a/service/src/main/resources/oulu/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/oulu/db/migration/afterMigrate__service_need_options.sql
@@ -99,26 +99,26 @@ UPDATE SET
     valid_from = EXCLUDED.valid_from,
     valid_to = EXCLUDED.valid_to
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.contract_days_per_month <> EXCLUDED.contract_days_per_month OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.display_order <> EXCLUDED.display_order OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.realized_occupancy_coefficient <> EXCLUDED.realized_occupancy_coefficient OR
-    service_need_option.realized_occupancy_coefficient_under_3y <> EXCLUDED.realized_occupancy_coefficient_under_3y OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
-    service_need_option.valid_to <> EXCLUDED.valid_to OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.contract_days_per_month IS DISTINCT FROM EXCLUDED.contract_days_per_month OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.realized_occupancy_coefficient IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient OR
+    service_need_option.realized_occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient_under_3y OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
+    service_need_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to OR
     (service_need_option.valid_to IS NULL AND EXCLUDED.valid_to IS NOT NULL);

--- a/service/src/main/resources/pirkkala/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/pirkkala/db/migration/afterMigrate__assistance_action_options.sql
@@ -21,7 +21,7 @@ UPDATE SET
     display_order = EXCLUDED.display_order,
     category = EXCLUDED.category
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category;

--- a/service/src/main/resources/pirkkala/db/migration/afterMigrate__care_areas.sql
+++ b/service/src/main/resources/pirkkala/db/migration/afterMigrate__care_areas.sql
@@ -13,7 +13,7 @@ UPDATE SET
     sub_cost_center = EXCLUDED.sub_cost_center,
     short_name = EXCLUDED.short_name
 WHERE
-    care_area.name <> EXCLUDED.name OR
+    care_area.name IS DISTINCT FROM EXCLUDED.name OR
     care_area.area_code IS DISTINCT FROM EXCLUDED.area_code OR
     care_area.sub_cost_center IS DISTINCT FROM EXCLUDED.sub_cost_center OR
-    care_area.short_name <> EXCLUDED.short_name;
+    care_area.short_name IS DISTINCT FROM EXCLUDED.short_name;

--- a/service/src/main/resources/pirkkala/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/pirkkala/db/migration/afterMigrate__service_need_options.sql
@@ -58,26 +58,26 @@ UPDATE SET
     show_for_citizen = EXCLUDED.show_for_citizen,
     display_order = EXCLUDED.display_order
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.realized_occupancy_coefficient <> EXCLUDED.realized_occupancy_coefficient OR
-    service_need_option.realized_occupancy_coefficient_under_3y <> EXCLUDED.realized_occupancy_coefficient_under_3y OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.realized_occupancy_coefficient IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient OR
+    service_need_option.realized_occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient_under_3y OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
     service_need_option.contract_days_per_month IS DISTINCT FROM EXCLUDED.contract_days_per_month OR
     service_need_option.daycare_hours_per_month IS DISTINCT FROM EXCLUDED.daycare_hours_per_month OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     service_need_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.display_order <> EXCLUDED.display_order;
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order;

--- a/service/src/main/resources/tampere/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/tampere/db/migration/afterMigrate__assistance_action_options.sql
@@ -37,9 +37,9 @@ UPDATE SET
     valid_from = EXCLUDED.valid_from,
     valid_to = EXCLUDED.valid_to
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
     assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category OR
     assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;

--- a/service/src/main/resources/tampere/db/migration/afterMigrate__care_areas.sql
+++ b/service/src/main/resources/tampere/db/migration/afterMigrate__care_areas.sql
@@ -16,7 +16,7 @@ UPDATE SET
     sub_cost_center = EXCLUDED.sub_cost_center,
     short_name = EXCLUDED.short_name
 WHERE
-    care_area.name <> EXCLUDED.name OR
+    care_area.name IS DISTINCT FROM EXCLUDED.name OR
     care_area.area_code IS DISTINCT FROM EXCLUDED.area_code OR
     care_area.sub_cost_center IS DISTINCT FROM EXCLUDED.sub_cost_center OR
-    care_area.short_name <> EXCLUDED.short_name;
+    care_area.short_name IS DISTINCT FROM EXCLUDED.short_name;

--- a/service/src/main/resources/tampere/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/tampere/db/migration/afterMigrate__service_need_options.sql
@@ -74,28 +74,28 @@ UPDATE SET
     show_for_citizen = EXCLUDED.show_for_citizen,
     display_order = EXCLUDED.display_order
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.realized_occupancy_coefficient <> EXCLUDED.realized_occupancy_coefficient OR
-    service_need_option.realized_occupancy_coefficient_under_3y <> EXCLUDED.realized_occupancy_coefficient_under_3y OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.realized_occupancy_coefficient IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient OR
+    service_need_option.realized_occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient_under_3y OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
     service_need_option.contract_days_per_month IS DISTINCT FROM EXCLUDED.contract_days_per_month OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     service_need_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.display_order <> EXCLUDED.display_order;
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order;
 
 INSERT INTO service_need_option_fee
     (id, service_need_option_id, validity, base_fee, sibling_discount_2, sibling_fee_2, sibling_discount_2_plus, sibling_fee_2_plus)
@@ -118,10 +118,10 @@ UPDATE SET
     sibling_discount_2_plus = EXCLUDED.sibling_discount_2_plus,
     sibling_fee_2_plus = EXCLUDED.sibling_fee_2_plus
 WHERE
-    service_need_option_fee.service_need_option_id <> EXCLUDED.service_need_option_id OR
-    service_need_option_fee.validity <> EXCLUDED.validity OR
-    service_need_option_fee.base_fee <> EXCLUDED.base_fee OR
-    service_need_option_fee.sibling_discount_2 <> EXCLUDED.sibling_discount_2 OR
-    service_need_option_fee.sibling_fee_2 <> EXCLUDED.sibling_fee_2 OR
-    service_need_option_fee.sibling_discount_2_plus <> EXCLUDED.sibling_discount_2_plus OR
-    service_need_option_fee.sibling_fee_2_plus <> EXCLUDED.sibling_fee_2_plus;
+    service_need_option_fee.service_need_option_id IS DISTINCT FROM EXCLUDED.service_need_option_id OR
+    service_need_option_fee.validity IS DISTINCT FROM EXCLUDED.validity OR
+    service_need_option_fee.base_fee IS DISTINCT FROM EXCLUDED.base_fee OR
+    service_need_option_fee.sibling_discount_2 IS DISTINCT FROM EXCLUDED.sibling_discount_2 OR
+    service_need_option_fee.sibling_fee_2 IS DISTINCT FROM EXCLUDED.sibling_fee_2 OR
+    service_need_option_fee.sibling_discount_2_plus IS DISTINCT FROM EXCLUDED.sibling_discount_2_plus OR
+    service_need_option_fee.sibling_fee_2_plus IS DISTINCT FROM EXCLUDED.sibling_fee_2_plus;

--- a/service/src/main/resources/turku/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/turku/db/migration/afterMigrate__assistance_action_options.sql
@@ -24,8 +24,8 @@ UPDATE SET
     display_order = EXCLUDED.display_order,
     category = EXCLUDED.category
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category;
 

--- a/service/src/main/resources/turku/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/turku/db/migration/afterMigrate__service_need_options.sql
@@ -133,24 +133,24 @@ UPDATE SET
     valid_from = EXCLUDED.valid_from,
     valid_to = EXCLUDED.valid_to
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.display_order <> EXCLUDED.display_order OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.daycare_hours_per_month <> EXCLUDED.daycare_hours_per_month OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
-    service_need_option.valid_to <> EXCLUDED.valid_to OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.daycare_hours_per_month IS DISTINCT FROM EXCLUDED.daycare_hours_per_month OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
+    service_need_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to OR
     (service_need_option.valid_to is null AND EXCLUDED.valid_to is not null);

--- a/service/src/main/resources/vesilahti/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/vesilahti/db/migration/afterMigrate__assistance_action_options.sql
@@ -24,7 +24,7 @@ UPDATE SET
     display_order = EXCLUDED.display_order,
     category = EXCLUDED.category
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
-    assistance_action_option.display_order <> EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category;
+    assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category;

--- a/service/src/main/resources/vesilahti/db/migration/afterMigrate__care_areas.sql
+++ b/service/src/main/resources/vesilahti/db/migration/afterMigrate__care_areas.sql
@@ -13,7 +13,7 @@ UPDATE SET
     sub_cost_center = EXCLUDED.sub_cost_center,
     short_name = EXCLUDED.short_name
 WHERE
-    care_area.name <> EXCLUDED.name OR
+    care_area.name IS DISTINCT FROM EXCLUDED.name OR
     care_area.area_code IS DISTINCT FROM EXCLUDED.area_code OR
     care_area.sub_cost_center IS DISTINCT FROM EXCLUDED.sub_cost_center OR
-    care_area.short_name <> EXCLUDED.short_name;
+    care_area.short_name IS DISTINCT FROM EXCLUDED.short_name;

--- a/service/src/main/resources/vesilahti/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/vesilahti/db/migration/afterMigrate__service_need_options.sql
@@ -57,25 +57,25 @@ UPDATE SET
     show_for_citizen = EXCLUDED.show_for_citizen,
     display_order = EXCLUDED.display_order
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.realized_occupancy_coefficient <> EXCLUDED.realized_occupancy_coefficient OR
-    service_need_option.realized_occupancy_coefficient_under_3y <> EXCLUDED.realized_occupancy_coefficient_under_3y OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.realized_occupancy_coefficient IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient OR
+    service_need_option.realized_occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient_under_3y OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
     service_need_option.contract_days_per_month IS DISTINCT FROM EXCLUDED.contract_days_per_month OR
     service_need_option.daycare_hours_per_month IS DISTINCT FROM EXCLUDED.daycare_hours_per_month OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.display_order <> EXCLUDED.display_order;
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order;

--- a/service/src/main/resources/vesilahti/db/migration/afterMigrate__special_diet.sql
+++ b/service/src/main/resources/vesilahti/db/migration/afterMigrate__special_diet.sql
@@ -5,4 +5,4 @@
 INSERT INTO special_diet (id, abbreviation)
 VALUES (0, 'erityisruokavalio')
 ON CONFLICT (id) DO UPDATE SET abbreviation = EXCLUDED.abbreviation
-WHERE special_diet.abbreviation <> EXCLUDED.abbreviation;
+WHERE special_diet.abbreviation IS DISTINCT FROM EXCLUDED.abbreviation;

--- a/service/src/main/resources/ylojarvi/db/migration/afterMigrate__assistance_action_options.sql
+++ b/service/src/main/resources/ylojarvi/db/migration/afterMigrate__assistance_action_options.sql
@@ -38,9 +38,9 @@ UPDATE SET
     valid_from = EXCLUDED.valid_from,
     valid_to = EXCLUDED.valid_to
 WHERE
-    assistance_action_option.name_fi <> EXCLUDED.name_fi OR
+    assistance_action_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
     assistance_action_option.description_fi IS DISTINCT FROM EXCLUDED.description_fi OR
     assistance_action_option.display_order IS DISTINCT FROM EXCLUDED.display_order OR
-    assistance_action_option.category <> EXCLUDED.category OR
+    assistance_action_option.category IS DISTINCT FROM EXCLUDED.category OR
     assistance_action_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     assistance_action_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to;

--- a/service/src/main/resources/ylojarvi/db/migration/afterMigrate__care_areas.sql
+++ b/service/src/main/resources/ylojarvi/db/migration/afterMigrate__care_areas.sql
@@ -13,7 +13,7 @@ UPDATE SET
     sub_cost_center = EXCLUDED.sub_cost_center,
     short_name = EXCLUDED.short_name
 WHERE
-    care_area.name <> EXCLUDED.name OR
+    care_area.name IS DISTINCT FROM EXCLUDED.name OR
     care_area.area_code IS DISTINCT FROM EXCLUDED.area_code OR
     care_area.sub_cost_center IS DISTINCT FROM EXCLUDED.sub_cost_center OR
-    care_area.short_name <> EXCLUDED.short_name;
+    care_area.short_name IS DISTINCT FROM EXCLUDED.short_name;

--- a/service/src/main/resources/ylojarvi/db/migration/afterMigrate__service_need_options.sql
+++ b/service/src/main/resources/ylojarvi/db/migration/afterMigrate__service_need_options.sql
@@ -79,26 +79,26 @@ ON CONFLICT (id) DO
                show_for_citizen = EXCLUDED.show_for_citizen,
                display_order = EXCLUDED.display_order
 WHERE
-    service_need_option.name_fi <> EXCLUDED.name_fi OR
-    service_need_option.name_sv <> EXCLUDED.name_sv OR
-    service_need_option.name_en <> EXCLUDED.name_en OR
-    service_need_option.valid_placement_type <> EXCLUDED.valid_placement_type OR
-    service_need_option.default_option <> EXCLUDED.default_option OR
-    service_need_option.fee_coefficient <> EXCLUDED.fee_coefficient OR
-    service_need_option.occupancy_coefficient <> EXCLUDED.occupancy_coefficient OR
-    service_need_option.occupancy_coefficient_under_3y <> EXCLUDED.occupancy_coefficient_under_3y OR
-    service_need_option.realized_occupancy_coefficient <> EXCLUDED.realized_occupancy_coefficient OR
-    service_need_option.realized_occupancy_coefficient_under_3y <> EXCLUDED.realized_occupancy_coefficient_under_3y OR
-    service_need_option.daycare_hours_per_week <> EXCLUDED.daycare_hours_per_week OR
+    service_need_option.name_fi IS DISTINCT FROM EXCLUDED.name_fi OR
+    service_need_option.name_sv IS DISTINCT FROM EXCLUDED.name_sv OR
+    service_need_option.name_en IS DISTINCT FROM EXCLUDED.name_en OR
+    service_need_option.valid_placement_type IS DISTINCT FROM EXCLUDED.valid_placement_type OR
+    service_need_option.default_option IS DISTINCT FROM EXCLUDED.default_option OR
+    service_need_option.fee_coefficient IS DISTINCT FROM EXCLUDED.fee_coefficient OR
+    service_need_option.occupancy_coefficient IS DISTINCT FROM EXCLUDED.occupancy_coefficient OR
+    service_need_option.occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.occupancy_coefficient_under_3y OR
+    service_need_option.realized_occupancy_coefficient IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient OR
+    service_need_option.realized_occupancy_coefficient_under_3y IS DISTINCT FROM EXCLUDED.realized_occupancy_coefficient_under_3y OR
+    service_need_option.daycare_hours_per_week IS DISTINCT FROM EXCLUDED.daycare_hours_per_week OR
     service_need_option.contract_days_per_month IS DISTINCT FROM EXCLUDED.contract_days_per_month OR
     service_need_option.daycare_hours_per_month IS DISTINCT FROM EXCLUDED.daycare_hours_per_month OR
-    service_need_option.part_day <> EXCLUDED.part_day OR
-    service_need_option.part_week <> EXCLUDED.part_week OR
-    service_need_option.fee_description_fi <> EXCLUDED.fee_description_fi OR
-    service_need_option.fee_description_sv <> EXCLUDED.fee_description_sv OR
-    service_need_option.voucher_value_description_fi <> EXCLUDED.voucher_value_description_fi OR
-    service_need_option.voucher_value_description_sv <> EXCLUDED.voucher_value_description_sv OR
-    service_need_option.valid_from <> EXCLUDED.valid_from OR
+    service_need_option.part_day IS DISTINCT FROM EXCLUDED.part_day OR
+    service_need_option.part_week IS DISTINCT FROM EXCLUDED.part_week OR
+    service_need_option.fee_description_fi IS DISTINCT FROM EXCLUDED.fee_description_fi OR
+    service_need_option.fee_description_sv IS DISTINCT FROM EXCLUDED.fee_description_sv OR
+    service_need_option.voucher_value_description_fi IS DISTINCT FROM EXCLUDED.voucher_value_description_fi OR
+    service_need_option.voucher_value_description_sv IS DISTINCT FROM EXCLUDED.voucher_value_description_sv OR
+    service_need_option.valid_from IS DISTINCT FROM EXCLUDED.valid_from OR
     service_need_option.valid_to IS DISTINCT FROM EXCLUDED.valid_to OR
-    service_need_option.show_for_citizen <> EXCLUDED.show_for_citizen OR
-    service_need_option.display_order <> EXCLUDED.display_order;
+    service_need_option.show_for_citizen IS DISTINCT FROM EXCLUDED.show_for_citizen OR
+    service_need_option.display_order IS DISTINCT FROM EXCLUDED.display_order;


### PR DESCRIPTION
`IS DISTINCT FROM` toimii oikein muiden arvojen lisäksi myös `NULL`:lle. Sitä käytetään nyt konsistentisti kaikissa afterMigrate-skripteissä kaikille kentille, jotta `NULL`-arvot eivät hajottaisi vertailuja.