### PR TITLE
Poistetaan kuntalaisen sessio, jos käyttäjää ei enää ole tietokannassa

### DIFF
--- a/apigw/src/enduser/__tests__/auth-status.ts
+++ b/apigw/src/enduser/__tests__/auth-status.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2017-2026 City of Espoo
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { configFromEnv } from '../../shared/config.ts'
+import type { CitizenUser } from '../../shared/service-client.ts'
+import { GatewayTester } from '../../shared/test/gateway-tester.ts'
+import { MockRedisClient } from '../../shared/test/mock-redis-client.ts'
+
+const mockUser: CitizenUser = {
+  id: '4f73e4f8-8759-46c6-9b9d-4da860138ce2'
+}
+
+describe('Citizen auth status', () => {
+  let tester: GatewayTester
+
+  beforeEach(async () => {
+    tester = await GatewayTester.start(
+      configFromEnv(),
+      'citizen',
+      new MockRedisClient()
+    )
+    tester.setCsrfHeader = true
+  })
+  afterEach(async () => {
+    await tester?.afterEach()
+    await tester?.stop()
+  })
+
+  async function weakLogin(): Promise<void> {
+    tester.nockScope.post('/system/citizen-weak-login').reply(200, mockUser)
+    const res = await tester.client.post(
+      '/api/citizen/auth/weak-login',
+      { username: 'user@example.com', password: 'password' },
+      { validateStatus: () => true }
+    )
+    tester.nockScope.done()
+    expect(res.status).toBe(200)
+  }
+
+  async function getStatus(): Promise<{ loggedIn: boolean }> {
+    const res = await tester.client.get('/api/citizen/auth/status', {
+      validateStatus: () => true
+    })
+    expect(res.status).toBe(200)
+    return res.data as { loggedIn: boolean }
+  }
+
+  test('a session whose person no longer exists is ended and reported as logged out', async () => {
+    await weakLogin()
+
+    // The person was removed behind the session, e.g. by a database reset
+    tester.nockScope.get(`/system/citizen/${mockUser.id}`).reply(404)
+    expect((await getStatus()).loggedIn).toBe(false)
+    tester.nockScope.done()
+
+    // The session is gone, so the person is not looked up again
+    expect((await getStatus()).loggedIn).toBe(false)
+    tester.nockScope.done()
+  })
+})

--- a/apigw/src/enduser/routes/auth-status.ts
+++ b/apigw/src/enduser/routes/auth-status.ts
@@ -30,17 +30,22 @@ const getAuthLevel = (user: EvakaSessionUser): 'STRONG' | 'WEAK' => {
 export const citizenAuthStatus = (sessions: Sessions<'citizen'>) =>
   toRequestHandler(async (req, res) => {
     const user = sessions.getUser(req)
-    let status: AuthStatus
-    if (user && user.id) {
-      const data = await getCitizenDetails(req, user.id)
-      status = {
+    const data = user?.id ? await getCitizenDetails(req, user.id) : undefined
+    if (user && data) {
+      res.status(200).send({
         loggedIn: true,
         user: data,
         apiVersion: appCommit,
         authLevel: getAuthLevel(user)
-      }
-    } else {
-      status = { loggedIn: false, apiVersion: appCommit }
+      } satisfies AuthStatus)
+      return
     }
-    res.status(200).send(status)
+    if (user && !data) {
+      // Citizen no longer exists, log them out. This can happen e.g. in dev
+      // environment if the database is reset
+      await sessions.destroy(req, res)
+    }
+    res
+      .status(200)
+      .send({ loggedIn: false, apiVersion: appCommit } satisfies AuthStatus)
   })

--- a/apigw/src/shared/service-client.ts
+++ b/apigw/src/shared/service-client.ts
@@ -268,14 +268,22 @@ export async function citizenWeakLoginCredentialsDelete(
 export async function getCitizenDetails(
   req: express.Request,
   personId: string
-) {
-  const { data } = await client.get<CitizenUserResponse>(
-    `/system/citizen/${encodeURIComponent(personId)}`,
-    {
-      headers: createServiceRequestHeaders(req, systemUserHeader)
+): Promise<CitizenUserResponse | undefined> {
+  try {
+    const { data } = await client.get<CitizenUserResponse>(
+      `/system/citizen/${encodeURIComponent(personId)}`,
+      {
+        headers: createServiceRequestHeaders(req, systemUserHeader)
+      }
+    )
+    return data
+  } catch (e: unknown) {
+    if (axios.isAxiosError(e) && e.response?.status === 404) {
+      return undefined
+    } else {
+      throw e
     }
-  )
-  return data
+  }
 }
 
 export interface ValidatePairingRequest {


### PR DESCRIPTION
Näin voi tapahtua kehitysympäristössä esim. database resetin yhteydessä.

Helpottaa PWA-kehitystä, koska ilman mahdollisuutta refreshata selainta tästä tilanteesta ei ole ulospääsyä.