### PR TITLE
Huomioidaan kalenterin aukiolo loma-ajan varauksessa ja kyselyssä tulevalle sijoitukselle

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
@@ -229,6 +229,63 @@ class HolidayPeriodControllerCitizenIntegrationTest :
     }
 
     @Test
+    fun `active questionnaire is eligible for a child with a future placement when the calendar is already open`() {
+        db.transaction { tx ->
+            tx.insertGuardian(parent.id, child2.id)
+            tx.insert(
+                DevPlacement(
+                    childId = child2.id,
+                    unitId = daycare.id,
+                    startDate =
+                        mockToday.plusDays(
+                            citizenCalendarEnv.calendarOpenBeforePlacementDays.toLong()
+                        ),
+                    endDate = mockToday.plusYears(1),
+                )
+            )
+        }
+        createFixedPeriodQuestionnaire(freePeriodQuestionnaire)
+
+        val response = getActiveQuestionnaires(mockToday)
+
+        assertEquals(1, response.size)
+        assertThat(response[0].eligibleChildren)
+            .containsExactlyInAnyOrderEntriesOf(
+                mapOf(
+                    child1.id to freePeriodQuestionnaire.periodOptions,
+                    child2.id to freePeriodQuestionnaire.periodOptions,
+                )
+            )
+    }
+
+    @Test
+    fun `active questionnaire is not eligible for a child with a future placement when the calendar is not yet open`() {
+        db.transaction { tx ->
+            tx.insertGuardian(parent.id, child2.id)
+            tx.insert(
+                DevPlacement(
+                    childId = child2.id,
+                    unitId = daycare.id,
+                    startDate =
+                        mockToday.plusDays(
+                            citizenCalendarEnv.calendarOpenBeforePlacementDays.toLong() + 1
+                        ),
+                    endDate = mockToday.plusYears(1),
+                )
+            )
+        }
+        createFixedPeriodQuestionnaire(freePeriodQuestionnaire)
+
+        val response = getActiveQuestionnaires(mockToday)
+
+        assertEquals(1, response.size)
+        assertThat(response[0].eligibleChildren)
+            .containsExactlyInAnyOrderEntriesOf(
+                mapOf(child1.id to freePeriodQuestionnaire.periodOptions)
+            )
+    }
+
+    @Test
     fun `questionnaire answer is saved and returned with active questionnaire`() {
         val id = createFixedPeriodQuestionnaire(freePeriodQuestionnaire.copy())
 
@@ -624,6 +681,35 @@ class HolidayPeriodControllerCitizenIntegrationTest :
 
         val absences = db.read { it.getAllAbsences() }
         assertThat(absences.map { it.childId }.toSet()).containsExactly(child1.id)
+    }
+
+    @Test
+    fun `open ranges submission is rejected for a child with a future placement when the calendar is not yet open`() {
+        db.transaction { tx ->
+            tx.insertGuardian(parent.id, child2.id)
+            tx.insert(
+                DevPlacement(
+                    childId = child2.id,
+                    unitId = daycare.id,
+                    startDate =
+                        mockToday.plusDays(
+                            citizenCalendarEnv.calendarOpenBeforePlacementDays.toLong() + 1
+                        ),
+                    endDate = mockToday.plusYears(1),
+                )
+            )
+        }
+
+        val id = createOpenRangesQuestionnaire(freeRangesQuestionnaire)
+        val range =
+            FiniteDateRange(
+                freeRangesQuestionnaire.period.start,
+                freeRangesQuestionnaire.period.start.plusDays(40),
+            )
+
+        assertThrows<BadRequest> {
+            reportFreeRanges(id, OpenRangesBody(mapOf(child2.id to listOf(range))))
+        }
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizenIntegrationTest.kt
@@ -229,6 +229,43 @@ class HolidayPeriodControllerCitizenIntegrationTest :
     }
 
     @Test
