### PR TITLE
Korjataan sticky elementtien sijainti iOS PWAssa v2

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -34,6 +34,7 @@ import { mobileBottomNavHeight } from './navigation/const'
 import GlobalDialog from './overlay/GlobalDialog'
 import { OverlayContext, OverlayContextProvider } from './overlay/state'
 import { InstallSuggestion } from './pwa/InstallSuggestion'
+import { useIsRunningInstalled } from './pwa/installed'
 import { queryClient, QueryClientProvider } from './query'
 
 const GlobalStyle = createGlobalStyle`
@@ -41,6 +42,25 @@ const GlobalStyle = createGlobalStyle`
     html {
       overflow-x: auto;
     }
+  }
+
+  html[data-standalone],
+  html[data-standalone] body {
+    height: 100%;
+  }
+
+  html[data-standalone] body {
+    overflow: hidden;
+  }
+
+  html[data-standalone] #app {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    /* Anything left with position: fixed resolves against this element rather
+       than the viewport iOS misreports, including the modals rendered through
+       the portal containers. */
+    transform: translateZ(0);
   }
 `
 
@@ -80,6 +100,11 @@ const FullPageContainer = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+
+  html[data-standalone] & {
+    min-height: 0;
+    flex: 1 1 auto;
+  }
 `
 
 const Content = React.memo(function Content({
@@ -124,9 +149,13 @@ const MainContainer = React.memo(function MainContainer({
   children: ReactNode
 }) {
   const { user } = useContext(AuthContext)
+  const runningInstalled = useIsRunningInstalled()
   const render = useCallback(() => <>{children}</>, [children])
   return (
-    <ScrollableMain aria-hidden={ariaHidden}>
+    <ScrollableMain
+      aria-hidden={ariaHidden}
+      data-scroll-root={runningInstalled ? '' : undefined}
+    >
       <UnwrapResult result={user}>{render}</UnwrapResult>
     </ScrollableMain>
   )
@@ -153,6 +182,15 @@ const ScrollableMain = styled.div`
 
   padding-bottom: ${mobileBottomNavHeight}px;
   @media (min-width: ${desktopMin}) {
+    padding-bottom: 0;
+  }
+
+  /* The installed app scrolls here instead of scrolling the document, and its
+     navigation is in the layout rather than fixed on top of it. */
+  html[data-standalone] & {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
     padding-bottom: 0;
   }
 `

--- a/frontend/src/citizen-frontend/calendar/DayElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayElem.tsx
@@ -10,7 +10,7 @@ import type { CitizenCalendarEvent } from 'lib-common/generated/api-types/calend
 import type { ReservationResponseDay } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
 import { capitalizeFirstLetter } from 'lib-common/string'
-import { scrollToPos } from 'lib-common/utils/scrolling'
+import { scrollToElement, scrollToPos } from 'lib-common/utils/scrolling'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { fontWeights } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -19,6 +19,7 @@ import { faCalendar } from 'lib-icons'
 
 import { useLang, useTranslation } from '../localization'
 import { headerHeightMobile } from '../navigation/const'
+import { useIsRunningInstalled } from '../pwa/installed'
 
 import {
   CalendarEventCount,
@@ -53,6 +54,7 @@ export default React.memo(function DayElem({
 
   const isToday = calendarDay.date.isToday()
   const isScrollToDate = calendarDay.date.isEqual(scrollToDate)
+  const runningInstalled = useIsRunningInstalled()
 
   const setRef = useCallback(
     (e: HTMLButtonElement) => {
@@ -78,6 +80,10 @@ export default React.memo(function DayElem({
   }, [selectDate, calendarDay.date])
 
   useEffect(() => {
+    if (runningInstalled) {
+      if (ref.current) scrollToElement(ref.current)
+      return
+    }
     const top = ref.current?.getBoundingClientRect().top
 
     if (top) {
@@ -89,7 +95,7 @@ export default React.memo(function DayElem({
         behavior: isToday ? 'smooth' : 'instant'
       })
     }
-  }, [isToday, scrollToDate])
+  }, [isToday, runningInstalled, scrollToDate])
 
   const eventCount = useMemo(
     () => countEventsForDay(events, calendarDay.date),
@@ -155,6 +161,11 @@ const Day = styled.button<{
   flex-direction: row;
   width: 100%;
   position: relative;
+
+  html[data-standalone] & {
+    // keeps a day scrolled into view clear of the sticky month heading
+    scroll-margin-top: 54px;
+  }
   padding: calc(${defaultMargins.s} - 6px) ${defaultMargins.s};
   background: transparent;
   margin: 0;

--- a/frontend/src/citizen-frontend/calendar/MonthElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthElem.tsx
@@ -174,6 +174,10 @@ const WeekTitle = styled(H3)`
 const MonthSummaryContainer = styled.div`
   position: sticky;
   top: 54px;
+
+  html[data-standalone] & {
+    top: 0;
+  }
   z-index: 1;
 
   padding: ${defaultMargins.s};

--- a/frontend/src/citizen-frontend/index.tsx
+++ b/frontend/src/citizen-frontend/index.tsx
@@ -15,6 +15,7 @@ import { appConfig, featureFlags } from 'lib-customizations/citizen'
 import 'leaflet/dist/leaflet.css'
 
 import { listenForInstallPrompt } from './pwa/installPrompt'
+import { trackRunningInstalled } from './pwa/installed'
 import { applyPwaMetadata } from './pwa/metadata'
 import {
   registerServiceWorker,
@@ -40,6 +41,7 @@ smoothScrollPolyfill()
 if (featureFlags.citizenPwa) {
   applyPwaMetadata()
   listenForInstallPrompt()
+  trackRunningInstalled()
 }
 
 const root = createRoot(document.getElementById('app')!)

--- a/frontend/src/citizen-frontend/navigation/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/MobileNav.tsx
@@ -160,6 +160,11 @@ const BottomBar = styled.nav`
   left: 0;
   box-shadow: 0px -2px 4px rgba(0, 0, 0, 0.15);
 
+  html[data-standalone] & {
+    position: static;
+    flex: 0 0 auto;
+  }
+
   @media (min-width: ${desktopMin}) {
     display: none;
   }

--- a/frontend/src/citizen-frontend/pwa/installed.ts
+++ b/frontend/src/citizen-frontend/pwa/installed.ts
@@ -21,3 +21,20 @@ const getIsRunningInstalled = () =>
 export function useIsRunningInstalled(): boolean {
   return useSyncExternalStore(subscribe, getIsRunningInstalled)
 }
+
+/**
+ * Marks the document while the app runs from the home screen, so the layout can
+ * be styled for it. iOS misplaces viewport positioned elements there, which the
+ * installed app avoids by scrolling a container instead of the document. A
+ * browser keeps scrolling the document, because that is what makes it collapse
+ * its own toolbar.
+ */
+export function trackRunningInstalled(): void {
+  const update = () =>
+    document.documentElement.toggleAttribute(
+      'data-standalone',
+      getIsRunningInstalled()
+    )
+  subscribe(update)
+  update()
+}

--- a/frontend/src/lib-common/utils/scrolling.ts
+++ b/frontend/src/lib-common/utils/scrolling.ts
@@ -26,11 +26,19 @@ export function scrollToRef(
   ref: MutableRefObject<HTMLElement | null>,
   timeout = 0
 ) {
-  scrollWithTimeout(
-    () =>
-      ref.current ? { top: getDocumentOffsetPosition(ref.current) } : undefined,
-    timeout
-  )
+  scrollWithTimeout(() => {
+    const element = ref.current
+    if (!element) return undefined
+    const root = scrollRoot()
+    return root
+      ? {
+          top:
+            element.getBoundingClientRect().top -
+            root.getBoundingClientRect().top +
+            root.scrollTop
+        }
+      : { top: getDocumentOffsetPosition(element) }
+  }, timeout)
 }
 
 export function scrollToElement(
@@ -70,6 +78,12 @@ export function scrollIntoViewSoftKeyboard(
   }, 1000)
 }
 
+// An app that scrolls a container instead of the document marks the container
+// with this attribute, because the window level scroll methods have nothing to
+// scroll there.
+const scrollRoot = () =>
+  document.querySelector<HTMLElement>('[data-scroll-root]')
+
 function scrollWithTimeout(
   getOptions: () => ScrollToOptions | undefined,
   timeout = 0,
@@ -80,8 +94,9 @@ function scrollWithTimeout(
   withTimeout(() => {
     const opts = getOptions()
     if (opts) {
-      if (element) {
-        element.scrollTo({ behavior: 'smooth', ...opts })
+      const target = element ?? scrollRoot()
+      if (target) {
+        target.scrollTo({ behavior: 'smooth', ...opts })
       } else {
         window.scrollTo({ behavior: 'smooth', ...opts })
       }


### PR DESCRIPTION
## Ennen tätä muutosta

iOS jättää PWA sovelluksessa visual viewportin dimensiot tietyissä tapauksissa "staleksi". Esim., kun näppäimistö sulkeutuu ja laite käännetään. Koska sekä `position: fixed` että `position: sticky` ratkaistaan vieporttia vasten, alanavigaatio, otsikkopalkki ja modaalit siirtyvät satoja pikseleitä väärään paikkaan. Tila korjaantuu vasta kun sovellus (WebKit moottori) käynnistetään uudelleen.

## Tämän muutoksen jälkeen

Asennettu sovellus täyttää ikkunan ja vierittää **sisältöaluetta**, eikä sticky elementtejä sijoiteta viewportia vasten. Selaimessa vieritetään edelleen dokumenttia, koska se saa selaimen piilottamaan oman alareunaan ankkuroidun työkalupalkkinsa. Muutos on rajattu `html[data-standalone]`-selektoriin, eli selaimessa layouttaus pysyy ennallaan.

Testattu iPhone 11 Prolla (iOS 26.4.1) ja iPadilla (iPadOS 17.7.11) stale viewport-tilassa.

## Upstream bugiraportit

- [WebKit #254861](https://bugs.webkit.org/show_bug.cgi?id=254861) iPadOS: Viewport doesn't correctly restore after dismissing software keyboard for installed web apps
- [WebKit #297779](https://bugs.webkit.org/show_bug.cgi?id=297779) Fixed elements move up and down when the scroll direction changes