### PR TITLE
Testataan ettei VTJ-päivitys tyhjennä huollettavien tietoja

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/pis/service/MockVtjClientService.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/service/MockVtjClientService.kt
@@ -76,7 +76,7 @@ class MockVtjClientService : IVtjClientService {
                     }
                 it.vakinainenKotimainenLahiosoite =
                     VTJHenkiloVastaussanoma.Henkilo.VakinainenKotimainenLahiosoite().also { o ->
-                        o.postitoimipaikkaS = person.streetAddress
+                        o.lahiosoiteS = person.streetAddress
                         o.postitoimipaikkaS = person.postOffice
                         o.postinumero = person.postalCode
                     }

--- a/service/src/integrationTest/kotlin/evaka/core/pis/service/MockVtjClientService.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/service/MockVtjClientService.kt
@@ -57,6 +57,32 @@ class MockVtjClientService : IVtjClientService {
                 }
         }
 
+        fun addHUOLLETTAVAHUOLTAJATRequestExpectation(
+            person: DevPerson,
+            guardians: List<DevPerson>,
+        ) {
+            queryRequestResponse[
+                Pair(person.ssn!!, IVtjClientService.RequestType.HUOLLETTAVA_HUOLTAJAT)] =
+                devPersonToVTJHenkiloVastaussanomaHenkilo(person).also { huollettava ->
+                    huollettava.huoltaja.addAll(
+                        0,
+                        guardians.map { guardian ->
+                            VTJHenkiloVastaussanoma.Henkilo.Huoltaja().also {
+                                it.henkilotunnus = guardian.ssn
+
+                                it.nykyisetEtunimet =
+                                    VTJHenkiloVastaussanoma.Henkilo.Huoltaja.NykyisetEtunimet()
+                                        .also { e -> e.etunimet = guardian.firstName }
+
+                                it.nykyinenSukunimi =
+                                    VTJHenkiloVastaussanoma.Henkilo.Huoltaja.NykyinenSukunimi()
+                                        .also { s -> s.sukunimi = guardian.lastName }
+                            }
+                        },
+                    )
+                }
+        }
+
         fun getPERUSSANOMA3RequestCount(person: DevPerson): Int {
             return queryCounts[Pair(person.ssn!!, IVtjClientService.RequestType.PERUSSANOMA3)] ?: 0
         }

