### PR TITLE
Ohje audit-tapahtumien security-merkinnöille

### DIFF
--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -31,4 +31,5 @@ This guide helps developers to discover and understand the custom frameworks, ut
 - **[Database Schema & Migrations](service/migrations.md)** - Schema conventions and Flyway migrations
 - **[ACL API](service/acl.md)** - Access control framework
 - **[Logging](service/logging.md)** - Application logging and audit logging for compliance
+- **[Security Events](service/security-events.md)** - When an audit event is a security event, and at what level
 - **[Async & Scheduled Jobs](service/async-jobs.md)** - Background task execution

--- a/docs/developer-guide/service/logging.md
+++ b/docs/developer-guide/service/logging.md
@@ -57,7 +57,7 @@ fun deleteServiceNeed(tx: Database.Transaction, id: ServiceNeedId, audit: AuditC
 - **Pattern: `EntityAction`** — e.g. `PlacementCreate`, `ApplicationSearch`, `DecisionAccept`.
 - **One event per endpoint.** The event is the user's intent; side effects are captured via context IDs, not separate events.
 - **Citizen vs employee:** share the event when the action and data scope are the same (they're distinguished by the `path` prefix). Use separate events when the semantics differ, and name them for the difference — e.g. `OwnChildrenRead` vs `ChildrenByGuardianRead`.
-- Each event sets `securityEvent` / `securityLevel` as enum properties when it's defined.
+- Each event sets `securityEvent` / `securityLevel` as enum properties when it's defined — see [Security events](security-events.md) for when to set them.
 
 ### Security-critical operations
 

--- a/docs/developer-guide/service/security-events.md
+++ b/docs/developer-guide/service/security-events.md
@@ -1,0 +1,39 @@
+<!--
+SPDX-FileCopyrightText: 2017-2026 City of Espoo
+
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+
+# Security Events
+
+Certain audit events are also security events: they must be marked with `securityEvent = true` and a `securityLevel`, so that security monitoring can be built on filters applied to the audit log stream. `securityEvent` and `securityLevel` are constructor arguments on the `Audit` enum constant, and which event carries which marking lives in `Audit.kt`. For how audit events are produced, see [Audit logging](logging.md).
+
+## Deciding the marking
+
+Take the first branch that applies, so an action that fits two levels gets the higher one.
+
+```mermaid
+flowchart TD
+    A["New or changed audit event"] --> B{"Does it create, delete, activate<br/>or deactivate a user account?"}
+    B -- "yes" --> HIGH["securityEvent = true<br/>securityLevel = high"]
+    B -- "no" --> C{"Does it grant or remove<br/>rights held by a user?"}
+    C -- "yes" --> D{"Do those rights<br/>apply system-wide?"}
+    D -- "yes" --> HIGH
+    D -- "no: scoped to a unit,<br/>a group or one person" --> MED["securityEvent = true<br/>securityLevel = medium"]
+    C -- "no" --> E{"Does it create, replace<br/>or revoke a credential?"}
+    E -- "yes" --> MED
+    E -- "no" --> F{"Is it a login,<br/>or an attempt at one?"}
+    F -- "yes" --> LOW["securityEvent = true<br/>securityLevel = low"]
+    F -- "no" --> N["Not a security event:<br/>set neither field"]
+```
+
+## Cases the tree does not settle
+
+- **Reads are never security events**, sensitive ones included, and neither are ordinary data changes. Reads open only to a very narrow role would need their own marker; `securityEvent` is not it.
+- **A `person` row is a data record, not an account.** What lets a citizen sign in is the credential attached to it.
+- **In a flow spanning several events (e.g. employee mobile device pairing), the steps where an acting person is easily identifiable carry the level of what is being authorised**, while the steps a device or the gateway performs on its own stay `medium`.
+- **An attempt should be logged at the level of what it attempts.**
+- **Renaming a credential is not a security event at all** — it changes no authentication material.
+- **The same operation carries the same marking wherever it is reached from**, and a scheduled job is marked like the same change made by a person.
+
+These rules cover the Kotlin `Audit` enum; the API gateway hard-codes `securityEvent: true, securityLevel: 'low'` on every event it emits (`apigw/src/shared/logging.ts`).


### PR DESCRIPTION
## Ennen tätä muutosta

`Audit`-enumin kentät `securityEvent` ja `securityLevel` on täytetty tapaus kerrallaan ilman kirjattua kriteeriä. `logging.md` mainitsee kentät yhdellä lauseella, mutta ei kerro milloin ne asetetaan. Tulos on epäyhtenäinen:

- sama toiminto sai eri merkinnän riippuen päätepisteestä (`UnitAclCreate` on ollut merkitsemättä vuodesta 2020, `EmployeeUpdateDaycareRoles` on ollut `high` vuodesta 2024),
- osa selvästi tietoturvamerkityksellisistä tapahtumista on kokonaan merkitsemättä (`PinCodeUpdate`, `MobileDevicesDelete`, `PinLogin`),
- 550 tapahtumasta 52 on merkitty, ja niistä 46 on tasolla `high` — taso ei siis erottele mitään.

## Tämän muutoksen jälkeen

`logging.md`:n rinnalle tulee uusi ohje `docs/developer-guide/service/security-events.md`, joka kertoo tarkalleen milloin merkintä asetetaan ja mille tasolle. Sisältö on tiimin sopima linjaus:

- Security-tapahtumia ovat vain **käyttäjätunnusten muutokset**, **käyttöoikeuksien muutokset**, **kirjautumistunnisteiden muutokset** ja **kirjautumiset**. Muu on tavallinen audit-tapahtuma.
- Kolme tasoa: `high` käyttäjätunnuksille ja järjestelmänlaajuisille oikeuksille, `medium` yksikkö- tai henkilötason oikeuksille ja kirjautumistunnisteille, `low` kirjautumisille ja kirjautumisyrityksille.
- Jatkossa **lukutapahtumat eivät ole koskaan security-tapahtumia.** Hyvin rajatulle roolille näkyvät luvut (esim. turvakiellollisen henkilön osoite) tarvitsevat oman tägäyksensä lokituksessa, mutta `securityEvent` ei ole se — tämä erillinen flägitys on tietoisesti rajattu tämän ohjeen ulkopuolelle.
- Päätöspuu (mermaid) kysyy jokaisen tason kvalifioivan kysymyksen ylhäältä alas, joten kahteen tasoon sopiva toiminto saa korkeamman. Puun jälkeen on erikseen ne säännöt, joita puu ei näytä: monivaiheiset operaatiot, sama toiminto eri päätepisteestä, ajastetut työt, uudelleennimeäminen, volyymi.

`logging.md`:hen ja kehittäjäoppaan hakemistoon lisätään linkki uuteen ohjeeseen.
