### PR TITLE
Tietojen poistot kun lapsella ei ole yhtään sijoitusta

### DIFF
--- a/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/dataremoval/DataRemovalServiceIntegrationTest.kt
@@ -111,6 +111,7 @@ import evaka.core.specialdiet.setSpecialDiets
 import evaka.core.user.updateLastStrongLogin
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.Period
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -259,15 +260,11 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         insertFamilyContact(child.id)
         insertNekkuSpecialDietChoice(child.id)
 
-        deleteExpiredChildLeafRows(
-            db,
-            expireDate = leafExpireDate,
-            now,
-            limit = 100,
-            leafTables = allLeafTables,
-        )
+        deleteExpiredChildLeafRows(db, now, limit = 100, tables = allLeafTables)
 
-        allLeafTables.forEach { assertEquals(0, rowCount(it), "table $it should be empty") }
+        allLeafTables.forEach {
+            assertEquals(0, rowCount(it.name), "table ${it.name} should be empty")
+        }
     }
 
     @Test
@@ -276,13 +273,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         insertChildStickyNote(child.id)
         insertCalendarEventAttendee(child.id)
 
-        deleteExpiredChildLeafRows(
-            db,
-            expireDate = leafExpireDate,
-            now,
-            limit = 100,
-            leafTables = allLeafTables,
-        )
+        deleteExpiredChildLeafRows(db, now, limit = 100, tables = allLeafTables)
 
         assertEquals(1, rowCount("child_sticky_note"))
         assertEquals(1, rowCount("calendar_event_attendee"))
@@ -293,13 +284,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         insertExpiredPlacement(child.id)
         repeat(5) { insertChildStickyNote(child.id) }
 
-        deleteExpiredChildLeafRows(
-            db,
-            expireDate = leafExpireDate,
-            now,
-            limit = 2,
-            leafTables = listOf("child_sticky_note"),
-        )
+        deleteExpiredChildLeafRows(db, now, limit = 2, tables = listOf(stickyNoteTable))
 
         assertEquals(3, rowCount("child_sticky_note"))
     }
@@ -315,10 +300,9 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         deleteExpiredChildLeafRows(
             db,
-            expireDate = leafExpireDate,
             now,
             limit = 100,
-            leafTables = listOf("preschool_assistance", "child_sticky_note"),
+            tables = listOf(leafTable("preschool_assistance"), stickyNoteTable),
         )
 
         assertEquals(1, rowCount("preschool_assistance"))
@@ -335,10 +319,9 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
 
         deleteExpiredChildLeafRows(
             db,
-            expireDate = leafExpireDate,
             now,
             limit = 100,
-            leafTables = listOf("preschool_assistance"),
+            tables = listOf(leafTable("preschool_assistance")),
         )
 
         assertEquals(0, rowCount("preschool_assistance"))
