### PR TITLE
Lapseen liittyvien vanhentuneiden viestien poisto (ei vielä käytössä)

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/dataremoval/MessageDataRemovalIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/dataremoval/MessageDataRemovalIntegrationTest.kt
@@ -21,6 +21,7 @@ import evaka.core.messaging.ReplyToMessageBody
 import evaka.core.messaging.UpdatableDraftContent
 import evaka.core.messaging.createDaycareGroupMessageAccount
 import evaka.core.messaging.createMunicipalMessageAccount
+import evaka.core.messaging.deleteMessageThreadsOfExpiredChildren
 import evaka.core.messaging.getCitizenMessageAccount
 import evaka.core.messaging.upsertEmployeeMessageAccount
 import evaka.core.pis.service.insertGuardian
@@ -38,6 +39,7 @@ import evaka.core.shared.async.AsyncJobRunner
 import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.auth.UserRole
 import evaka.core.shared.auth.insertDaycareAclRow
+import evaka.core.shared.db.QuerySql
 import evaka.core.shared.dev.DevCareArea
 import evaka.core.shared.dev.DevDaycare
 import evaka.core.shared.dev.DevDaycareGroup
@@ -151,6 +153,28 @@ class MessageDataRemovalIntegrationTest : FullApplicationTest(resetDbBeforeEach 
             )
             placementId
         }
+
+    private fun insertSibling(period: FiniteDateRange): ChildId {
+        val sibling = DevPerson()
+        db.transaction { tx ->
+            tx.insert(sibling, DevPersonType.CHILD)
+            tx.insertGuardian(guardian.id, sibling.id)
+        }
+        insertGroupPlacement(sibling.id, period)
+        return sibling.id
+    }
+
+    private fun insertChildOfAnotherGuardian(period: FiniteDateRange): ChildId {
+        val otherChild = DevPerson()
+        val otherGuardian = DevPerson()
+        db.transaction { tx ->
+            tx.insert(otherChild, DevPersonType.CHILD)
+            tx.insert(otherGuardian, DevPersonType.ADULT)
+            tx.insertGuardian(otherGuardian.id, otherChild.id)
+        }
+        insertGroupPlacement(otherChild.id, period)
+        return otherChild.id
+    }
 
     private fun sendMessage(
         sentAt: HelsinkiDateTime,
@@ -341,6 +365,21 @@ RETURNING id
             expiresBefore = bulletinExpiresBefore,
             limit = limit,
         )
+
+    private fun deleteMessageThreadsOfExpiredChildren(
+        expiredChildIds: List<ChildId>,
+        limit: Int = 100,
+    ) =
+        dataRemovalService.deleteMessageThreadsOfExpiredChildren(
+            db,
+            now,
+            expiredChildIdsQuery = expiredChildIdsQuery(expiredChildIds),
+            limit = limit,
+        )
+
+    private fun expiredChildIdsQuery(childIds: List<ChildId>) = QuerySql {
+        sql("SELECT id FROM child WHERE id = ANY(${bind(childIds)})")
+    }
 
     private fun deleteExpiredMessageDrafts(limit: Int = 100) =
         dataRemovalService.deleteExpiredMessageDrafts(
@@ -676,6 +715,202 @@ RETURNING id
     }
 
     @Test
