### PR TITLE
Muokattavat perustelut päätöksiin: Turku, Oulu

### DIFF
--- a/service/src/main/resources/espoo/templates/shared/layout.html
+++ b/service/src/main/resources/espoo/templates/shared/layout.html
@@ -117,6 +117,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
         white-space: pre-wrap;
       }
 
+      .reasoning-text + .reasoning-text {
+        margin-top: 1em;
+      }
+
       .page .decision-details-container {
         margin-top: 5mm;
         margin-bottom: 10mm;

--- a/service/src/main/resources/oulu/templates/club/decision.html
+++ b/service/src/main/resources/oulu/templates/club/decision.html
@@ -27,7 +27,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 <div class="page last-page">
     <div th:replace="~{ shared/common :: decision-details}"></div>
-    <div th:utext="#{decision.legalInstructions}"></div>
+    <div th:if="${reasoning == null}" th:utext="#{decision.legalInstructions.old}"></div>
     <th:block th:if="${reasoning != null}">
         <div th:replace="~{ shared/common :: decision-reasoning(${reasoning}) }"></div>
     </th:block>

--- a/service/src/main/resources/oulu/templates/club/decision.properties
+++ b/service/src/main/resources/oulu/templates/club/decision.properties
@@ -15,7 +15,7 @@ decision.instructions=\
   <li>Mikäli lapsi on ilmoittamatta pois toiminnasta kaksi kuukautta, lapsi menettää paikan.</li>\
   <li>Toimintaan osallistuminen on maksutonta, eikä sillä ole vaikutusta Kelan myöntämiin lastenhoidon tukiin.</li></ul>\
   <p>Lapsen jäädessä pois avoimesta varhaiskasvatustoiminnasta on paikka irtisanottava eVakassa.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <p><b>Sovelletut oikeusohjeet</b></p>\
   <ul><li>Varhaiskasvatuslaki</li></ul>
 address.title=Kirjaamon osoite on:

--- a/service/src/main/resources/oulu/templates/daycare/decision.html
+++ b/service/src/main/resources/oulu/templates/daycare/decision.html
@@ -24,7 +24,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <div th:replace="~{ shared/common :: child-and-unit-details}"></div>
     <div th:utext="#{decision.instructions}"></div>
     <div th:replace="~{ shared/common :: decision-details }"></div>
-    <div th:utext="#{decision.legalInstructions}"></div>
+    <div th:if="${reasoning == null}" th:utext="#{decision.legalInstructions.old}"></div>
     <th:block th:if="${reasoning != null}">
         <div th:replace="~{ shared/common :: decision-reasoning(${reasoning}) }"></div>
     </th:block>

--- a/service/src/main/resources/oulu/templates/daycare/decision.properties
+++ b/service/src/main/resources/oulu/templates/daycare/decision.properties
@@ -12,7 +12,7 @@ decision.instructions=\
   <p>Lapsen läsnäolovarauksia ja poissaoloja on mahdollista ilmoittaa eVakassa aikaisintaan neljä (4) viikkoa ennen varhaiskasvatuksen alkua. Varauskalenteri lukittuu joka sunnuntai klo 24.00 ei seuraavan, vaan sitä seuraavan viikon osalta. Jos varauskalenteri on lukkiutunut, ota yhteyttä lapsesi varhaiskasvatusyksikköön.</p>\
   <p>Tuloselvitys tulee tehdä eVakan kautta, kun lapsi aloittaa varhaiskasvatuksessa. Oikeus Kelan myöntämiin lastenhoidon tukiin lakkaa kunnallisen varhaiskasvatuksen alkaessa.</p>\
   <p>Lapsen jäädessä pois varhaiskasvatuksesta on paikka irtisanottava eVakassa. Irtisanomista ei voi tehdä takautuvasti.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <h2>Sovelletut oikeusohjeet</h2>\
   <ul><li>Varhaiskasvatuslaki 540/2018</li>\
   <li>Laki varhaiskasvatuksen asiakasmaksuista 1503/2016</li></ul>

--- a/service/src/main/resources/oulu/templates/daycare/voucher/decision.html
+++ b/service/src/main/resources/oulu/templates/daycare/voucher/decision.html
@@ -28,7 +28,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 <div class="page last-page">
     <div th:replace="~{ shared/common :: decision-details }"></div>
-    <p th:utext="#{decision.legalInstructions}"></p>
+    <p th:if="${reasoning == null}" th:utext="#{decision.legalInstructions.old}"></p>
+    <th:block th:if="${reasoning != null}">
+        <div th:replace="~{ shared/common :: decision-reasoning(${reasoning}) }"></div>
+    </th:block>
     <div th:replace="~{shared/daycare-correction :: daycare-voucher-correction}"></div>
 </div>
 

--- a/service/src/main/resources/oulu/templates/daycare/voucher/decision.properties
+++ b/service/src/main/resources/oulu/templates/daycare/voucher/decision.properties
@@ -15,7 +15,7 @@ decision.instructions=\
   <ul><li>Jos lapsi ei käytä varhaiskasvatuspaikkaa yhtäjaksoisesti 60 päivään (ei koske kesäajan kuukausia kesä-, heinä- ja elokuu eikä isyysvapaasta johtuvaa poissaoloa) oikeus palveluseteliin päättyy.</li></ul>\
   <p>Lapsen jäädessä pois varhaiskasvatustoiminnasta on palveluseteli irtisanottava eVakassa. Irtisanomista ei voi tehdä takautuvasti.</p>\
   <p>Tuloselvitys tulee tehdä eVakan kautta, kun lapsi aloittaa varhaiskasvatuksessa. Palvelusetelin lapsikohtaisesta arvosta ja omavastuuosuudesta tehdään erillinen päätös. Oikeus Kelan myöntämiin lastenhoidon tukiin lakkaa yksityisen varhaiskasvatuksen alkaessa.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <p><b>Sovelletut oikeusohjeet</b></p>\
   <ul><li>Varhaiskasvatuslaki (540/2018)</li>\
   <li>Laki sosiaali- ja terveyshuollon palvelusetelistä (569/2009)</li>\

--- a/service/src/main/resources/oulu/templates/preparatory/decision.html
+++ b/service/src/main/resources/oulu/templates/preparatory/decision.html
@@ -28,7 +28,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 <div class="page last-page">
 
-    <div th:utext="#{decision.legalInstructions}"></div>
+    <div th:if="${reasoning == null}" th:utext="#{decision.legalInstructions.old}"></div>
     <th:block th:if="${reasoning != null}">
         <div th:replace="~{ shared/common :: decision-reasoning(${reasoning}) }"></div>
     </th:block>

--- a/service/src/main/resources/oulu/templates/preparatory/decision.properties
+++ b/service/src/main/resources/oulu/templates/preparatory/decision.properties
@@ -9,7 +9,7 @@ decision.details.date=<strong>valmistavan opetuksen paikka ajalle</strong>
 decision.instructions=\
   <p>Lapsen jäädessä pois valmistavasta opetuksesta on paikka irtisanottava eVakassa.</p>\
   <p>Valmistavaa opetusta on viisi tuntia päivässä esiopetuksen työpäivinä.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <h2>Sovelletut oikeusohjeet</h2>\
   <ul><li>Perusopetuslaki ja -asetus</li></ul>
 decision.unitName=Esiopetusyksikkö

--- a/service/src/main/resources/oulu/templates/preschool/decision.html
+++ b/service/src/main/resources/oulu/templates/preschool/decision.html
@@ -28,7 +28,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 <div class="page last-page">
 
-    <div th:utext="#{decision.legalInstructions}"></div>
+    <div th:if="${reasoning == null}" th:utext="#{decision.legalInstructions.old}"></div>
     <th:block th:if="${reasoning != null}">
         <div th:replace="~{ shared/common :: decision-reasoning(${reasoning}) }"></div>
     </th:block>

--- a/service/src/main/resources/oulu/templates/preschool/decision.properties
+++ b/service/src/main/resources/oulu/templates/preschool/decision.properties
@@ -9,7 +9,7 @@ decision.details.date=<strong>esiopetuspaikka ajalle</strong>
 decision.instructions=\
   <p>Huoltajan tulee hyväksyä tai hylätä esiopetuspaikka <b>viimeistään kahden viikon kuluessa</b> tämän päätöksen saamisesta sähköisesti eVakassa osoitteessa <a href="https://varhaiskasvatus.ouka.fi">varhaiskasvatus.ouka.fi</a> (vaatii tunnistautumisen).</p>\
   <p>Lapsen jäädessä pois esiopetuksesta on paikka irtisanottava eVakassa.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <h2>Sovelletut oikeusohjeet</h2>\
   <ul><li>Perusopetuslaki ja -asetus</li></ul>
 decision.unitName=Esiopetusyksikkö

--- a/service/src/main/resources/oulu/templates/shared/common.html
+++ b/service/src/main/resources/oulu/templates/shared/common.html
@@ -70,6 +70,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
             white-space: pre-wrap;
         }
 
