### PR TITLE
Kuntalaisen asiakirjat -raportti huomioi sijoitusta edeltävän lähetysikkunan

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/reports/CitizenDocumentReportTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/reports/CitizenDocumentReportTest.kt
@@ -388,6 +388,7 @@ class CitizenDocumentReportTest : FullApplicationTest(resetDbBeforeEach = true) 
                     contentLockedAt = mockClock.now(),
                     modifiedAt = mockClock.now(),
                     modifiedBy = admin.evakaUserId,
+                    statusModifiedAt = mockClock.now(),
                     answeredAt = mockClock.now(),
                     contentLockedBy = admin.id,
                     answeredBy = admin.evakaUserId,
@@ -404,7 +405,9 @@ class CitizenDocumentReportTest : FullApplicationTest(resetDbBeforeEach = true) 
             val aapoEarlierResponse =
                 aapoLatestResponse.copy(
                     id = ChildDocumentId(UUID.randomUUID()),
+                    createdAt = mockClock.now().minusDays(1),
                     contentLockedAt = mockClock.now().minusDays(1),
+                    statusModifiedAt = mockClock.now().minusDays(1),
                     answeredAt = mockClock.now().minusDays(1),
                     content = negativeDocumentContent,
                 )
@@ -643,6 +646,59 @@ class CitizenDocumentReportTest : FullApplicationTest(resetDbBeforeEach = true) 
                     answeredBy = null,
                 )
 
+            // Test case Heidi:
+            // placed in group A1, an older unanswered document and a newer answered one
+            val testChildHeidi =
+                DevPerson(
+                    dateOfBirth = start.minusYears(4),
+                    firstName = "Heidi",
+                    lastName = "Hakala",
+                )
+            tx.insert(testChildHeidi, DevPersonType.CHILD)
+            val placementH =
+                DevPlacement(
+                    type = PlacementType.DAYCARE,
+                    childId = testChildHeidi.id,
+                    unitId = daycareData.first.id,
+                    startDate = defaultPlacementDuration.start,
+                    endDate = defaultPlacementDuration.end,
+                )
+            tx.insert(placementH)
+            tx.insert(
+                DevDaycareGroupPlacement(
+                    daycarePlacementId = placementH.id,
+                    daycareGroupId = daycareData.second.first().id,
+                    startDate = placementH.startDate,
+                    endDate = placementH.endDate,
+                )
+            )
+
+            val heidiUnansweredAt = mockClock.now().minusDays(30)
+            val heidiUnansweredResponse =
+                aapoLatestResponse.copy(
+                    id = ChildDocumentId(UUID.randomUUID()),
+                    childId = testChildHeidi.id,
+                    status = DocumentStatus.CITIZEN_DRAFT,
+                    content = negativeDocumentContent.copy(answers = emptyList()),
+                    createdAt = heidiUnansweredAt,
+                    statusModifiedAt = heidiUnansweredAt,
+                    contentLockedAt = heidiUnansweredAt,
+                    answeredAt = null,
+                    answeredBy = null,
+                )
+
+            val heidiAnsweredAt = mockClock.now().minusDays(5)
+            val heidiAnsweredResponse =
+                aapoLatestResponse.copy(
+                    id = ChildDocumentId(UUID.randomUUID()),
+                    childId = testChildHeidi.id,
+                    content = affirmativeDocumentContent,
+                    createdAt = heidiAnsweredAt,
+                    statusModifiedAt = heidiAnsweredAt,
+                    contentLockedAt = heidiAnsweredAt,
+                    answeredAt = heidiAnsweredAt,
+                )
+
             // Test case Demetrius
             // placed in group B1, backup placement to A1, no document sent
             val testChildDemetrius =
@@ -689,6 +745,8 @@ class CitizenDocumentReportTest : FullApplicationTest(resetDbBeforeEach = true) 
                     eemeliResponse,
                     fanniResponse,
                     gretaResponse,
+                    heidiUnansweredResponse,
+                    heidiAnsweredResponse,
                 )
                 .forEach { tx.insert(it) }
 
@@ -699,6 +757,7 @@ class CitizenDocumentReportTest : FullApplicationTest(resetDbBeforeEach = true) 
                 Pair(testChildEemeli, eemeliResponse),
                 Pair(testChildFanni, null),
                 Pair(testChildGreta, gretaResponse),