+    fun `active questionnaire is eligible for a child whose placement in a private voucher value unit has ended`() {
+        db.transaction { tx ->
+            tx.insertGuardian(parent.id, child4.id)
+            tx.insert(voucherDaycare)
+            tx.insert(
+                DevPlacement(
+                    childId = child4.id,
+                    unitId = voucherDaycare.id,
+                    startDate = mockToday.minusYears(2),
+                    endDate = mockToday.minusDays(1),
+                )
+            )
+            tx.insert(
+                DevPlacement(
+                    childId = child4.id,
+                    unitId = daycare.id,
+                    startDate = mockToday,
+                    endDate = mockToday.plusYears(1),
+                )
+            )
+        }
+
+        createFixedPeriodQuestionnaire(freePeriodQuestionnaire)
+
+        val response = getActiveQuestionnaires(mockToday)
+
+        assertEquals(1, response.size)
+        assertThat(response[0].eligibleChildren)
+            .containsExactlyInAnyOrderEntriesOf(
+                mapOf(
+                    child1.id to freePeriodQuestionnaire.periodOptions,
+                    child4.id to freePeriodQuestionnaire.periodOptions,
+                )
+            )
+    }
+
+    @Test
     fun `active questionnaire is eligible for a child with a future placement when the calendar is already open`() {
         db.transaction { tx ->
             tx.insertGuardian(parent.id, child2.id)

--- a/service/src/integrationTest/kotlin/evaka/core/placement/PlacementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/placement/PlacementControllerIntegrationTest.kt
@@ -115,6 +115,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
         AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
 
     private val citizenReservationThresholdHours: Long = 150
+    private val calendarOpenBeforePlacementDays = 30
 
     @BeforeEach
     fun setUp() {
@@ -330,6 +331,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
                     DailyReservationRequest.Absent(childId = childId, date = fourthAbsence),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -442,6 +444,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -539,6 +542,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
                     DailyReservationRequest.Absent(childId = childId, date = fourthAbsence),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -632,6 +636,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -710,6 +715,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
                     DailyReservationRequest.Absent(childId = childId, date = fourthAbsence),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -790,6 +796,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -866,6 +873,7 @@ class PlacementControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 

--- a/service/src/integrationTest/kotlin/evaka/core/reservations/CreateReservationsAndAbsencesTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/reservations/CreateReservationsAndAbsencesTest.kt
@@ -74,6 +74,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
     private val queryRange = FiniteDateRange(monday.minusDays(10), monday.plusDays(10))
 
     private val citizenReservationThresholdHours = 150L
+    private val calendarOpenBeforePlacementDays = 30
     private val beforeThreshold = HelsinkiDateTime.of(monday.minusDays(7), LocalTime.of(12, 0))
     private val afterThreshold = HelsinkiDateTime.of(monday.minusDays(7), LocalTime.of(21, 0))
 
@@ -144,6 +145,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -203,6 +205,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -250,6 +253,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -293,6 +297,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -342,6 +347,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -407,6 +413,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     )
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -457,6 +464,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                 AuditContext(),
                 listOf(DailyReservationRequest.Absent(childId = child.id, date = monday)),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -507,6 +515,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                 AuditContext(),
                 listOf(DailyReservationRequest.Absent(childId = child.id, date = monday)),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -572,6 +581,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     )
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -630,6 +640,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     DailyReservationRequest.Nothing(childId = child.id, date = tuesday),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -710,6 +721,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
                 true,
             )
         }
@@ -799,6 +811,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     DailyReservationRequest.Nothing(childId = child.id, date = wednesday),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -872,6 +885,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     DailyReservationRequest.Nothing(childId = child.id, date = wednesday),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -922,6 +936,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -940,6 +955,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     )
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -993,6 +1009,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                 AuditContext(),
                 listOf(DailyReservationRequest.Present(childId = child.id, date = monday)),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1054,6 +1071,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                         ),
                     ),
                     citizenReservationThresholdHours,
+                    calendarOpenBeforePlacementDays,
                 )
             }
 
@@ -1097,6 +1115,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     DailyReservationRequest.Present(childId = child.id, date = holidayPeriodStart)
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1153,6 +1172,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1213,6 +1233,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                         )
                     ),
                     citizenReservationThresholdHours,
+                    calendarOpenBeforePlacementDays,
                 )
             }
         }
@@ -1232,6 +1253,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                         )
                     ),
                     citizenReservationThresholdHours,
