### PR TITLE
Korjataan bugit ryhmänäkymän lasten muistiinpano-ikoneissa

### DIFF
--- a/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
+++ b/frontend/src/e2e-test/pages/employee/units/unit-groups-page.ts
@@ -380,6 +380,20 @@ export class GroupCollapsibleChildRow extends Element {
     await expect(this.#dailyNoteTooltip).toContainText(expectedText)
   }
 
+  async assertDailyNoteDoesNotContainText(unexpectedText: string) {
+    await this.#dailyNoteIcon.hover()
+    await expect(this.#dailyNoteTooltip).not.toContainText(unexpectedText)
+  }
+
+  async assertDailyNoteIconActive(active: boolean) {
+    // RoundIcon marks a lit-up icon with the `active` class
+    if (active) {
+      await expect(this.#dailyNoteIcon).toHaveClass(/\bactive\b/)
+    } else {
+      await expect(this.#dailyNoteIcon).not.toHaveClass(/\bactive\b/)
+    }
+  }
+
   async openDailyNoteModal() {
     await this.#dailyNoteIcon.click()
     return new ChildDailyNoteModal(this.findByDataQa('modal'))

--- a/frontend/src/e2e-test/specs/5_employee/employee-dailynote.spec.ts
+++ b/frontend/src/e2e-test/specs/5_employee/employee-dailynote.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import type { ChildDailyNoteBody } from 'lib-common/generated/api-types/note'
+import LocalDate from 'lib-common/local-date'
 
 import {
   Fixture,
@@ -13,6 +14,7 @@ import {
 import {
   createDefaultServiceNeedOptions,
   postChildDailyNote,
+  postChildStickyNote,
   resetServiceState
 } from '../../generated/api-clients'
 import type { DevDaycare, DevDaycareGroup } from '../../generated/api-types'
@@ -110,6 +112,29 @@ test.describe('Mobile employee daily notes', () => {
     await noteModal.submitButton.click()
 
     await childRow.assertDailyNoteContainsText('aardvark')
+  })
+
+  test('Child sticky note affects the note indicator of that child only', async () => {
+    const stickyNote = 'Huomioitavaa lähipäivinä'
+    await postChildStickyNote({
+      childId: testChild.id,
+      body: {
+        note: stickyNote,
+        expires: LocalDate.todayInHelsinkiTz().addDays(7)
+      }
+    })
+
+    await unitPage.navigateToUnit(daycare.id)
+    const groupsSection = await unitPage.openGroupsPage()
+    const group = await groupsSection.openGroupCollapsible(daycareGroup.id)
+
+    const childWithNote = group.childRow(testChild.id)
+    await childWithNote.assertDailyNoteIconActive(true)
+    await childWithNote.assertDailyNoteContainsText(stickyNote)
+
+    const otherChild = group.childRow(testChild2.id)
+    await otherChild.assertDailyNoteIconActive(false)
+    await otherChild.assertDailyNoteDoesNotContainText(stickyNote)
   })
 
   test('Group daycare daily notes can be written and are shown on group notes tab', async () => {

--- a/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
+++ b/frontend/src/employee-frontend/components/unit/tab-groups/groups/Group.tsx
@@ -29,6 +29,7 @@ import type {
   GroupId,
   PersonId
 } from 'lib-common/generated/api-types/shared'
+import LocalDate from 'lib-common/local-date'
 import { formatPersonName } from 'lib-common/names'
 import {
   first,
@@ -798,42 +799,57 @@ const DailyNote = React.memo(function DaycareDailyNote({
     const childNote = notes.childDailyNotes.find(
       (note) => note.childId === placement.child.id
     )
+    const childStickyNotes = notes.childStickyNotes.filter(
+      (note) =>
+        note.childId === placement.child.id &&
+        note.expires.isEqualOrAfter(LocalDate.todayInHelsinkiTz())
+    )
+    const hasNotes = childNote !== undefined || childStickyNotes.length > 0
     return (
       <Tooltip
         data-qa={`daycare-daily-note-hover-${placement.child.id}`}
         position="top"
         tooltip={
-          childNote ? (
+          hasNotes ? (
             <div>
-              <h4>{i18n.unit.groups.daycareDailyNote.header}</h4>
-              <p>{childNote.note}</p>
-              <h5>{i18n.unit.groups.daycareDailyNote.feedingHeader}</h5>
-              <p>
-                {childNote.feedingNote
-                  ? i18n.unit.groups.daycareDailyNote.level[
-                      childNote.feedingNote
-                    ]
-                  : ''}
-              </p>
-              <h5>{i18n.unit.groups.daycareDailyNote.sleepingHeader}</h5>
-              <p>{formatSleepingTooltipText(childNote, i18n)}</p>
-              <h5>{i18n.unit.groups.daycareDailyNote.reminderHeader}</h5>
-              <p>
-                {childNote.reminders
-                  .map(
-                    (reminder) =>
-                      i18n.unit.groups.daycareDailyNote.reminderType[reminder]
-                  )
-                  .join(',')}
-              </p>
-              <h5>
-                {i18n.unit.groups.daycareDailyNote.otherThingsToRememberHeader}
-              </h5>
-              <p>{childNote.reminderNote}</p>
-              {notes.childStickyNotes.length > 0 && (
+              {childNote && (
+                <>
+                  <h4>{i18n.unit.groups.daycareDailyNote.header}</h4>
+                  <p>{childNote.note}</p>
+                  <h5>{i18n.unit.groups.daycareDailyNote.feedingHeader}</h5>
+                  <p>
+                    {childNote.feedingNote
+                      ? i18n.unit.groups.daycareDailyNote.level[
+                          childNote.feedingNote
+                        ]
+                      : ''}
+                  </p>
+                  <h5>{i18n.unit.groups.daycareDailyNote.sleepingHeader}</h5>
+                  <p>{formatSleepingTooltipText(childNote, i18n)}</p>
+                  <h5>{i18n.unit.groups.daycareDailyNote.reminderHeader}</h5>
+                  <p>
+                    {childNote.reminders
+                      .map(
+                        (reminder) =>
+                          i18n.unit.groups.daycareDailyNote.reminderType[
+                            reminder
+                          ]
+                      )
+                      .join(',')}
+                  </p>
+                  <h5>
+                    {
+                      i18n.unit.groups.daycareDailyNote
+                        .otherThingsToRememberHeader
+                    }
+                  </h5>
+                  <p>{childNote.reminderNote}</p>
+                </>
+              )}
+              {childStickyNotes.length > 0 && (
                 <>
                   <h5>{i18n.unit.groups.daycareDailyNote.stickyNotesHeader}</h5>
-                  {notes.childStickyNotes.map((stickyNote) => (
+                  {childStickyNotes.map((stickyNote) => (
                     <p key={stickyNote.id}>{stickyNote.note}</p>
                   ))}
                 </>
@@ -853,7 +869,7 @@ const DailyNote = React.memo(function DaycareDailyNote({
         }
       >
         <RoundIcon
-          active={childNote != null || notes.childStickyNotes.length > 0}
+          active={hasNotes}
           data-qa={`daycare-daily-note-icon-${placement.child.id}`}
           content={faStickyNote}
           color={colors.main.m2}


### PR DESCRIPTION
Kaikkien lasten muistiinpano-ikoni näkyi värillisenä jos yhdelläkään ryhmän lapsella oli HUOM-muistiinpano. Logiikka ei myöskään filtteröinyt pois jo päättyneitä muistiinpanoja. Lisäksi korjattu vastaavat bugit ja epäloogisuudet tooltipissä.