+                Pair(testChildHeidi, heidiAnsweredResponse),
                 Pair(testChildDemetrius, null),
             )
         }

--- a/service/src/integrationTest/kotlin/evaka/core/reports/CitizenDocumentReportTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/reports/CitizenDocumentReportTest.kt
@@ -6,6 +6,7 @@ package evaka.core.reports
 
 import evaka.core.FullApplicationTest
 import evaka.core.daycare.CareType
+import evaka.core.document.CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT
 import evaka.core.document.ChildDocumentType
 import evaka.core.document.DocumentTemplate
 import evaka.core.document.DocumentTemplateContent
@@ -380,6 +381,7 @@ class CitizenDocumentReportTest : FullApplicationTest(resetDbBeforeEach = true) 
             val aapoLatestResponse =
                 DevChildDocument(
                     templateId = template.id,
+                    createdAt = mockClock.now(),
                     childId = testChildAapo.id,
                     status = DocumentStatus.COMPLETED,
                     content = affirmativeDocumentContent,
@@ -445,7 +447,7 @@ class CitizenDocumentReportTest : FullApplicationTest(resetDbBeforeEach = true) 
                 )
 
             // Test case Cecil:
-            // placed in group A1, 2 answers, latest (false, Radio 2)
+            // placed in group A1, split placement, answered during the earlier row
             val testChildCecil =
                 DevPerson(
                     dateOfBirth = start.minusYears(4),
@@ -489,15 +491,156 @@ class CitizenDocumentReportTest : FullApplicationTest(resetDbBeforeEach = true) 
                 )
             )
 
