### PR TITLE
Korjataan tehtävien klikkauksesta tapahtuva vieritys

### DIFF
--- a/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
+++ b/frontend/src/citizen-frontend/personal-details/PersonalDetails.tsx
@@ -13,7 +13,7 @@ import { useQueryResult } from 'lib-common/query'
 import { scrollRefIntoView } from 'lib-common/utils/scrolling'
 import Main from 'lib-components/atoms/Main'
 import RoundIcon from 'lib-components/atoms/RoundIcon'
-import { desktopMin } from 'lib-components/breakpoints'
+import { desktopMin, desktopMinPx } from 'lib-components/breakpoints'
 import { ContentArea, NarrowContainer } from 'lib-components/layout/Container'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { H1 } from 'lib-components/typography'
@@ -26,6 +26,7 @@ import { renderResult } from '../async-rendering'
 import { passkeysSupported } from '../auth/passkeys'
 import { AuthContext } from '../auth/state'
 import { useTranslation } from '../localization'
+import { headerHeightMobile } from '../navigation/const'
 import useTitle from '../useTitle'
 
 import ContactDetailsSection from './ContactDetailsSection'
@@ -42,6 +43,13 @@ import {
 } from './queries'
 import type { PersonalDetailsTaskSection } from './tasks'
 import { personalDetailsTaskConfig, usePersonalDetailsTasks } from './tasks'
+
+// the header is sticky on mobile, so scroll targets must stop below it
+const ScrollTargetArea = styled(ContentArea)`
+  @media (max-width: ${desktopMinPx - 1}px) {
+    scroll-margin-top: ${headerHeightMobile}px;
+  }
+`
 
 const DesktopTopGap = styled.div`
   display: none;
@@ -197,7 +205,11 @@ export default React.memo(function PersonalDetails() {
 
         <Gap $size="s" />
 
-        <ContentArea $opaque $paddingVertical="m" ref={contactDetailsSection}>
+        <ScrollTargetArea
+          $opaque
+          $paddingVertical="m"
+          ref={contactDetailsSection}
+        >
           {renderResult(
             combine(user, emailVerificationStatus),
             ([user, emailVerificationStatus]) =>
@@ -211,7 +223,7 @@ export default React.memo(function PersonalDetails() {
                 <Redirect replace to="/" />
               )
           )}
-        </ContentArea>
+        </ScrollTargetArea>
 
         {showFamilySizeSection && (
           <>
@@ -231,7 +243,11 @@ export default React.memo(function PersonalDetails() {
         {passkeysSupported() && (
           <>
             <Gap $size="s" />
-            <ContentArea $opaque $paddingVertical="m" ref={passkeysSection}>
+            <ScrollTargetArea
+              $opaque
+              $paddingVertical="m"
+              ref={passkeysSection}
+            >
               {renderResult(user, (user) =>
                 user ? (
                   <PasskeysSection user={user} />
@@ -239,13 +255,17 @@ export default React.memo(function PersonalDetails() {
                   <Redirect replace to="/" />
                 )
               )}
-            </ContentArea>
+            </ScrollTargetArea>
           </>
         )}
 
         <Gap $size="s" />
 
-        <ContentArea $opaque $paddingVertical="m" ref={loginDetailsSection}>
+        <ScrollTargetArea
+          $opaque
+          $paddingVertical="m"
+          ref={loginDetailsSection}
+        >
           {renderResult(
             combine(user, emailVerificationStatus, passwordConstraints),
             ([user, emailVerificationStatus, passwordConstraints]) =>
@@ -260,11 +280,11 @@ export default React.memo(function PersonalDetails() {
                 <Redirect replace to="/" />
               )
           )}
-        </ContentArea>
+        </ScrollTargetArea>
 
         <Gap $size="s" />
 
-        <ContentArea
+        <ScrollTargetArea
           $opaque
           $paddingVertical="m"
           ref={notificationSettingsSection}
@@ -275,7 +295,7 @@ export default React.memo(function PersonalDetails() {
               ref={notificationSettingsSection}
             />
           ))}
-        </ContentArea>
+        </ScrollTargetArea>
       </NarrowContainer>
       <Footer />
     </Main>


### PR DESCRIPTION
Omat tiedot -sivun yläreunan tehtävien klikkaus skrollaa oikeaan kohtaan sivua. Skrollaus osuu nyt oikeaan paikkaan myös mobiilissa, aiemmin otsikot jäivät sticky headerin alle.