+                    calendarOpenBeforePlacementDays,
                 )
             }
         }
@@ -1303,6 +1325,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1359,6 +1382,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     DailyReservationRequest.Present(childId = child.id, date = holidayPeriodStart)
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1412,6 +1436,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     DailyReservationRequest.Nothing(childId = child.id, date = holidayPeriodStart)
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1477,6 +1502,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     )
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1542,6 +1568,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     )
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1608,6 +1635,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1675,6 +1703,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1771,6 +1800,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     DailyReservationRequest.Reservations(child.id, date, timeRange)
                 },
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
                 plannedAbsenceEnabledForHourBasedServiceNeeds = true,
             )
         }
@@ -1836,6 +1866,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     DailyReservationRequest.Reservations(child.id, date, timeRange)
                 },
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
                 plannedAbsenceEnabledForHourBasedServiceNeeds = true,
             )
         }
@@ -1922,6 +1953,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                 AuditContext(),
                 listOf(DailyReservationRequest.Reservations(child.id, monday, preschoolTime)),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -1985,6 +2017,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     DailyReservationRequest.Reservations(child.id, monday, veryShortReservation)
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -2066,6 +2099,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 
@@ -2136,6 +2170,7 @@ class CreateReservationsAndAbsencesTest : PureJdbiTest(resetDbBeforeEach = true)
                     ),
                 ),
                 citizenReservationThresholdHours,
+                calendarOpenBeforePlacementDays,
             )
         }
 

--- a/service/src/integrationTest/kotlin/evaka/core/reservations/ReservationControllerCitizenIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/reservations/ReservationControllerCitizenIntegrationTest.kt
@@ -1510,7 +1510,8 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                     )
                 }
 
-            // Placement starts after reservation deadline => holiday period has no effect
+            // Placement starts after the reservation deadline, but the citizen calendar is
+            // already open for it => holiday period has an effect until the deadline has passed
             tx.insert(
                     DevPlacement(
                         type = PlacementType.DAYCARE,
@@ -1555,7 +1556,14 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                             reservationsOpenOn = tuesday,
                                         ),
                                 ),
-                                dayChild(child2.id, holidayPeriodEffect = null),
+                                dayChild(
+                                    child2.id,
+                                    holidayPeriodEffect =
+                                        HolidayPeriodEffect.NotYetReservable(
+                                            period = FiniteDateRange(thursday, thursday),
+                                            reservationsOpenOn = tuesday,
+                                        ),
+                                ),
                             )
                             .sortedBy { it.childId },
                 )
@@ -1580,7 +1588,10 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
                                     child1.id,
                                     holidayPeriodEffect = HolidayPeriodEffect.ReservationsOpen,
                                 ),
-                                dayChild(child2.id, holidayPeriodEffect = null),
+                                dayChild(
+                                    child2.id,
+                                    holidayPeriodEffect = HolidayPeriodEffect.ReservationsOpen,
+                                ),
                             )
                             .sortedBy { it.childId },
                 )
@@ -1612,6 +1623,67 @@ class ReservationControllerCitizenIntegrationTest : FullApplicationTest(resetDbB
             ),
             resOnThursday.days,
         )