@@ -347,14 +330,14 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     @Test
     fun `deleteExpiredChildLeafRows records when Koski input data was first removed`() {
         insertExpiredPlacement(child.id)
+        insertKoskiStudyRight(child.id)
         insertPreschoolAssistance(child.id)
 
         deleteExpiredChildLeafRows(
             db,
-            expireDate = leafExpireDate,
             now,
             limit = 100,
-            leafTables = listOf("preschool_assistance"),
+            tables = listOf(leafTable("preschool_assistance")),
         )
 
         assertEquals(0, rowCount("preschool_assistance"))
@@ -366,13 +349,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         insertExpiredPlacement(child.id)
         insertChildStickyNote(child.id)
 
-        deleteExpiredChildLeafRows(
-            db,
-            expireDate = leafExpireDate,
-            now,
-            limit = 100,
-            leafTables = listOf("child_sticky_note"),
-        )
+        deleteExpiredChildLeafRows(db, now, limit = 100, tables = listOf(stickyNoteTable))
 
         assertEquals(0, rowCount("child_sticky_note"))
         assertNull(koskiDataFirstRemovedAt(child.id))
@@ -382,22 +359,21 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     @Test
     fun `a later removal does not overwrite when Koski input data was first removed`() {
         insertExpiredPlacement(child.id)
+        insertKoskiStudyRight(child.id)
         insertPreschoolAssistance(child.id)
         insertOtherAssistanceMeasure(child.id)
 
         deleteExpiredChildLeafRows(
             db,
-            expireDate = leafExpireDate,
             now,
             limit = 100,
-            leafTables = listOf("preschool_assistance"),
+            tables = listOf(leafTable("preschool_assistance")),
         )
         deleteExpiredChildLeafRows(
             db,
-            expireDate = leafExpireDate,
             now.plusDays(1),
             limit = 100,
-            leafTables = listOf("other_assistance_measure"),
+            tables = listOf(leafTable("other_assistance_measure")),
         )
 
         assertEquals(0, rowCount("other_assistance_measure"))
@@ -409,15 +385,145 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         insertExpiredPlacement(child.id)
         insertChildStickyNote(child.id)
 
-        deleteExpiredChildLeafRows(
-            db,
-            expireDate = leafExpireDate,
-            now,
-            limit = 100,
-            leafTables = emptyList(),
-        )
+        deleteExpiredChildLeafRows(db, now, limit = 100, tables = emptyList())
 
         assertEquals(1, rowCount("child_sticky_note"))
+    }
+
+    private val tenYearAssistanceAction =
+        leafTable("assistance_action", retention = Period.ofYears(10))
+
+    @Test
+    fun `a never placed child's rows are removed once their own date expires`() {
+        insertAssistanceAction(child.id, createdAt = now.minusYears(11))
+
+        deleteExpiredChildLeafRows(
+            db,
+            now,
+            limit = 100,
+            tables = listOf(tenYearAssistanceAction),
+        )
+
+        assertEquals(0, rowCount("assistance_action"))
+    }
+
+    @Test
+    fun `a never placed child's rows are kept until their own date expires`() {
+        insertAssistanceAction(child.id, createdAt = now.minusYears(9))
+
+        deleteExpiredChildLeafRows(
+            db,
+            now,
+            limit = 100,
+            tables = listOf(tenYearAssistanceAction),
+        )
+
+        assertEquals(1, rowCount("assistance_action"))
+    }
+
+    @Test
+    fun `a never placed child's dateless rows are removed however recently they were added`() {
+        insertFamilyContact(child.id)
+
+        deleteExpiredChildLeafRows(
+            db,
+            now,
+            limit = 100,
+            tables = listOf(leafTable("family_contact", RetentionFallback.DeleteImmediately)),
+        )
+
+        assertEquals(0, rowCount("family_contact"))
+    }
+
+    @Test
+    fun `a never placed child's calendar attendance expires with the event`() {
+        insertCalendarEventAttendee(child.id, eventDate = today.minusYears(2))
+
+        deleteExpiredChildLeafRows(
+            db,
+            now,
+            limit = 100,
+            tables =
+                listOf(leafTable("calendar_event_attendee", RetentionFallback.CalendarEventEnd)),
+        )
+
+        assertEquals(0, rowCount("calendar_event_attendee"))
+    }
+
+    @Test
+    fun `a never placed child's calendar attendance is kept while the event is recent`() {
+        insertCalendarEventAttendee(child.id, eventDate = today)
+
+        deleteExpiredChildLeafRows(
+            db,
+            now,
+            limit = 100,
+            tables =
+                listOf(leafTable("calendar_event_attendee", RetentionFallback.CalendarEventEnd)),
+        )
+
+        assertEquals(1, rowCount("calendar_event_attendee"))
+    }
+
+    @Test
+    fun `calendar attendance that is not about a single child is left alone`() {
+        insertCalendarEventAttendee(childId = null, eventDate = today.minusYears(2))
+
+        deleteExpiredChildLeafRows(
+            db,
+            now,
+            limit = 100,
+            tables =
+                listOf(leafTable("calendar_event_attendee", RetentionFallback.CalendarEventEnd)),
+        )
+
+        assertEquals(1, rowCount("calendar_event_attendee"))
+    }
+
+    @Test
+    fun `retention counts from the last placement even for a row created since it ended`() {
+        insertPlacementEnding(child.id, tenYearExpireDate.minusDays(1))
+        insertAssistanceAction(child.id, createdAt = now.minusDays(1))
+
+        deleteExpiredChildLeafRows(
+            db,
+            now,
+            limit = 100,
+            tables = listOf(tenYearAssistanceAction),
+        )
+
+        assertEquals(0, rowCount("assistance_action"))
+    }
+
+    @Test
+    fun `rows of a child whose placement has not ended are kept however old they are`() {
+        insertActivePlacement(child.id)
+        insertAssistanceAction(child.id, createdAt = now.minusYears(11))
+
+        deleteExpiredChildLeafRows(
+            db,
+            now,
+            limit = 100,
+            tables = listOf(tenYearAssistanceAction),
+        )
+
+        assertEquals(1, rowCount("assistance_action"))
+    }
+
+    @Test
+    fun `Koski sync is not frozen for a child who was never synced to Koski`() {
+        insertExpiredPlacement(child.id)
+        insertPreschoolAssistance(child.id)
+
+        deleteExpiredChildLeafRows(
+            db,
+            now,
+            limit = 100,
+            tables = listOf(leafTable("preschool_assistance")),
+        )
+
+        assertEquals(0, rowCount("preschool_assistance"))
+        assertNull(koskiDataFirstRemovedAt(child.id))
     }
 
     @Test
@@ -572,6 +678,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     fun `deleteExpiredData cleans up leaf rows, child references, and images in one pass`() {
         insertExpiredPlacement(child.id)
         setUpChildDietReferences(child.id)
+        insertBackupPickup(child.id)
         insertCalendarEventAttendee(child.id)
         insertCalendarEventTime(child.id)
         insertChildStickyNote(child.id)
@@ -583,7 +690,9 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
             dataRemovalService.deleteExpiredData(db, clock, AsyncJob.DeleteExpiredData)
         }
 
-        allLeafTables.forEach { assertEquals(0, rowCount(it), "table $it should be empty") }
+        allLeafTables.forEach {
+            assertEquals(0, rowCount(it.name), "table ${it.name} should be empty")
+        }
         assertEquals(0, rowCount("child_images"))
         assertNull(koskiDataFirstRemovedAt(child.id), "no Koski input table expires in one year")
         assertNull(vardaDataFirstRemovedAt(child.id), "no Varda input table expires in one year")
@@ -595,8 +704,23 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
     }
 
     @Test
