### PR TITLE
Koski: Ei katkaista varhennetun oppivelvollisuuden jaksoa sijoituksen päättymiseen

### DIFF
--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -1523,7 +1523,7 @@ CREATE FUNCTION public.koski_active_preschool_study_right(today date, sync_range
              range_agg(pa.valid_during) FILTER (WHERE (pa.level = 'CHILD_SUPPORT_AND_OLD_EXTENDED_COMPULSORY_EDUCATION'::public.preschool_assistance_level)) AS child_support_and_old_extended_compulsory_education,
              range_agg(pa.valid_during) FILTER (WHERE (pa.level = 'CHILD_SUPPORT_2_AND_OLD_EXTENDED_COMPULSORY_EDUCATION'::public.preschool_assistance_level)) AS child_support_2_and_old_extended_compulsory_education
             FROM public.preschool_assistance pa
-           WHERE ((pa.child_id = p.child_id) AND (pa.valid_during && range_merge(p.placements)))) pras ON (true))
+           WHERE ((pa.child_id = p.child_id) AND (pa.valid_during && daterange(lower(range_merge(p.placements)), NULL::date)))) pras ON (true))
    WHERE ((p.type = 'PRESCHOOL'::public.koski_study_right_type) AND (EXISTS ( SELECT
             FROM public.koski_child
            WHERE (koski_child.id = p.child_id))));

--- a/service/src/integrationTest/kotlin/evaka/core/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/koski/KoskiIntegrationTest.kt
@@ -798,6 +798,61 @@ class KoskiIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     }
 
     @Test
+    fun `extended compulsory education starting after the current placements is sent to Koski`() {
+        insertPlacement(child1, period = preschoolTerm2026)
+        val nextTermEce = preschoolTerm2027
+        db.transaction { tx ->
+            tx.insert(
+                DevPreschoolAssistance(
+                    modifiedBy = employee.evakaUser,
+                    childId = child1.id,
+                    validDuring = nextTermEce,
+                    level =
+                        PreschoolAssistanceLevel.CHILD_SUPPORT_AND_EXTENDED_COMPULSORY_EDUCATION,
+                )
+            )
+        }
+
+        koskiTester.triggerUploads(today = preschoolTerm2026.start.plusDays(1))
+
+        val lisätiedot =
+            assertNotNull(koskiEndpoint.getStudyRights().values.single().opiskeluoikeus.lisätiedot)
+        assertEquals(
+            listOf(Aikajakso.from(nextTermEce)),
+            lisätiedot.varhennetunOppivelvollisuudenJaksot,
+        )
+        // the support decision itself stays within the study right
+        assertNull(lisätiedot.tuenPäätöksenJaksot)
+    }
+
+    @Test
+    fun `only the support decision is trimmed when extended compulsory education spans two terms`() {
+        insertPlacement(child1, period = preschoolTerm2026)
+        val ece = FiniteDateRange(preschoolTerm2026.start, preschoolTerm2027.end)
+        db.transaction { tx ->
+            tx.insert(
+                DevPreschoolAssistance(
+                    modifiedBy = employee.evakaUser,
+                    childId = child1.id,
+                    validDuring = ece,
+                    level =
+                        PreschoolAssistanceLevel.CHILD_SUPPORT_AND_EXTENDED_COMPULSORY_EDUCATION,
+                )
+            )
+        }
+
+        koskiTester.triggerUploads(today = preschoolTerm2026.start.plusDays(1))
+
+        val lisätiedot =
+            assertNotNull(koskiEndpoint.getStudyRights().values.single().opiskeluoikeus.lisätiedot)
+        assertEquals(listOf(Aikajakso.from(ece)), lisätiedot.varhennetunOppivelvollisuudenJaksot)
+        assertEquals(
+            listOf(Tukijakso.from(preschoolTerm2026)),
+            lisätiedot.tuenPäätöksenJaksot,
+        )
+    }
+
+    @Test
     fun `adjacent transport benefit ranges are sent as one joined range`() {
         insertPlacement(child1)
         val otherAssistanceMeasures =
@@ -1457,6 +1512,7 @@ private fun Database.Transaction.clearKoskiInputCache() = execute {
 
 private val preschoolTerm2019 = FiniteDateRange(LocalDate.of(2019, 8, 8), LocalDate.of(2020, 5, 29))
 private val preschoolTerm2020 = FiniteDateRange(LocalDate.of(2020, 8, 13), LocalDate.of(2021, 6, 4))
+private val preschoolTerm2026 = FiniteDateRange(LocalDate.of(2026, 8, 10), LocalDate.of(2027, 6, 2))
 private val preschoolTerm2027 = FiniteDateRange(LocalDate.of(2027, 8, 9), LocalDate.of(2028, 6, 2))
 
 private fun testPeriod(offsets: Pair<Long, Long?>) =

--- a/service/src/main/kotlin/evaka/core/koski/KoskiData.kt
+++ b/service/src/main/kotlin/evaka/core/koski/KoskiData.kt
@@ -24,7 +24,7 @@ import org.jdbi.v3.json.Json
  * This number should be incremented to bust the Koski input data cache, for example after making
  * changes to data processing code in this file.
  */
-const val KOSKI_DATA_VERSION: Int = 3
+const val KOSKI_DATA_VERSION: Int = 4
 
 data class KoskiData(val oppija: Oppija, val operation: KoskiOperation, val organizationOid: String)
 
@@ -367,6 +367,13 @@ data class KoskiActivePreschoolDataRaw(
         val childSupportWithNewEce =
             childSupportAndExtendedCompulsoryEducation.intersection(listOf(placementSpan))
 
+        // Not trimmed at the end like the other ranges: a decision for a coming term must reach
+        // Koski before that term's placement starts
+        val newEceIncludingFuture =
+            childSupportAndExtendedCompulsoryEducation.intersection(
+                listOf(FiniteDateRange(placementSpan.start, LocalDate.MAX))
+            )
+
         val allChildSupport =
             childSupportWithoutEce
                 .addAll(childSupportWithNewEce)
@@ -397,7 +404,7 @@ data class KoskiActivePreschoolDataRaw(
                 // deprecated
                 pidennettyOppivelvollisuus = longestOldEce?.let { Aikajakso.from(it) },
                 varhennetunOppivelvollisuudenJaksot =
-                    childSupportWithNewEce
+                    newEceIncludingFuture
                         .ranges()
                         .toList()
                         .map { Aikajakso.from(it) }

--- a/service/src/main/resources/db/migration/R__koski_views.sql
+++ b/service/src/main/resources/db/migration/R__koski_views.sql
@@ -117,7 +117,9 @@ BEGIN ATOMIC
             ) AS child_support_2_and_old_extended_compulsory_education
         FROM preschool_assistance pa
         WHERE pa.child_id = p.child_id
-        AND pa.valid_during && range_merge(placements)
+        -- Ranges past the last placement are needed for varhennettu oppivelvollisuus, which is
+        -- reported to Koski even when it starts after the current placements end
+        AND pa.valid_during && daterange(lower(range_merge(placements)), NULL)
     ) pras ON TRUE
     WHERE p.type = 'PRESCHOOL'
     AND EXISTS (SELECT FROM koski_child WHERE koski_child.id = p.child_id);


### PR DESCRIPTION
Aiheuttaa täyden Koski-ajon seuraavana yönä, mutta silti vain muuttuneet data lähetetään Kosken rajapintaan.