-            val cecilOutdatedResponse =
+            val cecilEarlierPlacementResponse =
                 aapoLatestResponse.copy(
                     id = ChildDocumentId(UUID.randomUUID()),
                     childId = testChildCecil.id,
                     content = affirmativeDocumentContent,
+                    createdAt =
+                        HelsinkiDateTime.of(placementC1.startDate.plusDays(1).atStartOfDay()),
+                    statusModifiedAt =
+                        HelsinkiDateTime.of(placementC1.startDate.plusDays(1).atStartOfDay()),
                     contentLockedAt =
                         HelsinkiDateTime.of(placementC1.startDate.plusDays(1).atStartOfDay()),
                     answeredAt =
                         HelsinkiDateTime.of(placementC1.startDate.plusDays(1).atStartOfDay()),
+                )
+
+            // Test case Eemeli:
+            // placed in group A1, sent at the edge of the creation window, no answer
+            val testChildEemeli =
+                DevPerson(
+                    dateOfBirth = start.minusYears(4),
+                    firstName = "Eemeli",
+                    lastName = "Eskola",
+                )
+            tx.insert(testChildEemeli, DevPersonType.CHILD)
+            val placementE =
+                DevPlacement(
+                    type = PlacementType.DAYCARE,
+                    childId = testChildEemeli.id,
+                    unitId = daycareData.first.id,
+                    startDate = defaultPlacementDuration.start,
+                    endDate = defaultPlacementDuration.end,
+                )
+            tx.insert(placementE)
+            tx.insert(
+                DevDaycareGroupPlacement(
+                    daycarePlacementId = placementE.id,
+                    daycareGroupId = daycareData.second.first().id,
+                    startDate = placementE.startDate,
+                    endDate = placementE.endDate,
+                )
+            )
+
+            val eemeliCreatedAt =
+                HelsinkiDateTime.of(
+                    placementE.startDate
+                        .minusDays(CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT.toLong())
+                        .atStartOfDay()
+                )
+            val eemeliResponse =
+                aapoLatestResponse.copy(
+                    id = ChildDocumentId(UUID.randomUUID()),
+                    childId = testChildEemeli.id,
+                    status = DocumentStatus.CITIZEN_DRAFT,
+                    content = negativeDocumentContent.copy(answers = emptyList()),
+                    createdAt = eemeliCreatedAt,
+                    statusModifiedAt = eemeliCreatedAt,
+                    contentLockedAt = eemeliCreatedAt,
+                    answeredAt = null,
+                    answeredBy = null,
+                )
+
+            // Test case Fanni:
+            // placed in group A1, answered one day before the creation window opened
+            val testChildFanni =
+                DevPerson(
+                    dateOfBirth = start.minusYears(4),
+                    firstName = "Fanni",
+                    lastName = "Forsberg",
+                )
+            tx.insert(testChildFanni, DevPersonType.CHILD)
+            val placementF =
+                DevPlacement(
+                    type = PlacementType.DAYCARE,
+                    childId = testChildFanni.id,
+                    unitId = daycareData.first.id,
+                    startDate = defaultPlacementDuration.start,
+                    endDate = defaultPlacementDuration.end,
+                )
+            tx.insert(placementF)
+            tx.insert(
+                DevDaycareGroupPlacement(
+                    daycarePlacementId = placementF.id,
+                    daycareGroupId = daycareData.second.first().id,
+                    startDate = placementF.startDate,
+                    endDate = placementF.endDate,
+                )
+            )
+
+            val fanniCreatedAt =
+                HelsinkiDateTime.of(
+                    placementF.startDate
+                        .minusDays(CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT + 1L)
+                        .atStartOfDay()
+                )
+            val fanniResponse =
+                aapoLatestResponse.copy(
+                    id = ChildDocumentId(UUID.randomUUID()),
+                    childId = testChildFanni.id,
+                    content = affirmativeDocumentContent,
+                    createdAt = fanniCreatedAt,
+                    statusModifiedAt = fanniCreatedAt,
+                    contentLockedAt = fanniCreatedAt,
+                    answeredAt = fanniCreatedAt,
+                )
+
+            // Test case Greta:
+            // placed in group A1, created before the creation window but sent inside it
+            val testChildGreta =
+                DevPerson(
+                    dateOfBirth = start.minusYears(4),
+                    firstName = "Greta",
+                    lastName = "Grönlund",
+                )
+            tx.insert(testChildGreta, DevPersonType.CHILD)
+            val placementG =
+                DevPlacement(
+                    type = PlacementType.DAYCARE,
+                    childId = testChildGreta.id,
+                    unitId = daycareData.first.id,
+                    startDate = defaultPlacementDuration.start,
+                    endDate = defaultPlacementDuration.end,
+                )
+            tx.insert(placementG)
+            tx.insert(
+                DevDaycareGroupPlacement(
+                    daycarePlacementId = placementG.id,
+                    daycareGroupId = daycareData.second.first().id,
+                    startDate = placementG.startDate,
+                    endDate = placementG.endDate,
+                )
+            )
+
+            val gretaCreatedAt =
+                HelsinkiDateTime.of(
+                    placementG.startDate
+                        .minusDays(CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT + 30L)
+                        .atStartOfDay()
+                )
+            val gretaSentAt = HelsinkiDateTime.of(placementG.startDate.minusDays(30).atStartOfDay())
+            val gretaResponse =
+                aapoLatestResponse.copy(
+                    id = ChildDocumentId(UUID.randomUUID()),
+                    childId = testChildGreta.id,
+                    status = DocumentStatus.CITIZEN_DRAFT,
+                    content = negativeDocumentContent.copy(answers = emptyList()),
+                    createdAt = gretaCreatedAt,
+                    statusModifiedAt = gretaSentAt,
+                    contentLockedAt = gretaCreatedAt,
+                    answeredAt = null,
+                    answeredBy = null,
                 )
 
             // Test case Demetrius
@@ -538,13 +681,24 @@ class CitizenDocumentReportTest : FullApplicationTest(resetDbBeforeEach = true) 
                 )
             )
 
-            listOf(aapoEarlierResponse, aapoLatestResponse, bertilResponse, cecilOutdatedResponse)
+            listOf(
+                    aapoEarlierResponse,
+                    aapoLatestResponse,
+                    bertilResponse,
+                    cecilEarlierPlacementResponse,
+                    eemeliResponse,
+                    fanniResponse,
+                    gretaResponse,
+                )
                 .forEach { tx.insert(it) }
 
             listOf(
                 Pair(testChildAapo, aapoLatestResponse),
                 Pair(testChildBertil, bertilResponse),
-                Pair(testChildCecil, null),
+                Pair(testChildCecil, cecilEarlierPlacementResponse),
+                Pair(testChildEemeli, eemeliResponse),
+                Pair(testChildFanni, null),
+                Pair(testChildGreta, gretaResponse),
                 Pair(testChildDemetrius, null),
             )
         }

