### PR TITLE
 Estetään automaattisten tietojen poiston vaikutus Vardaan

### DIFF
--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -2246,7 +2246,8 @@ CREATE TABLE public.child (
     meal_texture_id integer,
     nekku_diet public.nekku_product_meal_type,
     participates_in_breakfast boolean DEFAULT true CONSTRAINT child_nekku_eats_breakfast_not_null NOT NULL,
-    koski_data_first_removed_at timestamp with time zone
+    koski_data_first_removed_at timestamp with time zone,
+    varda_data_first_removed_at timestamp with time zone
 );
 
 -- Name: child_attendance; Type: TABLE; Schema: public

--- a/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
@@ -362,7 +362,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     }
 
     @Test
-    fun `deleteExpiredChildLeafRows of an unrelated table does not freeze Koski`() {
+    fun `deleteExpiredChildLeafRows of an unrelated table does not freeze Koski or Varda`() {
         insertExpiredPlacement(child.id)
         insertChildStickyNote(child.id)
 
@@ -376,6 +376,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         assertEquals(0, rowCount("child_sticky_note"))
         assertNull(koskiDataFirstRemovedAt(child.id))
+        assertNull(vardaDataFirstRemovedAt(child.id))
     }
 
     @Test
@@ -585,6 +586,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         allLeafTables.forEach { assertEquals(0, rowCount(it), "table $it should be empty") }
         assertEquals(0, rowCount("child_images"))
         assertNull(koskiDataFirstRemovedAt(child.id), "no Koski input table expires in one year")
+        assertNull(vardaDataFirstRemovedAt(child.id), "no Varda input table expires in one year")
         assertEquals(
             ChildDietColumns(dietId = null, mealTextureId = null, nekkuDiet = null),
             readChildDietColumns(child.id),
@@ -1135,6 +1137,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         deleteExpiredGuardians(
             db,
+            now,
             expireDate = tenYearExpireDate,
             citizenUserExpireDate = leafExpireDate,
             financeNoteExpireDate = financeExpireDate,
@@ -1152,6 +1155,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         deleteExpiredGuardians(
             db,
+            now,
             expireDate = tenYearExpireDate,
             citizenUserExpireDate = leafExpireDate,
             financeNoteExpireDate = financeExpireDate,
@@ -1162,12 +1166,54 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     }
 
     @Test
+    fun `deleteExpiredGuardians records when Varda input data was first removed`() {
+        val guardian = insertAdult()
+        insertGuardianship(guardian, child.id)
+        insertPlacementEnding(child.id, tenYearExpireDate.minusDays(1))
+
+        deleteExpiredGuardians(
+            db,
+            now,
+            expireDate = tenYearExpireDate,
+            citizenUserExpireDate = leafExpireDate,
+            financeNoteExpireDate = financeExpireDate,
+            limit = 100,
+        )
+
+        assertEquals(0, rowCount("guardian"))
+        assertEquals(now, vardaDataFirstRemovedAt(child.id))
+    }
+
+    @Test
+    fun `deleteExpiredGuardians keeps guardianship while the child could still attend`() {
+        val youngChild =
+            DevPerson(dateOfBirth = today.minusYears(SAFE_DATA_REMOVAL_AGE).plusDays(1))
+        db.transaction { it.insert(youngChild, DevPersonType.CHILD) }
+        val guardian = insertAdult()
+        insertGuardianship(guardian, youngChild.id)
+        insertPlacementEnding(youngChild.id, tenYearExpireDate.minusDays(1))
+
+        deleteExpiredGuardians(
+            db,
+            now,
+            expireDate = tenYearExpireDate,
+            citizenUserExpireDate = leafExpireDate,
+            financeNoteExpireDate = financeExpireDate,
+            limit = 100,
+        )
+
+        assertEquals(1, rowCount("guardian"))
+        assertNull(vardaDataFirstRemovedAt(youngChild.id))
+    }
+
+    @Test
     fun `deleteExpiredGuardians keeps guardianship of a child with no placements`() {
         val guardian = insertAdult()
         insertGuardianship(guardian, child.id)
 
         deleteExpiredGuardians(
             db,
+            now,
             expireDate = tenYearExpireDate,
             citizenUserExpireDate = leafExpireDate,
             financeNoteExpireDate = financeExpireDate,
@@ -1185,6 +1231,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         deleteExpiredGuardians(
             db,
+            now,
             expireDate = tenYearExpireDate,
             citizenUserExpireDate = leafExpireDate,
             financeNoteExpireDate = financeExpireDate,
@@ -1196,6 +1243,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         deleteExpiredCitizenUsers(db, expireDate = leafExpireDate, limit = 100)
         deleteExpiredGuardians(
             db,
+            now,
             expireDate = tenYearExpireDate,
             citizenUserExpireDate = leafExpireDate,
             financeNoteExpireDate = financeExpireDate,
@@ -1217,6 +1265,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         deleteExpiredGuardians(
             db,
+            now,
             expireDate = tenYearExpireDate,
             citizenUserExpireDate = leafExpireDate,
             financeNoteExpireDate = financeExpireDate,
@@ -1236,6 +1285,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         deleteExpiredGuardians(
             db,
+            now,
             expireDate = tenYearExpireDate,
             citizenUserExpireDate = leafExpireDate,
             financeNoteExpireDate = financeExpireDate,
@@ -1247,6 +1297,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         deleteExpiredFinanceNotes(db, expireDate = financeExpireDate, limit = 100)
         deleteExpiredGuardians(
             db,
+            now,
             expireDate = tenYearExpireDate,
             citizenUserExpireDate = leafExpireDate,
             financeNoteExpireDate = financeExpireDate,
@@ -1268,6 +1319,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         deleteExpiredGuardians(
             db,
+            now,
             expireDate = tenYearExpireDate,
             citizenUserExpireDate = leafExpireDate,
             financeNoteExpireDate = financeExpireDate,
@@ -2069,6 +2121,13 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
         tx.createQuery { sql("SELECT count(*) FROM $table") }.exactlyOne<Int>()
     }
 
+    private fun vardaDataFirstRemovedAt(childId: ChildId): HelsinkiDateTime? = db.read { tx ->
+        tx.createQuery {
+                sql("SELECT varda_data_first_removed_at FROM child WHERE id = ${bind(childId)}")
+            }
+            .exactlyOne<HelsinkiDateTime?>()
+    }
+
     private fun koskiDataFirstRemovedAt(childId: ChildId): HelsinkiDateTime? = db.read { tx ->
         tx.createQuery {
                 sql("SELECT koski_data_first_removed_at FROM child WHERE id = ${bind(childId)}")
@@ -2188,6 +2247,62 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
 
         assertEquals(setOf(tree.attachmentId.toString()), scheduledAttachmentDeletionIds())
         assertEquals(1, rowCount("attachment"))
+    }
+
+    @Test
+    fun `deleteExpiredApplications records when Varda input data was first removed`() {
+        val tree = insertApplicationTree(placementEnd = applicationExpireDate.minusDays(1))
+
+        dataRemovalService.deleteExpiredApplications(db, now, applicationExpireDate, limit = 100)
+
+        assertEquals(0, rowCount("application"))
+        assertEquals(now, vardaDataFirstRemovedAt(tree.childId))
+    }
+
+    @Test
+    fun `deleteExpiredApplications keeps applications while the child could still attend`() {
+        val tree =
+            insertApplicationTree(
+                placementEnd = applicationExpireDate.minusDays(1),
+                applicationChild =
+                    DevPerson(dateOfBirth = today.minusYears(SAFE_DATA_REMOVAL_AGE).plusDays(1)),
+            )
+
+        dataRemovalService.deleteExpiredApplications(db, now, applicationExpireDate, limit = 100)
+
+        assertEquals(1, rowCount("application"))
+        assertNull(vardaDataFirstRemovedAt(tree.childId))
+    }
+
+    @Test
+    fun `a later removal does not overwrite when Varda input data was first removed`() {
+        val tree = insertApplicationTree(placementEnd = applicationExpireDate.minusDays(1))
+
+        dataRemovalService.deleteExpiredApplications(db, now, applicationExpireDate, limit = 100)
+        deleteExpiredGuardians(
+            db,
+            now.plusDays(1),
+            expireDate = tenYearExpireDate,
+            citizenUserExpireDate = leafExpireDate,
+            financeNoteExpireDate = financeExpireDate,
+            limit = 100,
+        )
+
+        assertEquals(0, rowCount("guardian"))
+        assertEquals(now, vardaDataFirstRemovedAt(tree.childId))
+    }
+
+    @Test
+    fun `deleteExpiredData freezes Varda sync when it removes applications and guardianships`() {
+        val tree = insertApplicationTree(placementEnd = applicationExpireDate.minusDays(1))
+
+        withLimit(100) {
+            dataRemovalService.deleteExpiredData(db, clock, AsyncJob.DeleteExpiredData)
+        }
+
+        assertEquals(0, rowCount("application"))
+        assertEquals(0, rowCount("guardian"))
+        assertEquals(now, vardaDataFirstRemovedAt(tree.childId))
     }
 
     @Test
@@ -2344,16 +2459,17 @@ VALUES ('MESSAGE'::message_type, 'title', false, false, ${bind(applicationId)})
         val applicationId: ApplicationId,
         val decisionId: DecisionId,
         val attachmentId: AttachmentId,
+        val childId: ChildId,
     )
 
     private fun insertApplicationTree(
         placementEnd: LocalDate,
         decisionKey: String? = "decision-key",
         otherGuardianKey: String? = "other-guardian-key",
+        applicationChild: DevPerson = DevPerson(),
     ): ApplicationTree = db.transaction { tx ->
         val guardian = DevPerson()
         val otherGuardian = DevPerson()
-        val applicationChild = DevPerson()
         tx.insert(guardian, DevPersonType.ADULT)
         tx.insert(otherGuardian, DevPersonType.ADULT)
         tx.insert(applicationChild, DevPersonType.CHILD)
@@ -2457,7 +2573,7 @@ VALUES (${bind(process.id)}, 1, ${bind(CaseProcessState.INITIAL)}, ${bind(now)},
                 AttachmentParent.Application(applicationId),
                 type = ApplicationAttachmentType.URGENCY,
             )
-        ApplicationTree(applicationId, decisionId, attachmentId)
+        ApplicationTree(applicationId, decisionId, attachmentId, applicationChild.id)
     }
 
     private fun scheduledDecisionPdfDeletionKeys(): Set<String> =

--- a/service/src/integrationTest/kotlin/evaka/core/reports/VardaErrorReportTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/reports/VardaErrorReportTest.kt
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+package evaka.core.reports
+
+import evaka.core.FullApplicationTest
+import evaka.core.shared.auth.UserRole
+import evaka.core.shared.dev.DevEmployee
+import evaka.core.shared.dev.DevPerson
+import evaka.core.shared.dev.DevPersonType
+import evaka.core.shared.dev.insert
+import evaka.core.shared.domain.HelsinkiDateTime
+import evaka.core.shared.domain.MockEvakaClock
+import evaka.core.varda.freezeVardaSync
+import evaka.core.varda.setVardaUpdateError
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class VardaErrorReportTest : FullApplicationTest(resetDbBeforeEach = true) {
+    @Autowired private lateinit var vardaErrorReport: VardaErrorReport
+
+    private val now = HelsinkiDateTime.of(LocalDate.of(2026, 1, 1), LocalTime.of(12, 0))
+    private val clock = MockEvakaClock(now)
+
+    private val admin = DevEmployee(roles = setOf(UserRole.ADMIN))
+    private val erroredChild = DevPerson()
+    private val frozenChild = DevPerson()
+
+    @BeforeEach
+    fun setup() {
+        db.transaction { tx ->
+            tx.insert(admin)
+            listOf(erroredChild, frozenChild).forEach { child ->
+                tx.insert(child, DevPersonType.CHILD)
+                tx.execute {
+                    sql(
+                        "INSERT INTO varda_state (child_id, state) VALUES (${bind(child.id)}, NULL)"
+                    )
+                }
+                tx.setVardaUpdateError(child.id, now, "boom")
+            }
+            tx.freezeVardaSync(listOf(frozenChild.id), now)
+        }
+    }
+
+    @Test
+    fun `a child whose Varda data has been removed is left out of the error report`() {
+        val rows = vardaErrorReport.getVardaChildErrorsReport(dbInstance(), admin.user, clock)
+
+        assertEquals(listOf(erroredChild.id), rows.map { it.childId })
+    }
+}

--- a/service/src/integrationTest/kotlin/evaka/core/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/shared/job/ScheduledJobsTest.kt
@@ -427,6 +427,36 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
     }
 
     @Test
+    fun `RemoveGuardiansFromAdults freezes Varda sync for the children it removes guardians from`() {
+        val today = LocalDate.of(2024, 8, 15)
+        val now = HelsinkiDateTime.of(today, LocalTime.of(2, 0))
+        val clock = MockEvakaClock(now)
+
+        val adult = DevPerson()
+        val adultChild = DevPerson(dateOfBirth = today.minusYears(18))
+        val minorChild = DevPerson(dateOfBirth = today.minusYears(18).plusDays(1))
+        db.transaction { tx ->
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(adultChild, DevPersonType.CHILD)
+            tx.insert(minorChild, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, adultChild.id)
+            tx.insertGuardian(adult.id, minorChild.id)
+        }
+
+        scheduledJobs.removeGuardiansFromAdults(db, clock)
+
+        assertEquals(now, vardaDataFirstRemovedAt(adultChild.id))
+        assertNull(vardaDataFirstRemovedAt(minorChild.id))
+    }
+
+    private fun vardaDataFirstRemovedAt(childId: ChildId): HelsinkiDateTime? = db.read { tx ->
+        tx.createQuery {
+                sql("SELECT varda_data_first_removed_at FROM child WHERE id = ${bind(childId)}")
+            }
+            .exactlyOne<HelsinkiDateTime?>()
+    }
+
+    @Test
     fun removeExpiredStickyNotes() {
         // expired note
         db.transaction { tx ->

--- a/service/src/integrationTest/kotlin/evaka/core/varda/VardaUpdateServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/varda/VardaUpdateServiceIntegrationTest.kt
@@ -159,6 +159,63 @@ class VardaUpdateServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         assertEquals(emptySet(), getPlannedChildIds())
     }
 
+    @Test
+    fun `a child whose Varda data has been removed is not added to varda_state`() {
+        val area = DevCareArea()
+        val unit = DevDaycare(areaId = area.id)
+        val child = DevPerson(ssn = "030320A904N")
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(unit)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = unit.id,
+                    startDate = LocalDate.of(2021, 1, 1),
+                    endDate = LocalDate.of(2021, 2, 28),
+                )
+            )
+            tx.freezeVardaSync(listOf(child.id), now)
+        }
+
+        vardaUpdateService.planChildrenUpdate(db, clock)
+
+        assertEquals(emptySet(), getVardaStateChildIds())
+        assertEquals(emptySet(), getPlannedChildIds())
+    }
+
+    @Test
+    fun `no update is planned for a child whose Varda data has been removed`() {
+        val area = DevCareArea()
+        val unit = DevDaycare(areaId = area.id)
+        val child = DevPerson(ssn = "030320A904N")
+
+        db.transaction { tx ->
+            tx.insert(area)
+            tx.insert(unit)
+            tx.insert(child, DevPersonType.CHILD)
+            tx.insert(
+                DevPlacement(
+                    childId = child.id,
+                    unitId = unit.id,
+                    startDate = LocalDate.of(2021, 1, 1),
+                    endDate = LocalDate.of(2021, 2, 28),
+                )
+            )
+            tx.execute {
+                sql("INSERT INTO varda_state (child_id, state) VALUES (${bind(child.id)}, NULL)")
+            }
+            tx.freezeVardaSync(listOf(child.id), now)
+        }
+
+        vardaUpdateService.planChildrenUpdate(db, clock)
+
+        assertEquals(setOf(child.id), getVardaStateChildIds())
+        assertEquals(emptySet(), getPlannedChildIds())
+    }
+
     private fun getVardaStateChildIds(): Set<ChildId> =
         db.read { tx -> tx.getVardaUpdateChildIds() }.toSet()
 

--- a/service/src/integrationTest/kotlin/evaka/core/varda/VardaUpdaterIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/varda/VardaUpdaterIntegrationTest.kt
@@ -2888,6 +2888,40 @@ class VardaUpdaterIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
+    fun `nothing is sent for a child whose Varda data has been removed`() {
+        val child = DevPerson(ssn = "030320A904N")
+        val now = HelsinkiDateTime.of(LocalDate.of(2021, 1, 1), LocalTime.of(12, 0))
+
+        db.transaction { tx ->
+            tx.insert(child, DevPersonType.CHILD)
+            tx.execute {
+                sql("INSERT INTO varda_state (child_id, state) VALUES (${bind(child.id)}, NULL)")
+            }
+            tx.freezeVardaSync(listOf(child.id), now)
+        }
+
+        val updater =
+            VardaUpdater(DateRange(LocalDate.of(2019, 1, 1), null), "organizerOid", "sourceSystem")
+
+        updater.updateChild(
+            dbc = db,
+            readClient = FailEveryOperation(),
+            writeClient = DryRunClient(),
+            now = now,
+            childId = child.id,
+            saveState = true,
+        )
+
+        val error = db.read { tx ->
+            tx.createQuery {
+                    sql("SELECT error FROM varda_state WHERE child_id = ${bind(child.id)}")
+                }
+                .exactlyOne<String?>()
+        }
+        assertNull(error)
+    }
+
+    @Test
     fun `state is saved after update`() {
         val child = DevPerson(ssn = "030320A904N")
 

--- a/service/src/main/kotlin/evaka/core/Audit.kt
+++ b/service/src/main/kotlin/evaka/core/Audit.kt
@@ -202,6 +202,7 @@ enum class Audit(
     DataRemovalExpiredDelete,
     DataRemovalExpiredUnset,
     DataRemovalKoskiSyncFrozen,
+    DataRemovalVardaSyncFrozen,
     DaycareGroupPlacementCreate,
     DaycareGroupPlacementDelete,
     DaycareGroupPlacementTransfer,

--- a/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
+++ b/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
@@ -43,6 +43,8 @@ import evaka.core.shared.db.Predicate
 import evaka.core.shared.db.QuerySql
 import evaka.core.shared.domain.EvakaClock
 import evaka.core.shared.domain.HelsinkiDateTime
+import evaka.core.varda.VARDA_INPUT_TABLES
+import evaka.core.varda.freezeVardaSync
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Duration
 import java.time.LocalDate
@@ -53,7 +55,7 @@ private val logger = KotlinLogging.logger {}
 
 /**
  * Removing the rows an external data sync reads freezes that sync for the child permanently, so we
- * hold the data until starting or returning to preschool is no longer realistic.
+ * hold the data until returning to early childhood education or preschool is no longer realistic.
  */
 const val SAFE_DATA_REMOVAL_AGE: Long = 10
 
@@ -209,6 +211,7 @@ class DataRemovalService(
         // user or finance note removal is still pending
         deleteExpiredGuardians(
             dbc,
+            now,
             expireDate = today.minusYears(10),
             citizenUserExpireDate = citizenUserExpireDate,
             financeNoteExpireDate = financeNoteExpireDate,
@@ -263,36 +266,39 @@ class DataRemovalService(
         limit: Int,
     ) {
         logger.info { "Deleting at most $limit expired applications" }
-        val (deleted, unsetReferences) =
-            db.transaction { tx ->
-                val (results, unset) = tx.deleteExpiredApplicationsBatch(expireDate, limit)
-                val decisionKeys = results.flatMap { it.decisionDocumentKeys }
-                if (decisionKeys.isNotEmpty()) {
-                    asyncJobRunner.plan(
-                        tx = tx,
-                        payloads = decisionKeys.map { AsyncJob.DeleteDecisionPdf(it) },
-                        runAt = now,
-                    )
-                }
-                val attachmentIds = results.flatMap { it.attachmentIds }
-                if (attachmentIds.isNotEmpty()) {
-                    asyncJobRunner.plan(
-                        tx = tx,
-                        payloads = attachmentIds.map { AsyncJob.DeleteAttachment(it) },
-                        runAt = now,
-                    )
-                }
-                results to unset
+        val removal = db.transaction { tx ->
+            val (results, unset) = tx.deleteExpiredApplicationsBatch(expireDate, now, limit)
+            val decisionKeys = results.flatMap { it.decisionDocumentKeys }
+            if (decisionKeys.isNotEmpty()) {
+                asyncJobRunner.plan(
+                    tx = tx,
+                    payloads = decisionKeys.map { AsyncJob.DeleteDecisionPdf(it) },
+                    runAt = now,
+                )
             }
-        unsetReferences.forEach { ref ->
+            val attachmentIds = results.flatMap { it.attachmentIds }
+            if (attachmentIds.isNotEmpty()) {
+                asyncJobRunner.plan(
+                    tx = tx,
+                    payloads = attachmentIds.map { AsyncJob.DeleteAttachment(it) },
+                    runAt = now,
+                )
+            }
+            ExpiredApplicationRemoval(
+                deleted = results,
+                unsetReferences = unset,
+                frozenChildIds = tx.freezeVardaSync(results.map { it.childId }, now),
+            )
+        }
+        removal.unsetReferences.forEach { ref ->
             auditExpiredUnset(
                 entity = ref.entity,
                 targetId = ref.targetId,
                 meta = mapOf("clearedColumns" to ref.clearedColumns, "expireDate" to expireDate),
             )
         }
-        logger.info { "Deleted ${deleted.size} expired application(s)" }
-        deleted.forEach { app ->
+        logger.info { "Deleted ${removal.deleted.size} expired application(s)" }
+        removal.deleted.forEach { app ->
             auditExpiredDelete(
                 entity = "application",
                 targetId = AuditId(app.applicationId),
@@ -307,6 +313,9 @@ class DataRemovalService(
                         "expireDate" to expireDate,
                     ),
             )
+        }
+        removal.frozenChildIds.forEach { childId ->
+            Audit.DataRemovalVardaSyncFrozen.log(targetId = AuditId(childId))
         }
     }
 
@@ -499,25 +508,33 @@ fun deleteExpiredChildLeafRows(
 ) {
     leafTables.forEach { table ->
         logger.info { "Deleting at most $limit expired rows in table $table" }
-        val koskiInput = table in KOSKI_INPUT_TABLES
-        val (deletedIds, frozenChildIds) =
-            dbc.transaction { tx ->
-                val deleted = tx.deleteExpiredChildLeafRowsFromTable(expireDate, now, limit, table)
-                val frozen =
-                    if (koskiInput && deleted.isNotEmpty())
-                        tx.freezeKoskiSync(deleted.map { it.childId }.distinct(), now)
-                    else emptyList()
-                ExpiredLeafRemoval(deleted.map { it.id }, frozen)
-            }
-        deletedIds.forEach { id ->
+        val removal = dbc.transaction { tx ->
+            val deleted = tx.deleteExpiredChildLeafRowsFromTable(expireDate, now, limit, table)
+            val childIds = deleted.map { it.childId }.distinct()
+            ExpiredLeafRemoval(
+                deletedIds = deleted.map { it.id },
+                frozenKoskiChildIds =
+                    if (table in KOSKI_INPUT_TABLES && childIds.isNotEmpty())
+                        tx.freezeKoskiSync(childIds, now)
+                    else emptyList(),
+                frozenVardaChildIds =
+                    if (table in VARDA_INPUT_TABLES && childIds.isNotEmpty())
+                        tx.freezeVardaSync(childIds, now)
+                    else emptyList(),
+            )
+        }
+        removal.deletedIds.forEach { id ->
             auditExpiredDelete(
                 entity = table,
                 targetId = AuditId(id),
                 meta = mapOf("expireDate" to expireDate),
             )
         }
-        frozenChildIds.forEach { childId ->
+        removal.frozenKoskiChildIds.forEach { childId ->
             Audit.DataRemovalKoskiSyncFrozen.log(targetId = AuditId(childId))
+        }
+        removal.frozenVardaChildIds.forEach { childId ->
+            Audit.DataRemovalVardaSyncFrozen.log(targetId = AuditId(childId))
         }
     }
 }
@@ -526,7 +543,8 @@ private data class ExpiredLeafRow(val id: UUID, val childId: ChildId)
 
 private data class ExpiredLeafRemoval(
     val deletedIds: List<UUID>,
-    val frozenChildIds: List<ChildId>,
+    val frozenKoskiChildIds: List<ChildId>,
+    val frozenVardaChildIds: List<ChildId>,
 )
 
 private fun Database.Transaction.deleteExpiredChildLeafRowsFromTable(
@@ -536,7 +554,8 @@ private fun Database.Transaction.deleteExpiredChildLeafRowsFromTable(
     table: String,
 ): List<ExpiredLeafRow> {
     val removalAllowed =
-        if (table in KOSKI_INPUT_TABLES) childPastSafeDataRemovalAge(now.toLocalDate())
+        if (table in KOSKI_INPUT_TABLES || table in VARDA_INPUT_TABLES)
+            childPastSafeDataRemovalAge(now.toLocalDate())
         else Predicate.alwaysTrue()
     return createUpdate {
         sql(
@@ -648,6 +667,12 @@ data class DeletedApplication(
     val attachmentIds: List<AttachmentId>,
 )
 
+private data class ExpiredApplicationRemoval(
+    val deleted: List<DeletedApplication>,
+    val unsetReferences: List<UnsetReference>,
+    val frozenChildIds: List<ChildId>,
+)
+
 private data class UnsetReference(
     val entity: String,
     val targetId: AuditId,
@@ -656,6 +681,7 @@ private data class UnsetReference(
 
 private fun Database.Transaction.deleteExpiredApplicationsBatch(
     expireDate: LocalDate,
+    now: HelsinkiDateTime,
     limit: Int,
 ): Pair<List<DeletedApplication>, List<UnsetReference>> {
     val deletableRows = createQuery {
@@ -665,6 +691,7 @@ WITH del_batch AS (
     SELECT id
     FROM application
     WHERE child_id = ANY(${subquery(childIdsWithPlacementsEndingBefore(expireDate))})
+    AND ${predicate(childPastSafeDataRemovalAge(now.toLocalDate()).forTable("application"))}
     FOR UPDATE
     LIMIT ${bind(limit)}
 )
@@ -975,33 +1002,49 @@ RETURNING citizen_user.id
 
 fun deleteExpiredGuardians(
     dbc: Database.Connection,
+    now: HelsinkiDateTime,
     expireDate: LocalDate,
     citizenUserExpireDate: LocalDate,
     financeNoteExpireDate: LocalDate,
     limit: Int,
 ) {
     logger.info { "Deleting at most $limit expired guardian relationships" }
-    val deleted = dbc.transaction { tx ->
-        tx.deleteExpiredGuardiansBatch(
-            expireDate,
-            citizenUserExpireDate,
-            financeNoteExpireDate,
-            limit,
+    val removal = dbc.transaction { tx ->
+        val deleted =
+            tx.deleteExpiredGuardiansBatch(
+                expireDate,
+                now,
+                citizenUserExpireDate,
+                financeNoteExpireDate,
+                limit,
+            )
+        ExpiredGuardianRemoval(
+            deleted = deleted,
+            frozenChildIds = tx.freezeVardaSync(deleted.map { it.childId }, now),
         )
     }
-    deleted.forEach { row ->
+    removal.deleted.forEach { row ->
         auditExpiredDelete(
             entity = "guardian",
             targetId = AuditId(row.guardianId),
             meta = mapOf("childId" to row.childId, "expireDate" to expireDate),
         )
     }
+    removal.frozenChildIds.forEach { childId ->
+        Audit.DataRemovalVardaSyncFrozen.log(targetId = AuditId(childId))
+    }
 }
 
 private data class DeletedGuardian(val guardianId: PersonId, val childId: ChildId)
 
+private data class ExpiredGuardianRemoval(
+    val deleted: List<DeletedGuardian>,
+    val frozenChildIds: List<ChildId>,
+)
+
 private fun Database.Transaction.deleteExpiredGuardiansBatch(
     expireDate: LocalDate,
+    now: HelsinkiDateTime,
     citizenUserExpireDate: LocalDate,
     financeNoteExpireDate: LocalDate,
     limit: Int,
@@ -1013,6 +1056,7 @@ WITH del_batch AS (
     FROM guardian
     WHERE
         child_id = ANY(${subquery(childIdsWithPlacementsEndingBefore(expireDate))}) AND
+        ${predicate(childPastSafeDataRemovalAge(now.toLocalDate()).forTable("guardian"))} AND
         NOT guardian_id = ANY(${subquery(citizenUserIdsWithPlacementsEndingBefore(citizenUserExpireDate))}) AND
         NOT guardian_id = ANY(${subquery(personIdsWithPendingFinanceNoteRemoval(financeNoteExpireDate))})
     FOR UPDATE

--- a/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
+++ b/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
@@ -11,6 +11,7 @@ import evaka.core.caseprocess.deleteCaseProcesses
 import evaka.core.childimages.deleteImageFile
 import evaka.core.document.childdocument.deleteExpiredChildDocuments
 import evaka.core.koski.KOSKI_INPUT_TABLES
+import evaka.core.koski.freezeKoskiSync
 import evaka.core.messaging.DeletedMessageThreadBatch
 import evaka.core.messaging.deleteExpiredBulletinThreads
 import evaka.core.messaging.deleteExpiredMessageDrafts
@@ -578,23 +579,6 @@ RETURNING $table.id, $table.child_id
         .executeAndReturnGeneratedKeys()
         .toList()
 }
-
-private fun Database.Transaction.freezeKoskiSync(
-    childIds: Collection<ChildId>,
-    now: HelsinkiDateTime,
-): List<ChildId> = createUpdate {
-    sql(
-        """
-UPDATE child
-SET koski_data_first_removed_at = ${bind(now)}
-WHERE id = ANY(${bind(childIds)})
-AND koski_data_first_removed_at IS NULL
-RETURNING id
-"""
-    )
-}
-    .executeAndReturnGeneratedKeys()
-    .toList()
 
 fun unsetExpiredChildReferences(
     dbc: Database.Connection,

--- a/service/src/main/kotlin/evaka/core/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/evaka/core/koski/KoskiQueries.kt
@@ -27,12 +27,27 @@ data class KoskiStudyRightKey(
  * Once any of the child's data that affects Koski has been deleted due to retention policies, the
  * data synchronization to Koski must be stopped, so that the data is not deleted from there too.
  */
-private val koskiSyncActive = Predicate { where("$it.koski_data_first_removed_at IS NULL") }
+fun Database.Transaction.freezeKoskiSync(
+    childIds: Collection<ChildId>,
+    now: HelsinkiDateTime,
+): List<ChildId> = createUpdate {
+    sql(
+        """
+UPDATE child
+SET koski_data_first_removed_at = ${bind(now)}
+WHERE id = ANY(${bind(childIds)})
+AND koski_data_first_removed_at IS NULL
+RETURNING id
+"""
+    )
+}
+    .executeAndReturnGeneratedKeys()
+    .toList()
 
 private fun Database.Read.isKoskiSyncActive(childId: ChildId): Boolean = createQuery {
     sql(
         """
-SELECT ${predicate(koskiSyncActive.forTable("child"))}
+SELECT child.koski_data_first_removed_at IS NULL
 FROM child
 WHERE id = ${bind(childId)}
 """
@@ -60,7 +75,7 @@ WHERE (
     ksr.preschool_input_data IS DISTINCT FROM kasr.input_data OR
     ${predicate(dataVersionCheck.forTable("ksr"))}
 )
-AND ${predicate(koskiSyncActive.forTable("ch"))}
+AND ch.koski_data_first_removed_at IS NULL
 
 UNION
 
@@ -73,7 +88,7 @@ WHERE (
     ksr.preparatory_input_data IS DISTINCT FROM kasr.input_data OR
     ${predicate(dataVersionCheck.forTable("ksr"))}
 )
-AND ${predicate(koskiSyncActive.forTable("ch"))}
+AND ch.koski_data_first_removed_at IS NULL
 
 UNION
 
@@ -81,7 +96,7 @@ SELECT kvsr.child_id, kvsr.unit_id, kvsr.type
 FROM koski_voided_study_right(${bind(today)}) kvsr
 JOIN child ch ON ch.id = kvsr.child_id
 WHERE kvsr.void_date IS NULL
-AND ${predicate(koskiSyncActive.forTable("ch"))}
+AND ch.koski_data_first_removed_at IS NULL
 """
         )
     }

--- a/service/src/main/kotlin/evaka/core/pis/service/MergeService.kt
+++ b/service/src/main/kotlin/evaka/core/pis/service/MergeService.kt
@@ -67,7 +67,7 @@ SELECT min(min_date) AS min_date, max(max_date) AS max_date FROM dates HAVING mi
             tx.createUpdate {
                     sql(
                         """
-INSERT INTO child (id, allergies, diet, additionalinfo, koski_data_first_removed_at) VALUES (
+INSERT INTO child (id, allergies, diet, additionalinfo, koski_data_first_removed_at, varda_data_first_removed_at) VALUES (
     ${bind(master)},
     -- concat_ws() skips nulls, and nullif() makes an empty side null, so an absent
     -- value never leaves a stray separator behind
@@ -87,12 +87,17 @@ INSERT INTO child (id, allergies, diet, additionalinfo, koski_data_first_removed
     least(
         (SELECT koski_data_first_removed_at FROM child WHERE id = ${bind(master)}),
         (SELECT koski_data_first_removed_at FROM child WHERE id = ${bind(duplicate)})
+    ),
+    least(
+        (SELECT varda_data_first_removed_at FROM child WHERE id = ${bind(master)}),
+        (SELECT varda_data_first_removed_at FROM child WHERE id = ${bind(duplicate)})
     )
 ) ON CONFLICT(id) DO UPDATE SET
     allergies = excluded.allergies,
     diet = excluded.diet,
     additionalinfo = excluded.additionalinfo,
-    koski_data_first_removed_at = excluded.koski_data_first_removed_at;
+    koski_data_first_removed_at = excluded.koski_data_first_removed_at,
+    varda_data_first_removed_at = excluded.varda_data_first_removed_at;
     
 UPDATE child SET allergies = '', diet = '', additionalinfo = '' WHERE id = ${bind(duplicate)};
 

--- a/service/src/main/kotlin/evaka/core/reports/VardaErrorsReport.kt
+++ b/service/src/main/kotlin/evaka/core/reports/VardaErrorsReport.kt
@@ -13,7 +13,6 @@ import evaka.core.shared.domain.EvakaClock
 import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.security.AccessControl
 import evaka.core.shared.security.Action
-import evaka.core.varda.vardaSyncActive
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -73,7 +72,7 @@ SELECT
 FROM varda_state vs
 LEFT JOIN child c ON c.id = vs.child_id
 WHERE vs.errored_at IS NOT NULL
-AND ${predicate(vardaSyncActive.forTable("c"))}
+AND c.varda_data_first_removed_at IS NULL
 ORDER BY vs.errored_at DESC
     """
     )

--- a/service/src/main/kotlin/evaka/core/reports/VardaErrorsReport.kt
+++ b/service/src/main/kotlin/evaka/core/reports/VardaErrorsReport.kt
@@ -13,6 +13,7 @@ import evaka.core.shared.domain.EvakaClock
 import evaka.core.shared.domain.HelsinkiDateTime
 import evaka.core.shared.security.AccessControl
 import evaka.core.shared.security.Action
+import evaka.core.varda.vardaSyncActive
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -65,13 +66,15 @@ private fun Database.Read.getVardaChildErrors(): List<VardaChildErrorReportRow> 
     sql(
         """
 SELECT
-    child_id,
-    errored_at,
-    errored_since,
-    error
-FROM varda_state
-WHERE errored_at IS NOT NULL
-ORDER BY errored_at DESC
+    vs.child_id,
+    vs.errored_at,
+    vs.errored_since,
+    vs.error
+FROM varda_state vs
+LEFT JOIN child c ON c.id = vs.child_id
+WHERE vs.errored_at IS NOT NULL
+AND ${predicate(vardaSyncActive.forTable("c"))}
+ORDER BY vs.errored_at DESC
     """
     )
 }

--- a/service/src/main/kotlin/evaka/core/shared/job/ScheduledJobs.kt
+++ b/service/src/main/kotlin/evaka/core/shared/job/ScheduledJobs.kt
@@ -45,6 +45,7 @@ import evaka.core.reservations.MissingReservationsReminders
 import evaka.core.reservations.deleteInvalidatedShiftCareReservationsAfterDate
 import evaka.core.sficlient.SfiAsyncJobs
 import evaka.core.sficlient.SfiMessagesClient
+import evaka.core.shared.ChildId
 import evaka.core.shared.FeatureConfig
 import evaka.core.shared.async.AsyncJob
 import evaka.core.shared.async.AsyncJobRunner
@@ -58,6 +59,7 @@ import evaka.core.shared.db.runSanityChecks
 import evaka.core.shared.domain.EvakaClock
 import evaka.core.titania.cleanTitaniaErrors
 import evaka.core.varda.VardaUpdateService
+import evaka.core.varda.freezeVardaSync
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.api.trace.Tracer
 import java.nio.file.Path
@@ -560,18 +562,26 @@ WHERE id IN (SELECT id FROM attendances_to_end)
     }
 
     fun removeGuardiansFromAdults(db: Database.Connection, clock: EvakaClock) {
-        db.transaction { tx ->
-            tx.execute {
-                sql(
-                    """
+        val frozen = db.transaction { tx ->
+            val childIds =
+                tx.createUpdate {
+                        sql(
+                            """
                 DELETE FROM guardian g
                 WHERE EXISTS(
                     SELECT FROM person ch 
                     WHERE g.child_id = ch.id AND ch.date_of_birth <= ${bind(clock.today().minusYears(18))}
                 )
+                RETURNING g.child_id
             """
-                )
-            }
+                        )
+                    }
+                    .executeAndReturnGeneratedKeys()
+                    .toList<ChildId>()
+            tx.freezeVardaSync(childIds, clock.now())
+        }
+        frozen.forEach { childId ->
+            Audit.DataRemovalVardaSyncFrozen.log(targetId = AuditId(childId))
         }
     }
 

--- a/service/src/main/kotlin/evaka/core/varda/VardaQueries.kt
+++ b/service/src/main/kotlin/evaka/core/varda/VardaQueries.kt
@@ -9,12 +9,50 @@ import evaka.core.placement.PlacementType
 import evaka.core.shared.ChildId
 import evaka.core.shared.PersonId
 import evaka.core.shared.db.Database
+import evaka.core.shared.db.Predicate
 import evaka.core.shared.domain.DateRange
 import evaka.core.shared.domain.FiniteDateRange
 import evaka.core.shared.domain.HelsinkiDateTime
 import java.time.LocalDate
 import org.jdbi.v3.core.result.UnableToProduceResultException
 import tools.jackson.databind.DatabindException
+
+/** Child-scoped tables feeding the Varda payload. Keep in sync by hand. */
+val VARDA_INPUT_TABLES =
+    setOf(
+        "placement",
+        "service_need",
+        "person",
+        "guardian",
+        "application",
+        "decision",
+        "fee_decision",
+        "fee_decision_child",
+        "voucher_value_decision",
+    )
+
+/**
+ * Once any of the child's data that affects Varda has been deleted due to retention policies, the
+ * data synchronization to Varda must be stopped, so that the data is not deleted from there too.
+ */
+val vardaSyncActive = Predicate { where("$it.varda_data_first_removed_at IS NULL") }
+
+fun Database.Transaction.freezeVardaSync(
+    childIds: Collection<ChildId>,
+    now: HelsinkiDateTime,
+): List<ChildId> = createUpdate {
+    sql(
+        """
+UPDATE child
+SET varda_data_first_removed_at = ${bind(now)}
+WHERE id = ANY(${bind(childIds)})
+AND varda_data_first_removed_at IS NULL
+RETURNING id
+"""
+    )
+}
+    .executeAndReturnGeneratedKeys()
+    .toList()
 
 private val vardaPlacementTypes =
     listOf(
@@ -179,13 +217,15 @@ fun Database.Read.getVardaChildren(childIds: List<ChildId>): Map<ChildId, VardaC
         sql(
             """
                 SELECT
-                    id,
-                    first_name,
-                    last_name,
-                    social_security_number,
-                    oph_person_oid
-                FROM person
-                WHERE id = ANY(${bind(childIds)})
+                    p.id,
+                    p.first_name,
+                    p.last_name,
+                    p.social_security_number,
+                    p.oph_person_oid
+                FROM person p
+                LEFT JOIN child c ON c.id = p.id
+                WHERE p.id = ANY(${bind(childIds)})
+                AND ${predicate(vardaSyncActive.forTable("c"))}
                 """
         )
     }
@@ -230,9 +270,11 @@ fun Database.Transaction.addNewChildrenForVardaUpdate(): Int {
                     SELECT pl.child_id, null
                     FROM placement pl
                     JOIN person p ON p.id = pl.child_id
+                    JOIN child ch ON ch.id = pl.child_id
                     WHERE
                         pl.type = ANY(${bind(vardaPlacementTypes)}) AND
                         (p.social_security_number IS NOT NULL OR (p.oph_person_oid IS NOT NULL AND p.oph_person_oid != '')) AND
+                        ${predicate(vardaSyncActive.forTable("ch"))} AND
                         NOT EXISTS (SELECT FROM varda_state vs WHERE vs.child_id = pl.child_id)
                     ON CONFLICT (child_id) DO NOTHING
                     """

--- a/service/src/main/kotlin/evaka/core/varda/VardaQueries.kt
+++ b/service/src/main/kotlin/evaka/core/varda/VardaQueries.kt
@@ -9,7 +9,6 @@ import evaka.core.placement.PlacementType
 import evaka.core.shared.ChildId
 import evaka.core.shared.PersonId
 import evaka.core.shared.db.Database
-import evaka.core.shared.db.Predicate
 import evaka.core.shared.domain.DateRange
 import evaka.core.shared.domain.FiniteDateRange
 import evaka.core.shared.domain.HelsinkiDateTime
@@ -35,8 +34,6 @@ val VARDA_INPUT_TABLES =
  * Once any of the child's data that affects Varda has been deleted due to retention policies, the
  * data synchronization to Varda must be stopped, so that the data is not deleted from there too.
  */
-val vardaSyncActive = Predicate { where("$it.varda_data_first_removed_at IS NULL") }
-
 fun Database.Transaction.freezeVardaSync(
     childIds: Collection<ChildId>,
     now: HelsinkiDateTime,
@@ -225,7 +222,7 @@ fun Database.Read.getVardaChildren(childIds: List<ChildId>): Map<ChildId, VardaC
                 FROM person p
                 LEFT JOIN child c ON c.id = p.id
                 WHERE p.id = ANY(${bind(childIds)})
-                AND ${predicate(vardaSyncActive.forTable("c"))}
+                AND c.varda_data_first_removed_at IS NULL
                 """
         )
     }
@@ -274,7 +271,7 @@ fun Database.Transaction.addNewChildrenForVardaUpdate(): Int {
                     WHERE
                         pl.type = ANY(${bind(vardaPlacementTypes)}) AND
                         (p.social_security_number IS NOT NULL OR (p.oph_person_oid IS NOT NULL AND p.oph_person_oid != '')) AND
-                        ${predicate(vardaSyncActive.forTable("ch"))} AND
+                        ch.varda_data_first_removed_at IS NULL AND
                         NOT EXISTS (SELECT FROM varda_state vs WHERE vs.child_id = pl.child_id)
                     ON CONFLICT (child_id) DO NOTHING
                     """

--- a/service/src/main/kotlin/evaka/core/varda/VardaUpdateService.kt
+++ b/service/src/main/kotlin/evaka/core/varda/VardaUpdateService.kt
@@ -221,7 +221,9 @@ class VardaUpdater(
         try {
             val evakaState = dbc.read { tx -> getEvakaState(tx, now.toLocalDate(), childId) }
             if (evakaState == null) {
-                logger.info { "Cannot compute Varda state for $childId" }
+                logger.info {
+                    "No Varda state to send for $childId (no identifiers, or sync frozen)"
+                }
                 return
             }
 

--- a/service/src/main/resources/db/migration/V609__child_varda_data_removed.sql
+++ b/service/src/main/resources/db/migration/V609__child_varda_data_removed.sql
@@ -1,0 +1,2 @@
+ALTER TABLE child
+    ADD COLUMN varda_data_first_removed_at timestamp with time zone;

--- a/service/src/main/resources/migrations.txt
+++ b/service/src/main/resources/migrations.txt
@@ -604,3 +604,4 @@ V605__absence_categories_temporary_daycare.sql
 V606__koski_upload_error.sql
 V607__decision_reasoning_individual_language.sql
 V608__child_koski_data_removed.sql
+V609__child_varda_data_removed.sql


### PR DESCRIPTION
Muutokset

1. Riippumatta määritellystä säilytysajasta, ei poisteta automaattisesti tietoa tauluista, jotka vaikuttavat Vardaan, mikäli lapsi on alle 10 vuotias. Tämän jälkeen lapsi ei varmastikaan ole enää palaamassa varhaiskasvatukseen.
2. Kun Vardaan vaikuttavia lapsen tietoja ensimmäistä kertaa poistetaan automaattisesti, tehdään tästä merkintä. Mikäli tällainen merkintä löytyy, ei lapsen tietoja enää päivitetä Vardan, jotta evakasta poistunutta tietoa ei poisteta myös sieltä.