### PR TITLE
Korjataan kiinnitettyjen elementtien sijainti iOS PWAssa

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -14,7 +14,6 @@ import {
 } from 'lib-components/Notifications'
 import { EnvironmentLabel } from 'lib-components/atoms/EnvironmentLabel'
 import SkipToContent from 'lib-components/atoms/buttons/SkipToContent'
-import { desktopMin, zoomedMobileMax } from 'lib-components/breakpoints'
 import ErrorPage from 'lib-components/molecules/ErrorPage'
 import { LoginErrorModal } from 'lib-components/molecules/modals/LoginErrorModal'
 import SessionExpiredModal from 'lib-components/molecules/modals/SessionExpiredModal'
@@ -30,16 +29,28 @@ import { Localization, useTranslation } from './localization'
 import { MessageContextProvider } from './messages/state'
 import Header from './navigation/Header'
 import MobileNav from './navigation/MobileNav'
-import { mobileBottomNavHeight } from './navigation/const'
 import GlobalDialog from './overlay/GlobalDialog'
 import { OverlayContext, OverlayContextProvider } from './overlay/state'
 import { queryClient, QueryClientProvider } from './query'
 
 const GlobalStyle = createGlobalStyle`
-  @media screen and (max-width: ${zoomedMobileMax}) {
-    html {
-      overflow-x: auto;
-    }
+  html,
+  body {
+    height: 100%;
+  }
+
+  body {
+    overflow: hidden;
+  }
+
+  #app {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    /* Anything with position: fixed resolves against this element instead of
+       the visual viewport, which iOS leaves stale in the installed app after
+       the software keyboard closes and the device is rotated. */
+    transform: translateZ(0);
   }
 `
 