--- a/service/src/integrationTest/kotlin/evaka/core/pis/service/PersonDetailsServiceContractTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/service/PersonDetailsServiceContractTest.kt
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package evaka.core.pis.service
+
+import evaka.core.PureJdbiTest
+import evaka.core.pis.getPersonById
+import evaka.core.shared.auth.AuthenticatedUser
+import evaka.core.shared.dev.DevPerson
+import evaka.core.shared.dev.DevPersonType
+import evaka.core.shared.dev.insert
+import evaka.core.shared.domain.HelsinkiDateTime
+import evaka.core.vtjclient.mapper.VtjHenkiloMapper
+import evaka.core.vtjclient.service.persondetails.IPersonDetailsService
+import evaka.core.vtjclient.service.persondetails.MockPersonDetailsService
+import evaka.core.vtjclient.service.persondetails.VTJPersonDetailsService
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Relatives must come back fully populated: `upsertVtjPerson` writes each one into `person` with an
+ * unconditional SET, so a name+SSN stub blanks their address, language, nationalities and
+ * turvakielto. Subclass this for every new [IPersonDetailsService].
+ */
+abstract class PersonDetailsServiceContract : PureJdbiTest(resetDbBeforeEach = true) {
+    private val user = AuthenticatedUser.SystemInternalUser
+    private val now = HelsinkiDateTime.of(LocalDate.of(2026, 1, 1), LocalTime.of(12, 0))
+
+    protected val guardian =
+        DevPerson(
+            dateOfBirth = LocalDate.of(1981, 2, 22),
+            firstName = "Mikael",
+            lastName = "Högfors",
+            ssn = "220281-9456",
+            language = "fi",
+            streetAddress = "Kamreerintie 4",
+            postalCode = "02100",
+            postOffice = "Espoo",
+        )
+
+    protected val child =
+        DevPerson(
+            dateOfBirth = LocalDate.of(2013, 10, 7),
+            firstName = "Antero",
+            lastName = "Högfors",
+            ssn = "071013A960W",
+            language = "fi",
+            streetAddress = "Kamreerintie 4",
+            postalCode = "02100",
+            postOffice = "Espoo",
+        )
+
+    /** Seed the implementation's backing store with [guardian] as the parent of [child]. */
+    protected abstract fun createServiceReturningTheFamily(): IPersonDetailsService
+
+    @BeforeEach
+    fun insertFamily() {
+        db.transaction {
+            it.insert(guardian, DevPersonType.ADULT)
+            it.insert(child, DevPersonType.CHILD)
+        }
+    }
+
+    @Test
+    fun `refreshing a guardian preserves their dependant's address`() {
+        val personService = PersonService(createServiceReturningTheFamily())
+
+        db.transaction {
+            personService.getPersonWithChildren(it, user, now, guardian.id, forceRefresh = true)
+        }
+
+        val refreshed = db.read { it.getPersonById(child.id) }!!
+        assertEquals(child.streetAddress, refreshed.streetAddress)
+        assertEquals(child.postalCode, refreshed.postalCode)
+        assertEquals(child.postOffice, refreshed.postOffice)
+    }
+
+    @Test
+    fun `refreshing a child preserves their guardian's address`() {
+        val personService = PersonService(createServiceReturningTheFamily())
+
+        db.transaction { personService.getGuardians(it, user, now, child.id, forceRefresh = true) }
+
+        val refreshed = db.read { it.getPersonById(guardian.id) }!!
+        assertEquals(guardian.streetAddress, refreshed.streetAddress)
+        assertEquals(guardian.postalCode, refreshed.postalCode)
+        assertEquals(guardian.postOffice, refreshed.postOffice)
+    }
+}
+
+/** The production implementation, which hydrates by re-querying each relative with PERUSSANOMA3. */
+class VtjSoapPersonDetailsServiceContractTest : PersonDetailsServiceContract() {
+    override fun createServiceReturningTheFamily(): IPersonDetailsService {
+        MockVtjClientService.resetQueryCounts()
+        MockVtjClientService.addPERUSSANOMA3RequestExpectation(guardian)
+        MockVtjClientService.addPERUSSANOMA3RequestExpectation(child)
+        MockVtjClientService.addHUOLTAJAHUOLLETTAVARequestExpectation(guardian, listOf(child))
+        MockVtjClientService.addHUOLLETTAVAHUOLTAJATRequestExpectation(child, listOf(guardian))
+        return VTJPersonDetailsService(MockVtjClientService(), VtjHenkiloMapper())
+    }
+}
+
+/** Enrolled because the rest of the integration suite depends on this double staying hydrated. */
+class MockPersonDetailsServiceContractTest : PersonDetailsServiceContract() {
+    override fun createServiceReturningTheFamily(): IPersonDetailsService {
+        MockPersonDetailsService.reset()
+        MockPersonDetailsService.addPersons(guardian, child)
+        MockPersonDetailsService.addDependants(guardian, child)
+        return MockPersonDetailsService()
+    }
+}

--- a/service/src/integrationTest/kotlin/evaka/core/pis/service/VtjRefreshCallCountTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/service/VtjRefreshCallCountTest.kt
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package evaka.core.pis.service
+
+import evaka.core.PureJdbiTest
+import evaka.core.shared.auth.AuthenticatedUser
+import evaka.core.shared.dev.DevPerson
+import evaka.core.shared.dev.DevPersonType
+import evaka.core.shared.dev.insert
+import evaka.core.shared.domain.HelsinkiDateTime
+import evaka.core.vtjclient.mapper.VtjHenkiloMapper
+import evaka.core.vtjclient.service.persondetails.VTJPersonDetailsService
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * A guardian refresh costs one HUOLTAJA_HUOLLETTAVA plus one PERUSSANOMA3 per dependant; reading
+ * `upsertVtjChildren` alone suggests otherwise, because hydration happens a layer above it.
+ */
+class VtjRefreshCallCountTest : PureJdbiTest(resetDbBeforeEach = true) {
+    private val guardian =
+        DevPerson(
+            ssn = "220281-9456",
+            dateOfBirth = LocalDate.of(1981, 2, 22),
+            firstName = "Mikael",
+            lastName = "Högfors",
+            streetAddress = "Kamreerintie 4",
+            postalCode = "02100",
+            postOffice = "Espoo",
+        )
+
+    private val children =
+        listOf("071013A960W", "120915A931W", "101221A999S").mapIndexed { index, ssn ->
+            DevPerson(
+                ssn = ssn,
+                dateOfBirth = LocalDate.of(2013, 10, 7),
+                firstName = "Lapsi$index",
+                lastName = "Högfors",
+                streetAddress = "Kamreerintie 4",
+                postalCode = "02100",
+                postOffice = "Espoo",
+            )
+        }
+
+    @Test
+    fun `refreshing a guardian with three dependants costs one query plus one per dependant`() {
+        db.transaction { tx ->
+            tx.insert(guardian, DevPersonType.ADULT)
+            children.forEach { tx.insert(it, DevPersonType.CHILD) }
+        }
+        MockVtjClientService.resetQueryCounts()
+        MockVtjClientService.addHUOLTAJAHUOLLETTAVARequestExpectation(guardian, children)
+        children.forEach { MockVtjClientService.addPERUSSANOMA3RequestExpectation(it) }
+        val personService =
+            PersonService(VTJPersonDetailsService(MockVtjClientService(), VtjHenkiloMapper()))
+
+        db.transaction {
+            personService.getPersonWithChildren(
+                it,
+                AuthenticatedUser.SystemInternalUser,
+                HelsinkiDateTime.of(LocalDate.of(2026, 1, 1), LocalTime.of(12, 0)),
+                guardian.id,
+                forceRefresh = true,
+            )
+        }
+
+        assertEquals(1, MockVtjClientService.getHUOLTAJAHUOLLETTAVARequestCount(guardian))
+        children.forEach { assertEquals(1, MockVtjClientService.getPERUSSANOMA3RequestCount(it)) }
+    }
+}