+    }
+
+    @Test
+    fun `citizen can make a reservation without times for a child whose placement starts after the reservation deadline`() {
+        val area = DevCareArea()
+        val daycare =
+            DevDaycare(areaId = area.id, enabledPilotFeatures = setOf(PilotFeature.RESERVATIONS))
+
+        val adult = DevPerson()
+        val child = DevPerson(dateOfBirth = LocalDate.of(2017, 1, 1))
+
+        val placementStart = monday.plusWeeks(5)
+        // The citizen calendar opens for the placement exactly on the reservation deadline
+        val reservationDeadline =
+            placementStart.minusDays(citizenCalendarEnv.calendarOpenBeforePlacementDays.toLong())
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(daycare)
+
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, child.id)
+
+            tx.insert(
+                DevHolidayPeriod(
+                    period = FiniteDateRange(placementStart, placementStart),
+                    reservationsOpenOn = tuesday,
+                    reservationDeadline = reservationDeadline,
+                )
+            )
+
+            tx.insert(
+                DevPlacement(
+                    type = PlacementType.DAYCARE,
+                    childId = child.id,
+                    unitId = daycare.id,
+                    startDate = placementStart,
+                    endDate = placementStart,
+                )
+            )
+        }
+
+        postReservations(
+            adult.user(CitizenAuthLevel.STRONG),
+            listOf(DailyReservationRequest.Present(childId = child.id, date = placementStart)),
+            mockNow = HelsinkiDateTime.of(reservationDeadline, LocalTime.of(12, 0)),
+        )
+
+        val reservations = db.read {
+            it.getReservationsCitizen(
+                reservationDeadline,
+                adult.id,
+                FiniteDateRange(placementStart, placementStart),
+            )
+        }
+        assertEquals(1, reservations.size)
+        reservations.first().let {
+            assertEquals(placementStart, it.date)
+            assertEquals(Reservation.NoTimes, it.reservation)
+        }
     }
 
     @Test

