### PR TITLE
Lisätään kirjautumattomien hetullisten työntekijöiden automaattinen poisto

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/pis/InactiveEmployeesRoleResetIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/pis/InactiveEmployeesRoleResetIntegrationTest.kt
@@ -11,6 +11,7 @@ import evaka.core.shared.DaycareId
 import evaka.core.shared.EmployeeId
 import evaka.core.shared.GroupId
 import evaka.core.shared.auth.UserRole
+import evaka.core.shared.auth.hasAnyDaycareAclRow
 import evaka.core.shared.auth.insertDaycareAclRow
 import evaka.core.shared.auth.syncDaycareGroupAcl
 import evaka.core.shared.db.Database
@@ -24,6 +25,8 @@ import evaka.core.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.junit.jupiter.api.Test
 
@@ -32,6 +35,9 @@ class InactiveEmployeesRoleResetIntegrationTest : PureJdbiTest(resetDbBeforeEach
         HelsinkiDateTime.of(LocalDate.of(2021, 8, 1), LocalTime.of(3, 15))
 
     private val daysToDeactivation: Long = 8 * 7 + 1
+    private val daysToDeletion: Long = 5 + 1
+
+    private val ssn = "010107A9917"
 
     @Test
     fun `global roles are not reset when last_login is now`() {
@@ -284,6 +290,107 @@ class InactiveEmployeesRoleResetIntegrationTest : PureJdbiTest(resetDbBeforeEach
 
         val deactivated = db.transaction { it.deactivateInactiveEmployees(firstOfAugust2021) }
         assertEquals(1, deactivated.size)
+    }
+
+    @Test
+    fun `ssn employee who has not logged in within 5 days of creation is deleted together with unit acl rows`() {
+        val employeeId = db.transaction {
+            val employeeId =
+                it.insert(
+                    DevEmployee(
+                        ssn = ssn,
+                        lastLogin = null,
+                        created = firstOfAugust2021.minusDays(daysToDeletion),
+                    )
+                )
+            val areaId = it.insert(DevCareArea())
+            val unitId = it.insert(DevDaycare(areaId = areaId))
+            it.insertDaycareAclRow(
+                daycareId = unitId,
+                employeeId = employeeId,
+                role = UserRole.STAFF,
+            )
+            employeeId
+        }
+
+        val deleted = db.transaction { it.deleteNeverLoggedInSsnEmployees(firstOfAugust2021) }
+
+        assertEquals(listOf(employeeId), deleted)
+        assertNull(db.read { it.getEmployee(employeeId) })
+        assertFalse(db.read { it.hasAnyDaycareAclRow(employeeId) })
+    }
+
+    @Test
+    fun `ssn employee created exactly 5 days ago is not deleted`() {
+        val employeeId = db.transaction {
+            it.insert(
+                DevEmployee(
+                    ssn = ssn,
+                    lastLogin = null,
+                    created = firstOfAugust2021.minusDays(daysToDeletion - 1),
+                )
+            )
+        }
+
+        val deleted = db.transaction { it.deleteNeverLoggedInSsnEmployees(firstOfAugust2021) }
+
+        assertEquals(listOf(), deleted)
+        assertNotNull(db.read { it.getEmployee(employeeId) })
+    }
+
+    @Test
+    fun `employee without ssn who has not logged in is not deleted`() {
+        val employeeId = db.transaction {
+            it.insert(
+                DevEmployee(
+                    ssn = null,
+                    lastLogin = null,
+                    created = firstOfAugust2021.minusDays(1000),
+                )
+            )
+        }
+
+        val deleted = db.transaction { it.deleteNeverLoggedInSsnEmployees(firstOfAugust2021) }
+
+        assertEquals(listOf(), deleted)
+        assertNotNull(db.read { it.getEmployee(employeeId) })
+    }
+
+    @Test
+    fun `ssn employee who has logged in is not deleted`() {
+        val employeeId = db.transaction {
+            it.insert(
+                DevEmployee(
+                    ssn = ssn,
+                    lastLogin = firstOfAugust2021.minusDays(1000),
+                    created = firstOfAugust2021.minusDays(1000),
+                )
+            )
+        }
+
+        val deleted = db.transaction { it.deleteNeverLoggedInSsnEmployees(firstOfAugust2021) }
+
+        assertEquals(listOf(), deleted)
+        assertNotNull(db.read { it.getEmployee(employeeId) })
+    }
+
+    @Test
+    fun `deactivated ssn employee who has not logged in is also deleted`() {
+        val employeeId = db.transaction {
+            it.insert(
+                DevEmployee(
+                    ssn = ssn,
+                    lastLogin = null,
+                    created = firstOfAugust2021.minusDays(1000),
+                    active = false,
+                )
+            )
+        }
+
+        val deleted = db.transaction { it.deleteNeverLoggedInSsnEmployees(firstOfAugust2021) }
+
+        assertEquals(listOf(employeeId), deleted)
+        assertNull(db.read { it.getEmployee(employeeId) })
     }
 
     private fun Database.Transaction.setDaycareAclUpdated(

--- a/service/src/main/kotlin/evaka/core/Audit.kt
+++ b/service/src/main/kotlin/evaka/core/Audit.kt
@@ -217,7 +217,7 @@ enum class Audit(
     DocumentTemplateUpdateValidity,
     EmployeeActivate(securityEvent = true, securityLevel = "high"),
     EmployeeCreate(securityEvent = true, securityLevel = "high"),
-    EmployeeDeactivate(securityEvent = true),
+    EmployeeDeactivate(securityEvent = true, securityLevel = "high"),
     EmployeeDelete(securityEvent = true, securityLevel = "high"),
     EmployeeDeleteDaycareRoles(securityEvent = true, securityLevel = "high"),
     EmployeeDeleteScheduledDaycareRole(securityEvent = true, securityLevel = "high"),

--- a/service/src/main/kotlin/evaka/core/pis/EmployeeQueries.kt
+++ b/service/src/main/kotlin/evaka/core/pis/EmployeeQueries.kt
@@ -576,6 +576,24 @@ fun Database.Transaction.deactivateEmployeeRemoveRolesAndPin(id: EmployeeId) {
     listPersonalDevices(id).forEach { deleteDevice(it.id) }
 }
 
+fun Database.Transaction.deleteNeverLoggedInSsnEmployees(now: HelsinkiDateTime): List<EmployeeId> {
+    val employeeIds = createQuery {
+        sql(
+            """
+    SELECT id
+    FROM employee
+    WHERE social_security_number IS NOT NULL
+    AND last_login IS NULL
+    AND created < ${bind(now)} - interval '5 days'
+    FOR UPDATE
+"""
+        )
+    }
+        .toList<EmployeeId>()
+    employeeIds.forEach { employeeId -> deleteEmployee(employeeId) }
+    return employeeIds
+}
+
 fun Database.Transaction.setEmployeePreferredFirstName(
     employeeId: EmployeeId,
     preferredFirstName: String?,

--- a/service/src/main/kotlin/evaka/core/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/evaka/core/shared/job/ScheduledJobs.kt
@@ -4,6 +4,8 @@
 
 package evaka.core.shared.job
 
+import evaka.core.Audit
+import evaka.core.AuditId
 import evaka.core.ChildDocumentArchivalEnv
 import evaka.core.EvakaEnv
 import evaka.core.ScheduledJobsEnv
@@ -578,17 +580,15 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun inactiveEmployeesRoleReset(db: Database.Connection, clock: EvakaClock) {
-        db.transaction {
-            val ids = it.deactivateInactiveEmployees(clock.now())
-            logger.info { "Roles cleared for ${ids.size} inactive employees: $ids" }
-        }
+        val ids = db.transaction { it.deactivateInactiveEmployees(clock.now()) }
+        logger.info { "Roles cleared for ${ids.size} inactive employees: $ids" }
+        ids.forEach { Audit.EmployeeDeactivate.log(targetId = AuditId(it)) }
     }
 
     fun deleteNeverLoggedInSsnEmployees(db: Database.Connection, clock: EvakaClock) {
-        db.transaction {
-            val ids = it.deleteNeverLoggedInSsnEmployees(clock.now())
-            logger.info { "Deleted ${ids.size} SSN employees who never logged in: $ids" }
-        }
+        val ids = db.transaction { it.deleteNeverLoggedInSsnEmployees(clock.now()) }
+        logger.info { "Deleted ${ids.size} SSN employees who never logged in: $ids" }
+        ids.forEach { Audit.EmployeeDelete.log(targetId = AuditId(it)) }
     }
 
     fun sendMissingReservationReminders(db: Database.Connection, clock: EvakaClock) {

--- a/service/src/main/kotlin/evaka/core/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/evaka/core/shared/job/ScheduledJobs.kt
@@ -36,6 +36,7 @@ import evaka.core.note.child.daily.deleteExpiredNotes
 import evaka.core.pis.cleanUpInactivePeople
 import evaka.core.pis.deactivateInactiveEmployees
 import evaka.core.pis.deleteExpiredEmailVerifications
+import evaka.core.pis.deleteNeverLoggedInSsnEmployees
 import evaka.core.reports.freezeVoucherValueReportRows
 import evaka.core.reservations.MissingHolidayReservationsReminders
 import evaka.core.reservations.MissingReservationsReminders
@@ -214,6 +215,10 @@ enum class ScheduledJob(
     ),
     InactiveEmployeesRoleReset(
         ScheduledJobs::inactiveEmployeesRoleReset,
+        ScheduledJobSettings(enabled = true, schedule = JobSchedule.nightly()),
+    ),
+    DeleteNeverLoggedInSsnEmployees(
+        ScheduledJobs::deleteNeverLoggedInSsnEmployees,
         ScheduledJobSettings(enabled = true, schedule = JobSchedule.nightly()),
     ),
     SendMissingReservationReminders(
@@ -576,6 +581,13 @@ WHERE id IN (SELECT id FROM attendances_to_end)
         db.transaction {
             val ids = it.deactivateInactiveEmployees(clock.now())
             logger.info { "Roles cleared for ${ids.size} inactive employees: $ids" }
+        }
+    }
+
+    fun deleteNeverLoggedInSsnEmployees(db: Database.Connection, clock: EvakaClock) {
+        db.transaction {
+            val ids = it.deleteNeverLoggedInSsnEmployees(clock.now())
+            logger.info { "Deleted ${ids.size} SSN employees who never logged in: $ids" }
         }
     }
 


### PR DESCRIPTION
Poistetaan automaattisesti hetulliset työntekijät, jotka eivät ole kirjautuneet sisään kertaakaan 5 vuorokauteen käyttäjän luomisesta.

Kirjautumattomien käyttäjien deaktivointia oli jo aiemmin pidennetty 56 päivään: #7934