### PR TITLE
Korjataan poissaolokyselyn alustuminen vanhalla datalla

### DIFF
--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -14,10 +14,12 @@ import { constantQuery, useQueryResult } from 'lib-common/query'
 import Main from 'lib-components/atoms/Main'
 import { ContentArea } from 'lib-components/layout/Container'
 import { Desktop, RenderOnlyOn } from 'lib-components/layout/responsive-layout'
+import BaseModal from 'lib-components/molecules/modals/BaseModal'
 import { Gap } from 'lib-components/white-space'
 import { featureFlags } from 'lib-customizations/citizen'
 
 import Footer from '../Footer'
+import ModalAccessibilityWrapper from '../ModalAccessibilityWrapper'
 import RequireAuth from '../RequireAuth'
 import { renderResult, UnwrapResult } from '../async-rendering'
 import { useUser } from '../auth/state'
@@ -163,6 +165,10 @@ const CalendarPage = React.memo(function CalendarPage() {
   }, [data])
 
   if (!user || !user.accessibleFeatures.reservations) return null
+
+  const holidayQuestionnairePlaceholder = () => (
+    <HolidayModalPlaceholder close={closeModal} result={questionnaireResult} />
+  )
 
   return (
     <>
@@ -319,7 +325,11 @@ const CalendarPage = React.memo(function CalendarPage() {
                   />
                 )}
               {modalState?.type === 'holidays' && (
-                <UnwrapResult result={questionnaireResult}>
+                <UnwrapResult
+                  result={questionnaireResult}
+                  loading={holidayQuestionnairePlaceholder}
+                  failure={holidayQuestionnairePlaceholder}
+                >
                   {(questionnaire) =>
                     questionnaire ? (
                       <RequireAuth
@@ -359,6 +369,28 @@ const CalendarPage = React.memo(function CalendarPage() {
         }
       )}
     </>
+  )
+})
+
+const HolidayModalPlaceholder = React.memo(function HolidayModalPlaceholder({
+  close,
+  result
+}: {
+  close: () => void
+  result: Result<unknown>
+}) {
+  const i18n = useTranslation()
+  return (
+    <ModalAccessibilityWrapper>
+      <BaseModal
+        title=""
+        close={close}
+        closeLabel={i18n.common.closeModal}
+        mobileFullScreen
+      >
+        <UnwrapResult result={result} />
+      </BaseModal>
+    </ModalAccessibilityWrapper>
   )
 })
 

--- a/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
+++ b/frontend/src/citizen-frontend/calendar/CalendarPage.tsx
@@ -10,7 +10,7 @@ import { combine, isLoading } from 'lib-common/api'
 import FiniteDateRange from 'lib-common/finite-date-range'
 import type { CitizenCalendarEvent } from 'lib-common/generated/api-types/calendarevent'
 import LocalDate from 'lib-common/local-date'
-import { useQuery, useQueryResult } from 'lib-common/query'
+import { constantQuery, useQueryResult } from 'lib-common/query'
 import Main from 'lib-components/atoms/Main'
 import { ContentArea } from 'lib-components/layout/Container'
 import { Desktop, RenderOnlyOn } from 'lib-components/layout/responsive-layout'
@@ -19,7 +19,7 @@ import { featureFlags } from 'lib-customizations/citizen'
 
 import Footer from '../Footer'
 import RequireAuth from '../RequireAuth'
-import { renderResult } from '../async-rendering'
+import { renderResult, UnwrapResult } from '../async-rendering'
 import { useUser } from '../auth/state'
 import { useTranslation } from '../localization'
 import useTitle from '../useTitle'
@@ -136,7 +136,11 @@ const CalendarPage = React.memo(function CalendarPage() {
     [holidayPeriods]
   )
 
-  const { data: questionnaire } = useQuery(activeQuestionnaireQuery())
+  const questionnaireResult = useQueryResult(
+    modalState?.type === 'holidays'
+      ? activeQuestionnaireQuery()
+      : constantQuery(null)
+  )
 
   const firstReservableDate = useMemo(() => {
     if (data.isSuccess) {
@@ -314,34 +318,41 @@ const CalendarPage = React.memo(function CalendarPage() {
                     )}
                   />
                 )}
-              {modalState?.type === 'holidays' && questionnaire && (
-                <RequireAuth
-                  strength={
-                    questionnaire.questionnaire.requiresStrongAuth
-                      ? 'STRONG'
-                      : 'WEAK'
+              {modalState?.type === 'holidays' && (
+                <UnwrapResult result={questionnaireResult}>
+                  {(questionnaire) =>
+                    questionnaire ? (
+                      <RequireAuth
+                        strength={
+                          questionnaire.questionnaire.requiresStrongAuth
+                            ? 'STRONG'
+                            : 'WEAK'
+                        }
+                      >
+                        {questionnaire.questionnaire.type === 'FIXED_PERIOD' ? (
+                          <FixedPeriodSelectionModal
+                            close={closeModal}
+                            questionnaire={questionnaire.questionnaire}
+                            availableChildren={response.children}
+                            eligibleChildren={questionnaire.eligibleChildren}
+                            previousAnswers={questionnaire.previousAnswers}
+                          />
+                        ) : questionnaire.questionnaire.type ===
+                          'OPEN_RANGES' ? (
+                          <OpenRangesSelectionModal
+                            close={closeModal}
+                            questionnaire={questionnaire.questionnaire}
+                            availableChildren={response.children}
+                            eligibleChildren={questionnaire.eligibleChildren}
+                            previousAnswers={questionnaire.previousAnswers}
+                          />
+                        ) : (
+                          <div>Not Yet Implemented</div>
+                        )}
+                      </RequireAuth>
+                    ) : null
                   }
-                >
-                  {questionnaire.questionnaire.type === 'FIXED_PERIOD' ? (
-                    <FixedPeriodSelectionModal
-                      close={closeModal}
-                      questionnaire={questionnaire.questionnaire}
-                      availableChildren={response.children}
-                      eligibleChildren={questionnaire.eligibleChildren}
-                      previousAnswers={questionnaire.previousAnswers}
-                    />
-                  ) : questionnaire.questionnaire.type === 'OPEN_RANGES' ? (
-                    <OpenRangesSelectionModal
-                      close={closeModal}
-                      questionnaire={questionnaire.questionnaire}
-                      availableChildren={response.children}
-                      eligibleChildren={questionnaire.eligibleChildren}
-                      previousAnswers={questionnaire.previousAnswers}
-                    />
-                  ) : (
-                    <div>Not Yet Implemented</div>
-                  )}
-                </RequireAuth>
+                </UnwrapResult>
               )}
             </div>
           )

--- a/frontend/src/citizen-frontend/calendar/queries.ts
+++ b/frontend/src/citizen-frontend/calendar/queries.ts
@@ -61,10 +61,12 @@ export const deleteCalendarEventTimeReservationMutation = q.mutation(
 
 export const holidayPeriodsQuery = q.query(getHolidayPeriods)
 
-export const activeQuestionnaireQuery = q.query(() =>
-  getActiveQuestionnaires().then((questionnaires) =>
-    questionnaires.length > 0 ? questionnaires[0] : null
-  )
+export const activeQuestionnaireQuery = q.query(
+  () =>
+    getActiveQuestionnaires().then((questionnaires) =>
+      questionnaires.length > 0 ? questionnaires[0] : null
+    ),
+  { refetchOnWindowFocus: false, refetchOnReconnect: false }
 )
 
 export const answerFixedPeriodQuestionnaireMutation = q.mutation(

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts
@@ -314,7 +314,7 @@ test.describe('Holiday periods and questionnaires', () => {
       await assertFreeAbsences(false)
     })
 
-    test('Holidays can be marked an cleared for two children', async () => {
+    test('Holidays can be marked and cleared for two children', async () => {
       const calendar = new CitizenCalendarPage(page, 'desktop')
 
       const child2 = await setupAnotherChild()


### PR DESCRIPTION
Korjaa [epävakaan testin](https://github.com/espoon-voltti/evaka/blob/f1dc0a9ab2e87faf4516202c574b30a9dac288ba/frontend/src/e2e-test/specs/0_citizen/citizen-holiday-reservations.spec.ts#L317). Tallennuksen jälkeen vanhat queryt invalidoituu, mutta (lähinnä testeissä) heti tallennuksen jälkeen avattu modaali saattoi alustua vanhalla datalla. Korjauksena tilataan kysely vain, kun modaali on auki, ja renderöidään sisältö `UnwrapResult`illa.