### PR TITLE
Korjaus async-jobien throttlaukseen

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/shared/async/AsyncJobRunnerTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/shared/async/AsyncJobRunnerTest.kt
@@ -7,6 +7,7 @@ package evaka.core.shared.async
 import evaka.core.PureJdbiTest
 import evaka.core.shared.auth.AuthenticatedUser
 import evaka.core.shared.domain.HelsinkiDateTime
+import evaka.core.shared.domain.MockEvakaClock
 import evaka.core.shared.domain.RealEvakaClock
 import fi.espoo.voltti.logging.MdcKey
 import java.time.Duration
@@ -203,6 +204,37 @@ class AsyncJobRunnerTest : PureJdbiTest(resetDbBeforeEach = true) {
         assertThrows<ExecutionException> { failingFuture.get(10, TimeUnit.SECONDS) }
 
         assertEquals(0, asyncJobRunner.runPendingJobsSync(RealEvakaClock(), 1))
+    }
+
+    @Test
+    fun `a throttled worker does not sleep when the permit was written with a later clock`() {
+        val runner =
+            AsyncJobRunner(
+                TestJob::class,
+                listOf(
+                    AsyncJobRunner.Pool(
+                        AsyncJobPool.Id(TestJob::class, "throttled"),
+                        AsyncJobPool.Config(throttleInterval = Duration.ofMillis(100)),
+                        setOf(TestJob::class),
+                    )
+                ),
+                jdbi,
+                noopTracer,
+            )
+        runner.registerHandler { _, _, _: TestJob -> }
+        runner.use {
+            val now = HelsinkiDateTime.now()
+            val later = now.plusHours(1)
+
+            // Leaves the permit holding `later`
+            db.transaction { tx -> runner.plan(tx, listOf(TestJob()), runAt = later) }
+            runner.runPendingJobsSync(MockEvakaClock(later))
+
+            db.transaction { tx -> runner.plan(tx, listOf(TestJob()), runAt = now) }
+            val run = CompletableFuture.runAsync { runner.runPendingJobsSync(MockEvakaClock(now)) }
+            run.get(10, TimeUnit.SECONDS)
+            runner.waitUntilNoRunningJobs(timeout = Duration.ofSeconds(5))
+        }
     }
 
     private fun <R> setAsyncJobCallback(f: (msg: TestJob) -> R): Future<R> {

--- a/service/src/main/kotlin/evaka/core/shared/async/AsyncJobPool.kt
+++ b/service/src/main/kotlin/evaka/core/shared/async/AsyncJobPool.kt
@@ -66,6 +66,7 @@ class AsyncJobPool<T : AsyncJobPayload>(
     private val metrics: AtomicReference<Metrics> = AtomicReference()
 
     private val throttleInterval = config.throttleInterval ?: Duration.ZERO
+    private val isThrottled = !throttleInterval.isZero
     private val executor = config.let {
         val corePoolSize = 1
         val maximumPoolSize = it.concurrency
@@ -139,28 +140,40 @@ class AsyncJobPool<T : AsyncJobPayload>(
     private fun runWorker(clock: EvakaClock, maxCount: Int) =
         tracer.withDetachedSpan("asyncjob.worker $fullName") {
             Database(jdbi, tracer).connect { dbc ->
-                dbc.transaction { it.upsertPermit(this.id) }
+                if (isThrottled) {
+                    dbc.transaction { it.upsertPermit(this.id) }
+                }
                 var executed = 0
                 while (maxCount - executed > 0 && !executor.isTerminating) {
                     val job =
                         dbc.transaction { tx ->
                             tx.setStatementTimeout(Duration.ofSeconds(120))
-                            // In the worst case we need to wait for the duration of (N service
-                            // instances) * (M workers per pool) * (throttle interval) if every
-                            // worker in the cluster is queuing and every one sleeps.
-                            //
-                            // The value here is just a guess that should be long enough in all
-                            // valid cases, and we get a loud exception if this assumption is broken
-                            tx.setLockTimeout(Duration.ofSeconds(60))
-                            val permit = tx.claimPermit(this.id)
-                            Thread.sleep(
-                                Duration.between(
-                                    clock.now().toInstant(),
-                                    permit.availableAt.toInstant(),
+                            if (isThrottled) {
+                                // In the worst case we need to wait for the duration of (N service
+                                // instances) * (M workers per pool) * (throttle interval) if every
+                                // worker in the cluster is queuing and every one sleeps.
+                                //
+                                // The value here is just a guess that should be long enough in all
+                                // valid cases, and we get a loud exception if this assumption is
+                                // broken
+                                tx.setLockTimeout(Duration.ofSeconds(60))
+                                val permit = tx.claimPermit(this.id)
+
+                                // availableAt was written from clock.now(), which is mocked in
+                                // tests, so the difference can be any value. A real throttle wait
+                                // never exceeds the throttle interval.
+                                Thread.sleep(
+                                    Duration.between(
+                                            clock.now().toInstant(),
+                                            permit.availableAt.toInstant(),
+                                        )
+                                        .coerceIn(Duration.ZERO, throttleInterval)
                                 )
-                            )
+                            }
                             tx.claimJob(clock.now(), registration.jobTypes())?.also {
-                                tx.updatePermit(this.id, clock.now().plus(throttleInterval))
+                                if (isThrottled) {
+                                    tx.updatePermit(this.id, clock.now().plus(throttleInterval))
+                                }
                             }
                         } ?: break
                     tracer.withDetachedSpan(


### PR DESCRIPTION
1. Jos poolia ei throttleteta, ei myöskään kirjoiteta ja lueta permittejä turhaan.
2. Ei odoteta pidempään kuin throttle interval ennen kuin yritetään uudestaan ottaa permit. Testeissä permittien ajat saattavat tulla mock clockista ja olla väärin eri ajokertojen välillä.