### PR TITLE
Vanhentuneiden tuloselvitysmuistutusten tietojen poisto (ei vielä käytössä)

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
@@ -32,6 +32,8 @@ import evaka.core.document.childdocument.DocumentStatus
 import evaka.core.finance.notes.createFinanceNote
 import evaka.core.holidayperiod.QuestionnaireType
 import evaka.core.insertServiceNeedOptions
+import evaka.core.invoicing.service.IncomeNotificationType
+import evaka.core.invoicing.service.createIncomeNotification
 import evaka.core.nekku.NekkuProductMealType
 import evaka.core.note.child.sticky.ChildStickyNoteBody
 import evaka.core.note.child.sticky.createChildStickyNote
@@ -50,6 +52,7 @@ import evaka.core.shared.BackupPickupId
 import evaka.core.shared.ChildDocumentId
 import evaka.core.shared.ChildId
 import evaka.core.shared.DecisionId
+import evaka.core.shared.IncomeNotificationId
 import evaka.core.shared.PedagogicalDocumentId
 import evaka.core.shared.PersonId
 import evaka.core.shared.PlacementId
@@ -133,6 +136,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     private val financeExpireDate = today.minusYears(5)
     private val tenYearExpireDate = today.minusYears(10)
     private val applicationExpireDate = today.minusYears(10)
+    private val incomeNotificationExpireDate = today.minusYears(10)
 
     private val admin = DevEmployee(roles = setOf(UserRole.ADMIN))
     private val careArea = DevCareArea()
@@ -1820,6 +1824,19 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
         }
     }
 
+    private fun insertIncomeNotification(
+        receiverId: PersonId,
+        createdAt: HelsinkiDateTime,
+    ): IncomeNotificationId = db.transaction { tx ->
+        val id = tx.createIncomeNotification(receiverId, IncomeNotificationType.INITIAL_EMAIL)
+        tx.execute {
+            sql(
+                "UPDATE income_notification SET created = ${bind(createdAt)} WHERE id = ${bind(id)}"
+            )
+        }
+        id
+    }
+
     private fun insertCalendarEvent(): DevCalendarEvent {
         val event =
             DevCalendarEvent(
@@ -2348,6 +2365,13 @@ VALUES (${bind(process.id)}, 1, ${bind(CaseProcessState.INITIAL)}, ${bind(now)},
         tx.createQuery { sql("SELECT id FROM application") }.toList<ApplicationId>()
     }
 
+    private fun survivingIncomeNotificationIds(): Set<IncomeNotificationId> =
+        db.read { tx ->
+                tx.createQuery { sql("SELECT id FROM income_notification") }
+                    .toList<IncomeNotificationId>()
+            }
+            .toSet()
+
     private fun survivingDecisionIds(): List<DecisionId> = db.read { tx ->
         tx.createQuery { sql("SELECT id FROM decision") }.toList<DecisionId>()
     }
@@ -2445,5 +2469,59 @@ VALUES (${bind(process.id)}, 1, ${bind(CaseProcessState.INITIAL)}, ${bind(now)},
         assertEquals(1, rowCount("pedagogical_document"))
         assertEquals(1, rowCount("attachment"))
         assertTrue(scheduledAttachmentDeletionIds().isEmpty())
+    }
+
+    @Test
+    fun `deleteExpiredIncomeNotifications deletes notifications created over ten years ago and preserves newer ones`() {
+        val adultId = insertAdult()
+        insertIncomeNotification(
+            adultId,
+            HelsinkiDateTime.of(incomeNotificationExpireDate.minusDays(1), LocalTime.of(2, 0)),
+        )
+        val boundaryId =
+            insertIncomeNotification(
+                adultId,
+                HelsinkiDateTime.of(incomeNotificationExpireDate, LocalTime.MIDNIGHT),
+            )
+        val recentId = insertIncomeNotification(adultId, now)
+
+        deleteExpiredIncomeNotifications(db, expireDate = incomeNotificationExpireDate, limit = 100)
+
+        assertEquals(setOf(boundaryId, recentId), survivingIncomeNotificationIds())
+    }
+
+    @Test
+    fun `deleteExpiredIncomeNotifications doesn't remove more than the limit`() {
+        val adultId = insertAdult()
+        repeat(3) {
+            insertIncomeNotification(
+                adultId,
+                HelsinkiDateTime.of(incomeNotificationExpireDate.minusDays(1), LocalTime.of(2, 0)),
+            )
+        }
+
+        deleteExpiredIncomeNotifications(db, expireDate = incomeNotificationExpireDate, limit = 2)
+
+        assertEquals(1, rowCount("income_notification"))
+    }
+
+    @Test
+    fun `deleteExpiredData removes income notifications after ten years`() {
+        val adultId = insertAdult()
+        insertIncomeNotification(
+            adultId,
+            HelsinkiDateTime.of(incomeNotificationExpireDate.minusDays(1), LocalTime.of(2, 0)),
+        )
+        val retainedId =
+            insertIncomeNotification(
+                adultId,
+                HelsinkiDateTime.of(incomeNotificationExpireDate.plusDays(2), LocalTime.of(2, 0)),
+            )
+
+        withLimit(1000) {
+            dataRemovalService.deleteExpiredData(db, clock, AsyncJob.DeleteExpiredData)
+        }
+
+        assertEquals(setOf(retainedId), survivingIncomeNotificationIds())
     }
 }

--- a/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
+++ b/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
@@ -26,6 +26,7 @@ import evaka.core.shared.FinanceNoteId
 import evaka.core.shared.FosterParentId
 import evaka.core.shared.Id
 import evaka.core.shared.IncomeId
+import evaka.core.shared.IncomeNotificationId
 import evaka.core.shared.MessageThreadId
 import evaka.core.shared.ParentshipId
 import evaka.core.shared.PartnershipId
@@ -202,6 +203,8 @@ class DataRemovalService(
         )
 
         deleteExpiredGuardianBlocklistRows(dbc, expireDate = today.minusYears(10), limit)
+
+        deleteExpiredIncomeNotifications(dbc, expireDate = today.minusYears(10), limit)
     }
 
     fun deleteExpiredChildDocuments(db: Database.Connection, now: HelsinkiDateTime, limit: Int) {
@@ -871,6 +874,45 @@ FOR UPDATE
         )
     }
 }
