### PR TITLE
Ei käytetä `--force` flagia tsc:lle

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "dev": "concurrently -n tsc,vite -c blue,green 'yarn type-check:watch' 'vite --host'",
     "lint": "oxfmt -c ../.oxfmtrc.json --check && oxlint",
     "lint:fix": "oxfmt -c ../.oxfmtrc.json && oxlint --fix",
-    "type-check": "tsc --build --force .",
+    "type-check": "tsc --build .",
     "type-check:watch": "yarn type-check --watch --preserveWatchOutput",
     "build": "vite build",
     "test": "vitest run",


### PR DESCRIPTION
Se vaikuttaa tarpeettomalta (lisätty vuonna 2023), ja aiheuttaa tarpeettoman suurta CPU-kuormaa typecheckissä.