### PR TITLE
Poistetaan Groovy-riippuvuuden kiinnitys

### DIFF
--- a/service/evaka-bom/build.gradle.kts
+++ b/service/evaka-bom/build.gradle.kts
@@ -51,12 +51,6 @@ dependencies {
         api(libs.ktlint.rule.engine.core)
         api(libs.ktlint.test)
 
-        // Groovy 5.0.4 has a regression causing NPE in thymeleaf-layout-dialect.
-        // Pin to 5.0.3 until Groovy 5.0.5 is released with the fix.
-        // https://github.com/spring-projects/spring-boot/issues/49277
-        // Remove the below line altogether when Spring Boot with Groovy 5.0.5 is available
-        api("org.apache.groovy:groovy") { version { strictly("5.0.3") } }
-
         // These constraints are needed for CVE fixes
         api("org.apache.httpcomponents.client5:httpclient5:5.6.4")
         api("org.apache.httpcomponents.core5:httpcore5:5.4.3")


### PR DESCRIPTION
Kiinnitystä ei enää tarvita, `thymeleaf-layout-dialect`issa ollut null pointer exception regressio korjattu Groovyn versiossa 5.0.5. Versio tulee jatkossa jälleen spring bootin BOM:in kautta, joka on tällä hetkellä 5.0.6.
<!--
Ohjeet PR:n tekijälle:

- Kirjoita otsikko ja kuvaus suomeksi.

- Otsikko päätyy muutoslokille; otsikon pitää olla sopivan kuvaileva mutta silti
  tiivis.

- Kirjoita kuvaus niin, että sen ymmärtää henkilö, joka ei ole osa eVakan
  kehitystiimiä. Voit esim. lisätä selventävän ruutukaappauksen. Rikkovien
  muutosten tapauksessa lisää päivitysohjeet.

- Lisää linkki dokumentaation relevanttiin kohtaan.

- PR:t ryhmitellään muutoslokille labelien mukaisesti. Lisää PR:lle yksi label seuraavista:
  - breaking: Rikkova muutos, joka vaatii toimia päivitettäessä
  - enhancement: Uusi toiminnallisuus tai parannus
  - bug: Bugikorjaus olemassaolevaan toiminnallisuuteen
  - tech: Tekninen muutos, esim. refaktorointi
  - dependencies: Riippuvuuspäivitys
  - no-changelog: PR:ää ei sisällytetä muutoslokille lainkaan

- PR:t listataan eri kanavissa sen mukaan, mihin kuntaan ne vaikuttavat.
  - Lisää PR:lle yksi tai useampi label seuraavista: espoo, oulu, seutu, turku,
    core (ytimen muutokset)
  - Labelia ei tarvita jos muutos on dependencies tai no-changelog

- Lisää PR:lle yksi tai useampi label sen mukaan, missä muutos näkyy:
  - citizen: kuntalaisten käyttöliittymä
  - employee: henkilökunnan käyttöliittymä
  - employee-mobile: henkilökunnan mobiili
  - not-visible: muutos ei näy käyttöliittymässä (ei voi yhdistää muihin näkyvyys-labeleihin)
  - Labelia ei tarvita jos muutos on dependencies, tech tai no-changelog
-->
