### PR TITLE
Estetään automaattisten tietojen poiston vaikutus Koskeen

### DIFF
--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -2245,7 +2245,8 @@ CREATE TABLE public.child (
     diet_id integer,
     meal_texture_id integer,
     nekku_diet public.nekku_product_meal_type,
-    participates_in_breakfast boolean DEFAULT true CONSTRAINT child_nekku_eats_breakfast_not_null NOT NULL
+    participates_in_breakfast boolean DEFAULT true CONSTRAINT child_nekku_eats_breakfast_not_null NOT NULL,
+    koski_data_first_removed_at timestamp with time zone
 );
 
 -- Name: child_attendance; Type: TABLE; Schema: public

--- a/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
@@ -15,6 +15,7 @@ import evaka.core.application.persistence.daycare.Apply
 import evaka.core.application.persistence.daycare.Child as ApplicationFormChild
 import evaka.core.application.persistence.daycare.DaycareFormV0
 import evaka.core.assistance.OtherAssistanceMeasureType
+import evaka.core.assistance.PreschoolAssistanceLevel
 import evaka.core.attachment.AttachmentParent
 import evaka.core.attachment.insertAttachment
 import evaka.core.calendarevent.CalendarEventType
@@ -113,6 +114,7 @@ import java.time.LocalTime
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -260,6 +262,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         deleteExpiredChildLeafRows(
             db,
             expireDate = leafExpireDate,
+            now,
             limit = 100,
             leafTables = allLeafTables,
         )
@@ -276,6 +279,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         deleteExpiredChildLeafRows(
             db,
             expireDate = leafExpireDate,
+            now,
             limit = 100,
             leafTables = allLeafTables,
         )
@@ -292,11 +296,111 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         deleteExpiredChildLeafRows(
             db,
             expireDate = leafExpireDate,
+            now,
             limit = 2,
             leafTables = listOf("child_sticky_note"),
         )
 
         assertEquals(3, rowCount("child_sticky_note"))
+    }
+
+    @Test
+    fun `deleteExpiredChildLeafRows keeps Koski input rows while the child could still return`() {
+        val youngChild =
+            DevPerson(dateOfBirth = today.minusYears(SAFE_DATA_REMOVAL_AGE).plusDays(1))
+        db.transaction { it.insert(youngChild, DevPersonType.CHILD) }
+        insertExpiredPlacement(youngChild.id)
+        insertPreschoolAssistance(youngChild.id)
+        insertChildStickyNote(youngChild.id)
+
+        deleteExpiredChildLeafRows(
+            db,
+            expireDate = leafExpireDate,
+            now,
+            limit = 100,
+            leafTables = listOf("preschool_assistance", "child_sticky_note"),
+        )
+
+        assertEquals(1, rowCount("preschool_assistance"))
+        // not a Koski input table, so the age gate does not apply
+        assertEquals(0, rowCount("child_sticky_note"))
+    }
+
+    @Test
+    fun `deleteExpiredChildLeafRows deletes Koski input rows once the child reaches the removal age`() {
+        val oldEnoughChild = DevPerson(dateOfBirth = today.minusYears(SAFE_DATA_REMOVAL_AGE))
+        db.transaction { it.insert(oldEnoughChild, DevPersonType.CHILD) }
+        insertExpiredPlacement(oldEnoughChild.id)
+        insertPreschoolAssistance(oldEnoughChild.id)
+
+        deleteExpiredChildLeafRows(
+            db,
+            expireDate = leafExpireDate,
+            now,
+            limit = 100,
+            leafTables = listOf("preschool_assistance"),
+        )
+
+        assertEquals(0, rowCount("preschool_assistance"))
+    }
+
+    @Test
+    fun `deleteExpiredChildLeafRows records when Koski input data was first removed`() {
+        insertExpiredPlacement(child.id)
+        insertPreschoolAssistance(child.id)
+
+        deleteExpiredChildLeafRows(
+            db,
+            expireDate = leafExpireDate,
+            now,
+            limit = 100,
+            leafTables = listOf("preschool_assistance"),
+        )
+
+        assertEquals(0, rowCount("preschool_assistance"))
+        assertEquals(now, koskiDataFirstRemovedAt(child.id))
+    }
+
+    @Test
+    fun `deleteExpiredChildLeafRows of an unrelated table does not freeze Koski`() {
+        insertExpiredPlacement(child.id)
+        insertChildStickyNote(child.id)
+
+        deleteExpiredChildLeafRows(
+            db,
+            expireDate = leafExpireDate,
+            now,
+            limit = 100,
+            leafTables = listOf("child_sticky_note"),
+        )
+
+        assertEquals(0, rowCount("child_sticky_note"))
+        assertNull(koskiDataFirstRemovedAt(child.id))
+    }
+
+    @Test
+    fun `a later removal does not overwrite when Koski input data was first removed`() {
+        insertExpiredPlacement(child.id)
+        insertPreschoolAssistance(child.id)
+        insertOtherAssistanceMeasure(child.id)
+
+        deleteExpiredChildLeafRows(
+            db,
+            expireDate = leafExpireDate,
+            now,
+            limit = 100,
+            leafTables = listOf("preschool_assistance"),
+        )
+        deleteExpiredChildLeafRows(
+            db,
+            expireDate = leafExpireDate,
+            now.plusDays(1),
+            limit = 100,
+            leafTables = listOf("other_assistance_measure"),
+        )
+
+        assertEquals(0, rowCount("other_assistance_measure"))
+        assertEquals(now, koskiDataFirstRemovedAt(child.id))
     }
 
     @Test