+    fun `deleteExpiredData keeps child diet references for a child who was never placed`() {
+        setUpChildDietReferences(child.id)
+
+        withLimit(100) {
+            dataRemovalService.deleteExpiredData(db, clock, AsyncJob.DeleteExpiredData)
+        }
+
+        assertEquals(
+            ChildDietColumns(dietId = 1, mealTextureId = 2, nekkuDiet = "VEGAN"),
+            readChildDietColumns(child.id),
+        )
+    }
+
+    @Test
     fun `deleteExpiredData removes ten-year leaf rows for a child whose last placement ended over ten years ago`() {
         insertPlacementEnding(child.id, tenYearExpireDate.minusDays(1))
+        insertKoskiStudyRight(child.id)
         insertTenYearLeafData(child.id)
 
         withLimit(100) {
@@ -1170,6 +1294,7 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         val guardian = insertAdult()
         insertGuardianship(guardian, child.id)
         insertPlacementEnding(child.id, tenYearExpireDate.minusDays(1))
+        insertSyncedVardaState(child.id)
 
         deleteExpiredGuardians(
             db,
@@ -1771,13 +1896,22 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
             .toSet()
     }
 
+    private fun leafTable(
+        name: String,
+        fallback: RetentionFallback = RetentionFallback.Column("created_at"),
+        retention: Period = Period.ofYears(1),
+    ) = ChildLeafTable(name, retention, fallback)
+
+    private val stickyNoteTable = leafTable("child_sticky_note")
+
     private val allLeafTables =
         listOf(
-            "calendar_event_attendee",
-            "calendar_event_time",
-            "child_sticky_note",
-            "family_contact",
-            "nekku_special_diet_choices",
+            leafTable("backup_pickup", RetentionFallback.DeleteImmediately),
+            leafTable("calendar_event_attendee", RetentionFallback.CalendarEventEnd),
+            leafTable("calendar_event_time", RetentionFallback.Column("date")),
+            stickyNoteTable,
+            leafTable("family_contact", RetentionFallback.DeleteImmediately),
+            leafTable("nekku_special_diet_choices"),
         )
 
     private val allAssistanceTables =
@@ -1814,7 +1948,6 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
             "backup_care",
             "child_attendance",
             "absence_application",
-            "backup_pickup",
             "holiday_questionnaire_answer",
         )
 
@@ -1870,14 +2003,6 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
                     rejectedReason = null,
                 )
             )
-            tx.insert(
-                DevBackupPickup(
-                    id = BackupPickupId(UUID.randomUUID()),
-                    childId = childId,
-                    name = "Pickup Person",
-                    phone = "0401234567",
-                )
-            )
             val questionnaire =
                 DevHolidayQuestionnaire(
                     type = QuestionnaireType.FIXED_PERIOD,
@@ -1913,6 +2038,11 @@ class DataRemovalServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
         )
         block()
     }
+
+    private fun insertAssistanceAction(childId: ChildId, createdAt: HelsinkiDateTime) =
+        db.transaction { tx ->
+            tx.insert(DevAssistanceAction(childId = childId, createdAt = createdAt))
+        }
 
     private fun insertPreschoolAssistance(childId: ChildId) = db.transaction { tx ->
         tx.insert(
@@ -2003,12 +2133,12 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
         }
     }
 