+        .page .reasoning-text + .reasoning-text {
+            margin-top: 1em;
+        }
+
         .page strong.semi {
             font-family: 'Open Sans SemiBold', sans-serif;
             font-weight: 600;

--- a/service/src/main/resources/oulu/templates/shared/common.properties
+++ b/service/src/main/resources/oulu/templates/shared/common.properties
@@ -39,5 +39,5 @@ decision.unitmanagertitle=Palvelukoordinaattori
 decision.acceptance.child.name=Lapsen nimi:
 decision.acceptance.unit.name=Varhaiskasvatusyksikkö:
 decision.title=Päätös lapsen varhaiskasvatuksesta ja varhaiskasvatuspaikasta
-decision.reasoning.title=Päätöksen perustelut
+decision.reasoning.title=Päätöksen perustelut ja sovelletut oikeusohjeet
 startDate=Päätös voimassa alkaen

--- a/service/src/main/resources/turku/templates/club/decision.html
+++ b/service/src/main/resources/turku/templates/club/decision.html
@@ -26,7 +26,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <div th:utext="#{decision.jurisdiction}"></div>
     <div th:replace="~{ shared/common :: decision-details}"></div>
     <div th:utext="#{decision.notification}"></div>
-    <div th:utext="#{decision.legalInstructions}"></div>
+    <div th:if="${reasoning == null}" th:utext="#{decision.legalInstructions.old}"></div>
+    <th:block th:if="${reasoning != null}">
+        <div th:replace="~{shared/decision-reasoning :: section(${reasoning})}"></div>
+    </th:block>
 </div>
 
 <div class="page last-page">

--- a/service/src/main/resources/turku/templates/club/decision.properties
+++ b/service/src/main/resources/turku/templates/club/decision.properties
@@ -13,7 +13,7 @@ decision.instructions=\
   <p>Paikka tulee hyväksyä tai hylätä viimeistään kahden viikon kuluessa tämän päätöksen saamisesta sähköisesti osoitteessa <a href="https://evaka.turku.fi">evaka.turku.fi</a> (vaatii tunnistautumisen).</p>\
   <ul><li>Mikäli hylkäätte paikan, tulee lapselle tehdä tarvittaessa uusi hakemus.</li></ul>\
   <p>Lapsen jäädessä pois avoimesta varhaiskasvatustoiminnasta on paikka irtisanottava.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <p><b>Sovelletut oikeusohjeet</b></p>\
   <ul><li>Varhaiskasvatuslaki 540/2018</li></ul>
 decision.notification=\

--- a/service/src/main/resources/turku/templates/club/decision_sv.properties
+++ b/service/src/main/resources/turku/templates/club/decision_sv.properties
@@ -14,7 +14,7 @@ decision.instructions=\
   (kräver stark identifiering) eller genom att kontakta daghemsföreståndaren.</p>\
   <ul><li>Om ni avvisar platsen ska ni vid behov göra en ny ansökan om</li></ul>\
   <p>Om barnet slutar delta i den öppna småbarnspedagogiska verksamheten ska platsen sägas upp.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <p><b>Tillämpade rättsnormer</b></p>\
   <ul><li>Lag om småbarnspedagogik 540/2018</li></ul>
 decision.notification=\

--- a/service/src/main/resources/turku/templates/daycare/decision.html
+++ b/service/src/main/resources/turku/templates/daycare/decision.html
@@ -26,7 +26,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <div th:utext="#{decision.jurisdiction}"></div>
     <div th:replace="~{ shared/common :: decision-details }"></div>
     <div th:utext="#{decision.notification}"></div>
-    <div th:utext="#{decision.legalInstructions}"></div>
+    <div th:if="${reasoning == null}" th:utext="#{decision.legalInstructions.old}"></div>
+    <th:block th:if="${reasoning != null}">
+        <div th:replace="~{shared/decision-reasoning :: section(${reasoning})}"></div>
+    </th:block>
 </div>
 <div class="page last-page">
     <div th:replace="~{ shared/daycare-correction :: daycare-correction}"></div>

--- a/service/src/main/resources/turku/templates/daycare/decision.properties
+++ b/service/src/main/resources/turku/templates/daycare/decision.properties
@@ -24,7 +24,7 @@ decision.jurisdiction = \
   yleissivistävää aikuiskoulutusta sekä nuorisotyötä koskevissa laeissa määrättyä kunnan toimivaltaa käyttää lasten ja nuorten palveluiden johtaja.</p> \
   <p>Lasten ja nuorten palveluiden johtaja on 4.6.2026 § 67 päättänyt lasten ja nuorten palvelukokonaisuuden hallinnon järjestämisestä. \
   Päätöksen 12 §:n mukaan palveluohjauksessa toimiva palveluohjaaja päättää lasten ottamisesta Turun kaupungin järjestämään varhaiskasvatukseen.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <h2>Sovelletut oikeusohjeet</h2>\
   <ul><li>Varhaiskasvatuslaki 540/2018</li>\
   <li>Laki varhaiskasvatuksen asiakasmaksuista 1503/2016</li></ul>

--- a/service/src/main/resources/turku/templates/daycare/decision_sv.properties
+++ b/service/src/main/resources/turku/templates/daycare/decision_sv.properties
@@ -25,7 +25,7 @@ decision.jurisdiction = \
   <p>Barn- och ungdomstjänsternas direktör har den 4.6.2026 § 67 fattat beslut om organiseringen av förvaltningen inom helheten för \
   barn- och ungdomstjänster. Enligt 12 § i beslutet om ordnandet av förvaltningen beslutar den servicehandledare som arbetar i \
   servicehandledningen om antagningen av barn till småbarnspedagogik som ordnas av Åbo stad.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <h2>Tillämpade rättsnormer</h2>\
   <ul><li>Lag om småbarnspedagogik 540/2018</li>\
   <li>Lag om klientavgifter inom småbarnspedagogiken 1503/2016</li></ul>

--- a/service/src/main/resources/turku/templates/daycare/voucher/decision.html
+++ b/service/src/main/resources/turku/templates/daycare/voucher/decision.html
@@ -30,7 +30,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
     <div th:utext="#{decision.notification}"></div>
     <div th:utext="#{decision.jurisdiction}"></div>
     <div th:replace="~{ shared/common :: decision-details }"></div>
-    <p th:utext="#{decision.legalInstructions}"></p>
+    <p th:if="${reasoning == null}" th:utext="#{decision.legalInstructions.old}"></p>
+    <th:block th:if="${reasoning != null}">
+        <div th:replace="~{shared/decision-reasoning :: section(${reasoning})}"></div>
+    </th:block>
     <div th:replace="~{ shared/daycare-correction :: daycare-correction}"></div>
 </div>
 

--- a/service/src/main/resources/turku/templates/daycare/voucher/decision.properties
+++ b/service/src/main/resources/turku/templates/daycare/voucher/decision.properties
@@ -15,7 +15,7 @@ decision.instructions=\
   <p>Lapsen jäädessä pois varhaiskasvatustoiminnasta on palveluseteli irtisanottava palvelun tuottajalle. Irtisanomista ei voi tehdä takautuvasti.</p>\
   <p>Oikeus kotihoidon tukeen / yksityisen hoidon tukeen lakkaa yksityisen varhaiskasvatuksen alkaessa.</p>\
   <p>Palvelusetelin lapsikohtaisesta arvosta ja omavastuuosuudesta tehdään erillinen päätös. Tätä varten huoltajien tulee toimittaa voimassa olevat tulotiedot sähköisen asioinnin kautta. Mikäli sähköinen asiointi ei ole mahdollista, tulee huoltajien toimittaa tulotiedot varhaiskasvatuksen palveluohjaukseen Kauppatorin Monitoriin, osoitteeseen Aurakatu 8, 20100 Turku.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <p><b>Sovelletut oikeusohjeet</b></p>\
   <ul><li>Varhaiskasvatuslaki (540/2018)</li>\
   <li>Laki varhaiskasvatuksen palvelusetelistä (1048/2025)</li>\

--- a/service/src/main/resources/turku/templates/daycare/voucher/decision_sv.properties
+++ b/service/src/main/resources/turku/templates/daycare/voucher/decision_sv.properties
@@ -15,7 +15,7 @@ decision.instructions=\
   <p>Om barnet inte deltar i småbarnspedagogik ska platsen sägas upp. Uppsägningen kan inte göras retroaktivit.</p>\
   <p>Rätten till stöd slutar för hemvård av barn eller privat vård av barn upphör när den privata småbarnspedagogiken börjar.</p>\
   <p>Det fattas ett separat beslut om värdet av servicesedeln per barn och självriskandelen. Därför ska vårdnadshavarna lämna in sina aktuella uppgifter som sin inkomst via e-tjänsten. Om vårdnadshavaren inte har tillgång till e-tjänsten, ska denne lämna in sina inkomstuppgifter till småbarnspedagogikens servicehandledning vid Salutorgets Monitori på adressen Auragatan 8, 20100 Åbo.</p>
-decision.legalInstructions=\
+decision.legalInstructions.old=\
   <p><b>Tillämpade rättsnormer</b></p>\
   <ul><li>Lag\r\nom småbarnspedagogik (540/2018)</li>\
   <li>Lag om servicesedlar inom småbarnspedagogiken (1048/2025)</li>\

--- a/service/src/main/resources/turku/templates/preparatory/decision.html
+++ b/service/src/main/resources/turku/templates/preparatory/decision.html
@@ -29,8 +29,13 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 <div class="page last-page">
     <div th:utext="#{decision.notification}"></div>
-    <div th:utext="#{decision.preSchoolLegalInstructions}"></div>
-    <div th:utext="#{decision.reasoning}"></div>
+    <th:block th:if="${reasoning == null}">
+        <div th:utext="#{decision.preSchoolLegalInstructions.old}"></div>
+        <div th:utext="#{decision.reasoning.old}"></div>
+    </th:block>
+    <th:block th:if="${reasoning != null}">
+        <div th:replace="~{shared/decision-reasoning :: section(${reasoning})}"></div>
+    </th:block>
     <div th:utext="#{decision.appeal}"></div>
     <div th:replace="~{shared/daycare-correction :: preschool-correction}"></div>
 </div>

--- a/service/src/main/resources/turku/templates/preparatory/decision.properties
+++ b/service/src/main/resources/turku/templates/preparatory/decision.properties
@@ -10,10 +10,7 @@ decision.instructions=\
   <p>Päätös osallistumisesta maksuttomaan 6-vuotiaiden lasten perusopetukseen on nähtävissä osoitteessa <a href="https://evaka.turku.fi">evaka.turku.fi</a>.</p>\
   <p>Lapsen jäädessä pois perusopetukseen valmistavasta opetuksesta on paikka irtisanottava.</p>\
   <p>Valmistavaa opetusta on viisi tuntia päivässä esiopetuksen työpäivinä.</p>
-decision.legalInstructions=\
-  <h2>Sovelletut oikeusohjeet</h2>\
-  <ul><li>Perusopetuslaki ja -asetus</li></ul>
-decision.preSchoolLegalInstructions=\
+decision.preSchoolLegalInstructions.old=\
   <h2>Sovelletut oikeusohjeet</h2>\
   <ul><li>Perusopetuslaki 4 §, 6.2 § ja -asetus 23 a §</li>\
   <li>Turun kaupungin hallintosääntö 58 §, 60 §</li>\
@@ -23,7 +20,7 @@ decision.preSchoolLegalInstructions=\
 decision.notification=\
 <h2>Tiedoksianto</h2>\
 <p>Päätös toimitettu sähköisesti suomi.fi-viestin kautta. Jos asiakkaalla ei ole käytössä suomi.fi-palvelua, päätös toimitetaan kirjeitse.</p>
-decision.reasoning=\
+decision.reasoning.old=\
 <h2>PERUSTELUT </h2>\
 <p>Perusopetuslain 4 §:n mukaan kunta on velvollinen järjestämään sen alueella asuville oppivelvollisuusikäisille perusopetusta sekä \
   oppivelvollisuuden alkamista edeltävänä vuonna esiopetusta. Perusopetuslain 6 §:n 2 momentin mukaan kunta osoittaa oppivelvolliselle \

--- a/service/src/main/resources/turku/templates/preschool/decision.html
+++ b/service/src/main/resources/turku/templates/preschool/decision.html
@@ -29,8 +29,13 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 
 <div class="page last-page">
     <div th:utext="#{decision.notification}"></div>
-    <div th:utext="#{decision.preSchoolLegalInstructions}"></div>
-    <div th:utext="#{decision.reasoning}"></div>
+    <th:block th:if="${reasoning == null}">
+        <div th:utext="#{decision.preSchoolLegalInstructions.old}"></div>
+        <div th:utext="#{decision.reasoning.old}"></div>
+    </th:block>
+    <th:block th:if="${reasoning != null}">
+        <div th:replace="~{shared/decision-reasoning :: section(${reasoning})}"></div>
+    </th:block>
     <div th:utext="#{decision.appeal}"></div>
     <div th:replace="~{shared/daycare-correction :: preschool-correction}"></div>
 </div>

--- a/service/src/main/resources/turku/templates/preschool/decision.properties
+++ b/service/src/main/resources/turku/templates/preschool/decision.properties
@@ -8,10 +8,7 @@ decision.details.child=<strong>Lapsenne</strong> {0} {1} (s. {2})
 decision.details.date=<strong>esiopetuspaikka ajalle</strong>
 decision.instructions=\
   <p>Lapsen jäädessä pois esiopetuksesta on paikka irtisanottava.</p>
-decision.legalInstructions=\
-  <h2>Sovelletut oikeusohjeet</h2>\
-  <ul><li>Perusopetuslaki ja -asetus</li></ul>
-decision.preSchoolLegalInstructions=\
+decision.preSchoolLegalInstructions.old=\
   <h2>Sovelletut oikeusohjeet</h2>\
   <ul><li>Perusopetuslaki 4 §, 6.2 § ja -asetus 23 a §</li>\
   <li>Turun kaupungin hallintosääntö 58 §, 60 §</li>\
@@ -21,7 +18,7 @@ decision.preSchoolLegalInstructions=\
 decision.notification=\
 <h2>Tiedoksianto</h2>\
 <p>Päätös toimitettu sähköisesti suomi.fi-viestin kautta. Jos asiakkaalla ei ole käytössä suomi.fi-palvelua, päätös toimitetaan kirjeitse.</p>
-decision.reasoning=\
+decision.reasoning.old=\
 <h2>PERUSTELUT </h2>\
 <p>Perusopetuslain 4 §:n mukaan kunta on velvollinen järjestämään sen alueella asuville oppivelvollisuusikäisille perusopetusta sekä \
   oppivelvollisuuden alkamista edeltävänä vuonna esiopetusta. Perusopetuslain 6 §:n 2 momentin mukaan kunta osoittaa oppivelvolliselle \

--- a/service/src/main/resources/turku/templates/preschool/decision_sv.properties
+++ b/service/src/main/resources/turku/templates/preschool/decision_sv.properties
@@ -9,17 +9,14 @@ decision.details.date=<strong>enhet för förskoleundervisning under tiden</stro
 decision.instructions=\
   <p>Förskolebeslutet kan ses på <a href="https://evaka.turku.fi">evaka.turku.fi</a>.</p>\
   <p>Om barnet inte deltar i förskoleundervisningen ska platsen sägas upp.</p>
-decision.legalInstructions=\
-  <h2>Tillämpade rättsnormer</h2>\
-  <ul><li>Lag om grundläggande utbildning och förordning om grundläggande utbildning</li></ul>
-decision.preSchoolLegalInstructions=\
+decision.preSchoolLegalInstructions.old=\
   <h2>Tillämpade rättsnormer</h2>\
   <ul><li>Lag om grundläggande utbildning och förordning om grundläggande utbildning</li>\
   <li>Förvaltningslag 434/2003 Kapitel 7a 49§</li></ul>
 decision.notification=\
   <h2>Delgivning</h2>\
   <p>Beslutet har skickats elektroniskt som ett Suomi.fi-meddelande. Om kunden inte har tagit Suomi.fi-tjänsten i bruk, skickas beslutet via posten.</p>
-decision.reasoning=
+decision.reasoning.old=
 decision.appeal=
 decision.unitName=Förskoleenhet
 decision.placement.unit=Förskoleenhet

--- a/service/src/main/resources/turku/templates/shared/common.html
+++ b/service/src/main/resources/turku/templates/shared/common.html
@@ -70,6 +70,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
             white-space: pre-wrap;
         }
 