@@ -307,6 +411,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         deleteExpiredChildLeafRows(
             db,
             expireDate = leafExpireDate,
+            now,
             limit = 100,
             leafTables = emptyList(),
         )
@@ -479,6 +584,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         allLeafTables.forEach { assertEquals(0, rowCount(it), "table $it should be empty") }
         assertEquals(0, rowCount("child_images"))
+        assertNull(koskiDataFirstRemovedAt(child.id), "no Koski input table expires in one year")
         assertEquals(
             ChildDietColumns(dietId = null, mealTextureId = null, nekkuDiet = null),
             readChildDietColumns(child.id),
@@ -501,6 +607,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
             rowCount("assistance_action_option_ref"),
             "assistance_action_option_ref should be emptied via cascade",
         )
+        assertEquals(now, koskiDataFirstRemovedAt(child.id))
     }
 
     @Test
@@ -1755,6 +1862,30 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         block()
     }
 
+    private fun insertPreschoolAssistance(childId: ChildId) = db.transaction { tx ->
+        tx.insert(
+            DevPreschoolAssistance(
+                childId = childId,
+                validDuring =
+                    FiniteDateRange(leafExpireDate.minusYears(1), leafExpireDate.minusDays(1)),
+                level = PreschoolAssistanceLevel.SPECIAL_SUPPORT,
+                modifiedBy = admin.evakaUser,
+            )
+        )
+    }
+
+    private fun insertOtherAssistanceMeasure(childId: ChildId) = db.transaction { tx ->
+        tx.insert(
+            DevOtherAssistanceMeasure(
+                childId = childId,
+                validDuring =
+                    FiniteDateRange(leafExpireDate.minusYears(1), leafExpireDate.minusDays(1)),
+                type = OtherAssistanceMeasureType.TRANSPORT_BENEFIT,
+                modifiedBy = admin.evakaUser,
+            )
+        )
+    }
+
     private fun insertExpiredPlacement(childId: ChildId) =
         insertPlacementEnding(childId, leafExpireDate.minusDays(1))
 
@@ -1936,6 +2067,13 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
 
     private fun rowCount(table: String): Int = db.read { tx ->
         tx.createQuery { sql("SELECT count(*) FROM $table") }.exactlyOne<Int>()
+    }
+
+    private fun koskiDataFirstRemovedAt(childId: ChildId): HelsinkiDateTime? = db.read { tx ->
+        tx.createQuery {
+                sql("SELECT koski_data_first_removed_at FROM child WHERE id = ${bind(childId)}")
+            }
+            .exactlyOne<HelsinkiDateTime?>()
     }
 
     private fun countChildrenWithNull(column: String): Int = db.read { tx ->

--- a/service/src/integrationTest/kotlin/evaka/core/koski/KoskiIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/koski/KoskiIntegrationTest.kt
@@ -1046,6 +1046,16 @@ class KoskiIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
     }
 
     @Test
