### PR TITLE
Aggressiivisempi Postgres autovacuum analyze Turussa

### DIFF
--- a/service/src/main/resources/turku/db/migration/afterMigrate__autovacuum_analyze_options.sql
+++ b/service/src/main/resources/turku/db/migration/afterMigrate__autovacuum_analyze_options.sql
@@ -1,0 +1,39 @@
+-- SPDX-FileCopyrightText: 2026 City of Turku
+--
+-- SPDX-License-Identifier: LGPL-2.1-or-later
+
+-- Use more aggressive autovacuum_analyze settings for the biggest tables.
+-- This avoids stale statistics and poor query performance.
+
+DO $$
+DECLARE
+    target_table TEXT;
+    table_list TEXT[] := ARRAY[
+        'absence',
+        'async_job',
+        'attendance_reservation',
+        'child_attendance',
+        'message',
+        'message_recipients',
+        'message_thread',
+        'message_thread_children',
+        'message_thread_participant'
+    ];
+BEGIN
+    FOREACH target_table IN ARRAY table_list LOOP
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_class
+            WHERE relname = target_table
+              AND relnamespace = 'public'::regnamespace
+              AND 'autovacuum_analyze_scale_factor=0' = ANY(reloptions)
+              AND 'autovacuum_analyze_threshold=50000' = ANY(reloptions)
+        ) THEN
+            EXECUTE format('
+                ALTER TABLE public.%I SET (
+                    autovacuum_analyze_scale_factor = 0,
+                    autovacuum_analyze_threshold = 50000
+                )', target_table);
+        END IF;
+    END LOOP;
+END $$;


### PR DESCRIPTION
Asetetaan autovacuum-tuunauksia kuten aiemmin [Espoossa](https://github.com/espoon-voltti/evaka/pull/9216) ja [Oulussa](https://github.com/espoon-voltti/evaka/pull/9784)

Turussa poikkeuksena jätettiin toistaiseksi staff_attendance_realtime pois, nykyisellä rivimäärällä default-asetus ajaa analyzen jo useammin kuin tällä muutoksella.