+        .page .reasoning-text + .reasoning-text {
+            margin-top: 1em;
+        }
+
         .page strong.semi {
             font-family: 'Open Sans SemiBold', sans-serif;
             font-weight: 600;

--- a/service/src/main/resources/turku/templates/shared/common.html
+++ b/service/src/main/resources/turku/templates/shared/common.html
@@ -66,6 +66,10 @@ SPDX-License-Identifier: LGPL-2.1-or-later
             font-size: 10pt;
         }
 
+        .page .reasoning-text {
+            white-space: pre-wrap;
+        }
+
         .page strong.semi {
             font-family: 'Open Sans SemiBold', sans-serif;
             font-weight: 600;

--- a/service/src/main/resources/turku/templates/shared/decision-reasoning.html
+++ b/service/src/main/resources/turku/templates/shared/decision-reasoning.html
@@ -1,0 +1,15 @@
+<!--
+SPDX-FileCopyrightText: 2026 City of Turku
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+<th:block
+    xmlns:th="http://www.thymeleaf.org"
+    th:fragment="section(reasoning)"
+>
+    <h2 th:text="#{title}"></h2>
+    <th:block th:if="${not #lists.isEmpty(reasoning.individual)}">
+        <div th:each="ind : ${reasoning.individual}" class="reasoning-text" th:text="${ind}"></div>
+    </th:block>
+    <div class="reasoning-text" th:text="${reasoning.generic}"></div>
+</th:block>

--- a/service/src/main/resources/turku/templates/shared/decision-reasoning.properties
+++ b/service/src/main/resources/turku/templates/shared/decision-reasoning.properties
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 City of Turku
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+title=Päätöksen perustelut ja sovelletut oikeusohjeet

--- a/service/src/main/resources/turku/templates/shared/decision-reasoning_sv.properties
+++ b/service/src/main/resources/turku/templates/shared/decision-reasoning_sv.properties
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 City of Turku
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+title=Motivering till beslutet och tillämpade rättsnormer

--- a/service/src/test/kotlin/evaka/core/pdfgen/AbstractDecisionPdfGeneratorTest.kt
+++ b/service/src/test/kotlin/evaka/core/pdfgen/AbstractDecisionPdfGeneratorTest.kt
@@ -57,9 +57,13 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
+import org.openpdf.text.pdf.PdfReader
+import org.openpdf.text.pdf.parser.PdfTextExtractor
 
 private val logger = KotlinLogging.logger {}
 
@@ -228,6 +232,13 @@ abstract class AbstractDecisionPdfGeneratorTest {
                                 reasoningOrNull,
                             )
                         assertNotNull(bytes)
+                        val text = extractText(bytes)
+                        if (reasoningOrNull != null) {
+                            assertContains(text, reasoningOrNull.generic)
+                            reasoningOrNull.individual.forEach { assertContains(text, it) }
+                        } else {
+                            assertFalse(text.contains(reasoning.generic))
+                        }
                         writeTempFile("decision_${municipality}_$label", bytes)
                     }
                 }
