### PR TITLE
Lisätään tuki passkey käytölle vanhemmissa selaimissa

### DIFF
--- a/frontend/src/citizen-frontend/auth/passkeys.ts
+++ b/frontend/src/citizen-frontend/auth/passkeys.ts
@@ -6,12 +6,16 @@ import { client } from '../api-client'
 import { startPasskeyRegistration } from '../generated/api-clients/pis'
 
 import { passkeyProviderName } from './passkey-providers'
+import {
+  credentialToJSON,
+  parseCreationOptions,
+  parseRequestOptions
+} from './webauthn-json'
 
 export function passkeysSupported(): boolean {
   return (
     typeof window.PublicKeyCredential !== 'undefined' &&
-    typeof window.PublicKeyCredential.parseCreationOptionsFromJSON ===
-      'function'
+    typeof window.navigator.credentials?.create === 'function'
   )
 }
 
@@ -39,9 +43,7 @@ export async function authPasskeyLogin(
   let credential: Credential | null
   try {
     credential = await navigator.credentials.get({
-      publicKey: PublicKeyCredential.parseRequestOptionsFromJSON(
-        data.options.publicKey
-      ),
+      publicKey: parseRequestOptions(data.options.publicKey),
       mediation,
       signal
     })
@@ -52,12 +54,7 @@ export async function authPasskeyLogin(
   }
   if (!(credential instanceof PublicKeyCredential)) return 'failure'
 
-  // Some password managers (e.g. 1Password) don't include the required `clientExtensionResults`
-  // field in the credential, which causes the backend to reject the login.
-  const credentialJson = credential.toJSON()
-  if (!credentialJson.clientExtensionResults) {
-    credentialJson.clientExtensionResults = {}
-  }
+  const credentialJson = credentialToJSON(credential)
 
   try {
     await client.post('/citizen/auth/passkey-login/finish', {
@@ -93,9 +90,7 @@ export async function createPasskeyCredential(): Promise<PasskeyCreationResult> 
     const optionsJson = JSON.parse(options.credentialsCreate) as {
       publicKey: PublicKeyCredentialCreationOptionsJSON
     }
-    creationOptions = PublicKeyCredential.parseCreationOptionsFromJSON(
-      optionsJson.publicKey
-    )
+    creationOptions = parseCreationOptions(optionsJson.publicKey)
   } catch (e) {
     return { status: 'failure', errorCode: errorCodeOf(e) }
   }
@@ -123,12 +118,7 @@ export async function createPasskeyCredential(): Promise<PasskeyCreationResult> 
     return { status: 'failure', errorCode: undefined }
   }
 
-  // Some password managers (e.g. 1Password) don't include the required `clientExtensionResults`
-  // field in the credential, which causes the backend to reject the registration.
-  const credentialJson = credential.toJSON()
-  if (!credentialJson.clientExtensionResults) {
-    credentialJson.clientExtensionResults = {}
-  }
+  const credentialJson = credentialToJSON(credential)
 
   return {
     status: 'success',

--- a/frontend/src/citizen-frontend/auth/webauthn-json.ts
+++ b/frontend/src/citizen-frontend/auth/webauthn-json.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// The WebAuthn JSON serialization helpers only exist in Safari 18.4, Chrome 129
+// and Firefox 119 onwards, while passkeys themselves work in far older browsers.
+// These wrappers use the native helpers when present and convert by hand otherwise.
+
+function base64UrlToBuffer(value: string): ArrayBuffer {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=')
+  const binary = atob(padded)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes.buffer
+}
+
+function bufferToBase64Url(value: ArrayBuffer): string {
+  const bytes = new Uint8Array(value)
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+// The JSON and non-JSON DOM types differ in enum width, so conversions need a cast.
+// Extension inputs are passed through unconverted, as eVaka requests none.
+const parseDescriptor = (
+  descriptor: PublicKeyCredentialDescriptorJSON
+): PublicKeyCredentialDescriptor =>
+  ({
+    ...descriptor,
+    id: base64UrlToBuffer(descriptor.id)
+  }) as PublicKeyCredentialDescriptor
+
+export function parseCreationOptions(
+  json: PublicKeyCredentialCreationOptionsJSON
+): PublicKeyCredentialCreationOptions {
+  if (typeof PublicKeyCredential.parseCreationOptionsFromJSON === 'function') {
+    return PublicKeyCredential.parseCreationOptionsFromJSON(json)
+  }
+  return {
+    ...json,
+    challenge: base64UrlToBuffer(json.challenge),
+    user: { ...json.user, id: base64UrlToBuffer(json.user.id) },
+    excludeCredentials: json.excludeCredentials?.map(parseDescriptor)
+  } as PublicKeyCredentialCreationOptions
+}
+
+export function parseRequestOptions(
+  json: PublicKeyCredentialRequestOptionsJSON
+): PublicKeyCredentialRequestOptions {
+  if (typeof PublicKeyCredential.parseRequestOptionsFromJSON === 'function') {
+    return PublicKeyCredential.parseRequestOptionsFromJSON(json)
+  }
+  return {
+    ...json,
+    challenge: base64UrlToBuffer(json.challenge),
+    allowCredentials: json.allowCredentials?.map(parseDescriptor)
+  } as PublicKeyCredentialRequestOptions
+}
+
+type CredentialJSON = RegistrationResponseJSON | AuthenticationResponseJSON
+
+function attestationResponseToJSON(
+  response: AuthenticatorAttestationResponse
+): AuthenticatorAttestationResponseJSON {
+  const publicKey =
+    typeof response.getPublicKey === 'function' ? response.getPublicKey() : null
+  return {
+    clientDataJSON: bufferToBase64Url(response.clientDataJSON),
+    attestationObject: bufferToBase64Url(response.attestationObject),
+    transports:
+      typeof response.getTransports === 'function'
+        ? response.getTransports()
+        : [],
+    ...(publicKey ? { publicKey: bufferToBase64Url(publicKey) } : {}),
+    ...(typeof response.getPublicKeyAlgorithm === 'function'
+      ? { publicKeyAlgorithm: response.getPublicKeyAlgorithm() }
+      : {}),
+    ...(typeof response.getAuthenticatorData === 'function'
+      ? {
+          authenticatorData: bufferToBase64Url(response.getAuthenticatorData())
+        }
+      : {})
+  } as AuthenticatorAttestationResponseJSON
+}
+
+function assertionResponseToJSON(
+  response: AuthenticatorAssertionResponse
+): AuthenticatorAssertionResponseJSON {
+  return {
+    clientDataJSON: bufferToBase64Url(response.clientDataJSON),
+    authenticatorData: bufferToBase64Url(response.authenticatorData),
+    signature: bufferToBase64Url(response.signature),
+    userHandle: response.userHandle
+      ? bufferToBase64Url(response.userHandle)
+      : undefined
+  }
+}
+
+export function credentialToJSON(
+  credential: PublicKeyCredential
+): CredentialJSON {
+  const json =
+    typeof credential.toJSON === 'function'
+      ? credential.toJSON()
+      : ({
+          id: credential.id,
+          rawId: bufferToBase64Url(credential.rawId),
+          type: credential.type,
+          ...(credential.authenticatorAttachment
+            ? { authenticatorAttachment: credential.authenticatorAttachment }
+            : {}),
+          response:
+            credential.response instanceof AuthenticatorAttestationResponse
+              ? attestationResponseToJSON(credential.response)
+              : assertionResponseToJSON(
+                  credential.response as AuthenticatorAssertionResponse
+                ),
+          clientExtensionResults: credential.getClientExtensionResults()
+        } as CredentialJSON)
+  // Some password managers (e.g. 1Password) don't include the required `clientExtensionResults`
+  // field in the credential, which causes the backend to reject the ceremony.
+  if (!json.clientExtensionResults) {
+    json.clientExtensionResults = {}
+  }
+  return json
+}


### PR DESCRIPTION
## Ennen tätä muutosta

Pääsyavainten selaintuki tunnistettiin `PublicKeyCredential.parseCreationOptionsFromJSON`-funktion olemassaolosta. Funktio kuuluu WebAuthnin JSON-apufunktioihin, jotka tulivat vasta Safari 18.4:ään, Chrome 129:ään ja Firefox 119:ään. Pääsyavaimet itsessään ovat huomattavasti vanhempia.

Tämän vuoksi kirjautumissivun pääsyavainpainike ja koko pääsyavainosio Omissa tiedoissa piilotettiin selaimilta, jotka kuitenkin tukevat pääsyavaimia.

Kaikille laitteille tilannetta ei voi korjata tilannetta päivittämällä salainta. Esim. 6. sukupolven iPad on pysyvästi iPadOS 17:ään, jossa on vain Safari 17.14.

## Tämän muutoksen jälkeen

Funktiot `parseCreationOptionsFromJSON`, `parseRequestOptionsFromJSON` ja `PublicKeyCredential.toJSON` on kääritty apufunktioihin, jotka käyttävät selaimen omaa toteutusta silloin kun se on saatavilla ja tekevät muunnoksen itse muissa tapauksissa. Tuen tunnistus perustuu nyt WebAuthniin itseensä.

Oma toteutus tuottaa saman rakenteen kuin selaimen natiivi `toJSON`, mukaan lukien backendin vaatiman `clientExtensionResults`-kentän. Samalla 1Passwordia varten tehty kiertotie siirtyi yhteen paikkaan kahden kutsupaikan sijasta.

Todellinen passkeyn alaraja on jatkossa WebAuthn-tuki, eli käytännössä Safari 16 / Chrome 67.

## Testaus

Testattu iPadilla (iPadOS 17.7.11, Safari 17.14).