@@ -78,7 +89,8 @@ export function App({ children }: { children: React.ReactNode }) {
 const FullPageContainer = styled.div`
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  flex: 1 1 auto;
+  min-height: 0;
 `
 
 const Content = React.memo(function Content({
@@ -124,7 +136,7 @@ const MainContainer = React.memo(function MainContainer({
   const { user } = useContext(AuthContext)
   const render = useCallback(() => <>{children}</>, [children])
   return (
-    <ScrollableMain aria-hidden={ariaHidden}>
+    <ScrollableMain aria-hidden={ariaHidden} data-scroll-root>
       <UnwrapResult result={user}>{render}</UnwrapResult>
     </ScrollableMain>
   )
@@ -147,10 +159,7 @@ export function HandleRedirection() {
 }
 
 const ScrollableMain = styled.div`
-  flex-grow: 1;
-
-  padding-bottom: ${mobileBottomNavHeight}px;
-  @media (min-width: ${desktopMin}) {
-    padding-bottom: 0;
-  }
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
 `

--- a/frontend/src/citizen-frontend/calendar/DayElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayElem.tsx
@@ -10,7 +10,7 @@ import type { CitizenCalendarEvent } from 'lib-common/generated/api-types/calend
 import type { ReservationResponseDay } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
 import { capitalizeFirstLetter } from 'lib-common/string'
-import { scrollToPos } from 'lib-common/utils/scrolling'
+import { scrollToElement } from 'lib-common/utils/scrolling'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { fontWeights } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -18,7 +18,6 @@ import colors from 'lib-customizations/common'
 import { faCalendar } from 'lib-icons'
 
 import { useLang, useTranslation } from '../localization'
-import { headerHeightMobile } from '../navigation/const'
 
 import {
   CalendarEventCount,
@@ -78,16 +77,8 @@ export default React.memo(function DayElem({
   }, [selectDate, calendarDay.date])
 
   useEffect(() => {
-    const top = ref.current?.getBoundingClientRect().top
-
-    if (top) {
-      // Initial load scrolls smoothly to "today",
-      // subsequent loads to previous months use instant scroll to keep the list position
-      // at the place where "fetch previous" was clicked
-      scrollToPos({
-        top: top - headerHeightMobile - 54,
-        behavior: isToday ? 'smooth' : 'instant'
-      })
+    if (ref.current) {
+      scrollToElement(ref.current)
     }
   }, [isToday, scrollToDate])
 
@@ -147,6 +138,8 @@ export default React.memo(function DayElem({
 const ReservationsContainer = styled.div`
   flex: 1 0 0;
 `
+const monthHeadingHeight = 54
+
 const Day = styled.button<{
   $today: boolean
   $highlight?: 'nonEditableAbsence' | 'holidayPeriod' | undefined
@@ -155,6 +148,8 @@ const Day = styled.button<{
   flex-direction: row;
   width: 100%;
   position: relative;
+  // keeps a day scrolled into view from landing under the sticky month heading
+  scroll-margin-top: ${monthHeadingHeight}px;
   padding: calc(${defaultMargins.s} - 6px) ${defaultMargins.s};
   background: transparent;
   margin: 0;

--- a/frontend/src/citizen-frontend/calendar/MonthElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthElem.tsx
@@ -173,7 +173,7 @@ const WeekTitle = styled(H3)`
 `
 const MonthSummaryContainer = styled.div`
   position: sticky;
-  top: 54px;
+  top: 0;
   z-index: 1;
 
   padding: ${defaultMargins.s};

--- a/frontend/src/citizen-frontend/navigation/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/MobileNav.tsx
@@ -155,9 +155,7 @@ const BottomBar = styled.nav`
   height: ${mobileBottomNavHeight}px;
   width: 100%;
   padding: ${defaultMargins.xs};
-  position: fixed;
-  bottom: 0;
-  left: 0;
+  flex: 0 0 auto;
   box-shadow: 0px -2px 4px rgba(0, 0, 0, 0.15);
 
   @media (min-width: ${desktopMin}) {

--- a/frontend/src/lib-common/utils/scrolling.ts
+++ b/frontend/src/lib-common/utils/scrolling.ts
@@ -26,11 +26,19 @@ export function scrollToRef(
   ref: MutableRefObject<HTMLElement | null>,
   timeout = 0
 ) {
-  scrollWithTimeout(
-    () =>
-      ref.current ? { top: getDocumentOffsetPosition(ref.current) } : undefined,
-    timeout
-  )
+  scrollWithTimeout(() => {
+    const element = ref.current
+    if (!element) return undefined
+    const root = scrollRoot()
+    return root
+      ? {
+          top:
+            element.getBoundingClientRect().top -
+            root.getBoundingClientRect().top +
+            root.scrollTop
+        }
+      : { top: getDocumentOffsetPosition(element) }
+  }, timeout)
 }
 
 export function scrollToElement(
@@ -70,6 +78,12 @@ export function scrollIntoViewSoftKeyboard(
   }, 1000)
 }
 
+// An app that scrolls inside a container instead of the document marks the
+// container with this attribute, because the window level scroll methods have
+// nothing to scroll there.
+const scrollRoot = () =>
+  document.querySelector<HTMLElement>('[data-scroll-root]')
+
 function scrollWithTimeout(
   getOptions: () => ScrollToOptions | undefined,
   timeout = 0,
@@ -80,8 +94,9 @@ function scrollWithTimeout(
   withTimeout(() => {
     const opts = getOptions()
     if (opts) {
-      if (element) {
-        element.scrollTo({ behavior: 'smooth', ...opts })
+      const target = element ?? scrollRoot()
+      if (target) {
+        target.scrollTo({ behavior: 'smooth', ...opts })
       } else {
         window.scrollTo({ behavior: 'smooth', ...opts })
       }


### PR DESCRIPTION
## Ennen tätä muutosta

Kuntalaisen sovelluksessa vieritetään dokumenttia, ja alanavigaatio, kalenterin toimintopainike sekä modaalit on sijoitettu `position: fixed` -säännöllä.

iOS jättää kotinäytölle asennetussa sovelluksessa visual viewportin vanhentuneeksi: kun viestiin vastaa vaakatilassa ja lähettää sen niin että näppäimistö sulkeutuu, ja kääntää laitteen takaisin pystytilaan, viewport jää edellisen asennon korkeuteen. Koska iOS ratkaisee `position: fixed` -elementtien sijainnin visual viewportia vasten, ne siirtyvät `visualViewport.offsetTop`-verran liian ylös — mitattuna 441 px iPhone 11 Prossa ja 256 px iPadissa.

Tila ei korjaannu sivun uudelleenlatauksella eikä pakotetulla uudelleenladonnalla, vaan vasta kun sovellus käynnistetään uudelleen. Selaimessa ongelmaa ei esiinny.

## Tämän muutoksen jälkeen

Dokumenttia ei enää vieritetä: sovelluskehys täyttää ikkunan, sisältöalue vierittyy sen sisällä, ja alanavigaatio on tavallinen flex-elementti `position: fixed` -elementin sijaan. Mikään ei enää katso visual viewportia, joten vanhentunut siirtymä ei vaikuta mihinkään.

`#app` toimii lisäksi containing blockina niille elementeille, jotka yhä käyttävät `position: fixed` -sääntöä. Se kattaa myös portaalien kautta renderöidyt modaalit, jotka ovat sovelluskehyksen sisarelementtejä.

Muut muutokset seuraavat tästä:

- `scrollToPos` ja vastaavat vierittävät `data-scroll-root` -attribuutilla merkittyä säiliötä, koska ikkunatason vierityskutsuilla ei ole mitään vieritettävää säiliötä vierittävässä sovelluksessa. Työntekijän sovellukset eivät merkitse säiliötä, joten ne vierittävät dokumenttia kuten ennenkin.
- Kalenterin kuukausiotsikko kiinnittyy vierityalueen yläreunaan, koska sen päällä ei enää ole sivun otsikkopalkkia. Päivät varaavat otsikolle tilan `scroll-margin-top`-säännöllä sen sijaan, että vierityskohta laskettaisiin käsin.

## Testaus

Testattu etädebuggauksen kautta iPhone 11 Prolla (iOS 26.4.1) ja iPadilla (iPadOS 17.7.11), kun laitteen visual viewport oli vielä vanhentuneessa tilassa:

- alanavigaatio, kalenterin toimintopainike, kuukausiotsikko, päivänäkymä, viestieditori, toimintomodaali ja "Uusi versio eVakasta saatavilla" -ilmoitus sijoittuvat kaikki oikein
- kalenteri vierittyy edelleen kuluvaan päivään

Vielä varmistamatta: työpöytänäkymä, e2e-testit sekä näppäimistön kanssa käytettävä `scrollIntoViewSoftKeyboard`.