@@ -321,6 +332,13 @@ abstract class AbstractDecisionPdfGeneratorTest {
         val file = File.createTempFile("${prefix}_", ".pdf")
         FileOutputStream(file).use { it.write(bytes) }
         logger.debug { "Generated PDF to ${file.absolutePath}" }
+    }
+
+    private fun extractText(bytes: ByteArray): String {
+        val reader = PdfReader(bytes)
+        return (1..reader.numberOfPages)
+            .joinToString(" ") { PdfTextExtractor(reader).getTextFromPage(it) }
+            .replace(Regex("\\s+"), " ")
     }
 }
 

--- a/service/src/test/kotlin/evaka/instance/oulu/pdfgen/OuluDecisionPdfGeneratorTest.kt
+++ b/service/src/test/kotlin/evaka/instance/oulu/pdfgen/OuluDecisionPdfGeneratorTest.kt
@@ -24,6 +24,8 @@ class OuluDecisionPdfGeneratorTest : AbstractDecisionPdfGeneratorTest() {
     override val templateProvider: ITemplateProvider = OuluTemplateProvider()
     override val settings = populatedSettings
 
+    override fun reasoningVariants() = listOf(null, reasoning)
+
     override fun decisionScenarios() =
         listOf(
             DecisionScenario("kerho", DecisionType.CLUB),

--- a/service/src/test/kotlin/evaka/instance/turku/pdfgen/TurkuDecisionPdfGeneratorTest.kt
+++ b/service/src/test/kotlin/evaka/instance/turku/pdfgen/TurkuDecisionPdfGeneratorTest.kt
@@ -24,6 +24,8 @@ class TurkuDecisionPdfGeneratorTest : AbstractDecisionPdfGeneratorTest() {
     override val templateProvider: ITemplateProvider = TurkuTemplateProvider()
     override val settings = populatedSettings
 
+    override fun reasoningVariants() = listOf(null, reasoning)
+
     override fun decisionScenarios() =
         listOf(
             DecisionScenario("kerho", DecisionType.CLUB, languages = finnishAndSwedish),


### PR DESCRIPTION
Lisätty Turun ja Oulun päätöstemplaatteihin tuki dynaamisille perusteluille.

Ilman feature flagin päälle laittamista päätökset näyttävät siltä kuin ennenkin.