--- a/service/src/main/kotlin/evaka/core/reports/CitizenDocumentResponseReport.kt
+++ b/service/src/main/kotlin/evaka/core/reports/CitizenDocumentResponseReport.kt
@@ -205,8 +205,8 @@ LEFT JOIN LATERAL (
     WHERE cd.child_id = pl.child_id
       AND cd.template_id = ${bind(documentTemplateId)}
       AND (cd.status = 'COMPLETED' OR cd.status = 'CITIZEN_DRAFT')
-      AND GREATEST(cd.created_at, cd.status_modified_at)::date >= pl.start_date - ${bind(CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT)}
-    ORDER BY cd.answered_at DESC, cd.created_at DESC
+      AND cd.status_modified_at::date >= pl.start_date - ${bind(CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT)}
+    ORDER BY cd.status_modified_at DESC, cd.created_at DESC, cd.id DESC
     LIMIT 1) latest_doc ON true
 WHERE rp.group_id = ANY (${bind(groupIds)})
         """

--- a/service/src/main/kotlin/evaka/core/reports/CitizenDocumentResponseReport.kt
+++ b/service/src/main/kotlin/evaka/core/reports/CitizenDocumentResponseReport.kt
@@ -10,6 +10,7 @@ import evaka.core.daycare.DaycareGroup
 import evaka.core.daycare.getDaycare
 import evaka.core.daycare.getDaycareGroups
 import evaka.core.daycare.isValidDaycareId
+import evaka.core.document.CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT
 import evaka.core.document.DocumentTemplateContent
 import evaka.core.document.childdocument.DocumentContent
 import evaka.core.document.childdocument.DocumentStatus
@@ -204,7 +205,7 @@ LEFT JOIN LATERAL (
     WHERE cd.child_id = pl.child_id
       AND cd.template_id = ${bind(documentTemplateId)}
       AND (cd.status = 'COMPLETED' OR cd.status = 'CITIZEN_DRAFT')
-      AND daterange(pl.start_date, pl.end_date, '[]') @> cd.content_locked_at::date
+      AND GREATEST(cd.created_at, cd.status_modified_at)::date >= pl.start_date - ${bind(CITIZEN_DOCUMENT_CREATION_DAYS_BEFORE_PLACEMENT)}
     ORDER BY cd.answered_at DESC, cd.created_at DESC
     LIMIT 1) latest_doc ON true
 WHERE rp.group_id = ANY (${bind(groupIds)})


### PR DESCRIPTION
Kuntalaisen asiakirjat -raportilla luki "Ei lähetettyä asiakirjaa" myös silloin, kun asiakirja oli lähetetty huoltajalle ja vastattu.

Raportin haussa asiakirjalta katsottiin `content_locked_at`-kentän sisältöä, joka ei muutu esim tilanteessa jossa asiakirja lähetetään huoltajalle. Toisena ehtona oli aikaikkunan alaraja, joka oli sijoituksen aloituspäivämäärä - tähän lisättiin sama vakion arvo (60pv) jonka verran aikaisemmin asiakirjoja voi lähettää ennen sijoitusta -> tulevat nyt myös tälle raportille.

Aiemmin kun ehto ei osunut, kyselyn LEFT JOIN LATERAL tuotti tyhjän tuloksen, ja käyttöliittymä tulosti oletushaarasta tekstin "Ei lähetettyä asiakirjaa". Teksti tarkoitti siis pikemminkin "asiakirjaa ei löytynyt näillä ehdoilla" (koska aikaikkunasta puuttui osa alusta), kuin "asiakirjaa ei ole lähetetty".

Ehto käyttää nyt `content_locked_at`in sijaan myöhempää kahdesta: `created_at`, joka on se muuttumaton aikaleima jota luonnin tarkistus katsoo, ja `status_modified_at`, joka päivittyy kun asiakirja lähetetään huoltajalle tai vastataan. Asiakirja kelpaa siis jos se on luotu tälle sijoitukselle tai edennyt työnkulussa sen aikana. Jälkimmäinen kattaa tapauksen, jossa "edellisellä kierroksella" luotu asiakirja lähetetään tai siihen vastataan vasta nyt.