### PR TITLE
Muutetaan "puuttuvat tulotiedot"-raportin rajaussääntöjä

### DIFF
--- a/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/fi.tsx
@@ -4010,7 +4010,7 @@ export const fi = {
     incompleteIncomes: {
       title: 'Puuttuvat tulotiedot',
       description:
-        'Raportti vanhemmista, joiden tulotiedot ovat vanhentuneet, mutta lapsella on vielä sijoitus aktiivinen.',
+        'Raportti aikuisista, joiden tulotiedot ovat vanhentuneet ja joiden perheessä lapsella on voimassa oleva maksullinen sijoitus. Raportilla ei näytetä aikuisia, joiden samassa taloudessa asuva puoliso on antanut suostumuksen korkeimpaan maksuun.',
       validFrom: 'Alkupäivämäärä',
       fullName: 'Nimi',
       daycareName: 'Päiväkoti',

--- a/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/employee/i18n/sv.tsx
@@ -4044,7 +4044,7 @@ export const sv: typeof fi = {
     incompleteIncomes: {
       title: 'Saknade inkomstuppgifter',
       description:
-        'Rapport över föräldrar vars inkomstuppgifter har föråldrats, men barnet har fortfarande en aktiv placering.',
+        'Rapport över vuxna vars inkomstuppgifter har föråldrats och vars familj har ett barn med en gällande avgiftsbelagd placering. Vuxna vars make/maka eller sambo i samma hushåll har gett sitt samtycke till högsta avgiften visas inte i rapporten.',
       validFrom: 'Startdatum',
       fullName: 'Namn',
       daycareName: 'Daghem',

--- a/service/src/integrationTest/kotlin/evaka/core/reports/IncompleteIncomeReportTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/reports/IncompleteIncomeReportTest.kt
@@ -5,158 +5,336 @@
 package evaka.core.reports
 
 import evaka.core.PureJdbiTest
+import evaka.core.daycare.domain.ProviderType
 import evaka.core.invoicing.domain.IncomeEffect
+import evaka.core.placement.PlacementType
+import evaka.core.serviceneed.ServiceNeedOption
+import evaka.core.shared.ChildId
+import evaka.core.shared.DaycareId
+import evaka.core.shared.IncomeId
+import evaka.core.shared.PlacementId
+import evaka.core.shared.ServiceNeedOptionId
 import evaka.core.shared.auth.AuthenticatedUser
+import evaka.core.shared.db.Database
 import evaka.core.shared.dev.DevCareArea
 import evaka.core.shared.dev.DevDaycare
 import evaka.core.shared.dev.DevEmployee
-import evaka.core.shared.dev.DevGuardian
+import evaka.core.shared.dev.DevFridgeChild
+import evaka.core.shared.dev.DevFridgePartnership
 import evaka.core.shared.dev.DevIncome
 import evaka.core.shared.dev.DevPerson
 import evaka.core.shared.dev.DevPersonType
 import evaka.core.shared.dev.DevPlacement
+import evaka.core.shared.dev.DevServiceNeed
 import evaka.core.shared.dev.insert
-import evaka.core.shared.security.PilotFeature
+import evaka.core.shared.dev.insertServiceNeedOption
+import evaka.core.snDaycareFullDay35
+import evaka.core.snDefaultDaycare
+import evaka.core.snDefaultPreschool
+import java.math.BigDecimal
 import java.time.LocalDate
+import java.util.UUID
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class IncompleteIncomeReportTest : PureJdbiTest(resetDbBeforeEach = true) {
+    private val today = LocalDate.of(2024, 10, 20)
+    private val incomeValidFrom = LocalDate.of(2024, 10, 15)
 
-    val testArea = DevCareArea()
-
-    val testDaycare =
+    private val area = DevCareArea()
+    private val daycare = DevDaycare(areaId = area.id)
+    private val nonInvoicedDaycare = DevDaycare(areaId = area.id, invoicedByMunicipality = false)
+    private val voucherDaycare =
         DevDaycare(
-            name = "Test Daycare",
-            areaId = testArea.id,
-            ophOrganizerOid = "1.2.246.562.10.888888888888",
-            enabledPilotFeatures =
-                setOf(
-                    PilotFeature.MESSAGING,
-                    PilotFeature.MOBILE,
-                    PilotFeature.RESERVATIONS,
-                    PilotFeature.PLACEMENT_TERMINATION,
-                ),
-            openingDate = LocalDate.of(2000, 1, 1),
+            areaId = area.id,
+            invoicedByMunicipality = false,
+            providerType = ProviderType.PRIVATE_SERVICE_VOUCHER,
+        )
+    private val employee = DevEmployee()
+    private val headOfChild = DevPerson()
+    private val partner = DevPerson()
+    private val child = DevPerson(dateOfBirth = LocalDate.of(2020, 1, 1))
+    private val snZeroFeeDaycare =
+        snDaycareFullDay35.copy(
+            id = ServiceNeedOptionId(UUID.randomUUID()),
+            nameFi = "Maksuton varhaiskasvatus",
+            feeCoefficient = BigDecimal("0.00"),
         )
 
-    val testDecisionMaker_2 = DevEmployee()
-
-    val testAdult_1 =
-        DevPerson(
-            dateOfBirth = LocalDate.of(1980, 1, 1),
-            ssn = "010180-1232",
-            firstName = "John",
-            lastName = "Doe",
-        )
-
-    val testAdult_2 =
-        DevPerson(
-            dateOfBirth = LocalDate.of(1979, 2, 1),
-            ssn = "010279-123L",
-            firstName = "Joan",
-            lastName = "Doe",
-        )
-
-    val testIncome =
+    private val incompleteIncome =
         DevIncome(
-            personId = testAdult_1.id,
+            personId = headOfChild.id,
             effect = IncomeEffect.INCOMPLETE,
-            validFrom = LocalDate.of(2024, 10, 15),
+            validFrom = incomeValidFrom,
             validTo = null,
             modifiedBy = AuthenticatedUser.SystemInternalUser.evakaUserId,
-        )
-
-    val testIncomeUserEdited =
-        DevIncome(
-            personId = testAdult_1.id,
-            effect = IncomeEffect.INCOMPLETE,
-            validFrom = LocalDate.of(2024, 10, 15),
-            validTo = null,
-            modifiedBy = testDecisionMaker_2.evakaUserId,
-        )
-
-    val children =
-        setOf(
-            DevPerson(
-                dateOfBirth = LocalDate.of(LocalDate.now().year - 5, 6, 1),
-                ssn = "111111-999X",
-                restrictedDetailsEnabled = false,
-            ),
-            DevPerson(
-                dateOfBirth = LocalDate.of(LocalDate.now().year - 4, 7, 1),
-                ssn = "222222-998Y",
-                restrictedDetailsEnabled = false,
-            ),
-            DevPerson(
-                dateOfBirth = LocalDate.of(LocalDate.now().year - 6, 8, 1),
-                ssn = "333333-997Z",
-                restrictedDetailsEnabled = false,
-            ),
         )
 
     @BeforeEach
     fun beforeEach() {
         db.transaction { tx ->
-            tx.insert(testArea)
-            tx.insert(testDaycare)
-            tx.insert(testAdult_1, DevPersonType.RAW_ROW)
-            tx.insert(testAdult_2, DevPersonType.RAW_ROW)
-            children.forEachIndexed { i, it ->
-                tx.insert(it, DevPersonType.CHILD)
-                tx.insert(DevGuardian(guardianId = testAdult_1.id, childId = it.id))
-                if (i % 2 == 1) tx.insert(DevGuardian(guardianId = testAdult_2.id, childId = it.id))
-            }
-        }
-    }
-
-    @Test
-    fun `adults that have expired incomes and children have some placements, are found in report`() {
-        db.transaction { tx ->
-            tx.insert(testIncome)
-            children.forEach {
-                tx.insert(
-                    DevPlacement(
-                        childId = it.id,
-                        unitId = testDaycare.id,
-                        endDate = LocalDate.of(2024, 12, 31),
-                    )
+            tx.insert(area)
+            tx.insert(daycare)
+            tx.insert(nonInvoicedDaycare)
+            tx.insert(voucherDaycare)
+            tx.insert(employee)
+            tx.insert(headOfChild, DevPersonType.RAW_ROW)
+            tx.insert(partner, DevPersonType.RAW_ROW)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insertServiceNeedOption(snDefaultDaycare)
+            tx.insertServiceNeedOption(snDefaultPreschool)
+            tx.insertServiceNeedOption(snDaycareFullDay35)
+            tx.insertServiceNeedOption(snZeroFeeDaycare)
+            tx.insert(
+                DevFridgeChild(
+                    childId = child.id,
+                    headOfChild = headOfChild.id,
+                    startDate = child.dateOfBirth,
+                    endDate = child.dateOfBirth.plusYears(18),
                 )
-            }
+            )
         }
-        val report = getIncompleteIncomeReport(LocalDate.of(2024, 10, 20))
-        assertEquals(1, report.size)
     }
 
     @Test
-    fun `adults that have expired incomes but their children does not have any placements, are not found in report`() {
-        db.transaction { tx -> tx.insert(testIncome) }
-        val report = getIncompleteIncomeReport(LocalDate.of(2024, 10, 20))
-        assertEquals(0, report.size)
-    }
-
-    @Test
-    fun `after editing expired incomes by evaka employee, persons are not found in report`() {
+    fun `head of child and partner with expired income and paid placement are found in report`() {
         db.transaction { tx ->
-            tx.insert(testDecisionMaker_2)
-            tx.insert(testIncomeUserEdited)
-            children.forEach {
-                tx.insert(
-                    DevPlacement(
-                        childId = it.id,
-                        unitId = testDaycare.id,
-                        endDate = LocalDate.of(2024, 12, 31),
-                    )
-                )
-            }
+            tx.insertPartnership()
+            tx.insert(incompleteIncome)
+            tx.insert(
+                incompleteIncome.copy(id = IncomeId(UUID.randomUUID()), personId = partner.id)
+            )
+            tx.insertPlacement()
         }
-        val report = getIncompleteIncomeReport(LocalDate.of(2024, 10, 20))
-        assertEquals(0, report.size)
+        assertEquals(
+            setOf(headOfChild.id, partner.id),
+            getIncompleteIncomeReport().map { it.personId }.toSet(),
+        )
     }
 
-    private fun getIncompleteIncomeReport(date: LocalDate): List<IncompleteIncomeDbRow> {
+    @Test
+    fun `adults whose children do not have any placements are not found in report`() {
+        db.transaction { tx -> tx.insert(incompleteIncome) }
+        assertEquals(0, getIncompleteIncomeReport().size)
+    }
 
-        return db.read { it.getIncompleteReport(date) }
+    @Test
+    fun `placement without service need is not counted if its default option has no fee`() {
+        db.transaction { tx ->
+            tx.insert(incompleteIncome)
+            tx.insertPlacement(type = PlacementType.PRESCHOOL, option = null)
+        }
+        assertEquals(0, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `placement without service need is counted if its default option has a fee`() {
+        db.transaction { tx ->
+            tx.insert(incompleteIncome)
+            tx.insertPlacement(type = PlacementType.DAYCARE, option = null)
+        }
+        assertEquals(1, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `placement that ended yesterday is not counted`() {
+        db.transaction { tx ->
+            tx.insert(incompleteIncome)
+            tx.insertPlacement(endDate = today.minusDays(1))
+        }
+        assertEquals(0, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `service need with a fee that has ended does not make the placement paid`() {
+        db.transaction { tx ->
+            tx.insert(incompleteIncome)
+            val placementId = tx.insertPlacement(option = null)
+            tx.insertServiceNeed(placementId, snDaycareFullDay35, endDate = today.minusDays(1))
+            tx.insertServiceNeed(placementId, snZeroFeeDaycare, startDate = today)
+        }
+        assertEquals(0, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `placement in unit not invoiced by municipality is not counted`() {
+        db.transaction { tx ->
+            tx.insert(incompleteIncome)
+            tx.insertPlacement(unitId = nonInvoicedDaycare.id)
+        }
+        assertEquals(0, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `placement in service voucher unit is counted`() {
+        db.transaction { tx ->
+            tx.insert(incompleteIncome)
+            tx.insertPlacement(unitId = voucherDaycare.id)
+        }
+        assertEquals(1, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `after editing expired income by evaka employee, person is not found in report`() {
+        db.transaction { tx ->
+            tx.insert(
+                incompleteIncome.copy(
+                    id = IncomeId(UUID.randomUUID()),
+                    modifiedBy = employee.evakaUserId,
+                )
+            )
+            tx.insertPlacement()
+        }
+        assertEquals(0, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `head of child without partner is found in report`() {
+        db.transaction { tx ->
+            tx.insert(incompleteIncome)
+            tx.insertPlacement()
+        }
+        assertEquals(1, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `person whose partner has accepted max fee is not found in report`() {
+        db.transaction { tx ->
+            tx.insertPartnership()
+            tx.insert(incompleteIncome)
+            tx.insert(
+                DevIncome(
+                    personId = partner.id,
+                    effect = IncomeEffect.MAX_FEE_ACCEPTED,
+                    validFrom = today.minusYears(1),
+                    validTo = today.minusDays(1),
+                    modifiedBy = employee.evakaUserId,
+                )
+            )
+            tx.insertPlacement()
+        }
+        assertEquals(1, getIncompleteIncomeReport().size)
+
+        db.transaction { tx ->
+            tx.insert(
+                DevIncome(
+                    personId = partner.id,
+                    effect = IncomeEffect.MAX_FEE_ACCEPTED,
+                    validFrom = today,
+                    validTo = null,
+                    modifiedBy = employee.evakaUserId,
+                )
+            )
+        }
+        assertEquals(0, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `partner whose head of child has accepted max fee is not found in report`() {
+        db.transaction { tx ->
+            tx.insertPartnership()
+            tx.insert(
+                incompleteIncome.copy(id = IncomeId(UUID.randomUUID()), personId = partner.id)
+            )
+            tx.insert(
+                DevIncome(
+                    personId = headOfChild.id,
+                    effect = IncomeEffect.MAX_FEE_ACCEPTED,
+                    validFrom = today,
+                    validTo = null,
+                    modifiedBy = employee.evakaUserId,
+                )
+            )
+            tx.insertPlacement()
+        }
+        assertEquals(0, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `income with an end date is not counted`() {
+        db.transaction { tx ->
+            tx.insert(
+                incompleteIncome.copy(
+                    id = IncomeId(UUID.randomUUID()),
+                    validTo = today.plusMonths(1),
+                )
+            )
+            tx.insertPlacement()
+        }
+        assertEquals(0, getIncompleteIncomeReport().size)
+    }
+
+    @Test
+    fun `adult with multiple placed children is reported only once`() {
+        val child2 = DevPerson(dateOfBirth = LocalDate.of(2022, 1, 1))
+        db.transaction { tx ->
+            tx.insert(child2, DevPersonType.CHILD)
+            tx.insert(
+                DevFridgeChild(
+                    childId = child2.id,
+                    headOfChild = headOfChild.id,
+                    startDate = child2.dateOfBirth,
+                    endDate = child2.dateOfBirth.plusYears(18),
+                )
+            )
+            tx.insert(incompleteIncome)
+            tx.insertPlacement()
+            tx.insertPlacement(childId = child2.id)
+        }
+        assertEquals(1, getIncompleteIncomeReport().size)
+    }
+
+    private fun Database.Transaction.insertPartnership() {
+        insert(
+            DevFridgePartnership(
+                first = headOfChild.id,
+                second = partner.id,
+                startDate = child.dateOfBirth,
+            )
+        )
+    }
+
+    private fun Database.Transaction.insertPlacement(
+        unitId: DaycareId = daycare.id,
+        type: PlacementType = PlacementType.DAYCARE,
+        option: ServiceNeedOption? = snDaycareFullDay35,
+        childId: ChildId = child.id,
+        startDate: LocalDate = today.minusMonths(1),
+        endDate: LocalDate = today.plusMonths(1),
+    ): PlacementId {
+        val placementId =
+            insert(
+                DevPlacement(
+                    childId = childId,
+                    unitId = unitId,
+                    type = type,
+                    startDate = startDate,
+                    endDate = endDate,
+                )
+            )
+        if (option != null) insertServiceNeed(placementId, option, startDate, endDate)
+        return placementId
+    }
+
+    private fun Database.Transaction.insertServiceNeed(
+        placementId: PlacementId,
+        option: ServiceNeedOption,
+        startDate: LocalDate = today.minusMonths(1),
+        endDate: LocalDate = today.plusMonths(1),
+    ) {
+        insert(
+            DevServiceNeed(
+                placementId = placementId,
+                startDate = startDate,
+                endDate = endDate,
+                optionId = option.id,
+                confirmedBy = employee.evakaUserId,
+            )
+        )
+    }
+
+    private fun getIncompleteIncomeReport(): List<IncompleteIncomeDbRow> = db.read {
+        it.getIncompleteReport(today)
     }
 }

--- a/service/src/main/kotlin/evaka/core/reports/IncompleteIncomeReport.kt
+++ b/service/src/main/kotlin/evaka/core/reports/IncompleteIncomeReport.kt
@@ -44,21 +44,48 @@ fun Database.Read.getIncompleteReport(today: LocalDate): List<IncompleteIncomeDb
         sql(
             """
                 SELECT DISTINCT pe.id as personId, pe.first_name as firstName, pe.last_name as lastName, ie.valid_from as validFrom, dg.name as daycareName, ca.name as careareaName
-                FROM income ie
-                JOIN guardian gu
-                        ON ie.person_id = gu.guardian_id
-                JOIN placement pl
-                        ON gu.child_id = pl.child_id 
-                        AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(today)}
-                JOIN person pe
-                        ON gu.guardian_id = pe.id
-                JOIN daycare dg
-                        ON pl.unit_id = dg.id
-                JOIN care_area ca
-                        ON dg.care_area_id = ca.id
+                FROM placement pl
+                LEFT JOIN service_need_option default_sno ON default_sno.valid_placement_type = pl.type AND default_sno.default_option
+                JOIN daycare dg ON dg.id = pl.unit_id
+                JOIN care_area ca ON ca.id = dg.care_area_id
+                JOIN fridge_child fc_head ON fc_head.child_id = pl.child_id
+                    AND daterange(fc_head.start_date, fc_head.end_date, '[]') @> ${bind(today)}
+                    AND fc_head.conflict = false
+                LEFT JOIN fridge_partner fp ON fp.person_id = fc_head.head_of_child
+                    AND daterange(fp.start_date, fp.end_date, '[]') @> ${bind(today)}
+                    AND fp.conflict = false
+                LEFT JOIN fridge_partner fp_partner ON fp_partner.partnership_id = fp.partnership_id
+                    AND fp_partner.person_id <> fp.person_id
+                    AND daterange(fp_partner.start_date, fp_partner.end_date, '[]') @> ${bind(today)}
+                    AND fp_partner.conflict = false
+                -- one row per adult (head and possible partner), each paired with the other adult
+                -- for the max-fee check below. With no partner the NULL row is dropped by the person join
+                CROSS JOIN LATERAL (VALUES (fc_head.head_of_child, fp_partner.person_id), (fp_partner.person_id, fc_head.head_of_child)) AS adult(id, other_id)
+                JOIN person pe ON pe.id = adult.id
+                JOIN income ie ON ie.person_id = pe.id
                 WHERE ie.effect = 'INCOMPLETE'
-                AND ie.valid_to is null
-                AND ie.modified_by = '00000000-0000-0000-0000-000000000000'
+                AND ie.valid_to IS NULL
+                AND ie.modified_by = ${bind(AuthenticatedUser.SystemInternalUser.evakaUserId)}
+                -- placement is paid if its current service need has a fee,
+                -- or it has no current service need and the placement type's default option is paid
+                AND daterange(pl.start_date, pl.end_date, '[]') @> ${bind(today)}
+                AND COALESCE(
+                    (
+                        SELECT bool_or(sno.fee_coefficient > 0)
+                        FROM service_need sn
+                        JOIN service_need_option sno ON sno.id = sn.option_id
+                        WHERE sn.placement_id = pl.id
+                        AND daterange(sn.start_date, sn.end_date, '[]') @> ${bind(today)}
+                    ),
+                    default_sno.fee_coefficient > 0
+                )
+                AND (dg.invoiced_by_municipality OR dg.provider_type = 'PRIVATE_SERVICE_VOUCHER')
+                AND NOT EXISTS (
+                    SELECT FROM income partner_income
+                    WHERE partner_income.person_id = adult.other_id
+                    AND partner_income.effect = 'MAX_FEE_ACCEPTED'
+                    AND daterange(partner_income.valid_from, partner_income.valid_to, '[]') @> ${bind(today)}
+                )
                 ORDER BY ie.valid_from;
             """
                 .trimIndent()


### PR DESCRIPTION
Lisätyt rajaussäännöt:
1. Aikuisen pitää kuulua jääkaappiperheeseen, jossa ainakin yhdellä lapsella on voimassa oleva maksullinen sijoitus.
2. Ei oteta mukaan aikuisia, joilla samassa jääkaappiperheessä puoliso on suostunut korkeimpaan maksuun.