### PR TITLE
Työntekijän roolin lisääminen auditlokiin

### DIFF
--- a/docs/developer-guide/service/logging.md
+++ b/docs/developer-guide/service/logging.md
@@ -50,13 +50,13 @@ fun deleteServiceNeed(tx: Database.Transaction, id: ServiceNeedId, audit: AuditC
 - **Add request-derived values at construction.** By convention, the values you log that are known directly from the request are added when constructing the context at the beginning of the controller method. Values discovered later by querying are added where they surface.
 - Emit after the `db.connect { ... }` call returns, so the event is produced only when the transaction committed. If the endpoint throws, `log` is never reached and no entry is produced.
 
-**The requester is logged automatically.** The acting user's ID and type are always recorded, so never add an ID to the context just because that person made the request.
+**The requester is logged automatically.** The acting user's `userId` and `userIdHash` are always recorded, so never add an ID to the context just because that person made the request. For an employee, `userRoles` records every role they hold — not the role that authorized this particular action — which is what makes "who with role X reached this data" answerable long after roles have changed. Roles are sorted and wrapped in `|` (`|ADMIN|SERVICE_WORKER|`) so that a role matches exactly in CloudWatch with `filter strcontains(userRoles, "|ADMIN|")`. The user's type is not a field of its own; it follows from the `path` prefix (`/employee/`, `/citizen/`, `/employee-mobile/`).
 
 ### Naming the event
 
 - **Pattern: `EntityAction`** — e.g. `PlacementCreate`, `ApplicationSearch`, `DecisionAccept`.
 - **One event per endpoint.** The event is the user's intent; side effects are captured via context IDs, not separate events.
-- **Citizen vs employee:** share the event when the action and data scope are the same (they're distinguished by the auto-logged user type). Use separate events when the semantics differ, and name them for the difference — e.g. `OwnChildrenRead` vs `ChildrenByGuardianRead`.
+- **Citizen vs employee:** share the event when the action and data scope are the same (they're distinguished by the `path` prefix). Use separate events when the semantics differ, and name them for the difference — e.g. `OwnChildrenRead` vs `ChildrenByGuardianRead`.
 - Each event sets `securityEvent` / `securityLevel` as enum properties when it's defined.
 
 ### Security-critical operations

--- a/service/service-lib/src/main/kotlin/fi/espoo/voltti/logging/MdcKey.kt
+++ b/service/service-lib/src/main/kotlin/fi/espoo/voltti/logging/MdcKey.kt
@@ -16,6 +16,7 @@ enum class MdcKey(val key: String) {
     TRACE_ID("traceId"),
     USER_ID("userId"),
     USER_ID_HASH("userIdHash"),
+    USER_ROLES("userRoles"),
     HTTP_ROUTE("httpRoute"),
     HTTP_PATH_PARAM("httpPathParam");
 

--- a/service/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
+++ b/service/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/AppenderTest.kt
@@ -39,6 +39,7 @@ class AppenderTest {
             withTestLoggers {
                 MDC.put("userId", "$prefix.userId")
                 MDC.put("userIdHash", "$prefix.userIdHash")
+                MDC.put("userRoles", "$prefix.userRoles")
 
                 logger.audit(
                     "$prefix.description",

--- a/service/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/Utils.kt
+++ b/service/service-lib/src/test/kotlin/fi/espoo/voltti/logging/logback/Utils.kt
@@ -113,6 +113,7 @@ fun TestLoggers.withLatestSanitized(block: (Map<String, Any>) -> Unit) =
 data class AuditEvent(
     val userId: String,
     val userIdHash: String,
+    val userRoles: String,
     val description: String,
     val eventCode: String,
     val targetId: Any,
@@ -127,6 +128,7 @@ data class AuditEvent(
             eventCode,
             targetId,
             userIdHash,
+            userRoles,
             appName,
             EnvFields.appBuild,
             EnvFields.appCommit,
@@ -141,6 +143,7 @@ data class AuditEvent(
             AuditEvent(
                 userId = "$prefix.userId",
                 userIdHash = "$prefix.userIdHash",
+                userRoles = "$prefix.userRoles",
                 description = "$prefix.description",
                 eventCode = "$prefix.someEvent",
                 targetId = "$prefix.id",
@@ -155,6 +158,7 @@ private val auditEventProps =
         "eventCode",
         "targetId",
         "userIdHash",
+        "userRoles",
         "appName",
         "appBuild",
         "appCommit",

--- a/service/src/main/kotlin/evaka/core/shared/auth/RequestToAuthenticatedUser.kt
+++ b/service/src/main/kotlin/evaka/core/shared/auth/RequestToAuthenticatedUser.kt
@@ -43,11 +43,22 @@ class RequestToAuthenticatedUser(private val tracer: Tracer) : HttpFilter() {
                 (user as? AuthenticatedUser.MobileDevice)?.employeeIdHash?.let { employeeIdHash ->
                     MdcKey.SECONDARY_USER_ID_HASH.set(employeeIdHash.toString())
                 }
+                (user as? AuthenticatedUser.Employee)
+                    ?.let { it.globalRoles + it.allScopedRoles }
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.let { roles ->
+                        // Make the roles easily queryable (pipes separate e.g. ADMIN from
+                        // FINANCE_ADMIN)
+                        MdcKey.USER_ROLES.set(
+                            roles.map { it.name }.sorted().joinToString("|", "|", "|")
+                        )
+                    }
             }
         }
         try {
             chain.doFilter(request, response)
         } finally {
+            MdcKey.USER_ROLES.unset()
             MdcKey.SECONDARY_USER_ID_HASH.unset()
             MdcKey.USER_ID_HASH.unset()
             MdcKey.USER_ID.unset()

--- a/service/src/test/kotlin/evaka/core/shared/auth/RequestToAuthenticatedUserTest.kt
+++ b/service/src/test/kotlin/evaka/core/shared/auth/RequestToAuthenticatedUserTest.kt
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package evaka.core.shared.auth
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import evaka.core.shared.EmployeeId
+import evaka.core.shared.MobileDeviceId
+import evaka.core.shared.PersonId
+import evaka.core.shared.noopTracer
+import fi.espoo.voltti.auth.JwtTokenDecoder
+import fi.espoo.voltti.logging.MdcKey
+import jakarta.servlet.GenericServlet
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.AfterEach
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import tools.jackson.module.kotlin.jsonMapper
+
+class RequestToAuthenticatedUserTest {
+    private val algorithm = Algorithm.none()
+    private val jwtDecoder = JwtTokenDecoder(JWT.require(algorithm).build())
+    private val filter = RequestToAuthenticatedUser(noopTracer())
+
+    /** Captures MDC from inside the chain, because the filter clears it on the way out. */
+    private class MdcCapturingServlet : GenericServlet() {
+        var userRoles: String? = null
+
+        override fun service(req: ServletRequest, res: ServletResponse) {
+            userRoles = MdcKey.USER_ROLES.get()
+        }
+    }
+
+    @AfterEach fun afterEach() = MdcKey.USER_ROLES.unset()
+
+    private fun rolesLoggedFor(user: AuthenticatedUser): String? {
+        val request =
+            MockHttpServletRequest().apply {
+                addHeader("Authorization", "Bearer ${JWT.create().sign(algorithm)}")
+                addHeader("X-User", jsonMapper().writeValueAsString(user))
+            }
+        val response = MockHttpServletResponse()
+        val servlet = MdcCapturingServlet()
+        jwtDecoder.doFilter(request, response, MockFilterChain())
+        filter.doFilter(request, response, MockFilterChain(servlet))
+        return servlet.userRoles
+    }
+
+    @Test
+    fun `global and scoped roles are logged together, sorted and delimiter-wrapped`() {
+        val roles =
+            rolesLoggedFor(
+                AuthenticatedUser.Employee(
+                    EmployeeId(UUID.randomUUID()),
+                    setOf(
+                        UserRole.SERVICE_WORKER,
+                        UserRole.EARLY_CHILDHOOD_EDUCATION_SECRETARY,
+                        UserRole.ADMIN,
+                    ),
+                )
+            )
+        assertEquals("|ADMIN|EARLY_CHILDHOOD_EDUCATION_SECRETARY|SERVICE_WORKER|", roles)
+    }
+
+    @Test
+    fun `a single role is still wrapped in delimiters`() {
+        val roles =
+            rolesLoggedFor(
+                AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
+            )
+        assertEquals("|ADMIN|", roles)
+    }
+
+    @Test
+    fun `an employee without any role logs nothing`() {
+        assertNull(
+            rolesLoggedFor(AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), emptySet()))
+        )
+    }
+
+    @Test
+    fun `a citizen logs no roles`() {
+        assertNull(
+            rolesLoggedFor(
+                AuthenticatedUser.Citizen(PersonId(UUID.randomUUID()), CitizenAuthLevel.STRONG)
+            )
+        )
+    }
+
+    @Test
+    fun `a mobile device logs no roles`() {
+        assertNull(
+            rolesLoggedFor(
+                AuthenticatedUser.MobileDevice(
+                    MobileDeviceId(UUID.randomUUID()),
+                    EmployeeId(UUID.randomUUID()),
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `roles are cleared once the request completes`() {
+        val _ =
+            rolesLoggedFor(
+                AuthenticatedUser.Employee(EmployeeId(UUID.randomUUID()), setOf(UserRole.ADMIN))
+            )
+        assertNull(MdcKey.USER_ROLES.get())
+    }
+}


### PR DESCRIPTION
Työntekijän roolit lokitetaan putkimerkeillä `|` kehystettyinä yhteen string-kenttään. Perusteluna on se, että CloudWatchista hakeminen olisi mahdollisimman tehokasta. Vaihtoehtona olisi ollut JSON array, mutta niistä hakeminen onnistuu vain `@message`-kentän kautta, jolloin roolien nimet voivat sekoittua muuhun lokitettuun dataan, tai yksitellen `userRole.0`, `userRole.1` jne. kentistä, mikä on työlästä.