### PR TITLE
Tuki sähköpostikirjautumisen poistamiselle käytöstä

### DIFF
--- a/apigw/src/app.ts
+++ b/apigw/src/app.ts
@@ -12,6 +12,7 @@ import {
   authPasskeyLoginOptions
 } from './enduser/routes/auth-passkey-login.ts'
 import { citizenAuthStatus } from './enduser/routes/auth-status.ts'
+import { authWeakDeleteCredentials } from './enduser/routes/auth-weak-delete-credentials.ts'
 import { authWeakLogin } from './enduser/routes/auth-weak-login.ts'
 import { authWeakUpdateCredentials } from './enduser/routes/auth-weak-update-credentials.ts'
 import { passkeyDelete } from './enduser/routes/passkey-delete.ts'
@@ -304,6 +305,11 @@ export function apiRouter(config: Config, redisClient: RedisClient) {
     citizenSessions.requireAuthentication,
     express.json(),
     authWeakUpdateCredentials(redisClient)
+  )
+  router.delete(
+    '/citizen/personal-data/weak-login-credentials',
+    citizenSessions.requireAuthentication,
+    authWeakDeleteCredentials(redisClient)
   )
   router.delete(
     '/citizen/passkeys/:id',

--- a/apigw/src/enduser/__tests__/weak-credentials.ts
+++ b/apigw/src/enduser/__tests__/weak-credentials.ts
@@ -38,16 +38,10 @@ describe('Weak login credentials', () => {
     expect(res.status).toBe(200)
   }
 
-  test('deleting credentials requires a session', async () => {
-    const res = await tester.client.delete(
-      '/api/citizen/personal-data/weak-login-credentials',
-      { validateStatus: () => true }
-    )
-    expect(res.status).toBe(401)
-  })
-
-  test('deleting credentials logs out other weak sessions', async () => {
-    // two weak sessions for the same user, sharing the same Redis
+  // runs the body with a second weak session for the same user, sharing the same Redis
+  async function withSecondWeakSession(
+    f: (otherTester: GatewayTester) => Promise<void>
+  ): Promise<void> {
     const otherTester = await GatewayTester.start(
       configFromEnv(),
       'citizen',
@@ -57,7 +51,31 @@ describe('Weak login credentials', () => {
     try {
       await weakLogin(tester)
       await weakLogin(otherTester)
+      await f(otherTester)
+    } finally {
+      await otherTester.afterEach()
+      await otherTester.stop()
+    }
+  }
 
+  async function assertLoggedOut(onTester: GatewayTester): Promise<void> {
+    const status = await onTester.client.get('/api/citizen/auth/status', {
+      validateStatus: () => true
+    })
+    expect(status.status).toBe(200)
+    expect((status.data as { loggedIn: boolean }).loggedIn).toBe(false)
+  }
+
+  test('deleting credentials requires a session', async () => {
+    const res = await tester.client.delete(
+      '/api/citizen/personal-data/weak-login-credentials',
+      { validateStatus: () => true }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  test('deleting credentials logs out other weak sessions', async () => {
+    await withSecondWeakSession(async (otherTester) => {
       tester.nockScope
         .delete('/citizen/personal-data/weak-login-credentials')
         .reply(200)
@@ -68,14 +86,33 @@ describe('Weak login credentials', () => {
       tester.nockScope.done()
       expect(res.status).toBe(204)
 
-      const status = await otherTester.client.get('/api/citizen/auth/status', {
-        validateStatus: () => true
-      })
-      expect(status.status).toBe(200)
-      expect((status.data as { loggedIn: boolean }).loggedIn).toBe(false)
-    } finally {
-      await otherTester.afterEach()
-      await otherTester.stop()
-    }
+      await assertLoggedOut(otherTester)
+    })
+  })
+
+  test('updating credentials requires a session', async () => {
+    const res = await tester.client.put(
+      '/api/citizen/personal-data/weak-login-credentials',
+      { password: 'aifiefaeC3io?dee' },
+      { validateStatus: () => true }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  test('updating credentials logs out other weak sessions', async () => {
+    await withSecondWeakSession(async (otherTester) => {
+      tester.nockScope
+        .put('/citizen/personal-data/weak-login-credentials')
+        .reply(200)
+      const res = await tester.client.put(
+        '/api/citizen/personal-data/weak-login-credentials',
+        { password: 'aifiefaeC3io?dee' },
+        { validateStatus: () => true }
+      )
+      tester.nockScope.done()
+      expect(res.status).toBe(204)
+
+      await assertLoggedOut(otherTester)
+    })
   })
 })

--- a/apigw/src/enduser/__tests__/weak-credentials.ts
+++ b/apigw/src/enduser/__tests__/weak-credentials.ts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { configFromEnv } from '../../shared/config.ts'
+import type { CitizenUser } from '../../shared/service-client.ts'
+import { GatewayTester } from '../../shared/test/gateway-tester.ts'
+import { MockRedisClient } from '../../shared/test/mock-redis-client.ts'
+
+const mockUser: CitizenUser = {
+  id: '4f73e4f8-8759-46c6-9b9d-4da860138ce2'
+}
+
+describe('Weak login credentials', () => {
+  let redisClient: MockRedisClient
+  let tester: GatewayTester
+
+  beforeEach(async () => {
+    redisClient = new MockRedisClient()
+    tester = await GatewayTester.start(configFromEnv(), 'citizen', redisClient)
+    tester.setCsrfHeader = true
+  })
+  afterEach(async () => {
+    await tester?.afterEach()
+    await tester?.stop()
+  })
+
+  async function weakLogin(onTester: GatewayTester): Promise<void> {
+    onTester.nockScope.post('/system/citizen-weak-login').reply(200, mockUser)
+    const res = await onTester.client.post(
+      '/api/citizen/auth/weak-login',
+      { username: 'user@example.com', password: 'password' },
+      { validateStatus: () => true }
+    )
+    onTester.nockScope.done()
+    expect(res.status).toBe(200)
+  }
+
+  test('deleting credentials requires a session', async () => {
+    const res = await tester.client.delete(
+      '/api/citizen/personal-data/weak-login-credentials',
+      { validateStatus: () => true }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  test('deleting credentials logs out other weak sessions', async () => {
+    // two weak sessions for the same user, sharing the same Redis
+    const otherTester = await GatewayTester.start(
+      configFromEnv(),
+      'citizen',
+      redisClient
+    )
+    otherTester.setCsrfHeader = true
+    try {
+      await weakLogin(tester)
+      await weakLogin(otherTester)
+
+      tester.nockScope
+        .delete('/citizen/personal-data/weak-login-credentials')
+        .reply(200)
+      const res = await tester.client.delete(
+        '/api/citizen/personal-data/weak-login-credentials',
+        { validateStatus: () => true }
+      )
+      tester.nockScope.done()
+      expect(res.status).toBe(204)
+
+      const status = await otherTester.client.get('/api/citizen/auth/status', {
+        validateStatus: () => true
+      })
+      expect(status.status).toBe(200)
+      expect((status.data as { loggedIn: boolean }).loggedIn).toBe(false)
+    } finally {
+      await otherTester.afterEach()
+      await otherTester.stop()
+    }
+  })
+})

--- a/apigw/src/enduser/routes/auth-weak-delete-credentials.ts
+++ b/apigw/src/enduser/routes/auth-weak-delete-credentials.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { toRequestHandler } from '../../shared/express.ts'
+import { logAuditEvent } from '../../shared/logging.ts'
+import type { RedisClient } from '../../shared/redis-client.ts'
+import { citizenWeakLoginCredentialsDelete } from '../../shared/service-client.ts'
+import { revokeWeakSessions } from '../../shared/session.ts'
+
+export const authWeakDeleteCredentials = (redisClient: RedisClient) =>
+  toRequestHandler(async (req, res) => {
+    logAuditEvent(
+      'evaka.citizen_weak.credentials_delete_requested',
+      req,
+      'Delete weak login credentials endpoint called'
+    )
+    try {
+      if (!req.session.evaka) {
+        res.sendStatus(401)
+        return
+      }
+
+      await citizenWeakLoginCredentialsDelete(req, req.session.evaka.user)
+      logAuditEvent(
+        'evaka.citizen_weak.credentials_deleted',
+        req,
+        'Weak login credentials deleted'
+      )
+
+      if (await revokeWeakSessions(redisClient, req.session.evaka.userIdHash)) {
+        logAuditEvent(
+          'evaka.citizen_weak.logout_other_sessions',
+          req,
+          'Logged out other sessions'
+        )
+      }
+
+      res.status(204).send()
+    } catch (err) {
+      logAuditEvent(
+        'evaka.citizen_weak.credentials_delete_failed',
+        req,
+        `Error deleting weak login credentials. Error: ${err?.toString()}`
+      )
+      throw err
+    }
+  })

--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -256,6 +256,15 @@ export async function citizenWeakLoginCredentialsUpdate(
   )
 }
 
+export async function citizenWeakLoginCredentialsDelete(
+  req: express.Request,
+  user: EvakaSessionUser
+): Promise<void> {
+  await client.delete(`/citizen/personal-data/weak-login-credentials`, {
+    headers: createServiceRequestHeaders(req, createUserHeader(user))
+  })
+}
+
 export async function getCitizenDetails(
   req: express.Request,
   personId: string

--- a/frontend/src/citizen-frontend/generated/api-clients/pis.ts
+++ b/frontend/src/citizen-frontend/generated/api-clients/pis.ts
@@ -101,6 +101,18 @@ export async function updatePasskeyName(
 
 
 /**
+* Generated from evaka.core.pis.controllers.PersonalDataControllerCitizen.deleteWeakLoginCredentials
+*/
+export async function deleteWeakLoginCredentials(): Promise<void> {
+  const { data: json } = await client.request<JsonOf<void>>({
+    url: uri`/citizen/personal-data/weak-login-credentials`.toString(),
+    method: 'DELETE'
+  })
+  return json
+}
+
+
+/**
 * Generated from evaka.core.pis.controllers.PersonalDataControllerCitizen.getEmailVerificationStatus
 */
 export async function getEmailVerificationStatus(): Promise<EmailVerificationStatusResponse> {

--- a/frontend/src/citizen-frontend/login/last-login-method.ts
+++ b/frontend/src/citizen-frontend/login/last-login-method.ts
@@ -16,6 +16,16 @@ export function rememberLastLoginMethod(method: LastLoginMethod): void {
   }
 }
 
+export function forgetLastLoginMethod(method: LastLoginMethod): void {
+  try {
+    if (window.localStorage?.getItem(key) === method) {
+      window.localStorage.removeItem(key)
+    }
+  } catch {
+    // ignore
+  }
+}
+
 export function useLastLoginMethod(): LastLoginMethod | undefined {
   const [value] = useLocalStorage(
     key,

--- a/frontend/src/citizen-frontend/personal-details/LoginDetailsSection.tsx
+++ b/frontend/src/citizen-frontend/personal-details/LoginDetailsSection.tsx
@@ -11,34 +11,42 @@ import { useBoolean, useForm, useFormFields } from 'lib-common/form/hooks'
 import type { EmailVerificationStatusResponse } from 'lib-common/generated/api-types/pis'
 import type { PasswordConstraints } from 'lib-common/generated/api-types/shared'
 import { isPasswordStructureValid } from 'lib-common/password'
+import { useQueryResult } from 'lib-common/query'
 import { Chip } from 'lib-components/atoms/Chip'
 import { Button } from 'lib-components/atoms/buttons/Button'
-import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
+import {
+  FixedSpaceColumn,
+  MobileFixedSpaceRow
+} from 'lib-components/layout/flex-helpers'
 import { AlertBox } from 'lib-components/molecules/MessageBoxes'
 import PasswordInputF from 'lib-components/molecules/PasswordInputF'
 import BaseModal, {
   ModalButtons
 } from 'lib-components/molecules/modals/BaseModal'
 import { MutateFormModal } from 'lib-components/molecules/modals/FormModal'
-import { Label, LabelLike } from 'lib-components/typography'
+import { Label, LabelLike, P } from 'lib-components/typography'
 import { Gap } from 'lib-components/white-space'
-import { faCheck, faLockAlt } from 'lib-icons'
+import { faCheck, faLockAlt, faTrash } from 'lib-icons'
 
 import ModalAccessibilityWrapper from '../ModalAccessibilityWrapper'
 import type { User } from '../auth/state'
 import { useTranslation } from '../localization'
+import { forgetLastLoginMethod } from '../login/last-login-method'
 import { getStrongLoginUri } from '../navigation/const'
 
 import {
   DataRow,
   DataRowLabel,
   DataRowValue,
-  RowActions,
   SectionTitle,
   TitleAndEditRow
 } from './components'
 import { isEmailVerified } from './emailVerification'
-import { updateWeakLoginCredentialsMutation } from './queries'
+import {
+  deleteWeakLoginCredentialsMutation,
+  passkeysQuery,
+  updateWeakLoginCredentialsMutation
+} from './queries'
 
 export interface Props {
   user: User
@@ -60,7 +68,12 @@ export default React.memo(function LoginDetailsSection({
 
   const emailVerified = isEmailVerified(emailVerificationStatus)
 
+  const passkeys = useQueryResult(passkeysQuery())
+  const noPasskeys = passkeys.map((p) => p.length === 0).getOrElse(null)
+
   const [modalOpen, { off: closeModal, on: openModal }] = useBoolean(false)
+  const [disableModalOpen, { off: closeDisableModal, on: openDisableModal }] =
+    useBoolean(false)
   const [
     activationSuccessModalOpen,
     { off: closeActivationSuccessModal, on: openActivationSuccessModal }
@@ -75,17 +88,6 @@ export default React.memo(function LoginDetailsSection({
     <div data-qa="login-details-section">
       <TitleAndEditRow>
         <SectionTitle $noMargin>{t.title}</SectionTitle>
-        {!!user.weakLoginUsername && (
-          <RowActions>
-            <Button
-              appearance="inline"
-              data-qa="update-password"
-              text={t.updatePassword}
-              icon={canEdit ? undefined : faLockAlt}
-              onClick={canEdit ? openModal : navigateToLogin}
-            />
-          </RowActions>
-        )}
       </TitleAndEditRow>
 
       <Gap $size="xs" />
@@ -113,6 +115,23 @@ export default React.memo(function LoginDetailsSection({
             <DataRowLabel>{t.password}</DataRowLabel>
             <DataRowValue>********</DataRowValue>
           </DataRow>
+          <Gap $size="s" />
+          <MobileFixedSpaceRow $spacing="L">
+            <Button
+              appearance="inline"
+              data-qa="update-password"
+              text={t.updatePassword}
+              icon={canEdit ? undefined : faLockAlt}
+              onClick={canEdit ? openModal : navigateToLogin}
+            />
+            <Button
+              appearance="inline"
+              data-qa="disable-credentials"
+              text={t.disableCredentials}
+              icon={canEdit ? undefined : faLockAlt}
+              onClick={canEdit ? openDisableModal : navigateToLogin}
+            />
+          </MobileFixedSpaceRow>
         </>
       ) : emailVerified ? (
         <Button
@@ -125,6 +144,47 @@ export default React.memo(function LoginDetailsSection({
         <div data-qa="weak-login-disabled">{t.unverifiedEmailWarning}</div>
       )}
       <ModalAccessibilityWrapper>
+        {disableModalOpen && (
+          <MutateFormModal
+            data-qa="disable-credentials-modal"
+            type="danger"
+            title={t.disableConfirmTitle}
+            text={
+              <>
+                <P $noMargin>{t.disableConfirmText}</P>
+                {noPasskeys !== null && (
+                  <>
+                    <Gap $size="s" />
+                    <P
+                      $noMargin
+                      data-qa={
+                        noPasskeys ? 'no-passkeys-warning' : 'has-passkeys-info'
+                      }
+                    >
+                      {noPasskeys
+                        ? t.disableConfirmNoPasskeys
+                        : t.disableConfirmHasPasskeys}
+                    </P>
+                  </>
+                )}
+                <Gap $size="s" />
+                <P $noMargin>{t.disableConfirmReactivate}</P>
+              </>
+            }
+            icon={faTrash}
+            resolveLabel={t.disableCredentials}
+            resolveDanger
+            rejectLabel={i18n.common.cancel}
+            resolveMutation={deleteWeakLoginCredentialsMutation}
+            resolveAction={() => undefined}
+            rejectAction={closeDisableModal}
+            onSuccess={() => {
+              closeDisableModal()
+              forgetLastLoginMethod('email')
+              reloadUser()
+            }}
+          />
+        )}
         {!!emailVerificationStatus.verifiedEmail && (
           <>
             {modalOpen && (

--- a/frontend/src/citizen-frontend/personal-details/queries.ts
+++ b/frontend/src/citizen-frontend/personal-details/queries.ts
@@ -6,6 +6,7 @@ import { Queries } from 'lib-common/query'
 
 import {
   deletePasskey,
+  deleteWeakLoginCredentials,
   finishPasskeyRegistration,
   getEmailVerificationStatus,
   getFamily,
@@ -32,6 +33,10 @@ export const updatePersonalDetailsMutation = q.mutation(updatePersonalData, [
 
 export const updateWeakLoginCredentialsMutation = q.mutation(
   updateWeakLoginCredentials
+)
+
+export const deleteWeakLoginCredentialsMutation = q.mutation(
+  deleteWeakLoginCredentials
 )
 
 export const notificationSettingsQuery = q.query(getNotificationSettings)

--- a/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
+++ b/frontend/src/e2e-test/pages/citizen/citizen-personal-details.ts
@@ -183,6 +183,7 @@ export class LoginDetailsSection extends Element {
   weakLoginEnabled: Element
   weakLoginDisabled: Element
   updatePassword: Element
+  disableCredentials: Element
 
   constructor(element: Element) {
     super(element)
@@ -191,6 +192,18 @@ export class LoginDetailsSection extends Element {
     this.weakLoginEnabled = element.findByDataQa('weak-login-enabled')
     this.weakLoginDisabled = element.findByDataQa('weak-login-disabled')
     this.updatePassword = element.findByDataQa('update-password')
+    this.disableCredentials = element.findByDataQa('disable-credentials')
+  }
+}
+
+export class DisableCredentialsModal extends Element {
+  noPasskeysWarning: Element
+  ok: Element
+
+  constructor(page: Page) {
+    super(page.findByDataQa('disable-credentials-modal'))
+    this.noPasskeysWarning = this.findByDataQa('no-passkeys-warning')
+    this.ok = this.findByDataQa('modal-okBtn')
   }
 }
 

--- a/frontend/src/e2e-test/specs/0_citizen/citizen-weak-credentials.spec.ts
+++ b/frontend/src/e2e-test/specs/0_citizen/citizen-weak-credentials.spec.ts
@@ -13,6 +13,7 @@ import {
 import type { DevPerson } from '../../generated/api-types'
 import CitizenHeader from '../../pages/citizen/citizen-header'
 import CitizenPersonalDetailsPage, {
+  DisableCredentialsModal,
   WeakCredentialsModal
 } from '../../pages/citizen/citizen-personal-details'
 import { test, expect } from '../../playwright'
@@ -157,6 +158,42 @@ test.describe('Citizen weak credentials', () => {
     await modal.confirmPassword.fill(newPassword)
     await modal.ok.click()
     await expect(modal).toBeHidden()
+  })
+
+  test('a person with weak credentials can remove them', async ({ evaka }) => {
+    const email = 'test@example.com'
+    const password = 'aifiefaeC3io?dee'
+    const citizen = await Fixture.person({
+      email,
+      verifiedEmail: email
+    }).saveAdult({
+      updateMockVtjWithDependants: [],
+      updateWeakCredentials: { username: email, password }
+    })
+
+    const personalDetailsPage = await openPersonalDetailsPage(evaka, citizen)
+    const section = personalDetailsPage.loginDetailsSection
+    await expect(section.weakLoginEnabled).toBeVisible()
+    await section.disableCredentials.click()
+
+    const modal = new DisableCredentialsModal(evaka)
+    // the citizen has no passkey, so removing leaves only strong login
+    await expect(modal.noPasskeysWarning).toBeVisible()
+    await modal.ok.click()
+    await expect(modal).toBeHidden()
+
+    await expect(section.weakLoginEnabled).toBeHidden()
+    await expect(section.activateCredentials).toBeVisible()
+
+    await new CitizenHeader(evaka).logout()
+
+    await enduserLoginWeak(
+      evaka,
+      { username: email, password },
+      {
+        expectFailure: true
+      }
+    )
   })
 
   test('a person with a different email can change their username - email updated on the same page', async ({

--- a/frontend/src/e2e-test/utils/user.ts
+++ b/frontend/src/e2e-test/utils/user.ts
@@ -27,7 +27,8 @@ export async function enduserLogin(
 
 export async function enduserLoginWeak(
   page: Page,
-  credentials: { username: string; password: string }
+  credentials: { username: string; password: string },
+  options?: { expectFailure?: boolean }
 ) {
   await page.goto(config.enduserLoginUrl)
   await page.findByDataQa('weak-login').click()
@@ -35,6 +36,16 @@ export async function enduserLoginWeak(
   const form = page.findByDataQa('weak-login-form')
   await new TextInput(form.find('[id="username"]')).fill(credentials.username)
   await new TextInput(form.find('[id="password"]')).fill(credentials.password)
+
+  if (options?.expectFailure) {
+    const response = page.page.waitForResponse((r) =>
+      r.url().includes('/api/citizen/auth/weak-login')
+    )
+    await form.findByDataQa('login').click()
+    expect((await response).status()).toBe(403)
+    return
+  }
+
   await form.findByDataQa('login').click()
   await expect(form.findByDataQa('login')).toBeHidden()
 

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/en.tsx
@@ -1960,8 +1960,18 @@ const en: Translations = {
           `at least ${v} ${v > 1 ? 'special characters' : 'special character'}`
       },
       unacceptablePassword: 'The password is too easy to guess',
+      disableCredentials: 'Remove',
+      disableConfirmTitle: 'Remove email login?',
+      disableConfirmText:
+        'You can no longer sign in with your email address and password. You are signed out from other devices where you are signed in.',
+      disableConfirmNoPasskeys:
+        'From now on you can sign in using Suomi.fi. You have no passkeys, so it is your only way to sign in.',
+      disableConfirmHasPasskeys:
+        'From now on you can sign in with a passkey or using Suomi.fi.',
+      disableConfirmReactivate:
+        'You can take email login into use again later if you want.',
       usernameConflict: (username: string): ReactNode =>
-        `The username ${username} is already in use by another person`
+        `The username ${username} is already in use by another person. You can take email login into use by changing your email address in your personal details and verifying the new address.`
     },
     passkeysSection: {
       title: 'Passkey login',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/fi.tsx
@@ -2232,8 +2232,18 @@ export default {
           `vähintään ${v} ${v > 1 ? 'erikoismerkkiä' : 'erikoismerkki'}`
       },
       unacceptablePassword: 'Salasana on liian helposti arvattava',
+      disableCredentials: 'Poista käytöstä',
+      disableConfirmTitle: 'Poistetaanko sähköpostikirjautuminen käytöstä?',
+      disableConfirmText:
+        'Et voi enää kirjautua sähköpostilla ja salasanalla. Sinut kirjataan ulos muilta laitteilta, joilla olet kirjautuneena.',
+      disableConfirmNoPasskeys:
+        'Jatkossa voit kirjautua Suomi.fi-tunnistautumisella. Sinulla ei ole pääsyavaimia, joten se on ainoa kirjautumistapasi.',
+      disableConfirmHasPasskeys:
+        'Jatkossa voit kirjautua pääsyavaimella tai Suomi.fi-tunnistautumisella.',
+      disableConfirmReactivate:
+        'Voit halutessasi ottaa sähköpostikirjautumisen käyttöön myöhemmin uudelleen.',
       usernameConflict: (username: string): ReactNode =>
-        `Käyttäjätunnus ${username} on jo käytössä toisella henkilöllä`
+        `Käyttäjätunnus ${username} on jo käytössä toisella henkilöllä. Voit ottaa sähköpostikirjautumisen käyttöön vaihtamalla sähköpostiosoitteesi omissa tiedoissasi ja vahvistamalla uuden osoitteen.`
     },
     passkeysSection: {
       title: 'Pääsyavainkirjautuminen',

--- a/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/defaults/citizen/i18n/sv.tsx
@@ -2220,8 +2220,18 @@ const sv: Translations = {
           `${v} eller ${v > 1 ? 'flera specialtecken' : 'fler specialtecken'}`
       },
       unacceptablePassword: 'Lösenordet är för lätt att gissa',
+      disableCredentials: 'Ta bort',
+      disableConfirmTitle: 'Vill du ta bort e-postinloggningen?',
+      disableConfirmText:
+        'Du kan inte längre logga in med e-postadress och lösenord. Du loggas ut från andra enheter där du är inloggad.',
+      disableConfirmNoPasskeys:
+        'I fortsättningen kan du logga in med stark identifiering via Suomi.fi. Du har inga inloggningsnycklar, så det är ditt enda sätt att logga in.',
+      disableConfirmHasPasskeys:
+        'I fortsättningen kan du logga in med en inloggningsnyckel eller med stark identifiering via Suomi.fi.',
+      disableConfirmReactivate:
+        'Du kan vid behov ta e-postinloggningen i bruk igen senare.',
       usernameConflict: (username: string): ReactNode =>
-        `Användarnamnet ${username} används redan av en annan person`
+        `Användarnamnet ${username} används redan av en annan person. Du kan ta e-postinloggningen i bruk genom att byta din e-postadress i dina uppgifter och bekräfta den nya adressen.`
     },
     passkeysSection: {
       title: 'Inloggning med inloggningsnyckel',

--- a/service/src/integrationTest/kotlin/evaka/core/pis/controller/WeakCredentialsIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/controller/WeakCredentialsIntegrationTest.kt
@@ -321,6 +321,74 @@ class WeakCredentialsIntegrationTest : FullApplicationTest(resetDbBeforeEach = t
         assertEquals(otherPerson.id, bIdentity.id)
     }
 
+    @Test
+    fun `a person can delete their weak credentials and can no longer log in with them`() {
+        val password = Sensitive("test123123")
+        db.transaction { tx ->
+            tx.insert(person, DevPersonType.ADULT)
+            tx.insert(citizenUser(person.id, email, password))
+        }
+        MockPersonDetailsService.addPersons(person)
+
+        deleteWeakLoginCredentials()
+
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+        assertEquals(1, MockEmailClient.emails.size)
+        assertContains(
+            MockEmailClient.emails.first().content.subject,
+            "Sähköpostikirjautuminen on poistettu käytöstä",
+        )
+
+        assertThrows<Forbidden> { citizenWeakLogin(username = email, password = password) }
+    }
+
+    @Test
+    fun `deleting weak credentials clears the username and password timestamps`() {
+        val password = Sensitive("test123123")
+        db.transaction { tx ->
+            tx.insert(person, DevPersonType.ADULT)
+            tx.insert(citizenUser(person.id, email, password))
+        }
+
+        deleteWeakLoginCredentials()
+
+        val cleared = db.read { tx ->
+            tx.createQuery {
+                    sql(
+                        """
+SELECT username IS NULL AND password IS NULL
+    AND username_updated_at IS NULL AND password_updated_at IS NULL
+FROM citizen_user
+WHERE id = ${bind(person.id)}
+"""
+                    )
+                }
+                .exactlyOne<Boolean>()
+        }
+        assertEquals(true, cleared)
+    }
+
+    @Test
+    fun `deleting weak credentials does nothing when there are none`() {
+        db.transaction { tx -> tx.insert(person, DevPersonType.ADULT) }
+
+        deleteWeakLoginCredentials()
+
+        asyncJobRunner.runPendingJobsSync(RealEvakaClock())
+        assertEquals(0, MockEmailClient.emails.size)
+    }
+
+    @Test
+    fun `deleting weak credentials is not allowed in a weak session`() {
+        val password = Sensitive("test123123")
+        db.transaction { tx ->
+            tx.insert(person, DevPersonType.ADULT)
+            tx.insert(citizenUser(person.id, email, password))
+        }
+
+        assertThrows<Forbidden> { deleteWeakLoginCredentials(person.user(CitizenAuthLevel.WEAK)) }
+    }
+
     private fun updateWeakLoginCredentials(password: Sensitive<String>) =
         controller.updateWeakLoginCredentials(
             dbInstance(),
@@ -328,6 +396,9 @@ class WeakCredentialsIntegrationTest : FullApplicationTest(resetDbBeforeEach = t
             clock,
             PersonalDataControllerCitizen.UpdateWeakLoginCredentialsRequest(password),
         )
+
+    private fun deleteWeakLoginCredentials(citizen: AuthenticatedUser.Citizen = user) =
+        controller.deleteWeakLoginCredentials(dbInstance(), citizen, clock)
 
     private fun citizenStrongLogin() =
         systemController.citizenLogin(

--- a/service/src/main/kotlin/evaka/core/Audit.kt
+++ b/service/src/main/kotlin/evaka/core/Audit.kt
@@ -176,6 +176,8 @@ enum class Audit(
     CitizenNotificationSettingsRead,
     // CitizenNotificationSettingsUpdate,
     CitizenLogin(securityEvent = true, securityLevel = "high"),
+    CitizenCredentialsDelete(securityEvent = true, securityLevel = "high"),
+    CitizenCredentialsDeleteAttempt(securityEvent = true, securityLevel = "high"),
     CitizenCredentialsUpdate(securityEvent = true, securityLevel = "high"),
     CitizenCredentialsUpdateAttempt(securityEvent = true, securityLevel = "high"),
     CitizenPasskeyDelete(securityEvent = true, securityLevel = "high"),

--- a/service/src/main/kotlin/evaka/core/emailclient/EvakaEmailMessageProvider.kt
+++ b/service/src/main/kotlin/evaka/core/emailclient/EvakaEmailMessageProvider.kt
@@ -922,4 +922,20 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / E-postinloggningen har tagits bort från ditt eVaka-konto / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>E-postinloggningen har tagits bort från ditt eVaka-konto.</p>
+<p>Om du själv tog bort den kan du ignorera det här meddelandet. Om inte, logga in i eVaka med Suomi.fi-identifiering och kontrollera dina uppgifter.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/core/emailclient/IEmailMessageProvider.kt
+++ b/service/src/main/kotlin/evaka/core/emailclient/IEmailMessageProvider.kt
@@ -151,6 +151,8 @@ interface IEmailMessageProvider {
 
     fun passkeyRemoved(): EmailContent
 
+    fun weakCredentialsRemoved(): EmailContent
+
     fun messageDeletionSenderEmail(
         supportEmail: String?,
         data: MessageDeletionEmailData,

--- a/service/src/main/kotlin/evaka/core/pis/PersonEmailJobs.kt
+++ b/service/src/main/kotlin/evaka/core/pis/PersonEmailJobs.kt
@@ -30,6 +30,7 @@ class PersonEmailJobs(
         asyncJobRunner.registerHandler(::sendEmailChangedEmail)
         asyncJobRunner.registerHandler(::sendPasskeyAddedEmail)
         asyncJobRunner.registerHandler(::sendPasskeyRemovedEmail)
+        asyncJobRunner.registerHandler(::sendWeakCredentialsRemovedEmail)
     }
 
     private val logger = KotlinLogging.logger {}
@@ -114,6 +115,22 @@ AND expires_at > ${bind(clock.now())}
                 EmailMessageType.TRANSACTIONAL,
                 fromAddress = emailEnv.sender(Language.fi),
                 content = emailMessageProvider.passkeyRemoved(),
+                traceId = "${clock.today()}:${job.personId}",
+            )
+            ?.also { emailClient.send(it) }
+    }
+
+    fun sendWeakCredentialsRemovedEmail(
+        dbc: Database.Connection,
+        clock: EvakaClock,
+        job: AsyncJob.SendWeakCredentialsRemovedEmail,
+    ) {
+        Email.create(
+                dbc,
+                job.personId,
+                EmailMessageType.TRANSACTIONAL,
+                fromAddress = emailEnv.sender(Language.fi),
+                content = emailMessageProvider.weakCredentialsRemoved(),
                 traceId = "${clock.today()}:${job.personId}",
             )
             ?.also { emailClient.send(it) }

--- a/service/src/main/kotlin/evaka/core/pis/controllers/PersonalDataControllerCitizen.kt
+++ b/service/src/main/kotlin/evaka/core/pis/controllers/PersonalDataControllerCitizen.kt
@@ -26,12 +26,14 @@ import evaka.core.shared.security.AccessControl
 import evaka.core.shared.security.Action
 import evaka.core.shared.utils.EMAIL_PATTERN
 import evaka.core.shared.utils.PHONE_PATTERN
+import evaka.core.user.deleteWeakLoginCredentials
 import evaka.core.user.hasWeakCredentials
 import evaka.core.user.updatePreferredUiLanguage
 import evaka.core.user.updateWeakLoginCredentials
 import java.security.SecureRandom
 import java.time.Duration
 import kotlin.random.asKotlinRandom
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -233,6 +235,35 @@ class PersonalDataControllerCitizen(
             }
         }
         Audit.CitizenCredentialsUpdate.log(targetId = AuditId(user.id))
+    }
+
+    @DeleteMapping("/weak-login-credentials")
+    fun deleteWeakLoginCredentials(
+        db: Database,
+        user: AuthenticatedUser.Citizen,
+        clock: EvakaClock,
+    ) {
+        Audit.CitizenCredentialsDeleteAttempt.log(targetId = AuditId(user.id))
+        db.connect { dbc ->
+            dbc.transaction { tx ->
+                accessControl.requirePermissionFor(
+                    tx,
+                    user,
+                    clock,
+                    Action.Citizen.Person.DELETE_WEAK_LOGIN_CREDENTIALS,
+                    user.id,
+                )
+                if (tx.hasWeakCredentials(user.id)) {
+                    tx.deleteWeakLoginCredentials(user.id)
+                    asyncJobRunner.plan(
+                        tx,
+                        sequenceOf(AsyncJob.SendWeakCredentialsRemovedEmail(user.id)),
+                        runAt = clock.now(),
+                    )
+                }
+            }
+        }
+        Audit.CitizenCredentialsDelete.log(targetId = AuditId(user.id))
     }
 
     data class EmailVerificationStatusResponse(

--- a/service/src/main/kotlin/evaka/core/shared/async/AsyncJob.kt
+++ b/service/src/main/kotlin/evaka/core/shared/async/AsyncJob.kt
@@ -486,6 +486,10 @@ sealed interface AsyncJob : AsyncJobPayload {
         override val user: AuthenticatedUser? = null
     }
 
+    data class SendWeakCredentialsRemovedEmail(val personId: PersonId) : AsyncJob {
+        override val user: AuthenticatedUser? = null
+    }
+
     data class SendEmailChangedEmail(val personId: PersonId, val oldEmail: String) : AsyncJob {
         override val user: AuthenticatedUser? = null
     }
@@ -599,6 +603,7 @@ sealed interface AsyncJob : AsyncJobPayload {
                     SendPendingDecisionEmail::class,
                     SendServiceApplicationDecidedEmail::class,
                     SendSpecialDietNullificationWarningEmail::class,
+                    SendWeakCredentialsRemovedEmail::class,
                 ),
             )
         val urgent =

--- a/service/src/main/kotlin/evaka/core/shared/security/Action.kt
+++ b/service/src/main/kotlin/evaka/core/shared/security/Action.kt
@@ -566,6 +566,7 @@ sealed interface Action {
             UPDATE_NOTIFICATION_SETTINGS(IsCitizen(allowWeakLogin = true).self()),
             UPDATE_PREFERRED_UI_LANGUAGE(IsCitizen(allowWeakLogin = true).self()),
             UPDATE_WEAK_LOGIN_CREDENTIALS(IsCitizen(allowWeakLogin = false).self()),
+            DELETE_WEAK_LOGIN_CREDENTIALS(IsCitizen(allowWeakLogin = false).self()),
             READ_EMAIL_VERIFICATION_STATUS(IsCitizen(allowWeakLogin = true).self()),
             VERIFY_EMAIL(IsCitizen(allowWeakLogin = false).self()),
             READ_PASSKEYS(IsCitizen(allowWeakLogin = true).self()),

--- a/service/src/main/kotlin/evaka/core/user/CitizenUserQueries.kt
+++ b/service/src/main/kotlin/evaka/core/user/CitizenUserQueries.kt
@@ -99,6 +99,17 @@ RETURNING (old_username IS NOT NULL AND old_username != username) AS username_ch
         .exactlyOne()
 }
 
+fun Database.Transaction.deleteWeakLoginCredentials(id: PersonId) = createUpdate {
+    sql(
+        """
+UPDATE citizen_user
+SET username = NULL, username_updated_at = NULL, password = NULL, password_updated_at = NULL
+WHERE id = ${bind(id)}
+"""
+    )
+}
+    .execute()
+
 fun Database.Transaction.updatePreferredUiLanguage(id: PersonId, language: UiLanguage) =
     createUpdate {
         sql(

--- a/service/src/main/kotlin/evaka/instance/hameenkyro/emailclient/config/EmailConfiguration.kt
+++ b/service/src/main/kotlin/evaka/instance/hameenkyro/emailclient/config/EmailConfiguration.kt
@@ -713,4 +713,17 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/instance/kangasala/emailclient/config/EmailConfiguration.kt
+++ b/service/src/main/kotlin/evaka/instance/kangasala/emailclient/config/EmailConfiguration.kt
@@ -713,4 +713,17 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/instance/lempaala/emailclient/config/EmailConfiguration.kt
+++ b/service/src/main/kotlin/evaka/instance/lempaala/emailclient/config/EmailConfiguration.kt
@@ -713,4 +713,17 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/instance/nokia/emailclient/config/EmailConfiguration.kt
+++ b/service/src/main/kotlin/evaka/instance/nokia/emailclient/config/EmailConfiguration.kt
@@ -713,4 +713,17 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/instance/orivesi/emailclient/config/EmailConfiguration.kt
+++ b/service/src/main/kotlin/evaka/instance/orivesi/emailclient/config/EmailConfiguration.kt
@@ -713,4 +713,17 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/instance/oulu/OuluEmailMessageProvider.kt
+++ b/service/src/main/kotlin/evaka/instance/oulu/OuluEmailMessageProvider.kt
@@ -1170,4 +1170,17 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/instance/pirkkala/emailclient/config/EmailConfiguration.kt
+++ b/service/src/main/kotlin/evaka/instance/pirkkala/emailclient/config/EmailConfiguration.kt
@@ -713,4 +713,17 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/instance/tampere/emailclient/config/EmailConfiguration.kt
+++ b/service/src/main/kotlin/evaka/instance/tampere/emailclient/config/EmailConfiguration.kt
@@ -709,4 +709,17 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/instance/turku/TurkuEmailMessageProvider.kt
+++ b/service/src/main/kotlin/evaka/instance/turku/TurkuEmailMessageProvider.kt
@@ -1490,4 +1490,20 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / E-postinloggningen har tagits bort från ditt eVaka-konto / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>E-postinloggningen har tagits bort från ditt eVaka-konto.</p>
+<p>Om du själv tog bort den kan du ignorera det här meddelandet. Om inte, logga in i eVaka med Suomi.fi-identifiering och kontrollera dina uppgifter.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/instance/vesilahti/emailclient/config/EmailConfiguration.kt
+++ b/service/src/main/kotlin/evaka/instance/vesilahti/emailclient/config/EmailConfiguration.kt
@@ -713,4 +713,17 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }

--- a/service/src/main/kotlin/evaka/instance/ylojarvi/emailclient/config/EmailConfiguration.kt
+++ b/service/src/main/kotlin/evaka/instance/ylojarvi/emailclient/config/EmailConfiguration.kt
@@ -713,4 +713,17 @@ $unsubscribeEn
 <p>If you removed the passkey yourself, you can ignore this message. If not, log in to eVaka with strong authentication (Sign in using Suomi.fi) and check your personal details.</p>
 """,
         )
+
+    override fun weakCredentialsRemoved(): EmailContent =
+        EmailContent.fromHtml(
+            subject =
+                "Sähköpostikirjautuminen on poistettu käytöstä eVaka-tililtäsi / Email login has been removed from your eVaka account",
+            html =
+                """<p>eVaka-tilisi sähköpostikirjautuminen on poistettu käytöstä.</p>
+<p>Jos poistit sen itse, voit jättää tämän viestin huomiotta. Muussa tapauksessa kirjaudu eVakaan Suomi.fi-tunnistautumisella ja tarkista omat tietosi.</p>
+<hr>
+<p>Email login has been removed from your eVaka account.</p>
+<p>If you removed it yourself, you can ignore this message. If not, log in to eVaka using Suomi.fi and check your personal details.</p>
+""",
+        )
 }


### PR DESCRIPTION
Nyt kun kevytkirjautuminen on mahdollista myös pääsyavaimella, mahdollistetaan sähköpostikirjautumisen poisto käytöstä.

"Sinulla ei ole pääsyavaimia..." teksti näytetään vain jos käytöstä poistamisen jälkeen suomi.fi jää ainoaksi kirjautumistavaksi.

<img width="381" height="287" alt="image" src="https://github.com/user-attachments/assets/f4d65b6e-13fc-48fc-a534-618e1729351c" />
<br>
<img width="383" height="547" alt="image" src="https://github.com/user-attachments/assets/f63f8142-4d89-4c5c-9a01-9d19876cab11" />