--- a/service/src/integrationTest/kotlin/evaka/core/pis/service/VtjRelativeStubIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/service/VtjRelativeStubIntegrationTest.kt
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package evaka.core.pis.service
+
+import evaka.core.PureJdbiTest
+import evaka.core.pis.getPersonById
+import evaka.core.shared.auth.AuthenticatedUser
+import evaka.core.shared.dev.DevPerson
+import evaka.core.shared.dev.DevPersonType
+import evaka.core.shared.dev.insert
+import evaka.core.shared.domain.HelsinkiDateTime
+import evaka.core.vtjclient.dto.NativeLanguage
+import evaka.core.vtjclient.dto.PersonAddress
+import evaka.core.vtjclient.dto.RestrictedDetails
+import evaka.core.vtjclient.dto.VtjPerson
+import evaka.core.vtjclient.service.persondetails.IPersonDetailsService
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * What an [IPersonDetailsService] returning name+SSN stubs does to the database. No shipped
+ * implementation behaves this way, but nothing in the write path prevents it and DVV's REST
+ * `/perustiedot` returns relatives in exactly this shape.
+ */
+class VtjRelativeStubIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
+    private val user = AuthenticatedUser.SystemInternalUser
+    private val now = HelsinkiDateTime.of(LocalDate.of(2026, 1, 1), LocalTime.of(12, 0))
+
+    private val guardian =
+        DevPerson(
+            dateOfBirth = LocalDate.of(1981, 2, 22),
+            firstName = "Mikael",
+            lastName = "Högfors",
+            ssn = "220281-9456",
+            language = "fi",
+            streetAddress = "Kamreerintie 4",
+            postalCode = "02100",
+            postOffice = "Espoo",
+            residenceCode = "abc123",
+            municipalityOfResidence = "Espoo",
+            nationalities = listOf("246"),
+        )
+
+    private val child =
+        DevPerson(
+            dateOfBirth = LocalDate.of(2013, 10, 7),
+            firstName = "Antero",
+            lastName = "Högfors",
+            ssn = "071013A960W",
+            language = "fi",
+            streetAddress = "Kamreerintie 4",
+            postalCode = "02100",
+            postOffice = "Espoo",
+            residenceCode = "abc123",
+            municipalityOfResidence = "Espoo",
+            nationalities = listOf("246"),
+            restrictedDetailsEnabled = true,
+            restrictedDetailsEndDate = LocalDate.of(2030, 1, 1),
+        )
+
+    private val personService = PersonService(StubRelativeDetailsService(guardian, child))
+
+    @BeforeEach
+    fun insertFamily() {
+        db.transaction {
+            it.insert(guardian, DevPersonType.ADULT)
+            it.insert(child, DevPersonType.CHILD)
+        }
+    }
+
+    @Test
+    fun `refreshing a guardian blanks every VTJ-owned field of their dependant`() {
+        refreshGuardian()
+
+        val refreshed = db.read { it.getPersonById(child.id) }!!
+        assertEquals("", refreshed.streetAddress)
+        assertEquals("", refreshed.postalCode)
+        assertEquals("", refreshed.postOffice)
+        assertEquals("", refreshed.residenceCode)
+        assertEquals("", refreshed.municipalityOfResidence)
+        assertEquals("", refreshed.language)
+        assertEquals(emptyList(), refreshed.nationalities)
+    }
+
+    @Test
+    fun `refreshing a guardian clears their dependant's restricted details`() {
+        refreshGuardian()
+
+        val refreshed = db.read { it.getPersonById(child.id) }!!
+        assertFalse(refreshed.restrictedDetailsEnabled)
+        assertNull(refreshed.restrictedDetailsEndDate)
+    }
+
+    /** `personsLiveInTheSameAddress` gates `createParentship`, so no fridge family forms. */
+    @Test
+    fun `a blanked dependant stops counting as living with their guardian`() {
+        refreshGuardian()
+
+        val refreshedGuardian = db.read { it.getPersonById(guardian.id) }!!
+        val refreshedChild = db.read { it.getPersonById(child.id) }!!
+        assertFalse(personService.personsLiveInTheSameAddress(refreshedChild, refreshedGuardian))
+    }
+
+    private fun refreshGuardian() {
+        db.transaction {
+            personService.getPersonWithChildren(it, user, now, guardian.id, forceRefresh = true)
+        }
+    }
+}
+
+/**
+ * Returns the queried person in full but their relatives as name+SSN only — the shape of VTJ's
+ * HUOLTAJA_HUOLLETTAVA response and of DVV's REST `/perustiedot` response before hydration.
+ */
+private class StubRelativeDetailsService(private vararg val persons: DevPerson) :
+    IPersonDetailsService {
+    override fun getBasicDetailsFor(query: IPersonDetailsService.DetailsQuery): VtjPerson =
+        persons.single { it.ssn == query.targetIdentifier.ssn }.toFullVtjPerson()
+
+    override fun getPersonWithDependants(query: IPersonDetailsService.DetailsQuery): VtjPerson =
+        getBasicDetailsFor(query).copy(dependants = relativesOf(query))
+
+    override fun getPersonWithGuardians(query: IPersonDetailsService.DetailsQuery): VtjPerson =
+        getBasicDetailsFor(query).copy(guardians = relativesOf(query))
+
+    private fun relativesOf(query: IPersonDetailsService.DetailsQuery) =
+        persons.filter { it.ssn != query.targetIdentifier.ssn }.map { it.toRelativeStub() }
+}
+
+private fun DevPerson.toFullVtjPerson() =
+    VtjPerson(
+        firstNames = firstName,
+        lastName = lastName,
+        socialSecurityNumber = ssn!!,
+        address = PersonAddress(streetAddress, postalCode, postOffice),
+        nativeLanguage = language?.let { NativeLanguage(code = it) },
+        residenceCode = residenceCode,
+        municipalityOfResidence = municipalityOfResidence,
+        restrictedDetails = RestrictedDetails(restrictedDetailsEnabled, restrictedDetailsEndDate),
+    )
+
+private fun DevPerson.toRelativeStub() =
+    VtjPerson(
+        firstNames = firstName,
+        lastName = lastName,
+        socialSecurityNumber = ssn!!,
+        restrictedDetails = null,
+    )


