### PR TITLE
Heitetään poikkeus oikein testeissä

### DIFF
--- a/service/src/main/kotlin/evaka/core/shared/async/AsyncJobRunner.kt
+++ b/service/src/main/kotlin/evaka/core/shared/async/AsyncJobRunner.kt
@@ -217,7 +217,7 @@ class AsyncJobRunner<T : AsyncJobPayload>(
             if (!isBusy) return
             TimeUnit.MILLISECONDS.sleep(100)
         } while (Duration.between(start, Instant.now()).abs() < timeout)
-        error { "Timed out while waiting for running jobs to finish" }
+        error("Timed out while waiting for running jobs to finish")
     }
 
     override fun close() {


### PR DESCRIPTION
`error` ottaa argumenttina viestin, ei lambdaa.