### PR TITLE
Korjataan lapsen profiilikuvan valinnasta aiheutuva kaatuminen kasvattajan mobiilissa

### DIFF
--- a/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
+++ b/frontend/src/employee-mobile-frontend/child-info/AttendanceChildPage.tsx
@@ -117,10 +117,6 @@ export default React.memo(function AttendanceChildPage({
     )
   }
 
-  const NoGuardianInfoBoxContainer = styled.div`
-    margin: ${defaultMargins.xs};
-  `
-
   return (
     <>
       <TallContentAreaNoOverflow
@@ -397,6 +393,10 @@ export default React.memo(function AttendanceChildPage({
     </>
   )
 })
+
+const NoGuardianInfoBoxContainer = styled.div`
+  margin: ${defaultMargins.xs};
+`
 
 const ChildStatus = styled.div`
   color: ${colors.grayscale.g35};


### PR DESCRIPTION
`styled-components` kutsuu `useState`-hookia ainakin Reactin dev-tilassa. Yksi styled-elementti oli määritelty `AttendanceChildPage`n sisällä, jolloin kuvan rajaustoiminnon aikainen palautus esti elementin hookien kutsumisen, joka aiheutti Rendered fewer hooks than expected -virheen. Korjauksena siirretty styled-elementti moduulitasolle.