### PR TITLE
Korjaa sijoitussuunnitelmasivun vanhentunut lomaketila

### DIFF
--- a/frontend/src/employee-frontend/components/placement-plan/PlacementPlanDraft.tsx
+++ b/frontend/src/employee-frontend/components/placement-plan/PlacementPlanDraft.tsx
@@ -203,15 +203,18 @@ export default React.memo(function PlacementPlanDraft() {
     () => navigate('/applications'),
     [navigate]
   )
-  const initialized = useRef(false)
+  const initializedWithType = useRef<PlacementType | null>(null)
   useEffect(() => {
-    initialized.current = false
+    initializedWithType.current = null
   }, [applicationId])
 
   useEffect(() => {
     const withoutOldPlacements = removeOldPlacements(rawDraft)
-    if (withoutOldPlacements.isSuccess && !initialized.current) {
-      initialized.current = true
+    if (
+      withoutOldPlacements.isSuccess &&
+      initializedWithType.current !== withoutOldPlacements.value.type
+    ) {
+      initializedWithType.current = withoutOldPlacements.value.type
       setPlacementPlanDraft(Success.of(withoutOldPlacements.value))
       const preselectedUnit =
         withoutOldPlacements.value.placementDraft?.unit?.id ?? null

--- a/frontend/src/employee-frontend/components/placement-plan/PlacementPlanDraft.tsx
+++ b/frontend/src/employee-frontend/components/placement-plan/PlacementPlanDraft.tsx
@@ -248,6 +248,7 @@ export default React.memo(function PlacementPlanDraft() {
     placementType === 'PREPARATORY' ||
     placementType === 'PRESCHOOL_DAYCARE' ||
     placementType === 'PRESCHOOL_DAYCARE_ONLY' ||
+    placementType === 'PRESCHOOL_CLUB' ||
     placementType === 'PREPARATORY_DAYCARE'
 
   const preschoolDatesAreValid = useMemo(() => {

--- a/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
@@ -1344,6 +1344,123 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
     }
 
     @Test
+    fun `createPlacementPlan - preschool with daycare fails without a connected period`() {
+        db.transaction { tx ->
+            tx.insertApplication(
+                appliedType = PlacementType.PRESCHOOL_DAYCARE,
+                applicationId = applicationId,
+                preferredStartDate = LocalDate.of(2020, 8, 1),
+            )
+            service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, AuditContext(), applicationId)
+        }
+        db.transaction { tx ->
+            assertThrows<BadRequest> {
+                service.createPlacementPlan(
+                    tx,
+                    serviceWorker,
+                    clock,
+                    AuditContext(),
+                    applicationId,
+                    DaycarePlacementPlan(
+                        unitId = daycare.id,
+                        period = mainPeriod,
+                        preschoolDaycarePeriod = null,
+                    ),
+                )
+            }
+        }
+        db.read { tx ->
+            assertNull(tx.getPlacementPlan(applicationId))
+            assertEquals(
+                ApplicationStatus.WAITING_PLACEMENT,
+                tx.fetchApplicationDetails(applicationId)!!.status,
+            )
+        }
+    }
+
+    @Test
+    fun `createPlacementPlan - preparatory with daycare fails without a connected period`() {
+        db.transaction { tx ->
+            tx.insertApplication(
+                appliedType = PlacementType.PREPARATORY_DAYCARE,
+                applicationId = applicationId,
+                preferredStartDate = LocalDate.of(2020, 8, 1),
+            )
+            service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, AuditContext(), applicationId)
+        }
+        db.transaction { tx ->
+            assertThrows<BadRequest> {
+                service.createPlacementPlan(
+                    tx,
+                    serviceWorker,
+                    clock,
+                    AuditContext(),
+                    applicationId,
+                    DaycarePlacementPlan(
+                        unitId = daycare.id,
+                        period = mainPeriod,
+                        preschoolDaycarePeriod = null,
+                    ),
+                )
+            }
+        }
+        db.read { tx ->
+            assertNull(tx.getPlacementPlan(applicationId))
+            assertEquals(
+                ApplicationStatus.WAITING_PLACEMENT,
+                tx.fetchApplicationDetails(applicationId)!!.status,
+            )
+        }
+    }
+
+    @Test
+    fun `createPlacementPlan - preschool with club fails without a connected period`() {
+        db.transaction { tx ->
+            val serviceNeedOption =
+                ServiceNeedOption(
+                    id = snPreschoolClub45.id,
+                    nameFi = snPreschoolClub45.nameFi,
+                    nameSv = snPreschoolClub45.nameSv,
+                    nameEn = snPreschoolClub45.nameEn,
+                    validPlacementType = PlacementType.PRESCHOOL_CLUB,
+                )
+            tx.insertApplication(
+                appliedType = PlacementType.PRESCHOOL_CLUB,
+                applicationId = applicationId,
+                preferredStartDate = LocalDate.of(2020, 8, 1),
+                serviceNeedOption = serviceNeedOption,
+            )
+            service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, AuditContext(), applicationId)
+        }
+        db.transaction { tx ->
+            assertThrows<BadRequest> {
+                service.createPlacementPlan(
+                    tx,
+                    serviceWorker,
+                    clock,
+                    AuditContext(),
+                    applicationId,
+                    DaycarePlacementPlan(
+                        unitId = daycare.id,
+                        period = mainPeriod,
+                        preschoolDaycarePeriod = null,
+                    ),
+                )
+            }
+        }
+        db.read { tx ->
+            assertNull(tx.getPlacementPlan(applicationId))
+            assertEquals(
+                ApplicationStatus.WAITING_PLACEMENT,
+                tx.fetchApplicationDetails(applicationId)!!.status,
+            )
+        }
+    }
+
+    @Test
     fun `cancelPlacementPlan - removes placement plan and decision drafts and changes status`() {
         db.transaction { tx ->
             // given

--- a/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
@@ -1344,6 +1344,87 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
     }
 
     @Test
+    fun `createPlacementPlan - preparatory with daycare`() {
+        db.transaction { tx ->
+            // given
+            tx.insertApplication(
+                appliedType = PlacementType.PREPARATORY_DAYCARE,
+                applicationId = applicationId,
+                preferredStartDate = LocalDate.of(2020, 8, 1),
+            )
+            service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
+            service.moveToWaitingPlacement(tx, serviceWorker, clock, AuditContext(), applicationId)
+        }
+        db.transaction { tx ->
+            // when
+            service.createPlacementPlan(
+                tx,
+                serviceWorker,
+                clock,
+                AuditContext(),
+                applicationId,
+                DaycarePlacementPlan(
+                    unitId = daycare.id,
+                    period = mainPeriod,
+                    preschoolDaycarePeriod = connectedPeriod,
+                ),
+            )
+        }
+        db.read { tx ->
+            // then
+            val application = tx.fetchApplicationDetails(applicationId)!!
+            assertEquals(ApplicationStatus.WAITING_DECISION, application.status)
+
+            val placementPlan = tx.getPlacementPlan(applicationId)!!
+            assertEquals(
+                PlacementPlan(
+                    id = placementPlan.id,
+                    unitId = daycare.id,
+                    applicationId = applicationId,
+                    type = PlacementType.PREPARATORY_DAYCARE,
+                    period = mainPeriod,
+                    preschoolDaycarePeriod = connectedPeriod,
+                ),
+                placementPlan,
+            )
+
+            val decisionDrafts = tx.fetchDecisionDrafts(applicationId)
+            assertEquals(2, decisionDrafts.size)
+
+            decisionDrafts
+                .find { it.type == DecisionType.PREPARATORY_EDUCATION }!!
+                .let {
+                    assertEquals(
+                        DecisionDraft(
+                            id = it.id,
+                            type = DecisionType.PREPARATORY_EDUCATION,
+                            startDate = mainPeriod.start,
+                            endDate = mainPeriod.end,
+                            unitId = daycare.id,
+                            planned = true,
+                        ),
+                        it,
+                    )
+                }
+            decisionDrafts
+                .find { it.type == DecisionType.PRESCHOOL_DAYCARE }!!
+                .let {
+                    assertEquals(
+                        DecisionDraft(
+                            id = it.id,
+                            type = DecisionType.PRESCHOOL_DAYCARE,
+                            startDate = connectedPeriod.start,
+                            endDate = connectedPeriod.end,
+                            unitId = daycare.id,
+                            planned = true,
+                        ),
+                        it,
+                    )
+                }
+        }
+    }
+
+    @Test
     fun `createPlacementPlan - preschool with daycare fails without a connected period`() {
         db.transaction { tx ->
             tx.insertApplication(

--- a/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/application/ApplicationStateServiceIntegrationTests.kt
@@ -94,6 +94,7 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
 import java.util.UUID
+import java.util.stream.Stream
 import kotlin.enums.enumEntries
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -105,7 +106,19 @@ import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
+
+data class ConnectedPlacementPlanTestCase(
+    val appliedType: PlacementType,
+    val primaryDecision: DecisionType,
+    val connectedDecision: DecisionType,
+    val serviceNeedOption: ServiceNeedOption? = null,
+) {
+    override fun toString() = appliedType.name
+}
 
 class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBeforeEach = true) {
     @Autowired private lateinit var attachmentsController: AttachmentsController
@@ -1172,14 +1185,51 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         }
     }
 
-    @Test
-    fun `createPlacementPlan - preschool with daycare`() {
+    @Suppress("unused")
+    fun connectedPlacementPlanCases(): Stream<Arguments> =
+        listOf(
+                Arguments.of(
+                    ConnectedPlacementPlanTestCase(
+                        appliedType = PlacementType.PRESCHOOL_DAYCARE,
+                        primaryDecision = DecisionType.PRESCHOOL,
+                        connectedDecision = DecisionType.PRESCHOOL_DAYCARE,
+                    )
+                ),
+                Arguments.of(
+                    ConnectedPlacementPlanTestCase(
+                        appliedType = PlacementType.PRESCHOOL_CLUB,
+                        primaryDecision = DecisionType.PRESCHOOL,
+                        connectedDecision = DecisionType.PRESCHOOL_CLUB,
+                        serviceNeedOption =
+                            ServiceNeedOption(
+                                id = snPreschoolClub45.id,
+                                nameFi = snPreschoolClub45.nameFi,
+                                nameSv = snPreschoolClub45.nameSv,
+                                nameEn = snPreschoolClub45.nameEn,
+                                validPlacementType = PlacementType.PRESCHOOL_CLUB,
+                            ),
+                    )
+                ),
+                Arguments.of(
+                    ConnectedPlacementPlanTestCase(
+                        appliedType = PlacementType.PREPARATORY_DAYCARE,
+                        primaryDecision = DecisionType.PREPARATORY_EDUCATION,
+                        connectedDecision = DecisionType.PRESCHOOL_DAYCARE,
+                    )
+                ),
+            )
+            .stream()
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("connectedPlacementPlanCases")
+    fun `createPlacementPlan - connected placement type`(test: ConnectedPlacementPlanTestCase) {
         db.transaction { tx ->
             // given
             tx.insertApplication(
-                appliedType = PlacementType.PRESCHOOL_DAYCARE,
+                appliedType = test.appliedType,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1),
+                serviceNeedOption = test.serviceNeedOption,
             )
             service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, clock, AuditContext(), applicationId)
@@ -1210,7 +1260,7 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
                     id = placementPlan.id,
                     unitId = daycare.id,
                     applicationId = applicationId,
-                    type = PlacementType.PRESCHOOL_DAYCARE,
+                    type = test.appliedType,
                     period = mainPeriod,
                     preschoolDaycarePeriod = connectedPeriod,
                 ),
@@ -1219,218 +1269,22 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
 
             val decisionDrafts = tx.fetchDecisionDrafts(applicationId)
             assertEquals(2, decisionDrafts.size)
-
-            decisionDrafts
-                .find { it.type == DecisionType.PRESCHOOL }!!
-                .let {
-                    assertEquals(
-                        DecisionDraft(
-                            id = it.id,
-                            type = DecisionType.PRESCHOOL,
-                            startDate = mainPeriod.start,
-                            endDate = mainPeriod.end,
-                            unitId = daycare.id,
-                            planned = true,
-                        ),
-                        it,
-                    )
-                }
-            decisionDrafts
-                .find { it.type == DecisionType.PRESCHOOL_DAYCARE }!!
-                .let {
-                    assertEquals(
-                        DecisionDraft(
-                            id = it.id,
-                            type = DecisionType.PRESCHOOL_DAYCARE,
-                            startDate = connectedPeriod.start,
-                            endDate = connectedPeriod.end,
-                            unitId = daycare.id,
-                            planned = true,
-                        ),
-                        it,
-                    )
-                }
+            assertDecisionDraft(decisionDrafts, test.primaryDecision, mainPeriod)
+            assertDecisionDraft(decisionDrafts, test.connectedDecision, connectedPeriod)
         }
     }
 
-    @Test
-    fun `createPlacementPlan - preschool with club`() {
-        db.transaction { tx ->
-            // given
-            val serviceNeedOption =
-                ServiceNeedOption(
-                    id = snPreschoolClub45.id,
-                    nameFi = snPreschoolClub45.nameFi,
-                    nameSv = snPreschoolClub45.nameSv,
-                    nameEn = snPreschoolClub45.nameEn,
-                    validPlacementType = PlacementType.PRESCHOOL_CLUB,
-                )
-            tx.insertApplication(
-                appliedType = PlacementType.PRESCHOOL_CLUB,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1),
-                serviceNeedOption = serviceNeedOption,
-            )
-            service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
-            service.moveToWaitingPlacement(tx, serviceWorker, clock, AuditContext(), applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.createPlacementPlan(
-                tx,
-                serviceWorker,
-                clock,
-                AuditContext(),
-                applicationId,
-                DaycarePlacementPlan(
-                    unitId = daycare.id,
-                    period = mainPeriod,
-                    preschoolDaycarePeriod = connectedPeriod,
-                ),
-            )
-        }
-        db.read { tx ->
-            // then
-            val application = tx.fetchApplicationDetails(applicationId)!!
-            assertEquals(ApplicationStatus.WAITING_DECISION, application.status)
-
-            val placementPlan = tx.getPlacementPlan(applicationId)!!
-            assertEquals(
-                PlacementPlan(
-                    id = placementPlan.id,
-                    unitId = daycare.id,
-                    applicationId = applicationId,
-                    type = PlacementType.PRESCHOOL_CLUB,
-                    period = mainPeriod,
-                    preschoolDaycarePeriod = connectedPeriod,
-                ),
-                placementPlan,
-            )
-
-            val decisionDrafts = tx.fetchDecisionDrafts(applicationId)
-            assertEquals(2, decisionDrafts.size)
-
-            decisionDrafts
-                .find { it.type == DecisionType.PRESCHOOL }!!
-                .let {
-                    assertEquals(
-                        DecisionDraft(
-                            id = it.id,
-                            type = DecisionType.PRESCHOOL,
-                            startDate = mainPeriod.start,
-                            endDate = mainPeriod.end,
-                            unitId = daycare.id,
-                            planned = true,
-                        ),
-                        it,
-                    )
-                }
-            decisionDrafts
-                .find { it.type == DecisionType.PRESCHOOL_CLUB }!!
-                .let {
-                    assertEquals(
-                        DecisionDraft(
-                            id = it.id,
-                            type = DecisionType.PRESCHOOL_CLUB,
-                            startDate = connectedPeriod.start,
-                            endDate = connectedPeriod.end,
-                            unitId = daycare.id,
-                            planned = true,
-                        ),
-                        it,
-                    )
-                }
-        }
-    }
-
-    @Test
-    fun `createPlacementPlan - preparatory with daycare`() {
-        db.transaction { tx ->
-            // given
-            tx.insertApplication(
-                appliedType = PlacementType.PREPARATORY_DAYCARE,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1),
-            )
-            service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
-            service.moveToWaitingPlacement(tx, serviceWorker, clock, AuditContext(), applicationId)
-        }
-        db.transaction { tx ->
-            // when
-            service.createPlacementPlan(
-                tx,
-                serviceWorker,
-                clock,
-                AuditContext(),
-                applicationId,
-                DaycarePlacementPlan(
-                    unitId = daycare.id,
-                    period = mainPeriod,
-                    preschoolDaycarePeriod = connectedPeriod,
-                ),
-            )
-        }
-        db.read { tx ->
-            // then
-            val application = tx.fetchApplicationDetails(applicationId)!!
-            assertEquals(ApplicationStatus.WAITING_DECISION, application.status)
-
-            val placementPlan = tx.getPlacementPlan(applicationId)!!
-            assertEquals(
-                PlacementPlan(
-                    id = placementPlan.id,
-                    unitId = daycare.id,
-                    applicationId = applicationId,
-                    type = PlacementType.PREPARATORY_DAYCARE,
-                    period = mainPeriod,
-                    preschoolDaycarePeriod = connectedPeriod,
-                ),
-                placementPlan,
-            )
-
-            val decisionDrafts = tx.fetchDecisionDrafts(applicationId)
-            assertEquals(2, decisionDrafts.size)
-
-            decisionDrafts
-                .find { it.type == DecisionType.PREPARATORY_EDUCATION }!!
-                .let {
-                    assertEquals(
-                        DecisionDraft(
-                            id = it.id,
-                            type = DecisionType.PREPARATORY_EDUCATION,
-                            startDate = mainPeriod.start,
-                            endDate = mainPeriod.end,
-                            unitId = daycare.id,
-                            planned = true,
-                        ),
-                        it,
-                    )
-                }
-            decisionDrafts
-                .find { it.type == DecisionType.PRESCHOOL_DAYCARE }!!
-                .let {
-                    assertEquals(
-                        DecisionDraft(
-                            id = it.id,
-                            type = DecisionType.PRESCHOOL_DAYCARE,
-                            startDate = connectedPeriod.start,
-                            endDate = connectedPeriod.end,
-                            unitId = daycare.id,
-                            planned = true,
-                        ),
-                        it,
-                    )
-                }
-        }
-    }
-
-    @Test
-    fun `createPlacementPlan - preschool with daycare fails without a connected period`() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("connectedPlacementPlanCases")
+    fun `createPlacementPlan - connected placement type fails without a connected period`(
+        test: ConnectedPlacementPlanTestCase
+    ) {
         db.transaction { tx ->
             tx.insertApplication(
-                appliedType = PlacementType.PRESCHOOL_DAYCARE,
+                appliedType = test.appliedType,
                 applicationId = applicationId,
                 preferredStartDate = LocalDate.of(2020, 8, 1),
+                serviceNeedOption = test.serviceNeedOption,
             )
             service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
             service.moveToWaitingPlacement(tx, serviceWorker, clock, AuditContext(), applicationId)
@@ -1460,85 +1314,23 @@ class ApplicationStateServiceIntegrationTests : FullApplicationTest(resetDbBefor
         }
     }
 
-    @Test
-    fun `createPlacementPlan - preparatory with daycare fails without a connected period`() {
-        db.transaction { tx ->
-            tx.insertApplication(
-                appliedType = PlacementType.PREPARATORY_DAYCARE,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1),
-            )
-            service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
-            service.moveToWaitingPlacement(tx, serviceWorker, clock, AuditContext(), applicationId)
-        }
-        db.transaction { tx ->
-            assertThrows<BadRequest> {
-                service.createPlacementPlan(
-                    tx,
-                    serviceWorker,
-                    clock,
-                    AuditContext(),
-                    applicationId,
-                    DaycarePlacementPlan(
-                        unitId = daycare.id,
-                        period = mainPeriod,
-                        preschoolDaycarePeriod = null,
-                    ),
-                )
-            }
-        }
-        db.read { tx ->
-            assertNull(tx.getPlacementPlan(applicationId))
-            assertEquals(
-                ApplicationStatus.WAITING_PLACEMENT,
-                tx.fetchApplicationDetails(applicationId)!!.status,
-            )
-        }
-    }
-
-    @Test
-    fun `createPlacementPlan - preschool with club fails without a connected period`() {
-        db.transaction { tx ->
-            val serviceNeedOption =
-                ServiceNeedOption(
-                    id = snPreschoolClub45.id,
-                    nameFi = snPreschoolClub45.nameFi,
-                    nameSv = snPreschoolClub45.nameSv,
-                    nameEn = snPreschoolClub45.nameEn,
-                    validPlacementType = PlacementType.PRESCHOOL_CLUB,
-                )
-            tx.insertApplication(
-                appliedType = PlacementType.PRESCHOOL_CLUB,
-                applicationId = applicationId,
-                preferredStartDate = LocalDate.of(2020, 8, 1),
-                serviceNeedOption = serviceNeedOption,
-            )
-            service.sendApplication(tx, serviceWorker, clock, AuditContext(), applicationId)
-            service.moveToWaitingPlacement(tx, serviceWorker, clock, AuditContext(), applicationId)
-        }
-        db.transaction { tx ->
-            assertThrows<BadRequest> {
-                service.createPlacementPlan(
-                    tx,
-                    serviceWorker,
-                    clock,
-                    AuditContext(),
-                    applicationId,
-                    DaycarePlacementPlan(
-                        unitId = daycare.id,
-                        period = mainPeriod,
-                        preschoolDaycarePeriod = null,
-                    ),
-                )
-            }
-        }
-        db.read { tx ->
-            assertNull(tx.getPlacementPlan(applicationId))
-            assertEquals(
-                ApplicationStatus.WAITING_PLACEMENT,
-                tx.fetchApplicationDetails(applicationId)!!.status,
-            )
-        }
+    private fun assertDecisionDraft(
+        drafts: List<DecisionDraft>,
+        type: DecisionType,
+        period: FiniteDateRange,
+    ) {
+        val draft = drafts.find { it.type == type }!!
+        assertEquals(
+            DecisionDraft(
+                id = draft.id,
+                type = type,
+                startDate = period.start,
+                endDate = period.end,
+                unitId = daycare.id,
+                planned = true,
+            ),
+            draft,
+        )
     }
 
     @Test

--- a/service/src/integrationTest/kotlin/evaka/core/decision/DecisionResolutionIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/decision/DecisionResolutionIntegrationTest.kt
@@ -269,6 +269,62 @@ class DecisionResolutionIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("testCases")
+    fun testPreschoolClubFull(test: DecisionResolutionTestCase) {
+        val period = FiniteDateRange(LocalDate.of(2020, 8, 15), LocalDate.of(2021, 6, 4))
+        val preschoolDaycarePeriod =
+            FiniteDateRange(LocalDate.of(2020, 8, 1), LocalDate.of(2021, 6, 4))
+        val ids =
+            insertInitialData(
+                status = ApplicationStatus.WAITING_CONFIRMATION,
+                type = PlacementType.PRESCHOOL_CLUB,
+                period = period,
+                preschoolDaycarePeriod = preschoolDaycarePeriod,
+            )
+        val user = if (test.isServiceWorker) serviceWorker else endUser
+        if (test.isAccept) {
+            acceptDecisionAndAssert(user, applicationId, ids.primaryId!!, period.start)
+            db.read { r ->
+                assertEquals(
+                    ApplicationStatus.WAITING_CONFIRMATION,
+                    r.getApplicationStatus(ids.applicationId),
+                )
+                r.getPlacementRowsByChild(child.id).exactlyOne().also {
+                    assertEquals(PlacementType.PRESCHOOL, it.type)
+                    assertEquals(daycare.id, it.unitId)
+                    assertEquals(period, it.period())
+                }
+            }
+            acceptDecisionAndAssert(
+                user,
+                applicationId,
+                ids.preschoolDaycareId!!,
+                preschoolDaycarePeriod.start,
+            )
+            db.read { r ->
+                assertEquals(ApplicationStatus.ACTIVE, r.getApplicationStatus(ids.applicationId))
+                r.getPlacementRowsByChild(child.id).exactlyOne().also {
+                    assertEquals(PlacementType.PRESCHOOL_CLUB, it.type)
+                    assertEquals(daycare.id, it.unitId)
+                    assertEquals(preschoolDaycarePeriod, it.period())
+                }
+                assertTrue(r.getPlacementPlanRowByApplication(ids.applicationId).deleted)
+            }
+        } else {
+            rejectDecisionAndAssert(user, applicationId, ids.primaryId!!)
+            db.read { r ->
+                assertEquals(ApplicationStatus.REJECTED, r.getApplicationStatus(ids.applicationId))
+                assertTrue(r.getPlacementRowsByChild(child.id).toList().isEmpty())
+                assertTrue(
+                    r.getDecisionRowsByApplication(ids.applicationId).toList().all {
+                        it.status == DecisionStatus.REJECTED
+                    }
+                )
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("testCases")
     fun testPreparatoryFull(test: DecisionResolutionTestCase) {
         val period = FiniteDateRange(LocalDate.of(2020, 8, 15), LocalDate.of(2021, 6, 4))
         val preschoolDaycarePeriod =
@@ -465,8 +521,7 @@ class DecisionResolutionIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         preschoolDaycarePeriod: FiniteDateRange? = null,
         preschoolDaycareWithoutPreschool: Boolean = false,
     ): DataIdentifiers = db.transaction { tx ->
-        val preschoolDaycare =
-            type in listOf(PlacementType.PRESCHOOL_DAYCARE, PlacementType.PREPARATORY_DAYCARE)
+        val preschoolDaycare = type.hasConnectedDaycare()
         tx.insertTestApplication(
             id = applicationId,
             status = status,
@@ -572,7 +627,9 @@ class DecisionResolutionIntegrationTest : FullApplicationTest(resetDbBeforeEach 
                     createdBy = employee.evakaUserId,
                     unitId = unit.id,
                     applicationId = applicationId,
-                    type = DecisionType.PRESCHOOL_DAYCARE,
+                    type =
+                        if (type == PlacementType.PRESCHOOL_CLUB) DecisionType.PRESCHOOL_CLUB
+                        else DecisionType.PRESCHOOL_DAYCARE,
                     startDate = it.start,
                     endDate = it.end,
                 )

--- a/service/src/integrationTest/kotlin/evaka/core/occupancy/OccupancyControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/occupancy/OccupancyControllerIntegrationTest.kt
@@ -49,6 +49,7 @@ import evaka.core.shared.dev.DevStaffAttendance
 import evaka.core.shared.dev.insert
 import evaka.core.shared.dev.insertApplication
 import evaka.core.shared.dev.insertTestApplication
+import evaka.core.shared.domain.BadRequest
 import evaka.core.shared.domain.FiniteDateRange
 import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.domain.MockEvakaClock
@@ -59,6 +60,7 @@ import java.util.UUID
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 
 class OccupancyControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach = true) {
@@ -1258,6 +1260,21 @@ class OccupancyControllerIntegrationTest : FullApplicationTest(resetDbBeforeEach
             ),
             occupanciesForGroup1,
         )
+    }
+
+    @Test
+    fun `Connected daycare application without a preschool daycare period is rejected`() {
+        val applicationId =
+            createApplication(child1.id, ApplicationType.PRESCHOOL, connectedDaycare = true)
+
+        assertThrows<BadRequest> {
+            getSpeculatedOccupancies(
+                daycare.id,
+                applicationId,
+                period = FiniteDateRange(startDate, endDate),
+                preschoolDaycarePeriod = null,
+            )
+        }
     }
 
     private fun createApplication(

--- a/service/src/main/kotlin/evaka/core/application/ApplicationStateService.kt
+++ b/service/src/main/kotlin/evaka/core/application/ApplicationStateService.kt
@@ -1045,36 +1045,30 @@ class ApplicationStateService(
                 ?: throw IllegalStateException("Application $applicationId has no placement plan")
 
         val extent =
-            when (plan.type) {
-                PlacementType.PRESCHOOL_DAYCARE,
-                PlacementType.PRESCHOOL_CLUB,
-                PlacementType.PREPARATORY_DAYCARE -> {
-                    when (decision.type) {
-                        DecisionType.PRESCHOOL,
-                        DecisionType.PREPARATORY_EDUCATION -> {
-                            PlacementPlanExtent.OnlyPreschool(
-                                plan.period.copy(start = requestedStartDate)
-                            )
-                        }
+            if (plan.type.hasConnectedDaycare()) {
+                when (decision.type) {
+                    DecisionType.PRESCHOOL,
+                    DecisionType.PREPARATORY_EDUCATION -> {
+                        PlacementPlanExtent.OnlyPreschool(
+                            plan.period.copy(start = requestedStartDate)
+                        )
+                    }
 
-                        DecisionType.PRESCHOOL_DAYCARE,
-                        DecisionType.PRESCHOOL_CLUB -> {
-                            PlacementPlanExtent.OnlyPreschoolDaycare(
-                                plan.preschoolDaycarePeriod!!.copy(start = requestedStartDate)
-                            )
-                        }
+                    DecisionType.PRESCHOOL_DAYCARE,
+                    DecisionType.PRESCHOOL_CLUB -> {
+                        PlacementPlanExtent.OnlyPreschoolDaycare(
+                            plan.preschoolDaycarePeriod!!.copy(start = requestedStartDate)
+                        )
+                    }
 
-                        else -> {
-                            throw IllegalStateException(
-                                "Placement plan ${plan.id} has type ${plan.type} but decision ${decision.id} has type ${decision.type}"
-                            )
-                        }
+                    else -> {
+                        throw IllegalStateException(
+                            "Placement plan ${plan.id} has type ${plan.type} but decision ${decision.id} has type ${decision.type}"
+                        )
                     }
                 }
-
-                else -> {
-                    PlacementPlanExtent.FullSingle(plan.period.copy(start = requestedStartDate))
-                }
+            } else {
+                PlacementPlanExtent.FullSingle(plan.period.copy(start = requestedStartDate))
             }
 
         // everything validated now!

--- a/service/src/main/kotlin/evaka/core/decision/DecisionDraftService.kt
+++ b/service/src/main/kotlin/evaka/core/decision/DecisionDraftService.kt
@@ -298,16 +298,8 @@ private fun planPreschoolDecisionDrafts(
             planned = primaryPlanned,
         )
 
-    val appliedForConnectedCare =
-        plan.type in
-            listOf(
-                PlacementType.PRESCHOOL_DAYCARE,
-                PlacementType.PRESCHOOL_CLUB,
-                PlacementType.PREPARATORY_DAYCARE,
-            )
-
     val connected =
-        if (appliedForConnectedCare)
+        if (plan.type.hasConnectedDaycare())
             DecisionDraft(
                 id = DecisionId(UUID.randomUUID()), // placeholder
                 unitId = plan.unitId,

--- a/service/src/main/kotlin/evaka/core/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/evaka/core/placement/PlacementPlanService.kt
@@ -19,10 +19,12 @@ import evaka.core.shared.ChildId
 import evaka.core.shared.DaycareId
 import evaka.core.shared.EvakaUserId
 import evaka.core.shared.FeatureConfig
+import evaka.core.shared.PlacementPlanId
 import evaka.core.shared.async.AsyncJob
 import evaka.core.shared.async.AsyncJobRunner
 import evaka.core.shared.data.DateSet
 import evaka.core.shared.db.Database
+import evaka.core.shared.domain.BadRequest
 import evaka.core.shared.domain.Conflict
 import evaka.core.shared.domain.EvakaClock
 import evaka.core.shared.domain.FiniteDateRange
@@ -211,7 +213,20 @@ class PlacementPlanService(
         tx: Database.Transaction,
         application: ApplicationDetails,
         placementPlan: DaycarePlacementPlan,
-    ) = tx.createPlacementPlan(application.id, application.derivePlacementType(), placementPlan)
+    ): PlacementPlanId {
+        val type = application.derivePlacementType()
+        if (
+            type in
+                listOf(
+                    PlacementType.PRESCHOOL_DAYCARE,
+                    PlacementType.PRESCHOOL_CLUB,
+                    PlacementType.PREPARATORY_DAYCARE,
+                ) && placementPlan.preschoolDaycarePeriod == null
+        ) {
+            throw BadRequest("Placement plan of type $type requires a preschool daycare period")
+        }
+        return tx.createPlacementPlan(application.id, type, placementPlan)
+    }
 
     fun getPlacementTypePeriods(
         tx: Database.Read,
@@ -357,7 +372,13 @@ class PlacementPlanService(
                     PlacementType.PRESCHOOL_DAYCARE,
                     PlacementType.PRESCHOOL_CLUB,
                     PlacementType.PREPARATORY_DAYCARE -> {
-                        PlacementPlanExtent.FullDouble(period, preschoolDaycarePeriod!!)
+                        PlacementPlanExtent.FullDouble(
+                            period,
+                            preschoolDaycarePeriod
+                                ?: throw BadRequest(
+                                    "Placement type $placementType requires a preschool daycare period"
+                                ),
+                        )
                     }
 
                     else -> {

--- a/service/src/main/kotlin/evaka/core/placement/PlacementPlanService.kt
+++ b/service/src/main/kotlin/evaka/core/placement/PlacementPlanService.kt
@@ -215,14 +215,7 @@ class PlacementPlanService(
         placementPlan: DaycarePlacementPlan,
     ): PlacementPlanId {
         val type = application.derivePlacementType()
-        if (
-            type in
-                listOf(
-                    PlacementType.PRESCHOOL_DAYCARE,
-                    PlacementType.PRESCHOOL_CLUB,
-                    PlacementType.PREPARATORY_DAYCARE,
-                ) && placementPlan.preschoolDaycarePeriod == null
-        ) {
+        if (type.hasConnectedDaycare() && placementPlan.preschoolDaycarePeriod == null) {
             throw BadRequest("Placement plan of type $type requires a preschool daycare period")
         }
         return tx.createPlacementPlan(application.id, type, placementPlan)
@@ -368,22 +361,16 @@ class PlacementPlanService(
                 application.childId,
                 unit.id,
                 placementType,
-                when (placementType) {
-                    PlacementType.PRESCHOOL_DAYCARE,
-                    PlacementType.PRESCHOOL_CLUB,
-                    PlacementType.PREPARATORY_DAYCARE -> {
-                        PlacementPlanExtent.FullDouble(
-                            period,
-                            preschoolDaycarePeriod
-                                ?: throw BadRequest(
-                                    "Placement type $placementType requires a preschool daycare period"
-                                ),
-                        )
-                    }
-
-                    else -> {
-                        PlacementPlanExtent.FullSingle(period)
-                    }
+                if (placementType.hasConnectedDaycare()) {
+                    PlacementPlanExtent.FullDouble(
+                        period,
+                        preschoolDaycarePeriod
+                            ?: throw BadRequest(
+                                "Placement type $placementType requires a preschool daycare period"
+                            ),
+                    )
+                } else {
+                    PlacementPlanExtent.FullSingle(period)
                 },
             )
 

--- a/service/src/main/kotlin/evaka/core/placement/PlacementType.kt
+++ b/service/src/main/kotlin/evaka/core/placement/PlacementType.kt
@@ -49,6 +49,26 @@ enum class PlacementType : DatabaseEnum {
             PREPARATORY_DAYCARE -> true
         }
 
+    fun hasConnectedDaycare(): Boolean =
+        when (this) {
+            PRESCHOOL_DAYCARE,
+            PRESCHOOL_CLUB,
+            PREPARATORY_DAYCARE -> true
+
+            CLUB,
+            DAYCARE,
+            DAYCARE_PART_TIME,
+            DAYCARE_FIVE_YEAR_OLDS,
+            DAYCARE_PART_TIME_FIVE_YEAR_OLDS,
+            PRESCHOOL,
+            PRESCHOOL_DAYCARE_ONLY,
+            PREPARATORY,
+            PREPARATORY_DAYCARE_ONLY,
+            TEMPORARY_DAYCARE,
+            TEMPORARY_DAYCARE_PART_DAY,
+            SCHOOL_SHIFT_CARE -> false
+        }
+
     fun isInvoiced(): Boolean =
         when (this) {
             CLUB -> false


### PR DESCRIPTION
## Ennen tätä muutosta

Sijoitussuunnitelmasivun lomake alustettiin luonnoksen tiedoilla vain kerran hakemusta
kohden. Jos luonnoksen sijoitustyyppi ehti vaihtua sivun ollessa auki — esimerkiksi kun
samaa hakemusta käsiteltiin kahdessa selainvälilehdessä — lomakkeeseen jäi edellisen
sijoitustyypin mukainen tila.

Kerhohakemukset puuttuivat liittyvän varhaiskasvatuksen päivämäärien tarkistuksesta, joten
lähetyspainike pysyi käytettävissä, vaikka jakson päivämäärät oli tyhjennetty.

Palvelin ei estänyt sijoitussuunnitelman tallentamista, vaikka pyynnöstä puuttui liittyvän
varhaiskasvatuksen jakso. Tietokannan rajoite kattaa vain esiopetuksen ja liittyvän
varhaiskasvatuksen, joten kerhon ja valmistavan opetuksen sijoitussuunnitelmat saattoivat
tallentua ilman jaksoa, jolloin liittyvän varhaiskasvatuksen päätös käytti esiopetuksen
jaksoa. Täyttöasteen ennuste puolestaan kaatui puuttuvaan jaksoon, joten
sijoitussuunnitelmasivun yksikkökorteille ei saatu täyttöastetta lainkaan — tämä näkyi
tuotannossa NullPointerExceptionina.

## Tämän muutoksen jälkeen

Lomake alustetaan uudelleen, kun luonnoksen sijoitustyyppi vaihtuu. Tavallisessa
käsittelyssä alustus tehdään yhä vain kerran, joten työntekijän tekemät
päivämäärämuokkaukset säilyvät.

Kerhohakemukset ovat mukana liittyvän varhaiskasvatuksen päivämäärien tarkistuksessa, joten
lähetyspainike ei ole käytettävissä ilman päivämääriä.

Sijoitussuunnitelman luonti hylätään, jos sijoitustyyppi vaatii liittyvän varhaiskasvatuksen
jakson eikä sitä ole annettu. Sama tarkistus kattaa täyttöasteen ennusteen, joka vastaa nyt
virheellä 400 eikä 500.