### PR TITLE
Hakukausi-validaatio ei koske palveluohjaajien lähettämiä/muokkaamia hakemuksia

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
@@ -9,6 +9,10 @@ import evaka.core.FullApplicationTest
 import evaka.core.application.notes.getApplicationNotes
 import evaka.core.application.notes.getServiceWorkerApplicationNote
 import evaka.core.application.notes.updateServiceWorkerApplicationNote
+import evaka.core.application.persistence.club.Adult as ClubAdult
+import evaka.core.application.persistence.club.Apply as ClubApply
+import evaka.core.application.persistence.club.Child as ClubChild
+import evaka.core.application.persistence.club.ClubFormV0
 import evaka.core.application.persistence.daycare.Address
 import evaka.core.application.persistence.daycare.Adult
 import evaka.core.application.persistence.daycare.Apply
@@ -22,6 +26,7 @@ import evaka.core.caseprocess.CaseProcessState
 import evaka.core.caseprocess.ProcessMetadataController
 import evaka.core.caseprocess.ProcessType
 import evaka.core.caseprocess.getCaseProcessByApplicationId
+import evaka.core.clubTerm2020
 import evaka.core.daycare.getChild
 import evaka.core.decision.Decision
 import evaka.core.decision.DecisionDraft
@@ -646,6 +651,104 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         db.transaction { tx ->
             assertThrows<BadRequest> {
                 service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
+            }
+        }
+    }
+
+    @Test
+    fun `sendApplication - citizen cannot send a preschool application before the term's application period has started`() {
+        db.transaction { tx ->
+            tx.insert(preschoolTerm2021)
+            tx.insertApplication(
+                appliedType = PlacementType.PRESCHOOL,
+                applicationId = applicationId,
+                preferredStartDate = preschoolTerm2021.finnishPreschool.start,
+            )
+        }
+
+        db.transaction { tx ->
+            assertThrows<BadRequest> {
+                service.sendApplication(
+                    tx,
+                    adult5.user(CitizenAuthLevel.STRONG),
+                    clock,
+                    AuditContext(),
+                    applicationId,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `sendApplication - service worker can send a club application after the term's application period has ended`() {
+        db.transaction { tx ->
+            tx.insert(clubTerm2020)
+            tx.insertClubApplication(preferredStartDate = clubTerm2020.term.start)
+        }
+
+        db.transaction { tx ->
+            service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
+        }
+
+        db.read {
+            assertEquals(ApplicationStatus.SENT, it.fetchApplicationDetails(applicationId)!!.status)
+        }
+    }
+
+    @Test
+    fun `sendApplication - citizen cannot send a club application after the term's application period has ended`() {
+        db.transaction { tx ->
+            tx.insert(clubTerm2020)
+            tx.insertClubApplication(preferredStartDate = clubTerm2020.term.start)
+        }
+
+        db.transaction { tx ->
+            assertThrows<BadRequest> {
+                service.sendApplication(
+                    tx,
+                    adult5.user(CitizenAuthLevel.STRONG),
+                    clock,
+                    AuditContext(),
+                    applicationId,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `updateApplicationContentsServiceWorker - club preferred start date can be updated after the term's application period has ended`() {
+        db.transaction { tx ->
+            tx.insert(clubTerm2020)
+            tx.insertClubApplication(preferredStartDate = clubTerm2020.term.start)
+        }
+
+        val newStartDate = clubTerm2020.term.start.plusMonths(1)
+        db.transaction { tx -> updateAsServiceWorker(tx, preferredStartDate = newStartDate) }
+
+        db.read {
+            assertEquals(
+                newStartDate,
+                it.fetchApplicationDetails(applicationId)!!.form.preferences.preferredStartDate,
+            )
+        }
+    }
+
+    @Test
+    fun `updateApplicationContentsServiceWorker - preferred start date must still be within a term`() {
+        db.transaction { tx ->
+            tx.insertApplication(
+                appliedType = PlacementType.PRESCHOOL,
+                applicationId = applicationId,
+                preferredStartDate = preschoolTerm2020.finnishPreschool.start,
+            )
+        }
+
+        db.transaction { tx ->
+            assertThrows<BadRequest> {
+                updateAsServiceWorker(
+                    tx,
+                    preferredStartDate = preschoolTerm2020.extendedTerm.start.minusDays(1),
+                )
             }
         }
     }
@@ -2808,6 +2911,46 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                             otherInfo = otherInfo,
                         ),
                 ),
+        )
+    }
+
+    private fun Database.Transaction.insertClubApplication(preferredStartDate: LocalDate) {
+        insertTestApplication(
+            id = applicationId,
+            status = ApplicationStatus.CREATED,
+            guardianId = adult5.id,
+            childId = child6.id,
+            type = ApplicationType.CLUB,
+            document =
+                ClubFormV0(
+                    child = ClubChild(dateOfBirth = child6.dateOfBirth),
+                    guardian =
+                        ClubAdult(
+                            firstName = adult5.firstName,
+                            lastName = adult5.lastName,
+                            socialSecurityNumber = adult5.ssn!!,
+                        ),
+                    apply = ClubApply(preferredUnits = listOf(daycare.id)),
+                    preferredStartDate = preferredStartDate,
+                ),
+        )
+    }
+
+    private fun updateAsServiceWorker(tx: Database.Transaction, preferredStartDate: LocalDate) {
+        val form = ApplicationFormUpdate.from(tx.fetchApplicationDetails(applicationId)!!.form)
+        service.updateApplicationContentsServiceWorker(
+            tx,
+            serviceWorker,
+            now,
+            AuditContext(),
+            applicationId,
+            ApplicationUpdate(
+                form =
+                    form.copy(
+                        preferences = form.preferences.copy(preferredStartDate = preferredStartDate)
+                    )
+            ),
+            serviceWorker.evakaUserId,
         )
     }
 

--- a/service/src/main/kotlin/evaka/core/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/evaka/core/application/ApplicationStateService.kt
@@ -310,8 +310,7 @@ class ApplicationStateService(
             application.type,
             application.form,
             currentDate,
-            strict = user is AuthenticatedUser.Citizen,
-            validateApplicationPeriod = true,
+            citizen = user is AuthenticatedUser.Citizen,
         )
 
         val _ = personService.getGuardians(tx, user, now, application.childId)
@@ -1268,8 +1267,7 @@ class ApplicationStateService(
                 original.type,
                 updatedForm,
                 now.toLocalDate(),
-                strict = true,
-                validateApplicationPeriod = true,
+                citizen = true,
             )
 
             if (listOf(SENT).contains(original.status)) {
@@ -1304,7 +1302,6 @@ class ApplicationStateService(
         applicationId: ApplicationId,
         update: ApplicationUpdate,
         userId: EvakaUserId,
-        validateApplicationPeriod: Boolean = true,
     ) {
         val original =
             tx.fetchApplicationDetails(applicationId)
@@ -1324,8 +1321,7 @@ class ApplicationStateService(
             original.type,
             updatedForm,
             now.toLocalDate(),
-            strict = false,
-            validateApplicationPeriod,
+            citizen = false,
         )
 
         if (!updatedForm.preferences.urgent) {
@@ -1529,15 +1525,14 @@ class ApplicationStateService(
         type: ApplicationType,
         application: ApplicationForm,
         currentDate: LocalDate,
-        strict: Boolean,
-        validateApplicationPeriod: Boolean,
+        citizen: Boolean,
     ) {
         val preferredStartDate = application.preferences.preferredStartDate
         if (type == ApplicationType.PRESCHOOL && preferredStartDate != null) {
             val activePreschoolTerm = tx.getPreschoolTerm(preferredStartDate)
             val canApplyForPreferredDate =
                 activePreschoolTerm?.isApplicationAccepted(currentDate) == true ||
-                    (activePreschoolTerm != null && !validateApplicationPeriod)
+                    (activePreschoolTerm != null && !citizen)
             if (!canApplyForPreferredDate) {
                 throw BadRequest("Cannot apply to preschool on $preferredStartDate at the moment")
             }
@@ -1546,8 +1541,7 @@ class ApplicationStateService(
                 application.preferences.connectedDaycarePreferredStartDate
             if (
                 connectedDaycarePreferredStartDate != null &&
-                    connectedDaycarePreferredStartDate != preferredStartDate &&
-                    validateApplicationPeriod
+                    connectedDaycarePreferredStartDate != preferredStartDate
             ) {
                 val connectedPreschoolTerm = tx.getPreschoolTerm(connectedDaycarePreferredStartDate)
                 if (connectedPreschoolTerm != activePreschoolTerm) {
@@ -1576,7 +1570,8 @@ class ApplicationStateService(
         if (type == ApplicationType.CLUB && preferredStartDate != null) {
             val activeClubTerm = tx.getClubTerm(preferredStartDate)
             val canApplyForPreferredDate =
-                activeClubTerm?.applicationPeriod?.includes(currentDate) == true
+                activeClubTerm?.applicationPeriod?.includes(currentDate) == true ||
+                    (activeClubTerm != null && !citizen)
             if (!canApplyForPreferredDate) {
                 throw BadRequest("Cannot apply to club on $preferredStartDate")
             }
@@ -1634,7 +1629,7 @@ class ApplicationStateService(
             if (daycares.size < unitIds.toSet().size) {
                 throw BadRequest("Some unit was not found")
             }
-            if (strict) {
+            if (citizen) {
                 if (preferredStartDate != null) {
                     for (daycare in daycares) {
                         if (

--- a/service/src/main/kotlin/evaka/core/application/PlacementToolService.kt
+++ b/service/src/main/kotlin/evaka/core/application/PlacementToolService.kt
@@ -379,7 +379,6 @@ WHERE application.type = 'PRESCHOOL'
             application.id,
             ApplicationUpdate(form = ApplicationFormUpdate.from(updatedApplication.form)),
             user.evakaUserId,
-            validateApplicationPeriod = false,
         )
     }
 


### PR DESCRIPTION
Palveluohjaajan on voitava tallentaa paperihakemus myös hakuajan umpeuduttua. Aiemmin edes hakemuksen muokkaaminen ei ollut mahdollista tämän jälkeen. Validaatio ei myöskään ollut synkassa front/backend osalta. Jatkossa palveluohjaajien puolella toivotun aloituspäivän on edelleen oltava toimintakauden sisällä, mutta hakukausi jätetään kokonaan huomiotta.