### PR DESCRIPTION
Yöajon muutospäivityksessä VTJ palauttaa huollettavat nimi+hetu-tynkinä, ja `upsertVtjPerson` kirjoittaa ne `person`-riville ehdottomalla SET:llä, joten tyngistä kirjoitettuna jokaiselta lapselta nollautuisi osoite,
äidinkieli, kansalaisuus ja turvakielto.
Näin ei käy, koska `VTJPersonDetailsService` hakee kunkin huollettavan täydet tiedot erikseen (PERUSSANOMA3) ennen kuin mitään kirjoitetaan. Sitä ei kuitenkaan valvonut mikään testi, tyyppi tai tarkistus.

DVV:n uusi REST-rajapinta (`/perustiedot`) on korvaamassa nykyisen SOAP-haun, ja se palauttaa huollettavat samalla tavalla pelkkinä niminä ja henkilötunnuksina. Tämä PR lisää testit, jotka torppaavat tyngillä tallentamisen:

- `PersonDetailsServiceContract` - yhteinen testipohja, jota henkilötietolähteiden on noudatettava. SOAP- ja mock-toteutukset mukana
- `VtjRelativeStubIntegrationTest` - mitä tyngät tekevät kannassa, mukaan lukien se että perhesuhteet lakkaavat muodostumasta hiljaisesti
- `VtjRefreshCallCountTest` - yöajon todellinen kutsumäärä on 1 + huollettavat

Lisäksi yhden rivin korjaus testiapuriin (`MockVtjClientService`): kenttä `postitoimipaikkaS` asetettiin kahdesti, jolloin katuosoite jäi kokonaan asettamatta.