### PR TITLE
Korjataan lasten sisään/uloskirjaus mobiilissa riittävän vanhoilla selaimilla

### DIFF
--- a/frontend/src/lib-common/uri.ts
+++ b/frontend/src/lib-common/uri.ts
@@ -32,7 +32,8 @@ class Uri {
   }
 
   appendQuery(params: URLSearchParams): Uri {
-    return params.size > 0 ? new Uri(`${this.value}?${params}`) : this
+    const query = params.toString()
+    return query ? new Uri(`${this.value}?${query}`) : this
   }
 
   toString(): string {


### PR DESCRIPTION
`URLSearchParams.size` on tuettu Chrome 113:sta ja iOS Safari 17:stä lähtien, ja kun jälkimmäinen täytti 3 vuotta hiljattain niin polyfilliä ei enää lisätä.

[wouter käyttää sitä myös](https://github.com/molefrog/wouter/blob/780f2869b7fce9f57e4faddfe39e0f1884ed9bce/packages/wouter/src/index.js#L235), joten kaikki käyttöpaikat eivät valitettavasti tällä korjaannu.