### PR TITLE
Korjataan tuloselvityslistauksen alueiden satunnainen vaihtelu

### DIFF
--- a/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
+++ b/frontend/src/employee-frontend/components/income-statements/IncomeStatementsPage.tsx
@@ -128,7 +128,9 @@ function IncomeStatementsList({
                 {row.personName}
               </Link>
             </Td>
-            <Td>{row.primaryCareArea}</Td>
+            <Td data-qa="care-areas">
+              {row.careAreas.length > 0 ? row.careAreas.join(', ') : '-'}
+            </Td>
             <Td>{row.sentAt.toLocalDate().format()}</Td>
             <Td>{row.citizenModifiedAt.toLocalDate().format()}</Td>
             <Td>{row.startDate.format()}</Td>

--- a/frontend/src/lib-common/generated/api-types/incomestatement.ts
+++ b/frontend/src/lib-common/generated/api-types/incomestatement.ts
@@ -231,6 +231,7 @@ export type IncomeStatementAttachmentType = typeof incomeStatementAttachmentType
 * Generated from evaka.core.incomestatement.IncomeStatementAwaitingHandler
 */
 export interface IncomeStatementAwaitingHandler {
+  careAreas: string[]
   citizenModifiedAt: HelsinkiDateTime
   handlerNote: string
   id: IncomeStatementId
@@ -239,7 +240,6 @@ export interface IncomeStatementAwaitingHandler {
   personId: PersonId
   personLastName: string
   personName: string
-  primaryCareArea: string | null
   sentAt: HelsinkiDateTime
   startDate: LocalDate
   type: IncomeStatementType

--- a/service/src/integrationTest/kotlin/evaka/core/incomestatement/IncomeStatementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/incomestatement/IncomeStatementControllerIntegrationTest.kt
@@ -77,6 +77,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
     private val child3 = DevPerson(firstName = "Hillary", lastName = "Foo")
     private val child4 = DevPerson(firstName = "Maisa", lastName = "Farang")
     private val child5 = DevPerson(firstName = "Visa", lastName = "Virén")
+    private val child6 = DevPerson(firstName = "Aatos", lastName = "Doe")
 
     private val employee = DevEmployee(roles = setOf(UserRole.FINANCE_ADMIN))
 
@@ -94,7 +95,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
             listOf(adult1, adult2, adult3, adult4, adult5, adult6).forEach {
                 tx.insert(it, DevPersonType.ADULT)
             }
-            listOf(child1, child2, child3, child4, child5).forEach {
+            listOf(child1, child2, child3, child4, child5, child6).forEach {
                 tx.insert(it, DevPersonType.CHILD)
             }
             tx.insert(employee)
@@ -486,7 +487,17 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 DevPlacement(
                     type = PlacementType.PRESCHOOL_DAYCARE,
                     childId = child3.id,
-                    unitId = daycare2.id,
+                    unitId = daycare1.id,
+                    startDate = placementStart,
+                    endDate = placementEnd,
+                )
+            )
+
+            // adult1 also heads a child with no placement, which has no care area of its own
+            tx.insert(
+                DevParentship(
+                    childId = child6.id,
+                    headOfChildId = adult1.id,
                     startDate = placementStart,
                     endDate = placementEnd,
                 )
@@ -580,7 +591,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area2.name,
+                        primaryCareArea = "${area1.name}, ${area2.name}",
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement3.id,
@@ -593,7 +604,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult3.id,
                         personLastName = "Foo",
                         personFirstName = "Mark",
-                        primaryCareArea = area2.name,
+                        primaryCareArea = "${area1.name}, ${area2.name}",
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement4.id,

--- a/service/src/integrationTest/kotlin/evaka/core/incomestatement/IncomeStatementControllerIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/incomestatement/IncomeStatementControllerIntegrationTest.kt
@@ -578,7 +578,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult1.id,
                         personLastName = "Doe",
                         personFirstName = "John",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement2.id,
@@ -591,7 +591,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = "${area1.name}, ${area2.name}",
+                        careAreas = listOf(area1.name, area2.name),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement3.id,
@@ -604,7 +604,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult3.id,
                         personLastName = "Foo",
                         personFirstName = "Mark",
-                        primaryCareArea = "${area1.name}, ${area2.name}",
+                        careAreas = listOf(area1.name, area2.name),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement4.id,
@@ -617,7 +617,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult4.id,
                         personLastName = "Aman",
                         personFirstName = "Dork",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement5.id,
@@ -630,7 +630,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult5.id,
                         personLastName = "Karhula",
                         personFirstName = "Johannes Olavi Antero Tapio",
-                        primaryCareArea = null,
+                        careAreas = emptyList(),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement6.id,
@@ -643,7 +643,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult6.id,
                         personLastName = "Vilkas",
                         personFirstName = "Ville",
-                        primaryCareArea = null,
+                        careAreas = emptyList(),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement7.id,
@@ -656,7 +656,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = child1.id,
                         personLastName = "Doe",
                         personFirstName = "Ricky",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     ),
                 ),
                 7,
@@ -725,7 +725,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area2.name,
+                        careAreas = listOf(area2.name),
                     )
                 ),
                 1,
@@ -799,7 +799,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area2.name,
+                        careAreas = listOf(area2.name),
                     )
                 ),
                 1,
