### PR TITLE
Lisätään kustannuspaikka SFI Viestit rajapintaan

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClientIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClientIntegrationTest.kt
@@ -13,11 +13,14 @@ import evaka.core.SfiPrintingEnv
 import evaka.core.s3.Document
 import evaka.core.sficlient.SfiMessage
 import evaka.core.shared.SfiMessageId
+import evaka.core.shared.config.defaultJsonMapperBuilder
 import java.net.URI
 import java.util.UUID
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -168,6 +171,53 @@ class SfiMessagesRestClientIntegrationTest : FullApplicationTest(resetDbBeforeEa
     }
 
     @Test
+    fun `it sends a sfi message with costPool when configured`() {
+        val costPoolValue = "test-cost-pool-123"
+        val envWithCostPool =
+            createEnv().let {
+                it.copy(printing = it.printing.copy(costPool = costPoolValue))
+            }
+        val costPoolClient =
+            SfiMessagesRestClient(
+                envWithCostPool,
+                getDocument = { location ->
+                    assertEquals(message.documentBucket, location.bucket)
+                    assertEquals(message.documentKey, location.key)
+                    Document(location.key, fileContent, contentType = "content-type")
+                },
+                passwordStore =
+                    MockPasswordStore(
+                        initialPassword = MockSfiMessagesRestEndpoint.DEFAULT_PASSWORD
+                    ),
+            )
+
+        costPoolClient.send(message)
+
+        MockSfiMessagesRestEndpoint.getCapturedMessages().entries.let {
+            assertEquals(1, it.size)
+            val (_, captured) = it.first().value
+            assertEquals(
+                costPoolValue,
+                captured.paperMail.printingAndEnvelopingService.costPool,
+            )
+        }
+    }
+
+    @Test
+    fun `it sends a sfi message without costPool when not configured`() {
+        client.send(message)
+
+        MockSfiMessagesRestEndpoint.getCapturedMessages().entries.let {
+            assertEquals(1, it.size)
+            val (_, captured) = it.first().value
+            assertEquals(
+                null,
+                captured.paperMail.printingAndEnvelopingService.costPool,
+            )
+        }
+    }
+
+    @Test
     fun `it handles duplicate message status 409 correctly`() {
         client.send(message)
         assertEquals(1, MockSfiMessagesRestEndpoint.getCapturedMessages().size)
@@ -209,5 +259,77 @@ class SfiMessagesRestClientIntegrationTest : FullApplicationTest(resetDbBeforeEa
         // sending a message should still work after password change
         client.send(message)
         assertEquals(1, MockSfiMessagesRestEndpoint.getCapturedMessages().size)
+    }
+
+    @Test
+    fun `costPool is omitted from JSON when null`() {
+        val jsonMapper = defaultJsonMapperBuilder().build()
+        val service =
+            PrintingAndEnvelopingService(
+                postiMessaging =
+                    PostiMessaging(
+                        contactDetails = ContactDetails(email = "test@example.com"),
+                        username = "billing-username",
+                        password = "billing-password",
+                    )
+            )
+        val json = jsonMapper.writeValueAsString(service)
+
+        assertFalse(json.contains("costPool"), "costPool should not appear in JSON when null")
+        assertTrue(json.contains("postiMessaging"))
+    }
+
+    @Test
+    fun `costPool is included in JSON when set`() {
+        val jsonMapper = defaultJsonMapperBuilder().build()
+        val service =
+            PrintingAndEnvelopingService(
+                postiMessaging =
+                    PostiMessaging(
+                        contactDetails = ContactDetails(email = "test@example.com"),
+                        username = "billing-username",
+                        password = "billing-password",
+                    ),
+                costPool = "my-cost-pool",
+            )
+        val json = jsonMapper.writeValueAsString(service)
+
+        assertTrue(json.contains("\"costPool\""), "costPool should appear in JSON when set")
+        assertTrue(json.contains("\"my-cost-pool\""))
+    }
+
+    @Test
+    fun `costPool round-trips through serialization`() {
+        val jsonMapper = defaultJsonMapperBuilder().build()
+        val service =
+            PrintingAndEnvelopingService(
+                postiMessaging =
+                    PostiMessaging(
+                        contactDetails = ContactDetails(email = "test@example.com"),
+                        username = "billing-username",
+                        password = "billing-password",
+                    ),
+                costPool = "department-42",
+            )
+        val json = jsonMapper.writeValueAsString(service)
+        val deserialized = jsonMapper.readValue(json, PrintingAndEnvelopingService::class.java)
+        assertEquals(service, deserialized)
+    }
+
+    @Test
+    fun `costPool defaults to null when absent in JSON`() {
+        val jsonMapper = defaultJsonMapperBuilder().build()
+        val service =
+            PrintingAndEnvelopingService(
+                postiMessaging =
+                    PostiMessaging(
+                        contactDetails = ContactDetails(email = "test@example.com"),
+                        username = "billing-username",
+                        password = "billing-password",
+                    )
+            )
+        val json = jsonMapper.writeValueAsString(service)
+        val deserialized = jsonMapper.readValue(json, PrintingAndEnvelopingService::class.java)
+        assertEquals(null, deserialized.costPool)
     }
 }

