### PR TITLE
Korjataan asiakirjan tunniste asianhallinnan metadatassa

### DIFF
--- a/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/en.tsx
@@ -191,8 +191,8 @@ const components: Translations = {
     generic: 'Check'
   },
   metadata: {
-    title: 'Archivable metadata',
-    notFound: 'No archivable metadata for the document',
+    title: 'Case management metadata',
+    notFound: 'No case management metadata for the document',
     case: 'Case',
     caseIdentifier: 'Case identifier',
     processName: 'Case process',

--- a/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/fi.tsx
@@ -188,8 +188,8 @@ const components: Translations = {
     generic: 'Tarkista'
   },
   metadata: {
-    title: 'Arkistoitava metadata',
-    notFound: 'Asiakirjalle ei ole arkistoitavaa metadataa',
+    title: 'Asianhallinnan metadata',
+    notFound: 'Asiakirjalle ei ole asianhallinnan metadataa',
     case: 'Asia',
     caseIdentifier: 'Asiatunnus',
     processName: 'Asiaprosessi',

--- a/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/components/i18n/sv.tsx
@@ -191,8 +191,8 @@ const components: Translations = {
     generic: 'Kolla'
   },
   metadata: {
-    title: 'Arkiverbar metadata',
-    notFound: 'Det finns ingen arkiverbar metadata för dokumentet',
+    title: 'Metadata för ärendehantering',
+    notFound: 'Det finns ingen metadata för ärendehantering för dokumentet',
     case: 'Ärende',
     caseIdentifier: 'Ärendekod',
     processName: 'Ärendeprocess',

--- a/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/childdocument/ChildDocumentControllerIntegrationTest.kt
@@ -420,6 +420,7 @@ class ChildDocumentControllerIntegrationTest : FullApplicationTest(resetDbBefore
             assertEquals("1/123.456.789/2022", it.process.caseIdentifier)
             assertEquals("Espoon kaupungin esiopetus ja varhaiskasvatus", it.process.organization)
             assertEquals(120, it.process.archiveDurationMonths)
+            assertEquals(documentId.raw, it.primaryDocument.documentId)
             assertEquals("HOJKS", it.primaryDocument.name)
             assertEquals(ProcessType.CHILD_DOCUMENT_HOJKS, it.processType)
             assertEquals(

--- a/service/src/main/kotlin/evaka/core/caseprocess/ProcessMetadataQueries.kt
+++ b/service/src/main/kotlin/evaka/core/caseprocess/ProcessMetadataQueries.kt
@@ -57,7 +57,7 @@ fun Database.Read.getChildDocumentMetadata(documentId: ChildDocumentId): Documen
         sql(
             """
         SELECT 
-            dt.id,
+            cd.id,
             dt.name,
             cd.created_at,
             e.id AS created_by_id,


### PR DESCRIPTION
Aiemmin asiakirjan tunnisteena näytettiin virheellisesti asiakirjapohjan id eikä asiakirjan id:tä. Bugi ei vaikuttanut ulkoisiin arkistoihin vietävään dataan. Tätä vastaavasti korjataan myös osion otsikko vastaamaan paremmin todellisuutta.