+    fun `nothing is sent for a child whose Koski data has been removed`() {
+        insertPlacement()
+        markKoskiDataRemoved(child1.id)
+
+        koskiTester.triggerUploads(today = preschoolTerm2019.end.plusDays(1))
+
+        assertTrue(koskiEndpoint.getStudyRights().isEmpty())
+    }
+
+    @Test
     fun `a daycare with purchased provider type is marked as such in study rights`() {
         val daycareId = db.transaction {
             it.insert(
@@ -1484,6 +1494,14 @@ class KoskiIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
                 type = type,
             )
         )
+    }
+
+    private fun markKoskiDataRemoved(childId: ChildId) = db.transaction { tx ->
+        tx.execute {
+            sql(
+                "UPDATE child SET koski_data_first_removed_at = ${bind(koskiUploadTime(preschoolTerm2019.end))} WHERE id = ${bind(childId)}"
+            )
+        }
     }
 
     private fun insertAbsences(

--- a/service/src/integrationTest/kotlin/evaka/core/pis/service/MergeServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/service/MergeServiceIntegrationTest.kt
@@ -79,6 +79,93 @@ class MergeServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach = true
     }
 
     @Test
+    fun `merging children combines child details from both`() {
+        val master = DevPerson()
+        val duplicate = DevPerson()
+        db.transaction { tx ->
+            tx.insert(master, DevPersonType.CHILD)
+            tx.insert(duplicate, DevPersonType.CHILD)
+        }
+        setChildDetails(master.id, "pollen", "vegan", "from master")
+        setChildDetails(duplicate.id, "peanuts", "lactose free", "from duplicate")
+
+        db.transaction { mergeService.mergePeople(it, clock, master.id, duplicate.id) }
+
+        assertEquals(
+            ChildDetails("pollen peanuts", "vegan lactose free", "from master from duplicate"),
+            childDetails(master.id),
+        )
+    }
+
+    @Test
+    fun `merging children keeps the duplicate's child details when the master has no child row`() {
+        val master = DevPerson()
+        val duplicate = DevPerson()
+        db.transaction { tx ->
+            tx.insert(master, DevPersonType.RAW_ROW)
+            tx.insert(duplicate, DevPersonType.CHILD)
+        }
+        setChildDetails(duplicate.id, "peanuts", "vegan", "from duplicate")
+
+        db.transaction { mergeService.mergePeople(it, clock, master.id, duplicate.id) }
+
+        assertEquals(
+            ChildDetails("peanuts", "vegan", "from duplicate"),
+            childDetails(master.id),
+        )
+    }
+
+    @Test
+    fun `merging children does not add a separator when the master has no child details`() {
+        val master = DevPerson()
+        val duplicate = DevPerson()
+        db.transaction { tx ->
+            tx.insert(master, DevPersonType.CHILD)
+            tx.insert(duplicate, DevPersonType.CHILD)
+        }
+        setChildDetails(duplicate.id, "peanuts", "vegan", "from duplicate")
+
+        db.transaction { mergeService.mergePeople(it, clock, master.id, duplicate.id) }
+
+        assertEquals(
+            ChildDetails("peanuts", "vegan", "from duplicate"),
+            childDetails(master.id),
+        )
+    }
+
+    private data class ChildDetails(
+        val allergies: String,
+        val diet: String,
+        val additionalInfo: String,
+    )
+
+    private fun setChildDetails(
+        childId: PersonId,
+        allergies: String,
+        diet: String,
+        additionalInfo: String,
+    ) = db.transaction { tx ->
+        tx.execute {
+            sql(
+                """
+UPDATE child
+SET allergies = ${bind(allergies)}, diet = ${bind(diet)}, additionalinfo = ${bind(additionalInfo)}
+WHERE id = ${bind(childId)}
+"""
+            )
+        }
+    }
+
+    private fun childDetails(childId: PersonId): ChildDetails = db.read { tx ->
+        tx.createQuery {
+                sql(
+                    "SELECT allergies, diet, additionalinfo AS additional_info FROM child WHERE id = ${bind(childId)}"
+                )
+            }
+            .exactlyOne<ChildDetails>()
+    }
+
+    @Test
     fun `empty person can be deleted`() {
         val id = ChildId(UUID.randomUUID())
         db.transaction { it.insert(DevPerson(id = id), DevPersonType.CHILD) }

--- a/service/src/main/kotlin/evaka/core/Audit.kt
+++ b/service/src/main/kotlin/evaka/core/Audit.kt
@@ -201,6 +201,7 @@ enum class Audit(
     CustomerFeesReportRead,
     DataRemovalExpiredDelete,
     DataRemovalExpiredUnset,
+    DataRemovalKoskiSyncFrozen,
     DaycareGroupPlacementCreate,
     DaycareGroupPlacementDelete,
     DaycareGroupPlacementTransfer,

--- a/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
+++ b/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
@@ -10,6 +10,7 @@ import evaka.core.DataRemovalEnv
 import evaka.core.caseprocess.deleteCaseProcesses
 import evaka.core.childimages.deleteImageFile
 import evaka.core.document.childdocument.deleteExpiredChildDocuments
+import evaka.core.koski.KOSKI_INPUT_TABLES
 import evaka.core.messaging.DeletedMessageThreadBatch
 import evaka.core.messaging.deleteExpiredBulletinThreads
 import evaka.core.messaging.deleteExpiredMessageDrafts
@@ -24,7 +25,6 @@ import evaka.core.shared.ChildImageId
 import evaka.core.shared.DecisionId
 import evaka.core.shared.FinanceNoteId
 import evaka.core.shared.FosterParentId
-import evaka.core.shared.Id
 import evaka.core.shared.IncomeId
 import evaka.core.shared.MessageThreadId
 import evaka.core.shared.ParentshipId
@@ -39,15 +39,40 @@ import evaka.core.shared.async.AsyncJobRunner
 import evaka.core.shared.async.AsyncJobType
 import evaka.core.shared.async.removeUnclaimedJobs
 import evaka.core.shared.db.Database
+import evaka.core.shared.db.Predicate
 import evaka.core.shared.db.QuerySql
 import evaka.core.shared.domain.EvakaClock
 import evaka.core.shared.domain.HelsinkiDateTime
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Duration
 import java.time.LocalDate
+import java.util.UUID
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {}
+
+/**
+ * Removing the rows an external data sync reads freezes that sync for the child permanently, so we
+ * hold the data until starting or returning to preschool is no longer realistic.
+ *
+ * This currently never excludes anything on its own: the Koski input tables are removed only after
+ * ten years without a placement, which already implies this age. It is here so that moving one of
+ * them to a shorter retention period cannot quietly freeze children who could still start
+ * preschool.
+ */
+const val SAFE_DATA_REMOVAL_AGE: Long = 10
+
+private fun childPastSafeDataRemovalAge(today: LocalDate) = Predicate {
+    where(
+        """
+EXISTS (
+    SELECT FROM person p
+    WHERE p.id = $it.child_id
+    AND p.date_of_birth <= ${bind(today.minusYears(SAFE_DATA_REMOVAL_AGE))}
+)
+"""
+    )
+}
 
 private fun auditExpiredDelete(
     entity: String,
@@ -107,6 +132,7 @@ class DataRemovalService(
         deleteExpiredChildLeafRows(
             dbc,
             expireDate = today.minusYears(1),
+            now,
             limit,
             leafTables =
                 listOf(
@@ -121,6 +147,7 @@ class DataRemovalService(
         deleteExpiredChildLeafRows(
             dbc,
             expireDate = today.minusYears(10),
+            now,
             limit,
             leafTables =
                 listOf(
@@ -303,8 +330,10 @@ class DataRemovalService(
         limit: Int,
     ) {
         val ids = dbc.transaction { tx ->
-            val childImageIds: List<ChildImageId> =
-                tx.deleteExpiredChildLeafRowsFromTable(expireDate, limit, table = "child_images")
+            val childImageIds =
+                tx.deleteExpiredChildLeafRowsFromTable(expireDate, now, limit, "child_images").map {
+                    ChildImageId(it.id)
+                }
             asyncJobRunner.plan(
                 tx,
                 childImageIds.map { AsyncJob.DeleteChildImage(it) },
@@ -469,43 +498,84 @@ class DataRemovalService(
 fun deleteExpiredChildLeafRows(
     dbc: Database.Connection,
     expireDate: LocalDate,
+    now: HelsinkiDateTime,
     limit: Int,
     leafTables: List<String>,
 ) {
     leafTables.forEach { table ->
         logger.info { "Deleting at most $limit expired rows in table $table" }
-        val deleted = dbc.transaction { tx ->
-            tx.deleteExpiredChildLeafRowsFromTable<Id<*>>(expireDate, limit, table)
-        }
-        deleted.forEach { id ->
+        val koskiInput = table in KOSKI_INPUT_TABLES
+        val (deleted, frozen) =
+            dbc.transaction { tx ->
+                val deleted = tx.deleteExpiredChildLeafRowsFromTable(expireDate, now, limit, table)
+                val frozen =
+                    if (koskiInput && deleted.isNotEmpty())
+                        tx.freezeKoskiSync(deleted.map { it.childId }.distinct(), now)
+                    else emptyList()
+                deleted to frozen
+            }
+        deleted.forEach { row ->
             auditExpiredDelete(
                 entity = table,
-                targetId = AuditId(id),
+                targetId = AuditId(row.id),
                 meta = mapOf("expireDate" to expireDate),
             )
+        }
+        frozen.forEach { childId ->
+            Audit.DataRemovalKoskiSyncFrozen.log(targetId = AuditId(childId))
         }
     }
 }
 
-private inline fun <reified T : Id<*>> Database.Transaction.deleteExpiredChildLeafRowsFromTable(
+private data class ExpiredLeafRow(val id: UUID, val childId: ChildId)
+
+private fun Database.Transaction.deleteExpiredChildLeafRowsFromTable(
     expireDate: LocalDate,
+    now: HelsinkiDateTime,
     limit: Int,
     table: String,
-): List<T> = createUpdate {
-    sql(
-        """
+): List<ExpiredLeafRow> {
+    val removalAllowed =
+        if (table in KOSKI_INPUT_TABLES) childPastSafeDataRemovalAge(now.toLocalDate())
+        else Predicate.alwaysTrue()
+    return createUpdate {
+        sql(
+            """
 WITH del_batch AS (
-    SELECT id
+    SELECT id, child_id
     FROM $table
     WHERE child_id = ANY(${subquery(childIdsWithPlacementsEndingBefore(expireDate))})
+    AND ${predicate(removalAllowed.forTable(table))}
     FOR UPDATE
     LIMIT ${bind(limit)}
 )
 DELETE FROM $table
 USING del_batch
 WHERE $table.id = del_batch.id
-RETURNING $table.id
+RETURNING $table.id, $table.child_id
         """
+        )
+    }
+        .executeAndReturnGeneratedKeys()
+        .toList()
+}
+
+/**
+ * Removing rows the Koski payload is built from permanently freezes the child's sync. Returns the
+ * children frozen by this call, i.e. those that were not already frozen.
+ */
+private fun Database.Transaction.freezeKoskiSync(
+    childIds: Collection<ChildId>,
+    now: HelsinkiDateTime,
+): List<ChildId> = createUpdate {
+    sql(
+        """
+UPDATE child
+SET koski_data_first_removed_at = ${bind(now)}
+WHERE id = ANY(${bind(childIds)})
+AND koski_data_first_removed_at IS NULL
+RETURNING id
+"""
     )
 }
     .executeAndReturnGeneratedKeys()

--- a/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
+++ b/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
@@ -54,11 +54,6 @@ private val logger = KotlinLogging.logger {}
 /**
  * Removing the rows an external data sync reads freezes that sync for the child permanently, so we
  * hold the data until starting or returning to preschool is no longer realistic.
- *
- * This currently never excludes anything on its own: the Koski input tables are removed only after
- * ten years without a placement, which already implies this age. It is here so that moving one of
- * them to a shorter retention period cannot quietly freeze children who could still start
- * preschool.
  */
 const val SAFE_DATA_REMOVAL_AGE: Long = 10
 
@@ -505,29 +500,34 @@ fun deleteExpiredChildLeafRows(
     leafTables.forEach { table ->
         logger.info { "Deleting at most $limit expired rows in table $table" }
         val koskiInput = table in KOSKI_INPUT_TABLES
-        val (deleted, frozen) =
+        val (deletedIds, frozenChildIds) =
             dbc.transaction { tx ->
                 val deleted = tx.deleteExpiredChildLeafRowsFromTable(expireDate, now, limit, table)
                 val frozen =
                     if (koskiInput && deleted.isNotEmpty())
                         tx.freezeKoskiSync(deleted.map { it.childId }.distinct(), now)
                     else emptyList()
-                deleted to frozen
+                ExpiredLeafRemoval(deleted.map { it.id }, frozen)
             }
-        deleted.forEach { row ->
+        deletedIds.forEach { id ->
             auditExpiredDelete(
                 entity = table,
-                targetId = AuditId(row.id),
+                targetId = AuditId(id),
                 meta = mapOf("expireDate" to expireDate),
             )
         }
-        frozen.forEach { childId ->
+        frozenChildIds.forEach { childId ->
             Audit.DataRemovalKoskiSyncFrozen.log(targetId = AuditId(childId))
         }
     }
 }
 
 private data class ExpiredLeafRow(val id: UUID, val childId: ChildId)
+
+private data class ExpiredLeafRemoval(
+    val deletedIds: List<UUID>,
+    val frozenChildIds: List<ChildId>,
+)
 
 private fun Database.Transaction.deleteExpiredChildLeafRowsFromTable(
     expireDate: LocalDate,
@@ -560,10 +560,6 @@ RETURNING $table.id, $table.child_id
         .toList()
 }
 
-/**
- * Removing rows the Koski payload is built from permanently freezes the child's sync. Returns the
- * children frozen by this call, i.e. those that were not already frozen.
- */
 private fun Database.Transaction.freezeKoskiSync(
     childIds: Collection<ChildId>,
     now: HelsinkiDateTime,

--- a/service/src/main/kotlin/evaka/core/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/evaka/core/koski/KoskiQueries.kt
@@ -13,11 +13,33 @@ import evaka.core.shared.db.QuerySql
 import evaka.core.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
 
+/** Child-keyed tables feeding the payload in `R__koski_views.sql`. Keep in sync by hand. */
+val KOSKI_INPUT_TABLES =
+    setOf("placement", "person", "preschool_assistance", "other_assistance_measure", "absence")
+
 data class KoskiStudyRightKey(
     val childId: ChildId,
     val unitId: DaycareId,
     val type: OpiskeluoikeudenTyyppiKoodi,
 )
+
+/**
+ * Koski is the system of record for the education history, so once retention has removed rows the
+ * payload is built from, we must stop reconciling: rebuilding it from what is left would amend the
+ * loss into the national register. Nothing lifts this again.
+ */
+private val koskiSyncActive = Predicate { where("$it.koski_data_first_removed_at IS NULL") }
+
+private fun Database.Read.isKoskiSyncActive(childId: ChildId): Boolean = createQuery {
+    sql(
+        """
+SELECT ${predicate(koskiSyncActive.forTable("child"))}
+FROM child
+WHERE id = ${bind(childId)}
+"""
+    )
+}
+    .exactlyOne()
 
 fun Database.Read.getPendingStudyRights(
     today: LocalDate,
@@ -32,29 +54,35 @@ fun Database.Read.getPendingStudyRights(
             """
 SELECT kasr.child_id, kasr.unit_id, 'PRESCHOOL'::koski_study_right_type AS type
 FROM koski_active_preschool_study_right(${bind(today)}, ${bind(syncRangeStart)}) kasr
+JOIN child ch ON ch.id = kasr.child_id
 LEFT JOIN koski_study_right ksr
 ON (kasr.child_id, kasr.unit_id, 'PRESCHOOL') = (ksr.child_id, ksr.unit_id, ksr.type)
 WHERE (
     ksr.preschool_input_data IS DISTINCT FROM kasr.input_data OR
     ${predicate(dataVersionCheck.forTable("ksr"))}
 )
+AND ${predicate(koskiSyncActive.forTable("ch"))}
 
 UNION
 
 SELECT kasr.child_id, kasr.unit_id, 'PREPARATORY'::koski_study_right_type AS type
 FROM koski_active_preparatory_study_right(${bind(today)}, ${bind(syncRangeStart)}) kasr
+JOIN child ch ON ch.id = kasr.child_id
 LEFT JOIN koski_study_right ksr
 ON (kasr.child_id, kasr.unit_id, 'PREPARATORY') = (ksr.child_id, ksr.unit_id, ksr.type)
 WHERE (
     ksr.preparatory_input_data IS DISTINCT FROM kasr.input_data OR
     ${predicate(dataVersionCheck.forTable("ksr"))}
 )
+AND ${predicate(koskiSyncActive.forTable("ch"))}
 
 UNION
 
 SELECT kvsr.child_id, kvsr.unit_id, kvsr.type
 FROM koski_voided_study_right(${bind(today)}) kvsr
+JOIN child ch ON ch.id = kvsr.child_id
 WHERE kvsr.void_date IS NULL
+AND ${predicate(koskiSyncActive.forTable("ch"))}
 """
         )
     }
@@ -128,6 +156,7 @@ fun Database.Transaction.beginKoskiUpload(
     today: LocalDate,
     syncRangeStart: LocalDate?,
 ): KoskiData? {
+    if (!isKoskiSyncActive(key.childId)) return null
     val (id, voided) = refreshStudyRight(key, today, syncRangeStart)
     return if (voided) {
         createQuery {

--- a/service/src/main/kotlin/evaka/core/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/evaka/core/koski/KoskiQueries.kt
@@ -24,9 +24,8 @@ data class KoskiStudyRightKey(
 )
 
 /**
- * Koski is the system of record for the education history, so once retention has removed rows the
- * payload is built from, we must stop reconciling: rebuilding it from what is left would amend the
- * loss into the national register. Nothing lifts this again.
+ * Once any of the child's data that affects Koski has been deleted due to retention policies, the
+ * data synchronization to Koski must be stopped, so that the data is not deleted from there too.
  */
 private val koskiSyncActive = Predicate { where("$it.koski_data_first_removed_at IS NULL") }
 

--- a/service/src/main/kotlin/evaka/core/pis/service/MergeService.kt
+++ b/service/src/main/kotlin/evaka/core/pis/service/MergeService.kt
@@ -67,15 +67,21 @@ SELECT min(min_date) AS min_date, max(max_date) AS max_date FROM dates HAVING mi
             tx.createUpdate {
                     sql(
                         """
-INSERT INTO child (id, allergies, diet, additionalinfo) VALUES (
+INSERT INTO child (id, allergies, diet, additionalinfo, koski_data_first_removed_at) VALUES (
     ${bind(master)},
     coalesce((SELECT allergies FROM child WHERE id = ${bind(master)}), ''),
     coalesce((SELECT diet FROM child WHERE id = ${bind(master)}), ''),
-    coalesce((SELECT additionalinfo FROM child WHERE id = ${bind(master)}), '')
+    coalesce((SELECT additionalinfo FROM child WHERE id = ${bind(master)}), ''),
+    -- least() ignores nulls, so the merged child stays frozen if either side was
+    least(
+        (SELECT koski_data_first_removed_at FROM child WHERE id = ${bind(master)}),
+        (SELECT koski_data_first_removed_at FROM child WHERE id = ${bind(duplicate)})
+    )
 ) ON CONFLICT(id) DO UPDATE SET
     allergies = concat((SELECT allergies FROM child WHERE id = ${bind(master)}), ' ', coalesce((SELECT allergies FROM child WHERE id = ${bind(duplicate)}), '')),
     diet = concat( (SELECT diet FROM child WHERE id = ${bind(master)}), ' ', coalesce((SELECT diet FROM child WHERE id = ${bind(duplicate)}), '')),
-    additionalinfo = concat((SELECT additionalinfo FROM child WHERE id = ${bind(master)}), ' ', coalesce((SELECT additionalinfo FROM child WHERE id = ${bind(duplicate)}), ''));
+    additionalinfo = concat((SELECT additionalinfo FROM child WHERE id = ${bind(master)}), ' ', coalesce((SELECT additionalinfo FROM child WHERE id = ${bind(duplicate)}), '')),
+    koski_data_first_removed_at = excluded.koski_data_first_removed_at;
     
 UPDATE child SET allergies = '', diet = '', additionalinfo = '' WHERE id = ${bind(duplicate)};
 

--- a/service/src/main/kotlin/evaka/core/pis/service/MergeService.kt
+++ b/service/src/main/kotlin/evaka/core/pis/service/MergeService.kt
@@ -69,18 +69,29 @@ SELECT min(min_date) AS min_date, max(max_date) AS max_date FROM dates HAVING mi
                         """
 INSERT INTO child (id, allergies, diet, additionalinfo, koski_data_first_removed_at) VALUES (
     ${bind(master)},
-    coalesce((SELECT allergies FROM child WHERE id = ${bind(master)}), ''),
-    coalesce((SELECT diet FROM child WHERE id = ${bind(master)}), ''),
-    coalesce((SELECT additionalinfo FROM child WHERE id = ${bind(master)}), ''),
+    -- concat_ws() skips nulls, and nullif() makes an empty side null, so an absent
+    -- value never leaves a stray separator behind
+    concat_ws(' ',
+        nullif((SELECT allergies FROM child WHERE id = ${bind(master)}), ''),
+        nullif((SELECT allergies FROM child WHERE id = ${bind(duplicate)}), '')
+    ),
+    concat_ws(' ',
+        nullif((SELECT diet FROM child WHERE id = ${bind(master)}), ''),
+        nullif((SELECT diet FROM child WHERE id = ${bind(duplicate)}), '')
+    ),
+    concat_ws(' ',
+        nullif((SELECT additionalinfo FROM child WHERE id = ${bind(master)}), ''),
+        nullif((SELECT additionalinfo FROM child WHERE id = ${bind(duplicate)}), '')
+    ),
     -- least() ignores nulls, so the merged child stays frozen if either side was
     least(
         (SELECT koski_data_first_removed_at FROM child WHERE id = ${bind(master)}),
         (SELECT koski_data_first_removed_at FROM child WHERE id = ${bind(duplicate)})
     )
 ) ON CONFLICT(id) DO UPDATE SET
-    allergies = concat((SELECT allergies FROM child WHERE id = ${bind(master)}), ' ', coalesce((SELECT allergies FROM child WHERE id = ${bind(duplicate)}), '')),
-    diet = concat( (SELECT diet FROM child WHERE id = ${bind(master)}), ' ', coalesce((SELECT diet FROM child WHERE id = ${bind(duplicate)}), '')),
-    additionalinfo = concat((SELECT additionalinfo FROM child WHERE id = ${bind(master)}), ' ', coalesce((SELECT additionalinfo FROM child WHERE id = ${bind(duplicate)}), '')),
+    allergies = excluded.allergies,
+    diet = excluded.diet,
+    additionalinfo = excluded.additionalinfo,
     koski_data_first_removed_at = excluded.koski_data_first_removed_at;
     
 UPDATE child SET allergies = '', diet = '', additionalinfo = '' WHERE id = ${bind(duplicate)};

--- a/service/src/main/resources/db/migration/V608__child_koski_data_removed.sql
+++ b/service/src/main/resources/db/migration/V608__child_koski_data_removed.sql
@@ -1,0 +1,2 @@
+ALTER TABLE child
+    ADD COLUMN koski_data_first_removed_at timestamp with time zone;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -603,3 +603,4 @@ V604__citizen_user_preferred_ui_language.sql
 V605__absence_categories_temporary_daycare.sql
 V606__koski_upload_error.sql
 V607__decision_reasoning_individual_language.sql
+V608__child_koski_data_removed.sql


### PR DESCRIPTION
Muutokset

1. Riippumatta määritellystä säilytysajasta, ei poisteta automaattisesti tietoa tauluista, jotka vaikuttavat Koskeen, mikäli lapsi on alle 10 vuotias. Tämän jälkeen lapsi ei varmastikaan ole enää palaamassa esiopetukseen eikä valmistavaan opetukseen.
2. Kun koskeen vaikuttavia lapsen tietoja ensimmäistä kertaa poistetaan automaattisesti, tehdään tästä merkintä. Mikäli tällainen merkintä löytyy, ei lapsen tietoja enää päivitetä Koskeen, jotta evakasta poistunutta tietoa ei poisteta myös sieltä.
