### PR TITLE
Korjauksia uuteen päätösten muokkaus -näkymään

### DIFF
--- a/frontend/src/employee-frontend/components/decision-draft/DecisionDraftRedesign.tsx
+++ b/frontend/src/employee-frontend/components/decision-draft/DecisionDraftRedesign.tsx
@@ -216,9 +216,11 @@ const DecisionDraftRedesignInner = React.memo(
     const dataIncomplete = incompleteUnit !== null
 
     const noDecisionsPlanned =
-      connectedDecision !== null &&
-      !primaryDecision.planned &&
-      !connectedDecision.planned
+      !primaryDecision.planned && !connectedDecision?.planned
+    // A lone decision is always sent, so it needs no checkbox — unless it arrived
+    // unplanned, which would otherwise leave nothing that can be planned.
+    const showPrimaryPlannedCheckbox =
+      connectedDecision !== null || !primaryDecision.planned
     const childName = formatPersonName(child, 'First Last')
 
     return (
@@ -270,7 +272,7 @@ const DecisionDraftRedesignInner = React.memo(
               <DecisionCard
                 decision={primaryDecision}
                 primaryDecisionType={primaryDecision.type}
-                showPlannedCheckbox={connectedDecision !== null}
+                showPlannedCheckbox={showPrimaryPlannedCheckbox}
                 childName={childName}
                 language={decisionLanguage(primaryDecision.unitId)}
                 unitLanguageUnsupported={misconfigured(primaryDecision.unitId)}

--- a/frontend/src/employee-frontend/components/decision-draft/IndividualReasoningPickerModal.tsx
+++ b/frontend/src/employee-frontend/components/decision-draft/IndividualReasoningPickerModal.tsx
@@ -18,7 +18,7 @@ import BaseModal, {
   ModalButtons
 } from 'lib-components/molecules/modals/BaseModal'
 import { fontWeights } from 'lib-components/typography'
-import { Gap } from 'lib-components/white-space'
+import { defaultMargins, Gap } from 'lib-components/white-space'
 import colors from 'lib-customizations/common'
 
 import { useTranslation } from '../../state/i18n'
@@ -29,6 +29,16 @@ import { getIndividualReasoningsQuery } from './queries'
 
 const Subtitle = styled.div`
   color: ${colors.grayscale.g70};
+`
+
+const StickyButtons = styled(ModalButtons)`
+  position: sticky;
+  bottom: 0;
+  background: ${colors.grayscale.g0};
+  box-shadow: 0 -2px 4px 0 rgba(0, 0, 0, 0.1);
+  margin-top: ${defaultMargins.L};
+  margin-bottom: 0;
+  padding: ${defaultMargins.s} 0;
 `
 
 const RowList = styled.div`
@@ -153,14 +163,14 @@ export default React.memo(function IndividualReasoningPickerModal({
           </RowList>
         )
       })}
-      <ModalButtons $justifyContent="center">
+      <StickyButtons $justifyContent="center">
         <Button
           primary
           data-qa="modal-closeBtn"
           onClick={onClose}
           text={i18n.common.close}
         />
-      </ModalButtons>
+      </StickyButtons>
     </BaseModal>
   )
 })

--- a/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
@@ -1049,7 +1049,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
             )
 
             val decisionDrafts = tx.fetchDecisionDrafts(applicationId)
-            assertEquals(2, decisionDrafts.size)
+            assertEquals(1, decisionDrafts.size)
 
             decisionDrafts
                 .find { it.type == DecisionType.PRESCHOOL }!!
@@ -1062,21 +1062,6 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                             endDate = mainPeriod.end,
                             unitId = daycare.id,
                             planned = true,
-                        ),
-                        it,
-                    )
-                }
-            decisionDrafts
-                .find { it.type == DecisionType.PRESCHOOL_DAYCARE }!!
-                .let {
-                    assertEquals(
-                        DecisionDraft(
-                            id = it.id,
-                            type = DecisionType.PRESCHOOL_DAYCARE,
-                            startDate = mainPeriod.start,
-                            endDate = mainPeriod.end,
-                            unitId = daycare.id,
-                            planned = false,
                         ),
                         it,
                     )

--- a/service/src/integrationTest/kotlin/evaka/core/decision/DecisionCreationIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/decision/DecisionCreationIntegrationTest.kt
@@ -270,16 +270,6 @@ class DecisionCreationIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
                     planned = true,
                     genericReasoning = defaultPreschoolDecisionReasoningGeneric.asResolved(),
                 ),
-            connectedDecision =
-                DecisionDraft(
-                    id = connectedDecisionId,
-                    unitId = testDaycare.id,
-                    type = DecisionType.PRESCHOOL_DAYCARE,
-                    startDate = period.start,
-                    endDate = period.end,
-                    planned = false,
-                    genericReasoning = defaultDaycareDecisionReasoningGeneric.asResolved(),
-                ),
             otherGuardian = otherGuardian,
         )
 
@@ -356,6 +346,54 @@ class DecisionCreationIntegrationTest : FullApplicationTest(resetDbBeforeEach = 
         assertEquals(testDaycare.id, decision2.unitId)
         assertEquals(preschoolDaycarePeriod.start, decision2.startDate)
         assertEquals(preschoolDaycarePeriod.end, decision2.endDate)
+    }
+
+    @Test
+    fun testPreparatoryOnly() {
+        val guardian = DevPerson(ssn = "070644-937X")
+        val otherGuardian = DevPerson(ssn = "311299-999E")
+        val child = DevPerson(ssn = "070714A9126")
+        db.transaction { tx ->
+            listOf(guardian, otherGuardian).forEach { tx.insert(it, DevPersonType.ADULT) }
+            tx.insert(child, DevPersonType.CHILD)
+        }
+        MockPersonDetailsService.addPersons(guardian, otherGuardian, child)
+        MockPersonDetailsService.addDependants(guardian, child)
+        MockPersonDetailsService.addDependants(otherGuardian, child)
+        val period = FiniteDateRange(LocalDate.of(2020, 8, 15), LocalDate.of(2021, 5, 31))
+        val applicationId =
+            insertInitialData(
+                type = PlacementType.PREPARATORY,
+                adult = guardian,
+                child = child,
+                period = period,
+                preparatoryEducation = true,
+            )
+        checkDecisionDrafts(
+            applicationId,
+            adult = guardian,
+            child = child,
+            primaryDecision =
+                DecisionDraft(
+                    id = primaryDecisionId,
+                    unitId = testDaycare.id,
+                    type = DecisionType.PREPARATORY_EDUCATION,
+                    startDate = period.start,
+                    endDate = period.end,
+                    planned = true,
+                    genericReasoning = defaultPreschoolDecisionReasoningGeneric.asResolved(),
+                ),
+            otherGuardian = otherGuardian,
+        )
+
+        val decisions = createDecisions(applicationId)
+        assertEquals(1, decisions.size)
+
+        val decision = decisions[0]
+        assertEquals(testDaycare.id, decision.unitId)
+        assertEquals(DecisionType.PREPARATORY_EDUCATION, decision.type)
+        assertEquals(period.start, decision.startDate)
+        assertEquals(period.end, decision.endDate)
     }
 
     @Test

--- a/service/src/main/kotlin/evaka/core/decision/DecisionDraftService.kt
+++ b/service/src/main/kotlin/evaka/core/decision/DecisionDraftService.kt
@@ -290,25 +290,29 @@ private fun planPreschoolDecisionDrafts(
             planned = primaryPlanned,
         )
 
-    val connected =
-        DecisionDraft(
-            id = DecisionId(UUID.randomUUID()), // placeholder
-            unitId = plan.unitId,
-            type =
-                if (plan.type == PlacementType.PRESCHOOL_CLUB) DecisionType.PRESCHOOL_CLUB
-                else DecisionType.PRESCHOOL_DAYCARE,
-            startDate = plan.preschoolDaycarePeriod?.start ?: plan.period.start,
-            endDate = plan.preschoolDaycarePeriod?.end ?: plan.period.end,
-            planned =
-                plan.type in
-                    listOf(
-                        PlacementType.PRESCHOOL_DAYCARE,
-                        PlacementType.PRESCHOOL_CLUB,
-                        PlacementType.PREPARATORY_DAYCARE,
-                    ),
-        )
+    val appliedForConnectedCare =
+        plan.type in
+            listOf(
+                PlacementType.PRESCHOOL_DAYCARE,
+                PlacementType.PRESCHOOL_CLUB,
+                PlacementType.PREPARATORY_DAYCARE,
+            )
 
-    return listOf(primary, connected)
+    val connected =
+        if (appliedForConnectedCare)
+            DecisionDraft(
+                id = DecisionId(UUID.randomUUID()), // placeholder
+                unitId = plan.unitId,
+                type =
+                    if (plan.type == PlacementType.PRESCHOOL_CLUB) DecisionType.PRESCHOOL_CLUB
+                    else DecisionType.PRESCHOOL_DAYCARE,
+                startDate = plan.preschoolDaycarePeriod?.start ?: plan.period.start,
+                endDate = plan.preschoolDaycarePeriod?.end ?: plan.period.end,
+                planned = true,
+            )
+        else null
+
+    return listOfNotNull(primary, connected)
 }
 
 fun Database.Transaction.clearDecisionDrafts(applicationIds: List<ApplicationId>) {


### PR DESCRIPTION
- Aiemmin liittyvän päätöksen pystyi tekemään, vaikka sitä ei olisi haettu. Jatkossa se ei ole enää mahdollista.
- Yksilöllisten perustelujen valinta-dialogin sulje-nappi muutettu niin, että pysyy aina näkyvissä.