### PR TITLE
iOS Safari PWA layout-korjaus

### DIFF
--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -8,6 +8,7 @@ import React, { useCallback, useContext } from 'react'
 import styled, { createGlobalStyle, ThemeProvider } from 'styled-components'
 import { Redirect } from 'wouter'
 
+import { useRegisterScrollContainer } from 'lib-common/utils/scrolling'
 import {
   Notifications,
   NotificationsContextProvider
@@ -34,6 +35,7 @@ import { mobileBottomNavHeight } from './navigation/const'
 import GlobalDialog from './overlay/GlobalDialog'
 import { OverlayContext, OverlayContextProvider } from './overlay/state'
 import { InstallSuggestion } from './pwa/InstallSuggestion'
+import { useStandaloneAttribute } from './pwa/installed'
 import { queryClient, QueryClientProvider } from './query'
 
 const GlobalStyle = createGlobalStyle`
@@ -76,10 +78,83 @@ export function App({ children }: { children: React.ReactNode }) {
   )
 }
 
-const FullPageContainer = styled.div`
+// The app has the following DOM structure:
+//
+// <AppShell>
+//   <Header />
+//   (...other fixed elements, e.g. notifications...)
+//   <ScrollArea (flex-grow)>
+//     (...content...)
+//   </ScrollArea>
+//   <MobileNav />
+// </AppShell>
+//
+// Normally the document scrolls, header and other fixed elements stick to the
+// top and the mobile navi is fixed to the bottom.
+//
+// In mobile and tablet PWA (standalone), AppShell is a flex column that fills
+// the screen, and ScrollArea is the only scrollable element. This avoids
+// anchoring topbar or navi with `position: fixed` or `position sticky`,
+// because those cause subtle layout bugs in iOS PWA.
+//
+const AppShell = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+
+  html[data-standalone] & {
+    height: 100%;
+    min-height: auto;
+    position: relative;
+    overflow: hidden;
+
+    // A scrollbar that is always there stops the content from shifting when it
+    // grows past the window, as the document scrollbar does
+    @media (min-width: ${desktopMin}) {
+      overflow-x: hidden;
+      overflow-y: scroll;
+    }
+
+    @media print {
+      display: block;
+      height: auto;
+      overflow: visible;
+    }
+  }
+`
+
+const ScrollArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
+
+  html[data-standalone] & {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    overscroll-behavior: contain;
+
+    @media screen and (max-width: ${zoomedMobileMax}) {
+      overflow-x: auto;
+    }
+
+    @media (min-width: ${desktopMin}) {
+      flex-shrink: 0;
+      min-height: auto;
+      overflow: visible;
+    }
+
+    @media print {
+      overflow: visible;
+    }
+  }
+`
+
+const FullPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
 `
 
 const Content = React.memo(function Content({
@@ -98,13 +173,19 @@ const Content = React.memo(function Content({
       user.map((usr) => !!usr).getOrElse(false)
     )
   useChildrenStartingNotification()
+  useStandaloneAttribute()
+  const { shellRef, scrollAreaRef } = useRegisterScrollContainer()
   return (
-    <FullPageContainer>
+    <AppShell ref={shellRef}>
       <SkipToContent target="main">{t.skipLinks.mainContent}</SkipToContent>
       <Header ariaHidden={modalOpen} />
       <InstallSuggestion />
       <Notifications apiVersion={apiVersion} sticky offsetTop />
-      <MainContainer ariaHidden={modalOpen}>{children}</MainContainer>
+      <ScrollArea ref={scrollAreaRef} data-qa="scroll-area">
+        <FullPageContainer>
+          <MainContainer ariaHidden={modalOpen}>{children}</MainContainer>
+        </FullPageContainer>
+      </ScrollArea>
       <MobileNav />
       {sessionExpirationDetected && (
         <SessionExpiredModal onClose={() => dismissSessionExpiredDetection()} />
@@ -112,7 +193,7 @@ const Content = React.memo(function Content({
       {!!featureFlags.environmentLabel && (
         <EnvironmentLabel>{featureFlags.environmentLabel}</EnvironmentLabel>
       )}
-    </FullPageContainer>
+    </AppShell>
   )
 })
 
@@ -153,6 +234,10 @@ const ScrollableMain = styled.div`
 
   padding-bottom: ${mobileBottomNavHeight}px;
   @media (min-width: ${desktopMin}) {
+    padding-bottom: 0;
+  }
+
+  html[data-standalone] & {
     padding-bottom: 0;
   }
 `

--- a/frontend/src/citizen-frontend/App.tsx
+++ b/frontend/src/citizen-frontend/App.tsx
@@ -92,10 +92,10 @@ export function App({ children }: { children: React.ReactNode }) {
 // Normally the document scrolls, header and other fixed elements stick to the
 // top and the mobile navi is fixed to the bottom.
 //
-// In mobile and tablet PWA (standalone), AppShell is a flex column that fills
-// the screen, and ScrollArea is the only scrollable element. This avoids
-// anchoring topbar or navi with `position: fixed` or `position sticky`,
-// because those cause subtle layout bugs in iOS PWA.
+// In PWA (standalone), AppShell is a flex column that fills the screen, and
+// ScrollArea is the only scrollable element. This avoids anchoring topbar or
+// navi with `position: fixed` or `position sticky`, because those cause subtle
+// layout bugs in iOS PWA.
 //
 const AppShell = styled.div`
   display: flex;
@@ -107,13 +107,6 @@ const AppShell = styled.div`
     min-height: auto;
     position: relative;
     overflow: hidden;
-
-    // A scrollbar that is always there stops the content from shifting when it
-    // grows past the window, as the document scrollbar does
-    @media (min-width: ${desktopMin}) {
-      overflow-x: hidden;
-      overflow-y: scroll;
-    }
 
     @media print {
       display: block;
@@ -137,12 +130,6 @@ const ScrollArea = styled.div`
 
     @media screen and (max-width: ${zoomedMobileMax}) {
       overflow-x: auto;
-    }
-
-    @media (min-width: ${desktopMin}) {
-      flex-shrink: 0;
-      min-height: auto;
-      overflow: visible;
     }
 
     @media print {

--- a/frontend/src/citizen-frontend/calendar/DayElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/DayElem.tsx
@@ -10,7 +10,7 @@ import type { CitizenCalendarEvent } from 'lib-common/generated/api-types/calend
 import type { ReservationResponseDay } from 'lib-common/generated/api-types/reservations'
 import LocalDate from 'lib-common/local-date'
 import { capitalizeFirstLetter } from 'lib-common/string'
-import { scrollToPos } from 'lib-common/utils/scrolling'
+import { scrollToElementTop } from 'lib-common/utils/scrolling'
 import { FixedSpaceColumn } from 'lib-components/layout/flex-helpers'
 import { fontWeights } from 'lib-components/typography'
 import { defaultMargins, Gap } from 'lib-components/white-space'
@@ -19,6 +19,7 @@ import { faCalendar } from 'lib-icons'
 
 import { useLang, useTranslation } from '../localization'
 import { headerHeightMobile } from '../navigation/const'
+import { useIsRunningInstalled } from '../pwa/installed'
 
 import {
   CalendarEventCount,
@@ -38,6 +39,9 @@ interface DayProps {
   events: CitizenCalendarEvent[]
   scrollToDate: LocalDate
 }
+
+// Space left above the day for the month summary that sticks to the top of the list
+const stickyMonthSummaryHeight = 54
 
 export default React.memo(function DayElem({
   calendarDay,
@@ -77,19 +81,25 @@ export default React.memo(function DayElem({
     selectDate(calendarDay.date)
   }, [selectDate, calendarDay.date])
 
-  useEffect(() => {
-    const top = ref.current?.getBoundingClientRect().top
+  // In a browser the sticky header is inside the scrolling document, so it
+  // takes space above the day as well
+  const runningInstalled = useIsRunningInstalled()
+  const spaceAboveDay = runningInstalled
+    ? stickyMonthSummaryHeight
+    : headerHeightMobile + stickyMonthSummaryHeight
 
-    if (top) {
+  useEffect(() => {
+    if (ref.current) {
       // Initial load scrolls smoothly to "today",
       // subsequent loads to previous months use instant scroll to keep the list position
       // at the place where "fetch previous" was clicked
-      scrollToPos({
-        top: top - headerHeightMobile - 54,
-        behavior: isToday ? 'smooth' : 'instant'
-      })
+      scrollToElementTop(
+        ref.current,
+        spaceAboveDay,
+        isToday ? 'smooth' : 'instant'
+      )
     }
-  }, [isToday, scrollToDate])
+  }, [isToday, scrollToDate, spaceAboveDay])
 
   const eventCount = useMemo(
     () => countEventsForDay(events, calendarDay.date),

--- a/frontend/src/citizen-frontend/calendar/MonthElem.tsx
+++ b/frontend/src/citizen-frontend/calendar/MonthElem.tsx
@@ -176,6 +176,11 @@ const MonthSummaryContainer = styled.div`
   top: 54px;
   z-index: 1;
 
+  html[data-standalone] & {
+    // Keeps the top border out of view while stuck, as it is under the header in a browser
+    top: -6px;
+  }
+
   padding: ${defaultMargins.s};
   background-color: ${(p) => p.theme.colors.main.m4};
   border-top: 6px solid ${colors.main.m3};

--- a/frontend/src/citizen-frontend/index.css
+++ b/frontend/src/citizen-frontend/index.css
@@ -51,3 +51,21 @@ a {
 #app {
   height: 100%;
 }
+
+/* When the app runs installed, all scrolling happens inside the app shell (see App.tsx) */
+html[data-standalone],
+html[data-standalone] body,
+html[data-standalone] #app {
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+@media print {
+  html[data-standalone],
+  html[data-standalone] body,
+  html[data-standalone] #app {
+    height: auto;
+    overflow: visible;
+  }
+}

--- a/frontend/src/citizen-frontend/navigation/Header.tsx
+++ b/frontend/src/citizen-frontend/navigation/Header.tsx
@@ -102,6 +102,10 @@ const HeaderContainer = styled.header<{ $narrow: boolean }>`
 
   ${(p) => (p.$narrow ? narrowWidthStyles : wideWidthStyles)}
 
+  html[data-standalone] & {
+    position: static;
+  }
+
   @media print {
     display: none;
   }

--- a/frontend/src/citizen-frontend/navigation/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/MobileNav.tsx
@@ -160,6 +160,11 @@ const BottomBar = styled.nav`
   left: 0;
   box-shadow: 0px -2px 4px rgba(0, 0, 0, 0.15);
 
+  html[data-standalone] & {
+    position: static;
+    flex: none;
+  }
+
   @media (min-width: ${desktopMin}) {
     display: none;
   }
@@ -463,6 +468,14 @@ const MenuContainer = styled.div`
   flex-direction: column;
   align-items: flex-end;
   text-align: right;
+
+  html[data-standalone] & {
+    position: absolute;
+    overflow-y: auto;
+    left: 0;
+    width: auto;
+    height: auto;
+  }
 
   @media (min-width: ${desktopMin}) {
     display: none;

--- a/frontend/src/citizen-frontend/navigation/MobileNav.tsx
+++ b/frontend/src/citizen-frontend/navigation/MobileNav.tsx
@@ -31,7 +31,6 @@ import {
 } from 'lib-icons'
 
 import ModalAccessibilityWrapper from '../ModalAccessibilityWrapper'
-import { UnwrapResult } from '../async-rendering'
 import type { User } from '../auth/state'
 import { AuthContext } from '../auth/state'
 import { langs, useLang, useTranslation } from '../localization'
@@ -77,71 +76,63 @@ export default React.memo(function MobileNav() {
   )
   const closeMenu = useCallback(() => setMenuOpen(undefined), [])
 
-  if (!user.getOrElse(undefined)) {
+  const currentUser = user.getOrElse(undefined)
+  if (!currentUser) {
     return null
   }
 
   return (
-    <UnwrapResult result={user} loading={() => null}>
-      {(user) =>
-        user ? (
-          <>
-            <BottomBar>
-              {user.accessibleFeatures.reservations && (
-                <BottomBarLink
-                  to="/calendar"
-                  data-qa="nav-calendar-mobile"
-                  text={t.header.nav.calendar}
-                  icon={faCalendar}
-                  activeIcon={fasCalendar}
-                  showNotification={false}
-                  onClick={closeMenu}
-                />
-              )}
-              {user.accessibleFeatures.messages && (
-                <BottomBarLink
-                  to="/messages"
-                  data-qa="nav-messages-mobile"
-                  text={t.header.nav.messages}
-                  icon={faEnvelope}
-                  activeIcon={fasEnvelope}
-                  showNotification={(unreadMessagesCount ?? 0) > 0}
-                  onClick={closeMenu}
-                />
-              )}
-              <ChildrenLink
-                toggleChildrenMenu={toggleChildrenMenu}
-                closeMenu={closeMenu}
-              />
-              <StyledButton
-                onClick={toggleSubMenu}
-                data-qa="sub-nav-menu-mobile"
-              >
-                <AttentionIndicator
-                  toggled={hasPersonalDetailsTasks || unreadDecisions > 0}
-                  position="top"
-                  data-qa="attention-indicator-sub-menu-mobile"
-                >
-                  <FontAwesomeIcon
-                    icon={menuOpen === 'submenu' ? farXmark : faBars}
-                  />
-                </AttentionIndicator>
-                {t.header.nav.subNavigationMenu}
-              </StyledButton>
-            </BottomBar>
-            {menuOpen === 'submenu' ? (
-              <Menu
-                user={user}
-                closeMenu={closeMenu}
-                unreadDecisions={unreadDecisions}
-              />
-            ) : menuOpen === 'children' ? (
-              <ChildrenMenu closeMenu={closeMenu} />
-            ) : null}
-          </>
-        ) : null
-      }
-    </UnwrapResult>
+    <>
+      <BottomBar>
+        {currentUser.accessibleFeatures.reservations && (
+          <BottomBarLink
+            to="/calendar"
+            data-qa="nav-calendar-mobile"
+            text={t.header.nav.calendar}
+            icon={faCalendar}
+            activeIcon={fasCalendar}
+            showNotification={false}
+            onClick={closeMenu}
+          />
+        )}
+        {currentUser.accessibleFeatures.messages && (
+          <BottomBarLink
+            to="/messages"
+            data-qa="nav-messages-mobile"
+            text={t.header.nav.messages}
+            icon={faEnvelope}
+            activeIcon={fasEnvelope}
+            showNotification={(unreadMessagesCount ?? 0) > 0}
+            onClick={closeMenu}
+          />
+        )}
+        <ChildrenLink
+          toggleChildrenMenu={toggleChildrenMenu}
+          closeMenu={closeMenu}
+        />
+        <StyledButton onClick={toggleSubMenu} data-qa="sub-nav-menu-mobile">
+          <AttentionIndicator
+            toggled={hasPersonalDetailsTasks || unreadDecisions > 0}
+            position="top"
+            data-qa="attention-indicator-sub-menu-mobile"
+          >
+            <FontAwesomeIcon
+              icon={menuOpen === 'submenu' ? farXmark : faBars}
+            />
+          </AttentionIndicator>
+          {t.header.nav.subNavigationMenu}
+        </StyledButton>
+      </BottomBar>
+      {menuOpen === 'submenu' ? (
+        <Menu
+          user={currentUser}
+          closeMenu={closeMenu}
+          unreadDecisions={unreadDecisions}
+        />
+      ) : menuOpen === 'children' ? (
+        <ChildrenMenu closeMenu={closeMenu} />
+      ) : null}
+    </>
   )
 })
 

--- a/frontend/src/citizen-frontend/pwa/InstallSuggestion.tsx
+++ b/frontend/src/citizen-frontend/pwa/InstallSuggestion.tsx
@@ -134,6 +134,10 @@ const Banner = styled.div`
   @media (min-width: ${desktopMin}) {
     top: 0;
   }
+
+  html[data-standalone] & {
+    top: 0;
+  }
 `
 
 const Note = styled.button`

--- a/frontend/src/citizen-frontend/pwa/installed.ts
+++ b/frontend/src/citizen-frontend/pwa/installed.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import { useSyncExternalStore } from 'react'
+import { useLayoutEffect, useSyncExternalStore } from 'react'
 
 const standaloneQuery = () => window.matchMedia('(display-mode: standalone)')
 
@@ -12,12 +12,26 @@ const subscribe = (onChange: () => void) => {
   return () => query.removeEventListener('change', onChange)
 }
 
-const getIsRunningInstalled = () =>
+const isRunningInstalled = () =>
   standaloneQuery().matches ||
   // iOS Safari does not implement the display-mode media feature, so the home
   // screen app is only recognisable through this non-standard property.
   ('standalone' in navigator && navigator.standalone === true)
 
 export function useIsRunningInstalled(): boolean {
-  return useSyncExternalStore(subscribe, getIsRunningInstalled)
+  return useSyncExternalStore(subscribe, isRunningInstalled)
+}
+
+/**
+ * Marks the document while the app runs installed. Styles target the app
+ * shell layout (see App.tsx) with `html[data-standalone] &`.
+ */
+export function useStandaloneAttribute() {
+  const runningInstalled = useIsRunningInstalled()
+  useLayoutEffect(() => {
+    document.documentElement.toggleAttribute(
+      'data-standalone',
+      runningInstalled
+    )
+  }, [runningInstalled])
 }

--- a/frontend/src/lib-common/utils/scrolling.ts
+++ b/frontend/src/lib-common/utils/scrolling.ts
@@ -2,9 +2,41 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-import type { MutableRefObject } from 'react'
+import { useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
 
 import { isAutomatedTest } from './helpers'
+
+type ScrollContainerResolver = () => HTMLElement | null
+
+/**
+ * Registers how to find the element that scrolls the page in place of the
+ * window. The page-level scroll helpers below ask the resolver on every call,
+ * because which element scrolls, if any, can depend on the viewport width and
+ * on the app layout. Without a resolver, or when it returns null, they scroll
+ * the window.
+ */
+let resolveScrollContainer: ScrollContainerResolver = () => null
+
+const scrollsItsContent = (el: HTMLElement) =>
+  /auto|scroll/.test(getComputedStyle(el).overflowY)
+
+// Which of the two scrolls, if either, depends on the viewport width and on
+// the app layout, so the choice is made on every call rather than once
+export function useRegisterScrollContainer() {
+  const shellRef = useRef<HTMLDivElement>(null)
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    resolveScrollContainer = () =>
+      [scrollAreaRef.current, shellRef.current].find(
+        (el): el is HTMLDivElement => !!el && scrollsItsContent(el)
+      ) ?? null
+    return () => {
+      resolveScrollContainer = () => null
+    }
+  }, [])
+  return { shellRef, scrollAreaRef }
+}
 
 export function scrollToPos(options: ScrollToOptions, timeout = 0) {
   scrollWithTimeout(() => options, timeout)
@@ -22,13 +54,23 @@ export function scrollToTop(timeout = 0) {
   scrollWithTimeout(() => ({ top: 0, left: 0 }), timeout)
 }
 
-export function scrollToRef(
-  ref: MutableRefObject<HTMLElement | null>,
+export function scrollToRef(ref: RefObject<HTMLElement | null>, timeout = 0) {
+  scrollWithTimeout(
+    () =>
+      ref.current ? { top: getScrollOffsetPosition(ref.current) } : undefined,
+    timeout
+  )
+}
+
+/** Scrolls the page so that the element's top edge lands `offset` px below the top of the scrolling area */
+export function scrollToElementTop(
+  element: HTMLElement,
+  offset: number,
+  behavior: ScrollBehavior,
   timeout = 0
 ) {
   scrollWithTimeout(
-    () =>
-      ref.current ? { top: getDocumentOffsetPosition(ref.current) } : undefined,
+    () => ({ top: getScrollOffsetPosition(element) - offset, behavior }),
     timeout
   )
 }
@@ -42,7 +84,7 @@ export function scrollToElement(
 }
 
 export function scrollRefIntoView(
-  ref: MutableRefObject<HTMLElement | null>,
+  ref: RefObject<HTMLElement | null>,
   timeout = 0,
   blockPosition: ScrollLogicalPosition = 'start'
 ) {
@@ -80,8 +122,9 @@ function scrollWithTimeout(
   withTimeout(() => {
     const opts = getOptions()
     if (opts) {
-      if (element) {
-        element.scrollTo({ behavior: 'smooth', ...opts })
+      const target = element ?? resolveScrollContainer()
+      if (target) {
+        target.scrollTo({ behavior: 'smooth', ...opts })
       } else {
         window.scrollTo({ behavior: 'smooth', ...opts })
       }
@@ -110,13 +153,10 @@ function withTimeout(callback: () => void, timeout = 0) {
   }
 }
 
-function getDocumentOffsetPosition(elem: HTMLElement): number {
-  let elemTop = elem.offsetTop
-  if (elem.offsetParent) {
-    const parentOffsetTop = getDocumentOffsetPosition(
-      elem.offsetParent as HTMLElement
-    )
-    elemTop = elemTop + parentOffsetTop
-  }
-  return elemTop
+function getScrollOffsetPosition(elem: HTMLElement): number {
+  const top = elem.getBoundingClientRect().top
+  const container = resolveScrollContainer()
+  return container
+    ? top - container.getBoundingClientRect().top + container.scrollTop
+    : top + window.scrollY
 }


### PR DESCRIPTION
iOS Safari on buginen PWA-moodissa viewporttiin suhteutettujen position: fixed ja position: fixed positioinnissa. Ei siis käytetä sellaisia, vaan positioidaan sivun header ja navigaatio flexboxilla, ja tehdään niiden välissä oleva sisältöalue skrollattavaksi.

Uutta verrattuna [edelliseen PR:ää](https://github.com/espoon-voltti/evaka/pull/9791):
- PWA:n ulkopuolella koko dokumentti skrollaa maksimaalisen yhteensopivuuden takaamiseksi
- Tämä uusi layout on käytössä ruudun koosta riippumatta aina PWA:ssa, koska osa iPad-laitteista on niin isoja että ne saavat desktop-layoutin