@@ -889,7 +889,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area2.name,
+                        careAreas = listOf(area2.name),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement1.id,
@@ -902,7 +902,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult1.id,
                         personLastName = "Doe",
                         personFirstName = "John",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     ),
                 ),
                 2,
@@ -1026,7 +1026,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     )
                 ),
                 1,
@@ -1107,7 +1107,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult1.id,
                         personLastName = "Doe",
                         personFirstName = "John",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     )
                 ),
                 1,
@@ -1135,7 +1135,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     )
                 ),
                 1,
@@ -1230,7 +1230,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult1.id,
                         personLastName = "Doe",
                         personFirstName = "John",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement2.id,
@@ -1243,7 +1243,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement3.id,
@@ -1256,7 +1256,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult3.id,
                         personLastName = "Foo",
                         personFirstName = "Mark",
-                        primaryCareArea = null,
+                        careAreas = emptyList(),
                     ),
                 ),
                 3,
@@ -1281,7 +1281,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     )
                 ),
                 1,
@@ -1307,7 +1307,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult1.id,
                         personLastName = "Doe",
                         personFirstName = "John",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement2.id,
@@ -1320,7 +1320,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     ),
                 ),
                 2,
@@ -1427,7 +1427,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     ),
                     IncomeStatementAwaitingHandler(
                         id = incomeStatement3.id,
@@ -1440,7 +1440,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult3.id,
                         personLastName = "Foo",
                         personFirstName = "Mark",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     ),
                 ),
                 2,
@@ -1463,7 +1463,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult3.id,
                         personLastName = "Foo",
                         personFirstName = "Mark",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     )
                 ),
                 1,
@@ -1488,7 +1488,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                         personId = adult2.id,
                         personLastName = "Doe",
                         personFirstName = "Joan",
-                        primaryCareArea = area1.name,
+                        careAreas = listOf(area1.name),
                     )
                 ),
                 1,