--- a/service/src/integrationTest/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClientIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClientIntegrationTest.kt
@@ -171,9 +171,7 @@ class SfiMessagesRestClientIntegrationTest : FullApplicationTest(resetDbBeforeEa
     fun `it sends a sfi message with costPool when configured`() {
         val costPoolValue = "test-cost-pool-123"
         val envWithCostPool =
-            createEnv().let {
-                it.copy(printing = it.printing.copy(costPool = costPoolValue))
-            }
+            createEnv().let { it.copy(printing = it.printing.copy(costPool = costPoolValue)) }
         val costPoolClient =
             SfiMessagesRestClient(
                 envWithCostPool,
@@ -193,10 +191,7 @@ class SfiMessagesRestClientIntegrationTest : FullApplicationTest(resetDbBeforeEa
         MockSfiMessagesRestEndpoint.getCapturedMessages().entries.let {
             assertEquals(1, it.size)
             val (_, captured) = it.first().value
-            assertEquals(
-                costPoolValue,
-                captured.paperMail.printingAndEnvelopingService.costPool,
-            )
+            assertEquals(costPoolValue, captured.paperMail.printingAndEnvelopingService.costPool)
         }
     }
 
@@ -207,10 +202,7 @@ class SfiMessagesRestClientIntegrationTest : FullApplicationTest(resetDbBeforeEa
         MockSfiMessagesRestEndpoint.getCapturedMessages().entries.let {
             assertEquals(1, it.size)
             val (_, captured) = it.first().value
-            assertEquals(
-                null,
-                captured.paperMail.printingAndEnvelopingService.costPool,
-            )
+            assertEquals(null, captured.paperMail.printingAndEnvelopingService.costPool)
         }
     }
 

--- a/service/src/integrationTest/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClientIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClientIntegrationTest.kt
@@ -13,14 +13,11 @@ import evaka.core.SfiPrintingEnv
 import evaka.core.s3.Document
 import evaka.core.sficlient.SfiMessage
 import evaka.core.shared.SfiMessageId
-import evaka.core.shared.config.defaultJsonMapperBuilder
 import java.net.URI
 import java.util.UUID
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -259,77 +256,5 @@ class SfiMessagesRestClientIntegrationTest : FullApplicationTest(resetDbBeforeEa
         // sending a message should still work after password change
         client.send(message)
         assertEquals(1, MockSfiMessagesRestEndpoint.getCapturedMessages().size)
-    }
-
-    @Test
-    fun `costPool is omitted from JSON when null`() {
-        val jsonMapper = defaultJsonMapperBuilder().build()
-        val service =
-            PrintingAndEnvelopingService(
-                postiMessaging =
-                    PostiMessaging(
-                        contactDetails = ContactDetails(email = "test@example.com"),
-                        username = "billing-username",
-                        password = "billing-password",
-                    )
-            )
-        val json = jsonMapper.writeValueAsString(service)
-
-        assertFalse(json.contains("costPool"), "costPool should not appear in JSON when null")
-        assertTrue(json.contains("postiMessaging"))
-    }
-
-    @Test
-    fun `costPool is included in JSON when set`() {
-        val jsonMapper = defaultJsonMapperBuilder().build()
-        val service =
-            PrintingAndEnvelopingService(
-                postiMessaging =
-                    PostiMessaging(
-                        contactDetails = ContactDetails(email = "test@example.com"),
-                        username = "billing-username",
-                        password = "billing-password",
-                    ),
-                costPool = "my-cost-pool",
-            )
-        val json = jsonMapper.writeValueAsString(service)
-
-        assertTrue(json.contains("\"costPool\""), "costPool should appear in JSON when set")
-        assertTrue(json.contains("\"my-cost-pool\""))
-    }
-
-    @Test
-    fun `costPool round-trips through serialization`() {
-        val jsonMapper = defaultJsonMapperBuilder().build()
-        val service =
-            PrintingAndEnvelopingService(
-                postiMessaging =
-                    PostiMessaging(
-                        contactDetails = ContactDetails(email = "test@example.com"),
-                        username = "billing-username",
-                        password = "billing-password",
-                    ),
-                costPool = "department-42",
-            )
-        val json = jsonMapper.writeValueAsString(service)
-        val deserialized = jsonMapper.readValue(json, PrintingAndEnvelopingService::class.java)
-        assertEquals(service, deserialized)
-    }
-
-    @Test
-    fun `costPool defaults to null when absent in JSON`() {
-        val jsonMapper = defaultJsonMapperBuilder().build()
-        val service =
-            PrintingAndEnvelopingService(
-                postiMessaging =
-                    PostiMessaging(
-                        contactDetails = ContactDetails(email = "test@example.com"),
-                        username = "billing-username",
-                        password = "billing-password",
-                    )
-            )
-        val json = jsonMapper.writeValueAsString(service)
-        val deserialized = jsonMapper.readValue(json, PrintingAndEnvelopingService::class.java)
-        assertEquals(null, deserialized.costPool)
     }
 }

--- a/service/src/main/kotlin/evaka/core/EvakaEnv.kt
+++ b/service/src/main/kotlin/evaka/core/EvakaEnv.kt
@@ -478,7 +478,7 @@ data class SfiPrintingEnv(
     val billingId: String,
     /** Billing password, if required by the printing provider */
     val billingPassword: Sensitive<String>?,
-    /** Optional cost pool identifier sent to the printing provider */
+    /** Optional costpool identifier sent to the printing provider */
     val costPool: String? = null,
 ) {
     companion object {
@@ -488,6 +488,7 @@ data class SfiPrintingEnv(
                 billingPassword =
                     env.lookup<String?>("evaka.integration.sfi.printing.billing.password")
                         ?.let(::Sensitive),
+                costPool = env.lookup("evaka.integration.sfi.printing.billing.costpool"),
             )
     }
 }

--- a/service/src/main/kotlin/evaka/core/EvakaEnv.kt
+++ b/service/src/main/kotlin/evaka/core/EvakaEnv.kt
@@ -478,6 +478,8 @@ data class SfiPrintingEnv(
     val billingId: String,
     /** Billing password, if required by the printing provider */
     val billingPassword: Sensitive<String>?,
+    /** Optional cost pool identifier sent to the printing provider */
+    val costPool: String? = null,
 ) {
     companion object {
         fun fromEnvironment(env: Environment) =

--- a/service/src/main/kotlin/evaka/core/sficlient/rest/RestSchema.kt
+++ b/service/src/main/kotlin/evaka/core/sficlient/rest/RestSchema.kt
@@ -159,7 +159,10 @@ data class PaperMailPart(
 }
 
 // https://api.messages-qa.suomi.fi/api-docs#model-messages.api.rest.v2.PrintingAndEnvelopingService
-data class PrintingAndEnvelopingService(val postiMessaging: PostiMessaging)
+data class PrintingAndEnvelopingService(
+    val postiMessaging: PostiMessaging,
+    @JsonInclude(JsonInclude.Include.NON_NULL) val costPool: String? = null,
+)
 
 // https://api.messages-qa.suomi.fi/api-docs#model-messages.api.rest.v2.PostiMessaging
 data class PostiMessaging(

--- a/service/src/main/kotlin/evaka/core/sficlient/rest/RestSchema.kt
+++ b/service/src/main/kotlin/evaka/core/sficlient/rest/RestSchema.kt
@@ -161,10 +161,10 @@ data class PaperMailPart(
 // https://api.messages-qa.suomi.fi/api-docs#model-messages.api.rest.v2.PrintingAndEnvelopingService
 data class PrintingAndEnvelopingService(
     val postiMessaging: PostiMessaging,
-    val costPool: String,
+    @JsonInclude(JsonInclude.Include.NON_NULL) val costPool: String? = null,
 ) {
     init {
-        require(costPool.isNotBlank()) { "costPool must not be blank" }
+        require(costPool == null || costPool.isNotBlank()) { "costPool must not be blank" }
     }
 }
 

--- a/service/src/main/kotlin/evaka/core/sficlient/rest/RestSchema.kt
+++ b/service/src/main/kotlin/evaka/core/sficlient/rest/RestSchema.kt
@@ -161,8 +161,12 @@ data class PaperMailPart(
 // https://api.messages-qa.suomi.fi/api-docs#model-messages.api.rest.v2.PrintingAndEnvelopingService
 data class PrintingAndEnvelopingService(
     val postiMessaging: PostiMessaging,
-    @JsonInclude(JsonInclude.Include.NON_NULL) val costPool: String? = null,
-)
+    val costPool: String,
+) {
+    init {
+        require(costPool.isNotBlank()) { "costPool must not be blank" }
+    }
+}
 
 // https://api.messages-qa.suomi.fi/api-docs#model-messages.api.rest.v2.PostiMessaging
 data class PostiMessaging(

--- a/service/src/main/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClient.kt
+++ b/service/src/main/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClient.kt
@@ -31,20 +31,22 @@ class Config(env: SfiEnv) {
         )
     private val printingAndEnvelopingService =
         PrintingAndEnvelopingService(
-            PostiMessaging(
-                contactDetails =
-                    ContactDetails(
-                        email =
-                            requireNotNull(env.contactPerson.email) {
-                                "SFI contact person email must be set"
-                            }
-                    ),
-                username = env.printing.billingId,
-                password =
-                    requireNotNull(env.printing.billingPassword?.value) {
-                        "SFI printing billing password must be set"
-                    },
-            )
+            postiMessaging =
+                PostiMessaging(
+                    contactDetails =
+                        ContactDetails(
+                            email =
+                                requireNotNull(env.contactPerson.email) {
+                                    "SFI contact person email must be set"
+                                }
+                        ),
+                    username = env.printing.billingId,
+                    password =
+                        requireNotNull(env.printing.billingPassword?.value) {
+                            "SFI printing billing password must be set"
+                        },
+                ),
+            costPool = env.printing.costPool,
         )
 
     private val sender = Sender(serviceId = env.serviceIdentifier)

--- a/service/src/main/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClient.kt
+++ b/service/src/main/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClient.kt
@@ -46,7 +46,9 @@ class Config(env: SfiEnv) {
                             "SFI printing billing password must be set"
                         },
                 ),
-            costPool = env.printing.costPool,
+            costPool = requireNotNull(env.printing.costPool) {
+                "SFI printing cost pool must be set"
+            }
         )
 
     private val sender = Sender(serviceId = env.serviceIdentifier)

--- a/service/src/main/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClient.kt
+++ b/service/src/main/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClient.kt
@@ -46,9 +46,7 @@ class Config(env: SfiEnv) {
                             "SFI printing billing password must be set"
                         },
                 ),
-            costPool = requireNotNull(env.printing.costPool) {
-                "SFI printing cost pool must be set"
-            }
+            costPool = env.printing.costPool,
         )
 
     private val sender = Sender(serviceId = env.serviceIdentifier)


### PR DESCRIPTION
Korvaa PR:n #9028 (@jsarkiniemi), joka oli jäänyt vahingossa unohduksiin. Forkista tehty PR ei voi läpäistä pakollisia statustarkistuksia (municipality-smoke-test ohitetaan forkeille eikä dependency-review voi lähettää riippuvuusgraafia read-only-tokenilla), joten sama sisältö on rebasetettu masterin päälle ja avattu uudelleen origin-haarasta. Commitit ja tekijyys säilyvät ennallaan.

Closes #8883.

## Ennen tätä muutosta

Suomi.fi Viestit REST-rajapinnan `PrintingAndEnvelopingService`-skeemasta käytettiin vain `postiMessaging`-osaa, eikä kustannuspaikkaa (`costPool`) voinut asettaa. Kunnat eivät voineet eritellä kirjanpitoonsa paperipostin lähetyksestä koituvia kustannuksia omalle kustannuspaikalleen.

## Tämän muutoksen jälkeen

Paperipostin kustannuspaikan voi asettaa uudella valinnaisella ympäristömuuttujalla `EVAKA_INTEGRATION_SFI_PRINTING_BILLING_COSTPOOL` (`evaka.integration.sfi.printing.billing.costpool`). Kun arvo on asetettu, se lähetetään `costPool`-kenttänä Suomi.fi Viestit -rajapintaan; kun arvoa ei ole asetettu, kenttä jätetään pois pyynnöstä ja toiminta säilyy täsmälleen ennallaan. Tyhjä arvo hylätään (`require`), kuten muissakin skeeman kentissä.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3XfgaLTDr872f6arkbHRj