--- a/service/src/main/kotlin/evaka/core/holidayperiod/HolidayPeriod.kt
+++ b/service/src/main/kotlin/evaka/core/holidayperiod/HolidayPeriod.kt
@@ -44,11 +44,23 @@ data class HolidayPeriod(
     fun effect(
         today: LocalDate,
         reservationEnabledPlacementRanges: List<ReservationEnabledPlacementRange>,
-    ): HolidayPeriodEffect? =
-        when {
-            reservationEnabledPlacementRanges.none {
-                it.range.overlaps(FiniteDateRange(reservationsOpenOn, reservationDeadline))
-            } -> {
+        calendarOpenBeforePlacementDays: Int,
+    ): HolidayPeriodEffect? {
+        // No effect unless a placement was active during the reservation period. Before the
+        // deadline, placements starting in the near future also count if the citizen calendar
+        // is already open for them (it opens calendarOpenBeforePlacementDays before the
+        // placement starts). After the deadline they no longer count, so a child who could not
+        // answer in time is free to make normal reservations instead of being locked.
+        val relevantPeriod =
+            if (today <= reservationDeadline)
+                FiniteDateRange(
+                    reservationsOpenOn,
+                    reservationDeadline.plusDays(calendarOpenBeforePlacementDays.toLong()),
+                )
+            else FiniteDateRange(reservationsOpenOn, reservationDeadline)
+
+        return when {
+            reservationEnabledPlacementRanges.none { it.range.overlaps(relevantPeriod) } -> {
                 null
             }
 
@@ -80,6 +92,7 @@ data class HolidayPeriod(
                 }
             }
         }
+    }
 }
 
 data class HolidayPeriodCreate(

--- a/service/src/main/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -381,6 +381,20 @@ class HolidayPeriodControllerCitizen(
                 } else {
                     tx.getUserChildIds(date, user.id)
                 }
+                .let { children ->
+                    // The questionnaire can only be answered for children whose citizen calendar
+                    // is already open (it opens calendarOpenBeforePlacementDays before the
+                    // placement starts)
+                    val childrenWithCalendarOpen =
+                        tx.getChildIdsWithPlacementInRange(
+                            children,
+                            FiniteDateRange(
+                                date,
+                                date.plusDays(calendarOpenBeforePlacementDays.toLong()),
+                            ),
+                        )
+                    children.filter { it in childrenWithCalendarOpen }
+                }
                 .filter { childId ->
                     tx.getPlacementsForChildDuring(childId, date, date).none { placement ->
                         tx.getDaycare(placement.unitId)?.providerType ==
@@ -417,19 +431,8 @@ class HolidayPeriodControllerCitizen(
                         PlacementType.invoiced,
                         questionnaire.period,
                     )
-                val childrenWithPlacementInWindow =
-                    tx.getChildIdsWithPlacementInRange(
-                        eligibleChildren,
-                        FiniteDateRange(
-                            date,
-                            date.plusDays(calendarOpenBeforePlacementDays.toLong()),
-                        ),
-                    )
                 eligibleChildren
-                    .filter { childId ->
-                        placementRangesByChild[childId]?.isNotEmpty() == true &&
-                            childId in childrenWithPlacementInWindow
-                    }
+                    .filter { childId -> placementRangesByChild[childId]?.isNotEmpty() == true }
                     .associateWith { listOf(questionnaire.period) }
             }
         }

--- a/service/src/main/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/holidayperiod/HolidayPeriodControllerCitizen.kt
@@ -13,13 +13,12 @@ import evaka.core.absence.FullDayAbsenseUpsert
 import evaka.core.absence.clearOldCitizenEditableAbsences
 import evaka.core.absence.upsertFullDayAbsences
 import evaka.core.daycare.Daycare
-import evaka.core.daycare.domain.ProviderType
-import evaka.core.daycare.getDaycare
 import evaka.core.daycare.getDaycaresById
 import evaka.core.daycare.isUnitOperationDay
 import evaka.core.placement.Placement
 import evaka.core.placement.PlacementType
 import evaka.core.placement.getChildIdsWithPlacementInRange
+import evaka.core.placement.getChildIdsWithVoucherPlacementAt
 import evaka.core.placement.getConsecutivePlacementRanges
 import evaka.core.placement.getPlacementsForChildDuring
 import evaka.core.reservations.clearOldReservations
@@ -374,51 +373,52 @@ class HolidayPeriodControllerCitizen(
         questionnaire: HolidayQuestionnaire,
         calendarOpenBeforePlacementDays: Int,
     ): Map<ChildId, List<FiniteDateRange>> {
-        val continuousPlacementPeriod = questionnaire.conditions.continuousPlacement
-        val eligibleChildren =
-            if (continuousPlacementPeriod != null) {
-                    tx.getChildrenWithContinuousPlacement(date, user.id, continuousPlacementPeriod)
-                } else {
-                    tx.getUserChildIds(date, user.id)
-                }
-                .let { children ->
-                    // The questionnaire can only be answered for children whose citizen calendar
-                    // is already open (it opens calendarOpenBeforePlacementDays before the
-                    // placement starts)
-                    val childrenWithCalendarOpen =
-                        tx.getChildIdsWithPlacementInRange(
-                            children,
-                            FiniteDateRange(
-                                date,
-                                date.plusDays(calendarOpenBeforePlacementDays.toLong()),
-                            ),
-                        )
-                    children.filter { it in childrenWithCalendarOpen }
-                }
-                .filter { childId ->
-                    tx.getPlacementsForChildDuring(childId, date, date).none { placement ->
-                        tx.getDaycare(placement.unitId)?.providerType ==
-                            ProviderType.PRIVATE_SERVICE_VOUCHER
-                    }
-                }
-        return when (questionnaire) {
+        val userChildren =
+            when (val continuousPlacement = questionnaire.conditions.continuousPlacement) {
+                null -> tx.getUserChildIds(date, user.id)
+                else -> tx.getChildrenWithContinuousPlacement(date, user.id, continuousPlacement)
+            }
+
+        // The questionnaire can only be answered for children whose citizen calendar is already
+        // open (it opens calendarOpenBeforePlacementDays before the placement starts)
+        val childrenWithCalendarOpen =
+            tx.getChildIdsWithPlacementInRange(
+                userChildren,
+                FiniteDateRange(date, date.plusDays(calendarOpenBeforePlacementDays.toLong())),
+            )
+
+        // Holiday questionnaires are only used by the municipality units
+        val childrenWithVoucherPlacement =
+            tx.getChildIdsWithVoucherPlacementAt(childrenWithCalendarOpen, date)
+        val childrenWithoutVoucherPlacement = childrenWithCalendarOpen.filterNot {
+            it in childrenWithVoucherPlacement
+        }
+
+        return getAnswerablePeriods(tx, questionnaire, childrenWithoutVoucherPlacement)
+    }
+
+    private fun getAnswerablePeriods(
+        tx: Database.Read,
+        questionnaire: HolidayQuestionnaire,
+        children: List<ChildId>,
+    ): Map<ChildId, List<FiniteDateRange>> =
+        when (questionnaire) {
             is HolidayQuestionnaire.FixedPeriodQuestionnaire -> {
                 val periodOptions = questionnaire.periodOptions
-                val min = periodOptions.minOf { it.start }
-                val max = periodOptions.maxOf { it.end }
                 val placementRangesByChild =
                     tx.getConsecutivePlacementRanges(
-                        eligibleChildren,
+                        children,
                         PlacementType.invoiced,
-                        FiniteDateRange(min, max),
+                        FiniteDateRange(
+                            periodOptions.minOf { it.start },
+                            periodOptions.maxOf { it.end },
+                        ),
                     )
-                eligibleChildren
+                children
                     .mapNotNull { childId ->
                         placementRangesByChild[childId]?.let { placementRanges ->
-                            val dates = periodOptions.filter { option ->
-                                placementRanges.contains(option)
-                            }
-                            if (dates.isNotEmpty()) childId to dates else null
+                            val options = periodOptions.filter { placementRanges.contains(it) }
+                            if (options.isNotEmpty()) childId to options else null
                         }
                     }
                     .toMap()
@@ -427,16 +427,15 @@ class HolidayPeriodControllerCitizen(
             is HolidayQuestionnaire.OpenRangesQuestionnaire -> {
                 val placementRangesByChild =
                     tx.getConsecutivePlacementRanges(
-                        eligibleChildren,
+                        children,
                         PlacementType.invoiced,
                         questionnaire.period,
                     )
-                eligibleChildren
+                children
                     .filter { childId -> placementRangesByChild[childId]?.isNotEmpty() == true }
                     .associateWith { listOf(questionnaire.period) }
             }
         }
-    }
 
     private fun upsertAbsences(
         tx: Database.Transaction,

--- a/service/src/main/kotlin/evaka/core/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/evaka/core/placement/PlacementQueries.kt
@@ -117,6 +117,23 @@ WHERE child_id = ANY(${bind(childIds)}) AND daterange(start_date, end_date, '[]'
 }
     .toSet<ChildId>()
 
+fun Database.Read.getChildIdsWithVoucherPlacementAt(
+    childIds: Collection<ChildId>,
+    date: LocalDate,
+): Set<ChildId> = createQuery {
+    sql(
+        """
+SELECT DISTINCT p.child_id
+FROM placement p
+JOIN daycare d ON d.id = p.unit_id
+WHERE p.child_id = ANY(${bind(childIds)})
+  AND daterange(p.start_date, p.end_date, '[]') @> ${bind(date)}
+  AND d.provider_type = 'PRIVATE_SERVICE_VOUCHER'
+"""
+    )
+}
+    .toSet<ChildId>()
+
 fun Database.Read.getPlacementsForChildrenAt(
     childIds: Set<ChildId>,
     date: LocalDate,

--- a/service/src/main/kotlin/evaka/core/reservations/AttendanceReservationController.kt
+++ b/service/src/main/kotlin/evaka/core/reservations/AttendanceReservationController.kt
@@ -7,6 +7,7 @@ package evaka.core.reservations
 import evaka.core.Audit
 import evaka.core.AuditContext
 import evaka.core.AuditId
+import evaka.core.CitizenCalendarEnv
 import evaka.core.EvakaEnv
 import evaka.core.absence.AbsenceCategory
 import evaka.core.absence.AbsenceType
@@ -79,6 +80,7 @@ class AttendanceReservationController(
     private val ac: AccessControl,
     private val featureConfig: FeatureConfig,
     private val env: EvakaEnv,
+    private val citizenCalendarEnv: CitizenCalendarEnv,
 ) {
     @GetMapping("/employee/attendance-reservations")
     fun getAttendanceReservations(
@@ -328,6 +330,7 @@ class AttendanceReservationController(
                         audit,
                         body,
                         featureConfig.citizenReservationThresholdHours,
+                        citizenCalendarEnv.calendarOpenBeforePlacementDays,
                         env.plannedAbsenceEnabledForHourBasedServiceNeeds,
                     )
                 }

--- a/service/src/main/kotlin/evaka/core/reservations/ReservationControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/reservations/ReservationControllerCitizen.kt
@@ -236,6 +236,8 @@ class ReservationControllerCitizen(
                                                                     today,
                                                                     reservationEnabledPlacementRangesByChild[
                                                                         child.id]!!,
+                                                                    citizenCalendarEnv
+                                                                        .calendarOpenBeforePlacementDays,
                                                                 ),
                                                         )
                                                     }
@@ -292,6 +294,7 @@ class ReservationControllerCitizen(
                         audit,
                         body,
                         featureConfig.citizenReservationThresholdHours,
+                        citizenCalendarEnv.calendarOpenBeforePlacementDays,
                         env.plannedAbsenceEnabledForHourBasedServiceNeeds,
                     )
                 }

--- a/service/src/main/kotlin/evaka/core/reservations/Reservations.kt
+++ b/service/src/main/kotlin/evaka/core/reservations/Reservations.kt
@@ -198,6 +198,7 @@ fun createReservationsAndAbsences(
     audit: AuditContext,
     requests: List<DailyReservationRequest>,
     citizenReservationThresholdHours: Long,
+    calendarOpenBeforePlacementDays: Int,
     plannedAbsenceEnabledForHourBasedServiceNeeds: Boolean = false,
 ) {
     if (requests.isEmpty()) return
@@ -246,7 +247,11 @@ fun createReservationsAndAbsences(
         val reservationEnabledPlacementRanges =
             reservationEnabledPlacementRangesByChild[req.childId]
         if (holidayPeriod != null && reservationEnabledPlacementRanges != null) {
-            holidayPeriod.effect(today, reservationEnabledPlacementRanges)
+            holidayPeriod.effect(
+                today,
+                reservationEnabledPlacementRanges,
+                calendarOpenBeforePlacementDays,
+            )
         } else {
             null
         }

--- a/service/src/main/kotlin/evaka/core/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/evaka/core/shared/dev/DevApi.kt
@@ -6,6 +6,7 @@ package evaka.core.shared.dev
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import evaka.core.AuditContext
+import evaka.core.CitizenCalendarEnv
 import evaka.core.EvakaEnv
 import evaka.core.ExcludeCodeGen
 import evaka.core.Sensitive
@@ -219,6 +220,7 @@ class DevApi(
     private val decisionService: DecisionService,
     private val documentClient: DocumentService,
     private val env: EvakaEnv,
+    private val citizenCalendarEnv: CitizenCalendarEnv,
     private val emailMessageProvider: IEmailMessageProvider,
     private val invoiceGenerator: InvoiceGenerator,
     private val featureConfig: FeatureConfig,
@@ -1071,6 +1073,7 @@ UPDATE placement SET end_date = ${bind(req.endDate)}, termination_requested_date
                     AuditContext(),
                     body,
                     featureConfig.citizenReservationThresholdHours,
+                    citizenCalendarEnv.calendarOpenBeforePlacementDays,
                     plannedAbsenceEnabledForHourBasedServiceNeeds = true,
                 )
             }

--- a/service/src/test/kotlin/evaka/core/holidayperiod/HolidayPeriodTest.kt
+++ b/service/src/test/kotlin/evaka/core/holidayperiod/HolidayPeriodTest.kt
@@ -24,16 +24,30 @@ class HolidayPeriodTest {
             reservationDeadline,
         )
 
+    private val calendarOpenBeforePlacementDays = 30
+
     private val jan1 = LocalDate.of(2024, 1, 1)
     private val dec31 = LocalDate.of(2024, 12, 31)
     private val wholeYear =
         ReservationEnabledPlacementRange(created = jan1, range = FiniteDateRange(jan1, dec31))
 
+    // Placement starts after the reservation deadline, but the citizen calendar opens for it
+    // during the reservation period (start - calendarOpenBeforePlacementDays <= deadline)
+    private val futurePlacementWithCalendarOpenDuringReservationPeriod =
+        ReservationEnabledPlacementRange(
+            created = jan1,
+            range = FiniteDateRange(reservationDeadline.plusDays(10), dec31),
+        )
+
     @Test
     fun `not yet reservable`() {
         assertEquals(
             HolidayPeriodEffect.NotYetReservable(period, reservationsOpenOn),
-            holidayPeriod.effect(reservationsOpenOn.minusDays(1), listOf(wholeYear)),
+            holidayPeriod.effect(
+                reservationsOpenOn.minusDays(1),
+                listOf(wholeYear),
+                calendarOpenBeforePlacementDays,
+            ),
         )
     }
 
@@ -41,7 +55,11 @@ class HolidayPeriodTest {
     fun `reservations open`() {
         assertEquals(
             HolidayPeriodEffect.ReservationsOpen,
-            holidayPeriod.effect(reservationsOpenOn, listOf(wholeYear)),
+            holidayPeriod.effect(
+                reservationsOpenOn,
+                listOf(wholeYear),
+                calendarOpenBeforePlacementDays,
+            ),
         )
     }
 
@@ -49,13 +67,24 @@ class HolidayPeriodTest {
     fun `reservations closed`() {
         assertEquals(
             HolidayPeriodEffect.ReservationsClosed,
-            holidayPeriod.effect(reservationDeadline.plusDays(1), listOf(wholeYear)),
+            holidayPeriod.effect(
+                reservationDeadline.plusDays(1),
+                listOf(wholeYear),
+                calendarOpenBeforePlacementDays,
+            ),
         )
     }
 
     @Test
     fun `no placements - no effect`() {
-        assertEquals(null, holidayPeriod.effect(reservationDeadline.plusDays(1), emptyList()))
+        assertEquals(
+            null,
+            holidayPeriod.effect(
+                reservationDeadline.plusDays(1),
+                emptyList(),
+                calendarOpenBeforePlacementDays,
+            ),
+        )
     }
 
     @Test
@@ -74,6 +103,7 @@ class HolidayPeriodTest {
                         range = FiniteDateRange(reservationDeadline.plusDays(1), dec31),
                     ),
                 ),
+                calendarOpenBeforePlacementDays,
             ),
         )
     }
@@ -94,6 +124,7 @@ class HolidayPeriodTest {
                         range = FiniteDateRange(period.start.plusDays(3), period.end),
                     ),
                 ),
+                calendarOpenBeforePlacementDays,
             ),
         )
     }
