### PR TITLE
Ohjataan passkey-virheestä omiin tietoihin

### DIFF
--- a/frontend/src/citizen-frontend/login/LoginPage.tsx
+++ b/frontend/src/citizen-frontend/login/LoginPage.tsx
@@ -100,7 +100,7 @@ export default React.memo(function LoginPage() {
             <>
               <InfoBox
                 message={i18n.loginPage.login.passkeyError(
-                  getStrongLoginUri(unvalidatedNextPath ?? '/')
+                  getStrongLoginUri('/personal-details')
                 )}
                 darkBackground
                 wide

--- a/frontend/src/citizen-frontend/login/WeakLoginFormPage.tsx
+++ b/frontend/src/citizen-frontend/login/WeakLoginFormPage.tsx
@@ -165,9 +165,7 @@ const WeakLoginForm = React.memo(function WeakLogin({
         {rateLimitError && <AlertBox message={t.rateLimitError} noMargin />}
         {passkeyFailed && (
           <InfoBox
-            message={t.passkeyError(
-              getStrongLoginUri(unvalidatedNextPath ?? '/')
-            )}
+            message={t.passkeyError(getStrongLoginUri('/personal-details'))}
             darkBackground
             wide
             data-qa="passkey-login-error"

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -254,7 +254,8 @@ const en: Translations = {
         <>
           Logging in with a passkey was interrupted. Try again, log in with your
           email address or{' '}
-          <a href={strongLoginUri}>authenticate in the Suomi.fi service</a>.
+          <a href={strongLoginUri}>authenticate in the Suomi.fi service</a> and
+          create a new passkey in your personal information.
         </>
       ),
       usedLast: 'Used last'

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -253,7 +253,7 @@ export default {
           Kirjautuminen pääsyavaimella keskeytyi. Yritä uudelleen, kirjaudu
           sähköpostiosoitteella tai{' '}
           <a href={strongLoginUri}>tunnistaudu Suomi.fi-palvelussa</a> ja luo
-          itsellesi uusi pääsyavain.
+          itsellesi uusi pääsyavain omissa tiedoissa.
         </>
       ),
       usedLast: 'Käytit viimeksi'

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -253,7 +253,8 @@ const sv: Translations = {
         <>
           Inloggningen med inloggningsnyckel avbröts. Försök igen, logga in med
           e-postadress eller{' '}
-          <a href={strongLoginUri}>autentisera dig i tjänsten Suomi.fi</a>.
+          <a href={strongLoginUri}>autentisera dig i tjänsten Suomi.fi</a> och
+          skapa en ny inloggningsnyckel i dina egna uppgifter.
         </>
       ),
       usedLast: 'Senast använd'


### PR DESCRIPTION
Jos passkey-kirjautuminen keskeytyy, ohjataan käyttäjää kirjautumaan suomi.fi:n kautta ja luomaan uusi passkey. Päivitetään ohjetekstiä ja ohjataan kirjautumisen jälkeen suoraan omat tiedot -sivulle.