### PR TITLE
Korjaus läsnäolovarauksiin lomakaudella

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/absence/AbsenceControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/absence/AbsenceControllerIntegrationTest.kt
@@ -294,6 +294,47 @@ class AbsenceControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach =
     }
 
     @Test
+    fun `deleting absences does not add holiday reservations when the placement type does not require them`() {
+        // PRESCHOOL is not in requiringAttendanceReservations, so it must never get a reservation
+        val preschoolChild = DevPerson()
+        val startDate = today
+        val endDate = today.plusDays(3)
+        db.transaction { tx ->
+            tx.insertHolidayPeriod(
+                period = FiniteDateRange(startDate, endDate),
+                reservationsOpenOn = today,
+                reservationDeadline = today,
+            )
+
+            tx.insert(preschoolChild, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    type = PlacementType.PRESCHOOL,
+                    childId = preschoolChild.id,
+                    unitId = daycare.id,
+                    startDate = today,
+                    endDate = today.plusYears(1),
+                )
+            )
+        }
+
+        addPresences(
+            FiniteDateRange(startDate, endDate)
+                .dates()
+                .map { date ->
+                    Presence(
+                        childId = preschoolChild.id,
+                        date = date,
+                        category = AbsenceCategory.NONBILLABLE,
+                    )
+                }
+                .toList()
+        )
+
+        assertEquals(emptyList<Reservation>(), getAllReservations())
+    }
+
+    @Test
     fun `deleting holiday reservations deletes reservations and absences`() {
         //                   0 1 2 3
         // holiday period:   - x x x

--- a/service/src/main/kotlin/evaka/core/absence/AbsenceQueries.kt
+++ b/service/src/main/kotlin/evaka/core/absence/AbsenceQueries.kt
@@ -200,6 +200,12 @@ INSERT INTO attendance_reservation (child_id, date, start_time, end_time, create
 SELECT ${bind { it.childId }}, ${bind { it.date }}, NULL, NULL, ${bind(createdBy)}
 WHERE
     EXISTS (SELECT 1 FROM holiday_period WHERE period @> ${bind { it.date }}) AND
+    EXISTS (
+        SELECT 1 FROM placement pl
+        WHERE pl.child_id = ${bind { it.childId }}
+        AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind { it.date }}
+        AND pl.type = ANY(${bind(PlacementType.requiringAttendanceReservations)})
+    ) AND
     NOT EXISTS (SELECT 1 FROM attendance_reservation WHERE child_id = ${bind { it.childId }} AND date = ${bind { it.date }})
 RETURNING id
 """


### PR DESCRIPTION
Seuraavien ehtojen täyttyessä:
- Ryhmän kalenterista tehdään merkintä "Ei poissaoloa"
- Lapsella on sijoitustyyppi, joka ei vaadi läsnäolovarauksia
- Merkinnän päivä on lomakautena

Ennen muutosta lapselle tehtiin virheellisesti läsnäolovaraus. Tämä on korjattu, ja muutoksen jälkeen läsnäolovarausta ei enää tehdä.