@@ -115,6 +146,54 @@ class HolidayPeriodTest {
                         range = FiniteDateRange(period.start.plusDays(4), period.end),
                     ),
                 ),
+                calendarOpenBeforePlacementDays,
+            ),
+        )
+    }
+
+    @Test
+    fun `calendar open for future placement during reservation period - reservations open`() {
+        assertEquals(
+            HolidayPeriodEffect.ReservationsOpen,
+            holidayPeriod.effect(
+                reservationsOpenOn,
+                listOf(futurePlacementWithCalendarOpenDuringReservationPeriod),
+                calendarOpenBeforePlacementDays,
+            ),
+        )
+    }
+
+    @Test
+    fun `calendar not yet open for future placement during reservation period - no effect`() {
+        assertEquals(
+            null,
+            holidayPeriod.effect(
+                reservationsOpenOn,
+                listOf(
+                    ReservationEnabledPlacementRange(
+                        created = jan1,
+                        range =
+                            FiniteDateRange(
+                                reservationDeadline.plusDays(
+                                    calendarOpenBeforePlacementDays.toLong() + 1
+                                ),
+                                dec31,
+                            ),
+                    )
+                ),
+                calendarOpenBeforePlacementDays,
+            ),
+        )
+    }
+
+    @Test
+    fun `calendar open for future placement during reservation period - no effect after deadline`() {
+        assertEquals(
+            null,
+            holidayPeriod.effect(
+                reservationDeadline.plusDays(1),
+                listOf(futurePlacementWithCalendarOpenDuringReservationPeriod),
+                calendarOpenBeforePlacementDays,
             ),
         )
     }


### PR DESCRIPTION
Muutetaan loma-ajan varausta siten, että läsnä/poissa-valinta näkyy kyselyssä oikein lapselle jonka sijoitus on tulevaisuudessa, mutta kalenteri on auki jo varausaikana. Varausajan jälkeen aloittavalle lapselle voidaan tehdä tarkkoja varauksia kyselyn jälkeen. Muutetaan myös kyselyn ja notifikaation näyttämistä siten, että ne näytetään vain kun lapsen kalenteri on auki.