+    fun `deleteMessageThreadsOfExpiredChildren deletes a thread with its messages, recipients, participants, children and content`() {
+        insertGroupPlacement(child.id, expiredPlacementPeriod)
+        val sent =
+            sendMessage(
+                sentAt = sendTimeOverFiveYearsAgo,
+                type = MessageType.MESSAGE,
+                attachmentCount = 1,
+            )
+        replyToThread(sent.threadIds.single(), sentAt = now.minusYears(1))
+
+        deleteMessageThreadsOfExpiredChildren(listOf(child.id))
+
+        assertEquals(0, rowCount("message_thread"))
+        assertEquals(0, rowCount("message"))
+        assertEquals(0, rowCount("message_recipients"))
+        assertEquals(0, rowCount("message_thread_participant"))
+        assertEquals(0, rowCount("message_thread_children"))
+        assertEquals(0, rowCount("message_content"))
+        assertEquals(
+            sent.attachmentIds.map { it.toString() }.toSet(),
+            scheduledAttachmentDeletionIds(),
+        )
+    }
+
+    @Test
+    fun `deleteMessageThreadsOfExpiredChildren keeps the threads of a child who has not expired`() {
+        insertGroupPlacement(child.id, expiredPlacementPeriod)
+        val retained = sendMessage(sentAt = sendTimeOverFiveYearsAgo, type = MessageType.MESSAGE)
+        val otherChild = insertChildOfAnotherGuardian(expiredPlacementPeriod)
+        sendMessage(
+            sentAt = sendTimeOverFiveYearsAgo,
+            recipients = listOf(MessageRecipient.Child(otherChild)),
+            type = MessageType.MESSAGE,
+        )
+
+        deleteMessageThreadsOfExpiredChildren(listOf(otherChild))
+
+        assertEquals(retained.threadIds, survivingMessageThreadIds())
+        assertEquals(1, rowCount("message_content"))
+    }
+
+    @Test
+    fun `deleteMessageThreadsOfExpiredChildren deletes nothing while no child has expired`() {
+        insertGroupPlacement(child.id, expiredPlacementPeriod)
+        sendMessage(sentAt = sendTimeOverFiveYearsAgo, type = MessageType.MESSAGE)
+
+        deleteMessageThreadsOfExpiredChildren(emptyList())
+
+        assertEquals(1, rowCount("message_thread"))
+        assertEquals(1, rowCount("message_content"))
+    }
+
+    @Test
+    fun `deleteMessageThreadsOfExpiredChildren keeps a thread until its last child has expired`() {
+        insertGroupPlacement(child.id, expiredPlacementPeriod)
+        val sibling = insertSibling(expiredPlacementPeriod)
+        sendMessage(
+            sentAt = sendTimeOverFiveYearsAgo,
+            recipients = listOf(MessageRecipient.Child(child.id), MessageRecipient.Child(sibling)),
+            type = MessageType.MESSAGE,
+        )
+        assertEquals(1, rowCount("message_thread"))
+        assertEquals(2, rowCount("message_thread_children"), "both children are on one thread")
+
+        deleteMessageThreadsOfExpiredChildren(listOf(child.id))
+
+        assertEquals(1, rowCount("message_thread"))
+        assertEquals(1, rowCount("message_content"))
+
+        deleteMessageThreadsOfExpiredChildren(listOf(child.id, sibling))
+
+        assertEquals(0, rowCount("message_thread"))
+        assertEquals(0, rowCount("message_content"))
+    }
+
+    @Test
+    fun `deleteMessageThreadsOfExpiredChildren returns the children of a deleted thread`() {
+        // The children of a thread must be read before the delete cascades them away, or the
+        // audit trail of the removal loses them
+        insertGroupPlacement(child.id, expiredPlacementPeriod)
+        val sibling = insertSibling(expiredPlacementPeriod)
+        val sent =
+            sendMessage(
+                sentAt = sendTimeOverFiveYearsAgo,
+                recipients =
+                    listOf(MessageRecipient.Child(child.id), MessageRecipient.Child(sibling)),
+                type = MessageType.MESSAGE,
+            )
+
+        val batch = db.transaction { tx ->
+            tx.deleteMessageThreadsOfExpiredChildren(
+                expiredChildIdsQuery(listOf(child.id, sibling)),
+                limit = 100,
+            )
+        }
+
+        assertEquals(sent.threadIds, batch.threads.map { it.threadId })
+        assertEquals(setOf(child.id, sibling), batch.threads.single().childIds.toSet())
+    }
+
+    @Test
+    fun `deleteMessageThreadsOfExpiredChildren keeps a content shared by the thread of a child who has not expired`() {
+        insertGroupPlacement(child.id, expiredPlacementPeriod)
+        val otherChild = insertChildOfAnotherGuardian(expiredPlacementPeriod)
+        val sent =
+            sendMessage(
+                sentAt = sendTimeOverFiveYearsAgo,
+                recipients =
+                    listOf(MessageRecipient.Child(child.id), MessageRecipient.Child(otherChild)),
+                type = MessageType.MESSAGE,
+                attachmentCount = 1,
+            )
+        assertEquals(2, sent.threadIds.size, "the children have guardians of their own")
+
+        deleteMessageThreadsOfExpiredChildren(listOf(child.id))
+
+        assertEquals(1, rowCount("message_thread"))
+        assertEquals(1, rowCount("message_content"))
+        assertTrue(scheduledAttachmentDeletionIds().isEmpty())
+    }
+
+    @Test
+    fun `deleteMessageThreadsOfExpiredChildren deletes a bulletin of an expired child however recent it is`() {
+        insertGroupPlacement(child.id, ongoingPlacementPeriod)
+        sendMessage(sentAt = now.minusDays(1))
+
+        deleteMessageThreadsOfExpiredChildren(listOf(child.id))
+
+        assertEquals(0, rowCount("message_thread"))
+        assertEquals(0, rowCount("message_content"))
+    }
+
+    @Test
+    fun `deleteMessageThreadsOfExpiredChildren leaves a staff copy for the bulletin removal to delete`() {
+        // A copy records no children of its own, so it outlives the bulletin of an expired child
+        createGroupMessageAccount()
+        insertGroupPlacement(child.id, ongoingPlacementPeriod)
+        val sent =
+            sendMessage(
+                sentAt = sendTimeWithinFiveYears,
+                recipients = listOf(MessageRecipient.Group(daycareGroup.id)),
+                attachmentCount = 1,
+            )
+        val copyId = staffCopyThreadIds().single()
+
+        deleteMessageThreadsOfExpiredChildren(listOf(child.id))
+
+        assertEquals(listOf(copyId), survivingMessageThreadIds())
+        assertEquals(1, rowCount("message_content"))
+
+        deleteExpiredBulletinThreads()
+
+        assertEquals(0, rowCount("message_thread"))
+        assertEquals(0, rowCount("message_content"))
+        assertEquals(
+            sent.attachmentIds.map { it.toString() }.toSet(),
+            scheduledAttachmentDeletionIds(),
+        )
+    }
+
+    @Test
+    fun `deleteMessageThreadsOfExpiredChildren keeps a thread that is linked to an application`() {
+        insertGroupPlacement(child.id, expiredPlacementPeriod)
+        val sent = sendMessage(sentAt = sendTimeOverFiveYearsAgo, type = MessageType.MESSAGE)
+        setThreadApplication(sent.threadIds.single(), insertApplication())
+
+        deleteMessageThreadsOfExpiredChildren(listOf(child.id))
+
+        assertEquals(1, rowCount("message_thread"))
+        assertEquals(1, rowCount("message_content"))
+    }
+
+    @Test
+    fun `deleteMessageThreadsOfExpiredChildren keeps a thread whose content an application note references`() {
+        insertGroupPlacement(child.id, expiredPlacementPeriod)
+        val sent = sendMessage(sentAt = sendTimeOverFiveYearsAgo, type = MessageType.MESSAGE)
+        insertApplicationNote(insertApplication(), sent.contentId)
+
+        deleteMessageThreadsOfExpiredChildren(listOf(child.id))
+
+        assertEquals(1, rowCount("message_thread"))
+        assertEquals(1, rowCount("message_content"))
+    }
+
+    @Test
+    fun `deleteMessageThreadsOfExpiredChildren doesn't remove more threads than the limit`() {
+        insertGroupPlacement(child.id, expiredPlacementPeriod)
+        repeat(3) { sendMessage(sentAt = sendTimeOverFiveYearsAgo, type = MessageType.MESSAGE) }
+
+        deleteMessageThreadsOfExpiredChildren(listOf(child.id), limit = 2)
+
+        assertEquals(1, rowCount("message_thread"))
+        assertEquals(1, rowCount("message_content"))
+    }
+
+    @Test
     fun `deleteExpiredMessageDrafts deletes an expired draft and enqueues its attachment deletion`() {
         val draftId = createDraft(createdAt = draftExpiresBefore.minusDays(1))
         val attachmentId = insertDraftAttachment(draftId, now)
@@ -801,6 +1036,26 @@ RETURNING id
 
         assertEquals(1, rowCount("message_thread"))
         assertEquals(1, rowCount("message_draft"))
+    }
+
+    @Test
+    fun `deleteExpiredData keeps a regular message thread of a child who left care over ten years ago`() {
+        // Regular messages are retained as long as the data of their children, and the rule that
+        // expires a child is not in use yet
+        val leftCareTenYearsAgo = FiniteDateRange(today.minusYears(12), today.minusYears(11))
+        insertGroupPlacement(child.id, leftCareTenYearsAgo)
+        sendMessage(
+            sentAt =
+                HelsinkiDateTime.of(leftCareTenYearsAgo.start.plusDays(1), LocalTime.of(12, 0)),
+            type = MessageType.MESSAGE,
+        )
+
+        withLimit(1000) {
+            dataRemovalService.deleteExpiredData(db, clock, AsyncJob.DeleteExpiredData)
+        }
+
+        assertEquals(1, rowCount("message_thread"))
+        assertEquals(1, rowCount("message_content"))
     }
 
     private fun insertApplication(childId: ChildId = child.id): ApplicationId =