+
+fun deleteExpiredIncomeNotifications(dbc: Database.Connection, expireDate: LocalDate, limit: Int) {
+    logger.info { "Deleting at most $limit expired income notifications" }
+    val deleted = dbc.transaction { tx ->
+        tx.deleteExpiredIncomeNotificationsBatch(expireDate, limit)
+    }
+    deleted.forEach { notification ->
+        auditExpiredDelete(
+            entity = "income_notification",
+            targetId = AuditId(notification.id),
+            meta = mapOf("receiverId" to notification.receiverId, "expireDate" to expireDate),
+        )
+    }
+}
+
+data class DeletedIncomeNotification(val id: IncomeNotificationId, val receiverId: PersonId)
+
+private fun Database.Transaction.deleteExpiredIncomeNotificationsBatch(
+    expireDate: LocalDate,
+    limit: Int,
+): List<DeletedIncomeNotification> = createUpdate {
+    sql(
+        """
+WITH del_batch AS (
+    SELECT id
+    FROM income_notification
+    WHERE created < ${bind(HelsinkiDateTime.atStartOfDay(expireDate))}
+    FOR UPDATE
+    LIMIT ${bind(limit)}
+)
+DELETE FROM income_notification
+USING del_batch
+WHERE income_notification.id = del_batch.id
+RETURNING income_notification.id, income_notification.receiver_id
+"""
+    )
+}
+    .executeAndReturnGeneratedKeys()
+    .toList<DeletedIncomeNotification>()
 
 fun deleteExpiredCitizenUsers(dbc: Database.Connection, expireDate: LocalDate, limit: Int) {
     logger.info { "Deleting at most $limit expired citizen users" }


### PR DESCRIPTION
Lisätään tuloselvitysmuistutuksien tietojen poisto 10 vuotta muistutuksen lähettämisestä.