### PR TITLE
Kääntäjävirheitä käyttämättömistä paluuarvoista

### DIFF
--- a/frontend/src/e2e-test/generated/api-clients.ts
+++ b/frontend/src/e2e-test/generated/api-clients.ts
@@ -2187,9 +2187,9 @@ export async function setPersonEmail(
   request: {
     body: DevPersonEmail
   }
-): Promise<number> {
+): Promise<void> {
   try {
-    const { data: json } = await devClient.request<JsonOf<number>>({
+    const { data: json } = await devClient.request<JsonOf<void>>({
       url: uri`/person-email`.toString(),
       method: 'POST',
       data: request.body satisfies JsonCompatible<DevPersonEmail>

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -218,7 +218,7 @@ allprojects {
             jvmTarget = JvmTarget.fromTarget(libs.versions.java.get())
             allWarningsAsErrors = true
             freeCompilerArgs =
-                listOf(
+                listOfNotNull(
                     // Workaround for a bug that will be fixed in the next Kotlin release
                     // https://youtrack.jetbrains.com/issue/KT-78352
                     "-Xwarning-level=IDENTITY_SENSITIVE_OPERATIONS_WITH_VALUE_TYPE:disabled",
@@ -226,6 +226,13 @@ allprojects {
                     // This will become the default in the future
                     // https://kotlinlang.org/docs/whatsnew2020.html#data-class-copy-function-to-have-the-same-visibility-as-constructor
                     "-Xconsistent-data-class-copy-visibility",
+
+                    if(name.lowercase().contains("test")) null else {
+                        // Warnings from discarded return values
+                        // https://kotlinlang.org/docs/unused-return-value-checker.html
+                        "-Xreturn-value-checker=full"
+                    },
+                    "-Xallow-returns-result-of",
                 )
         }
     }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -227,9 +227,10 @@ allprojects {
                     // https://kotlinlang.org/docs/whatsnew2020.html#data-class-copy-function-to-have-the-same-visibility-as-constructor
                     "-Xconsistent-data-class-copy-visibility",
 
-                    if(name.lowercase().contains("test")) null else {
-                        // Warnings from discarded return values
-                        // https://kotlinlang.org/docs/unused-return-value-checker.html
+                    // Warnings from discarded return values
+                    // https://kotlinlang.org/docs/unused-return-value-checker.html
+                    if (name.lowercase().contains("integrationtest")) null
+                    else {
                         "-Xreturn-value-checker=full"
                     },
                     "-Xallow-returns-result-of",

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -219,10 +219,6 @@ allprojects {
             allWarningsAsErrors = true
             freeCompilerArgs =
                 listOfNotNull(
-                    // Workaround for a bug that will be fixed in the next Kotlin release
-                    // https://youtrack.jetbrains.com/issue/KT-78352
-                    "-Xwarning-level=IDENTITY_SENSITIVE_OPERATIONS_WITH_VALUE_TYPE:disabled",
-
                     // This will become the default in the future
                     // https://kotlinlang.org/docs/whatsnew2020.html#data-class-copy-function-to-have-the-same-visibility-as-constructor
                     "-Xconsistent-data-class-copy-visibility",

--- a/service/codegen/src/test/kotlin/evaka/codegen/api/TsRepresentationTest.kt
+++ b/service/codegen/src/test/kotlin/evaka/codegen/api/TsRepresentationTest.kt
@@ -6,8 +6,8 @@ package evaka.codegen.api
 
 import com.fasterxml.jackson.annotation.JsonValue
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class TsRepresentationTest {
     enum class BasicEnum {
@@ -29,6 +29,6 @@ class TsRepresentationTest {
 
     @Test
     fun `TsStringEnum prohibits enums with JsonValue field`() {
-        assertThrows<IllegalStateException> { TsStringEnum(ComplexEnum::class) }
+        assertFailsWith<IllegalStateException> { TsStringEnum(ComplexEnum::class) }
     }
 }

--- a/service/custom-ktlint-rules/src/main/kotlin/evaka/ktlint/NoJUnit4Imports.kt
+++ b/service/custom-ktlint-rules/src/main/kotlin/evaka/ktlint/NoJUnit4Imports.kt
@@ -18,19 +18,21 @@ class NoJUnit4Imports : EvakaRule("no-old-junit-imports"), RuleAutocorrectApprov
         val importDirective = (node.psi as? KtImportDirective) ?: return
         val path = importDirective.importPath?.pathStr ?: return
         if (path.contains("org.junit") && !path.contains("jupiter")) {
-            emit(
-                node.startOffset,
-                "Importing from JUnit 4, use org.junit.jupiter.* for JUnit 5 instead.",
-                false,
-            )
+            val _ =
+                emit(
+                    node.startOffset,
+                    "Importing from JUnit 4, use org.junit.jupiter.* for JUnit 5 instead.",
+                    false,
+                )
         }
 
         if (path.contains("org.junit.jupiter.api.Assertions.")) {
-            emit(
-                node.startOffset,
-                "Use kotlin.test assertions instead of junit assertions for better type-safety",
-                false,
-            )
+            val _ =
+                emit(
+                    node.startOffset,
+                    "Use kotlin.test assertions instead of junit assertions for better type-safety",
+                    false,
+                )
         }
     }
 }

--- a/service/custom-ktlint-rules/src/main/kotlin/evaka/ktlint/NoPrint.kt
+++ b/service/custom-ktlint-rules/src/main/kotlin/evaka/ktlint/NoPrint.kt
@@ -24,7 +24,7 @@ class NoPrint : EvakaRule("no-println"), RuleAutocorrectApproveHandler {
                 e is KtReferenceExpression && printFunctions.contains(e.text)
             }
         if (isPrintCall) {
-            emit(node.startOffset, ERROR_MESSAGE, false)
+            val _ = emit(node.startOffset, ERROR_MESSAGE, false)
         }
     }
 

--- a/service/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
+++ b/service/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
@@ -35,7 +35,7 @@ class AppenderTest {
 
     @Test
     fun `audit appender`() {
-        listOf("test1", "test2").map { prefix ->
+        listOf("test1", "test2").forEach { prefix ->
             withTestLoggers {
                 MDC.put("userId", "$prefix.userId")
                 MDC.put("userIdHash", "$prefix.userIdHash")

--- a/service/src/integrationTest/kotlin/evaka/core/reports/TitaniaErrorsReportTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/reports/TitaniaErrorsReportTest.kt
@@ -152,6 +152,31 @@ internal class TitaniaErrorsReportTest : FullApplicationTest(resetDbBeforeEach =
         assertEquals("Yksikkö", supervisorResult.first().units.first().unitName)
     }
 
+    @Test
+    fun `supervisor should be able to clear an error of an employee in their unit`() {
+
+        insertTestData()
+        val clock = MockEvakaClock(2025, 12, 12, 12, 0, 0)
+        val conflictId =
+            titaniaErrorsReport
+                .getTitaniaErrorsReport(dbInstance(), supervisor.user, clock)
+                .first()
+                .units
+                .first()
+                .employees
+                .first()
+                .conflictingShifts
+                .first()
+                .id
+
+        titaniaErrorsReport.clearTitaniaErrors(dbInstance(), supervisor.user, clock, conflictId)
+
+        assertEquals(
+            emptyList(),
+            titaniaErrorsReport.getTitaniaErrorsReport(dbInstance(), supervisor.user, clock),
+        )
+    }
+
     fun insertTestData() {
         db.transaction { tx ->
             tx.insert(area)

--- a/service/src/main/kotlin/evaka/core/AuditContext.kt
+++ b/service/src/main/kotlin/evaka/core/AuditContext.kt
@@ -22,12 +22,14 @@ class AuditContext {
     var minDate: LocalDate? = null
         private set
 
+    @IgnorableReturnValue
     inline fun <reified T : DatabaseTable> add(id: Id<T>): AuditContext {
         val key = T::class.simpleName!!.replaceFirstChar { it.lowercase() } + "Id"
         ids.getOrPut(key) { mutableSetOf() }.add(id)
         return this
     }
 
+    @IgnorableReturnValue
     inline fun <reified T : DatabaseTable> add(ids: Collection<Id<T>>): AuditContext {
         if (ids.isEmpty()) return this
         val key = T::class.simpleName!!.replaceFirstChar { it.lowercase() } + "Id"
@@ -42,6 +44,7 @@ class AuditContext {
      *
      * Never put sensitive data (free text, personal details, SSNs, notes) here.
      */
+    @IgnorableReturnValue
     fun addMeta(key: String, value: Any?): AuditContext {
         metaEntries[key] = value
         return this
@@ -53,6 +56,7 @@ class AuditContext {
      * earlier than the current one. `null` is ignored, so callers can pass nullable entity dates
      * directly.
      */
+    @IgnorableReturnValue
     fun observeDate(date: LocalDate?): AuditContext {
         if (date == null) return this
         val current = minDate

--- a/service/src/main/kotlin/evaka/core/absence/AbsenceQueries.kt
+++ b/service/src/main/kotlin/evaka/core/absence/AbsenceQueries.kt
@@ -39,6 +39,7 @@ data class AbsenceUpsert(
 )
 
 /** Fails if any of the absences already exists */
+@IgnorableReturnValue
 fun Database.Transaction.insertAbsences(
     now: HelsinkiDateTime,
     userId: EvakaUserId,
@@ -77,6 +78,7 @@ RETURNING id
         .toList()
 
 /** If the absence already exists, updates only if was generated */
+@IgnorableReturnValue
 fun Database.Transaction.upsertGeneratedAbsences(
     now: HelsinkiDateTime,
     absences: List<AbsenceUpsert>,
@@ -122,6 +124,7 @@ data class FullDayAbsenseUpsert(
  * Creates absences for all absences categories of the child's placement on the given date ("full
  * day absence"). Does nothing if an absence already exists on the given date.
  */
+@IgnorableReturnValue
 fun Database.Transaction.upsertFullDayAbsences(
     userId: EvakaUserId,
     now: HelsinkiDateTime,
@@ -230,6 +233,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .toList()
 
+@IgnorableReturnValue
 fun Database.Transaction.deleteOldGeneratedAbsencesInRange(
     now: HelsinkiDateTime,
     childId: ChildId,

--- a/service/src/main/kotlin/evaka/core/absence/AbsenceService.kt
+++ b/service/src/main/kotlin/evaka/core/absence/AbsenceService.kt
@@ -492,6 +492,7 @@ fun getFutureAbsencesOfChild(
  * Inserts/deletes absences to achieve the given state. Does not replace identical existing
  * absences. Returns ids of inserted and deleted absences.
  */
+@IgnorableReturnValue
 fun setChildDateAbsences(
     tx: Database.Transaction,
     now: HelsinkiDateTime,

--- a/service/src/main/kotlin/evaka/core/application/ApplicationQueries.kt
+++ b/service/src/main/kotlin/evaka/core/application/ApplicationQueries.kt
@@ -1307,6 +1307,7 @@ WHERE application_id = ${bind(id)}
 }
     .toSet()
 
+@IgnorableReturnValue
 fun Database.Transaction.syncApplicationOtherGuardians(
     id: ApplicationId,
     today: LocalDate,

--- a/service/src/main/kotlin/evaka/core/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/evaka/core/application/ApplicationStateService.kt
@@ -314,7 +314,7 @@ class ApplicationStateService(
             validateApplicationPeriod = true,
         )
 
-        personService.getGuardians(tx, user, now, application.childId)
+        val _ = personService.getGuardians(tx, user, now, application.childId)
 
         val applicationFlags = tx.applicationFlags(application, currentDate)
         tx.updateApplicationFlags(application.id, applicationFlags, now, user.evakaUserId)
@@ -665,6 +665,7 @@ class ApplicationStateService(
         tx.setApplicationVerified(applicationId, true, clock.now(), user.evakaUserId)
     }
 
+    @IgnorableReturnValue
     fun createPlacementPlan(
         tx: Database.Transaction,
         user: AuthenticatedUser,
@@ -694,7 +695,7 @@ class ApplicationStateService(
             .observeDate(placementPlan.period.start)
             .observeDate(placementPlan.preschoolDaycarePeriod?.start)
 
-        personService.getGuardians(tx, user, now, application.childId)
+        val _ = personService.getGuardians(tx, user, now, application.childId)
         tx.syncApplicationOtherGuardians(applicationId, today).also { audit.add(it) }
         tx.updateApplicationStatus(application.id, WAITING_DECISION, user.evakaUserId, clock.now())
         tx.deleteApplicationPlacementDraftIfExists(applicationId)?.also { audit.add(it.unitId) }

--- a/service/src/main/kotlin/evaka/core/application/PendingDecisionEmailService.kt
+++ b/service/src/main/kotlin/evaka/core/application/PendingDecisionEmailService.kt
@@ -47,6 +47,7 @@ class PendingDecisionEmailService(
 
     data class GuardianDecisions(val guardianId: PersonId, val decisionIds: List<DecisionId>)
 
+    @IgnorableReturnValue
     fun scheduleSendPendingDecisionsEmails(db: Database.Connection, clock: EvakaClock): Int {
         val jobCount = db.transaction { tx ->
             tx.removeUnclaimedJobs(setOf(AsyncJobType(AsyncJob.SendPendingDecisionEmail::class)))

--- a/service/src/main/kotlin/evaka/core/application/notes/ApplicationNoteQueries.kt
+++ b/service/src/main/kotlin/evaka/core/application/notes/ApplicationNoteQueries.kt
@@ -71,6 +71,7 @@ ORDER BY n.created
 }
     .toList()
 
+@IgnorableReturnValue
 fun Database.Transaction.createApplicationNote(
     now: HelsinkiDateTime,
     applicationId: ApplicationId,

--- a/service/src/main/kotlin/evaka/core/application/utils/KotlinUtils.kt
+++ b/service/src/main/kotlin/evaka/core/application/utils/KotlinUtils.kt
@@ -13,4 +13,4 @@ package evaka.core.application.utils
  * }.exhaust()
  * ```
  */
-fun <T> T.exhaust(): T = this
+@IgnorableReturnValue fun <T> T.exhaust(): T = this

--- a/service/src/main/kotlin/evaka/core/assistanceaction/AssistanceActionQueries.kt
+++ b/service/src/main/kotlin/evaka/core/assistanceaction/AssistanceActionQueries.kt
@@ -52,11 +52,12 @@ RETURNING id
     return getAssistanceActionById(id)
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insertAssistanceActionOptionRefs(
     actionId: AssistanceActionId,
     options: Set<String>,
-): IntArray =
-    executeBatch(options) {
+) =
+    executeBatchAndReturnCounts(options) {
         sql(
             """
 INSERT INTO assistance_action_option_ref (action_id, option_id)
@@ -114,9 +115,10 @@ fun Database.Transaction.updateAssistanceAction(
     id: AssistanceActionId,
     data: AssistanceActionRequest,
 ): AssistanceAction {
-    createQuery {
-        sql(
-            """
+    val _ =
+        createQuery {
+            sql(
+                """
 UPDATE assistance_action SET 
     start_date = ${bind(data.startDate)},
     end_date = ${bind(data.endDate)},
@@ -126,9 +128,10 @@ UPDATE assistance_action SET
 WHERE id = ${bind(id)}
 RETURNING id
 """
-        )
-    }
-        .exactlyOneOrNull<AssistanceActionId>() ?: throw NotFound("Assistance action $id not found")
+            )
+        }
+            .exactlyOneOrNull<AssistanceActionId>()
+            ?: throw NotFound("Assistance action $id not found")
 
     deleteAssistanceActionOptionRefsByActionId(id, data.actions)
     insertAssistanceActionOptionRefs(id, data.actions)
@@ -155,14 +158,16 @@ RETURNING *
 }
 
 fun Database.Transaction.deleteAssistanceAction(id: AssistanceActionId) {
-    val deleted = execute { sql("DELETE FROM assistance_action WHERE id = ${bind(id)}") }
+    val deleted = executeAndReturnCount {
+        sql("DELETE FROM assistance_action WHERE id = ${bind(id)}")
+    }
     if (deleted == 0) throw NotFound("Assistance action $id not found")
 }
 
 fun Database.Transaction.deleteAssistanceActionOptionRefsByActionId(
     actionId: AssistanceActionId,
     excluded: Set<String>,
-): Int = execute {
+) = execute {
     sql(
         """
 DELETE FROM assistance_action_option_ref

--- a/service/src/main/kotlin/evaka/core/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientQueries.kt
+++ b/service/src/main/kotlin/evaka/core/assistanceneed/vouchercoefficient/AssistanceNeedVoucherCoefficientQueries.kt
@@ -71,6 +71,7 @@ WHERE a.child_id = ${bind(childId)}
 }
     .toList()
 
+@IgnorableReturnValue
 fun Database.Transaction.updateAssistanceNeedVoucherCoefficient(
     user: AuthenticatedUser,
     now: HelsinkiDateTime,
@@ -94,6 +95,7 @@ WITH a AS (
     }
         .exactlyOneOrNull() ?: throw NotFound("Assistance need voucher coefficient $id not found")
 
+@IgnorableReturnValue
 fun Database.Transaction.deleteAssistanceNeedVoucherCoefficient(
     id: AssistanceNeedVoucherCoefficientId
 ): AssistanceNeedVoucherCoefficient? = createQuery {

--- a/service/src/main/kotlin/evaka/core/attachment/AttachmentQueries.kt
+++ b/service/src/main/kotlin/evaka/core/attachment/AttachmentQueries.kt
@@ -203,6 +203,7 @@ fun Database.Read.getAttachment(id: AttachmentId): Pair<Attachment, AttachmentPa
         )
     }
 
+@IgnorableReturnValue
 fun Database.Transaction.dissociateAttachmentsByApplicationAndType(
     applicationId: ApplicationId,
     type: ApplicationAttachmentType,
@@ -246,7 +247,7 @@ WHERE ${predicate(predicate.forTable("attachment"))}
 """
     )
 }
-    .execute()
+    .executeAndReturnCount()
 
 /**
  * Associates *orphan* attachments with a new parent.
@@ -276,6 +277,7 @@ fun Database.Transaction.associateOrphanAttachments(
 }
 
 /** Dissociates all attachments from the given parent, so that they become orphans. */
+@IgnorableReturnValue
 fun Database.Transaction.dissociateAttachmentsOfParent(
     uploadedBy: EvakaUserId,
     parent: AttachmentParent,

--- a/service/src/main/kotlin/evaka/core/attendance/ChildAttendanceController.kt
+++ b/service/src/main/kotlin/evaka/core/attendance/ChildAttendanceController.kt
@@ -231,7 +231,7 @@ class ChildAttendanceController(
                     // constraint
                     body.children.sorted().map { childId ->
                         // Validate that the child is placed in the unit
-                        tx.fetchChildPlacementBasics(childId, unitId, today)
+                        val _ = tx.fetchChildPlacementBasics(childId, unitId, today)
                         try {
                             tx.insertAttendance(
                                 childId = childId,
@@ -273,7 +273,8 @@ class ChildAttendanceController(
                     Action.Unit.UPDATE_CHILD_ATTENDANCES,
                     unitId,
                 )
-                tx.fetchChildPlacementBasics(childId, unitId, clock.today())
+                // Validate that the child is placed in the unit
+                val _ = tx.fetchChildPlacementBasics(childId, unitId, clock.today())
 
                 val attendance = tx.getOngoingAttendanceForChild(childId, unitId)
                 if (attendance != null) tx.deleteAttendance(attendance.id)
@@ -503,7 +504,8 @@ class ChildAttendanceController(
                 )
                 val now = clock.now()
 
-                tx.fetchChildPlacementBasics(childId, unitId, clock.today())
+                // Validate that the child is placed in the unit
+                val _ = tx.fetchChildPlacementBasics(childId, unitId, clock.today())
 
                 tx.getChildAttendanceId(childId, unitId, now)?.also {
                     tx.unsetAttendanceEndTime(it, now, user.evakaUserId)

--- a/service/src/main/kotlin/evaka/core/attendance/ChildAttendanceQueries.kt
+++ b/service/src/main/kotlin/evaka/core/attendance/ChildAttendanceQueries.kt
@@ -27,6 +27,7 @@ import java.time.LocalDate
 import java.time.LocalTime
 import org.jdbi.v3.core.mapper.Nested
 
+@IgnorableReturnValue
 fun Database.Transaction.insertAttendance(
     childId: ChildId,
     unitId: DaycareId,
@@ -456,6 +457,7 @@ fun Database.Transaction.deleteAttendance(id: ChildAttendanceId) {
     }
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.deleteAbsencesByDate(childId: ChildId, date: LocalDate): List<AbsenceId> =
     createUpdate {
         sql(
@@ -469,6 +471,7 @@ fun Database.Transaction.deleteAbsencesByDate(childId: ChildId, date: LocalDate)
     .executeAndReturnGeneratedKeys()
     .toList()
 
+@IgnorableReturnValue
 fun Database.Transaction.deleteAttendancesByDate(
     childId: ChildId,
     date: LocalDate,
@@ -480,6 +483,7 @@ fun Database.Transaction.deleteAttendancesByDate(
     .executeAndReturnGeneratedKeys()
     .toList()
 
+@IgnorableReturnValue
 fun Database.Transaction.deleteAbsencesByFiniteDateRange(
     childId: ChildId,
     dateRange: FiniteDateRange,

--- a/service/src/main/kotlin/evaka/core/attendance/StaffAttendancePlanQueries.kt
+++ b/service/src/main/kotlin/evaka/core/attendance/StaffAttendancePlanQueries.kt
@@ -43,11 +43,12 @@ fun Database.Read.findStaffAttendancePlansBy(
 }
     .toList<StaffAttendancePlan>()
 
+@IgnorableReturnValue
 fun Database.Transaction.insertStaffAttendancePlans(plans: List<StaffAttendancePlan>): IntArray {
     if (plans.isEmpty()) {
         return IntArray(0)
     }
-    return executeBatch(plans) {
+    return executeBatchAndReturnCounts(plans) {
         sql(
             """
 INSERT INTO staff_attendance_plan (employee_id, type, start_time, end_time, description)
@@ -57,6 +58,7 @@ VALUES (${bind { it.employeeId }}, ${bind { it.type }}, ${bind { it.startTime }}
     }
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.deleteStaffAttendancePlansBy(
     employeeIds: Collection<EmployeeId>? = null,
     period: FiniteDateRange? = null,

--- a/service/src/main/kotlin/evaka/core/attendance/StaffOccupancyCoefficientQueries.kt
+++ b/service/src/main/kotlin/evaka/core/attendance/StaffOccupancyCoefficientQueries.kt
@@ -54,6 +54,7 @@ WHERE soc.daycare_id = ${bind(unitId)}
 }
     .toList<StaffOccupancyCoefficient>()
 
+@IgnorableReturnValue
 fun Database.Transaction.upsertOccupancyCoefficient(
     params: OccupancyCoefficientUpsert
 ): StaffOccupancyCoefficientId = createUpdate {

--- a/service/src/main/kotlin/evaka/core/backupcare/BackupCareQueries.kt
+++ b/service/src/main/kotlin/evaka/core/backupcare/BackupCareQueries.kt
@@ -110,6 +110,7 @@ WHERE id = ${bind(id)}
 }
     .exactlyOneOrNull<BackupCareInfo>()
 
+@IgnorableReturnValue
 fun Database.Transaction.createBackupCare(
     user: EvakaUserId,
     now: HelsinkiDateTime,

--- a/service/src/main/kotlin/evaka/core/calendarevent/CalendarEventController.kt
+++ b/service/src/main/kotlin/evaka/core/calendarevent/CalendarEventController.kt
@@ -890,14 +890,14 @@ class CalendarEventController(
                         tx.getDiscussionTimeDetailsByEventTimeId(body.calendarEventTimeId)
                             ?: throw BadRequest("Calendar event time not found")
 
-                    val count =
+                    val reserved =
                         tx.insertCalendarEventTimeReservation(
                             eventTimeId = body.calendarEventTimeId,
                             childId = body.childId,
                             modifiedAt = clock.now(),
                             modifiedBy = user.evakaUserId,
                         )
-                    if (count != 1) {
+                    if (!reserved) {
                         throw Conflict(
                             "Calendar event time already reserved",
                             errorCode = "TIME_ALREADY_RESERVED",

--- a/service/src/main/kotlin/evaka/core/calendarevent/CalendarEventQueries.kt
+++ b/service/src/main/kotlin/evaka/core/calendarevent/CalendarEventQueries.kt
@@ -175,6 +175,7 @@ AND (child_id IS NULL OR child_id = ${bind(childId)})
 }
     .toList<CalendarEventTime>()
 
+@IgnorableReturnValue
 fun Database.Transaction.createCalendarEventTime(
     calendarEventId: CalendarEventId,
     time: CalendarEventTimeForm,
@@ -270,6 +271,7 @@ WHERE id = ${bind(eventId)}
 }
     .updateExactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insertCalendarEventTimeReservation(
     eventTimeId: CalendarEventTimeId,
     childId: ChildId?,
@@ -320,18 +322,18 @@ fun Database.Transaction.freeCalendarEventTimeReservations(
     user: AuthenticatedUser,
     now: HelsinkiDateTime,
     calendarEventTimeIds: Set<CalendarEventTimeId>,
-) =
-    if (calendarEventTimeIds.isEmpty()) 0
-    else
-        execute {
-            sql(
-                """
+) {
+    if (calendarEventTimeIds.isEmpty()) return
+    execute {
+        sql(
+            """
 UPDATE calendar_event_time
 SET child_id = NULL::uuid, modified_at = ${bind(now)}, modified_by = ${bind(user.evakaUserId)}
 WHERE id = ANY(${bind(calendarEventTimeIds)})
 """
-            )
-        }
+        )
+    }
+}
 
 fun Database.Read.getCalendarEventTimesByChildAndEvent(
     childId: PersonId,

--- a/service/src/main/kotlin/evaka/core/childimages/ChildImage.kt
+++ b/service/src/main/kotlin/evaka/core/childimages/ChildImage.kt
@@ -36,6 +36,7 @@ fun replaceImage(
     return imageId
 }
 
+@IgnorableReturnValue
 fun deleteImage(
     tx: Database.Transaction,
     documentClient: DocumentService,

--- a/service/src/main/kotlin/evaka/core/dailyservicetimes/DailyServiceTimes.kt
+++ b/service/src/main/kotlin/evaka/core/dailyservicetimes/DailyServiceTimes.kt
@@ -349,13 +349,14 @@ SELECT recipient.id FROM recipient
     }
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.deleteOldDailyServiceTimeNotifications(now: HelsinkiDateTime): Int =
     createUpdate {
         sql(
             "DELETE FROM daily_service_time_notification WHERE created_at < ${bind(now.minusMonths(2))}"
         )
     }
-    .execute()
+    .executeAndReturnCount()
 
 fun Database.Transaction.deleteChildDailyServiceTimes(id: DailyServiceTimesId) {
     execute { sql("DELETE FROM daily_service_time WHERE id = ${bind(id)}") }

--- a/service/src/main/kotlin/evaka/core/daycare/Caretaker.kt
+++ b/service/src/main/kotlin/evaka/core/daycare/Caretaker.kt
@@ -92,7 +92,7 @@ fun updateCaretakers(
         throw BadRequest("End date cannot be before start")
 
     try {
-        tx.execute {
+        tx.executeAndReturnCount {
                 sql(
                     """
 UPDATE daycare_caretaker
@@ -108,7 +108,7 @@ WHERE id = ${bind(id)} AND group_id = ${bind(groupId)}
 }
 
 fun deleteCaretakers(tx: Database.Transaction, groupId: GroupId, id: DaycareCaretakerId) {
-    tx.execute {
+    tx.executeAndReturnCount {
             sql(
                 "DELETE FROM daycare_caretaker WHERE id = ${bind(id)} AND group_id = ${bind(groupId)}"
             )

--- a/service/src/main/kotlin/evaka/core/daycare/DaycareQueries.kt
+++ b/service/src/main/kotlin/evaka/core/daycare/DaycareQueries.kt
@@ -25,6 +25,7 @@ import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.domain.TimeRange
 import evaka.core.shared.security.PilotFeature
 import evaka.core.shared.security.actionrule.AccessControlFilter
+import evaka.core.shared.security.actionrule.forTable
 import evaka.core.shared.security.actionrule.toPredicate
 import java.time.LocalDate
 
@@ -530,13 +531,14 @@ SELECT EXISTS(
     .exactlyOne<Boolean>()
 
 fun Database.Read.getUnitOperationPeriods(
-    unitIds: List<DaycareId>?
+    unitIds: List<DaycareId>?,
+    filter: AccessControlFilter<DaycareId>,
 ): Map<DaycareId, UnitOperationPeriod> = createQuery {
     sql(
         """
 SELECT id, opening_date, closing_date
 FROM daycare unit
-WHERE id = ANY(${bind(unitIds)})
+WHERE id = ANY(${bind(unitIds)}) AND ${predicate(filter.forTable("unit"))}
 """
     )
 }

--- a/service/src/main/kotlin/evaka/core/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/evaka/core/daycare/controllers/DaycareController.kt
@@ -262,7 +262,7 @@ class DaycareController(private val accessControl: AccessControl) {
                         Action.Unit.SET_SERVICE_WORKER_NOTE,
                         daycareId,
                     )
-                    tx.execute {
+                    tx.executeAndReturnCount {
                             sql(
                                 """
                     UPDATE daycare

--- a/service/src/main/kotlin/evaka/core/daycare/controllers/DaycareController.kt
+++ b/service/src/main/kotlin/evaka/core/daycare/controllers/DaycareController.kt
@@ -867,8 +867,9 @@ class DaycareController(private val accessControl: AccessControl) {
     ): Map<DaycareId, UnitOperationPeriod> {
         return db.connect { dbc ->
                 dbc.read { tx ->
-                    accessControl.requireAuthorizationFilter(tx, user, clock, Action.Unit.READ)
-                    tx.getUnitOperationPeriods(unitIds)
+                    val filter =
+                        accessControl.requireAuthorizationFilter(tx, user, clock, Action.Unit.READ)
+                    tx.getUnitOperationPeriods(unitIds, filter)
                 }
             }
             .also { response ->

--- a/service/src/main/kotlin/evaka/core/daycare/controllers/TermsController.kt
+++ b/service/src/main/kotlin/evaka/core/daycare/controllers/TermsController.kt
@@ -29,6 +29,7 @@ import evaka.core.shared.domain.FiniteDateRange
 import evaka.core.shared.domain.NotFound
 import evaka.core.shared.security.AccessControl
 import evaka.core.shared.security.Action
+import evaka.core.shared.utils.assertNotNull
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -86,7 +87,7 @@ class TermsController(private val accessControl: AccessControl) {
                 dbc.transaction { tx ->
                     accessControl.requirePermissionFor(tx, user, clock, Action.ClubTerm.UPDATE, id)
 
-                    tx.getClubTerm(id) ?: throw NotFound("Club term $id does not exist")
+                    tx.getClubTerm(id).assertNotNull(msg = "Club term $id does not exist")
 
                     validateClubTermRequest(tx, body, id)
 
@@ -168,7 +169,7 @@ class TermsController(private val accessControl: AccessControl) {
                         id,
                     )
 
-                    tx.getPreschoolTerm(id) ?: throw NotFound("Preschool term $id does not exist")
+                    tx.getPreschoolTerm(id).assertNotNull(msg = "Preschool term $id does not exist")
 
                     validatePreschoolTermRequest(tx, body, id)
 

--- a/service/src/main/kotlin/evaka/core/decision/DecisionService.kt
+++ b/service/src/main/kotlin/evaka/core/decision/DecisionService.kt
@@ -220,7 +220,13 @@ class DecisionService(
             tx.getDecision(decisionId) ?: throw NotFound("No decision with id: $decisionId")
 
         // make sure VTJ guardians are up-to-date
-        personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, now, decision.childId)
+        val _ =
+            personService.getGuardians(
+                tx,
+                AuthenticatedUser.SystemInternalUser,
+                now,
+                decision.childId,
+            )
 
         val applicationId = decision.applicationId
         val application =
@@ -344,7 +350,8 @@ class DecisionService(
             val childId = application.childId
 
             // make sure VTJ guardians are up-to-date
-            personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, now, childId)
+            val _ =
+                personService.getGuardians(tx, AuthenticatedUser.SystemInternalUser, now, childId)
 
             val currentGuardians = tx.getChildGuardiansAndFosterParents(childId, today)
 

--- a/service/src/main/kotlin/evaka/core/decision/reasoning/DecisionReasoningQueries.kt
+++ b/service/src/main/kotlin/evaka/core/decision/reasoning/DecisionReasoningQueries.kt
@@ -95,7 +95,7 @@ WHERE id = ${bind(id)} AND ready = false
 """
         )
     }
-        .execute()
+        .executeAndReturnCount()
     if (updated == 0) {
         throw NotFound("Generic reasoning $id not found in expected state (not ready)")
     }
@@ -211,7 +211,7 @@ WHERE id = ${bind(id)} AND removed_at IS NULL
 """
         )
     }
-        .execute()
+        .executeAndReturnCount()
     if (updated == 0) {
         throw NotFound("Individual reasoning $id not found")
     }

--- a/service/src/main/kotlin/evaka/core/document/childdocument/ChildDocumentQueries.kt
+++ b/service/src/main/kotlin/evaka/core/document/childdocument/ChildDocumentQueries.kt
@@ -373,7 +373,7 @@ fun Database.Transaction.tryTakeWriteLock(
     """
     )
 }
-    .execute()
+    .executeAndReturnCount()
     .let { it > 0 }
 
 fun Database.Transaction.updateChildDocumentContent(
@@ -742,6 +742,7 @@ WHERE new_document.id = ${bind(documentId)} AND cdd.status = 'ACCEPTED'
         .toList<AcceptedChildDecisions>()
 }
 
+@IgnorableReturnValue
 fun Database.Read.endChildDocumentDecisionsWithSubstitutiveDecision(
     childId: ChildId,
     endingDecisionIds: List<ChildDocumentDecisionId>,

--- a/service/src/main/kotlin/evaka/core/document/childdocument/ChildDocumentService.kt
+++ b/service/src/main/kotlin/evaka/core/document/childdocument/ChildDocumentService.kt
@@ -320,6 +320,7 @@ class ChildDocumentService(
      * @param emailPolicy Controls when to schedule email notifications
      * @return The created version number, or null if content was already up to date
      */
+    @IgnorableReturnValue
     fun publishAndScheduleNotifications(
         tx: Database.Transaction,
         user: AuthenticatedUser,

--- a/service/src/main/kotlin/evaka/core/dvv/DvvModificationsBatchRefreshService.kt
+++ b/service/src/main/kotlin/evaka/core/dvv/DvvModificationsBatchRefreshService.kt
@@ -37,6 +37,7 @@ class DvvModificationsBatchRefreshService(
         }
     }
 
+    @IgnorableReturnValue
     fun scheduleBatch(db: Database.Connection, clock: EvakaClock): Int {
         val jobCount = db.transaction { tx ->
             tx.removeUnclaimedJobs(setOf(AsyncJobType(AsyncJob.DvvModificationsRefresh::class)))

--- a/service/src/main/kotlin/evaka/core/dvv/DvvModificationsService.kt
+++ b/service/src/main/kotlin/evaka/core/dvv/DvvModificationsService.kt
@@ -37,8 +37,8 @@ class DvvModificationsService(
                 .let { modificationsForPersons ->
                     val ssnsToUpdateFromVtj: MutableSet<String> = emptySet<String>().toMutableSet()
 
-                    modificationsForPersons.dvvModifications.map { personModifications ->
-                        personModifications.tietoryhmat.map { infoGroup ->
+                    modificationsForPersons.dvvModifications.forEach { personModifications ->
+                        personModifications.tietoryhmat.forEach { infoGroup ->
                             try {
                                 when (infoGroup) {
                                     is DeathDvvInfoGroup -> {
@@ -225,28 +225,32 @@ class DvvModificationsService(
         db: Database.Connection,
         ssn: String,
         restrictedInfoDvvInfoGroup: RestrictedInfoDvvInfoGroup,
-    ) = db.transaction { tx ->
-        tx.getPersonBySSN(ssn)?.let {
-            logger.info {
-                "Dvv modification for ${it.id}: restricted ${restrictedInfoDvvInfoGroup.turvakieltoAktiivinen}"
-            }
-            tx.updatePersonFromVtj(
-                it.copy(
-                    restrictedDetailsEnabled = restrictedInfoDvvInfoGroup.turvakieltoAktiivinen,
-                    restrictedDetailsEndDate =
-                        restrictedInfoDvvInfoGroup.turvaLoppuPv?.asLocalDate(),
-                    streetAddress =
-                        if (restrictedInfoDvvInfoGroup.turvakieltoAktiivinen) ""
-                        else it.streetAddress,
-                    postalCode =
-                        if (restrictedInfoDvvInfoGroup.turvakieltoAktiivinen) "" else it.postalCode,
-                    postOffice =
-                        if (restrictedInfoDvvInfoGroup.turvakieltoAktiivinen) "" else it.postOffice,
-                    municipalityOfResidence =
-                        if (restrictedInfoDvvInfoGroup.turvakieltoAktiivinen) ""
-                        else it.municipalityOfResidence,
+    ) {
+        val _ = db.transaction { tx ->
+            tx.getPersonBySSN(ssn)?.let {
+                logger.info {
+                    "Dvv modification for ${it.id}: restricted ${restrictedInfoDvvInfoGroup.turvakieltoAktiivinen}"
+                }
+                tx.updatePersonFromVtj(
+                    it.copy(
+                        restrictedDetailsEnabled = restrictedInfoDvvInfoGroup.turvakieltoAktiivinen,
+                        restrictedDetailsEndDate =
+                            restrictedInfoDvvInfoGroup.turvaLoppuPv?.asLocalDate(),
+                        streetAddress =
+                            if (restrictedInfoDvvInfoGroup.turvakieltoAktiivinen) ""
+                            else it.streetAddress,
+                        postalCode =
+                            if (restrictedInfoDvvInfoGroup.turvakieltoAktiivinen) ""
+                            else it.postalCode,
+                        postOffice =
+                            if (restrictedInfoDvvInfoGroup.turvakieltoAktiivinen) ""
+                            else it.postOffice,
+                        municipalityOfResidence =
+                            if (restrictedInfoDvvInfoGroup.turvakieltoAktiivinen) ""
+                            else it.municipalityOfResidence,
+                    )
                 )
-            )
+            }
         }
     }
 
@@ -254,14 +258,16 @@ class DvvModificationsService(
         db: Database.Connection,
         ssn: String,
         ssnDvvInfoGroup: SsnDvvInfoGroup,
-    ) = db.transaction { tx ->
-        tx.getPersonBySSN(ssn)?.let {
-            logger.info { "Dvv modification for ${it.id}: ssn change" }
+    ) {
+        val _ = db.transaction { tx ->
+            tx.getPersonBySSN(ssn)?.let {
+                logger.info { "Dvv modification for ${it.id}: ssn change" }
 
-            if (!ssnDvvInfoGroup.aktiivinenHenkilotunnus.isNullOrEmpty()) {
-                tx.addSSNToPerson(it.id, ssnDvvInfoGroup.aktiivinenHenkilotunnus)
-            } else {
-                logger.error { "Dvv modification for ${it.id}: ssn is set to null or empty" }
+                if (!ssnDvvInfoGroup.aktiivinenHenkilotunnus.isNullOrEmpty()) {
+                    tx.addSSNToPerson(it.id, ssnDvvInfoGroup.aktiivinenHenkilotunnus)
+                } else {
+                    logger.error { "Dvv modification for ${it.id}: ssn is set to null or empty" }
+                }
             }
         }
     }

--- a/service/src/main/kotlin/evaka/core/emailclient/MockEmailClient.kt
+++ b/service/src/main/kotlin/evaka/core/emailclient/MockEmailClient.kt
@@ -19,9 +19,13 @@ class MockEmailClient : EmailClient {
         val emails: List<Email>
             get() = lock.read { data.toList() }
 
-        fun clear() = lock.write { data.clear() }
+        fun clear() {
+            lock.write { data.clear() }
+        }
 
-        fun addEmail(email: Email) = lock.write { data.add(email) }
+        fun addEmail(email: Email) {
+            lock.write { data.add(email) }
+        }
 
         fun getEmail(toAddress: String): Email? = lock.read {
             emails.find { email -> email.toAddress == toAddress }

--- a/service/src/main/kotlin/evaka/core/finance/notes/FinanceNoteQueries.kt
+++ b/service/src/main/kotlin/evaka/core/finance/notes/FinanceNoteQueries.kt
@@ -32,6 +32,7 @@ ORDER BY n.created_at DESC
 }
     .toList()
 
+@IgnorableReturnValue
 fun Database.Transaction.createFinanceNote(
     personId: PersonId,
     content: String,

--- a/service/src/main/kotlin/evaka/core/identity/SSNUtils.kt
+++ b/service/src/main/kotlin/evaka/core/identity/SSNUtils.kt
@@ -58,7 +58,7 @@ fun isValidSSN(ssn: String?): Boolean {
 
 private fun containsValidDate(ssn: String): Boolean =
     try {
-        getDobFromSsn(ssn)
+        val _ = getDobFromSsn(ssn)
         true
     } catch (e: Exception) {
         false

--- a/service/src/main/kotlin/evaka/core/invoicing/data/IncomeQueries.kt
+++ b/service/src/main/kotlin/evaka/core/invoicing/data/IncomeQueries.kt
@@ -25,6 +25,7 @@ import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.user.EvakaUser
 import java.time.LocalDate
 
+@IgnorableReturnValue
 fun Database.Transaction.insertIncome(
     now: HelsinkiDateTime,
     income: IncomeRequest,

--- a/service/src/main/kotlin/evaka/core/invoicing/data/InvoiceQueries.kt
+++ b/service/src/main/kotlin/evaka/core/invoicing/data/InvoiceQueries.kt
@@ -470,6 +470,7 @@ fun Database.Transaction.lockInvoices(ids: List<InvoiceId>) {
     createUpdate { sql("SELECT id FROM invoice WHERE id = ANY(${bind(ids)}) FOR UPDATE") }.execute()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insertDraftInvoices(
     invoices: List<DraftInvoice>,
     status: InvoiceStatus,

--- a/service/src/main/kotlin/evaka/core/invoicing/service/IncomeQueries.kt
+++ b/service/src/main/kotlin/evaka/core/invoicing/service/IncomeQueries.kt
@@ -207,6 +207,7 @@ data class IncomeNotification(
     val created: HelsinkiDateTime,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.createIncomeNotification(
     receiverId: PersonId,
     notificationType: IncomeNotificationType,

--- a/service/src/main/kotlin/evaka/core/invoicing/service/InvoiceCorrectionQueries.kt
+++ b/service/src/main/kotlin/evaka/core/invoicing/service/InvoiceCorrectionQueries.kt
@@ -102,12 +102,14 @@ data class InvoiceCorrectionInsert(
     val note: String,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insertInvoiceCorrection(
     correction: InvoiceCorrectionInsert,
     userId: EvakaUserId,
     now: HelsinkiDateTime,
 ): InvoiceCorrectionId = insertInvoiceCorrections(listOf(correction), userId, now).first()
 
+@IgnorableReturnValue
 fun Database.Transaction.insertInvoiceCorrections(
     corrections: Iterable<InvoiceCorrectionInsert>,
     userId: EvakaUserId,

--- a/service/src/main/kotlin/evaka/core/messaging/MessageAccountQueries.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageAccountQueries.kt
@@ -185,15 +185,19 @@ WHERE acc.id = ${bind(accountId)}
         }
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.createMunicipalMessageAccount(): MessageAccountId =
     createSingletonMessageAccount(AccountType.MUNICIPAL)
 
+@IgnorableReturnValue
 fun Database.Transaction.createServiceWorkerMessageAccount(): MessageAccountId =
     createSingletonMessageAccount(AccountType.SERVICE_WORKER)
 
+@IgnorableReturnValue
 fun Database.Transaction.createFinanceMessageAccount(): MessageAccountId =
     createSingletonMessageAccount(AccountType.FINANCE)
 
+@IgnorableReturnValue
 private fun Database.Transaction.createSingletonMessageAccount(
     accountType: AccountType
 ): MessageAccountId {
@@ -202,6 +206,7 @@ private fun Database.Transaction.createSingletonMessageAccount(
         .exactlyOne()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.createDaycareGroupMessageAccount(
     daycareGroupId: GroupId
 ): MessageAccountId {
@@ -227,6 +232,7 @@ DELETE FROM message_account WHERE daycare_group_id = ${bind(daycareGroupId)}
         .execute()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.createPersonMessageAccount(personId: PersonId): MessageAccountId {
     return createQuery {
         sql(
@@ -239,6 +245,7 @@ RETURNING id
         .exactlyOne<MessageAccountId>()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.upsertEmployeeMessageAccount(employeeId: EmployeeId): MessageAccountId {
     return createQuery {
         sql(

--- a/service/src/main/kotlin/evaka/core/messaging/MessageController.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageController.kt
@@ -31,6 +31,7 @@ import evaka.core.shared.domain.Forbidden
 import evaka.core.shared.domain.NotFound
 import evaka.core.shared.security.AccessControl
 import evaka.core.shared.security.Action
+import evaka.core.shared.utils.assertNotNull
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -1293,6 +1294,7 @@ class MessageController(
                     )
                 it.getEmployeeMessageAccountIds(filter)
             }
-            .find { it == accountId } ?: throw Forbidden("Message account not found for user")
+            .find { it == accountId }
+            .assertNotNull(::Forbidden, "Message account not found for user")
     }
 }

--- a/service/src/main/kotlin/evaka/core/messaging/MessageQueries.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageQueries.kt
@@ -206,6 +206,7 @@ GROUP BY ta.id, ta.daycare_group_id
         .toSet<UnreadCountByAccountAndGroup>()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.markThreadRead(
     now: HelsinkiDateTime,
     accountId: MessageAccountId,
@@ -224,13 +225,13 @@ WHERE rec.message_id = msg.id
 """
         )
     }
-        .execute()
+        .executeAndReturnCount()
 }
 
 fun Database.Transaction.markLastReceivedMessageUnread(
     accountId: MessageAccountId,
     threadId: MessageThreadId,
-) = execute {
+) = executeAndReturnCount {
     sql(
         """
     UPDATE message_recipients
@@ -538,10 +539,9 @@ fun Database.Transaction.insertThread(
 fun Database.Transaction.reAssociateMessageAttachments(
     attachmentIds: Set<AttachmentId>,
     messageContentId: MessageContentId,
-): Int {
-    return createUpdate {
-        sql(
-            """
+) = createUpdate {
+    sql(
+        """
 UPDATE attachment
 SET
     message_content_id = ${bind(messageContentId)},
@@ -549,10 +549,9 @@ SET
 WHERE
     id = ANY(${bind(attachmentIds)})
 """
-        )
-    }
-        .execute()
+    )
 }
+    .execute()
 
 private data class ReceivedThread(
     val id: MessageThreadId,
@@ -2225,7 +2224,9 @@ WHERE id = ${bind(id)}
     .exactlyOne<MessageThreadStub>()
 
 fun Database.Read.lockMessageContentForUpdate(id: MessageContentId) {
-    createQuery { sql("SELECT 1 FROM message_content WHERE id = ${bind(id)} FOR UPDATE ") }
+    val _ = createQuery {
+        sql("SELECT 1 FROM message_content WHERE id = ${bind(id)} FOR UPDATE ")
+    }
         .exactlyOneOrNull<Int>()
 }
 

--- a/service/src/main/kotlin/evaka/core/messaging/MessageService.kt
+++ b/service/src/main/kotlin/evaka/core/messaging/MessageService.kt
@@ -30,6 +30,7 @@ import evaka.core.shared.domain.EvakaClock
 import evaka.core.shared.domain.Forbidden
 import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.domain.NotFound
+import evaka.core.shared.utils.assertNotNull
 import org.springframework.stereotype.Component
 
 private const val DELETION_WINDOW_DAYS = 8L
@@ -112,6 +113,7 @@ class MessageService(
         return CitizenMessageSent(messageId, threadId, contentId)
     }
 
+    @IgnorableReturnValue
     fun sendMessageAsEmployee(
         tx: Database.Transaction,
         user: AuthenticatedUser,
@@ -127,8 +129,9 @@ class MessageService(
         initialFolder: MessageThreadFolderId? = null,
     ): Pair<MessageContentId?, Int> {
         if (initialFolder != null) {
-            tx.getFolder(initialFolder)?.takeIf { it.ownerId == sender }
-                ?: throw NotFound("Folder not found")
+            tx.getFolder(initialFolder)
+                ?.takeIf { it.ownerId == sender }
+                .assertNotNull(msg = "Folder not found")
         }
 
         val senderAccount = tx.getSenderAccount(sender)
@@ -406,7 +409,7 @@ class MessageService(
                     """
                     )
                 }
-                .execute()
+                .executeAndReturnCount()
 
         if (rows == 0) throw Conflict("Message already deleted")
 

--- a/service/src/main/kotlin/evaka/core/nekku/NekkuQueries.kt
+++ b/service/src/main/kotlin/evaka/core/nekku/NekkuQueries.kt
@@ -105,9 +105,10 @@ WHERE nekku_customer_number != ALL (${bind(newNekkuCustomerNumbers)})
     return affectedGroups
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.setCustomerNumbers(customerNumbers: List<NekkuCustomer>): Int {
     val newCustomerNumbers = customerNumbers.map { it.number }
-    val deletedCustomerCount = execute {
+    val deletedCustomerCount = executeAndReturnCount {
         sql("DELETE FROM nekku_customer WHERE number != ALL (${bind(newCustomerNumbers)})")
     }
     executeBatch(customerNumbers) {
@@ -369,7 +370,7 @@ AND value != ALL(${bind { (_, option) -> option.map { it.value } }})
     }
 
     val deletedSpecialOptionsCount =
-        executeBatch(specialDietOptions) {
+        executeBatchAndReturnCounts(specialDietOptions) {
             sql(
                 """
 DELETE FROM nekku_special_diet_option 
@@ -547,7 +548,7 @@ fun fetchAndUpdateNekkuProducts(client: NekkuClient, db: Database.Connection) {
 
 fun Database.Transaction.setProductNumbers(productNumbers: List<NekkuProduct>): Int {
     val newProductNumbers = productNumbers.map { it.sku }
-    val deletedProductCount = execute {
+    val deletedProductCount = executeAndReturnCount {
         sql("DELETE FROM nekku_product WHERE sku != ALL (${bind(newProductNumbers)})")
     }
     executeBatch(productNumbers) {
@@ -836,7 +837,7 @@ fun Database.Transaction.setNekkuReportOrderReport(
             )
         }
 
-    val deletedNekkuOrders = execute {
+    val deletedNekkuOrders = executeAndReturnCount {
         sql(
             """
 DELETE FROM nekku_orders_report
@@ -899,7 +900,7 @@ fun Database.Transaction.setNekkuReportOrderErrorReport(
     val reportRow =
         NekkuOrdersReport(date, daycareId, groupId, "", 0, null, null, null, nekkuOrderError, now)
 
-    val deletedNekkuOrders = execute {
+    val deletedNekkuOrders = executeAndReturnCount {
         sql(
             """
 DELETE FROM nekku_orders_report

--- a/service/src/main/kotlin/evaka/core/pis/EmailVerificationQueries.kt
+++ b/service/src/main/kotlin/evaka/core/pis/EmailVerificationQueries.kt
@@ -121,8 +121,9 @@ fun Database.Transaction.markEmailVerificationSent(
     }
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.deleteExpiredEmailVerifications(now: HelsinkiDateTime): Int =
     createUpdate {
         sql("DELETE FROM person_email_verification WHERE expires_at <= ${bind(now)}")
     }
-    .execute()
+    .executeAndReturnCount()

--- a/service/src/main/kotlin/evaka/core/pis/EmployeeQueries.kt
+++ b/service/src/main/kotlin/evaka/core/pis/EmployeeQueries.kt
@@ -105,6 +105,7 @@ RETURNING id, first_name, last_name, email, external_id, created, updated, roles
     .executeAndReturnGeneratedKeys()
     .exactlyOne<Employee>()
 
+@IgnorableReturnValue
 fun Database.Transaction.updateExternalIdByEmployeeNumber(
     employeeNumber: String,
     externalId: ExternalId,
@@ -346,7 +347,7 @@ fun Database.Transaction.updateEmployeeGlobalRoles(id: EmployeeId, globalRoles: 
     """
         )
     }
-        .execute()
+        .executeAndReturnCount()
 
     if (updated != 1) throw NotFound("employee $id not found")
 }
@@ -480,7 +481,7 @@ ON CONFLICT (user_id) DO UPDATE SET
 """
                 )
             }
-            .execute()
+            .executeAndReturnCount()
 
     if (updated == 0) throw NotFound("Could not update pin code for $userId. User not found")
 }

--- a/service/src/main/kotlin/evaka/core/pis/FosterParentQueries.kt
+++ b/service/src/main/kotlin/evaka/core/pis/FosterParentQueries.kt
@@ -96,13 +96,13 @@ WHERE id = ${bind(id)}
 """
     )
 }
-    .execute()
-    .also {
+    .executeAndReturnCount()
+    .let {
         if (it != 1) throw BadRequest("Could not update validity of foster_parent row with id $id")
     }
 
 fun Database.Transaction.deleteFosterParentRelationship(id: FosterParentId) = createUpdate {
     sql("DELETE FROM foster_parent WHERE id = ${bind(id)}")
 }
-    .execute()
-    .also { if (it != 1) throw BadRequest("Could not delete foster_parent row with id $id") }
+    .executeAndReturnCount()
+    .let { if (it != 1) throw BadRequest("Could not delete foster_parent row with id $id") }

--- a/service/src/main/kotlin/evaka/core/pis/InactivePeopleCleanup.kt
+++ b/service/src/main/kotlin/evaka/core/pis/InactivePeopleCleanup.kt
@@ -13,6 +13,7 @@ import java.time.LocalDate
 
 private val logger = KotlinLogging.logger {}
 
+@IgnorableReturnValue
 fun cleanUpInactivePeople(tx: Database.Transaction, queryDate: LocalDate): Set<PersonId> {
     val twoMonthsAgo = queryDate.minusMonths(2)
     tx.setStatementTimeout(Duration.ofMinutes(20))

--- a/service/src/main/kotlin/evaka/core/pis/ParentshipQueries.kt
+++ b/service/src/main/kotlin/evaka/core/pis/ParentshipQueries.kt
@@ -73,6 +73,7 @@ AND (${bind(includeConflicts)} OR conflict = false)
         .toList(toParentshipDetailed("child", "head"))
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.createParentship(
     childId: ChildId,
     headOfChildId: PersonId,
@@ -108,6 +109,7 @@ JOIN person head ON fc.head_of_child = head.id
         .exactlyOne(toParentship("child", "head"))
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.updateParentshipDuration(
     id: ParentshipId,
     startDate: LocalDate,
@@ -135,7 +137,7 @@ fun Database.Transaction.updateParentshipDuration(
             """
         )
     }
-        .execute() > 0
+        .executeAndReturnCount() > 0
 }
 
 fun Database.Transaction.retryParentship(

--- a/service/src/main/kotlin/evaka/core/pis/PartnershipQueries.kt
+++ b/service/src/main/kotlin/evaka/core/pis/PartnershipQueries.kt
@@ -116,6 +116,7 @@ AND (${bind(includeConflicts)} OR fp.conflict = false)
         .toList(toPartner("p"))
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.createPartnership(
     personId1: PersonId,
     personId2: PersonId,
@@ -173,6 +174,7 @@ fun Database.Transaction.createPartnership(
         .exactlyOne(toPartnership("p1", "p2"))
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.updatePartnershipDuration(
     id: PartnershipId,
     startDate: LocalDate,
@@ -210,6 +212,7 @@ fun Database.Transaction.retryPartnership(
         .execute()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.deletePartnership(id: PartnershipId): Boolean {
     return createQuery {
         sql(

--- a/service/src/main/kotlin/evaka/core/pis/PersonQueries.kt
+++ b/service/src/main/kotlin/evaka/core/pis/PersonQueries.kt
@@ -360,6 +360,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOneOrNull<PersonId>()
 
+@IgnorableReturnValue
 fun Database.Transaction.updatePersonFromVtj(person: PersonDTO): PersonDTO {
     val p = person.copy(updatedFromVtj = HelsinkiDateTime.now())
     return createQuery {

--- a/service/src/main/kotlin/evaka/core/pis/SystemController.kt
+++ b/service/src/main/kotlin/evaka/core/pis/SystemController.kt
@@ -79,7 +79,7 @@ class SystemController(
                     tx.updateLastStrongLogin(now, citizen.id)
                     tx.updateCitizenOnLogin(now, citizen.id)
                     tx.upsertCitizenUser(citizen.id)
-                    personService.getPersonWithChildren(tx, user, now, citizen.id)
+                    val _ = personService.getPersonWithChildren(tx, user, now, citizen.id)
                     citizen
                 }
             }
@@ -124,7 +124,7 @@ class SystemController(
                     val now = clock.now()
                     tx.updateLastWeakLogin(now, citizen.id)
                     tx.updateCitizenOnLogin(now, citizen.id)
-                    personService.getPersonWithChildren(tx, user, now, citizen.id)
+                    val _ = personService.getPersonWithChildren(tx, user, now, citizen.id)
                     CitizenUserIdentity(citizen.id)
                 }
                 .also {
@@ -200,7 +200,7 @@ class SystemController(
                     }
                     tx.updateLastWeakLogin(now, finished.person)
                     tx.updateCitizenOnLogin(now, finished.person)
-                    personService.getPersonWithChildren(tx, user, now, finished.person)
+                    val _ = personService.getPersonWithChildren(tx, user, now, finished.person)
                     finished.passkey.id to CitizenUserIdentity(finished.person)
                 }
                 .let { (passkeyId, identity) ->

--- a/service/src/main/kotlin/evaka/core/pis/controllers/PasskeyControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/pis/controllers/PasskeyControllerCitizen.kt
@@ -19,6 +19,7 @@ import evaka.core.shared.domain.EvakaClock
 import evaka.core.shared.domain.NotFound
 import evaka.core.shared.security.AccessControl
 import evaka.core.shared.security.Action
+import evaka.core.shared.utils.assertNotNull
 import evaka.core.user.CitizenPasskey
 import evaka.core.user.NewPasskey
 import evaka.core.user.PasskeyService
@@ -236,7 +237,7 @@ class PasskeyControllerCitizen(
                     Action.Citizen.Person.DELETE_PASSKEY,
                     user.id,
                 )
-                tx.deleteCitizenPasskey(user.id, id) ?: throw NotFound("Passkey not found")
+                tx.deleteCitizenPasskey(user.id, id).assertNotNull(msg = "Passkey not found")
                 asyncJobRunner.plan(
                     tx,
                     sequenceOf(AsyncJob.SendPasskeyRemovedEmail(user.id)),

--- a/service/src/main/kotlin/evaka/core/pis/controllers/PersonController.kt
+++ b/service/src/main/kotlin/evaka/core/pis/controllers/PersonController.kt
@@ -596,7 +596,14 @@ class PersonController(
                     tx.blockGuardian(childId, body.guardianId)
                 } else {
                     tx.unblockGuardian(childId, body.guardianId)
-                    personService.getGuardians(tx, user, clock.now(), childId, forceRefresh = true)
+                    val _ =
+                        personService.getGuardians(
+                            tx,
+                            user,
+                            clock.now(),
+                            childId,
+                            forceRefresh = true,
+                        )
                 }
             }
         }

--- a/service/src/main/kotlin/evaka/core/pis/service/GuardianQueries.kt
+++ b/service/src/main/kotlin/evaka/core/pis/service/GuardianQueries.kt
@@ -165,7 +165,7 @@ fun Database.Read.getGuardianChildIds(guardianId: PersonId): List<ChildId> {
         .toList<ChildId>()
 }
 
-fun Database.Transaction.deleteGuardianChildRelationShips(guardianId: PersonId): Int {
+fun Database.Transaction.deleteGuardianChildRelationShips(guardianId: PersonId) {
     return createUpdate {
         sql(
             """
@@ -177,7 +177,7 @@ fun Database.Transaction.deleteGuardianChildRelationShips(guardianId: PersonId):
         .execute()
 }
 
-fun Database.Transaction.deleteChildGuardianRelationships(childId: ChildId): Int {
+fun Database.Transaction.deleteChildGuardianRelationships(childId: ChildId) {
     return createUpdate {
         sql(
             """

--- a/service/src/main/kotlin/evaka/core/pis/service/ParentshipService.kt
+++ b/service/src/main/kotlin/evaka/core/pis/service/ParentshipService.kt
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Service
 class ParentshipService(private val asyncJobRunner: AsyncJobRunner<AsyncJob>) {
     private val logger = KotlinLogging.logger {}
 
+    @IgnorableReturnValue
     fun createParentship(
         tx: Database.Transaction,
         clock: EvakaClock,
@@ -54,6 +55,7 @@ class ParentshipService(private val asyncJobRunner: AsyncJobRunner<AsyncJob>) {
         }
     }
 
+    @IgnorableReturnValue
     fun updateParentshipDuration(
         tx: Database.Transaction,
         clock: EvakaClock,

--- a/service/src/main/kotlin/evaka/core/pis/service/PersonService.kt
+++ b/service/src/main/kotlin/evaka/core/pis/service/PersonService.kt
@@ -213,6 +213,7 @@ class PersonService(private val personDetailsService: IPersonDetailsService) {
         }
     }
 
+    @IgnorableReturnValue
     fun patchUserDetails(tx: Database.Transaction, id: PersonId, data: PersonPatch): PersonDTO {
         val person = tx.getPersonById(id) ?: throw NotFound("Person $id not found")
 
@@ -730,6 +731,7 @@ private fun upsertVtjChildren(
     return guardian.toVtjPersonDTO().copy(children = children.map { it.toVtjPersonDTO() })
 }
 
+@IgnorableReturnValue
 private fun upsertVtjPerson(tx: Database.Transaction, inputPerson: VtjPersonDTO): PersonDTO {
     val existingPerson = tx.lockPersonBySSN(inputPerson.socialSecurityNumber)
 

--- a/service/src/main/kotlin/evaka/core/placement/PlacementPlanQueries.kt
+++ b/service/src/main/kotlin/evaka/core/placement/PlacementPlanQueries.kt
@@ -42,6 +42,7 @@ AND NOT EXISTS (
         .execute()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.createPlacementPlan(
     applicationId: ApplicationId,
     type: PlacementType,

--- a/service/src/main/kotlin/evaka/core/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/evaka/core/placement/PlacementPlanService.kt
@@ -206,6 +206,7 @@ class PlacementPlanService(
         applicationId: ApplicationId,
     ) = tx.softDeletePlacementPlanIfUnused(applicationId)
 
+    @IgnorableReturnValue
     fun createPlacementPlan(
         tx: Database.Transaction,
         application: ApplicationDetails,

--- a/service/src/main/kotlin/evaka/core/placement/PlacementQueries.kt
+++ b/service/src/main/kotlin/evaka/core/placement/PlacementQueries.kt
@@ -147,6 +147,7 @@ fun Database.Read.getPlacementsForChildrenAt(
         )
         .associateBy { it.childId }
 
+@IgnorableReturnValue
 fun Database.Transaction.insertPlacement(
     type: PlacementType,
     childId: ChildId,
@@ -203,6 +204,7 @@ RETURNING *
 }
 
 /** Derive a new placement from an existing one, allowing to change the type and dates */
+@IgnorableReturnValue
 fun Database.Transaction.insertDerivedPlacement(
     placement: Placement,
     newType: PlacementType,
@@ -344,6 +346,7 @@ data class CancelPlacementResult(
     val endDate: LocalDate,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.cancelPlacement(
     modifiedAt: HelsinkiDateTime,
     modifiedBy: EvakaUserId,
@@ -918,6 +921,7 @@ fun Database.Read.getGroupPlacementChildren(
         .toList<ChildId>()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.createGroupPlacement(
     placementId: PlacementId,
     groupId: GroupId,
@@ -936,6 +940,7 @@ RETURNING id
         .exactlyOne<GroupPlacementId>()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.updateGroupPlacementStartDate(
     id: GroupPlacementId,
     startDate: LocalDate,
@@ -948,6 +953,7 @@ fun Database.Transaction.updateGroupPlacementStartDate(
         .exactlyOneOrNull<GroupPlacementId>() != null
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.updateGroupPlacementEndDate(
     id: GroupPlacementId,
     endDate: LocalDate,
@@ -960,6 +966,7 @@ fun Database.Transaction.updateGroupPlacementEndDate(
         .exactlyOneOrNull<GroupPlacementId>() != null
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.deleteGroupPlacement(id: GroupPlacementId): Boolean {
     val dgPlacement = getDaycareGroupPlacement(id)
     if (dgPlacement != null) {

--- a/service/src/main/kotlin/evaka/core/placement/PlacementService.kt
+++ b/service/src/main/kotlin/evaka/core/placement/PlacementService.kt
@@ -52,6 +52,7 @@ data class ApplicationServiceNeed(
     val placementType: PlacementType,
 )
 
+@IgnorableReturnValue
 fun createPlacements(
     tx: Database.Transaction,
     childId: ChildId,
@@ -107,6 +108,7 @@ fun createPlacements(
     }
 }
 
+@IgnorableReturnValue
 fun createPlacement(
     tx: Database.Transaction,
     childId: ChildId,
@@ -141,6 +143,7 @@ fun createPlacement(
     )
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.updatePlacement(
     id: PlacementId,
     startDate: LocalDate,
@@ -216,6 +219,7 @@ fun Database.Transaction.updatePlacement(
     return old
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.checkAndCreateGroupPlacement(
     daycarePlacementId: PlacementId,
     groupId: GroupId,

--- a/service/src/main/kotlin/evaka/core/reports/TitaniaErrorsReport.kt
+++ b/service/src/main/kotlin/evaka/core/reports/TitaniaErrorsReport.kt
@@ -56,11 +56,12 @@ class TitaniaErrorReport(private val accessControl: AccessControl) {
     ) {
         return db.connect { dbc ->
                 dbc.transaction { tx ->
-                    accessControl.requireAuthorizationFilter(
+                    accessControl.requirePermissionFor(
                         tx,
                         user,
                         clock,
-                        Action.Unit.READ_TITANIA_ERRORS,
+                        Action.TitaniaError.DELETE,
+                        conflictId,
                     )
                     tx.deleteTitaniaError(conflictId)
                 }

--- a/service/src/main/kotlin/evaka/core/reservations/ReservationQueries.kt
+++ b/service/src/main/kotlin/evaka/core/reservations/ReservationQueries.kt
@@ -47,6 +47,7 @@ fun Database.Transaction.deleteAbsencesCreatedFromQuestionnaire(
         .execute()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.clearOldReservations(
     reservations: List<Pair<ChildId, LocalDate>>
 ): List<AttendanceReservationId> =
@@ -62,7 +63,7 @@ RETURNING id
         .executeAndReturn()
         .toList()
 
-fun Database.Transaction.deleteReservationsInRange(childId: ChildId, range: DateRange): Int {
+fun Database.Transaction.deleteReservationsInRange(childId: ChildId, range: DateRange) {
     return createUpdate {
         sql(
             """
@@ -103,6 +104,7 @@ RETURNING id
 
 data class ReservationInsert(val childId: ChildId, val date: LocalDate, val range: TimeRange?)
 
+@IgnorableReturnValue
 fun Database.Transaction.insertValidReservations(
     userId: EvakaUserId,
     createdAt: HelsinkiDateTime,
@@ -734,6 +736,7 @@ fun Database.Read.getReservationEnabledPlacementRangesByChild(
     }
     .useSequence { rows -> rows.groupBy({ it.first }, { it.second }) }
 
+@IgnorableReturnValue
 fun Database.Transaction.deleteInvalidatedShiftCareReservationsAfterDate(date: LocalDate): Int {
     val futureHolidays = getHolidays(FiniteDateRange(date, date.plusMonths(6)))
     return createUpdate {
@@ -758,5 +761,5 @@ fun Database.Transaction.deleteInvalidatedShiftCareReservationsAfterDate(date: L
                     """
         )
     }
-        .execute()
+        .executeAndReturnCount()
 }

--- a/service/src/main/kotlin/evaka/core/s3/ContentTypeUtils.kt
+++ b/service/src/main/kotlin/evaka/core/s3/ContentTypeUtils.kt
@@ -43,8 +43,9 @@ enum class ContentTypePattern(
 
 fun checkFileContentType(file: InputStream, allowedContentTypes: Set<ContentTypePattern>): String {
     val detectedContentType = tika.detect(file)
-    allowedContentTypes.find { it.matchesContentType(detectedContentType) }
-        ?: throw BadRequest("Invalid content type $detectedContentType", "INVALID_CONTENT_TYPE")
+    if (allowedContentTypes.none { it.matchesContentType(detectedContentType) }) {
+        throw BadRequest("Invalid content type $detectedContentType", "INVALID_CONTENT_TYPE")
+    }
     return detectedContentType
 }
 

--- a/service/src/main/kotlin/evaka/core/s3/DocumentService.kt
+++ b/service/src/main/kotlin/evaka/core/s3/DocumentService.kt
@@ -31,6 +31,7 @@ interface DocumentService {
     fun responseInline(location: DocumentLocation, fileName: String?) =
         response(location, ContentDisposition.inline().filename(fileName, Charsets.UTF_8).build())
 
+    @IgnorableReturnValue
     fun upload(key: DocumentKey, bytes: ByteArray, contentType: String): DocumentLocation =
         bytes.inputStream().use { stream ->
             val location = locate(key)

--- a/service/src/main/kotlin/evaka/core/serviceneed/ServiceNeedQueries.kt
+++ b/service/src/main/kotlin/evaka/core/serviceneed/ServiceNeedQueries.kt
@@ -123,6 +123,7 @@ WHERE sn.id = ${bind(id)}
         .exactlyOneOrNull<ServiceNeedChildRange>() ?: throw NotFound("Service need $id not found")
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insertServiceNeed(
     placementId: PlacementId,
     startDate: LocalDate,

--- a/service/src/main/kotlin/evaka/core/serviceneed/application/ServiceApplicationControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/serviceneed/application/ServiceApplicationControllerCitizen.kt
@@ -105,9 +105,10 @@ class ServiceApplicationControllerCitizen(private val accessControl: AccessContr
                     val placement =
                         tx.getPlacementsForChildDuring(childId, date, date).firstOrNull()
                             ?: return@read emptyList()
-                    tx.getDaycare(placement.unitId)?.takeIf {
-                        it.enabledPilotFeatures.contains(PilotFeature.SERVICE_APPLICATIONS)
-                    } ?: return@read emptyList()
+                    val _ =
+                        tx.getDaycare(placement.unitId)?.takeIf {
+                            it.enabledPilotFeatures.contains(PilotFeature.SERVICE_APPLICATIONS)
+                        } ?: return@read emptyList()
 
                     tx.getServiceNeedOptions()
                         .filter {

--- a/service/src/main/kotlin/evaka/core/sficlient/MockSfiMessagesClient.kt
+++ b/service/src/main/kotlin/evaka/core/sficlient/MockSfiMessagesClient.kt
@@ -76,16 +76,18 @@ class MockSfiMessagesClient : SfiMessagesClient {
 
         fun getMessages() = lock.read { data.values.toList() }
 
-        fun reset() = lock.write {
-            data.clear()
-            events.clear()
-            messageId = 0
+        fun reset() {
+            lock.write {
+                data.clear()
+                events.clear()
+                messageId = 0
+            }
         }
 
         fun getEvents() = lock.read { events.toList() }
 
-        fun addEventsResponse(getEventsResponse: GetEventsResponse) = lock.write {
-            events.add(getEventsResponse)
+        fun addEventsResponse(getEventsResponse: GetEventsResponse) {
+            lock.write { events.add(getEventsResponse) }
         }
 
         fun getNextMessageId(): Long {

--- a/service/src/main/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClient.kt
+++ b/service/src/main/kotlin/evaka/core/sficlient/rest/SfiMessagesRestClient.kt
@@ -285,7 +285,7 @@ class SfiMessagesRestClient(
                 logger.info { "Pending password found -> testing if it's valid" }
                 val gotAccessToken =
                     try {
-                        getAccessToken(pending.password)
+                        val _ = getAccessToken(pending.password)
                         true
                     } catch (e: Exception) {
                         logger.error(e) { "Failed to get access token with pending password" }

--- a/service/src/main/kotlin/evaka/core/shared/Tracing.kt
+++ b/service/src/main/kotlin/evaka/core/shared/Tracing.kt
@@ -45,9 +45,11 @@ class ToStringAttributeKey<T>(key: String) {
 
 data class AttributeValue<T>(val key: AttributeKey<T>, val value: T)
 
+@IgnorableReturnValue
 fun <T> Span.setAttribute(attribute: ToStringAttributeKey<T>, value: T): Span =
     value?.let { setAttribute(attribute.key, it.toString()) } ?: this
 
+@IgnorableReturnValue
 fun <T> SpanBuilder.withAttribute(attribute: AttributeValue<T>): SpanBuilder =
     attribute.value?.let { setAttribute(attribute.key, it) } ?: this
 

--- a/service/src/main/kotlin/evaka/core/shared/async/AsyncJobPool.kt
+++ b/service/src/main/kotlin/evaka/core/shared/async/AsyncJobPool.kt
@@ -135,6 +135,7 @@ class AsyncJobPool<T : AsyncJobPayload>(
         return task.get()
     }
 
+    @IgnorableReturnValue
     private fun runWorker(clock: EvakaClock, maxCount: Int) =
         tracer.withDetachedSpan("asyncjob.worker $fullName") {
             Database(jdbi, tracer).connect { dbc ->

--- a/service/src/main/kotlin/evaka/core/shared/async/AsyncJobQueries.kt
+++ b/service/src/main/kotlin/evaka/core/shared/async/AsyncJobQueries.kt
@@ -148,6 +148,7 @@ WHERE id = ${bind(job.jobId)}
 }
     .execute()
 
+@IgnorableReturnValue
 fun Database.Transaction.removeCompletedJobs(completedBefore: HelsinkiDateTime): Int =
     createUpdate {
         sql(
@@ -157,21 +158,21 @@ WHERE completed_at < ${bind(completedBefore)}
 """
         )
     }
-    .execute()
+    .executeAndReturnCount()
 
-fun Database.Transaction.removeUnclaimedJobs(jobTypes: Collection<AsyncJobType<*>>): Int =
-    createUpdate {
-        sql(
-            """
+fun Database.Transaction.removeUnclaimedJobs(jobTypes: Collection<AsyncJobType<*>>) = createUpdate {
+    sql(
+        """
 DELETE FROM async_job
 WHERE completed_at IS NULL
 AND claimed_at IS NULL
 AND type = ANY(${bind(jobTypes.map { it.name })})
     """
-        )
-    }
+    )
+}
     .execute()
 
+@IgnorableReturnValue
 fun Database.Transaction.removeUncompletedJobs(runBefore: HelsinkiDateTime): Int = createUpdate {
     sql(
         """
@@ -181,7 +182,7 @@ AND run_at < ${bind(runBefore)}
 """
     )
 }
-    .execute()
+    .executeAndReturnCount()
 
 fun Database.Connection.removeOldAsyncJobs(now: HelsinkiDateTime) {
     val completedBefore = now.minusMonths(6)

--- a/service/src/main/kotlin/evaka/core/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/evaka/core/shared/async/AsyncJobRunner.kt
@@ -194,6 +194,7 @@ class AsyncJobRunner<T : AsyncJobPayload>(
 
     fun disableAfterCommitHooks() = stateLock.write { afterCommitHooks = emptyMap() }
 
+    @IgnorableReturnValue
     fun runPendingJobsSync(clock: EvakaClock, maxCount: Int = 1_000): Int {
         var totalCount = 0
         do {

--- a/service/src/main/kotlin/evaka/core/shared/config/ActuatorConfig.kt
+++ b/service/src/main/kotlin/evaka/core/shared/config/ActuatorConfig.kt
@@ -26,9 +26,10 @@ class DatabaseHealthIndicator(private val jdbi: Jdbi, private val tracer: Tracer
     AbstractHealthIndicator() {
     override fun doHealthCheck(builder: Health.Builder) {
         try {
-            Database(jdbi, tracer).connect { db ->
-                db.read { tx -> tx.createQuery { sql("SELECT 1") }.exactlyOne<Int>() }
-            }
+            val _ =
+                Database(jdbi, tracer).connect { db ->
+                    db.read { tx -> tx.createQuery { sql("SELECT 1") }.exactlyOne<Int>() }
+                }
             builder.up()
         } catch (e: JdbiException) {
             builder.down(e)

--- a/service/src/main/kotlin/evaka/core/shared/db/Database.kt
+++ b/service/src/main/kotlin/evaka/core/shared/db/Database.kt
@@ -8,6 +8,9 @@ import evaka.core.shared.domain.NotFound
 import evaka.core.shared.withSpan
 import io.opentelemetry.api.trace.Tracer
 import java.time.Duration
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -56,7 +59,11 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
      *
      * Throws `IllegalStateException` if a connection is already open
      */
-    fun <T> connect(f: (db: Connection) -> T): T = connectWithManualLifecycle().use(f)
+    @OptIn(ExperimentalContracts::class)
+    fun <T> connect(f: (db: Connection) -> T): T {
+        contract { returnsResultOf(f) }
+        return connectWithManualLifecycle().use(f)
+    }
 
     /**
      * Opens a new database connection and returns it. The connection *must be closed after use*.
@@ -125,7 +132,9 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
          * Throws `IllegalStateException` if this database connection is already in read mode or a
          * transaction.
          */
+        @OptIn(ExperimentalContracts::class)
         fun <T> transaction(f: (db: Transaction) -> T): T {
+            contract { returnsResultOf(f) }
             threadId.assertCurrentThread()
             val handle = this.getRawHandle()
             check(!handle.isInTransaction) { "Already in a transaction" }
@@ -137,17 +146,19 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
                 .also { hooks.afterCommit.forEach { it() } }
         }
 
-        fun executeOutsideTransaction(f: QuerySql.Builder.() -> QuerySql): Int {
+        @OptIn(ExperimentalContracts::class)
+        fun executeOutsideTransaction(f: QuerySql.Builder.() -> QuerySql) {
+            contract { callsInPlace(f, InvocationKind.EXACTLY_ONCE) }
             threadId.assertCurrentThread()
             val handle = this.getRawHandle()
             check(!handle.isInTransaction) { "Already in a transaction" }
-            return tracer.withSpan("db.executeOutsideTransaction read/write") {
-                val fragment = QuerySql.Builder().run { f(this) }
+            val fragment = QuerySql.Builder().run { f(this) }
+            tracer.withSpan("db.executeOutsideTransaction read/write") {
                 val raw = handle.createUpdate(fragment.sql.toString())
                 for ((idx, binding) in fragment.bindings.withIndex()) {
                     raw.bindByType(idx, binding.value, binding.type)
                 }
-                raw.execute()
+                val _ = raw.execute()
             }
         }
 
@@ -176,11 +187,13 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
             return Query(raw)
         }
 
-        fun setLockTimeout(duration: Duration) =
+        fun setLockTimeout(duration: Duration) {
             handle.execute("SET LOCAL lock_timeout = '${duration.toMillis()}ms'")
+        }
 
-        fun setStatementTimeout(duration: Duration) =
+        fun setStatementTimeout(duration: Duration) {
             handle.execute("SET LOCAL statement_timeout = '${duration.toMillis()}ms'")
+        }
     }
 
     /**
@@ -206,8 +219,12 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
             return Update(raw)
         }
 
-        fun execute(f: QuerySql.Builder.() -> QuerySql): Int =
-            createUpdate(QuerySql.Builder().run { f(this) }).execute()
+        fun execute(f: QuerySql.Builder.() -> QuerySql) {
+            val _ = executeAndReturnCount(f)
+        }
+
+        fun executeAndReturnCount(f: QuerySql.Builder.() -> QuerySql): Int =
+            createUpdate(QuerySql.Builder().run { f(this) }).executeAndReturnCount()
 
         fun <R> prepareBatch(f: BatchSql.Builder<R>.() -> BatchSql<R>): PreparedBatch<R> {
             val batch = BatchSql.Builder<R>().run { f(this) }
@@ -225,15 +242,29 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
             f: BatchSql.Builder<R>.() -> BatchSql<R>,
         ): PreparedBatch<R> = prepareBatch(f).addAll(rows)
 
+        fun <R> executeBatchAndReturnCounts(
+            rows: Iterable<R>,
+            f: BatchSql.Builder<R>.() -> BatchSql<R>,
+        ): IntArray = prepareBatch(f).addAll(rows).executeAndReturnCounts()
+
+        fun <R> executeBatchAndReturnCounts(
+            rows: Sequence<R>,
+            f: BatchSql.Builder<R>.() -> BatchSql<R>,
+        ): IntArray = prepareBatch(f).addAll(rows).executeAndReturnCounts()
+
         fun <R> executeBatch(
             rows: Iterable<R>,
             f: BatchSql.Builder<R>.() -> BatchSql<R>,
-        ): IntArray = prepareBatch(f).addAll(rows).execute()
+        ) {
+            val _ = executeBatchAndReturnCounts(rows, f)
+        }
 
         fun <R> executeBatch(
             rows: Sequence<R>,
             f: BatchSql.Builder<R>.() -> BatchSql<R>,
-        ): IntArray = prepareBatch(f).addAll(rows).execute()
+        ) {
+            val _ = executeBatchAndReturnCounts(rows, f)
+        }
 
         /**
          * Registers a function to be called after this transaction has been committed successfully.
@@ -245,7 +276,9 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
             hooks.afterCommit += f
         }
 
+        @OptIn(ExperimentalContracts::class)
         fun <T> subTransaction(f: () -> T): T {
+            contract { returnsResultOf(f) }
             val savepointName = nextSavepoint()
             handle.savepoint(savepointName)
             val result =
@@ -445,7 +478,11 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
         SqlStatement<Update>() {
         override fun self(): Update = this
 
-        fun execute() = raw.execute()
+        fun execute() {
+            val _ = executeAndReturnCount()
+        }
+
+        fun executeAndReturnCount() = raw.execute()
 
         fun executeAndReturnGeneratedKeys(): UpdateResult =
             UpdateResult(raw.executeAndReturnGeneratedKeys())
@@ -454,15 +491,16 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
             notFoundMsg: String = "Not found",
             foundMultipleMsg: String = "Found multiple",
         ) {
-            val rows = this.execute()
+            val rows = this.executeAndReturnCount()
             if (rows == 0) throw NotFound(notFoundMsg)
             if (rows > 1) throw Error(foundMultipleMsg)
         }
 
-        fun updateNoneOrOne(foundMultipleMsg: String = "Found multiple"): Int {
-            val rows = this.execute()
+        @IgnorableReturnValue
+        fun updateNoneOrOne(foundMultipleMsg: String = "Found multiple"): Boolean {
+            val rows = this.executeAndReturnCount()
             if (rows > 1) throw Error(foundMultipleMsg)
-            return rows
+            return rows == 1
         }
     }
 
@@ -471,7 +509,11 @@ class Database(private val jdbi: Jdbi, private val tracer: Tracer) {
         private val raw: org.jdbi.v3.core.statement.PreparedBatch,
         private val bindings: List<BatchBinding<R, *>>,
     ) {
-        fun execute(): IntArray = raw.execute()
+        fun execute() {
+            val _ = executeAndReturnCounts()
+        }
+
+        fun executeAndReturnCounts() = raw.execute()
 
         fun executeAndReturn(): UpdateResult = UpdateResult(raw.executePreparedBatch())
 

--- a/service/src/main/kotlin/evaka/core/shared/db/JdbiExtensions.kt
+++ b/service/src/main/kotlin/evaka/core/shared/db/JdbiExtensions.kt
@@ -268,10 +268,15 @@ private class Parser(private var text: CharSequence) {
             }
         }
         val result = mutableListOf<T>()
-        while (true) {
-            when (peekChar()) {
-                ',' -> parseChar()
-                '}' -> break
+        while (peekChar() != '}') {
+            if (result.isNotEmpty()) {
+                when (val char = parseChar()) {
+                    ',' -> {}
+
+                    else -> {
+                        error("Expected comma, got $char")
+                    }
+                }
             }
             result.add(parseRange(this))
         }

--- a/service/src/main/kotlin/evaka/core/shared/dev/DataInitializers.kt
+++ b/service/src/main/kotlin/evaka/core/shared/dev/DataInitializers.kt
@@ -165,6 +165,7 @@ fun Database.Transaction.ensureDevData() {
     }
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: AbsenceApplication): AbsenceApplicationId = createUpdate {
     sql(
         """
@@ -203,6 +204,7 @@ INSERT INTO absence_application (
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevCareArea): AreaId = createUpdate {
     sql(
         """
@@ -215,6 +217,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(
     row: DevDailyServiceTimeNotification
 ): DailyServiceTimeNotificationId = createUpdate {
@@ -246,6 +249,7 @@ VALUES (
         .execute()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevDaycare): DaycareId = createUpdate {
     sql(
         """
@@ -335,6 +339,7 @@ INSERT INTO evaka_user (id, type, mobile_device_id, name) VALUES (${bind(id)}, '
         .execute()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevEmployee) = createUpdate {
     sql(
         """
@@ -348,6 +353,7 @@ RETURNING id
     .exactlyOne<EmployeeId>()
     .also { upsertEmployeeUser(it) }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(
     row: DevEmployee,
     unitRoles: Map<DaycareId, UserRole> = mapOf(),
@@ -375,6 +381,7 @@ RETURNING id
         }
     }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevMobileDevice) = createUpdate {
     sql(
         """
@@ -388,6 +395,7 @@ RETURNING id
     .exactlyOne<MobileDeviceId>()
     .also { upsertMobileDeviceUser(it) }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevPersonalMobileDevice) = createUpdate {
     sql(
         """
@@ -406,6 +414,7 @@ enum class DevPersonType {
     RAW_ROW,
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(person: DevPerson, type: DevPersonType): PersonId {
     val p = person.copy(updatedFromVtj = if (person.ssn != null) HelsinkiDateTime.now() else null)
     return createUpdate {
@@ -446,6 +455,7 @@ RETURNING id
         }
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevParentship): ParentshipId = createUpdate {
     sql(
         """
@@ -457,6 +467,7 @@ VALUES (${bind(row.id)}, ${bind(row.headOfChildId)}, ${bind(row.childId)}, ${bin
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insertTestPartnership(
     adult1: PersonId,
     adult2: PersonId,
@@ -491,6 +502,7 @@ fun Database.Transaction.insertTestPartnership(
     return id
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insertTestApplication(
     id: ApplicationId = ApplicationId(UUID.randomUUID()),
     type: ApplicationType,
@@ -535,6 +547,7 @@ VALUES (${bind(id)}, ${bind(otherGuardianId)})
     return id
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevChild): ChildId = createUpdate {
     sql(
         """
@@ -549,6 +562,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevPlacement): PlacementId = createUpdate {
     sql(
         """
@@ -601,6 +615,7 @@ data class DevIncome(
     val modifiedBy: EvakaUserId,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevIncome): IncomeId = createUpdate {
     sql(
         """
@@ -626,6 +641,7 @@ data class DevIncomeStatement(
     val handledAt: HelsinkiDateTime? = null,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevIncomeStatement): IncomeStatementId {
     // insertion has complex bind logic, so workaround for reusing that
     val databaseGeneratedId =
@@ -668,6 +684,7 @@ data class DevFeeAlteration(
     val modifiedAt: HelsinkiDateTime = HelsinkiDateTime.now(),
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevFeeAlteration): FeeAlterationId = createUpdate {
     sql(
         """
@@ -679,6 +696,7 @@ VALUES (${bind(row.id)}, ${bind(row.personId)}, ${bind(row.type)}::fee_alteratio
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: FeeThresholds): FeeThresholdsId = createUpdate {
     sql(
         """
@@ -691,6 +709,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevDaycareGroup): GroupId = createUpdate {
     sql(
         """
@@ -702,6 +721,7 @@ VALUES (${bind(row.id)}, ${bind(row.daycareId)}, ${bind(row.name)}, ${bind(row.s
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevDaycareGroupPlacement): GroupPlacementId = createUpdate {
     sql(
         """
@@ -726,6 +746,7 @@ data class DevPlacementPlan(
     val deleted: Boolean? = false,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevPlacementPlan): PlacementPlanId = createUpdate {
     sql(
         """
@@ -778,6 +799,7 @@ data class TestDecision(
     val genericReasoningId: DecisionGenericReasoningId? = null,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insertTestDecision(decision: TestDecision): DecisionId = createUpdate {
     sql(
         """
@@ -790,6 +812,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevAssistanceAction): AssistanceActionId = createUpdate {
     sql(
         """
@@ -832,6 +855,7 @@ data class DevStaffAttendancePlan(
     val description: String? = null,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevStaffAttendancePlan): StaffAttendancePlanId = createUpdate {
     sql(
         """
@@ -843,6 +867,7 @@ VALUES (${bind(row.id)}, ${bind(row.employeeId)}, ${bind(row.type)}, ${bind(row.
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevStaffAttendance): StaffAttendanceRealtimeId = createUpdate {
     sql(
         """
@@ -908,6 +933,7 @@ VALUES (${bind(childId)}, ${bind(unitId)}, ${bind { (date, _, _) -> date }}, ${b
     }
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevBackupCare): BackupCareId = createUpdate {
     sql(
         """
@@ -920,6 +946,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insertApplication(application: DevApplicationWithForm): ApplicationId {
     if (application.type == ApplicationType.CLUB) {
             ClubFormV0.fromForm2(application.form, false, false)
@@ -986,6 +1013,7 @@ data class DevFamilyContact(
     val priority: Int,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevFamilyContact): FamilyContactId = createUpdate {
     sql(
         """
@@ -1005,6 +1033,7 @@ data class DevBackupPickup(
     val phone: String,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevBackupPickup): BackupPickupId = createUpdate {
     sql(
         """
@@ -1026,6 +1055,7 @@ data class DevFridgeChild(
     val conflict: Boolean = false,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevFridgeChild): ParentshipId = createUpdate {
     sql(
         """
@@ -1049,6 +1079,7 @@ data class DevFridgePartner(
     val conflict: Boolean = false,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevFridgePartner): PartnershipId = createUpdate {
     sql(
         """
@@ -1071,6 +1102,7 @@ data class DevFridgePartnership(
     val conflict: Boolean = false,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(partnership: DevFridgePartnership): PartnershipId =
     insert(
             DevFridgePartner(
@@ -1116,6 +1148,7 @@ data class DevFosterParent(
     val modifiedBy: EvakaUserId,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevFosterParent): FosterParentId = createUpdate {
     sql(
         """
@@ -1128,6 +1161,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevEmployeePin): EmployeePinId = createUpdate {
     sql(
         """
@@ -1167,6 +1201,7 @@ data class DevPedagogicalDocument(
     val modifiedBy: EvakaUserId = AuthenticatedUser.SystemInternalUser.evakaUserId,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevPedagogicalDocument): PedagogicalDocumentId = createUpdate {
     sql(
         """
@@ -1189,6 +1224,7 @@ data class DevReservation(
     val createdBy: EvakaUserId,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevReservation): AttendanceReservationId = createUpdate {
     sql(
         """
@@ -1236,6 +1272,7 @@ data class DevInvoiceRow(
     val idx: Int? = null,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(invoice: DevInvoice): InvoiceId {
     execute {
         sql(
@@ -1258,6 +1295,7 @@ VALUES (${bind(row.id)}, ${bind(invoice.id)}, ${bind(row.childId)}, ${bind(row.a
     return invoice.id
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(invoices: List<DevInvoice>): List<InvoiceId> {
     invoices.forEach { insert(it) }
     return invoices.map { it.id }
@@ -1294,6 +1332,7 @@ data class DevInvoiceCorrection(
     val modifiedBy: EvakaUserId = AuthenticatedUser.SystemInternalUser.evakaUserId,
 )
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevInvoiceCorrection): InvoiceCorrectionId = createUpdate {
     sql(
         """
@@ -1306,6 +1345,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevPayment): PaymentId = createUpdate {
     sql(
         """
@@ -1318,6 +1358,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevCalendarEvent): CalendarEventId = createUpdate {
     sql(
         """
@@ -1330,6 +1371,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevCalendarEventAttendee): CalendarEventAttendeeId =
     createUpdate {
         sql(
@@ -1343,6 +1385,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevCalendarEventTime): CalendarEventTimeId = createUpdate {
     sql(
         """
@@ -1357,6 +1400,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevDailyServiceTimes): DailyServiceTimesId = createUpdate {
     sql(
         """
@@ -1382,6 +1426,7 @@ ON CONFLICT (guardian_id, child_id) DO NOTHING
         .execute()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevAbsence): AbsenceId = createUpdate {
     sql(
         """
@@ -1394,6 +1439,7 @@ RETURNING id
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevDaycareCaretaker): DaycareCaretakerId = createUpdate {
     sql(
         """
@@ -1405,6 +1451,7 @@ VALUES (${bind(row.id)}, ${bind(row.groupId)}, ${bind(row.amount)}, ${bind(row.s
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevDocumentTemplate): DocumentTemplateId = createUpdate {
     sql(
         """
@@ -1416,6 +1463,7 @@ VALUES (${bind(row.id)}, ${bind(row.name)}, ${bind(row.type)}, ${bind(row.placem
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevChildDocument): ChildDocumentId {
     val type = createQuery {
         sql("SELECT type FROM document_template WHERE id = ${bind(row.templateId)}")
@@ -1451,6 +1499,7 @@ VALUES (${bind(documentId)}, ${bind(version.versionNumber)}, ${bind(version.crea
     return documentId
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevChildDocumentDecision): ChildDocumentDecisionId {
     return createUpdate {
         sql(
@@ -1474,6 +1523,7 @@ fun Database.Transaction.updateDaycareOperationTimes(
 }
     .execute()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevAssistanceFactor): AssistanceFactorId = createUpdate {
     sql(
         """
@@ -1485,6 +1535,7 @@ VALUES (${bind(row.id)}, ${bind(row.childId)}, ${bind(row.validDuring)}, ${bind(
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevDaycareAssistance): DaycareAssistanceId = createUpdate {
     sql(
         """
@@ -1496,6 +1547,7 @@ VALUES (${bind(row.id)}, ${bind(row.childId)}, ${bind(row.validDuring)}, ${bind(
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevPreschoolAssistance): PreschoolAssistanceId = createUpdate {
     sql(
         """
@@ -1507,6 +1559,7 @@ VALUES (${bind(row.id)}, ${bind(row.childId)}, ${bind(row.validDuring)}, ${bind(
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevOtherAssistanceMeasure): OtherAssistanceMeasureId =
     createUpdate {
         sql(
@@ -1519,6 +1572,7 @@ VALUES (${bind(row.id)}, ${bind(row.childId)}, ${bind(row.validDuring)}, ${bind(
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevServiceNeed): ServiceNeedId = createUpdate {
     sql(
         """
@@ -1530,6 +1584,7 @@ VALUES (${bind(row.id)}, ${bind(row.optionId)}, ${bind(row.placementId)}, ${bind
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevServiceApplication): ServiceApplicationId = createUpdate {
     sql(
         """
@@ -1541,6 +1596,7 @@ VALUES (${bind(row.id)}, ${bind(row.sentAt)}, ${bind(row.personId)}, ${bind(row.
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevChildAttendance): ChildAttendanceId = createUpdate {
     sql(
         """
@@ -1552,6 +1608,7 @@ VALUES (${bind(row.childId)}, ${bind(row.unitId)}, ${bind(row.date)}, ${bind(row
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevPreschoolTerm): PreschoolTermId = createUpdate {
     sql(
         """
@@ -1563,6 +1620,7 @@ VALUES (${bind(row.id)}, ${bind(row.finnishPreschool)}, ${bind(row.swedishPresch
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevMessageThreadFolder): MessageThreadFolderId = createUpdate {
     sql(
         """
@@ -1583,6 +1641,7 @@ VALUES (${bind(row.id)}, ${bind(row.term)}, ${bind(row.applicationPeriod)}, ${bi
     )
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevClubTerm): ClubTermId = createUpdate {
     sql(
         """
@@ -1594,6 +1653,7 @@ VALUES (${bind(row.id)}, ${bind(row.term)}, ${bind(row.applicationPeriod)}, ${bi
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevAssistanceActionOption): AssistanceActionOptionId =
     createUpdate {
         sql(
@@ -1606,6 +1666,7 @@ VALUES (${bind(row.id)}, ${bind(row.value)}, ${bind(row.nameFi)}, ${bind(row.des
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(
     row: DevAssistanceNeedVoucherCoefficient
 ): AssistanceNeedVoucherCoefficientId = createUpdate {
@@ -1619,6 +1680,7 @@ VALUES (${bind(row.id)}, ${bind(row.childId)}, ${bind(row.validityPeriod)}, ${bi
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(decision: DevFeeDecision): FeeDecisionId {
     return createUpdate {
         sql(
@@ -1723,6 +1785,7 @@ INSERT INTO fee_decision_child (
         .execute()
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(decision: DevVoucherValueDecision): VoucherValueDecisionId {
     return createUpdate {
         sql(
@@ -1896,6 +1959,7 @@ VALUES (${bind(hqa.id)}, ${bind(hqa.modifiedBy)}, ${bind(hqa.questionnaireId)}, 
     }
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(row: DevDecisionReasoningGeneric): DecisionGenericReasoningId =
     createUpdate {
         sql(
@@ -1937,6 +2001,7 @@ val defaultClubDecisionReasoningGeneric =
         modifiedAt = HelsinkiDateTime.of(LocalDate.of(2000, 1, 1), LocalTime.of(12, 0, 0)),
     )
 
+@IgnorableReturnValue
 fun Database.Transaction.insertDefaultDecisionGenericReasonings():
     Map<DecisionReasoningCollectionType, DecisionGenericReasoningId> {
     return mapOf(
@@ -1947,6 +2012,7 @@ fun Database.Transaction.insertDefaultDecisionGenericReasonings():
     )
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.insert(
     row: DevDecisionReasoningIndividual
 ): DecisionIndividualReasoningId = createUpdate {

--- a/service/src/main/kotlin/evaka/core/shared/dev/DevApi.kt
+++ b/service/src/main/kotlin/evaka/core/shared/dev/DevApi.kt
@@ -853,9 +853,9 @@ UPDATE placement SET end_date = ${bind(req.endDate)}, termination_requested_date
         db.connect { dbc ->
             dbc.transaction { tx ->
                 val user = AuthenticatedUser.SystemInternalUser
-                personService.getUpToDatePersonFromVtj(tx, user, person)
-                personService.getGuardians(tx, user, now, person)
-                personService.getPersonWithChildren(tx, user, now, person)
+                val _ = personService.getUpToDatePersonFromVtj(tx, user, person)
+                val _ = personService.getGuardians(tx, user, now, person)
+                val _ = personService.getPersonWithChildren(tx, user, now, person)
             }
         }
     }
@@ -1719,7 +1719,7 @@ UPDATE person SET email=${bind(body.email)} WHERE id=${bind(body.personId)}
         db.connect { dbc ->
             dbc.transaction { tx ->
                 tx.updateLastStrongLogin(clock.now(), id)
-                tx.updateWeakLoginCredentials(clock.now(), id, request.username, password)
+                val _ = tx.updateWeakLoginCredentials(clock.now(), id, request.username, password)
             }
         }
     }

--- a/service/src/main/kotlin/evaka/core/shared/dev/TemplateDbManager.kt
+++ b/service/src/main/kotlin/evaka/core/shared/dev/TemplateDbManager.kt
@@ -117,7 +117,7 @@ WHERE
                 sql("CREATE DATABASE \"$templateDbName\" TEMPLATE \"$baseDbName\"")
             }
             // Reopen the connection pool (swap with same URL creates a fresh pool)
-            swappableDataSource.swap(env.url)
+            val _ = swappableDataSource.swap(env.url)
 
             // Reset the template database to a clean state
             val templatePool =

--- a/service/src/main/kotlin/evaka/core/shared/security/Action.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/Action.kt
@@ -57,6 +57,7 @@ import evaka.core.shared.PreschoolAssistanceId
 import evaka.core.shared.PreschoolTermId
 import evaka.core.shared.ServiceApplicationId
 import evaka.core.shared.ServiceNeedId
+import evaka.core.shared.TitaniaConflictId
 import evaka.core.shared.VoucherValueDecisionId
 import evaka.core.shared.auth.UserRole.ADMIN
 import evaka.core.shared.auth.UserRole.DIRECTOR
@@ -1933,6 +1934,14 @@ sealed interface Action {
                 .withUnitFeatures(PilotFeature.SERVICE_APPLICATIONS)
                 .inPlacementUnitOfChildOfServiceApplication(),
         );
+
+        override fun toString(): String = "${javaClass.name}.$name"
+    }
+
+    enum class TitaniaError(
+        override vararg val defaultRules: ScopedActionRule<in TitaniaConflictId>
+    ) : ScopedAction<TitaniaConflictId> {
+        DELETE(HasGlobalRole(ADMIN), HasUnitRole(UNIT_SUPERVISOR).inUnitOfTitaniaErrorEmployee());
 
         override fun toString(): String = "${javaClass.name}.$name"
     }

--- a/service/src/main/kotlin/evaka/core/shared/security/actionrule/HasUnitRole.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/actionrule/HasUnitRole.kt
@@ -42,6 +42,7 @@ import evaka.core.shared.PlacementId
 import evaka.core.shared.PreschoolAssistanceId
 import evaka.core.shared.ServiceApplicationId
 import evaka.core.shared.ServiceNeedId
+import evaka.core.shared.TitaniaConflictId
 import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.auth.UserRole
 import evaka.core.shared.db.QuerySql
@@ -829,6 +830,19 @@ JOIN calendar_event ce ON ce.id = cea.calendar_event_id
 JOIN calendar_event_time cet ON cet.calendar_event_id = ce.id
 JOIN daycare_acl acl ON acl.daycare_id = cea.unit_id
 WHERE employee_id = ${bind(user.id)}
+            """
+            )
+        }
+
+    fun inUnitOfTitaniaErrorEmployee() =
+        rule<TitaniaConflictId> { user, _ ->
+            sql(
+                """
+SELECT te.id, acl.role, acl.daycare_id AS unit_id
+FROM titania_errors te
+JOIN daycare_acl employee_acl ON employee_acl.employee_id = te.employee_id
+JOIN daycare_acl acl ON acl.daycare_id = employee_acl.daycare_id
+WHERE acl.employee_id = ${bind(user.id)}
             """
             )
         }

--- a/service/src/main/kotlin/evaka/core/shared/utils/Kotlin.kt
+++ b/service/src/main/kotlin/evaka/core/shared/utils/Kotlin.kt
@@ -4,6 +4,7 @@
 
 package evaka.core.shared.utils
 
+import evaka.core.shared.domain.NotFound
 import java.util.EnumSet
 
 inline fun <T> T.applyIf(condition: Boolean, block: T.() -> Unit): T =
@@ -11,6 +12,13 @@ inline fun <T> T.applyIf(condition: Boolean, block: T.() -> Unit): T =
 
 inline fun <T> T.letIf(condition: Boolean, block: (T) -> T): T =
     if (condition) this.let(block) else this
+
+inline fun <T : Any> T?.assertNotNull(
+    error: (String) -> Exception = ::NotFound,
+    msg: String = "Not found",
+) {
+    if (this == null) throw error(msg)
+}
 
 inline fun <reified T : Enum<T>> Array<out T>.toEnumSet(): EnumSet<T> =
     emptyEnumSet<T>().also { it += this }

--- a/service/src/main/kotlin/evaka/core/specialdiet/SpecialDietQueries.kt
+++ b/service/src/main/kotlin/evaka/core/specialdiet/SpecialDietQueries.kt
@@ -26,6 +26,7 @@ data class NulledSpecialDiet(
  * in the new list. Returns a map from ChildId to SpecialDiet that was previously set for that
  * child.
  */
+@IgnorableReturnValue
 fun Database.Transaction.resetSpecialDietsNotContainedWithin(
     today: LocalDate,
     specialDietList: List<SpecialDiet>,
@@ -61,11 +62,12 @@ WHERE child.diet_id != ALL (${bind(newSpecialDietIds)})
     return previousDiets
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.resetMealTexturesNotContainedWithin(
     mealTextureList: List<MealTexture>
 ): Int {
     val newMealTextureIds = mealTextureList.map { it.id }
-    val affectedRows = execute {
+    val affectedRows = executeAndReturnCount {
         sql(
             "UPDATE child SET meal_texture_id = null WHERE meal_texture_id != ALL (${bind(newMealTextureIds)})"
         )
@@ -74,9 +76,10 @@ fun Database.Transaction.resetMealTexturesNotContainedWithin(
 }
 
 /** Replaces special_diet list with the given list. Returns count of removed diets */
+@IgnorableReturnValue
 fun Database.Transaction.setSpecialDiets(specialDietList: List<SpecialDiet>): Int {
     val newSpecialDietIds = specialDietList.map { it.id }
-    val deletedDietCount = execute {
+    val deletedDietCount = executeAndReturnCount {
         sql("DELETE FROM special_diet WHERE id != ALL (${bind(newSpecialDietIds)})")
     }
     executeBatch(specialDietList) {
@@ -95,9 +98,10 @@ ON CONFLICT (id) DO UPDATE SET
     return deletedDietCount
 }
 
+@IgnorableReturnValue
 fun Database.Transaction.setMealTextures(mealTextures: List<MealTexture>): Int {
     val newTextureIds = mealTextures.map { it.id }
-    val deletedTextureCount = execute {
+    val deletedTextureCount = executeAndReturnCount {
         sql("DELETE FROM meal_texture WHERE id != ALL (${bind(newTextureIds)})")
     }
     executeBatch(mealTextures) {

--- a/service/src/main/kotlin/evaka/core/user/CitizenPasskeyQueries.kt
+++ b/service/src/main/kotlin/evaka/core/user/CitizenPasskeyQueries.kt
@@ -102,6 +102,7 @@ RETURNING id, name, created_at, last_used_at, device_class, operating_system_nam
     .executeAndReturnGeneratedKeys()
     .exactlyOne()
 
+@IgnorableReturnValue
 fun Database.Transaction.updateCitizenPasskeyName(
     person: PersonId,
     id: CitizenPasskeyId,
@@ -134,6 +135,7 @@ RETURNING id, name, created_at, last_used_at, device_class, operating_system_nam
     .executeAndReturnGeneratedKeys()
     .exactlyOneOrNull()
 
+@IgnorableReturnValue
 fun Database.Transaction.updatePasskeyAfterLogin(
     id: CitizenPasskeyId,
     now: HelsinkiDateTime,
@@ -147,7 +149,7 @@ WHERE id = ${bind(id)}
 """
     )
 }
-    .execute()
+    .executeAndReturnCount()
 
 fun Database.Transaction.upsertPasskeyRegistration(
     person: PersonId,

--- a/service/src/main/kotlin/evaka/core/varda/VardaClient.kt
+++ b/service/src/main/kotlin/evaka/core/varda/VardaClient.kt
@@ -142,7 +142,7 @@ interface VardaWriteClient {
         val paos_organisaatio_oid: String?,
     )
 
-    fun createLapsi(body: CreateLapsiRequest): CreateResponse
+    @IgnorableReturnValue fun createLapsi(body: CreateLapsiRequest): CreateResponse
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     data class CreateVarhaiskasvatuspaatosRequest(
@@ -159,6 +159,7 @@ interface VardaWriteClient {
         val lahdejarjestelma: String,
     )
 
+    @IgnorableReturnValue
     fun createVarhaiskasvatuspaatos(body: CreateVarhaiskasvatuspaatosRequest): CreateResponse
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -170,6 +171,7 @@ interface VardaWriteClient {
         val paattymis_pvm: LocalDate?,
     )
 
+    @IgnorableReturnValue
     fun createVarhaiskasvatussuhde(body: CreateVarhaiskasvatussuhdeRequest): CreateResponse
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -185,7 +187,7 @@ interface VardaWriteClient {
         val perheen_koko: Int?,
     )
 
-    fun createMaksutieto(body: CreateMaksutietoRequest): CreateResponse
+    @IgnorableReturnValue fun createMaksutieto(body: CreateMaksutietoRequest): CreateResponse
 
     fun <T : VardaEntity> delete(data: T)
 

--- a/service/src/main/kotlin/evaka/core/varda/VardaQueries.kt
+++ b/service/src/main/kotlin/evaka/core/varda/VardaQueries.kt
@@ -221,8 +221,9 @@ fun Database.Read.getVardaGuardians(childIds: List<ChildId>): Map<ChildId, List<
     .mapTo<VardaGuardian>()
     .useSequence { rows -> rows.groupBy { it.childId } }
 
+@IgnorableReturnValue
 fun Database.Transaction.addNewChildrenForVardaUpdate(): Int {
-    return execute {
+    return executeAndReturnCount {
         sql(
             """
                     INSERT INTO varda_state (child_id, state)

--- a/service/src/main/kotlin/evaka/core/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/evaka/core/varda/VardaUpdateService.kt
@@ -500,6 +500,7 @@ class VardaUpdater(
     }
 
     /** Returns true if the lapsi and associated data were deleted */
+    @IgnorableReturnValue
     private fun VardaWriteClient.deleteLapsiDeep(vardaLapsi: VardaLapsiNode): Boolean {
         val maksutiedotDeleted = vardaLapsi.maksutiedot.allSucceed { deleteMaksutieto(it) }
         val varhaiskasvatuspaatoksetDeleted =
@@ -513,6 +514,7 @@ class VardaUpdater(
     }
 
     /** Returns true if the varhaiskasvatuspaatos and associated data were deleted */
+    @IgnorableReturnValue
     private fun VardaWriteClient.deleteVarhaiskasvatuspaatosDeep(
         vardaVarhaiskasvatuspaatos: VardaVarhaiskasvatuspaatosNode
     ): Boolean {
@@ -539,6 +541,7 @@ class VardaUpdater(
     }
 
     /** Returns true if the varhaiskasvatussuhde was deleted */
+    @IgnorableReturnValue
     private fun VardaWriteClient.deleteVarhaiskasvatussuhde(
         vardaVarhaiskasvatussuhde: VardaReadClient.VarhaiskasvatussuhdeResponse
     ): Boolean =
@@ -558,6 +561,7 @@ class VardaUpdater(
         }
 
     /** Returns true if the maksutieto was deleted */
+    @IgnorableReturnValue
     private fun VardaWriteClient.deleteMaksutieto(
         vardaMaksutieto: VardaReadClient.MaksutietoResponse
     ): Boolean =

--- a/service/src/main/kotlin/evaka/core/webpush/WebPushController.kt
+++ b/service/src/main/kotlin/evaka/core/webpush/WebPushController.kt
@@ -30,7 +30,7 @@ data class WebPushSubscription(
         require(authSecret.size <= 1024) {
             "Expected auth secret to be at most 1024 bytes, got ${authSecret.size}"
         }
-        WebPushCrypto.decodePublicKey(ecdhKey.toByteArray())
+        val _ = WebPushCrypto.decodePublicKey(ecdhKey.toByteArray())
     }
 }
 

--- a/service/src/main/kotlin/evaka/instance/oulu/dw/DwExportJob.kt
+++ b/service/src/main/kotlin/evaka/instance/oulu/dw/DwExportJob.kt
@@ -21,7 +21,7 @@ class DwExportJob(private val client: DwExportClient) {
 
             query(tx) { records ->
                 val stream = CsvInputStream(CSV_CHARSET, records)
-                client.sendDwCsvFile(queryName, clock, stream)
+                val _ = client.sendDwCsvFile(queryName, clock, stream)
             }
         }
     }

--- a/service/src/main/kotlin/evaka/instance/tampere/TampereScheduledJobs.kt
+++ b/service/src/main/kotlin/evaka/instance/tampere/TampereScheduledJobs.kt
@@ -70,11 +70,12 @@ class TampereScheduledJobs(
     fun exportPreschoolChildDocuments(db: Database.Connection, clock: EvakaClock) {
         db.read { tx ->
             tx.setStatementTimeout(REPORT_STATEMENT_TIMEOUT)
-            exportPreschoolChildDocumentsService.exportPreschoolChildDocuments(
-                tx,
-                clock.now(),
-                properties.bucket.export,
-            )
+            val _ =
+                exportPreschoolChildDocumentsService.exportPreschoolChildDocuments(
+                    tx,
+                    clock.now(),
+                    properties.bucket.export,
+                )
         }
     }
 

--- a/service/src/main/kotlin/evaka/instance/tampere/export/ExportUnitsAclService.kt
+++ b/service/src/main/kotlin/evaka/instance/tampere/export/ExportUnitsAclService.kt
@@ -40,6 +40,7 @@ class ExportUnitsAclService(
 
     private val mapper = CsvMapper()
 
+    @IgnorableReturnValue
     fun exportUnitsAcl(tx: Database.Read, timestamp: HelsinkiDateTime): Pair<String, String> {
         val unitsAcl = tx.getUnitAclRows()
 

--- a/service/src/main/kotlin/evaka/trevaka/export/ExportPreschoolChildDocumentsService.kt
+++ b/service/src/main/kotlin/evaka/trevaka/export/ExportPreschoolChildDocumentsService.kt
@@ -88,6 +88,7 @@ class ExportPreschoolChildDocumentsService(
     private val s3Client: S3Client,
     private val ophEnv: OphEnv,
 ) {
+    @IgnorableReturnValue
     fun exportPreschoolChildDocuments(
         tx: Database.Read,
         timestamp: HelsinkiDateTime,

--- a/service/src/test/kotlin/evaka/core/document/archival/DocumentMetadataUtilsTest.kt
+++ b/service/src/test/kotlin/evaka/core/document/archival/DocumentMetadataUtilsTest.kt
@@ -503,11 +503,12 @@ class DocumentMetadataUtilsTest {
 
     @Test
     fun `createCreation prefers case process initial date when available`() {
-        val documentMetadata = createTestDocumentMetadata()
-        documentMetadata.copy(
-            createdAtDate = LocalDate.of(2023, 2, 1),
-            createdAtTime = LocalTime.of(12, 10),
-        )
+        val documentMetadata =
+            createTestDocumentMetadata()
+                .copy(
+                    createdAtDate = LocalDate.of(2023, 2, 1),
+                    createdAtTime = LocalTime.of(12, 10),
+                )
 
         // Create case process with different initial date than document metadata
         val caseProcessInitialDate = LocalDateTime.parse("2019-01-15T10:30:00")

--- a/service/src/test/kotlin/evaka/core/dvv/DvvModificationsServiceClientSslTest.kt
+++ b/service/src/test/kotlin/evaka/core/dvv/DvvModificationsServiceClientSslTest.kt
@@ -21,6 +21,7 @@ import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSession
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import okhttp3.OkHttpClient
@@ -29,7 +30,6 @@ import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -179,7 +179,7 @@ class DvvModificationsServiceClientSslTest {
         val trustManager = client.x509TrustManager!!
         assertContains(1..Int.MAX_VALUE, trustManager.acceptedIssuers.size)
         val untrustedCert = generateSelfSignedCert()
-        assertThrows<CertificateException> {
+        assertFailsWith<CertificateException> {
             trustManager.checkServerTrusted(arrayOf(untrustedCert), "RSA")
         }
     }

--- a/service/src/test/kotlin/evaka/core/identity/SSNUtilsTest.kt
+++ b/service/src/test/kotlin/evaka/core/identity/SSNUtilsTest.kt
@@ -6,10 +6,10 @@ package evaka.core.identity
 
 import java.time.LocalDate
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class SSNUtilsTest {
     @Test
@@ -26,7 +26,7 @@ class SSNUtilsTest {
 
     @Test
     fun `Invalid ssn century marker throws exception`() {
-        assertThrows<IllegalArgumentException> { getDobFromSsn("150715J0101") }
+        assertFailsWith<IllegalArgumentException> { getDobFromSsn("150715J0101") }
     }
 
     @Test

--- a/service/src/test/kotlin/evaka/core/reports/patu/EspooPatuIntegrationClientTest.kt
+++ b/service/src/test/kotlin/evaka/core/reports/patu/EspooPatuIntegrationClientTest.kt
@@ -8,13 +8,13 @@ import evaka.core.Sensitive
 import evaka.core.shared.config.defaultJsonMapperBuilder
 import evaka.instance.espoo.EspooPatuIntegrationEnv
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import okhttp3.Credentials
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class EspooPatuIntegrationClientTest {
 
@@ -66,6 +66,6 @@ class EspooPatuIntegrationClientTest {
             )
         val client = EspooPatuIntegrationClient(env, jsonMapper)
 
-        assertThrows<IllegalStateException> { client.send(emptyList()) }
+        assertFailsWith<IllegalStateException> { client.send(emptyList()) }
     }
 }

--- a/service/src/test/kotlin/evaka/core/shared/db/PredicateTest.kt
+++ b/service/src/test/kotlin/evaka/core/shared/db/PredicateTest.kt
@@ -5,15 +5,15 @@
 package evaka.core.shared.db
 
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class PredicateTest {
     @Test
     fun `predicate builder allows only one where call`() {
-        assertThrows<IllegalStateException> {
+        assertFailsWith<IllegalStateException> {
             Predicate {
-                    where("TRUE")
+                    val _ = where("TRUE")
                     where("FALSE -- this fails")
                 }
                 .forTable("some_table")

--- a/service/src/test/kotlin/evaka/core/shared/domain/FiniteDateRangeTest.kt
+++ b/service/src/test/kotlin/evaka/core/shared/domain/FiniteDateRangeTest.kt
@@ -8,11 +8,11 @@ import evaka.core.shared.data.BoundedRange
 import java.lang.IllegalArgumentException
 import java.time.LocalDate
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class FiniteDateRangeTest {
     @Test
@@ -24,7 +24,7 @@ class FiniteDateRangeTest {
 
     @Test
     fun `start cannot be after end`() {
-        assertThrows<IllegalArgumentException> { testRange(2, 1) }
+        assertFailsWith<IllegalArgumentException> { testRange(2, 1) }
         assertNull(FiniteDateRange.tryCreate(testDate(2), testDate(1)))
     }
 

--- a/service/src/test/kotlin/evaka/core/shared/domain/HelsinkiDateTimeRangeTest.kt
+++ b/service/src/test/kotlin/evaka/core/shared/domain/HelsinkiDateTimeRangeTest.kt
@@ -7,24 +7,24 @@ package evaka.core.shared.domain
 import evaka.core.shared.data.BoundedRange
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class HelsinkiDateTimeRangeTest {
     @Test
     fun `start is inclusive and end is exclusive, so a range containing just one date is invalid`() {
         // TODO: change constructor semantics
-        // assertThrows<IllegalArgumentException> { testRange(1, 1) }
+        // assertFailsWith<IllegalArgumentException> { testRange(1, 1) }
         assertNull(HelsinkiDateTimeRange.tryCreate(testDateTime(1), testDateTime(1)))
     }
 
     @Test
     fun `start cannot be after end`() {
         // TODO: change constructor to throw IllegalArgumentException instead
-        assertThrows<IllegalStateException> { testRange(2, 1) }
+        assertFailsWith<IllegalStateException> { testRange(2, 1) }
         assertNull(HelsinkiDateTimeRange.tryCreate(testDateTime(2), testDateTime(1)))
     }
 

--- a/service/src/test/kotlin/evaka/core/shared/domain/HelsinkiDateTimeTest.kt
+++ b/service/src/test/kotlin/evaka/core/shared/domain/HelsinkiDateTimeTest.kt
@@ -11,8 +11,8 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZonedDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import tools.jackson.databind.exc.InvalidFormatException
 
 class HelsinkiDateTimeTest {
@@ -62,7 +62,7 @@ class HelsinkiDateTimeTest {
 
     @Test
     fun `a JSON timestamp with no offset throws an error`() {
-        assertThrows<InvalidFormatException> {
+        assertFailsWith<InvalidFormatException> {
             jsonMapper.readValue("\"2021-04-14T13:02:00\"", HelsinkiDateTime::class.java)
         }
     }

--- a/service/src/test/kotlin/evaka/core/shared/domain/RectangleTest.kt
+++ b/service/src/test/kotlin/evaka/core/shared/domain/RectangleTest.kt
@@ -5,15 +5,15 @@
 package evaka.core.shared.domain
 
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class RectangleTest {
     @Test
     fun fromString() {
         assertEquals(Rectangle(1, 2, 345, 6), Rectangle.fromString("1,2,345,6"))
-        assertThrows<IllegalArgumentException> { Rectangle.fromString("foobar") }
-        assertThrows<IllegalArgumentException> { Rectangle.fromString("1,2,3") }
-        assertThrows<IllegalArgumentException> { Rectangle.fromString("foo,bar,baz,quux") }
+        assertFailsWith<IllegalArgumentException> { Rectangle.fromString("foobar") }
+        assertFailsWith<IllegalArgumentException> { Rectangle.fromString("1,2,3") }
+        assertFailsWith<IllegalArgumentException> { Rectangle.fromString("foo,bar,baz,quux") }
     }
 }

--- a/service/src/test/kotlin/evaka/core/shared/domain/TimeRangeTest.kt
+++ b/service/src/test/kotlin/evaka/core/shared/domain/TimeRangeTest.kt
@@ -7,16 +7,16 @@ package evaka.core.shared.domain
 import evaka.core.shared.data.BoundedRange
 import java.time.LocalTime
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class TimeRangeTest {
     @Test
     fun `start is inclusive and end is exclusive, so a range containing just one time is invalid`() {
-        assertThrows<IllegalArgumentException> { testRange(1, 1) }
+        assertFailsWith<IllegalArgumentException> { testRange(1, 1) }
     }
 
     @Test
@@ -26,7 +26,7 @@ class TimeRangeTest {
 
     @Test
     fun `start cannot be after end`() {
-        assertThrows<IllegalArgumentException> { testRange(2, 1) }
+        assertFailsWith<IllegalArgumentException> { testRange(2, 1) }
     }
 
     @Test

--- a/service/src/test/kotlin/evaka/core/shared/utils/OkHttpExtensionsTest.kt
+++ b/service/src/test/kotlin/evaka/core/shared/utils/OkHttpExtensionsTest.kt
@@ -10,6 +10,7 @@ import java.io.ByteArrayInputStream
 import java.net.URI
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import okhttp3.Credentials
 import okhttp3.MediaType.Companion.toMediaType
@@ -22,7 +23,6 @@ import okio.Buffer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class OkHttpExtensionsTest {
 
@@ -252,7 +252,7 @@ class OkHttpExtensionsTest {
         val request = Request.Builder().url(mockWebServer.url("/test")).build()
 
         val exception =
-            assertThrows<IllegalStateException> {
+            assertFailsWith<IllegalStateException> {
                 client.executeWithRetries(
                     request,
                     remainingTries = 5,
@@ -270,7 +270,7 @@ class OkHttpExtensionsTest {
         val request = Request.Builder().url(mockWebServer.url("/test")).build()
 
         val exception =
-            assertThrows<IllegalStateException> {
+            assertFailsWith<IllegalStateException> {
                 client.executeWithRetries(request, remainingTries = 5)
             }
 
@@ -289,7 +289,7 @@ class OkHttpExtensionsTest {
 
         // With remainingTries=2, it can only retry twice, so it will fail
         val exception =
-            assertThrows<IllegalStateException> {
+            assertFailsWith<IllegalStateException> {
                 client.executeWithRetries(
                     request,
                     remainingTries = 2,
@@ -315,7 +315,7 @@ class OkHttpExtensionsTest {
         val request = Request.Builder().url(mockWebServer.url("/test")).put(body).build()
 
         val exception =
-            assertThrows<IllegalStateException> {
+            assertFailsWith<IllegalStateException> {
                 client.executeWithRetries(request, remainingTries = 5)
             }
 
@@ -388,7 +388,7 @@ class OkHttpExtensionsTest {
     @Test
     fun `buildUrl rejects absolute endpoint paths`() {
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertFailsWith<IllegalArgumentException> {
                 buildUrl(URI("https://example.com/v1/"), "/absolute/path")
             }
         assertTrue(exception.message?.contains("relative path") ?: false)
@@ -397,7 +397,7 @@ class OkHttpExtensionsTest {
     @Test
     fun `buildUrl rejects endpoints that resolve to a different host`() {
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertFailsWith<IllegalArgumentException> {
                 buildUrl(URI("https://example.com/v1/"), "https://evil.com/path")
             }
         assertTrue(exception.message?.contains("does not match root URL host") ?: false)
@@ -406,7 +406,7 @@ class OkHttpExtensionsTest {
     @Test
     fun `buildUrl rejects endpoints that escape root URL path via path traversal`() {
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertFailsWith<IllegalArgumentException> {
                 buildUrl(URI("https://example.com/v1/"), "../../admin/secret")
             }
         assertTrue(exception.message?.contains("escapes root URL path") ?: false)
@@ -477,7 +477,7 @@ class OkHttpExtensionsTest {
         val body = "data".toRequestBody("text/plain".toMediaType())
 
         val exception =
-            assertThrows<IllegalStateException> {
+            assertFailsWith<IllegalStateException> {
                 configuredClient.put<Unit>("upload", body = body)
             }
 
@@ -550,7 +550,7 @@ class OkHttpExtensionsTest {
 
         val configuredClient = configuredClient(jsonMapper)
 
-        configuredClient.get<TestItem>("endpoint", headers = mapOf("X-Custom" to "value"))
+        val _ = configuredClient.get<TestItem>("endpoint", headers = mapOf("X-Custom" to "value"))
 
         val recorded = mockWebServer.takeRequest()
         assertEquals("value", recorded.getHeader("X-Custom"))
@@ -591,7 +591,7 @@ class OkHttpExtensionsTest {
         val configuredClient = configuredClient(jsonMapper)
         val body = "data".toRequestBody("text/plain".toMediaType())
 
-        assertThrows<IllegalArgumentException> {
+        assertFailsWith<IllegalArgumentException> {
             configuredClient.post<Unit>("endpoint", body = body, jsonBody = TestItem(1, "x"))
         }
     }
@@ -600,6 +600,6 @@ class OkHttpExtensionsTest {
     fun `post rejects neither body nor jsonBody`() {
         val configuredClient = configuredClient(jsonMapper)
 
-        assertThrows<IllegalArgumentException> { configuredClient.post<Unit>("endpoint") }
+        assertFailsWith<IllegalArgumentException> { configuredClient.post<Unit>("endpoint") }
     }
 }

--- a/service/src/test/kotlin/evaka/core/vtjclient/service/VtjClientServiceTest.kt
+++ b/service/src/test/kotlin/evaka/core/vtjclient/service/VtjClientServiceTest.kt
@@ -102,7 +102,7 @@ class VtjClientServiceTest {
         whenever(responseMapper.mapResponseToHenkilo(response))
             .thenReturn(createPersonResponse(forSsn = ssn))
 
-        service.query(query)
+        val _ = service.query(query)
 
         argumentCaptor<ILoggingEvent>().apply {
             verify(mockAppender, times(2)).doAppend(capture())
@@ -134,7 +134,7 @@ class VtjClientServiceTest {
             .thenReturn(response)
         whenever(responseMapper.mapResponseToHenkilo(response)).thenReturn(null)
 
-        service.query(query)
+        val _ = service.query(query)
 
         argumentCaptor<ILoggingEvent>().apply {
             verify(mockAppender, times(2)).doAppend(capture())
@@ -166,7 +166,7 @@ class VtjClientServiceTest {
             .thenThrow(expectedException)
 
         try {
-            service.query(query)
+            val _ = service.query(query)
             fail<Exception>("Exception not thrown")
         } catch (ex: ClassCastException) {
             assertThat(ex.message).isEqualTo(expectedException.message)
@@ -210,7 +210,7 @@ class VtjClientServiceTest {
         whenever(responseMapper.mapResponseToHenkilo(response))
             .thenReturn(createPersonResponse(forSsn = ssn))
 
-        service.query(query)
+        val _ = service.query(query)
 
         argumentCaptor<ILoggingEvent>().apply {
             verify(mockAppender, times(2)).doAppend(capture())
@@ -244,9 +244,9 @@ class VtjClientServiceTest {
             .thenReturn(response)
         whenever(responseMapper.mapResponseToHenkilo(response)).thenReturn(createPersonResponse())
 
-        service.query(query)
+        val _ = service.query(query)
 
-        verify(mockRequestAdapter).createCallback(query)
+        val _ = verify(mockRequestAdapter).createCallback(query)
     }
 
     @Test
@@ -270,7 +270,7 @@ class VtjClientServiceTest {
         val password = "*/89+74563876t5123v bg12"
         whenever(mockVtjProps.password).thenReturn(Sensitive(password))
 
-        service.query(query)
+        val _ = service.query(query)
 
         argumentCaptor<JAXBElement<HenkiloTunnusKyselyReqBody>>().apply {
             verify(mockWSTemplate).marshalSendAndReceive(capture(), eq(mockCallback))

--- a/service/src/test/kotlin/evaka/core/vtjclient/service/persondetails/DVVPersonDetailsServiceTest.kt
+++ b/service/src/test/kotlin/evaka/core/vtjclient/service/persondetails/DVVPersonDetailsServiceTest.kt
@@ -99,13 +99,13 @@ class DVVPersonDetailsServiceTest {
         assertThat(childResult.address).isEqualTo(expectedChildResult.address)
 
         argumentCaptor<VTJQuery>().apply {
-            verify(vtjService, times(2)).query(capture())
+            val _ = verify(vtjService, times(2)).query(capture())
             assertThat(firstValue).isEqualTo(expectedVtjQuery)
             assertThat(secondValue).isEqualTo(expectedChildVtjQuery)
         }
 
         argumentCaptor<Henkilo>().apply {
-            verify(henkiloMapper, times(2)).mapToVtjPerson(capture())
+            val _ = verify(henkiloMapper, times(2)).mapToVtjPerson(capture())
             assertThat(firstValue).isEqualTo(expectedVTJResponse)
             assertThat(secondValue).isEqualTo(expectedChildVtjResponse)
         }

--- a/service/src/test/kotlin/evaka/instance/oulu/invoice/service/OuluInvoiceClientTest.kt
+++ b/service/src/test/kotlin/evaka/instance/oulu/invoice/service/OuluInvoiceClientTest.kt
@@ -48,9 +48,9 @@ internal class OuluInvoiceClientTest {
             )
         whenever(invoiceGenerator.generateInvoice(invoiceList)).thenReturn(invoiceGeneratorResult)
 
-        ouluInvoiceClient.send(mockNow, invoiceList)
+        val _ = ouluInvoiceClient.send(mockNow, invoiceList)
 
-        verify(invoiceGenerator).generateInvoice(invoiceList)
+        val _ = verify(invoiceGenerator).generateInvoice(invoiceList)
     }
 
     @Test
@@ -65,7 +65,7 @@ internal class OuluInvoiceClientTest {
             )
         whenever(invoiceGenerator.generateInvoice(invoiceList)).thenReturn(invoiceGeneratorResult)
 
-        ouluInvoiceClient.send(mockNow, invoiceList)
+        val _ = ouluInvoiceClient.send(mockNow, invoiceList)
 
         val captor = argumentCaptor<InputStream>()
         verify(sftpClient).put(captor.capture(), eq(fileName))
@@ -80,7 +80,7 @@ internal class OuluInvoiceClientTest {
             StringInvoiceGenerator.InvoiceGeneratorResult(InvoiceIntegrationClient.SendResult(), "")
         whenever(invoiceGenerator.generateInvoice(invoiceList)).thenReturn(invoiceGeneratorResult)
 
-        ouluInvoiceClient.send(mockNow, invoiceList)
+        val _ = ouluInvoiceClient.send(mockNow, invoiceList)
 
         verify(sftpClient, never()).put(any<InputStream>(), any())
     }
@@ -187,7 +187,7 @@ internal class OuluInvoiceClientTest {
                 )
             )
 
-        ouluInvoiceClient.send(mockNow, invoiceList)
+        val _ = ouluInvoiceClient.send(mockNow, invoiceList)
 
         assertThat(output).contains("Successfully sent 1 invoices and created 1 manual invoice")
     }
@@ -207,7 +207,7 @@ internal class OuluInvoiceClientTest {
             )
 
         doThrow(RuntimeException::class).whenever(sftpClient).put(any<InputStream>(), any<String>())
-        ouluInvoiceClient.send(mockNow, invoiceList)
+        val _ = ouluInvoiceClient.send(mockNow, invoiceList)
 
         assertThat(output).contains("Failed to send 2 invoices")
     }
@@ -216,7 +216,6 @@ internal class OuluInvoiceClientTest {
     fun `should format the sent file name correctly`() {
         val validInvoice = validInvoice()
         val invoiceList = listOf(validInvoice)
-        val proEInvoice1 = "xx"
         whenever(invoiceGenerator.generateInvoice(invoiceList))
             .thenReturn(
                 StringInvoiceGenerator.InvoiceGeneratorResult(
@@ -224,7 +223,7 @@ internal class OuluInvoiceClientTest {
                     "xx",
                 )
             )
-        val sendResult = ouluInvoiceClient.send(mockNow, invoiceList)
+        val _ = ouluInvoiceClient.send(mockNow, invoiceList)
 
         verify(sftpClient).put(any<InputStream>(), eq("proe-20221012-133456.txt"))
     }

--- a/service/src/test/kotlin/evaka/instance/oulu/payment/service/OuluPaymentIntegrationClientTest.kt
+++ b/service/src/test/kotlin/evaka/instance/oulu/payment/service/OuluPaymentIntegrationClientTest.kt
@@ -46,9 +46,9 @@ internal class OuluPaymentIntegrationClientTest {
             ProEPaymentGenerator.Result(PaymentIntegrationClient.SendResult(), proEPayment1)
         whenever(paymentGenerator.generatePayments(paymentList)).thenReturn(paymentGeneratorResult)
 
-        paymentClient.send(paymentList, tx)
+        val _ = paymentClient.send(paymentList, tx)
 
-        verify(paymentGenerator).generatePayments(paymentList)
+        val _ = verify(paymentGenerator).generatePayments(paymentList)
     }
 
     @Test
@@ -63,7 +63,7 @@ internal class OuluPaymentIntegrationClientTest {
             )
         whenever(paymentGenerator.generatePayments(paymentList)).thenReturn(paymentGeneratorResult)
 
-        paymentClient.send(paymentList, tx)
+        val _ = paymentClient.send(paymentList, tx)
 
         val captor = argumentCaptor<InputStream>()
         verify(sftpClient).put(captor.capture(), eq(fileName))
@@ -78,7 +78,7 @@ internal class OuluPaymentIntegrationClientTest {
             ProEPaymentGenerator.Result(PaymentIntegrationClient.SendResult(), "")
         whenever(paymentGenerator.generatePayments(paymentList)).thenReturn(paymentGeneratorResult)
 
-        paymentClient.send(paymentList, tx)
+        val _ = paymentClient.send(paymentList, tx)
 
         verify(sftpClient, never()).put(any<InputStream>(), any())
     }
@@ -183,7 +183,7 @@ internal class OuluPaymentIntegrationClientTest {
                 )
             )
 
-        paymentClient.send(paymentList, tx)
+        val _ = paymentClient.send(paymentList, tx)
 
         Assertions.assertThat(output).contains("Successfully sent 1 payments")
     }
@@ -202,7 +202,7 @@ internal class OuluPaymentIntegrationClientTest {
             )
 
         doThrow(RuntimeException::class).whenever(sftpClient).put(any<InputStream>(), any<String>())
-        paymentClient.send(paymentList, tx)
+        val _ = paymentClient.send(paymentList, tx)
 
         Assertions.assertThat(output).contains("Failed to send 2 payments")
     }

--- a/service/src/test/kotlin/evaka/instance/turku/invoice/service/TurkuInvoiceClientTest.kt
+++ b/service/src/test/kotlin/evaka/instance/turku/invoice/service/TurkuInvoiceClientTest.kt
@@ -44,9 +44,9 @@ internal class TurkuInvoiceClientTest {
             )
         whenever(invoiceGenerator.generateInvoice(invoiceList)).thenReturn(invoiceGeneratorResult)
 
-        eVakaTurkuInvoiceClient.send(mockNow, invoiceList)
+        val _ = eVakaTurkuInvoiceClient.send(mockNow, invoiceList)
 
-        verify(invoiceGenerator).generateInvoice(invoiceList)
+        val _ = verify(invoiceGenerator).generateInvoice(invoiceList)
     }
 
     @Test
@@ -61,7 +61,7 @@ internal class TurkuInvoiceClientTest {
             )
         whenever(invoiceGenerator.generateInvoice(invoiceList)).thenReturn(invoiceGeneratorResult)
 
-        eVakaTurkuInvoiceClient.send(mockNow, invoiceList)
+        val _ = eVakaTurkuInvoiceClient.send(mockNow, invoiceList)
 
         val captor = argumentCaptor<InputStream>()
         verify(sftpClient)
@@ -76,7 +76,7 @@ internal class TurkuInvoiceClientTest {
             StringInvoiceGenerator.InvoiceGeneratorResult(InvoiceIntegrationClient.SendResult(), "")
         whenever(invoiceGenerator.generateInvoice(invoiceList)).thenReturn(invoiceGeneratorResult)
 
-        eVakaTurkuInvoiceClient.send(mockNow, invoiceList)
+        val _ = eVakaTurkuInvoiceClient.send(mockNow, invoiceList)
 
         verify(sftpClient, never()).put(any<InputStream>(), any())
     }
@@ -189,7 +189,7 @@ internal class TurkuInvoiceClientTest {
                 )
             )
 
-        eVakaTurkuInvoiceClient.send(mockNow, invoiceList)
+        val _ = eVakaTurkuInvoiceClient.send(mockNow, invoiceList)
 
         assertThat(output).contains("Successfully sent 1 invoices and created 1 manual invoice")
     }
@@ -215,7 +215,7 @@ internal class TurkuInvoiceClientTest {
                 )
             )
             .thenThrow(RuntimeException::class.java)
-        eVakaTurkuInvoiceClient.send(mockNow, invoiceList)
+        val _ = eVakaTurkuInvoiceClient.send(mockNow, invoiceList)
 
         assertThat(output).contains("Failed to send 2 invoices")
     }

--- a/service/src/test/kotlin/evaka/instance/turku/payment/service/SapPaymentGeneratorTest.kt
+++ b/service/src/test/kotlin/evaka/instance/turku/payment/service/SapPaymentGeneratorTest.kt
@@ -43,9 +43,9 @@ class SapPaymentGeneratorTest {
         whenever(mockIdocGenerator.generate(any(), any(), any())).thenReturn(FIDCCP02.IDOC())
         whenever(mockMarshaller.marshal(any())).thenReturn("XML")
 
-        sapPaymentGenerator.generatePayments(listOf(payment), mockFetcher)
+        val _ = sapPaymentGenerator.generatePayments(listOf(payment), mockFetcher)
 
-        verify(mockIdocGenerator).generate(payment, 4510, "fi")
+        val _ = verify(mockIdocGenerator).generate(payment, 4510, "fi")
     }
 
     @Test


### PR DESCRIPTION
Otetaan käyttöön eksperimentaalinen feature, jossa kääntäjä varoittaa käyttämättömästä paluuarvosta. 

Funktiot, joiden paluuarvon voi turvallisesti jättää huomiotta voi merkitä `@IgnorableReturnValue`. Yksittäistapaukset voi ignorata `val _ = ` syntaksilla. Lisäksi joissain funktioissa, jotka ottavat lambdan parametrina, täytyi käyttää eksperimentaalisia kontrakteja, jotka antavat lisävihjeitä kääntäjälle. Testeissä täytyy käyttää `assertThrows` sijaan `assertFailsWith`.

Ohessa löytyi ja korjattiin muutamia bugeja. Osa liittyy myös authorisaatioon, mutta ei mitään kriittistä.

Muutosta ei ainakaan toistaiseksi kohdistettu integraatiotesteihin, koska niissä on todella paljon paikkoja, joissa esimerkiksi kutsutaan controlleria mutta ei käytetä sen paluuarvoa.