--- a/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
+++ b/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
@@ -10,8 +10,10 @@ import evaka.core.DataRemovalEnv
 import evaka.core.caseprocess.deleteCaseProcesses
 import evaka.core.childimages.deleteImageFile
 import evaka.core.document.childdocument.deleteExpiredChildDocuments
+import evaka.core.messaging.DeletedMessageThreadBatch
 import evaka.core.messaging.deleteExpiredBulletinThreads
 import evaka.core.messaging.deleteExpiredMessageDrafts
+import evaka.core.messaging.deleteMessageThreadsOfExpiredChildren
 import evaka.core.s3.DocumentKey
 import evaka.core.s3.DocumentService
 import evaka.core.shared.ApplicationId
@@ -143,6 +145,13 @@ class DataRemovalService(
             dbc,
             now,
             expireDate = today.minusYears(10),
+            limit = limit,
+        )
+
+        deleteMessageThreadsOfExpiredChildren(
+            dbc,
+            now,
+            expiredChildIdsQuery = expiredChildIdsQuery(),
             limit = limit,
         )
 
@@ -355,9 +364,44 @@ class DataRemovalService(
         limit: Int,
     ) {
         logger.info { "Deleting at most $limit expired bulletin threads" }
+        val deletedCount =
+            deleteMessageThreads(
+                dbc,
+                now,
+                auditMeta =
+                    mapOf(
+                        "expireDate" to expiresBefore.toLocalDate(),
+                        "recipientExpireDate" to recipientExpireDate,
+                    ),
+            ) { tx ->
+                tx.deleteExpiredBulletinThreads(recipientExpireDate, expiresBefore, limit)
+            }
+        logger.info { "Deleted $deletedCount expired bulletin thread(s)" }
+    }
+
+    fun deleteMessageThreadsOfExpiredChildren(
+        dbc: Database.Connection,
+        now: HelsinkiDateTime,
+        expiredChildIdsQuery: QuerySql,
+        limit: Int,
+    ) {
+        logger.info { "Deleting at most $limit message threads of expired children" }
+        val deletedCount =
+            deleteMessageThreads(dbc, now) { tx ->
+                tx.deleteMessageThreadsOfExpiredChildren(expiredChildIdsQuery, limit)
+            }
+        logger.info { "Deleted $deletedCount message thread(s) of expired children" }
+    }
+
+    private fun deleteMessageThreads(
+        dbc: Database.Connection,
+        now: HelsinkiDateTime,
+        auditMeta: Map<String, Any?> = emptyMap(),
+        deleteBatch: (Database.Transaction) -> DeletedMessageThreadBatch,
+    ): Int {
         val deleted = dbc.transaction { tx ->
             tx.setStatementTimeout(Duration.ofMinutes(10))
-            val batch = tx.deleteExpiredBulletinThreads(recipientExpireDate, expiresBefore, limit)
+            val batch = deleteBatch(tx)
             asyncJobRunner.plan(
                 tx = tx,
                 payloads =
@@ -368,28 +412,21 @@ class DataRemovalService(
             )
             batch
         }
-        logger.info { "Deleted ${deleted.threadIds.size} expired bulletin thread(s)" }
-        val expireDate = expiresBefore.toLocalDate()
-        deleted.threadIds.forEach { threadId ->
+        deleted.threads.forEach { thread ->
             auditExpiredDelete(
                 entity = "message_thread",
-                targetId = AuditId(threadId),
-                meta =
-                    mapOf("expireDate" to expireDate, "recipientExpireDate" to recipientExpireDate),
+                targetId = AuditId(thread.threadId),
+                meta = auditMeta + ("childIds" to thread.childIds),
             )
         }
         deleted.contents.forEach { content ->
             auditExpiredDelete(
                 entity = "message_content",
                 targetId = AuditId(content.contentId),
-                meta =
-                    mapOf(
-                        "attachmentIds" to content.attachmentIds,
-                        "expireDate" to expireDate,
-                        "recipientExpireDate" to recipientExpireDate,
-                    ),
+                meta = auditMeta + ("attachmentIds" to content.attachmentIds),
             )
         }
+        return deleted.threads.size
     }
 
     fun deleteExpiredMessageDrafts(
@@ -1090,3 +1127,9 @@ HAVING max(p.end_date) < ${bind(date)}
 """
     )
 }
+
+/**
+ * Selects the ids of the children whose data can be removed altogether. The rule that decides this
+ * is not known yet, so no child expires.
+ */
+private fun expiredChildIdsQuery() = QuerySql { sql("SELECT id FROM child WHERE FALSE") }

--- a/service/src/main/kotlin/evaka/core/messaging/MessageDataRemovalQueries.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageDataRemovalQueries.kt
@@ -5,38 +5,61 @@
 package evaka.core.messaging
 
 import evaka.core.shared.AttachmentId
+import evaka.core.shared.ChildId
 import evaka.core.shared.MessageContentId
 import evaka.core.shared.MessageDraftId
 import evaka.core.shared.MessageThreadId
 import evaka.core.shared.db.Database
+import evaka.core.shared.db.Predicate
+import evaka.core.shared.db.QuerySql
 import evaka.core.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
 
-data class DeletedBulletinContent(
+data class DeletedThreadContent(
     val contentId: MessageContentId,
     val attachmentIds: List<AttachmentId>,
 )
 
-data class DeletedBulletinThreadBatch(
-    val threadIds: List<MessageThreadId>,
-    val contents: List<DeletedBulletinContent>,
+data class DeletedMessageThread(val threadId: MessageThreadId, val childIds: List<ChildId>)
+
+data class DeletedMessageThreadBatch(
+    val threads: List<DeletedMessageThread>,
+    val contents: List<DeletedThreadContent>,
 )
 
 data class DeletedMessageDraft(val draftId: MessageDraftId, val attachmentIds: List<AttachmentId>)
+
+/**
+ * A thread that an application still references survives its own retention rules. Removing an
+ * expired application clears the application link of its threads and cascades away the notes that
+ * copy the messages, which is what eventually satisfies this predicate.
+ */
+private val unreferencedByApplication = Predicate {
+    where(
+        """
+$it.application_id IS NULL AND
+NOT EXISTS (
+    SELECT 1
+    FROM message m
+    JOIN application_note an ON an.message_content_id = m.content_id
+    WHERE m.thread_id = $it.id
+)
+"""
+    )
+}
 
 fun Database.Transaction.deleteExpiredBulletinThreads(
     recipientExpireDate: LocalDate,
     expiresBefore: HelsinkiDateTime,
     limit: Int,
-): DeletedBulletinThreadBatch {
+): DeletedMessageThreadBatch {
     // A municipal bulletin shares one thread across a whole area or unit and records no children at
     // all, so it has no placement to expire by and falls to the age limit instead.
     //
     // A staff copy shares its content with the bulletin it copies. A copy is deleted as soon as the
     // original bulletin is gone, which takes one further round.
     //
-    // Bulletins linked to an application exist only because of an earlier bug. Those bulletins are
-    // deleted after the application is expired and deleted.
+    // Bulletins linked to an application exist only because of an earlier bug.
     val threadIds = createQuery {
         sql(
             """
@@ -50,7 +73,7 @@ LEFT JOIN LATERAL (
 ) recipients ON true
 WHERE
     mt.message_type = 'BULLETIN' AND
-    mt.application_id IS NULL AND
+    ${predicate(unreferencedByApplication.forTable("mt"))} AND
     CASE
         WHEN mt.is_copy THEN NOT EXISTS (
             SELECT 1
@@ -68,13 +91,7 @@ WHERE
                 FROM message m
                 WHERE m.thread_id = mt.id AND m.created >= ${bind(expiresBefore)}
             )
-    END AND
-    NOT EXISTS (
-        SELECT 1
-        FROM message m
-        JOIN application_note an ON an.message_content_id = m.content_id
-        WHERE m.thread_id = mt.id
-    )
+    END
 LIMIT ${bind(limit)}
 FOR UPDATE OF mt
 """
@@ -82,7 +99,69 @@ FOR UPDATE OF mt
     }
         .toList<MessageThreadId>()
 
-    if (threadIds.isEmpty()) return DeletedBulletinThreadBatch(emptyList(), emptyList())
+    return deleteMessageThreads(threadIds)
+}
+
+/**
+ * Deletes every thread, of any message type, whose children have all expired. A thread of several
+ * children survives until the last of them expires, because the whole conversation is also part of
+ * the data of the children who are still retained.
+ *
+ * A thread that records no children at all - a municipal bulletin, a staff copy, or a message of
+ * the service worker or the finance account - has nothing to expire by and is left to the rules of
+ * its own message type.
+ *
+ * A thread of an application, or one whose content an application note references, is kept even
+ * when its children have expired, until the application itself is expired and deleted.
+ */
+fun Database.Transaction.deleteMessageThreadsOfExpiredChildren(
+    expiredChildIdsQuery: QuerySql,
+    limit: Int,
+): DeletedMessageThreadBatch {
+    val threadIds = createQuery {
+        sql(
+            """
+WITH expired_child (id) AS (
+    ${subquery(expiredChildIdsQuery)}
+), expired_child_thread AS (
+    SELECT DISTINCT mtc.thread_id
+    FROM message_thread_children mtc
+    JOIN expired_child ec ON ec.id = mtc.child_id
+)
+SELECT mt.id
+FROM expired_child_thread ect
+JOIN message_thread mt ON mt.id = ect.thread_id
+WHERE
+    NOT EXISTS (
+        SELECT 1
+        FROM message_thread_children mtc
+        WHERE
+            mtc.thread_id = mt.id AND
+            NOT EXISTS (SELECT 1 FROM expired_child ec WHERE ec.id = mtc.child_id)
+    ) AND
+    ${predicate(unreferencedByApplication.forTable("mt"))}
+LIMIT ${bind(limit)}
+FOR UPDATE OF mt
+"""
+        )
+    }
+        .toList<MessageThreadId>()
+
+    return deleteMessageThreads(threadIds)
+}
+
+private fun Database.Transaction.deleteMessageThreads(
+    threadIds: List<MessageThreadId>
+): DeletedMessageThreadBatch {
+    if (threadIds.isEmpty()) return DeletedMessageThreadBatch(emptyList(), emptyList())
+
+    val childIdsByThread = createQuery {
+        sql(
+            "SELECT thread_id, child_id FROM message_thread_children WHERE thread_id = ANY(${bind(threadIds)})"
+        )
+    }
+        .toList { columnPair<MessageThreadId, ChildId>("thread_id", "child_id") }
+        .groupBy({ it.first }, { it.second })
 
     val contentIds = createQuery {
         sql("SELECT DISTINCT content_id FROM message WHERE thread_id = ANY(${bind(threadIds)})")
@@ -91,8 +170,8 @@ FOR UPDATE OF mt
 
     execute { sql("DELETE FROM message_thread WHERE id = ANY(${bind(threadIds)})") }
 
-    return DeletedBulletinThreadBatch(
-        threadIds = threadIds,
+    return DeletedMessageThreadBatch(
+        threads = threadIds.map { DeletedMessageThread(it, childIdsByThread[it] ?: emptyList()) },
         contents = deleteUnreferencedMessageContents(contentIds),
     )
 }
@@ -103,7 +182,7 @@ FOR UPDATE OF mt
  */
 private fun Database.Transaction.deleteUnreferencedMessageContents(
     contentIds: List<MessageContentId>
-): List<DeletedBulletinContent> {
+): List<DeletedThreadContent> {
     if (contentIds.isEmpty()) return emptyList()
 
     val deletableIds = createQuery {
@@ -133,7 +212,7 @@ WHERE
 
     execute { sql("DELETE FROM message_content WHERE id = ANY(${bind(deletableIds)})") }
 
-    return deletableIds.map { DeletedBulletinContent(it, attachmentsByContent[it] ?: emptyList()) }
+    return deletableIds.map { DeletedThreadContent(it, attachmentsByContent[it] ?: emptyList()) }
 }
 
 fun Database.Transaction.deleteExpiredMessageDrafts(


### PR DESCRIPTION
- Kun lapsen tiedot vanhenevat, lapseen liittyvät viestiketjut poistetaan kokonaan: huoltajien ja henkilökunnan väliset keskustelut (esim. VEO, johtaja tai ryhmän henkilökunta) molempiin suuntiin, liitteineen.
- Palveluohjauksen ja talouden viesteissä ei ole lasta suoraan tallennettu, ja niitä ei poisteta tämän PR:n myötä.
- Useampaa lasta koskeva ketju säilyy siihen asti, kunnes viimeisenkin lapsen tiedot vanhenevat.
- Vielä on määrittelemättä, mitkä ovat lapsen tietojen vanhenemisen ehdot.