@@ -1597,7 +1597,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult1.id,
                 personLastName = "Doe",
                 personFirstName = "John",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         val expected2 =
             IncomeStatementAwaitingHandler(
@@ -1611,7 +1611,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult2.id,
                 personLastName = "Doe",
                 personFirstName = "Joan",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         assertEquals(
             PagedIncomeStatementsAwaitingHandler(listOf(expected1, expected2), 2, 1),
@@ -1710,7 +1710,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult1.id,
                 personLastName = "Doe",
                 personFirstName = "John",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         val expected2 =
             IncomeStatementAwaitingHandler(
@@ -1724,7 +1724,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult2.id,
                 personLastName = "Doe",
                 personFirstName = "Joan",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         assertEquals(
             PagedIncomeStatementsAwaitingHandler(listOf(expected1, expected2), 2, 1),
@@ -1805,7 +1805,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult1.id,
                 personLastName = "Doe",
                 personFirstName = "John",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         val expected2 =
             IncomeStatementAwaitingHandler(
@@ -1819,7 +1819,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = child2.id,
                 personLastName = "Doe",
                 personFirstName = "Micky",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         assertEquals(
             PagedIncomeStatementsAwaitingHandler(listOf(expected1, expected2), 2, 1),
@@ -1914,7 +1914,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult1.id,
                 personLastName = "Doe",
                 personFirstName = "John",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         val expected2 =
             IncomeStatementAwaitingHandler(
@@ -1928,7 +1928,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult2.id,
                 personLastName = "Doe",
                 personFirstName = "Joan",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         assertEquals(
             PagedIncomeStatementsAwaitingHandler(listOf(expected1, expected2), 2, 1),
@@ -2009,7 +2009,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult1.id,
                 personLastName = "Doe",
                 personFirstName = "John",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         val expected2 =
             IncomeStatementAwaitingHandler(
@@ -2023,7 +2023,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult2.id,
                 personLastName = "Doe",
                 personFirstName = "Joan",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         assertEquals(
             PagedIncomeStatementsAwaitingHandler(listOf(expected2, expected1), 2, 1),
@@ -2121,7 +2121,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult1.id,
                 personLastName = "Doe",
                 personFirstName = "John",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
         val expected2 =
             IncomeStatementAwaitingHandler(
@@ -2135,7 +2135,7 @@ class IncomeStatementControllerIntegrationTest : FullApplicationTest(resetDbBefo
                 personId = adult2.id,
                 personLastName = "Doe",
                 personFirstName = "Joan",
-                primaryCareArea = area1.name,
+                careAreas = listOf(area1.name),
             )
 
         val result =

--- a/service/src/main/kotlin/evaka/core/incomestatement/IncomeStatementQueries.kt
+++ b/service/src/main/kotlin/evaka/core/incomestatement/IncomeStatementQueries.kt
@@ -681,7 +681,7 @@ private fun awaitingHandlerQuery(
 
     sql(
         """
-SELECT DISTINCT ON (sent_at, start_date, income_end_date, type, handler_note, last_name, first_name, id)
+SELECT
     i.id,
     i.type,
     i.sent_at,
@@ -691,7 +691,7 @@ SELECT DISTINCT ON (sent_at, start_date, income_end_date, type, handler_note, la
     person.id AS personId,
     person.last_name AS person_last_name,
     person.first_name AS person_first_name,
-    ca.name AS primaryCareArea,
+    string_agg(DISTINCT ca.name, ', ' ORDER BY ca.name) AS primaryCareArea,
     (
         SELECT valid_to FROM income
         WHERE person_id = i.person_id AND effect <> 'INCOMPLETE'
@@ -741,6 +741,7 @@ LEFT JOIN care_area ca ON ca.id = d.care_area_id
 WHERE
     between_start_and_end(tstzrange(${bind(sentStart)}, ${bind(sentEnd)}, '[)'), i.sent_at) AND
     ${predicate(filters)}
+GROUP BY i.id, person.id
 """
     )
 }

--- a/service/src/main/kotlin/evaka/core/incomestatement/IncomeStatementQueries.kt
+++ b/service/src/main/kotlin/evaka/core/incomestatement/IncomeStatementQueries.kt
@@ -641,7 +641,7 @@ data class IncomeStatementAwaitingHandler(
     val personLastName: String,
     val personFirstName: String,
     val personName: String = "$personLastName $personFirstName",
-    val primaryCareArea: String?,
+    val careAreas: List<String>,
 )
 
 private fun awaitingHandlerQuery(
@@ -691,7 +691,10 @@ SELECT
     person.id AS personId,
     person.last_name AS person_last_name,
     person.first_name AS person_first_name,
-    string_agg(DISTINCT ca.name, ', ' ORDER BY ca.name) AS primaryCareArea,
+    coalesce(
+        array_agg(DISTINCT ca.name ORDER BY ca.name) FILTER (WHERE ca.name IS NOT NULL),
+        '{}'
+    ) AS care_areas,
     (
         SELECT valid_to FROM income
         WHERE person_id = i.person_id AND effect <> 'INCOMPLETE'


### PR DESCRIPTION
## Ennen tätä muutosta

Käsittelyä odottavien tuloselvitysten "Alue"-sarakkeen arvo vaihteli satunnaisesti hakukerrasta toiseen. Alue päätellään liitosketjun kautta (perheen lapset → sijoitus → yksikkö → alue), joten yhtä tuloselvitystä kohti syntyy monta riviä, ja niistä valittiin yksi `DISTINCT ON`illa ilman `ORDER BY`:tä — tällöin PostgreSQL saa palauttaa ryhmästä minkä tahansa rivin. Myös tyhjä arvo saatettiin valita sattumanvaraisesti listaukseen: sijoitukseton lapsi, esimerkiksi kouluikäinen sisarus, tuottaa oman alueettoman rivinsä joka joinataan mukaan.

## Tämän muutoksen jälkeen

Kysely kokoaa henkilön alueet yhdeksi aakkosjärjestetyksi listaksi, joten sama haku tuottaa aina saman tuloksen. Sarakkeessa näytetään kaikki alueet pilkulla eroteltuna ("Itä, Länsi") ja viiva, jos aluetta ei löydy. Yksiköttömät rivit jätetään pois joinista. Aluerajaus toimii ennallaan: sen ollessa päällä näkyvät vain valintaan osuvat alueet.

Ensimmäinen kommitti korjaa vian. Toinen nimeää kentän `primaryCareArea` → `careAreas` ja muuttaa sen tyypin.