-    private fun insertCalendarEvent(): DevCalendarEvent {
+    private fun insertCalendarEvent(eventDate: LocalDate = today): DevCalendarEvent {
         val event =
             DevCalendarEvent(
                 title = "title",
                 description = "desc",
-                period = FiniteDateRange(today, today),
+                period = FiniteDateRange(eventDate, eventDate),
                 modifiedAt = now,
                 modifiedBy = admin.evakaUserId,
                 eventType = CalendarEventType.DAYCARE_EVENT,
@@ -2017,8 +2147,8 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
         return event
     }
 
-    private fun insertCalendarEventAttendee(childId: ChildId) {
-        val event = insertCalendarEvent()
+    private fun insertCalendarEventAttendee(childId: ChildId?, eventDate: LocalDate = today) {
+        val event = insertCalendarEvent(eventDate)
         db.transaction { tx ->
             tx.insert(
                 DevCalendarEventAttendee(
@@ -2053,6 +2183,19 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
             tx.createChildStickyNote(
                 childId = childId,
                 note = ChildStickyNoteBody(note = "note", expires = today.plusDays(1)),
+            )
+        }
+    }
+
+    private fun insertBackupPickup(childId: ChildId) {
+        db.transaction { tx ->
+            tx.insert(
+                DevBackupPickup(
+                    id = BackupPickupId(UUID.randomUUID()),
+                    childId = childId,
+                    name = "Pickup Person",
+                    phone = "0401234567",
+                )
             )
         }
     }
@@ -2126,6 +2269,28 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
                 sql("SELECT varda_data_first_removed_at FROM child WHERE id = ${bind(childId)}")
             }
             .exactlyOne<HelsinkiDateTime?>()
+    }
+
+    private fun insertSyncedVardaState(childId: ChildId) = db.transaction { tx ->
+        tx.execute {
+            sql(
+                """
+INSERT INTO varda_state (child_id, state, last_success_at)
+VALUES (${bind(childId)}, NULL, ${bind(now)})
+"""
+            )
+        }
+    }
+
+    private fun insertKoskiStudyRight(childId: ChildId) = db.transaction { tx ->
+        tx.execute {
+            sql(
+                """
+INSERT INTO koski_study_right (child_id, unit_id, type, payload, version, data_version)
+VALUES (${bind(childId)}, ${bind(daycare.id)}, 'PRESCHOOL', '{}', 0, 1)
+"""
+            )
+        }
     }
 
     private fun koskiDataFirstRemovedAt(childId: ChildId): HelsinkiDateTime? = db.read { tx ->
@@ -2252,6 +2417,7 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
     @Test
     fun `deleteExpiredApplications records when Varda input data was first removed`() {
         val tree = insertApplicationTree(placementEnd = applicationExpireDate.minusDays(1))
+        insertSyncedVardaState(tree.childId)
 
         dataRemovalService.deleteExpiredApplications(db, now, applicationExpireDate, limit = 100)
 
@@ -2277,6 +2443,7 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
     @Test
     fun `a later removal does not overwrite when Varda input data was first removed`() {
         val tree = insertApplicationTree(placementEnd = applicationExpireDate.minusDays(1))
+        insertSyncedVardaState(tree.childId)
 
         dataRemovalService.deleteExpiredApplications(db, now, applicationExpireDate, limit = 100)
         deleteExpiredGuardians(
@@ -2293,8 +2460,19 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
     }
 
     @Test
+    fun `Varda sync is not frozen for a child who was never synced to Varda`() {
+        val tree = insertApplicationTree(placementEnd = applicationExpireDate.minusDays(1))
+
+        dataRemovalService.deleteExpiredApplications(db, now, applicationExpireDate, limit = 100)
+
+        assertEquals(0, rowCount("application"))
+        assertNull(vardaDataFirstRemovedAt(tree.childId))
+    }
+
+    @Test
     fun `deleteExpiredData freezes Varda sync when it removes applications and guardianships`() {
         val tree = insertApplicationTree(placementEnd = applicationExpireDate.minusDays(1))
+        insertSyncedVardaState(tree.childId)
 
         withLimit(100) {
             dataRemovalService.deleteExpiredData(db, clock, AsyncJob.DeleteExpiredData)
@@ -2313,6 +2491,24 @@ VALUES (${bind(documentId)}, ${bind(personId)}, ${bind(now)})
 
         assertEquals(1, rowCount("application"))
         assertTrue(scheduledDecisionPdfDeletionKeys().isEmpty())
+    }
+
+    @Test
+    fun `deleteExpiredApplications removes an old application of a child who was never placed`() {
+        insertApplication(createdAt = now.minusYears(11))
+
+        dataRemovalService.deleteExpiredApplications(db, now, applicationExpireDate, limit = 100)
+
+        assertEquals(0, rowCount("application"))
+    }
+
+    @Test
+    fun `deleteExpiredApplications retains a recent application of a child who was never placed`() {
+        insertApplication(createdAt = now.minusYears(9))
+
+        dataRemovalService.deleteExpiredApplications(db, now, applicationExpireDate, limit = 100)
+
+        assertEquals(1, rowCount("application"))
     }
 
     @Test
@@ -2461,6 +2657,24 @@ VALUES ('MESSAGE'::message_type, 'title', false, false, ${bind(applicationId)})
         val attachmentId: AttachmentId,
         val childId: ChildId,
     )
+
+    private fun insertApplication(createdAt: HelsinkiDateTime) = db.transaction { tx ->
+        val guardian = DevPerson()
+        tx.insert(guardian, DevPersonType.ADULT)
+        tx.insertTestApplication(
+            type = ApplicationType.DAYCARE,
+            guardianId = guardian.id,
+            childId = child.id,
+            document =
+                DaycareFormV0(
+                    type = ApplicationType.DAYCARE,
+                    child = ApplicationFormChild(dateOfBirth = null),
+                    guardian = Adult(),
+                    apply = Apply(preferredUnits = listOf(daycare.id)),
+                ),
+            modifiedAt = createdAt,
+        )
+    }
 
     private fun insertApplicationTree(
         placementEnd: LocalDate,

--- a/service/src/integrationTest/kotlin/evaka/core/document/childdocument/DeleteExpiredChildDocumentsTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/document/childdocument/DeleteExpiredChildDocumentsTest.kt
@@ -165,10 +165,21 @@ class DeleteExpiredChildDocumentsTest : PureJdbiTest(resetDbBeforeEach = true) {
     }
 
     @Test
-    fun `PLACEMENT_END - never deleted when child has no placements`() {
+    fun `PLACEMENT_END - counts from the status transition when the child has no placements`() {
         val template =
-            insertTemplate(retentionDays = 1, basis = DocumentDeletionBasis.PLACEMENT_END)
-        val docId = insertDocument(template)
+            insertTemplate(retentionDays = 365, basis = DocumentDeletionBasis.PLACEMENT_END)
+        val docId = insertDocument(template, statusModifiedAt = now.minusDays(365))
+
+        val result = db.transaction { tx -> tx.deleteExpiredChildDocuments(now) }
+        assertEquals(1, result.size)
+        assertDocumentDoesNotExist(docId)
+    }
+
+    @Test
+    fun `PLACEMENT_END - not deleted before the status transition fallback has elapsed`() {
+        val template =
+            insertTemplate(retentionDays = 365, basis = DocumentDeletionBasis.PLACEMENT_END)
+        val docId = insertDocument(template, statusModifiedAt = now.minusDays(364))
 
         val result = db.transaction { tx -> tx.deleteExpiredChildDocuments(now) }
         assertEquals(0, result.size)

--- a/service/src/integrationTest/kotlin/evaka/core/reports/VardaErrorReportTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/reports/VardaErrorReportTest.kt
@@ -39,7 +39,7 @@ class VardaErrorReportTest : FullApplicationTest(resetDbBeforeEach = true) {
                 tx.insert(child, DevPersonType.CHILD)
                 tx.execute {
                     sql(
-                        "INSERT INTO varda_state (child_id, state) VALUES (${bind(child.id)}, NULL)"
+                        "INSERT INTO varda_state (child_id, state, last_success_at) VALUES (${bind(child.id)}, NULL, ${bind(now)})"
                     )
                 }
                 tx.setVardaUpdateError(child.id, now, "boom")

--- a/service/src/integrationTest/kotlin/evaka/core/shared/job/ScheduledJobsTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/shared/job/ScheduledJobsTest.kt
@@ -441,12 +441,41 @@ class ScheduledJobsTest : FullApplicationTest(resetDbBeforeEach = true) {
             tx.insert(minorChild, DevPersonType.CHILD)
             tx.insertGuardian(adult.id, adultChild.id)
             tx.insertGuardian(adult.id, minorChild.id)
+            listOf(adultChild, minorChild).forEach {
+                tx.execute {
+                    sql(
+                        """
+INSERT INTO varda_state (child_id, state, last_success_at)
+VALUES (${bind(it.id)}, NULL, ${bind(now)})
+"""
+                    )
+                }
+            }
         }
 
         scheduledJobs.removeGuardiansFromAdults(db, clock)
 
         assertEquals(now, vardaDataFirstRemovedAt(adultChild.id))
         assertNull(vardaDataFirstRemovedAt(minorChild.id))
+    }
+
+    @Test
+    fun `RemoveGuardiansFromAdults does not freeze Varda sync for a child who was never synced`() {
+        val today = LocalDate.of(2024, 8, 15)
+        val now = HelsinkiDateTime.of(today, LocalTime.of(2, 0))
+        val clock = MockEvakaClock(now)
+
+        val adult = DevPerson()
+        val adultChild = DevPerson(dateOfBirth = today.minusYears(18))
+        db.transaction { tx ->
+            tx.insert(adult, DevPersonType.ADULT)
+            tx.insert(adultChild, DevPersonType.CHILD)
+            tx.insertGuardian(adult.id, adultChild.id)
+        }
+
+        scheduledJobs.removeGuardiansFromAdults(db, clock)
+
+        assertNull(vardaDataFirstRemovedAt(adultChild.id))
     }
 
     private fun vardaDataFirstRemovedAt(childId: ChildId): HelsinkiDateTime? = db.read { tx ->

--- a/service/src/integrationTest/kotlin/evaka/core/varda/VardaUpdateServiceIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/varda/VardaUpdateServiceIntegrationTest.kt
@@ -177,7 +177,11 @@ class VardaUpdateServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
                     endDate = LocalDate.of(2021, 2, 28),
                 )
             )
-            tx.freezeVardaSync(listOf(child.id), now)
+            tx.execute {
+                sql(
+                    "UPDATE child SET varda_data_first_removed_at = ${bind(now)} WHERE id = ${bind(child.id)}"
+                )
+            }
         }
 
         vardaUpdateService.planChildrenUpdate(db, clock)
@@ -205,7 +209,9 @@ class VardaUpdateServiceIntegrationTest : FullApplicationTest(resetDbBeforeEach 
                 )
             )
             tx.execute {
-                sql("INSERT INTO varda_state (child_id, state) VALUES (${bind(child.id)}, NULL)")
+                sql(
+                    "INSERT INTO varda_state (child_id, state, last_success_at) VALUES (${bind(child.id)}, NULL, ${bind(now)})"
+                )
             }
             tx.freezeVardaSync(listOf(child.id), now)
         }

--- a/service/src/integrationTest/kotlin/evaka/core/varda/VardaUpdaterIntegrationTest.kt
+++ b/service/src/integrationTest/kotlin/evaka/core/varda/VardaUpdaterIntegrationTest.kt
@@ -2895,7 +2895,9 @@ class VardaUpdaterIntegrationTest : PureJdbiTest(resetDbBeforeEach = true) {
         db.transaction { tx ->
             tx.insert(child, DevPersonType.CHILD)
             tx.execute {
-                sql("INSERT INTO varda_state (child_id, state) VALUES (${bind(child.id)}, NULL)")
+                sql(
+                    "INSERT INTO varda_state (child_id, state, last_success_at) VALUES (${bind(child.id)}, NULL, ${bind(now)})"
+                )
             }
             tx.freezeVardaSync(listOf(child.id), now)
         }

--- a/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
+++ b/service/src/main/kotlin/evaka/core/dataremoval/DataRemovalService.kt
@@ -49,6 +49,7 @@ import evaka.core.varda.freezeVardaSync
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Duration
 import java.time.LocalDate
+import java.time.Period
 import java.util.UUID
 import org.springframework.stereotype.Service
 
@@ -127,42 +128,7 @@ class DataRemovalService(
 
         deleteExpiredApplications(dbc, now, expireDate = today.minusYears(10), limit)
 
-        deleteExpiredChildLeafRows(
-            dbc,
-            expireDate = today.minusYears(1),
-            now,
-            limit,
-            leafTables =
-                listOf(
-                    "calendar_event_attendee",
-                    "calendar_event_time",
-                    "child_sticky_note",
-                    "family_contact",
-                    "nekku_special_diet_choices",
-                ),
-        )
-
-        deleteExpiredChildLeafRows(
-            dbc,
-            expireDate = today.minusYears(10),
-            now,
-            limit,
-            leafTables =
-                listOf(
-                    "assistance_factor",
-                    "assistance_action",
-                    "daycare_assistance",
-                    "preschool_assistance",
-                    "other_assistance_measure",
-                    "daily_service_time",
-                    "attendance_reservation",
-                    "backup_care",
-                    "child_attendance",
-                    "absence_application",
-                    "backup_pickup",
-                    "holiday_questionnaire_answer",
-                ),
-        )
+        deleteExpiredChildLeafRows(dbc, now, limit, tables = CHILD_LEAF_TABLES)
 
         deleteExpiredServiceApplications(dbc, expireDate = today.minusYears(10), limit)
 
@@ -336,9 +302,14 @@ class DataRemovalService(
     ) {
         val ids = dbc.transaction { tx ->
             val childImageIds =
-                tx.deleteExpiredChildLeafRowsFromTable(expireDate, now, limit, "child_images").map {
-                    ChildImageId(it.id)
-                }
+                tx.deleteExpiredChildLeafRowsFromTable(
+                        expireDate,
+                        now,
+                        limit,
+                        "child_images",
+                        RetentionFallback.Column("created"),
+                    )
+                    .map { ChildImageId(it.id) }
             asyncJobRunner.plan(
                 tx,
                 childImageIds.map { AsyncJob.DeleteChildImage(it) },
@@ -502,31 +473,38 @@ class DataRemovalService(
 
 fun deleteExpiredChildLeafRows(
     dbc: Database.Connection,
-    expireDate: LocalDate,
     now: HelsinkiDateTime,
     limit: Int,
-    leafTables: List<String>,
+    tables: List<ChildLeafTable>,
 ) {
-    leafTables.forEach { table ->
-        logger.info { "Deleting at most $limit expired rows in table $table" }
+    tables.forEach { table ->
+        val expireDate = now.toLocalDate().minus(table.retention)
+        logger.info { "Deleting at most $limit expired rows in table ${table.name}" }
         val removal = dbc.transaction { tx ->
-            val deleted = tx.deleteExpiredChildLeafRowsFromTable(expireDate, now, limit, table)
+            val deleted =
+                tx.deleteExpiredChildLeafRowsFromTable(
+                    expireDate,
+                    now,
+                    limit,
+                    table.name,
+                    table.fallback,
+                )
             val childIds = deleted.map { it.childId }.distinct()
             ExpiredLeafRemoval(
                 deletedIds = deleted.map { it.id },
                 frozenKoskiChildIds =
-                    if (table in KOSKI_INPUT_TABLES && childIds.isNotEmpty())
+                    if (table.name in KOSKI_INPUT_TABLES && childIds.isNotEmpty())
                         tx.freezeKoskiSync(childIds, now)
                     else emptyList(),
                 frozenVardaChildIds =
-                    if (table in VARDA_INPUT_TABLES && childIds.isNotEmpty())
+                    if (table.name in VARDA_INPUT_TABLES && childIds.isNotEmpty())
                         tx.freezeVardaSync(childIds, now)
                     else emptyList(),
             )
         }
         removal.deletedIds.forEach { id ->
             auditExpiredDelete(
-                entity = table,
+                entity = table.name,
                 targetId = AuditId(id),
                 meta = mapOf("expireDate" to expireDate),
             )
@@ -553,6 +531,7 @@ private fun Database.Transaction.deleteExpiredChildLeafRowsFromTable(
     now: HelsinkiDateTime,
     limit: Int,
     table: String,
+    fallback: RetentionFallback,
 ): List<ExpiredLeafRow> {
     val removalAllowed =
         if (table in KOSKI_INPUT_TABLES || table in VARDA_INPUT_TABLES)
@@ -564,7 +543,7 @@ private fun Database.Transaction.deleteExpiredChildLeafRowsFromTable(
 WITH del_batch AS (
     SELECT id, child_id
     FROM $table
-    WHERE child_id = ANY(${subquery(childIdsWithPlacementsEndingBefore(expireDate))})
+    WHERE ${predicate(childDataExpired(expireDate, fallback).forTable(table))}
     AND ${predicate(removalAllowed.forTable(table))}
     FOR UPDATE
     LIMIT ${bind(limit)}
@@ -641,6 +620,147 @@ HAVING max(end_date) < ${bind(date)}
     )
 }
 
+/** The date a row's retention counts from when the child has no placements. */
+sealed interface RetentionFallback {
+    data class Column(val name: String) : RetentionFallback
+
+    data object CalendarEventEnd : RetentionFallback
+
+    data object DeleteImmediately : RetentionFallback
+}
+
+data class ChildLeafTable(
+    val name: String,
+    val retention: Period,
+    val fallback: RetentionFallback,
+)
+
+private val CHILD_LEAF_TABLES =
+    listOf(
+        ChildLeafTable(
+            name = "backup_pickup",
+            retention = Period.ofYears(1),
+            fallback = RetentionFallback.DeleteImmediately,
+        ),
+        ChildLeafTable(
+            name = "calendar_event_attendee",
+            retention = Period.ofYears(1),
+            fallback = RetentionFallback.CalendarEventEnd,
+        ),
+        ChildLeafTable(
+            name = "calendar_event_time",
+            retention = Period.ofYears(1),
+            fallback = RetentionFallback.Column("date"),
+        ),
+        ChildLeafTable(
+            name = "child_sticky_note",
+            retention = Period.ofYears(1),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "family_contact",
+            retention = Period.ofYears(1),
+            fallback = RetentionFallback.DeleteImmediately,
+        ),
+        ChildLeafTable(
+            name = "nekku_special_diet_choices",
+            retention = Period.ofYears(1),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "absence_application",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "assistance_action",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "assistance_factor",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "attendance_reservation",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "backup_care",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "child_attendance",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "daily_service_time",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created"),
+        ),
+        ChildLeafTable(
+            name = "daycare_assistance",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "holiday_questionnaire_answer",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "other_assistance_measure",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+        ChildLeafTable(
+            name = "preschool_assistance",
+            retention = Period.ofYears(10),
+            fallback = RetentionFallback.Column("created_at"),
+        ),
+    )
+
+private val childIdNotNull = Predicate { where("$it.child_id IS NOT NULL") }
+
+private val childHasNoPlacement = Predicate {
+    where("NOT EXISTS (SELECT FROM placement p WHERE p.child_id = $it.child_id)")
+}
+
+private fun lastPlacementEndedBefore(date: LocalDate) = Predicate {
+    where("$it.child_id = ANY(${subquery(childIdsWithPlacementsEndingBefore(date))})")
+}
+
+private fun fallbackDateBefore(date: LocalDate, fallback: RetentionFallback): Predicate =
+    when (fallback) {
+        is RetentionFallback.Column -> Predicate { where("$it.${fallback.name} < ${bind(date)}") }
+
+        RetentionFallback.CalendarEventEnd ->
+            Predicate {
+                where(
+                    "(SELECT upper(ce.period) FROM calendar_event ce WHERE ce.id = $it.calendar_event_id) < ${bind(date)}"
+                )
+            }
+
+        RetentionFallback.DeleteImmediately -> Predicate.alwaysTrue()
+    }
+
+/**
+ * A child's data expires once their last placement ended long enough ago. Without placements there
+ * is no such date, so the row's own fallback decides.
+ */
+private fun childDataExpired(expireDate: LocalDate, fallback: RetentionFallback): Predicate =
+    Predicate.all(
+        childIdNotNull,
+        Predicate.any(
+            lastPlacementEndedBefore(expireDate),
+            Predicate.all(fallbackDateBefore(expireDate, fallback), childHasNoPlacement),
+        ),
+    )
+
 data class DeletedApplication(
     val applicationId: ApplicationId,
     val childId: ChildId,
@@ -668,13 +788,14 @@ private fun Database.Transaction.deleteExpiredApplicationsBatch(
     now: HelsinkiDateTime,
     limit: Int,
 ): Pair<List<DeletedApplication>, List<UnsetReference>> {
+    val expired = childDataExpired(expireDate, RetentionFallback.Column("created_at"))
     val deletableRows = createQuery {
         sql(
             """
 WITH del_batch AS (
     SELECT id
     FROM application
-    WHERE child_id = ANY(${subquery(childIdsWithPlacementsEndingBefore(expireDate))})
+    WHERE ${predicate(expired.forTable("application"))}
     AND ${predicate(childPastSafeDataRemovalAge(now.toLocalDate()).forTable("application"))}
     FOR UPDATE
     LIMIT ${bind(limit)}
@@ -858,12 +979,13 @@ private fun Database.Transaction.deleteExpiredServiceApplicationsBatch(
     expireDate: LocalDate,
     limit: Int,
 ): Pair<List<ServiceApplicationId>, List<PlacementId>> {
+    val expired = childDataExpired(expireDate, RetentionFallback.Column("created_at"))
     val batch = createQuery {
         sql(
             """
 SELECT id
 FROM service_application
-WHERE child_id = ANY(${subquery(childIdsWithPlacementsEndingBefore(expireDate))})
+WHERE ${predicate(expired.forTable("service_application"))}
 FOR UPDATE
 LIMIT ${bind(limit)}
 """
@@ -906,12 +1028,13 @@ private fun Database.Transaction.deleteExpiredPedagogicalDocumentsBatch(
     expireDate: LocalDate,
     limit: Int,
 ): List<DeletedPedagogicalDocument> {
+    val expired = childDataExpired(expireDate, RetentionFallback.Column("created_at"))
     val documents = createQuery {
         sql(
             """
 SELECT id, child_id
 FROM pedagogical_document
-WHERE child_id = ANY(${subquery(childIdsWithPlacementsEndingBefore(expireDate))})
+WHERE ${predicate(expired.forTable("pedagogical_document"))}
 ORDER BY created_at
 LIMIT ${bind(limit)}
 FOR UPDATE

--- a/service/src/main/kotlin/evaka/core/document/childdocument/ChildDocumentQueries.kt
+++ b/service/src/main/kotlin/evaka/core/document/childdocument/ChildDocumentQueries.kt
@@ -821,13 +821,24 @@ WITH del_batch AS (
     SELECT cd.id
     FROM child_document cd
     JOIN document_template dt ON dt.id = cd.template_id
+    LEFT JOIN LATERAL (
+        SELECT max(p.end_date) AS last_placement_end
+        FROM placement p
+        WHERE p.child_id = cd.child_id
+    ) placement ON true
     WHERE (NOT dt.archive_externally OR cd.archived_at IS NOT NULL)
       AND CASE dt.deletion_retention_basis
         WHEN 'STATUS_TRANSITION' THEN
             cd.status_modified_at + make_interval(days => dt.deletion_retention_days) <= ${bind(now)}
         WHEN 'PLACEMENT_END' THEN
-            (SELECT MAX(p.end_date) FROM placement p WHERE p.child_id = cd.child_id)
-                + make_interval(days => dt.deletion_retention_days) <= ${bind(today)}
+            CASE WHEN placement.last_placement_end IS NOT NULL THEN
+                placement.last_placement_end
+                    + make_interval(days => dt.deletion_retention_days) <= ${bind(today)}
+            ELSE
+                -- if all the child's placements have been deleted, count from the last status
+                -- transition instead
+                cd.status_modified_at + make_interval(days => dt.deletion_retention_days) <= ${bind(now)}
+            END
       END
     FOR UPDATE OF cd
     ${if (limit != null) "LIMIT ${bind(limit)}" else ""}

--- a/service/src/main/kotlin/evaka/core/koski/KoskiQueries.kt
+++ b/service/src/main/kotlin/evaka/core/koski/KoskiQueries.kt
@@ -37,6 +37,7 @@ UPDATE child
 SET koski_data_first_removed_at = ${bind(now)}
 WHERE id = ANY(${bind(childIds)})
 AND koski_data_first_removed_at IS NULL
+AND EXISTS (SELECT FROM koski_study_right ksr WHERE ksr.child_id = child.id)
 RETURNING id
 """
     )

--- a/service/src/main/kotlin/evaka/core/varda/VardaQueries.kt
+++ b/service/src/main/kotlin/evaka/core/varda/VardaQueries.kt
@@ -44,6 +44,10 @@ UPDATE child
 SET varda_data_first_removed_at = ${bind(now)}
 WHERE id = ANY(${bind(childIds)})
 AND varda_data_first_removed_at IS NULL
+AND EXISTS (
+    SELECT FROM varda_state vs
+    WHERE vs.child_id = child.id AND vs.last_success_at IS NOT NULL
+)
 RETURNING id
 """
     )


### PR DESCRIPTION
Automaattisten tietojen poistojen ajankohta lasketaan yleensä lapsen viimeisimmän sijoituksen päättymispäivästä eteenpäin. Mikäli lapsella ei ole yhtään sijoitusta, ei tietoja tällä hetkellä poisteta koskaan. Tällainen tilanne syntyy todennäköisimmin silloin kun lapsi ei jostain syystä aloitakaan myönnetyssä paikassa, jolloin sijoitus poistetaan, mutta jotain tietoja on kuitenkin ehtinyt kertyä.

Tällaisissa tapauksissa tiedot poistetaan N vuotta niiden luomisesta eikä N vuotta viimeisimmän sijoituksen päättymisestä. 

Perheen yhteystiedoille ja varahakijoille ei ole tallessa luontipäivää, joten ne poistetaan välittömästi. Nämä ovat kuitenkin tietoja (monen muun ohella), joita ei käytännössä lisätä ennen kuin lapsi aloittaa, joten tällaista tilannetta ei käytännössä tule.

Muutetaan myös Koski ja Varda integraatioiden jäädytyslogiikkaa niin, että tietojen poisto ei aiheuta jäädytystä, jos Koskeen / Vardaan ei olla vielä viety mitään tietoa.

Varahakijoiden säilytysaika lyhennetty yhteen vuoteen.