### PR TITLE
Oulun/Turun DW-exportin virheidenhallinnan parannuksia

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/shared/sftp/SftpClientTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/shared/sftp/SftpClientTest.kt
@@ -7,8 +7,12 @@ package evaka.core.shared.sftp
 import com.jcraft.jsch.JSchException
 import evaka.core.Sensitive
 import evaka.core.SftpEnv
+import java.net.ServerSocket
+import java.net.SocketTimeoutException
+import java.time.Duration
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -82,6 +86,28 @@ class SftpClientTest {
             )
         "hello world".byteInputStream(Charsets.UTF_8).use { client.put(it, "upload/test.txt") }
         assertEquals("hello world", client.getAsString("upload/test.txt", Charsets.UTF_8))
+    }
+
+    @Test
+    fun `connecting to a server that accepts the connection but never responds times out`() {
+        ServerSocket(0).use { unresponsiveServer ->
+            val client =
+                SftpClient(
+                    env.copy(
+                        port = unresponsiveServer.localPort,
+                        password = Sensitive(password),
+                        privateKey = null,
+                    ),
+                    connectTimeout = Duration.ofSeconds(1),
+                )
+            val exception =
+                assertThrows<JSchException> {
+                    "hello".byteInputStream(Charsets.UTF_8).use {
+                        client.put(it, "upload/test.txt")
+                    }
+                }
+            assertIs<SocketTimeoutException>(exception.cause)
+        }
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/evaka/instance/oulu/dw/DwExportJobTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/instance/oulu/dw/DwExportJobTest.kt
@@ -4,6 +4,7 @@
 
 package evaka.instance.oulu.dw
 
+import com.jcraft.jsch.JSchException
 import evaka.core.BucketEnv
 import evaka.core.FullApplicationTest
 import evaka.core.Sensitive
@@ -35,7 +36,9 @@ import java.time.LocalTime
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
@@ -47,6 +50,7 @@ class DwExportJobTest : FullApplicationTest(resetDbBeforeEach = true) {
     @Autowired private lateinit var bucketEnv: BucketEnv
     @Autowired private lateinit var s3Client: S3Client
 
+    private lateinit var ouluEnv: OuluEnv
     private lateinit var job: DwExportJob
 
     companion object {
@@ -56,7 +60,7 @@ class DwExportJobTest : FullApplicationTest(resetDbBeforeEach = true) {
 
     @BeforeAll
     fun setup() {
-        val ouluEnv =
+        ouluEnv =
             OuluEnv(
                 intimeInvoices =
                     SftpProperties(
@@ -129,6 +133,40 @@ class DwExportJobTest : FullApplicationTest(resetDbBeforeEach = true) {
                 sendAndAssertQueryCsv(it.queryName, it.query)
             }
         }
+
+    @Test
+    fun `a failed upload fails the job instead of being swallowed`() {
+        val badCredentials = ouluEnv.dwExport.sftp.toSftpEnv().copy(password = Sensitive("wrong"))
+        val failingJob =
+            DwExportJob(
+                FileDwExportClient(
+                    s3Client,
+                    SftpClient(badCredentials, ouluEnv.dwExport.sftp.path),
+                    ouluEnv,
+                )
+            )
+        val query = DwQuery.entries.first()
+
+        assertThrows<JSchException> {
+            failingJob.sendQuery(db, clock, query.queryName, query.query)
+        }
+    }
+
+    @Test
+    fun `a failed S3 upload does not fail the job when SFTP delivery succeeded`() {
+        val missingBucket = ouluEnv.copy(bucket = BucketProperties(export = "no-such-bucket"))
+        val tolerantJob =
+            DwExportJob(
+                FileDwExportClient(
+                    s3Client,
+                    SftpClient(ouluEnv.dwExport.sftp.toSftpEnv(), ouluEnv.dwExport.sftp.path),
+                    missingBucket,
+                )
+            )
+        val query = DwQuery.entries.first()
+
+        tolerantJob.sendQuery(db, clock, query.queryName, query.query)
+    }
 
     private fun sendAndAssertQueryCsv(name: String, query: CsvQuery) {
         job.sendQuery(db, clock, name, query)

--- a/service/src/integrationTest/kotlin/evaka/instance/turku/dw/DwExportJobTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/instance/turku/dw/DwExportJobTest.kt
@@ -4,6 +4,7 @@
 
 package evaka.instance.turku.dw
 
+import com.jcraft.jsch.JSchException
 import evaka.core.BucketEnv
 import evaka.core.FullApplicationTest
 import evaka.core.Sensitive
@@ -35,7 +36,9 @@ import java.time.LocalTime
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
@@ -47,6 +50,7 @@ class DwExportJobTest : FullApplicationTest(resetDbBeforeEach = true) {
     @Autowired private lateinit var bucketEnv: BucketEnv
     @Autowired private lateinit var s3Client: S3Client
 
+    private lateinit var turkuEnv: TurkuEnv
     private lateinit var job: DwExportJob
 
     companion object {
@@ -56,7 +60,7 @@ class DwExportJobTest : FullApplicationTest(resetDbBeforeEach = true) {
 
     @BeforeAll
     fun setup() {
-        val turkuEnv =
+        turkuEnv =
             TurkuEnv(
                 sapInvoicing =
                     SftpProperties(
@@ -109,6 +113,18 @@ class DwExportJobTest : FullApplicationTest(resetDbBeforeEach = true) {
         DwQuery.entries.map {
             DynamicTest.dynamicTest("Test '${it.queryName}' export") { sendAndAssertDwQueryCsv(it) }
         }
+
+    @Test
+    fun `a failed upload fails the job instead of being swallowed`() {
+        val badCredentials = turkuEnv.dwExport.sftp.toSftpEnv().copy(password = Sensitive("wrong"))
+        val failingJob =
+            DwExportJob(FileDWExportClient(SftpClient(badCredentials, turkuEnv.dwExport.sftp.path)))
+        val query = DwQuery.entries.first()
+
+        assertThrows<JSchException> {
+            failingJob.sendDwQuery(db, clock, query.queryName, query.query)
+        }
+    }
 
     private fun sendAndAssertDwQueryCsv(query: DwQuery) {
         job.sendDwQuery(db, clock, query.queryName, query.query)

--- a/service/src/main/kotlin/evaka/core/shared/sftp/SftpClient.kt
+++ b/service/src/main/kotlin/evaka/core/shared/sftp/SftpClient.kt
@@ -15,11 +15,20 @@ import java.io.BufferedReader
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.charset.Charset
+import java.time.Duration
 import java.util.*
 
 private val logger = KotlinLogging.logger {}
 
-class SftpClient(private val sftpEnv: SftpEnv, basePath: String = "") {
+private val DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(60)
+private val DEFAULT_READ_TIMEOUT = Duration.ofSeconds(60)
+
+class SftpClient(
+    private val sftpEnv: SftpEnv,
+    basePath: String = "",
+    private val connectTimeout: Duration = DEFAULT_CONNECT_TIMEOUT,
+    private val readTimeout: Duration = DEFAULT_READ_TIMEOUT,
+) {
     private val basePath = basePath.trim('/')
 
     fun put(inputStream: InputStream, filename: String) = session { it.put(inputStream, filename) }
@@ -66,11 +75,12 @@ class SftpClient(private val sftpEnv: SftpEnv, basePath: String = "") {
                 "Connecting to ${sftpEnv.host}:${sftpEnv.port} with host key verification disabled"
             }
         }
+        session.timeout = readTimeout.toMillis().toInt()
         try {
-            session.connect()
+            session.connect(connectTimeout.toMillis().toInt())
             val channel = session.openChannel("sftp") as ChannelSftp
             try {
-                channel.connect()
+                channel.connect(connectTimeout.toMillis().toInt())
                 return callback(channel)
             } finally {
                 channel.exit()

--- a/service/src/main/kotlin/evaka/instance/oulu/OuluScheduledJobs.kt
+++ b/service/src/main/kotlin/evaka/instance/oulu/OuluScheduledJobs.kt
@@ -16,6 +16,7 @@ import evaka.core.shared.job.ScheduledJobDefinition
 import evaka.core.shared.job.ScheduledJobSettings
 import evaka.instance.oulu.dw.DwQuery
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Duration
 import java.time.LocalTime
 
 enum class OuluScheduledJob(
@@ -52,7 +53,8 @@ class OuluScheduledJobs(
                 tx,
                 DwQuery.entries.asSequence().map(OuluAsyncJob::SendDWQuery),
                 runAt = clock.now(),
-                retryCount = 1,
+                retryCount = 5,
+                retryInterval = Duration.ofMinutes(15),
             )
         }
     }

--- a/service/src/main/kotlin/evaka/instance/oulu/dw/FileDwExportClient.kt
+++ b/service/src/main/kotlin/evaka/instance/oulu/dw/FileDwExportClient.kt
@@ -45,20 +45,27 @@ class FileDwExportClient(
 
             logger.info { "Sending DW content for '$queryName' to S3" }
 
-            val response =
-                s3Client
-                    .putObject({ r -> r.bucket(bucket).key(key).contentType("text/csv") }, tempFile)
-                    .sdkHttpResponse()
+            try {
+                val response =
+                    s3Client
+                        .putObject(
+                            { r -> r.bucket(bucket).key(key).contentType("text/csv") },
+                            tempFile,
+                        )
+                        .sdkHttpResponse()
 
-            if (response.isSuccessful) {
-                logger.info { "DW file '$key' successfully sent" }
-            } else {
-                logger.warn {
-                    "DW file '$key' sending failed: ${response.statusCode()} ${response.statusText()}"
+                if (response.isSuccessful) {
+                    logger.info { "DW file '$key' successfully sent" }
+                } else {
+                    logger.error {
+                        "DW file '$key' sending failed: ${response.statusCode()} ${response.statusText()}"
+                    }
+                }
+            } catch (e: Exception) {
+                logger.error(e) {
+                    "Failed to send DW file '$key' to S3, ignored because the SFTP upload is the primary delivery"
                 }
             }
-        } catch (e: Exception) {
-            logger.warn(e) { "Failed to send DW content for '$queryName'" }
         } finally {
             val wasDeleted = tempFile.deleteIfExists()
             if (!wasDeleted) {

--- a/service/src/main/kotlin/evaka/instance/turku/TurkuScheduledJobs.kt
+++ b/service/src/main/kotlin/evaka/instance/turku/TurkuScheduledJobs.kt
@@ -15,6 +15,7 @@ import evaka.core.shared.job.ScheduledJobDefinition
 import evaka.core.shared.job.ScheduledJobSettings
 import evaka.instance.turku.dw.DwQuery
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Duration
 import java.time.LocalTime
 
 enum class TurkuScheduledJob(
@@ -51,7 +52,8 @@ class TurkuScheduledJobs(
                 tx,
                 queries.asSequence().map(TurkuAsyncJob::SendDWQuery),
                 runAt = clock.now(),
-                retryCount = 1,
+                retryCount = 5,
+                retryInterval = Duration.ofMinutes(15),
             )
         }
     }

--- a/service/src/main/kotlin/evaka/instance/turku/dw/FileDWExportClient.kt
+++ b/service/src/main/kotlin/evaka/instance/turku/dw/FileDWExportClient.kt
@@ -27,8 +27,6 @@ class FileDWExportClient(private val sftpClient: SftpClient) : DwExportClient {
                 BufferedOutputStream(fos).use { bos -> stream.transferTo(bos) }
             }
             tempFile.toFile().inputStream().use { input -> sftpClient.put(input, fileName) }
-        } catch (e: Exception) {
-            logger.warn(e) { "Failed to send DW content for '$queryName'" }
         } finally {
             val wasDeleted = tempFile.deleteIfExists()
             if (!wasDeleted) {


### PR DESCRIPTION
- SFTP-clientissä on asetettu timeout-arvot, jotta yhteys (ja jobi jossa se ajetaan) ei jumiudu lopullisesti missään vaiheessa. Tämä muutos koskee kaikkia SFTP:tä käyttäviä integraatioita.
- SFTP-lähetyksen virhetilanteissa kutakin tiedostokohtaista siirtoa yritetään uudestaan 4 kertaa 15 minuutin välein. Lopullisesta epäonnistumisesta raportoidaan error-tason lokilla. S3-tiedonsiirrossa tapahtuvien virheiden jälkeen uudelleenlähetystä ei tehdä, ei SFTP:hen eikä S3:een, mutta error-tason loki kirjoitetaan.